### PR TITLE
expression: implement vectorized evaluation for `builtinFromUnixTime2ArgSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -300,6 +300,31 @@ func (g *timeFormatGener) gen() interface{} {
 	}
 }
 
+type dateFormatGener struct {
+	nullRation float64
+}
+
+// gen (generate) date format specifiers
+// format specifier list:
+// https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-format
+func (g *dateFormatGener) gen() interface{} {
+	if rand.Float64() < g.nullRation {
+		return nil
+	}
+	switch rand.Uint32() % 4 {
+	case 0:
+		return "%Y-%M-%D %H:%I:%S %X"
+	case 1:
+		return "%y-%m-%d %h:%i:%s %x"
+	case 2:
+		return "%a %b %c %e %f %j %k %l"
+	case 3:
+		return "%p %r %T %U %u %V %v %W %w %Y %y %% %z"
+	default:
+		return nil
+	}
+}
+
 // rangeRealGener is used to generate float64 items in [begin, end].
 type rangeRealGener struct {
 	begin float64
@@ -398,7 +423,7 @@ func (g *ipv4ByteGener) gen() interface{} {
 	return string(ip[:net.IPv4len])
 }
 
-// ipv4Compat is used to generate ipv4 compatible ipv6 strings
+// ipv4CompatByteGener is used to generate ipv4 compatible ipv6 strings
 type ipv4CompatByteGener struct {
 }
 
@@ -806,6 +831,7 @@ func genVecBuiltinFuncBenchCase(ctx sessionctx.Context, funcName string, testCas
 	return baseFunc, fts, input, result
 }
 
+// getColumnLen
 // a hack way to calculate length of a chunk.Column.
 func getColumnLen(col *chunk.Column, eType types.EvalType) int {
 	chk := chunk.New([]*types.FieldType{eType2FieldType(eType)}, 1024, 1024)

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -313,7 +313,7 @@ func (g *dateFormatGener) gen() interface{} {
 	}
 	switch rand.Uint32() % 4 {
 	case 0:
-		return "%Y-%M-%D %H:%I:%S %X"
+		return "%Y-%M-%D %H:%i:%S %X"
 	case 1:
 		return "%y-%m-%d %h:%i:%s %x"
 	case 2:

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -189,6 +189,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDecimal},
 			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}},
 		},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETString},
+			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}, &timeFormatGener{0.5}},
+		},
 	},
 }
 

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -190,7 +190,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}},
 		},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETString},
-			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}, &timeFormatGener{0.5}},
+			geners: []dataGenerator{gener{defaultGener{eType: types.ETDecimal, nullRation: 0.9}}, &dateFormatGener{0.5}},
 		},
 	},
 }


### PR DESCRIPTION
PCP #12106 

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinFromUnixTime2ArgSig` at #12106 

### What is changed and how it works?
It gets faster about 33.7%.
Other tiny typo fixes of comments according to `goword` result

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
```
> GO111MODULE=on go test -check.f TestVectorizedBuiltinTimeFunc
PASS: builtin_time_vec_test.go:202: testEvaluatorSuite.TestVectorizedBuiltinTimeFunc	0.129s
PASS: builtin_time_vec_generated_test.go:172: testEvaluatorSuite.TestVectorizedBuiltinTimeFuncGenerated	0.036s
OK: 2 passed
PASS
ok  	github.com/pingcap/tidb/expression	0.191s
```

 - Benchmark
```
> go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args builtinFromUnixTime2ArgSig
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.00675 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinFromUnixTime2ArgSig-VecBuiltinFunc-12         	   36835	     31454 ns/op	    6293 B/op	     226 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinFromUnixTime2ArgSig-NonVecBuiltinFunc-12      	   24978	     47419 ns/op	    6293 B/op	     226 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.244s
```

 - Manual test (add detailed scripts or steps below)
```sql
mysql> SELECT FROM_UNIXTIME(1447430881);
+---------------------------+
| FROM_UNIXTIME(1447430881) |
+---------------------------+
| 2015-11-14 00:08:01       |
+---------------------------+
1 row in set (0.00 sec)

mysql> SELECT FROM_UNIXTIME(1447430881) + 0;
+-------------------------------+
| FROM_UNIXTIME(1447430881) + 0 |
+-------------------------------+
|                20151114000801 |
+-------------------------------+
1 row in set (0.00 sec)

mysql> SELECT FROM_UNIXTIME(1447430881, '%Y-%M-%D %H:%i:%S %X');
+---------------------------------------------------+
| FROM_UNIXTIME(1447430881, '%Y-%M-%D %H:%i:%S %X') |
+---------------------------------------------------+
| 2015-November-14th 00:08:01 2015                  |
+---------------------------------------------------+
1 row in set (0.00 sec)

mysql> 
```
