### PR TITLE
planner/cascades: add ImplementationRule for TopN

### DIFF
--- a/planner/cascades/enforcer_rules.go
+++ b/planner/cascades/enforcer_rules.go
@@ -30,7 +30,7 @@ type Enforcer interface {
 	// required physical property.
 	OnEnforce(reqProp *property.PhysicalProperty, child memo.Implementation) (impl memo.Implementation)
 	// GetEnforceCost calculates cost of enforcing required physical property.
-	GetEnforceCost(g *memo.Group, inputCount float64) float64
+	GetEnforceCost(g *memo.Group) float64
 }
 
 // GetEnforcerRules gets all candidate enforcer rules based
@@ -54,7 +54,7 @@ var orderEnforcer = &OrderEnforcer{}
 // NewProperty removes order property from required physical property.
 func (e *OrderEnforcer) NewProperty(prop *property.PhysicalProperty) (newProp *property.PhysicalProperty) {
 	// Order property cannot be empty now.
-	newProp = &property.PhysicalProperty{ExpectedCnt: prop.ExpectedCnt}
+	newProp = &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64}
 	return
 }
 
@@ -76,10 +76,10 @@ func (e *OrderEnforcer) OnEnforce(reqProp *property.PhysicalProperty, child memo
 }
 
 // GetEnforceCost calculates cost of sort operator.
-func (e *OrderEnforcer) GetEnforceCost(g *memo.Group, inputCount float64) float64 {
+func (e *OrderEnforcer) GetEnforceCost(g *memo.Group) float64 {
 	// We need a SessionCtx to calculate the cost of a sort.
 	sctx := g.Equivalents.Front().Value.(*memo.GroupExpr).ExprNode.SCtx()
 	sort := plannercore.PhysicalSort{}.Init(sctx, nil, 0, nil)
-	cost := sort.GetCost(inputCount)
+	cost := sort.GetCost(g.Prop.Stats.RowCount)
 	return cost
 }

--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -316,7 +316,7 @@ type ImplTopNAsLimit struct {
 func (r *ImplTopNAsLimit) Match(expr *memo.GroupExpr, prop *property.PhysicalProperty) (matched bool) {
 	topN := expr.ExprNode.(*plannercore.LogicalTopN)
 	_, canUseLimit := plannercore.GetPropByOrderByItems(topN.ByItems)
-	return plannercore.MatchItems(prop, topN.ByItems) && canUseLimit
+	return canUseLimit && plannercore.MatchItems(prop, topN.ByItems)
 }
 
 // OnImplement implements ImplementationRule OnImplement interface.

--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -14,9 +14,9 @@
 package cascades
 
 import (
-	"github.com/pingcap/tidb/expression"
 	"math"
 
+	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	impl "github.com/pingcap/tidb/planner/implementation"
 	"github.com/pingcap/tidb/planner/memo"

--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -14,6 +14,7 @@
 package cascades
 
 import (
+	"github.com/pingcap/tidb/expression"
 	"math"
 
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -58,6 +59,10 @@ var defaultImplementationMap = map[memo.Operand][]ImplementationRule{
 	},
 	memo.OperandLimit: {
 		&ImplLimit{},
+	},
+	memo.OperandTopN: {
+		&ImplTopN{},
+		&ImplTopNAsLimit{},
 	},
 }
 
@@ -270,5 +275,62 @@ func (r *ImplLimit) OnImplement(expr *memo.GroupExpr, reqProp *property.Physical
 		Offset: logicalLimit.Offset,
 		Count:  logicalLimit.Count,
 	}.Init(logicalLimit.SCtx(), expr.Group.Prop.Stats, logicalLimit.SelectBlockOffset(), newProp)
+	return impl.NewLimitImpl(physicalLimit), nil
+}
+
+// ImplTopN is the implementation rule which implements LogicalTopN
+// to PhysicalTopN.
+type ImplTopN struct {
+}
+
+// Match implements ImplementationRule Match interface.
+func (r *ImplTopN) Match(expr *memo.GroupExpr, prop *property.PhysicalProperty) (matched bool) {
+	topN := expr.ExprNode.(*plannercore.LogicalTopN)
+	return plannercore.MatchItems(prop, topN.ByItems)
+}
+
+// OnImplement implements ImplementationRule OnImplement interface.
+func (r *ImplTopN) OnImplement(expr *memo.GroupExpr, reqProp *property.PhysicalProperty) (memo.Implementation, error) {
+	lt := expr.ExprNode.(*plannercore.LogicalTopN)
+	resultProp := &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64}
+	topN := plannercore.PhysicalTopN{
+		ByItems: lt.ByItems,
+		Count:   lt.Count,
+		Offset:  lt.Offset,
+	}.Init(lt.SCtx(), expr.Group.Prop.Stats, lt.SelectBlockOffset(), resultProp)
+	switch expr.Group.EngineType {
+	case memo.EngineTiDB:
+		return impl.NewTiDBTopNImpl(topN), nil
+	default:
+		// TODO: return TiKVTopNImpl after we have implemented push topN down gather.
+		return nil, plannercore.ErrInternal.GenWithStack("Unsupported EngineType '%s' for TopN.", expr.Group.EngineType.String())
+	}
+}
+
+// ImplTopNAsLimit is the implementation rule which implements LogicalTopN
+// as PhysicalLimit with required order property.
+type ImplTopNAsLimit struct {
+}
+
+// Match implements ImplementationRule Match interface.
+func (r *ImplTopNAsLimit) Match(expr *memo.GroupExpr, prop *property.PhysicalProperty) (matched bool) {
+	topN := expr.ExprNode.(*plannercore.LogicalTopN)
+	_, canUseLimit := plannercore.GetPropByOrderByItems(topN.ByItems)
+	return plannercore.MatchItems(prop, topN.ByItems) && canUseLimit
+}
+
+// OnImplement implements ImplementationRule OnImplement interface.
+func (r *ImplTopNAsLimit) OnImplement(expr *memo.GroupExpr, reqProp *property.PhysicalProperty) (memo.Implementation, error) {
+	lt := expr.ExprNode.(*plannercore.LogicalTopN)
+	newProp := &property.PhysicalProperty{ExpectedCnt: float64(lt.Count + lt.Offset)}
+	newProp.Items = make([]property.Item, len(lt.ByItems))
+	for i, item := range lt.ByItems {
+		newProp.Items[i].Col = item.Expr.(*expression.Column)
+		newProp.Items[i].Desc = item.Desc
+	}
+	physicalLimit := plannercore.PhysicalLimit{
+		Offset: lt.Offset,
+		Count:  lt.Count,
+	}.Init(lt.SCtx(), expr.Group.Prop.Stats, lt.SelectBlockOffset(), newProp)
 	return impl.NewLimitImpl(physicalLimit), nil
 }

--- a/planner/cascades/optimize.go
+++ b/planner/cascades/optimize.go
@@ -16,7 +16,6 @@ package cascades
 import (
 	"container/list"
 	"math"
-	"reflect"
 
 	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -262,11 +261,6 @@ func (opt *Optimizer) onPhaseImplementation(sctx sessionctx.Context, g *memo.Gro
 	prop := &property.PhysicalProperty{
 		ExpectedCnt: math.MaxFloat64,
 	}
-	println("*********************************************")
-	groupString := ToString(g)
-	for _, s := range groupString {
-		println(s)
-	}
 	// TODO replace MaxFloat64 costLimit by variable from sctx, or other sources.
 	impl, err := opt.implGroup(g, prop, math.MaxFloat64)
 	if err != nil {
@@ -326,8 +320,6 @@ func (opt *Optimizer) implGroup(g *memo.Group, reqPhysProp *property.PhysicalPro
 				continue
 			}
 			cumCost = impl.CalcCost(outCount, childImpls...)
-			println(reflect.TypeOf(impl).String())
-			println(int64(impl.GetCost()))
 			if cumCost > costLimit {
 				continue
 			}

--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -50,7 +50,9 @@
     "name": "TestSimplePlans",
     "cases": [
       "select a from t limit 2",
-      "select a from t limit 1 offset 2"
+      "select a from t limit 1 offset 2",
+      "select b from t order by b limit 3",
+      "select a from t order by a limit 1 offset 2"
     ]
   }
 ]

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -303,6 +303,32 @@
         "Result": [
           "3"
         ]
+      },
+      {
+        "SQL": "select b from t order by b limit 3",
+        "Plan": [
+          "TopN_8 3.00 root Column#3:asc, offset:0, count:3",
+          "└─Projection_10 10000.00 root Column#2",
+          "  └─TableReader_11 10000.00 root data:TableScan_12",
+          "    └─TableScan_12 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "11",
+          "22",
+          "33"
+        ]
+      },
+      {
+        "SQL": "select a from t order by a limit 1 offset 2",
+        "Plan": [
+          "Limit_9 1.00 root offset:2, count:1",
+          "└─Projection_13 3.00 root Column#1",
+          "  └─TableReader_14 3.00 root data:TableScan_15",
+          "    └─TableScan_15 3.00 cop[tikv] table:t, range:[-inf,+inf], keep order:true, stats:pseudo"
+        ],
+        "Result": [
+          "3"
+        ]
       }
     ]
   }

