### PR TITLE
ddl: fix error code and error name

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -221,7 +221,7 @@ func onAddColumn(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error)
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 		asyncNotifyEvent(d, &util.Event{Tp: model.ActionAddColumn, TableInfo: tblInfo, ColumnInfo: columnInfo})
 	default:
-		err = ErrInvalidColumnState.GenWithStack("invalid column state %v", columnInfo.State)
+		err = ErrInvalidDDLState.GenWithStackByArgs("column", columnInfo.State)
 	}
 
 	return ver, errors.Trace(err)
@@ -284,7 +284,7 @@ func onDropColumn(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 			job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		}
 	default:
-		err = ErrInvalidTableState.GenWithStack("invalid table state %v", tblInfo.State)
+		err = errInvalidDDLJob.GenWithStackByArgs("table", tblInfo.State)
 	}
 	return ver, errors.Trace(err)
 }

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -950,7 +950,7 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 		{"varchar(10)", "varchar(8)", errUnsupportedModifyColumn.GenWithStackByArgs("length 8 is less than origin 10")},
 		{"varchar(10)", "varchar(11)", nil},
 		{"varchar(10) character set utf8 collate utf8_bin", "varchar(10) character set utf8", nil},
-		{"decimal(2,1)", "decimal(3,2)", errUnsupportedModifyColumn.GenWithStack("unsupported modify decimal column precision")},
+		{"decimal(2,1)", "decimal(3,2)", errUnsupportedModifyColumn.GenWithStackByArgs("can't change decimal column precision")},
 		{"decimal(2,1)", "decimal(2,1)", nil},
 	}
 	for _, tt := range tests {

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -450,10 +450,10 @@ func (s *testStateChangeSuite) TestAppendEnum(c *C) {
 	c.Assert(err.Error(), Equals, "[table:1366]Incorrect enum value: 'A' for column 'c2' at row 1")
 	failAlterTableSQL1 := "alter table t change c2 c2 enum('N') DEFAULT 'N'"
 	_, err = s.se.Execute(context.Background(), failAlterTableSQL1)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify column: the number of enum column's elements is less than the original: 2")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: the number of enum column's elements is less than the original: 2")
 	failAlterTableSQL2 := "alter table t change c2 c2 int default 0"
 	_, err = s.se.Execute(context.Background(), failAlterTableSQL2)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from utf8 to binary")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from utf8 to binary")
 	alterTableSQL := "alter table t change c2 c2 enum('N','Y','A') DEFAULT 'A'"
 	_, err = s.se.Execute(context.Background(), alterTableSQL)
 	c.Assert(err, IsNil)

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -450,10 +450,10 @@ func (s *testStateChangeSuite) TestAppendEnum(c *C) {
 	c.Assert(err.Error(), Equals, "[table:1366]Incorrect enum value: 'A' for column 'c2' at row 1")
 	failAlterTableSQL1 := "alter table t change c2 c2 enum('N') DEFAULT 'N'"
 	_, err = s.se.Execute(context.Background(), failAlterTableSQL1)
-	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify column the number of enum column's elements is less than the original: 2")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify column: the number of enum column's elements is less than the original: 2")
 	failAlterTableSQL2 := "alter table t change c2 c2 int default 0"
 	_, err = s.se.Execute(context.Background(), failAlterTableSQL2)
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from utf8 to binary")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from utf8 to binary")
 	alterTableSQL := "alter table t change c2 c2 enum('N','Y','A') DEFAULT 'A'"
 	_, err = s.se.Execute(context.Background(), alterTableSQL)
 	c.Assert(err, IsNil)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -635,13 +635,13 @@ func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {
 		rs.Close()
 	}
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from latin1 to utf8")
 	rs, err = tk.Exec("alter table t modify column a varchar(20) charset utf8mb4")
 	if rs != nil {
 		rs.Close()
 	}
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from latin1 to utf8mb4")
 
 	rs, err = tk.Exec("alter table t modify column a varchar(20) charset utf8mb4 collate utf8bin")
 	if rs != nil {
@@ -675,7 +675,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	if rs != nil {
 		rs.Close()
 	}
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from latin1 to utf8")
 
 	rs, err = tk.Exec("alter table t charset utf8 collate latin1_bin")
 	if rs != nil {
@@ -686,7 +686,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	if rs != nil {
 		rs.Close()
 	}
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from latin1 to utf8mb4")
 
 	rs, err = tk.Exec("alter table t charset utf8mb4 collate utf8mb4_bin")
 	c.Assert(err, NotNil)
@@ -736,7 +736,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	tk.MustExec("create table t(a varchar(10) character set ascii) charset utf8mb4")
 	_, err = tk.Exec("alter table t convert to charset utf8mb4;")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from ascii to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify charset from ascii to utf8mb4")
 
 	tk.MustExec("drop table t;")
 	tk.MustExec("create table t(a varchar(10) character set utf8) charset utf8")
@@ -813,7 +813,7 @@ func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 	tk.MustExec("create database if not exists test")
 	tk.MustExec("use test")
 
-	errMsg := "[ddl:8050]" // unsupported modify column with references
+	errMsg := "[ddl:8200]" // unsupported modify column with references
 	assertErrCode := func(sql string, errCodeStr string) {
 		_, err := tk.Exec(sql)
 		c.Assert(err, NotNil)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -463,7 +463,7 @@ func (s *testIntegrationSuite5) TestMySQLErrorCode(c *C) {
 	sql = "alter table test_error_code_succ drop index idx_not_exist"
 	tk.MustGetErrCode(sql, tmysql.ErrCantDropFieldOrKey)
 	sql = "alter table test_error_code_succ drop column c3"
-	tk.MustGetErrCode(sql, int(tmysql.ErrUnknown))
+	tk.MustGetErrCode(sql, int(tmysql.ErrUnsupportedDDLOperation))
 	// modify column
 	sql = "alter table test_error_code_succ modify testx.test_error_code_succ.c1 bigint"
 	tk.MustGetErrCode(sql, tmysql.ErrWrongDBName)
@@ -635,13 +635,13 @@ func (s *testIntegrationSuite3) TestChangingCharsetToUtf8(c *C) {
 		rs.Close()
 	}
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from latin1 to utf8")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8")
 	rs, err = tk.Exec("alter table t modify column a varchar(20) charset utf8mb4")
 	if rs != nil {
 		rs.Close()
 	}
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from latin1 to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8mb4")
 
 	rs, err = tk.Exec("alter table t modify column a varchar(20) charset utf8mb4 collate utf8bin")
 	if rs != nil {
@@ -675,7 +675,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	if rs != nil {
 		rs.Close()
 	}
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from latin1 to utf8")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8")
 
 	rs, err = tk.Exec("alter table t charset utf8 collate latin1_bin")
 	if rs != nil {
@@ -686,7 +686,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	if rs != nil {
 		rs.Close()
 	}
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from latin1 to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from latin1 to utf8mb4")
 
 	rs, err = tk.Exec("alter table t charset utf8mb4 collate utf8mb4_bin")
 	c.Assert(err, NotNil)
@@ -736,7 +736,7 @@ func (s *testIntegrationSuite4) TestChangingTableCharset(c *C) {
 	tk.MustExec("create table t(a varchar(10) character set ascii) charset utf8mb4")
 	_, err = tk.Exec("alter table t convert to charset utf8mb4;")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:210]unsupported modify charset from ascii to utf8mb4")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify charset from ascii to utf8mb4")
 
 	tk.MustExec("drop table t;")
 	tk.MustExec("create table t(a varchar(10) character set utf8) charset utf8")
@@ -813,7 +813,7 @@ func (s *testIntegrationSuite5) TestModifyingColumnOption(c *C) {
 	tk.MustExec("create database if not exists test")
 	tk.MustExec("use test")
 
-	errMsg := "[ddl:203]" // unsupported modify column with references
+	errMsg := "[ddl:8050]" // unsupported modify column with references
 	assertErrCode := func(sql string, errCodeStr string) {
 		_, err := tk.Exec(sql)
 		c.Assert(err, NotNil)

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1688,9 +1688,9 @@ func (s *testIntegrationSuite3) TestUnsupportedPartitionManagementDDLs(c *C) {
 	`)
 
 	_, err := tk.Exec("alter table test_1465 truncate partition p1, p2")
-	c.Assert(err, ErrorMatches, ".*can't run multi schema change")
+	c.Assert(err, ErrorMatches, ".*Unsupported multi schema change")
 	_, err = tk.Exec("alter table test_1465 drop partition p1, p2")
-	c.Assert(err, ErrorMatches, ".*can't run multi schema change")
+	c.Assert(err, ErrorMatches, ".*Unsupported multi schema change")
 
 	_, err = tk.Exec("alter table test_1465 partition by hash(a)")
 	c.Assert(err, ErrorMatches, ".*alter table partition is unsupported")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -332,7 +332,7 @@ LOOP:
 		case err := <-done:
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 			break LOOP
 		case <-ticker.C:
 			if times >= 10 {
@@ -414,7 +414,7 @@ func (s *testDBSuite4) TestCancelAddIndex1(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 	t := s.testGetTable(c, "t")
@@ -495,7 +495,7 @@ func (s *testDBSuite5) TestCancelDropIndex(c *C) {
 		if testCase.cancelSucc {
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 			c.Assert(indexInfo, NotNil)
 			c.Assert(indexInfo.State, Equals, model.StatePublic)
 		} else {
@@ -553,7 +553,7 @@ func (s *testDBSuite5) TestCancelTruncateTable(c *C) {
 	_, err := s.tk.Exec("truncate table t")
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 }
 
@@ -606,7 +606,7 @@ func (s *testDBSuite1) TestCancelRenameIndex(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 	t := s.testGetTable(c, "t")
 	for _, idx := range t.Indices() {
@@ -696,7 +696,7 @@ func (s *testDBSuite2) TestCancelDropTableAndSchema(c *C) {
 		if testCase.cancelSucc {
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 			s.mustExec(c, "insert into t values (?, ?)", i, i)
 		} else {
 			c.Assert(err, IsNil)
@@ -1205,7 +1205,7 @@ func (s *testDBSuite3) TestCancelDropColumn(c *C) {
 			c.Assert(checkErr, IsNil)
 			c.Assert(col1, NotNil)
 			c.Assert(col1.Name.L, Equals, "c3")
-			c.Assert(err1.Error(), Equals, "[ddl:12]cancelled DDL job")
+			c.Assert(err1.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 		} else {
 			c.Assert(col1, IsNil)
 			c.Assert(err1, IsNil)
@@ -1459,11 +1459,11 @@ LOOP:
 	// test add unsupported constraint
 	s.mustExec(c, "create table t_add_unsupported_constraint (a int);")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int AUTO_INCREMENT;")
-	c.Assert(err.Error(), Equals, "[ddl:202]unsupported add column 'id' constraint AUTO_INCREMENT when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint AUTO_INCREMENT when altering 'test_db.t_add_unsupported_constraint'")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int KEY;")
-	c.Assert(err.Error(), Equals, "[ddl:202]unsupported add column 'id' constraint PRIMARY KEY when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint PRIMARY KEY when altering 'test_db.t_add_unsupported_constraint'")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int UNIQUE;")
-	c.Assert(err.Error(), Equals, "[ddl:202]unsupported add column 'id' constraint UNIQUE KEY when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint UNIQUE KEY when altering 'test_db.t_add_unsupported_constraint'")
 }
 
 func (s *testDBSuite) testDropColumn(c *C) {
@@ -1635,7 +1635,7 @@ func (s *testDBSuite4) TestChangeColumn(c *C) {
 	sql = "alter table t4 change c2 a bigint not null;"
 	s.tk.MustGetErrCode(sql, tmysql.WarnDataTruncated)
 	sql = "alter table t3 modify en enum('a', 'z', 'b', 'c') not null default 'a'"
-	s.tk.MustGetErrCode(sql, tmysql.ErrUnknown)
+	s.tk.MustGetErrCode(sql, tmysql.ErrUnsupportedDDLOperation)
 	// Rename to an existing column.
 	s.mustExec(c, "alter table t3 add column a bigint")
 	sql = "alter table t3 change aa a bigint"
@@ -2403,7 +2403,7 @@ func (s *testDBSuite4) TestRebaseAutoID(c *C) {
 	s.tk.MustQuery("select * from tidb.test").Check(testkit.Rows("1 1", "6000 1", "11000 1", "16000 1"))
 
 	s.tk.MustExec("create table tidb.test2 (a int);")
-	s.tk.MustGetErrCode("alter table tidb.test2 add column b int auto_increment key, auto_increment=10;", tmysql.ErrUnknown)
+	s.tk.MustGetErrCode("alter table tidb.test2 add column b int auto_increment key, auto_increment=10;", tmysql.ErrUnsupportedDDLOperation)
 }
 
 func (s *testDBSuite5) TestCheckColumnDefaultValue(c *C) {
@@ -2655,7 +2655,7 @@ LOOP:
 		select {
 		case err := <-done:
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 			break LOOP
 		case <-ticker.C:
 			s.mustExec(c, "insert into t1(c2) values (null);")
@@ -3012,7 +3012,7 @@ func (s *testDBSuite5) TestAddIndexForGeneratedColumn(c *C) {
 	s.tk.MustExec("insert into t values()")
 	s.tk.MustExec("ALTER TABLE t ADD COLUMN y1 year as (y + 2)")
 	_, err := s.tk.Exec("ALTER TABLE t ADD INDEX idx_y(y1)")
-	c.Assert(err.Error(), Equals, "[ddl:15]cannot decode index value, because cannot convert datum from unsigned bigint to type year.")
+	c.Assert(err.Error(), Equals, "[ddl:8049]Cannot decode index value, because cannot convert datum from unsigned bigint to type year.")
 
 	t := s.testGetTable(c, "t")
 	for _, idx := range t.Indices() {

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -332,7 +332,7 @@ LOOP:
 		case err := <-done:
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 			break LOOP
 		case <-ticker.C:
 			if times >= 10 {
@@ -414,7 +414,7 @@ func (s *testDBSuite4) TestCancelAddIndex1(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 	t := s.testGetTable(c, "t")
@@ -495,7 +495,7 @@ func (s *testDBSuite5) TestCancelDropIndex(c *C) {
 		if testCase.cancelSucc {
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 			c.Assert(indexInfo, NotNil)
 			c.Assert(indexInfo.State, Equals, model.StatePublic)
 		} else {
@@ -553,7 +553,7 @@ func (s *testDBSuite5) TestCancelTruncateTable(c *C) {
 	_, err := s.tk.Exec("truncate table t")
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 }
 
@@ -606,7 +606,7 @@ func (s *testDBSuite1) TestCancelRenameIndex(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
 	t := s.testGetTable(c, "t")
 	for _, idx := range t.Indices() {
@@ -696,7 +696,7 @@ func (s *testDBSuite2) TestCancelDropTableAndSchema(c *C) {
 		if testCase.cancelSucc {
 			c.Assert(checkErr, IsNil)
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 			s.mustExec(c, "insert into t values (?, ?)", i, i)
 		} else {
 			c.Assert(err, IsNil)
@@ -1205,7 +1205,7 @@ func (s *testDBSuite3) TestCancelDropColumn(c *C) {
 			c.Assert(checkErr, IsNil)
 			c.Assert(col1, NotNil)
 			c.Assert(col1.Name.L, Equals, "c3")
-			c.Assert(err1.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+			c.Assert(err1.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 		} else {
 			c.Assert(col1, IsNil)
 			c.Assert(err1, IsNil)
@@ -1459,11 +1459,11 @@ LOOP:
 	// test add unsupported constraint
 	s.mustExec(c, "create table t_add_unsupported_constraint (a int);")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int AUTO_INCREMENT;")
-	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint AUTO_INCREMENT when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8200]unsupported add column 'id' constraint AUTO_INCREMENT when altering 'test_db.t_add_unsupported_constraint'")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int KEY;")
-	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint PRIMARY KEY when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8200]unsupported add column 'id' constraint PRIMARY KEY when altering 'test_db.t_add_unsupported_constraint'")
 	_, err = s.tk.Exec("ALTER TABLE t_add_unsupported_constraint ADD id int UNIQUE;")
-	c.Assert(err.Error(), Equals, "[ddl:8050]unsupported add column 'id' constraint UNIQUE KEY when altering 'test_db.t_add_unsupported_constraint'")
+	c.Assert(err.Error(), Equals, "[ddl:8200]unsupported add column 'id' constraint UNIQUE KEY when altering 'test_db.t_add_unsupported_constraint'")
 }
 
 func (s *testDBSuite) testDropColumn(c *C) {
@@ -2655,7 +2655,7 @@ LOOP:
 		select {
 		case err := <-done:
 			c.Assert(err, NotNil)
-			c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+			c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 			break LOOP
 		case <-ticker.C:
 			s.mustExec(c, "insert into t1(c2) values (null);")
@@ -3012,7 +3012,7 @@ func (s *testDBSuite5) TestAddIndexForGeneratedColumn(c *C) {
 	s.tk.MustExec("insert into t values()")
 	s.tk.MustExec("ALTER TABLE t ADD COLUMN y1 year as (y + 2)")
 	_, err := s.tk.Exec("ALTER TABLE t ADD INDEX idx_y(y1)")
-	c.Assert(err.Error(), Equals, "[ddl:8049]Cannot decode index value, because cannot convert datum from unsigned bigint to type year.")
+	c.Assert(err.Error(), Equals, "[ddl:8202]Cannot decode index value, because cannot convert datum from unsigned bigint to type year.")
 
 	t := s.testGetTable(c, "t")
 	for _, idx := range t.Indices() {

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -81,20 +81,19 @@ var (
 	errInvalidDDLJob         = terror.ClassDDL.New(mysql.ErrInvalidDDLJob, mysql.MySQLErrName[mysql.ErrInvalidDDLJob])
 	errCancelledDDLJob       = terror.ClassDDL.New(mysql.ErrCancelledDDLJob, mysql.MySQLErrName[mysql.ErrCancelledDDLJob])
 	errFileNotFound          = terror.ClassDDL.New(mysql.ErrFileNotFound, mysql.MySQLErrName[mysql.ErrFileNotFound])
-	errInvalidJobFlag        = terror.ClassDDL.New(mysql.ErrInvalidJobFlag, mysql.MySQLErrName[mysql.ErrInvalidJobFlag])
-	errRunMultiSchemaChanges = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" multi schema change")
+	errInvalidDDLJobFlag     = terror.ClassDDL.New(mysql.ErrInvalidDDLJobFlag, mysql.MySQLErrName[mysql.ErrInvalidDDLJobFlag])
+	errRunMultiSchemaChanges = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "multi schema change"))
 	errWaitReorgTimeout      = terror.ClassDDL.New(mysql.ErrLockWaitTimeout, mysql.MySQLErrName[mysql.ErrWaitReorgTimeout])
 	errInvalidStoreVer       = terror.ClassDDL.New(mysql.ErrInvalidStoreVersion, mysql.MySQLErrName[mysql.ErrInvalidStoreVersion])
 
 	// We don't support dropping column with index covered now.
-	errCantDropColWithIndex     = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" drop column with index")
-	errUnsupportedAddColumn     = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" add column")
-	errUnsupportedModifyColumn  = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" modify column: %s")
-	errUnsupportedModifyCharset = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" modify %s")
-	errUnsupportedPKHandle      = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" drop integer primary key")
-	errUnsupportedCharset       = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" charset %s and collate %s")
-
-	errUnsupportedShardRowIDBits = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" shard_row_id_bits for table with primary key as row id.")
+	errCantDropColWithIndex      = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "drop column with index"))
+	errUnsupportedAddColumn      = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "add column"))
+	errUnsupportedModifyColumn   = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "modify column: %s"))
+	errUnsupportedModifyCharset  = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "modify %s"))
+	errUnsupportedPKHandle       = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "drop integer primary key"))
+	errUnsupportedCharset        = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "charset %s and collate %s"))
+	errUnsupportedShardRowIDBits = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "shard_row_id_bits for table with primary key as row id"))
 	errBlobKeyWithoutLength      = terror.ClassDDL.New(mysql.ErrBlobKeyWithoutLength, mysql.MySQLErrName[mysql.ErrBlobKeyWithoutLength])
 	errIncorrectPrefixKey        = terror.ClassDDL.New(mysql.ErrWrongSubKey, mysql.MySQLErrName[mysql.ErrWrongSubKey])
 	errTooLongKey                = terror.ClassDDL.New(mysql.ErrTooLongKey,
@@ -102,7 +101,7 @@ var (
 	errKeyColumnDoesNotExits    = terror.ClassDDL.New(mysql.ErrKeyColumnDoesNotExits, mysql.MySQLErrName[mysql.ErrKeyColumnDoesNotExits])
 	errUnknownTypeLength        = terror.ClassDDL.New(mysql.ErrUnknownTypeLength, mysql.MySQLErrName[mysql.ErrUnknownTypeLength])
 	errUnknownFractionLength    = terror.ClassDDL.New(mysql.ErrUnknownFractionLength, mysql.MySQLErrName[mysql.ErrUnknownFractionLength])
-	errInvalidJobVersion        = terror.ClassDDL.New(mysql.ErrInvalidJobVersion, mysql.MySQLErrName[mysql.ErrInvalidJobVersion])
+	errInvalidDDLJobVersion     = terror.ClassDDL.New(mysql.ErrInvalidDDLJobVersion, mysql.MySQLErrName[mysql.ErrInvalidDDLJobVersion])
 	errInvalidUseOfNull         = terror.ClassDDL.New(mysql.ErrInvalidUseOfNull, mysql.MySQLErrName[mysql.ErrInvalidUseOfNull])
 	errTooManyFields            = terror.ClassDDL.New(mysql.ErrTooManyFields, mysql.MySQLErrName[mysql.ErrTooManyFields])
 	errInvalidSplitRegionRanges = terror.ClassDDL.New(mysql.ErrInvalidSplitRegionRanges, mysql.MySQLErrName[mysql.ErrInvalidSplitRegionRanges])
@@ -129,34 +128,23 @@ var (
 	// ErrGeneratedColumnRefAutoInc forbids to refer generated columns to auto-increment columns .
 	ErrGeneratedColumnRefAutoInc = terror.ClassDDL.New(mysql.ErrGeneratedColumnRefAutoInc, mysql.MySQLErrName[mysql.ErrGeneratedColumnRefAutoInc])
 	// ErrUnsupportedAddPartition returns for does not support add partitions.
-	ErrUnsupportedAddPartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" add partitions")
+	ErrUnsupportedAddPartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "add partitions"))
 	// ErrUnsupportedCoalescePartition returns for does not support coalesce partitions.
-	ErrUnsupportedCoalescePartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" coalesce partitions")
+	ErrUnsupportedCoalescePartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "coalesce partitions"))
 	// ErrGeneratedColumnFunctionIsNotAllowed returns for unsupported functions for generated columns.
 	ErrGeneratedColumnFunctionIsNotAllowed = terror.ClassDDL.New(mysql.ErrGeneratedColumnFunctionIsNotAllowed, mysql.MySQLErrName[mysql.ErrGeneratedColumnFunctionIsNotAllowed])
 	// ErrUnsupportedPartitionByRangeColumns returns for does unsupported partition by range columns.
-	ErrUnsupportedPartitionByRangeColumns = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+
-		" partition by range columns")
-	errUnsupportedCreatePartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" partition type, treat as normal table")
-	errUnsupportedIndexType       = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" index type")
+	ErrUnsupportedPartitionByRangeColumns = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "partition by range columns"))
+	errUnsupportedCreatePartition         = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "partition type, treat as normal table"))
+	errUnsupportedIndexType               = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "index type"))
 
 	// ErrDupKeyName returns for duplicated key name
 	ErrDupKeyName = terror.ClassDDL.New(mysql.ErrDupKeyName, mysql.MySQLErrName[mysql.ErrDupKeyName])
-	// ErrInvalidDBState returns for invalid database state.
-	ErrInvalidDBState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "database"))
-	// ErrInvalidTableState returns for invalid Table state.
-	ErrInvalidTableState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "table"))
-	// ErrInvalidColumnState returns for invalid column state.
-	ErrInvalidColumnState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "column"))
-	// ErrInvalidIndexState returns for invalid index state.
-	ErrInvalidIndexState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "index"))
-	// ErrInvalidForeignKeyState returns for invalid foreign key state.
-	ErrInvalidForeignKeyState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "foreign key"))
-	// ErrInvalidTableLockState returns for invalid table state.
-	ErrInvalidTableLockState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "table lock"))
+	// ErrInvalidDDLState returns for invalid ddl model object state.
+	ErrInvalidDDLState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState]))
 	// ErrUnsupportedModifyPrimaryKey returns an error when add or drop the primary key.
 	// It's exported for testing.
-	ErrUnsupportedModifyPrimaryKey = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" %s primary key")
+	ErrUnsupportedModifyPrimaryKey = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "%s primary key"))
 
 	// ErrColumnBadNull returns for a bad null value.
 	ErrColumnBadNull = terror.ClassDDL.New(mysql.ErrBadNull, mysql.MySQLErrName[mysql.ErrBadNull])
@@ -682,8 +670,8 @@ func init() {
 		mysql.ErrInvalidDDLWorker:                     mysql.ErrInvalidDDLWorker,
 		mysql.ErrInvalidDefault:                       mysql.ErrInvalidDefault,
 		mysql.ErrInvalidGroupFuncUse:                  mysql.ErrInvalidGroupFuncUse,
-		mysql.ErrInvalidJobFlag:                       mysql.ErrInvalidJobFlag,
-		mysql.ErrInvalidJobVersion:                    mysql.ErrInvalidJobVersion,
+		mysql.ErrInvalidDDLJobFlag:                    mysql.ErrInvalidDDLJobFlag,
+		mysql.ErrInvalidDDLJobVersion:                 mysql.ErrInvalidDDLJobVersion,
 		mysql.ErrInvalidOnUpdate:                      mysql.ErrInvalidOnUpdate,
 		mysql.ErrInvalidSplitRegionRanges:             mysql.ErrInvalidSplitRegionRanges,
 		mysql.ErrInvalidStoreVersion:                  mysql.ErrInvalidStoreVersion,

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -74,166 +74,166 @@ var (
 
 var (
 	// errWorkerClosed means we have already closed the DDL worker.
-	errInvalidWorker = terror.ClassDDL.New(codeInvalidWorker, "invalid worker")
+	errInvalidWorker = terror.ClassDDL.New(mysql.ErrInvalidDDLWorker, mysql.MySQLErrName[mysql.ErrInvalidDDLWorker])
 	// errNotOwner means we are not owner and can't handle DDL jobs.
-	errNotOwner              = terror.ClassDDL.New(codeNotOwner, "not Owner")
-	errCantDecodeIndex       = terror.ClassDDL.New(codeCantDecodeIndex, "cannot decode index value, because %s")
-	errInvalidDDLJob         = terror.ClassDDL.New(codeInvalidDDLJob, "invalid DDL job")
-	errCancelledDDLJob       = terror.ClassDDL.New(codeCancelledDDLJob, "cancelled DDL job")
-	errInvalidJobFlag        = terror.ClassDDL.New(codeInvalidJobFlag, "invalid job flag")
-	errRunMultiSchemaChanges = terror.ClassDDL.New(codeRunMultiSchemaChanges, "can't run multi schema change")
-	errWaitReorgTimeout      = terror.ClassDDL.New(codeWaitReorgTimeout, "wait for reorganization timeout")
-	errInvalidStoreVer       = terror.ClassDDL.New(codeInvalidStoreVer, "invalid storage current version")
+	errNotOwner              = terror.ClassDDL.New(mysql.ErrNotOwner, mysql.MySQLErrName[mysql.ErrNotOwner])
+	errCantDecodeIndex       = terror.ClassDDL.New(mysql.ErrCantDecodeIndex, mysql.MySQLErrName[mysql.ErrCantDecodeIndex])
+	errInvalidDDLJob         = terror.ClassDDL.New(mysql.ErrInvalidDDLJob, mysql.MySQLErrName[mysql.ErrInvalidDDLJob])
+	errCancelledDDLJob       = terror.ClassDDL.New(mysql.ErrCancelledDDLJob, mysql.MySQLErrName[mysql.ErrCancelledDDLJob])
+	errFileNotFound          = terror.ClassDDL.New(mysql.ErrFileNotFound, mysql.MySQLErrName[mysql.ErrFileNotFound])
+	errInvalidJobFlag        = terror.ClassDDL.New(mysql.ErrInvalidJobFlag, mysql.MySQLErrName[mysql.ErrInvalidJobFlag])
+	errRunMultiSchemaChanges = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" multi schema change")
+	errWaitReorgTimeout      = terror.ClassDDL.New(mysql.ErrLockWaitTimeout, mysql.MySQLErrName[mysql.ErrWaitReorgTimeout])
+	errInvalidStoreVer       = terror.ClassDDL.New(mysql.ErrInvalidStoreVersion, mysql.MySQLErrName[mysql.ErrInvalidStoreVersion])
 
 	// We don't support dropping column with index covered now.
-	errCantDropColWithIndex     = terror.ClassDDL.New(codeCantDropColWithIndex, "can't drop column with index")
-	errUnsupportedAddColumn     = terror.ClassDDL.New(codeUnsupportedAddColumn, "unsupported add column")
-	errUnsupportedModifyColumn  = terror.ClassDDL.New(codeUnsupportedModifyColumn, "unsupported modify column %s")
-	errUnsupportedModifyCharset = terror.ClassDDL.New(codeUnsupportedModifyCharset, "unsupported modify %s")
-	errUnsupportedPKHandle      = terror.ClassDDL.New(codeUnsupportedDropPKHandle,
-		"unsupported drop integer primary key")
-	errUnsupportedCharset = terror.ClassDDL.New(codeUnsupportedCharset, "unsupported charset %s collate %s")
+	errCantDropColWithIndex     = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" drop column with index")
+	errUnsupportedAddColumn     = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" add column")
+	errUnsupportedModifyColumn  = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" modify column: %s")
+	errUnsupportedModifyCharset = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" modify %s")
+	errUnsupportedPKHandle      = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" drop integer primary key")
+	errUnsupportedCharset       = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" charset %s and collate %s")
 
-	errUnsupportedShardRowIDBits = terror.ClassDDL.New(codeUnsupportedShardRowIDBits, "unsupported shard_row_id_bits for table with primary key as row id.")
-	errBlobKeyWithoutLength      = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specify a key length")
-	errIncorrectPrefixKey        = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
-	errTooLongKey                = terror.ClassDDL.New(codeTooLongKey,
-		fmt.Sprintf("Specified key was too long; max key length is %d bytes", maxPrefixLength))
-	errKeyColumnDoesNotExits    = terror.ClassDDL.New(codeKeyColumnDoesNotExits, mysql.MySQLErrName[mysql.ErrKeyColumnDoesNotExits])
-	errUnknownTypeLength        = terror.ClassDDL.New(codeUnknownTypeLength, "Unknown length for type tp %d")
-	errUnknownFractionLength    = terror.ClassDDL.New(codeUnknownFractionLength, "Unknown Length for type tp %d and fraction %d")
-	errInvalidJobVersion        = terror.ClassDDL.New(codeInvalidJobVersion, "DDL job with version %d greater than current %d")
-	errFileNotFound             = terror.ClassDDL.New(codeFileNotFound, "Can't find file: './%s/%s.frm'")
-	errErrorOnRename            = terror.ClassDDL.New(codeErrorOnRename, "Error on rename of './%s/%s' to './%s/%s'")
-	errInvalidUseOfNull         = terror.ClassDDL.New(codeInvalidUseOfNull, "Invalid use of NULL value")
-	errTooManyFields            = terror.ClassDDL.New(codeTooManyFields, "Too many columns")
-	errInvalidSplitRegionRanges = terror.ClassDDL.New(codeInvalidRanges, "Failed to split region ranges")
-	errReorgPanic               = terror.ClassDDL.New(codeReorgWorkerPanic, "reorg worker panic.")
+	errUnsupportedShardRowIDBits = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" shard_row_id_bits for table with primary key as row id.")
+	errBlobKeyWithoutLength      = terror.ClassDDL.New(mysql.ErrBlobKeyWithoutLength, mysql.MySQLErrName[mysql.ErrBlobKeyWithoutLength])
+	errIncorrectPrefixKey        = terror.ClassDDL.New(mysql.ErrWrongSubKey, mysql.MySQLErrName[mysql.ErrWrongSubKey])
+	errTooLongKey                = terror.ClassDDL.New(mysql.ErrTooLongKey,
+		fmt.Sprintf(mysql.MySQLErrName[mysql.ErrTooLongKey], maxPrefixLength))
+	errKeyColumnDoesNotExits    = terror.ClassDDL.New(mysql.ErrKeyColumnDoesNotExits, mysql.MySQLErrName[mysql.ErrKeyColumnDoesNotExits])
+	errUnknownTypeLength        = terror.ClassDDL.New(mysql.ErrUnknownTypeLength, mysql.MySQLErrName[mysql.ErrUnknownTypeLength])
+	errUnknownFractionLength    = terror.ClassDDL.New(mysql.ErrUnknownFractionLength, mysql.MySQLErrName[mysql.ErrUnknownFractionLength])
+	errInvalidJobVersion        = terror.ClassDDL.New(mysql.ErrInvalidJobVersion, mysql.MySQLErrName[mysql.ErrInvalidJobVersion])
+	errInvalidUseOfNull         = terror.ClassDDL.New(mysql.ErrInvalidUseOfNull, mysql.MySQLErrName[mysql.ErrInvalidUseOfNull])
+	errTooManyFields            = terror.ClassDDL.New(mysql.ErrTooManyFields, mysql.MySQLErrName[mysql.ErrTooManyFields])
+	errInvalidSplitRegionRanges = terror.ClassDDL.New(mysql.ErrInvalidSplitRegionRanges, mysql.MySQLErrName[mysql.ErrInvalidSplitRegionRanges])
+	errReorgPanic               = terror.ClassDDL.New(mysql.ErrReorgPanic, mysql.MySQLErrName[mysql.ErrReorgPanic])
 
-	errOnlyOnRangeListPartition = terror.ClassDDL.New(codeOnlyOnRangeListPartition, mysql.MySQLErrName[mysql.ErrOnlyOnRangeListPartition])
+	errOnlyOnRangeListPartition = terror.ClassDDL.New(mysql.ErrOnlyOnRangeListPartition, mysql.MySQLErrName[mysql.ErrOnlyOnRangeListPartition])
 	// errWrongKeyColumn is for table column cannot be indexed.
-	errWrongKeyColumn = terror.ClassDDL.New(codeWrongKeyColumn, mysql.MySQLErrName[mysql.ErrWrongKeyColumn])
+	errWrongKeyColumn = terror.ClassDDL.New(mysql.ErrWrongKeyColumn, mysql.MySQLErrName[mysql.ErrWrongKeyColumn])
 	// errWrongFKOptionForGeneratedColumn is for wrong foreign key reference option on generated columns.
-	errWrongFKOptionForGeneratedColumn = terror.ClassDDL.New(codeWrongFKOptionForGeneratedColumn, mysql.MySQLErrName[mysql.ErrWrongFKOptionForGeneratedColumn])
+	errWrongFKOptionForGeneratedColumn = terror.ClassDDL.New(mysql.ErrWrongFKOptionForGeneratedColumn, mysql.MySQLErrName[mysql.ErrWrongFKOptionForGeneratedColumn])
 	// errUnsupportedOnGeneratedColumn is for unsupported actions on generated columns.
-	errUnsupportedOnGeneratedColumn = terror.ClassDDL.New(codeUnsupportedOnGeneratedColumn, mysql.MySQLErrName[mysql.ErrUnsupportedOnGeneratedColumn])
+	errUnsupportedOnGeneratedColumn = terror.ClassDDL.New(mysql.ErrUnsupportedOnGeneratedColumn, mysql.MySQLErrName[mysql.ErrUnsupportedOnGeneratedColumn])
 	// errGeneratedColumnNonPrior forbids to refer generated column non prior to it.
-	errGeneratedColumnNonPrior = terror.ClassDDL.New(codeGeneratedColumnNonPrior, mysql.MySQLErrName[mysql.ErrGeneratedColumnNonPrior])
+	errGeneratedColumnNonPrior = terror.ClassDDL.New(mysql.ErrGeneratedColumnNonPrior, mysql.MySQLErrName[mysql.ErrGeneratedColumnNonPrior])
 	// errDependentByGeneratedColumn forbids to delete columns which are dependent by generated columns.
-	errDependentByGeneratedColumn = terror.ClassDDL.New(codeDependentByGeneratedColumn, mysql.MySQLErrName[mysql.ErrDependentByGeneratedColumn])
+	errDependentByGeneratedColumn = terror.ClassDDL.New(mysql.ErrDependentByGeneratedColumn, mysql.MySQLErrName[mysql.ErrDependentByGeneratedColumn])
 	// errJSONUsedAsKey forbids to use JSON as key or index.
-	errJSONUsedAsKey = terror.ClassDDL.New(codeJSONUsedAsKey, mysql.MySQLErrName[mysql.ErrJSONUsedAsKey])
+	errJSONUsedAsKey = terror.ClassDDL.New(mysql.ErrJSONUsedAsKey, mysql.MySQLErrName[mysql.ErrJSONUsedAsKey])
 	// errBlobCantHaveDefault forbids to give not null default value to TEXT/BLOB/JSON.
-	errBlobCantHaveDefault = terror.ClassDDL.New(codeBlobCantHaveDefault, mysql.MySQLErrName[mysql.ErrBlobCantHaveDefault])
-	errTooLongIndexComment = terror.ClassDDL.New(codeErrTooLongIndexComment, mysql.MySQLErrName[mysql.ErrTooLongIndexComment])
+	errBlobCantHaveDefault = terror.ClassDDL.New(mysql.ErrBlobCantHaveDefault, mysql.MySQLErrName[mysql.ErrBlobCantHaveDefault])
+	errTooLongIndexComment = terror.ClassDDL.New(mysql.ErrTooLongIndexComment, mysql.MySQLErrName[mysql.ErrTooLongIndexComment])
 	// ErrInvalidDefaultValue returns for invalid default value for columns.
-	ErrInvalidDefaultValue = terror.ClassDDL.New(codeInvalidDefaultValue, mysql.MySQLErrName[mysql.ErrInvalidDefault])
+	ErrInvalidDefaultValue = terror.ClassDDL.New(mysql.ErrInvalidDefault, mysql.MySQLErrName[mysql.ErrInvalidDefault])
 	// ErrGeneratedColumnRefAutoInc forbids to refer generated columns to auto-increment columns .
-	ErrGeneratedColumnRefAutoInc = terror.ClassDDL.New(codeGeneratedColumnRefAutoInc, mysql.MySQLErrName[mysql.ErrGeneratedColumnRefAutoInc])
+	ErrGeneratedColumnRefAutoInc = terror.ClassDDL.New(mysql.ErrGeneratedColumnRefAutoInc, mysql.MySQLErrName[mysql.ErrGeneratedColumnRefAutoInc])
 	// ErrUnsupportedAddPartition returns for does not support add partitions.
-	ErrUnsupportedAddPartition = terror.ClassDDL.New(codeUnsupportedAddPartition, "unsupported add partitions")
+	ErrUnsupportedAddPartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" add partitions")
 	// ErrUnsupportedCoalescePartition returns for does not support coalesce partitions.
-	ErrUnsupportedCoalescePartition = terror.ClassDDL.New(codeUnsupportedCoalescePartition, "unsupported coalesce partitions")
+	ErrUnsupportedCoalescePartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" coalesce partitions")
 	// ErrGeneratedColumnFunctionIsNotAllowed returns for unsupported functions for generated columns.
-	ErrGeneratedColumnFunctionIsNotAllowed = terror.ClassDDL.New(codeGeneratedColumnFunctionIsNotAllowed, "Expression of generated column '%s' contains a disallowed function.")
+	ErrGeneratedColumnFunctionIsNotAllowed = terror.ClassDDL.New(mysql.ErrGeneratedColumnFunctionIsNotAllowed, mysql.MySQLErrName[mysql.ErrGeneratedColumnFunctionIsNotAllowed])
 	// ErrUnsupportedPartitionByRangeColumns returns for does unsupported partition by range columns.
-	ErrUnsupportedPartitionByRangeColumns = terror.ClassDDL.New(codeUnsupportedPartitionByRangeColumns,
-		"unsupported partition by range columns")
-	errUnsupportedCreatePartition = terror.ClassDDL.New(codeUnsupportedCreatePartition, "unsupported partition type, treat as normal table")
-	errUnsupportedIndexType       = terror.ClassDDL.New(codeUnsupportedIndexType, "unsupported index type")
+	ErrUnsupportedPartitionByRangeColumns = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+
+		" partition by range columns")
+	errUnsupportedCreatePartition = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" partition type, treat as normal table")
+	errUnsupportedIndexType       = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" index type")
 
 	// ErrDupKeyName returns for duplicated key name
-	ErrDupKeyName = terror.ClassDDL.New(codeDupKeyName, "duplicate key name")
+	ErrDupKeyName = terror.ClassDDL.New(mysql.ErrDupKeyName, mysql.MySQLErrName[mysql.ErrDupKeyName])
 	// ErrInvalidDBState returns for invalid database state.
-	ErrInvalidDBState = terror.ClassDDL.New(codeInvalidDBState, "invalid database state")
+	ErrInvalidDBState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "database"))
 	// ErrInvalidTableState returns for invalid Table state.
-	ErrInvalidTableState = terror.ClassDDL.New(codeInvalidTableState, "invalid table state")
+	ErrInvalidTableState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "table"))
 	// ErrInvalidColumnState returns for invalid column state.
-	ErrInvalidColumnState = terror.ClassDDL.New(codeInvalidColumnState, "invalid column state")
+	ErrInvalidColumnState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "column"))
 	// ErrInvalidIndexState returns for invalid index state.
-	ErrInvalidIndexState = terror.ClassDDL.New(codeInvalidIndexState, "invalid index state")
+	ErrInvalidIndexState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "index"))
 	// ErrInvalidForeignKeyState returns for invalid foreign key state.
-	ErrInvalidForeignKeyState = terror.ClassDDL.New(codeInvalidForeignKeyState, "invalid foreign key state")
+	ErrInvalidForeignKeyState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "foreign key"))
 	// ErrInvalidTableLockState returns for invalid table state.
-	ErrInvalidTableLockState = terror.ClassDDL.New(codeInvalidTableLockState, "invalid table lock state")
+	ErrInvalidTableLockState = terror.ClassDDL.New(mysql.ErrInvalidDDLState, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrInvalidDDLState], "table lock"))
 	// ErrUnsupportedModifyPrimaryKey returns an error when add or drop the primary key.
 	// It's exported for testing.
-	ErrUnsupportedModifyPrimaryKey = terror.ClassDDL.New(codeUnsupportedModifyPrimaryKey, "unsupported %s primary key")
+	ErrUnsupportedModifyPrimaryKey = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation]+" %s primary key")
 
 	// ErrColumnBadNull returns for a bad null value.
-	ErrColumnBadNull = terror.ClassDDL.New(codeBadNull, "column cann't be null")
+	ErrColumnBadNull = terror.ClassDDL.New(mysql.ErrBadNull, mysql.MySQLErrName[mysql.ErrBadNull])
 	// ErrBadField forbids to refer to unknown column.
-	ErrBadField = terror.ClassDDL.New(codeBadField, "Unknown column '%s' in '%s'")
+	ErrBadField = terror.ClassDDL.New(mysql.ErrBadField, mysql.MySQLErrName[mysql.ErrBadField])
 	// ErrCantRemoveAllFields returns for deleting all columns.
-	ErrCantRemoveAllFields = terror.ClassDDL.New(codeCantRemoveAllFields, "can't delete all columns with ALTER TABLE")
+	ErrCantRemoveAllFields = terror.ClassDDL.New(mysql.ErrCantRemoveAllFields, mysql.MySQLErrName[mysql.ErrCantRemoveAllFields])
 	// ErrCantDropFieldOrKey returns for dropping a non-existent field or key.
-	ErrCantDropFieldOrKey = terror.ClassDDL.New(codeCantDropFieldOrKey, "can't drop field; check that column/key exists")
+	ErrCantDropFieldOrKey = terror.ClassDDL.New(mysql.ErrCantDropFieldOrKey, mysql.MySQLErrName[mysql.ErrCantDropFieldOrKey])
 	// ErrInvalidOnUpdate returns for invalid ON UPDATE clause.
-	ErrInvalidOnUpdate = terror.ClassDDL.New(codeInvalidOnUpdate, mysql.MySQLErrName[mysql.ErrInvalidOnUpdate])
+	ErrInvalidOnUpdate = terror.ClassDDL.New(mysql.ErrInvalidOnUpdate, mysql.MySQLErrName[mysql.ErrInvalidOnUpdate])
 	// ErrTooLongIdent returns for too long name of database/table/column/index.
-	ErrTooLongIdent = terror.ClassDDL.New(codeTooLongIdent, mysql.MySQLErrName[mysql.ErrTooLongIdent])
+	ErrTooLongIdent = terror.ClassDDL.New(mysql.ErrTooLongIdent, mysql.MySQLErrName[mysql.ErrTooLongIdent])
 	// ErrWrongDBName returns for wrong database name.
-	ErrWrongDBName = terror.ClassDDL.New(codeWrongDBName, mysql.MySQLErrName[mysql.ErrWrongDBName])
+	ErrWrongDBName = terror.ClassDDL.New(mysql.ErrWrongDBName, mysql.MySQLErrName[mysql.ErrWrongDBName])
 	// ErrWrongTableName returns for wrong table name.
-	ErrWrongTableName = terror.ClassDDL.New(codeWrongTableName, mysql.MySQLErrName[mysql.ErrWrongTableName])
+	ErrWrongTableName = terror.ClassDDL.New(mysql.ErrWrongTableName, mysql.MySQLErrName[mysql.ErrWrongTableName])
 	// ErrWrongColumnName returns for wrong column name.
-	ErrWrongColumnName = terror.ClassDDL.New(codeWrongColumnName, mysql.MySQLErrName[mysql.ErrWrongColumnName])
+	ErrWrongColumnName = terror.ClassDDL.New(mysql.ErrWrongColumnName, mysql.MySQLErrName[mysql.ErrWrongColumnName])
 	// ErrInvalidGroupFuncUse returns for using invalid group functions.
-	ErrInvalidGroupFuncUse = terror.ClassDDL.New(codeInvalidGroupFuncUse, mysql.MySQLErrName[mysql.ErrInvalidGroupFuncUse])
+	ErrInvalidGroupFuncUse = terror.ClassDDL.New(mysql.ErrInvalidGroupFuncUse, mysql.MySQLErrName[mysql.ErrInvalidGroupFuncUse])
 	// ErrTableMustHaveColumns returns for missing column when creating a table.
-	ErrTableMustHaveColumns = terror.ClassDDL.New(codeTableMustHaveColumns, mysql.MySQLErrName[mysql.ErrTableMustHaveColumns])
+	ErrTableMustHaveColumns = terror.ClassDDL.New(mysql.ErrTableMustHaveColumns, mysql.MySQLErrName[mysql.ErrTableMustHaveColumns])
 	// ErrWrongNameForIndex returns for wrong index name.
-	ErrWrongNameForIndex = terror.ClassDDL.New(codeWrongNameForIndex, mysql.MySQLErrName[mysql.ErrWrongNameForIndex])
+	ErrWrongNameForIndex = terror.ClassDDL.New(mysql.ErrWrongNameForIndex, mysql.MySQLErrName[mysql.ErrWrongNameForIndex])
 	// ErrUnknownCharacterSet returns unknown character set.
-	ErrUnknownCharacterSet = terror.ClassDDL.New(codeUnknownCharacterSet, "Unknown character set: '%s'")
+	ErrUnknownCharacterSet = terror.ClassDDL.New(mysql.ErrUnknownCharacterSet, mysql.MySQLErrName[mysql.ErrUnknownCharacterSet])
 	// ErrUnknownCollation returns unknown collation.
-	ErrUnknownCollation = terror.ClassDDL.New(codeUnknownCollation, "Unknown collation: '%s'")
+	ErrUnknownCollation = terror.ClassDDL.New(mysql.ErrUnknownCollation, mysql.MySQLErrName[mysql.ErrUnknownCollation])
 	// ErrCollationCharsetMismatch returns when collation not match the charset.
-	ErrCollationCharsetMismatch = terror.ClassDDL.New(codeCollationCharsetMismatch, mysql.MySQLErrName[mysql.ErrCollationCharsetMismatch])
+	ErrCollationCharsetMismatch = terror.ClassDDL.New(mysql.ErrCollationCharsetMismatch, mysql.MySQLErrName[mysql.ErrCollationCharsetMismatch])
 	// ErrConflictingDeclarations return conflict declarations.
-	ErrConflictingDeclarations = terror.ClassDDL.New(codeConflictingDeclarations, "Conflicting declarations: 'CHARACTER SET %s' and 'CHARACTER SET %s'")
+	ErrConflictingDeclarations = terror.ClassDDL.New(mysql.ErrConflictingDeclarations, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrConflictingDeclarations], "CHARACTER SET ", "%s", "CHARACTER SET ", "%s"))
 	// ErrPrimaryCantHaveNull returns All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead
-	ErrPrimaryCantHaveNull = terror.ClassDDL.New(codePrimaryCantHaveNull, mysql.MySQLErrName[mysql.ErrPrimaryCantHaveNull])
+	ErrPrimaryCantHaveNull = terror.ClassDDL.New(mysql.ErrPrimaryCantHaveNull, mysql.MySQLErrName[mysql.ErrPrimaryCantHaveNull])
+	// ErrErrorOnRename returns error for wrong database name in alter table rename
+	ErrErrorOnRename = terror.ClassDDL.New(mysql.ErrErrorOnRename, mysql.MySQLErrName[mysql.ErrErrorOnRename])
 
-	// ErrNotAllowedTypeInPartition returns not allowed type error when creating table partiton with unsupport expression type.
-	ErrNotAllowedTypeInPartition = terror.ClassDDL.New(codeErrFieldTypeNotAllowedAsPartitionField, mysql.MySQLErrName[mysql.ErrFieldTypeNotAllowedAsPartitionField])
+	// ErrNotAllowedTypeInPartition returns not allowed type error when creating table partition with unsupported expression type.
+	ErrNotAllowedTypeInPartition = terror.ClassDDL.New(mysql.ErrFieldTypeNotAllowedAsPartitionField, mysql.MySQLErrName[mysql.ErrFieldTypeNotAllowedAsPartitionField])
 	// ErrPartitionMgmtOnNonpartitioned returns it's not a partition table.
-	ErrPartitionMgmtOnNonpartitioned = terror.ClassDDL.New(codePartitionMgmtOnNonpartitioned, "Partition management on a not partitioned table is not possible")
+	ErrPartitionMgmtOnNonpartitioned = terror.ClassDDL.New(mysql.ErrPartitionMgmtOnNonpartitioned, mysql.MySQLErrName[mysql.ErrPartitionMgmtOnNonpartitioned])
 	// ErrDropPartitionNonExistent returns error in list of partition.
-	ErrDropPartitionNonExistent = terror.ClassDDL.New(codeDropPartitionNonExistent, "Error in list of partitions to %s")
+	ErrDropPartitionNonExistent = terror.ClassDDL.New(mysql.ErrDropPartitionNonExistent, mysql.MySQLErrName[mysql.ErrDropPartitionNonExistent])
 	// ErrSameNamePartition returns duplicate partition name.
-	ErrSameNamePartition = terror.ClassDDL.New(codeSameNamePartition, "Duplicate partition name %s")
+	ErrSameNamePartition = terror.ClassDDL.New(mysql.ErrSameNamePartition, mysql.MySQLErrName[mysql.ErrSameNamePartition])
 	// ErrRangeNotIncreasing returns values less than value must be strictly increasing for each partition.
-	ErrRangeNotIncreasing = terror.ClassDDL.New(codeRangeNotIncreasing, "VALUES LESS THAN value must be strictly increasing for each partition")
+	ErrRangeNotIncreasing = terror.ClassDDL.New(mysql.ErrRangeNotIncreasing, mysql.MySQLErrName[mysql.ErrRangeNotIncreasing])
 	// ErrPartitionMaxvalue returns maxvalue can only be used in last partition definition.
-	ErrPartitionMaxvalue = terror.ClassDDL.New(codePartitionMaxvalue, "MAXVALUE can only be used in last partition definition")
+	ErrPartitionMaxvalue = terror.ClassDDL.New(mysql.ErrPartitionMaxvalue, mysql.MySQLErrName[mysql.ErrPartitionMaxvalue])
 	//ErrDropLastPartition returns cannot remove all partitions, use drop table instead.
-	ErrDropLastPartition = terror.ClassDDL.New(codeDropLastPartition, mysql.MySQLErrName[mysql.ErrDropLastPartition])
+	ErrDropLastPartition = terror.ClassDDL.New(mysql.ErrDropLastPartition, mysql.MySQLErrName[mysql.ErrDropLastPartition])
 	//ErrTooManyPartitions returns too many partitions were defined.
-	ErrTooManyPartitions = terror.ClassDDL.New(codeTooManyPartitions, mysql.MySQLErrName[mysql.ErrTooManyPartitions])
+	ErrTooManyPartitions = terror.ClassDDL.New(mysql.ErrTooManyPartitions, mysql.MySQLErrName[mysql.ErrTooManyPartitions])
 	//ErrPartitionFunctionIsNotAllowed returns this partition function is not allowed.
-	ErrPartitionFunctionIsNotAllowed = terror.ClassDDL.New(codePartitionFunctionIsNotAllowed, mysql.MySQLErrName[mysql.ErrPartitionFunctionIsNotAllowed])
+	ErrPartitionFunctionIsNotAllowed = terror.ClassDDL.New(mysql.ErrPartitionFunctionIsNotAllowed, mysql.MySQLErrName[mysql.ErrPartitionFunctionIsNotAllowed])
 	// ErrPartitionFuncNotAllowed returns partition function returns the wrong type.
-	ErrPartitionFuncNotAllowed = terror.ClassDDL.New(codeErrPartitionFuncNotAllowed, mysql.MySQLErrName[mysql.ErrPartitionFuncNotAllowed])
+	ErrPartitionFuncNotAllowed = terror.ClassDDL.New(mysql.ErrPartitionFuncNotAllowed, mysql.MySQLErrName[mysql.ErrPartitionFuncNotAllowed])
 	// ErrUniqueKeyNeedAllFieldsInPf returns must include all columns in the table's partitioning function.
-	ErrUniqueKeyNeedAllFieldsInPf = terror.ClassDDL.New(codeUniqueKeyNeedAllFieldsInPf, mysql.MySQLErrName[mysql.ErrUniqueKeyNeedAllFieldsInPf])
-	errWrongExprInPartitionFunc   = terror.ClassDDL.New(codeWrongExprInPartitionFunc, mysql.MySQLErrName[mysql.ErrWrongExprInPartitionFunc])
+	ErrUniqueKeyNeedAllFieldsInPf = terror.ClassDDL.New(mysql.ErrUniqueKeyNeedAllFieldsInPf, mysql.MySQLErrName[mysql.ErrUniqueKeyNeedAllFieldsInPf])
+	errWrongExprInPartitionFunc   = terror.ClassDDL.New(mysql.ErrWrongExprInPartitionFunc, mysql.MySQLErrName[mysql.ErrWrongExprInPartitionFunc])
 	// ErrWarnDataTruncated returns data truncated error.
-	ErrWarnDataTruncated = terror.ClassDDL.New(codeWarnDataTruncated, mysql.MySQLErrName[mysql.WarnDataTruncated])
+	ErrWarnDataTruncated = terror.ClassDDL.New(mysql.WarnDataTruncated, mysql.MySQLErrName[mysql.WarnDataTruncated])
 	// ErrCoalesceOnlyOnHashPartition returns coalesce partition can only be used on hash/key partitions.
-	ErrCoalesceOnlyOnHashPartition = terror.ClassDDL.New(codeCoalesceOnlyOnHashPartition, mysql.MySQLErrName[mysql.ErrCoalesceOnlyOnHashPartition])
+	ErrCoalesceOnlyOnHashPartition = terror.ClassDDL.New(mysql.ErrCoalesceOnlyOnHashPartition, mysql.MySQLErrName[mysql.ErrCoalesceOnlyOnHashPartition])
 	// ErrViewWrongList returns create view must include all columns in the select clause
-	ErrViewWrongList = terror.ClassDDL.New(codeViewWrongList, mysql.MySQLErrName[mysql.ErrViewWrongList])
+	ErrViewWrongList = terror.ClassDDL.New(mysql.ErrViewWrongList, mysql.MySQLErrName[mysql.ErrViewWrongList])
 	// ErrAlterOperationNotSupported returns when alter operations is not supported.
-	ErrAlterOperationNotSupported = terror.ClassDDL.New(codeNotSupportedAlterOperation, mysql.MySQLErrName[mysql.ErrAlterOperationNotSupportedReason])
+	ErrAlterOperationNotSupported = terror.ClassDDL.New(mysql.ErrAlterOperationNotSupportedReason, mysql.MySQLErrName[mysql.ErrAlterOperationNotSupportedReason])
 	// ErrWrongObject returns for wrong object.
-	ErrWrongObject = terror.ClassDDL.New(codeErrWrongObject, mysql.MySQLErrName[mysql.ErrWrongObject])
+	ErrWrongObject = terror.ClassDDL.New(mysql.ErrWrongObject, mysql.MySQLErrName[mysql.ErrWrongObject])
 	// ErrTableCantHandleFt returns FULLTEXT keys are not supported by table type
-	ErrTableCantHandleFt = terror.ClassDDL.New(codeErrTableCantHandleFt, mysql.MySQLErrName[mysql.ErrTableCantHandleFt])
+	ErrTableCantHandleFt = terror.ClassDDL.New(mysql.ErrTableCantHandleFt, mysql.MySQLErrName[mysql.ErrTableCantHandleFt])
 	// ErrFieldNotFoundPart returns an error when 'partition by columns' are not found in table columns.
-	ErrFieldNotFoundPart = terror.ClassDDL.New(codeFieldNotFoundPart, mysql.MySQLErrName[mysql.ErrFieldNotFoundPart])
+	ErrFieldNotFoundPart = terror.ClassDDL.New(mysql.ErrFieldNotFoundPart, mysql.MySQLErrName[mysql.ErrFieldNotFoundPart])
 	// ErrWrongTypeColumnValue returns 'Partition column values of incorrect type'
-	ErrWrongTypeColumnValue = terror.ClassDDL.New(codeWrongTypeColumnValue, mysql.MySQLErrName[mysql.ErrWrongTypeColumnValue])
+	ErrWrongTypeColumnValue = terror.ClassDDL.New(mysql.ErrWrongTypeColumnValue, mysql.MySQLErrName[mysql.ErrWrongTypeColumnValue])
 )
 
 // DDL is responsible for updating schema in data store and maintaining in-memory InfoSchema cache.
@@ -652,193 +652,91 @@ func (d *ddl) GetHook() Callback {
 	return d.mu.hook
 }
 
-// DDL error codes.
-const (
-	codeInvalidWorker         terror.ErrCode = 1
-	codeNotOwner                             = 2
-	codeInvalidDDLJob                        = 3
-	codeInvalidJobFlag                       = 5
-	codeRunMultiSchemaChanges                = 6
-	codeWaitReorgTimeout                     = 7
-	codeInvalidStoreVer                      = 8
-	codeUnknownTypeLength                    = 9
-	codeUnknownFractionLength                = 10
-	codeInvalidJobVersion                    = 11
-	codeCancelledDDLJob                      = 12
-	codeInvalidRanges                        = 13
-	codeReorgWorkerPanic                     = 14
-	codeCantDecodeIndex                      = 15
-
-	codeInvalidDBState         = 100
-	codeInvalidTableState      = 101
-	codeInvalidColumnState     = 102
-	codeInvalidIndexState      = 103
-	codeInvalidForeignKeyState = 104
-	codeInvalidTableLockState  = 105
-
-	codeCantDropColWithIndex               = 201
-	codeUnsupportedAddColumn               = 202
-	codeUnsupportedModifyColumn            = 203
-	codeUnsupportedDropPKHandle            = 204
-	codeUnsupportedCharset                 = 205
-	codeUnsupportedModifyPrimaryKey        = 206
-	codeUnsupportedShardRowIDBits          = 207
-	codeUnsupportedAddPartition            = 208
-	codeUnsupportedCoalescePartition       = 209
-	codeUnsupportedModifyCharset           = 210
-	codeUnsupportedPartitionByRangeColumns = 211
-	codeUnsupportedCreatePartition         = 212
-	codeUnsupportedIndexType               = 213
-
-	codeFileNotFound                           = 1017
-	codeErrorOnRename                          = 1025
-	codeBadNull                                = mysql.ErrBadNull
-	codeBadField                               = 1054
-	codeTooLongIdent                           = 1059
-	codeDupKeyName                             = 1061
-	codeInvalidDefaultValue                    = mysql.ErrInvalidDefault
-	codeTooLongKey                             = 1071
-	codeKeyColumnDoesNotExits                  = mysql.ErrKeyColumnDoesNotExits
-	codeIncorrectPrefixKey                     = 1089
-	codeCantRemoveAllFields                    = 1090
-	codeCantDropFieldOrKey                     = 1091
-	codeBlobCantHaveDefault                    = 1101
-	codeWrongDBName                            = 1102
-	codeWrongTableName                         = 1103
-	codeInvalidGroupFuncUse                    = terror.ErrCode(mysql.ErrInvalidGroupFuncUse)
-	codeTooManyFields                          = 1117
-	codeInvalidUseOfNull                       = 1138
-	codeWrongColumnName                        = 1166
-	codeWrongKeyColumn                         = 1167
-	codeBlobKeyWithoutLength                   = 1170
-	codeInvalidOnUpdate                        = 1294
-	codeErrWrongObject                         = terror.ErrCode(mysql.ErrWrongObject)
-	codeViewWrongList                          = 1353
-	codeGeneratedColumnFunctionIsNotAllowed    = terror.ErrCode(mysql.ErrGeneratedColumnFunctionIsNotAllowed)
-	codeUnsupportedAlterInplaceOnVirtualColumn = terror.ErrCode(mysql.ErrUnsupportedAlterInplaceOnVirtualColumn)
-	codeWrongFKOptionForGeneratedColumn        = terror.ErrCode(mysql.ErrWrongFKOptionForGeneratedColumn)
-	codeBadGeneratedColumn                     = terror.ErrCode(mysql.ErrBadGeneratedColumn)
-	codeUnsupportedOnGeneratedColumn           = terror.ErrCode(mysql.ErrUnsupportedOnGeneratedColumn)
-	codeGeneratedColumnNonPrior                = terror.ErrCode(mysql.ErrGeneratedColumnNonPrior)
-	codeDependentByGeneratedColumn             = terror.ErrCode(mysql.ErrDependentByGeneratedColumn)
-	codeGeneratedColumnRefAutoInc              = terror.ErrCode(mysql.ErrGeneratedColumnRefAutoInc)
-	codeJSONUsedAsKey                          = 3152
-	codeWrongNameForIndex                      = terror.ErrCode(mysql.ErrWrongNameForIndex)
-	codeErrTooLongIndexComment                 = terror.ErrCode(mysql.ErrTooLongIndexComment)
-	codeUnknownCharacterSet                    = terror.ErrCode(mysql.ErrUnknownCharacterSet)
-	codeUnknownCollation                       = terror.ErrCode(mysql.ErrUnknownCollation)
-	codeCollationCharsetMismatch               = terror.ErrCode(mysql.ErrCollationCharsetMismatch)
-	codeConflictingDeclarations                = terror.ErrCode(mysql.ErrConflictingDeclarations)
-	codeCantCreateTable                        = terror.ErrCode(mysql.ErrCantCreateTable)
-	codeTableMustHaveColumns                   = terror.ErrCode(mysql.ErrTableMustHaveColumns)
-	codePartitionsMustBeDefined                = terror.ErrCode(mysql.ErrPartitionsMustBeDefined)
-	codePartitionMgmtOnNonpartitioned          = terror.ErrCode(mysql.ErrPartitionMgmtOnNonpartitioned)
-	codeDropPartitionNonExistent               = terror.ErrCode(mysql.ErrDropPartitionNonExistent)
-	codeSameNamePartition                      = terror.ErrCode(mysql.ErrSameNamePartition)
-	codeRangeNotIncreasing                     = terror.ErrCode(mysql.ErrRangeNotIncreasing)
-	codePartitionMaxvalue                      = terror.ErrCode(mysql.ErrPartitionMaxvalue)
-	codeErrTooManyValues                       = terror.ErrCode(mysql.ErrTooManyValues)
-	codeDropLastPartition                      = terror.ErrCode(mysql.ErrDropLastPartition)
-	codeTooManyPartitions                      = terror.ErrCode(mysql.ErrTooManyPartitions)
-	codeNoParts                                = terror.ErrCode(mysql.ErrNoParts)
-	codePartitionFunctionIsNotAllowed          = terror.ErrCode(mysql.ErrPartitionFunctionIsNotAllowed)
-	codeErrPartitionFuncNotAllowed             = terror.ErrCode(mysql.ErrPartitionFuncNotAllowed)
-	codeErrFieldTypeNotAllowedAsPartitionField = terror.ErrCode(mysql.ErrFieldTypeNotAllowedAsPartitionField)
-	codeUniqueKeyNeedAllFieldsInPf             = terror.ErrCode(mysql.ErrUniqueKeyNeedAllFieldsInPf)
-	codePrimaryCantHaveNull                    = terror.ErrCode(mysql.ErrPrimaryCantHaveNull)
-	codeWrongExprInPartitionFunc               = terror.ErrCode(mysql.ErrWrongExprInPartitionFunc)
-	codeWarnDataTruncated                      = terror.ErrCode(mysql.WarnDataTruncated)
-	codeErrTableCantHandleFt                   = terror.ErrCode(mysql.ErrTableCantHandleFt)
-	codeCoalesceOnlyOnHashPartition            = terror.ErrCode(mysql.ErrCoalesceOnlyOnHashPartition)
-	codeUnknownPartition                       = terror.ErrCode(mysql.ErrUnknownPartition)
-	codeNotSupportedAlterOperation             = terror.ErrCode(mysql.ErrAlterOperationNotSupportedReason)
-	codeFieldNotFoundPart                      = terror.ErrCode(mysql.ErrFieldNotFoundPart)
-	codePartitionColumnList                    = terror.ErrCode(mysql.ErrPartitionColumnList)
-	codePartitionRequiresValues                = terror.ErrCode(mysql.ErrPartitionRequiresValues)
-	codePartitionWrongNoPart                   = terror.ErrCode(mysql.ErrPartitionWrongNoPart)
-	codePartitionWrongNoSubpart                = terror.ErrCode(mysql.ErrPartitionWrongNoSubpart)
-	codePartitionWrongValues                   = terror.ErrCode(mysql.ErrPartitionWrongValues)
-	codeRowSinglePartitionField                = terror.ErrCode(mysql.ErrRowSinglePartitionField)
-	codeSubpartition                           = terror.ErrCode(mysql.ErrSubpartition)
-	codeSystemVersioningWrongPartitions        = terror.ErrCode(mysql.ErrSystemVersioningWrongPartitions)
-	codeWrongPartitionTypeExpectedSystemTime   = terror.ErrCode(mysql.ErrWrongPartitionTypeExpectedSystemTime)
-	codeOnlyOnRangeListPartition               = terror.ErrCode(mysql.ErrOnlyOnRangeListPartition)
-	codeWrongTypeColumnValue                   = terror.ErrCode(mysql.ErrWrongTypeColumnValue)
-)
-
 func init() {
 	ddlMySQLErrCodes := map[terror.ErrCode]uint16{
-		codeBadNull:                                mysql.ErrBadNull,
-		codeCantRemoveAllFields:                    mysql.ErrCantRemoveAllFields,
-		codeCantDropFieldOrKey:                     mysql.ErrCantDropFieldOrKey,
-		codeInvalidOnUpdate:                        mysql.ErrInvalidOnUpdate,
-		codeBlobKeyWithoutLength:                   mysql.ErrBlobKeyWithoutLength,
-		codeIncorrectPrefixKey:                     mysql.ErrWrongSubKey,
-		codeTooLongIdent:                           mysql.ErrTooLongIdent,
-		codeTooLongKey:                             mysql.ErrTooLongKey,
-		codeKeyColumnDoesNotExits:                  mysql.ErrKeyColumnDoesNotExits,
-		codeDupKeyName:                             mysql.ErrDupKeyName,
-		codeWrongDBName:                            mysql.ErrWrongDBName,
-		codeWrongTableName:                         mysql.ErrWrongTableName,
-		codeFileNotFound:                           mysql.ErrFileNotFound,
-		codeErrorOnRename:                          mysql.ErrErrorOnRename,
-		codeBadField:                               mysql.ErrBadField,
-		codeInvalidGroupFuncUse:                    mysql.ErrInvalidGroupFuncUse,
-		codeInvalidUseOfNull:                       mysql.ErrInvalidUseOfNull,
-		codeWrongFKOptionForGeneratedColumn:        mysql.ErrWrongFKOptionForGeneratedColumn,
-		codeUnsupportedOnGeneratedColumn:           mysql.ErrUnsupportedOnGeneratedColumn,
-		codeGeneratedColumnNonPrior:                mysql.ErrGeneratedColumnNonPrior,
-		codeDependentByGeneratedColumn:             mysql.ErrDependentByGeneratedColumn,
-		codeJSONUsedAsKey:                          mysql.ErrJSONUsedAsKey,
-		codeBlobCantHaveDefault:                    mysql.ErrBlobCantHaveDefault,
-		codeWrongColumnName:                        mysql.ErrWrongColumnName,
-		codeWrongKeyColumn:                         mysql.ErrWrongKeyColumn,
-		codeWrongNameForIndex:                      mysql.ErrWrongNameForIndex,
-		codeTableMustHaveColumns:                   mysql.ErrTableMustHaveColumns,
-		codeTooManyFields:                          mysql.ErrTooManyFields,
-		codeErrTooLongIndexComment:                 mysql.ErrTooLongIndexComment,
-		codeViewWrongList:                          mysql.ErrViewWrongList,
-		codeUnknownCharacterSet:                    mysql.ErrUnknownCharacterSet,
-		codeUnknownCollation:                       mysql.ErrUnknownCollation,
-		codeCollationCharsetMismatch:               mysql.ErrCollationCharsetMismatch,
-		codeConflictingDeclarations:                mysql.ErrConflictingDeclarations,
-		codePartitionsMustBeDefined:                mysql.ErrPartitionsMustBeDefined,
-		codePartitionMgmtOnNonpartitioned:          mysql.ErrPartitionMgmtOnNonpartitioned,
-		codeDropPartitionNonExistent:               mysql.ErrDropPartitionNonExistent,
-		codeSameNamePartition:                      mysql.ErrSameNamePartition,
-		codeRangeNotIncreasing:                     mysql.ErrRangeNotIncreasing,
-		codePartitionMaxvalue:                      mysql.ErrPartitionMaxvalue,
-		codeErrTooManyValues:                       mysql.ErrTooManyValues,
-		codeDropLastPartition:                      mysql.ErrDropLastPartition,
-		codeTooManyPartitions:                      mysql.ErrTooManyPartitions,
-		codeNoParts:                                mysql.ErrNoParts,
-		codePartitionFunctionIsNotAllowed:          mysql.ErrPartitionFunctionIsNotAllowed,
-		codeErrPartitionFuncNotAllowed:             mysql.ErrPartitionFuncNotAllowed,
-		codeErrFieldTypeNotAllowedAsPartitionField: mysql.ErrFieldTypeNotAllowedAsPartitionField,
-		codeUniqueKeyNeedAllFieldsInPf:             mysql.ErrUniqueKeyNeedAllFieldsInPf,
-		codePrimaryCantHaveNull:                    mysql.ErrPrimaryCantHaveNull,
-		codeWrongExprInPartitionFunc:               mysql.ErrWrongExprInPartitionFunc,
-		codeWarnDataTruncated:                      mysql.WarnDataTruncated,
-		codeErrTableCantHandleFt:                   mysql.ErrTableCantHandleFt,
-		codeCoalesceOnlyOnHashPartition:            mysql.ErrCoalesceOnlyOnHashPartition,
-		codeUnknownPartition:                       mysql.ErrUnknownPartition,
-		codeNotSupportedAlterOperation:             mysql.ErrAlterOperationNotSupportedReason,
-		codeErrWrongObject:                         mysql.ErrWrongObject,
-		codeFieldNotFoundPart:                      mysql.ErrFieldNotFoundPart,
-		codePartitionColumnList:                    mysql.ErrPartitionColumnList,
-		codeInvalidDefaultValue:                    mysql.ErrInvalidDefault,
-		codeGeneratedColumnFunctionIsNotAllowed:    mysql.ErrGeneratedColumnFunctionIsNotAllowed,
-		codeGeneratedColumnRefAutoInc:              mysql.ErrGeneratedColumnRefAutoInc,
-		codePartitionRequiresValues:                mysql.ErrPartitionRequiresValues,
-		codePartitionWrongNoPart:                   mysql.ErrPartitionWrongNoPart,
-		codePartitionWrongNoSubpart:                mysql.ErrPartitionWrongNoSubpart,
-		codePartitionWrongValues:                   mysql.ErrPartitionWrongValues,
-		codeRowSinglePartitionField:                mysql.ErrRowSinglePartitionField,
-		codeSubpartition:                           mysql.ErrSubpartition,
-		codeSystemVersioningWrongPartitions:        mysql.ErrSystemVersioningWrongPartitions,
-		codeWrongPartitionTypeExpectedSystemTime:   mysql.ErrWrongPartitionTypeExpectedSystemTime,
-		codeOnlyOnRangeListPartition:               mysql.ErrOnlyOnRangeListPartition,
-		codeWrongTypeColumnValue:                   mysql.ErrWrongTypeColumnValue,
+		mysql.ErrAlterOperationNotSupportedReason:     mysql.ErrAlterOperationNotSupportedReason,
+		mysql.ErrBadField:                             mysql.ErrBadField,
+		mysql.ErrBadNull:                              mysql.ErrBadNull,
+		mysql.ErrBlobCantHaveDefault:                  mysql.ErrBlobCantHaveDefault,
+		mysql.ErrBlobKeyWithoutLength:                 mysql.ErrBlobKeyWithoutLength,
+		mysql.ErrCancelledDDLJob:                      mysql.ErrCancelledDDLJob,
+		mysql.ErrCantDecodeIndex:                      mysql.ErrCantDecodeIndex,
+		mysql.ErrCantDropFieldOrKey:                   mysql.ErrCantDropFieldOrKey,
+		mysql.ErrCantRemoveAllFields:                  mysql.ErrCantRemoveAllFields,
+		mysql.ErrCoalesceOnlyOnHashPartition:          mysql.ErrCoalesceOnlyOnHashPartition,
+		mysql.ErrCollationCharsetMismatch:             mysql.ErrCollationCharsetMismatch,
+		mysql.ErrConflictingDeclarations:              mysql.ErrConflictingDeclarations,
+		mysql.ErrDependentByGeneratedColumn:           mysql.ErrDependentByGeneratedColumn,
+		mysql.ErrDropLastPartition:                    mysql.ErrDropLastPartition,
+		mysql.ErrDropPartitionNonExistent:             mysql.ErrDropPartitionNonExistent,
+		mysql.ErrDupKeyName:                           mysql.ErrDupKeyName,
+		mysql.ErrErrorOnRename:                        mysql.ErrErrorOnRename,
+		mysql.ErrFieldNotFoundPart:                    mysql.ErrFieldNotFoundPart,
+		mysql.ErrFieldTypeNotAllowedAsPartitionField:  mysql.ErrFieldTypeNotAllowedAsPartitionField,
+		mysql.ErrFileNotFound:                         mysql.ErrFileNotFound,
+		mysql.ErrGeneratedColumnFunctionIsNotAllowed:  mysql.ErrGeneratedColumnFunctionIsNotAllowed,
+		mysql.ErrGeneratedColumnNonPrior:              mysql.ErrGeneratedColumnNonPrior,
+		mysql.ErrGeneratedColumnRefAutoInc:            mysql.ErrGeneratedColumnRefAutoInc,
+		mysql.ErrInvalidDDLJob:                        mysql.ErrInvalidDDLJob,
+		mysql.ErrInvalidDDLState:                      mysql.ErrInvalidDDLState,
+		mysql.ErrInvalidDDLWorker:                     mysql.ErrInvalidDDLWorker,
+		mysql.ErrInvalidDefault:                       mysql.ErrInvalidDefault,
+		mysql.ErrInvalidGroupFuncUse:                  mysql.ErrInvalidGroupFuncUse,
+		mysql.ErrInvalidJobFlag:                       mysql.ErrInvalidJobFlag,
+		mysql.ErrInvalidJobVersion:                    mysql.ErrInvalidJobVersion,
+		mysql.ErrInvalidOnUpdate:                      mysql.ErrInvalidOnUpdate,
+		mysql.ErrInvalidSplitRegionRanges:             mysql.ErrInvalidSplitRegionRanges,
+		mysql.ErrInvalidStoreVersion:                  mysql.ErrInvalidStoreVersion,
+		mysql.ErrInvalidUseOfNull:                     mysql.ErrInvalidUseOfNull,
+		mysql.ErrJSONUsedAsKey:                        mysql.ErrJSONUsedAsKey,
+		mysql.ErrKeyColumnDoesNotExits:                mysql.ErrKeyColumnDoesNotExits,
+		mysql.ErrLockWaitTimeout:                      mysql.ErrLockWaitTimeout,
+		mysql.ErrNoParts:                              mysql.ErrNoParts,
+		mysql.ErrNotOwner:                             mysql.ErrNotOwner,
+		mysql.ErrOnlyOnRangeListPartition:             mysql.ErrOnlyOnRangeListPartition,
+		mysql.ErrPartitionColumnList:                  mysql.ErrPartitionColumnList,
+		mysql.ErrPartitionFuncNotAllowed:              mysql.ErrPartitionFuncNotAllowed,
+		mysql.ErrPartitionFunctionIsNotAllowed:        mysql.ErrPartitionFunctionIsNotAllowed,
+		mysql.ErrPartitionMaxvalue:                    mysql.ErrPartitionMaxvalue,
+		mysql.ErrPartitionMgmtOnNonpartitioned:        mysql.ErrPartitionMgmtOnNonpartitioned,
+		mysql.ErrPartitionRequiresValues:              mysql.ErrPartitionRequiresValues,
+		mysql.ErrPartitionWrongNoPart:                 mysql.ErrPartitionWrongNoPart,
+		mysql.ErrPartitionWrongNoSubpart:              mysql.ErrPartitionWrongNoSubpart,
+		mysql.ErrPartitionWrongValues:                 mysql.ErrPartitionWrongValues,
+		mysql.ErrPartitionsMustBeDefined:              mysql.ErrPartitionsMustBeDefined,
+		mysql.ErrPrimaryCantHaveNull:                  mysql.ErrPrimaryCantHaveNull,
+		mysql.ErrRangeNotIncreasing:                   mysql.ErrRangeNotIncreasing,
+		mysql.ErrRowSinglePartitionField:              mysql.ErrRowSinglePartitionField,
+		mysql.ErrSameNamePartition:                    mysql.ErrSameNamePartition,
+		mysql.ErrSubpartition:                         mysql.ErrSubpartition,
+		mysql.ErrSystemVersioningWrongPartitions:      mysql.ErrSystemVersioningWrongPartitions,
+		mysql.ErrTableCantHandleFt:                    mysql.ErrTableCantHandleFt,
+		mysql.ErrTableMustHaveColumns:                 mysql.ErrTableMustHaveColumns,
+		mysql.ErrTooLongIdent:                         mysql.ErrTooLongIdent,
+		mysql.ErrTooLongIndexComment:                  mysql.ErrTooLongIndexComment,
+		mysql.ErrTooLongKey:                           mysql.ErrTooLongKey,
+		mysql.ErrTooManyFields:                        mysql.ErrTooManyFields,
+		mysql.ErrTooManyPartitions:                    mysql.ErrTooManyPartitions,
+		mysql.ErrTooManyValues:                        mysql.ErrTooManyValues,
+		mysql.ErrUniqueKeyNeedAllFieldsInPf:           mysql.ErrUniqueKeyNeedAllFieldsInPf,
+		mysql.ErrUnknownCharacterSet:                  mysql.ErrUnknownCharacterSet,
+		mysql.ErrUnknownCollation:                     mysql.ErrUnknownCollation,
+		mysql.ErrUnknownPartition:                     mysql.ErrUnknownPartition,
+		mysql.ErrUnsupportedDDLOperation:              mysql.ErrUnsupportedDDLOperation,
+		mysql.ErrUnsupportedOnGeneratedColumn:         mysql.ErrUnsupportedOnGeneratedColumn,
+		mysql.ErrViewWrongList:                        mysql.ErrViewWrongList,
+		mysql.ErrWrongColumnName:                      mysql.ErrWrongColumnName,
+		mysql.ErrWrongDBName:                          mysql.ErrWrongDBName,
+		mysql.ErrWrongExprInPartitionFunc:             mysql.ErrWrongExprInPartitionFunc,
+		mysql.ErrWrongFKOptionForGeneratedColumn:      mysql.ErrWrongFKOptionForGeneratedColumn,
+		mysql.ErrWrongKeyColumn:                       mysql.ErrWrongKeyColumn,
+		mysql.ErrWrongNameForIndex:                    mysql.ErrWrongNameForIndex,
+		mysql.ErrWrongObject:                          mysql.ErrWrongObject,
+		mysql.ErrWrongPartitionTypeExpectedSystemTime: mysql.ErrWrongPartitionTypeExpectedSystemTime,
+		mysql.ErrWrongSubKey:                          mysql.ErrWrongSubKey,
+		mysql.ErrWrongTableName:                       mysql.ErrWrongTableName,
+		mysql.ErrWrongTypeColumnValue:                 mysql.ErrWrongTypeColumnValue,
+		mysql.WarnDataTruncated:                       mysql.WarnDataTruncated,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassDDL] = ddlMySQLErrCodes
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2465,7 +2465,7 @@ func modifiableCharsetAndCollation(toCharset, toCollate, origCharset, origCollat
 		return errUnsupportedModifyCharset.GenWithStackByArgs(msg)
 	}
 	if toCollate != origCollate {
-		msg := fmt.Sprintf("collate from %s to %s", origCollate, toCollate)
+		msg := fmt.Sprintf("change collate from %s to %s", origCollate, toCollate)
 		return errUnsupportedModifyCharset.GenWithStackByArgs(msg)
 	}
 	return nil
@@ -2478,7 +2478,7 @@ func modifiableCharsetAndCollation(toCharset, toCollate, origCharset, origCollat
 func modifiable(origin *types.FieldType, to *types.FieldType) error {
 	// The root cause is modifying decimal precision needs to rewrite binary representation of that decimal.
 	if origin.Tp == mysql.TypeNewDecimal && (to.Flen != origin.Flen || to.Decimal != origin.Decimal) {
-		return errUnsupportedModifyColumn.GenWithStack("unsupported modify decimal column precision")
+		return errUnsupportedModifyColumn.GenWithStackByArgs("can't change decimal column precision")
 	}
 	if to.Flen > 0 && to.Flen < origin.Flen {
 		msg := fmt.Sprintf("length %d is less than origin %d", to.Flen, origin.Flen)
@@ -2495,7 +2495,7 @@ func modifiable(origin *types.FieldType, to *types.FieldType) error {
 	toUnsigned := mysql.HasUnsignedFlag(to.Flag)
 	originUnsigned := mysql.HasUnsignedFlag(origin.Flag)
 	if originUnsigned != toUnsigned {
-		msg := fmt.Sprintf("unsigned %v not match origin %v", toUnsigned, originUnsigned)
+		msg := fmt.Sprintf("can't change unsigned integer to signed or vice versa")
 		return errUnsupportedModifyColumn.GenWithStackByArgs(msg)
 	}
 	switch origin.Tp {
@@ -2520,20 +2520,20 @@ func modifiable(origin *types.FieldType, to *types.FieldType) error {
 			for index, originElem := range origin.Elems {
 				toElem := to.Elems[index]
 				if originElem != toElem {
-					msg := fmt.Sprintf("cannot modify enum column value %s to %s", originElem, toElem)
+					msg := fmt.Sprintf("can't change enum value %s to %s", originElem, toElem)
 					return errUnsupportedModifyColumn.GenWithStackByArgs(msg)
 				}
 			}
 			return nil
 		}
-		msg := fmt.Sprintf("cannot modify enum type column's to type %s", to.String())
+		msg := fmt.Sprintf("can't change enum type to %s", to.String())
 		return errUnsupportedModifyColumn.GenWithStackByArgs(msg)
 	default:
 		if origin.Tp == to.Tp {
 			return nil
 		}
 	}
-	msg := fmt.Sprintf("type %v not match origin %v", to.Tp, origin.Tp)
+	msg := fmt.Sprintf(":type not match, before: %v, after: %v", origin.Tp, to.Tp)
 	return errUnsupportedModifyColumn.GenWithStackByArgs(msg)
 }
 
@@ -2595,7 +2595,7 @@ func processColumnOptions(ctx sessionctx.Context, col *table.Column, options []*
 		case ast.ColumnOptionAutoIncrement:
 			col.Flag |= mysql.AutoIncrementFlag
 		case ast.ColumnOptionPrimaryKey, ast.ColumnOptionUniqKey:
-			return errUnsupportedModifyColumn.GenWithStack("unsupported modify column constraint - %v", opt.Tp)
+			return errUnsupportedModifyColumn.GenWithStack("can't change column constraint - %v", opt.Tp)
 		case ast.ColumnOptionOnUpdate:
 			// TODO: Support other time functions.
 			if col.Tp == mysql.TypeTimestamp || col.Tp == mysql.TypeDatetime {
@@ -2623,9 +2623,9 @@ func processColumnOptions(ctx sessionctx.Context, col *table.Column, options []*
 		case ast.ColumnOptionCollate:
 			col.Collate = opt.StrValue
 		case ast.ColumnOptionReference:
-			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("with references"))
+			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("can't modify with references"))
 		case ast.ColumnOptionFulltext:
-			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("with full text"))
+			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs("can't modify with full text"))
 		default:
 			return errors.Trace(errUnsupportedModifyColumn.GenWithStackByArgs(fmt.Sprintf("unknown column option type: %d", opt.Tp)))
 		}
@@ -2736,11 +2736,11 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 
 	// We don't support modifying column from not_auto_increment to auto_increment.
 	if !mysql.HasAutoIncrementFlag(col.Flag) && mysql.HasAutoIncrementFlag(newCol.Flag) {
-		return nil, errUnsupportedModifyColumn.GenWithStackByArgs("set auto_increment")
+		return nil, errUnsupportedModifyColumn.GenWithStackByArgs("can't set auto_increment")
 	}
 	// Disallow modifying column from auto_increment to not auto_increment if the session variable `AllowRemoveAutoInc` is false.
 	if !ctx.GetSessionVars().AllowRemoveAutoInc && mysql.HasAutoIncrementFlag(col.Flag) && !mysql.HasAutoIncrementFlag(newCol.Flag) {
-		return nil, errUnsupportedModifyColumn.GenWithStackByArgs("to remove auto_increment without @@tidb_allow_remove_auto_inc enabled")
+		return nil, errUnsupportedModifyColumn.GenWithStackByArgs("can't remove auto_increment without @@tidb_allow_remove_auto_inc enabled")
 	}
 
 	// We support modifying the type definitions of 'null' to 'not null' now.
@@ -3293,7 +3293,11 @@ func (d *ddl) RenameTable(ctx sessionctx.Context, oldIdent, newIdent ast.Ident, 
 	}
 	newSchema, ok := is.SchemaByName(newIdent.Schema)
 	if !ok {
-		return errErrorOnRename.GenWithStackByArgs(oldIdent.Schema, oldIdent.Name, newIdent.Schema, newIdent.Name)
+		return ErrErrorOnRename.GenWithStackByArgs(
+			fmt.Sprintf("%s.%s", oldIdent.Schema, oldIdent.Name),
+			fmt.Sprintf("%s.%s", newIdent.Schema, newIdent.Name),
+			168,
+			fmt.Sprintf("Database `%s` doesn't exist", newIdent.Schema))
 	}
 	if is.TableExists(newIdent.Schema, newIdent.Name) {
 		return infoschema.ErrTableExists.GenWithStackByArgs(newIdent)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -264,7 +264,7 @@ func (w *worker) deleteRange(job *model.Job) error {
 	if job.Version <= currentVersion {
 		err = w.delRangeManager.addDelRangeJob(job)
 	} else {
-		err = errInvalidJobVersion.GenWithStackByArgs(job.Version, currentVersion)
+		err = errInvalidDDLJobVersion.GenWithStackByArgs(job.Version, currentVersion)
 	}
 	return errors.Trace(err)
 }

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -202,7 +202,7 @@ func (s *testDDLSuite) TestInvalidDDLJob(c *C) {
 		Args:       []interface{}{},
 	}
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err.Error(), Equals, "[ddl:3]invalid ddl job type: none")
+	c.Assert(err.Error(), Equals, "[ddl:8051]invalid ddl job type: none")
 }
 
 func (s *testDDLSuite) TestForeignKeyError(c *C) {

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -202,7 +202,7 @@ func (s *testDDLSuite) TestInvalidDDLJob(c *C) {
 		Args:       []interface{}{},
 	}
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err.Error(), Equals, "[ddl:8051]invalid ddl job type: none")
+	c.Assert(err.Error(), Equals, "[ddl:8204]invalid ddl job type: none")
 }
 
 func (s *testDDLSuite) TestForeignKeyError(c *C) {

--- a/ddl/failtest/fail_db_test.go
+++ b/ddl/failtest/fail_db_test.go
@@ -407,5 +407,5 @@ func (s *testFailDBSuite) TestRunDDLJobPanic(c *C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/mockPanicInRunDDLJob", `1*panic("panic test")`), IsNil)
 	_, err := tk.Exec("create table t(c1 int, c2 int)")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 }

--- a/ddl/foreign_key.go
+++ b/ddl/foreign_key.go
@@ -50,7 +50,7 @@ func onCreateForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 		return ver, nil
 	default:
-		return ver, ErrInvalidForeignKeyState.GenWithStack("invalid fk state %v", fkInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStack("foreign key", fkInfo.State)
 	}
 }
 
@@ -106,7 +106,7 @@ func onDropForeignKey(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		return ver, nil
 	default:
-		return ver, ErrInvalidForeignKeyState.GenWithStack("invalid fk state %v", fkInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStackByArgs("foreign key", fkInfo.State)
 	}
 
 }

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -390,7 +390,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	default:
-		err = ErrInvalidIndexState.GenWithStack("invalid index state %v", tblInfo.State)
+		err = ErrInvalidDDLState.GenWithStackByArgs("index", tblInfo.State)
 	}
 
 	return ver, errors.Trace(err)
@@ -447,7 +447,7 @@ func onDropIndex(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 			job.Args = append(job.Args, indexInfo.ID, getPartitionIDs(tblInfo))
 		}
 	default:
-		err = ErrInvalidIndexState.GenWithStack("invalid index state %v", indexInfo.State)
+		err = ErrInvalidDDLState.GenWithStackByArgs("index", indexInfo.State)
 	}
 	return ver, errors.Trace(err)
 }

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -133,7 +133,7 @@ func rollingbackDropIndex(t *meta.Meta, job *model.Job) (ver int64, err error) {
 		job.State = model.JobStateRollbackDone
 		indexInfo.State = model.StatePublic
 	default:
-		return ver, ErrInvalidIndexState.GenWithStack("invalid index state %v", indexInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStackByArgs("index", indexInfo.State)
 	}
 
 	job.SchemaState = indexInfo.State

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -128,7 +128,7 @@ func (s *testSerialSuite) TestCancelAddIndexPanic(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 }
 
 func (s *testSerialSuite) TestRecoverTableByJobID(c *C) {
@@ -380,7 +380,7 @@ func (s *testSerialSuite) TestCancelJobByErrorCountLimit(c *C) {
 	tk.MustExec("drop table if exists t")
 	_, err := tk.Exec("create table t (a int)")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:12]cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
 }
 
 func (s *testSerialSuite) TestCanceledJobTakeTime(c *C) {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -128,7 +128,7 @@ func (s *testSerialSuite) TestCancelAddIndexPanic(c *C) {
 	}
 	c.Assert(checkErr, IsNil)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 }
 
 func (s *testSerialSuite) TestRecoverTableByJobID(c *C) {
@@ -380,7 +380,7 @@ func (s *testSerialSuite) TestCancelJobByErrorCountLimit(c *C) {
 	tk.MustExec("drop table if exists t")
 	_, err := tk.Exec("create table t (a int)")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8061]Cancelled DDL job")
+	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 }
 
 func (s *testSerialSuite) TestCanceledJobTakeTime(c *C) {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -79,7 +79,7 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateTable, TableInfo: tbInfo})
 		return ver, nil
 	default:
-		return ver, ErrInvalidTableState.GenWithStack("invalid table state %v", tbInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStackByArgs("table", tbInfo.State)
 	}
 }
 
@@ -141,7 +141,7 @@ func onCreateView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 		asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateView, TableInfo: tbInfo})
 		return ver, nil
 	default:
-		return ver, ErrInvalidTableState.GenWithStack("invalid view state %v", tbInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStackByArgs("table", tbInfo.State)
 	}
 }
 
@@ -177,7 +177,7 @@ func onDropTableOrView(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		startKey := tablecodec.EncodeTablePrefix(job.TableID)
 		job.Args = append(job.Args, startKey, getPartitionIDs(tblInfo))
 	default:
-		err = ErrInvalidTableState.GenWithStack("invalid table state %v", tblInfo.State)
+		err = ErrInvalidDDLState.GenWithStackByArgs("table", tblInfo.State)
 	}
 
 	return ver, errors.Trace(err)
@@ -290,7 +290,7 @@ func (w *worker) onRecoverTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver in
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	default:
-		return ver, ErrInvalidTableState.GenWithStack("invalid recover table state %v", tblInfo.State)
+		return ver, ErrInvalidDDLState.GenWithStackByArgs("table", tblInfo.State)
 	}
 	return ver, nil
 }
@@ -353,7 +353,7 @@ func getTableInfoAndCancelFaultJob(t *meta.Meta, job *model.Job, schemaID int64)
 
 	if tblInfo.State != model.StatePublic {
 		job.State = model.JobStateCancelled
-		return nil, ErrInvalidTableState.GenWithStack("table %s is not in public, but %s", tblInfo.Name, tblInfo.State)
+		return nil, ErrInvalidDDLState.GenWithStack("table %s is not in public, but %s", tblInfo.Name, tblInfo.State)
 	}
 
 	return tblInfo, nil

--- a/ddl/table_lock.go
+++ b/ddl/table_lock.go
@@ -91,7 +91,7 @@ func onLockTables(t *meta.Meta, job *model.Job) (ver int64, err error) {
 			}
 		default:
 			job.State = model.JobStateCancelled
-			return ver, ErrInvalidTableLockState.GenWithStack("invalid table lock state %v", tbInfo.Lock.State)
+			return ver, ErrInvalidDDLState.GenWithStackByArgs("table lock", tbInfo.Lock.State)
 		}
 	}
 

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -713,7 +713,7 @@ func (s *testSuite2) TestAdminCheckTable(c *C) {
 	tk.MustExec(`insert into t1 set a='1.9'`)
 	err = tk.ExecToErr(`alter table t1 modify column a decimal(3,2);`)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:203]unsupported modify decimal column precision")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify column: can't change decimal column precision")
 	tk.MustExec(`delete from t1;`)
 	tk.MustExec(`admin check table t1;`)
 }

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -713,7 +713,7 @@ func (s *testSuite2) TestAdminCheckTable(c *C) {
 	tk.MustExec(`insert into t1 set a='1.9'`)
 	err = tk.ExecToErr(`alter table t1 modify column a decimal(3,2);`)
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported modify column: can't change decimal column precision")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: can't change decimal column precision")
 	tk.MustExec(`delete from t1;`)
 	tk.MustExec(`admin check table t1;`)
 }

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -611,10 +611,10 @@ func (s *testSuite8) TestShardRowIDBits(c *C) {
 
 	// After PR 10759, shard_row_id_bits is not supported with pk_is_handle tables.
 	err = tk.ExecToErr("create table auto (id int not null auto_increment primary key, b int) shard_row_id_bits = 4")
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported shard_row_id_bits for table with primary key as row id.")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported shard_row_id_bits for table with primary key as row id")
 	tk.MustExec("create table auto (id int not null auto_increment primary key, b int) shard_row_id_bits = 0")
 	err = tk.ExecToErr("alter table auto shard_row_id_bits = 5")
-	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported shard_row_id_bits for table with primary key as row id.")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported shard_row_id_bits for table with primary key as row id")
 	tk.MustExec("alter table auto shard_row_id_bits = 0")
 
 	// Hack an existing table with shard_row_id_bits and primary key as handle

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -611,10 +611,10 @@ func (s *testSuite8) TestShardRowIDBits(c *C) {
 
 	// After PR 10759, shard_row_id_bits is not supported with pk_is_handle tables.
 	err = tk.ExecToErr("create table auto (id int not null auto_increment primary key, b int) shard_row_id_bits = 4")
-	c.Assert(err.Error(), Equals, "[ddl:207]unsupported shard_row_id_bits for table with primary key as row id.")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported shard_row_id_bits for table with primary key as row id.")
 	tk.MustExec("create table auto (id int not null auto_increment primary key, b int) shard_row_id_bits = 0")
 	err = tk.ExecToErr("alter table auto shard_row_id_bits = 5")
-	c.Assert(err.Error(), Equals, "[ddl:207]unsupported shard_row_id_bits for table with primary key as row id.")
+	c.Assert(err.Error(), Equals, "[ddl:8050]Unsupported shard_row_id_bits for table with primary key as row id.")
 	tk.MustExec("alter table auto shard_row_id_bits = 0")
 
 	// Hack an existing table with shard_row_id_bits and primary key as handle

--- a/go.mod
+++ b/go.mod
@@ -78,4 +78,4 @@ replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719
+replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20191104103048-40f562012fb1
 	github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9
-	github.com/pingcap/parser v0.0.0-20191111144324-e3789d96ce4f
+	github.com/pingcap/parser v0.0.0-20191112053614-3b43b46331d5
 	github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible
 	github.com/pingcap/tipb v0.0.0-20191105120856-bd4b782c8393
@@ -77,5 +77,3 @@ require (
 replace github.com/google/pprof => github.com/lonng/pprof v0.0.0-20191012154247-04dfd648ce8d
 
 go 1.13
-
-replace github.com/pingcap/parser => github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,8 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719 h1:l5NG9Be6fmxexAaElWSqAepPEx37l9L+Qzm/l7y7xkQ=
-github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
+github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627 h1:ZsLRMH0cKX5fNfXW8bf7t2qYXB4jHBIHeiEZK3nlDMQ=
+github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=

--- a/go.sum
+++ b/go.sum
@@ -5,8 +5,6 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
-github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627 h1:ZsLRMH0cKX5fNfXW8bf7t2qYXB4jHBIHeiEZK3nlDMQ=
-github.com/bb7133/parser v0.0.0-20191111190237-ac27f54aa627/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
@@ -196,8 +194,8 @@ github.com/pingcap/kvproto v0.0.0-20191104103048-40f562012fb1/go.mod h1:WWLmULLO
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20191111144324-e3789d96ce4f h1:lcI2PXJM/qkF93w6+Sq1AhA5N9pNrAszTWxhGRAxtgM=
-github.com/pingcap/parser v0.0.0-20191111144324-e3789d96ce4f/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20191112053614-3b43b46331d5 h1:gJUprtXZ95CeFSb3FsDvQ3cSLB9c0W/lPYdqsaRSOng=
+github.com/pingcap/parser v0.0.0-20191112053614-3b43b46331d5/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0 h1:GIEq+wZfrl2bcJxpuSrEH4H7/nlf5YdmpS+dU9lNIt8=
 github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0/go.mod h1:G/6rJpnYwM0LKMec2rI82/5Kg6GaZMvlfB+e6/tvYmI=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible h1:H1jg0aDWz2SLRh3hNBo2HFtnuHtudIUvBumU7syRkic=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f h1:5ZfJxyXo8KyX8
 github.com/StackExchange/wmi v0.0.0-20180725035823-b12b22c5341f/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719 h1:l5NG9Be6fmxexAaElWSqAepPEx37l9L+Qzm/l7y7xkQ=
+github.com/bb7133/parser v0.0.0-20191110105928-88bcbd1b0719/go.mod h1:Vavbz+Ti/y+IQGXwsgGMHASfCyvH4A6zVQspCFBuRXM=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973 h1:xJ4a3vCFaGF/jqvzLMYoU8P317H5OQ+Via4RmuPwCS0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR refines all `Error`s defined in `ddl/ddl.go`:

- Assign specific codes for each error to prevent `1105(Unknown)` error code.
- Assign code `8060` for all errors caused by invalid DDL object state, for example, `ErrInvalidTableState` and `ErrInvalidDatabaseState` shares error code `8060`.
- Assign code `8050` for most errors that caused by the operations that TiDB not supported yet, for example, `errRunMultiSchemaChanges` and `errCantDropColWithIndex`.

Related Parser PR: https://github.com/pingcap/parser/pull/630

### What is changed and how it works?
NA

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change

Side effects

 - Breaking backward compatibility

