### PR TITLE
expression: implement vectorized evaluation for `builtinMakeSetSig`

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -1564,12 +1564,13 @@ func (b *builtinMakeSetSig) vecEvalString(input *chunk.Chunk, result *chunk.Colu
 
 	bits := bitsBuf.Int64s()
 	result.ReserveString(nr)
+	sets := make([]string, 0, len(b.args)-1)
 	for i := 0; i < nr; i++ {
 		if bitsBuf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		sets := make([]string, 0, len(b.args)-1)
+		sets = sets[:0]
 		for j := 0; j < len(b.args)-1; j++ {
 			if strBuf[j].IsNull(i) || (bits[i]&(1<<uint(j))) == 0 {
 				continue

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -1534,13 +1534,52 @@ func (b *builtinReplaceSig) vecEvalString(input *chunk.Chunk, result *chunk.Colu
 }
 
 func (b *builtinMakeSetSig) vectorized() bool {
-	return false
+	return true
 }
 
 // evalString evals MAKE_SET(bits,str1,str2,...).
 // See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_make-set
 func (b *builtinMakeSetSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	nr := input.NumRows()
+	bitsBuf, err := b.bufAllocator.get(types.ETInt, nr)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(bitsBuf)
+	if err := b.args[0].VecEvalInt(b.ctx, input, bitsBuf); err != nil {
+		return err
+	}
+
+	strBuf := make([]*chunk.Column, len(b.args)-1)
+	for i := 1; i < len(b.args); i++ {
+		strBuf[i-1], err = b.bufAllocator.get(types.ETString, nr)
+		if err != nil {
+			return err
+		}
+		defer b.bufAllocator.put(strBuf[i-1])
+		if err := b.args[i].VecEvalString(b.ctx, input, strBuf[i-1]); err != nil {
+			return err
+		}
+	}
+
+	bits := bitsBuf.Int64s()
+	result.ReserveString(nr)
+	for i := 0; i < nr; i++ {
+		if bitsBuf.IsNull(i) {
+			result.AppendNull()
+			continue
+		}
+		sets := make([]string, 0, len(b.args)-1)
+		for j := 0; j < len(b.args)-1; j++ {
+			if strBuf[j].IsNull(i) || (bits[i]&(1<<uint(j))) == 0 {
+				continue
+			}
+			sets = append(sets, strBuf[j].GetString(i))
+		}
+		result.AppendString(strings.Join(sets, ","))
+	}
+
+	return nil
 }
 
 func (b *builtinOctIntSig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -148,7 +148,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	},
 	ast.FindInSet: {},
 	ast.Field:     {},
-	ast.MakeSet:   {},
+	ast.MakeSet: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString}},
+	},
 	ast.Oct: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&numStrGener{rangeInt64Gener{-10, 10}}}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12106 

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinMakeSetSig` from https://github.com/pingcap/tidb/issues/12106

### What is changed and how it works?
about 10% faster
```
BenchmarkVectorizedBuiltinStringFunc/builtinMakeSetSig-VecBuiltinFunc-12                    5234            207595 ns/op          151410 B/op       1582 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinMakeSetSig-NonVecBuiltinFunc-12                 4912            227713 ns/op          151344 B/op       1581 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test