### PR TITLE
expression: implement vectorized evaluation for `builtinYearWeekWithModeSig`

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1467,7 +1467,7 @@ func (b *builtinYearWeekWithModeSig) vectorized() bool {
 	return true
 }
 
-// evalInt evals YEARWEEK(date,mode).
+// vecEvalInt evals YEARWEEK(date,mode).
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_yearweek
 func (b *builtinYearWeekWithModeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -178,6 +178,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.YearWeek: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt}},
 	},
 	ast.WeekOfYear: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

PCP #12103 

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for `builtinYearWeekWithModeSig`

### What is changed and how it works?

```
$ make vectorized-bench VB_FILE=Time VB_FUNC=builtinYearWeekWithModeSig
cd ./expression && \
                go test -v -benchmem \
                        -bench=BenchmarkVectorizedBuiltinTimeFunc \
                        -run=BenchmarkVectorizedBuiltinTimeFunc \
                        -args "builtinYearWeekWithModeSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-8           1000000000               0.00732 ns/op         0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinYearWeekWithModeSig-VecBuiltinFunc-8             28470             41544 ns/op           29192 B/op          8 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinYearWeekWithModeSig-NonVecBuiltinFunc-8          19538             60255 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.505s
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
