### PR TITLE
expression: implement vectorized evaluation for `builtinHexIntArgSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -1808,11 +1808,29 @@ func (b *builtinSubstringBinary3ArgsSig) vecEvalString(input *chunk.Chunk, resul
 }
 
 func (b *builtinHexIntArgSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinHexIntArgSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err := b.args[0].VecEvalInt(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ReserveString(n)
+	i64s := buf.Int64s()
+	for i := 0; i < n; i++ {
+		if buf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		result.AppendString(strings.ToUpper(fmt.Sprintf("%x", uint64(i64s[i]))))
+	}
+	return nil
 }
 
 func (b *builtinFieldIntSig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -102,6 +102,7 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	},
 	ast.Hex: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randHexStrGener{10, 100}}},
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 	},
 	ast.Unhex: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&randHexStrGener{10, 100}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12106 

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinHexIntArgSig` from https://github.com/pingcap/tidb/issues/12106

### What is changed and how it works?
about 6% faster
```
BenchmarkVectorizedBuiltinStringFunc/builtinHexIntArgSig-VecBuiltinFunc-12                  6212            184285 ns/op           32673 B/op       2449 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinHexIntArgSig-NonVecBuiltinFunc-12               5490            196329 ns/op           32673 B/op       2449 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test