--- a/planner/implementation/simple_plans.go
+++ b/planner/implementation/simple_plans.go
@@ -108,3 +108,21 @@ type LimitImpl struct {
 func NewLimitImpl(limit *plannercore.PhysicalLimit) *LimitImpl {
 	return &LimitImpl{baseImpl{plan: limit}}
 }
+
+// TiDBTopNImpl is the implementation of PhysicalTopN in TiDB layer.
+type TiDBTopNImpl struct {
+	baseImpl
+}
+
+// CalcCost implements Implementation CalcCost interface.
+func (impl *TiDBTopNImpl) CalcCost(outCount float64, children ...memo.Implementation) float64 {
+	topN := impl.plan.(*plannercore.PhysicalTopN)
+	childCount := children[0].GetPlan().Stats().RowCount
+	impl.cost = topN.GetCost(childCount, true) + children[0].GetCost()
+	return impl.cost
+}
+
+// NewTiDBTopNImpl creates a new TiDBTopNImpl.
+func NewTiDBTopNImpl(topN *plannercore.PhysicalTopN) *TiDBTopNImpl {
+	return &TiDBTopNImpl{baseImpl{plan: topN}}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds ImplementationRule for TopN.

### What is changed and how it works?

1. LogicalTopN can be implemented as PhysicalTopN or PhysicalLimit with required property.

2. Fix a bug about the cost of enfored sort.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has interface methods change
