### PR TITLE
expression: panic in test mode if builtin function's PbCode unspecified

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -437,14 +437,19 @@ func (c *greatestFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	switch tp {
 	case types.ETInt:
 		sig = &builtinGreatestIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_GreatestInt)
 	case types.ETReal:
 		sig = &builtinGreatestRealSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_GreatestReal)
 	case types.ETDecimal:
 		sig = &builtinGreatestDecimalSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_GreatestDecimal)
 	case types.ETString:
 		sig = &builtinGreatestStringSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_GreatestString)
 	case types.ETDatetime:
 		sig = &builtinGreatestTimeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_GreatestTime)
 	}
 	return sig, nil
 }
@@ -631,14 +636,19 @@ func (c *leastFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	switch tp {
 	case types.ETInt:
 		sig = &builtinLeastIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeastInt)
 	case types.ETReal:
 		sig = &builtinLeastRealSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeastReal)
 	case types.ETDecimal:
 		sig = &builtinLeastDecimalSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeastDecimal)
 	case types.ETString:
 		sig = &builtinLeastStringSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeastString)
 	case types.ETDatetime:
 		sig = &builtinLeastTimeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeastTime)
 	}
 	return sig, nil
 }
@@ -838,8 +848,10 @@ func (c *intervalFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	var sig builtinFunc
 	if allInt {
 		sig = &builtinIntervalIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_IntervalInt)
 	} else {
 		sig = &builtinIntervalRealSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_IntervalReal)
 	}
 	return sig, nil
 }

--- a/expression/builtin_encryption.go
+++ b/expression/builtin_encryption.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/encrypt"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 var (
@@ -126,9 +127,13 @@ func (c *aesDecryptFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 		if len(args) != 3 {
 			return nil, ErrIncorrectParameterCount.GenWithStackByArgs("aes_decrypt")
 		}
-		return &builtinAesDecryptIVSig{bf, mode}, nil
+		sig := &builtinAesDecryptIVSig{bf, mode}
+		sig.setPbCode(tipb.ScalarFuncSig_AesDecryptIV)
+		return sig, nil
 	}
-	return &builtinAesDecryptSig{bf, mode}, nil
+	sig := &builtinAesDecryptSig{bf, mode}
+	sig.setPbCode(tipb.ScalarFuncSig_AesDecrypt)
+	return sig, nil
 }
 
 type builtinAesDecryptSig struct {
@@ -253,9 +258,13 @@ func (c *aesEncryptFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 		if len(args) != 3 {
 			return nil, ErrIncorrectParameterCount.GenWithStackByArgs("aes_encrypt")
 		}
-		return &builtinAesEncryptIVSig{bf, mode}, nil
+		sig := &builtinAesEncryptIVSig{bf, mode}
+		sig.setPbCode(tipb.ScalarFuncSig_AesEncryptIV)
+		return sig, nil
 	}
-	return &builtinAesEncryptSig{bf, mode}, nil
+	sig := &builtinAesEncryptSig{bf, mode}
+	sig.setPbCode(tipb.ScalarFuncSig_AesEncrypt)
+	return sig, nil
 }
 
 type builtinAesEncryptSig struct {
@@ -368,6 +377,7 @@ func (c *decodeFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 
 	bf.tp.Flen = args[0].GetType().Flen
 	sig := &builtinDecodeSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Decode)
 	return sig, nil
 }
 
@@ -427,6 +437,7 @@ func (c *encodeFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 
 	bf.tp.Flen = args[0].GetType().Flen
 	sig := &builtinEncodeSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Encode)
 	return sig, nil
 }
 
@@ -484,6 +495,7 @@ func (c *passwordFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = mysql.PWDHashLen + 1
 	sig := &builtinPasswordSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Password)
 	return sig, nil
 }
 
@@ -571,6 +583,7 @@ func (c *md5FunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 32
 	sig := &builtinMD5Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MD5)
 	return sig, nil
 }
 
@@ -607,6 +620,7 @@ func (c *sha1FunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 	bf.tp.Flen = 40
 	sig := &builtinSHA1Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_SHA1)
 	return sig, nil
 }
 
@@ -647,6 +661,7 @@ func (c *sha2FunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt)
 	bf.tp.Flen = 128 // sha512
 	sig := &builtinSHA2Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_SHA2)
 	return sig, nil
 }
 
@@ -747,6 +762,7 @@ func (c *compressFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf.tp.Flen = compressBound
 	types.SetBinChsClnFlag(bf.tp)
 	sig := &builtinCompressSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Compress)
 	return sig, nil
 }
 
@@ -809,6 +825,7 @@ func (c *uncompressFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	bf.tp.Flen = mysql.MaxBlobWidth
 	types.SetBinChsClnFlag(bf.tp)
 	sig := &builtinUncompressSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Uncompress)
 	return sig, nil
 }
 
@@ -862,6 +879,7 @@ func (c *uncompressedLengthFunctionClass) getFunction(ctx sessionctx.Context, ar
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
 	sig := &builtinUncompressedLengthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_UncompressedLength)
 	return sig, nil
 }
 

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/plancodec"
 	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 var (
@@ -302,8 +303,10 @@ func (c *lastInsertIDFunctionClass) getFunction(ctx sessionctx.Context, args []E
 
 	if len(args) == 1 {
 		sig = &builtinLastInsertIDWithIDSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LastInsertIDWithID)
 	} else {
 		sig = &builtinLastInsertIDSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LastInsertID)
 	}
 	return sig, err
 }
@@ -579,6 +582,7 @@ func (c *rowCountFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt)
 	sig = &builtinRowCountSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_RowCount)
 	return sig, nil
 }
 

--- a/expression/builtin_like.go
+++ b/expression/builtin_like.go
@@ -97,8 +97,10 @@ func (c *regexpFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	var sig builtinFunc
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[1].GetType()) {
 		sig = newBuiltinRegexpBinarySig(bf)
+		sig.setPbCode(tipb.ScalarFuncSig_RegexpBinarySig)
 	} else {
 		sig = newBuiltinRegexpSig(bf)
+		sig.setPbCode(tipb.ScalarFuncSig_RegexpSig)
 	}
 	return sig, nil
 }

--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -275,10 +275,13 @@ func (c *roundFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 		switch argTp {
 		case types.ETInt:
 			sig = &builtinRoundWithFracIntSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracInt)
 		case types.ETDecimal:
 			sig = &builtinRoundWithFracDecSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracDec)
 		case types.ETReal:
 			sig = &builtinRoundWithFracRealSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundWithFracReal)
 		default:
 			panic("unexpected argTp")
 		}
@@ -286,10 +289,13 @@ func (c *roundFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 		switch argTp {
 		case types.ETInt:
 			sig = &builtinRoundIntSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundInt)
 		case types.ETDecimal:
 			sig = &builtinRoundDecSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundDec)
 		case types.ETReal:
 			sig = &builtinRoundRealSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_RoundReal)
 		default:
 			panic("unexpected argTp")
 		}
@@ -818,8 +824,10 @@ func (c *logFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 
 	if argsLen == 1 {
 		sig = &builtinLog1ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Log1Arg)
 	} else {
 		sig = &builtinLog2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Log2Args)
 	}
 
 	return sig, nil
@@ -888,6 +896,7 @@ func (c *log2FunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinLog2Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Log2)
 	return sig, nil
 }
 
@@ -924,6 +933,7 @@ func (c *log10FunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinLog10Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Log10)
 	return sig, nil
 }
 
@@ -968,6 +978,7 @@ func (c *randFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	if len(args) == 0 {
 		seed := time.Now().UnixNano()
 		sig = &builtinRandSig{bt, &sync.Mutex{}, rand.New(rand.NewSource(seed))}
+		sig.setPbCode(tipb.ScalarFuncSig_Rand)
 	} else if _, isConstant := args[0].(*Constant); isConstant {
 		// According to MySQL manual:
 		// If an integer argument N is specified, it is used as the seed value:
@@ -981,8 +992,10 @@ func (c *randFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 			seed = time.Now().UnixNano()
 		}
 		sig = &builtinRandSig{bt, &sync.Mutex{}, rand.New(rand.NewSource(seed))}
+		sig.setPbCode(tipb.ScalarFuncSig_Rand)
 	} else {
 		sig = &builtinRandWithSeedSig{bt}
+		sig.setPbCode(tipb.ScalarFuncSig_RandWithSeed)
 	}
 	return sig, nil
 }
@@ -1047,6 +1060,7 @@ func (c *powFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal, types.ETReal)
 	sig := &builtinPowSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Pow)
 	return sig, nil
 }
 
@@ -1094,6 +1108,7 @@ func (c *convFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETInt)
 	bf.tp.Flen = 64
 	sig := &builtinConvSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Conv)
 	return sig, nil
 }
 
@@ -1199,6 +1214,7 @@ func (c *crc32FunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = 10
 	bf.tp.Flag |= mysql.UnsignedFlag
 	sig := &builtinCRC32Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_CRC32)
 	return sig, nil
 }
 
@@ -1233,6 +1249,7 @@ func (c *signFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETReal)
 	sig := &builtinSignSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Sign)
 	return sig, nil
 }
 
@@ -1272,6 +1289,7 @@ func (c *sqrtFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinSqrtSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Sqrt)
 	return sig, nil
 }
 
@@ -1308,6 +1326,7 @@ func (c *acosFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinAcosSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Acos)
 	return sig, nil
 }
 
@@ -1345,6 +1364,7 @@ func (c *asinFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinAsinSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Asin)
 	return sig, nil
 }
 
@@ -1395,8 +1415,10 @@ func (c *atanFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 
 	if argsLen == 1 {
 		sig = &builtinAtan1ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Atan1Arg)
 	} else {
 		sig = &builtinAtan2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Atan2Args)
 	}
 
 	return sig, nil
@@ -1459,6 +1481,7 @@ func (c *cosFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinCosSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Cos)
 	return sig, nil
 }
 
@@ -1492,6 +1515,7 @@ func (c *cotFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinCotSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Cot)
 	return sig, nil
 }
 
@@ -1533,6 +1557,7 @@ func (c *degreesFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinDegreesSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Degrees)
 	return sig, nil
 }
 
@@ -1567,6 +1592,7 @@ func (c *expFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinExpSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Exp)
 	return sig, nil
 }
 
@@ -1612,6 +1638,7 @@ func (c *piFunctionClass) getFunction(ctx sessionctx.Context, args []Expression)
 	bf.tp.Decimal = 6
 	bf.tp.Flen = 8
 	sig = &builtinPISig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_PI)
 	return sig, nil
 }
 
@@ -1641,6 +1668,7 @@ func (c *radiansFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinRadiansSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Radians)
 	return sig, nil
 }
 
@@ -1674,6 +1702,7 @@ func (c *sinFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinSinSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Sin)
 	return sig, nil
 }
 
@@ -1707,6 +1736,7 @@ func (c *tanFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinTanSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Tan)
 	return sig, nil
 }
 
@@ -1755,13 +1785,17 @@ func (c *truncateFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	case types.ETInt:
 		if mysql.HasUnsignedFlag(args[0].GetType().Flag) {
 			sig = &builtinTruncateUintSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_TruncateUint)
 		} else {
 			sig = &builtinTruncateIntSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_TruncateInt)
 		}
 	case types.ETReal:
 		sig = &builtinTruncateRealSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_TruncateReal)
 	case types.ETDecimal:
 		sig = &builtinTruncateDecimalSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_TruncateDecimal)
 	}
 
 	return sig, nil

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tipb/go-tipb"
 )
 
 var (
@@ -235,21 +236,28 @@ func (c *anyValueFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	switch argTp {
 	case types.ETDecimal:
 		sig = &builtinDecimalAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_DecimalAnyValue)
 	case types.ETDuration:
 		sig = &builtinDurationAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_DurationAnyValue)
 	case types.ETInt:
 		bf.tp.Decimal = 0
 		sig = &builtinIntAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_IntAnyValue)
 	case types.ETJson:
 		sig = &builtinJSONAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_JSONAnyValue)
 	case types.ETReal:
 		sig = &builtinRealAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_RealAnyValue)
 	case types.ETString:
 		bf.tp.Decimal = types.UnspecifiedLength
 		sig = &builtinStringAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_StringAnyValue)
 	case types.ETDatetime, types.ETTimestamp:
 		bf.tp.Charset, bf.tp.Collate, bf.tp.Flag = mysql.DefaultCharset, mysql.DefaultCollationName, 0
 		sig = &builtinTimeAnyValueSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_TimeAnyValue)
 	default:
 		return nil, errIncorrectArgs.GenWithStackByArgs("ANY_VALUE")
 	}

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -331,6 +331,7 @@ func (c *leftShiftFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinLeftShiftSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_LeftShift)
 	sig.tp.Flag |= mysql.UnsignedFlag
 	return sig, nil
 }
@@ -368,6 +369,7 @@ func (c *rightShiftFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETInt, types.ETInt)
 	sig := &builtinRightShiftSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_RightShift)
 	sig.tp.Flag |= mysql.UnsignedFlag
 	return sig, nil
 }

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tipb/go-tipb"
 	"go.uber.org/zap"
 	"golang.org/x/text/transform"
 )
@@ -186,6 +187,7 @@ func (c *lengthFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
 	sig := &builtinLengthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Length)
 	return sig, nil
 }
 
@@ -220,6 +222,7 @@ func (c *asciiFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 3
 	sig := &builtinASCIISig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_ASCII)
 	return sig, nil
 }
 
@@ -280,6 +283,7 @@ func (c *concatFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	}
 
 	sig := &builtinConcatSig{bf, maxAllowedPacket}
+	sig.setPbCode(tipb.ScalarFuncSig_Concat)
 	return sig, nil
 }
 
@@ -357,6 +361,7 @@ func (c *concatWSFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	}
 
 	sig := &builtinConcatWSSig{bf, maxAllowedPacket}
+	sig.setPbCode(tipb.ScalarFuncSig_ConcatWS)
 	return sig, nil
 }
 
@@ -429,9 +434,11 @@ func (c *leftFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
 		sig := &builtinLeftBinarySig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LeftBinary)
 		return sig, nil
 	}
 	sig := &builtinLeftSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Left)
 	return sig, nil
 }
 
@@ -509,9 +516,11 @@ func (c *rightFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	SetBinFlagOrBinStr(argType, bf.tp)
 	if types.IsBinaryStr(argType) {
 		sig := &builtinRightBinarySig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_RightBinary)
 		return sig, nil
 	}
 	sig := &builtinRightSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Right)
 	return sig, nil
 }
 
@@ -652,6 +661,7 @@ func (c *lowerFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = argTp.Flen
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	sig := &builtinLowerSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Lower)
 	return sig, nil
 }
 
@@ -696,8 +706,10 @@ func (c *reverseFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	var sig builtinFunc
 	if types.IsBinaryStr(bf.tp) {
 		sig = &builtinReverseBinarySig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ReverseBinary)
 	} else {
 		sig = &builtinReverseSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Reverse)
 	}
 	return sig, nil
 }
@@ -760,6 +772,7 @@ func (c *spaceFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 		return nil, err
 	}
 	sig := &builtinSpaceSig{bf, maxAllowedPacket}
+	sig.setPbCode(tipb.ScalarFuncSig_Space)
 	return sig, nil
 }
 
@@ -810,6 +823,7 @@ func (c *upperFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = argTp.Flen
 	SetBinFlagOrBinStr(argTp, bf.tp)
 	sig := &builtinUpperSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Upper)
 	return sig, nil
 }
 
@@ -850,6 +864,7 @@ func (c *strcmpFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	bf.tp.Flen = 2
 	types.SetBinChsClnFlag(bf.tp)
 	sig := &builtinStrcmpSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Strcmp)
 	return sig, nil
 }
 
@@ -898,6 +913,7 @@ func (c *replaceFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 		SetBinFlagOrBinStr(a.GetType(), bf.tp)
 	}
 	sig := &builtinReplaceSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Replace)
 	return sig, nil
 }
 
@@ -983,6 +999,7 @@ func (c *convertFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 
 	bf.tp.Flen = mysql.MaxBlobWidth
 	sig := &builtinConvertSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Convert)
 	return sig, nil
 }
 
@@ -1040,12 +1057,16 @@ func (c *substringFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	switch {
 	case len(args) == 3 && types.IsBinaryStr(argType):
 		sig = &builtinSubstringBinary3ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_SubstringBinary3Args)
 	case len(args) == 3:
 		sig = &builtinSubstring3ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Substring3Args)
 	case len(args) == 2 && types.IsBinaryStr(argType):
 		sig = &builtinSubstringBinary2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_SubstringBinary2Args)
 	case len(args) == 2:
 		sig = &builtinSubstring2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Substring2Args)
 	default:
 		// Should never happens.
 		return nil, errors.Errorf("SUBSTR invalid arg length, expect 2 or 3 but got: %v", len(args))
@@ -1220,6 +1241,7 @@ func (c *substringIndexFunctionClass) getFunction(ctx sessionctx.Context, args [
 	bf.tp.Flen = argType.Flen
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinSubstringIndexSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_SubstringIndex)
 	return sig, nil
 }
 
@@ -1298,12 +1320,16 @@ func (c *locateFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	switch {
 	case hasStartPos && hasBianryInput:
 		sig = &builtinLocateBinary3ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LocateBinary3Args)
 	case hasStartPos:
 		sig = &builtinLocate3ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Locate3Args)
 	case hasBianryInput:
 		sig = &builtinLocateBinary2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_LocateBinary2Args)
 	default:
 		sig = &builtinLocate2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Locate2Args)
 	}
 	return sig, nil
 }
@@ -1470,11 +1496,13 @@ func (c *hexFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 		// Use UTF-8 as default
 		bf.tp.Flen = args[0].GetType().Flen * 3 * 2
 		sig := &builtinHexStrArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_HexStrArg)
 		return sig, nil
 	case types.ETInt, types.ETReal, types.ETDecimal:
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 		bf.tp.Flen = args[0].GetType().Flen * 2
 		sig := &builtinHexIntArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_HexIntArg)
 		return sig, nil
 	default:
 		return nil, errors.Errorf("Hex invalid args, need int or string but get %T", args[0].GetType())
@@ -1551,6 +1579,7 @@ func (c *unhexFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = retFlen
 	types.SetBinChsClnFlag(bf.tp)
 	sig := &builtinUnHexSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_UnHex)
 	return sig, nil
 }
 
@@ -1605,6 +1634,7 @@ func (c *trimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 		bf.tp.Flen = argType.Flen
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim1ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Trim1Arg)
 		return sig, nil
 
 	case 2:
@@ -1612,6 +1642,7 @@ func (c *trimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 		argType := args[0].GetType()
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim2ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Trim2Args)
 		return sig, nil
 
 	case 3:
@@ -1620,6 +1651,7 @@ func (c *trimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 		bf.tp.Flen = argType.Flen
 		SetBinFlagOrBinStr(argType, bf.tp)
 		sig := &builtinTrim3ArgsSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Trim3Args)
 		return sig, nil
 
 	default:
@@ -1743,6 +1775,7 @@ func (c *lTrimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = argType.Flen
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinLTrimSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_LTrim)
 	return sig, nil
 }
 
@@ -1779,6 +1812,7 @@ func (c *rTrimFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = argType.Flen
 	SetBinFlagOrBinStr(argType, bf.tp)
 	sig := &builtinRTrimSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_RTrim)
 	return sig, nil
 }
 
@@ -1857,12 +1891,14 @@ func (c *lpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
 		sig := &builtinLpadBinarySig{bf, maxAllowedPacket}
+		sig.setPbCode(tipb.ScalarFuncSig_LpadBinary)
 		return sig, nil
 	}
 	if bf.tp.Flen *= 4; bf.tp.Flen > mysql.MaxBlobWidth {
 		bf.tp.Flen = mysql.MaxBlobWidth
 	}
 	sig := &builtinLpadSig{bf, maxAllowedPacket}
+	sig.setPbCode(tipb.ScalarFuncSig_Lpad)
 	return sig, nil
 }
 
@@ -1985,12 +2021,14 @@ func (c *rpadFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 
 	if types.IsBinaryStr(args[0].GetType()) || types.IsBinaryStr(args[2].GetType()) {
 		sig := &builtinRpadBinarySig{bf, maxAllowedPacket}
+		sig.setPbCode(tipb.ScalarFuncSig_RpadBinary)
 		return sig, nil
 	}
 	if bf.tp.Flen *= 4; bf.tp.Flen > mysql.MaxBlobWidth {
 		bf.tp.Flen = mysql.MaxBlobWidth
 	}
 	sig := &builtinRpadSig{bf, maxAllowedPacket}
+	sig.setPbCode(tipb.ScalarFuncSig_Rpad)
 	return sig, nil
 }
 
@@ -2102,6 +2140,7 @@ func (c *bitLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
 	sig := &builtinBitLengthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_BitLength)
 	return sig, nil
 }
 
@@ -2144,6 +2183,7 @@ func (c *charFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	types.SetBinChsClnFlag(bf.tp)
 
 	sig := &builtinCharSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Char)
 	return sig, nil
 }
 
@@ -2226,9 +2266,11 @@ func (c *charLengthFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	if types.IsBinaryStr(args[0].GetType()) {
 		sig := &builtinCharLengthBinarySig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_CharLengthBinary)
 		return sig, nil
 	}
 	sig := &builtinCharLengthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_CharLength)
 	return sig, nil
 }
 
@@ -2283,6 +2325,7 @@ func (c *findInSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETString)
 	bf.tp.Flen = 3
 	sig := &builtinFindInSetSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_FindInSet)
 	return sig, nil
 }
 
@@ -2354,10 +2397,13 @@ func (c *fieldFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	switch argTp {
 	case types.ETReal:
 		sig = &builtinFieldRealSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_FieldReal)
 	case types.ETInt:
 		sig = &builtinFieldIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_FieldInt)
 	case types.ETString:
 		sig = &builtinFieldStringSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_FieldString)
 	}
 	return sig, nil
 }
@@ -2494,6 +2540,7 @@ func (c *makeSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 		bf.tp.Flen = mysql.MaxBlobWidth
 	}
 	sig := &builtinMakeSetSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MakeSet)
 	return sig, nil
 }
 
@@ -2545,10 +2592,12 @@ func (c *octFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 		bf.tp.Flen, bf.tp.Decimal = 64, types.UnspecifiedLength
 		sig = &builtinOctIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_OctInt)
 	} else {
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString)
 		bf.tp.Flen, bf.tp.Decimal = 64, types.UnspecifiedLength
 		sig = &builtinOctStringSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_OctString)
 	}
 
 	return sig, nil
@@ -2627,6 +2676,7 @@ func (c *ordFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString)
 	bf.tp.Flen = 10
 	sig := &builtinOrdSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Ord)
 	return sig, nil
 }
 
@@ -2680,6 +2730,7 @@ func (c *quoteFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 		bf.tp.Flen = mysql.MaxBlobWidth
 	}
 	sig := &builtinQuoteSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Quote)
 	return sig, nil
 }
 
@@ -2743,6 +2794,7 @@ func (c *binFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETInt)
 	bf.tp.Flen = 64
 	sig := &builtinBinSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Bin)
 	return sig, nil
 }
 
@@ -2790,6 +2842,7 @@ func (c *eltFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 		}
 	}
 	sig := &builtinEltSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Elt)
 	return sig, nil
 }
 
@@ -2841,10 +2894,13 @@ func (c *exportSetFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	switch len(args) {
 	case 3:
 		sig = &builtinExportSet3ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ExportSet3Arg)
 	case 4:
 		sig = &builtinExportSet4ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ExportSet4Arg)
 	case 5:
 		sig = &builtinExportSet5ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ExportSet5Arg)
 	}
 	return sig, nil
 }
@@ -3001,8 +3057,10 @@ func (c *formatFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	var sig builtinFunc
 	if len(args) == 3 {
 		sig = &builtinFormatWithLocaleSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_FormatWithLocale)
 	} else {
 		sig = &builtinFormatSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_Format)
 	}
 	return sig, nil
 }
@@ -3341,8 +3399,10 @@ func (c *insertFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 
 	if types.IsBinaryStr(args[0].GetType()) {
 		sig = &builtinInsertBinarySig{bf, maxAllowedPacket}
+		sig.setPbCode(tipb.ScalarFuncSig_InsertBinary)
 	} else {
 		sig = &builtinInsertSig{bf, maxAllowedPacket}
+		sig.setPbCode(tipb.ScalarFuncSig_Insert)
 	}
 	return sig, nil
 }
@@ -3463,9 +3523,11 @@ func (c *instrFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf.tp.Flen = 11
 	if types.IsBinaryStr(bf.args[0].GetType()) || types.IsBinaryStr(bf.args[1].GetType()) {
 		sig := &builtinInstrBinarySig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_InstrBinary)
 		return sig, nil
 	}
 	sig := &builtinInstrSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Instr)
 	return sig, nil
 }
 

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -270,6 +270,7 @@ func (c *dateFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETDatetime)
 	bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, 10, 0
 	sig := &builtinDateSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Date)
 	return sig, nil
 }
 
@@ -364,6 +365,7 @@ func (c *dateDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime, types.ETDatetime)
 	sig := &builtinDateDiffSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DateDiff)
 	return sig, nil
 }
 
@@ -442,28 +444,37 @@ func (c *timeDiffFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 		switch arg1Tp {
 		case types.ETDuration:
 			sig = &builtinDurationDurationTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_DurationDurationTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
 			sig = &builtinNullTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_NullTimeDiff)
 		default:
 			sig = &builtinDurationStringTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_DurationStringTimeDiff)
 		}
 	case types.ETDatetime, types.ETTimestamp:
 		switch arg1Tp {
 		case types.ETDuration:
 			sig = &builtinNullTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_NullTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
 			sig = &builtinTimeTimeTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_TimeTimeTimeDiff)
 		default:
 			sig = &builtinTimeStringTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_TimeStringTimeDiff)
 		}
 	default:
 		switch arg1Tp {
 		case types.ETDuration:
 			sig = &builtinStringDurationTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_StringDurationTimeDiff)
 		case types.ETDatetime, types.ETTimestamp:
 			sig = &builtinStringTimeTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_StringTimeTimeDiff)
 		default:
 			sig = &builtinStringStringTimeDiffSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_StringStringTimeDiff)
 		}
 	}
 	return sig, nil
@@ -829,6 +840,7 @@ func (c *fromDaysFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETInt)
 	bf.tp.Flen, bf.tp.Decimal = 10, 0
 	sig := &builtinFromDaysSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_FromDays)
 	return sig, nil
 }
 
@@ -864,6 +876,7 @@ func (c *hourFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 3, 0
 	sig := &builtinHourSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Hour)
 	return sig, nil
 }
 
@@ -899,6 +912,7 @@ func (c *minuteFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
 	sig := &builtinMinuteSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Minute)
 	return sig, nil
 }
 
@@ -934,6 +948,7 @@ func (c *secondFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
 	sig := &builtinSecondSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Second)
 	return sig, nil
 }
 
@@ -969,6 +984,7 @@ func (c *microSecondFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen, bf.tp.Decimal = 6, 0
 	sig := &builtinMicroSecondSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MicroSecond)
 	return sig, nil
 }
 
@@ -1004,6 +1020,7 @@ func (c *monthFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
 	sig := &builtinMonthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Month)
 	return sig, nil
 }
 
@@ -1048,6 +1065,7 @@ func (c *monthNameFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDatetime)
 	bf.tp.Flen = 10
 	sig := &builtinMonthNameSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MonthName)
 	return sig, nil
 }
 
@@ -1086,6 +1104,7 @@ func (c *dayNameFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETDatetime)
 	bf.tp.Flen = 10
 	sig := &builtinDayNameSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DayName)
 	return sig, nil
 }
 
@@ -1151,6 +1170,7 @@ func (c *dayOfMonthFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 2
 	sig := &builtinDayOfMonthSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DayOfMonth)
 	return sig, nil
 }
 
@@ -1191,6 +1211,7 @@ func (c *dayOfWeekFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 1
 	sig := &builtinDayOfWeekSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DayOfWeek)
 	return sig, nil
 }
 
@@ -1229,6 +1250,7 @@ func (c *dayOfYearFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen = 3
 	sig := &builtinDayOfYearSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_DayOfYear)
 	return sig, nil
 }
 
@@ -1277,8 +1299,10 @@ func (c *weekFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	var sig builtinFunc
 	if len(args) == 2 {
 		sig = &builtinWeekWithModeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_WeekWithMode)
 	} else {
 		sig = &builtinWeekWithoutModeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_WeekWithoutMode)
 	}
 	return sig, nil
 }
@@ -1364,6 +1388,7 @@ func (c *weekDayFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	bf.tp.Flen = 1
 
 	sig := &builtinWeekDaySig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_WeekDay)
 	return sig, nil
 }
 
@@ -1402,6 +1427,7 @@ func (c *weekOfYearFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 2, 0
 	sig := &builtinWeekOfYearSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_WeekOfYear)
 	return sig, nil
 }
 
@@ -1443,6 +1469,7 @@ func (c *yearFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	bf.tp.Flen, bf.tp.Decimal = 4, 0
 	sig := &builtinYearSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Year)
 	return sig, nil
 }
 
@@ -1494,8 +1521,10 @@ func (c *yearWeekFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	var sig builtinFunc
 	if len(args) == 2 {
 		sig = &builtinYearWeekWithModeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_YearWeekWithMode)
 	} else {
 		sig = &builtinYearWeekWithoutModeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_YearWeekWithoutMode)
 	}
 	return sig, nil
 }
@@ -1589,7 +1618,9 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []E
 
 	if len(args) > 1 {
 		bf.tp.Flen = args[1].GetType().Flen
-		return &builtinFromUnixTime2ArgSig{bf}, nil
+		sig = &builtinFromUnixTime2ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_FromUnixTime2Arg)
+		return sig, nil
 	}
 
 	// Calculate the time fsp.
@@ -1609,7 +1640,9 @@ func (c *fromUnixTimeFunctionClass) getFunction(ctx sessionctx.Context, args []E
 		}
 	}
 
-	return &builtinFromUnixTime1ArgSig{bf}, nil
+	sig = &builtinFromUnixTime1ArgSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_FromUnixTime1Arg)
+	return sig, nil
 }
 
 func evalFromUnixTime(ctx sessionctx.Context, fsp int8, unixTimeStamp *types.MyDecimal) (res types.Time, isNull bool, err error) {
@@ -1722,6 +1755,7 @@ func (c *getFormatFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETString)
 	bf.tp.Flen = 17
 	sig := &builtinGetFormatSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_GetFormat)
 	return sig, nil
 }
 
@@ -1831,6 +1865,7 @@ func (c *strToDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETString, types.ETString)
 		bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, mysql.MaxDateWidth, int(types.MinFsp)
 		sig = &builtinStrToDateDateSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDate)
 	case mysql.TypeDatetime:
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETString, types.ETString)
 		if fsp == types.MinFsp {
@@ -1839,6 +1874,7 @@ func (c *strToDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 			bf.tp.Flen, bf.tp.Decimal = mysql.MaxDatetimeWidthWithFsp, int(types.MaxFsp)
 		}
 		sig = &builtinStrToDateDatetimeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDatetime)
 	case mysql.TypeDuration:
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, types.ETString, types.ETString)
 		if fsp == types.MinFsp {
@@ -1847,6 +1883,7 @@ func (c *strToDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 			bf.tp.Flen, bf.tp.Decimal = mysql.MaxDurationWidthWithFsp, int(types.MaxFsp)
 		}
 		sig = &builtinStrToDateDurationSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_StrToDateDuration)
 	}
 	return sig, nil
 }
@@ -1969,8 +2006,10 @@ func (c *sysDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	var sig builtinFunc
 	if len(args) == 1 {
 		sig = &builtinSysDateWithFspSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_SysDateWithFsp)
 	} else {
 		sig = &builtinSysDateWithoutFspSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_SysDateWithoutFsp)
 	}
 	return sig, nil
 }
@@ -2077,6 +2116,7 @@ func (c *currentTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 		bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration)
 		bf.tp.Flen, bf.tp.Decimal = mysql.MaxDurationWidthNoFsp, int(types.MinFsp)
 		sig = &builtinCurrentTime0ArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_CurrentTime0Arg)
 		return sig, nil
 	}
 	// args[0] must be a constant which should not be null.
@@ -2096,6 +2136,7 @@ func (c *currentTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, types.ETInt)
 	bf.tp.Flen, bf.tp.Decimal = mysql.MaxDurationWidthWithFsp, int(fsp)
 	sig = &builtinCurrentTime1ArgSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_CurrentTime1Arg)
 	return sig, nil
 }
 
@@ -2166,6 +2207,7 @@ func (c *timeFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 		return nil, err
 	}
 	sig := &builtinTimeSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Time)
 	return sig, nil
 }
 
@@ -2337,8 +2379,10 @@ func (c *utcTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	var sig builtinFunc
 	if len(args) == 1 {
 		sig = &builtinUTCTimestampWithArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UTCTimestampWithArg)
 	} else {
 		sig = &builtinUTCTimestampWithoutArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UTCTimestampWithoutArg)
 	}
 	return sig, nil
 }
@@ -2424,8 +2468,10 @@ func (c *nowFunctionClass) getFunction(ctx sessionctx.Context, args []Expression
 	var sig builtinFunc
 	if len(args) == 1 {
 		sig = &builtinNowWithArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_NowWithArg)
 	} else {
 		sig = &builtinNowWithoutArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_NowWithoutArg)
 	}
 	return sig, nil
 }
@@ -2539,9 +2585,11 @@ func (c *extractFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	if isDatetimeUnit {
 		bf = newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETDatetime)
 		sig = &builtinExtractDatetimeSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ExtractDatetime)
 	} else {
 		bf = newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETDuration)
 		sig = &builtinExtractDurationSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_ExtractDuration)
 	}
 	return sig, nil
 }
@@ -2903,81 +2951,97 @@ func (c *addDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateStringString)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETInt:
 		sig = &builtinAddDateStringIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateStringInt)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETReal:
 		sig = &builtinAddDateStringRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateStringReal)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETDecimal:
 		sig = &builtinAddDateStringDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateStringDecimal)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETString:
 		sig = &builtinAddDateIntStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateIntString)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETInt:
 		sig = &builtinAddDateIntIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateIntInt)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETReal:
 		sig = &builtinAddDateIntRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateIntReal)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETDecimal:
 		sig = &builtinAddDateIntDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateIntDecimal)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETString:
 		sig = &builtinAddDateDatetimeStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDatetimeString)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETInt:
 		sig = &builtinAddDateDatetimeIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDatetimeInt)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETReal:
 		sig = &builtinAddDateDatetimeRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDatetimeReal)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETDecimal:
 		sig = &builtinAddDateDatetimeDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDatetimeDecimal)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETString:
 		sig = &builtinAddDateDurationStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDurationString)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETInt:
 		sig = &builtinAddDateDurationIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDurationInt)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETReal:
 		sig = &builtinAddDateDurationRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDurationReal)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETDecimal:
 		sig = &builtinAddDateDurationDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_AddDateDurationDecimal)
 	}
 	return sig, nil
 }
@@ -3555,81 +3619,97 @@ func (c *subDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateStringString)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETInt:
 		sig = &builtinSubDateStringIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateStringInt)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETReal:
 		sig = &builtinSubDateStringRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateStringReal)
 	case dateEvalTp == types.ETString && intervalEvalTp == types.ETDecimal:
 		sig = &builtinSubDateStringDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateStringDecimal)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETString:
 		sig = &builtinSubDateIntStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateIntString)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETInt:
 		sig = &builtinSubDateIntIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateIntInt)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETReal:
 		sig = &builtinSubDateIntRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateIntReal)
 	case dateEvalTp == types.ETInt && intervalEvalTp == types.ETDecimal:
 		sig = &builtinSubDateIntDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateIntDecimal)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETString:
 		sig = &builtinSubDateDatetimeStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDatetimeString)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETInt:
 		sig = &builtinSubDateDatetimeIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDatetimeInt)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETReal:
 		sig = &builtinSubDateDatetimeRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDatetimeReal)
 	case dateEvalTp == types.ETDatetime && intervalEvalTp == types.ETDecimal:
 		sig = &builtinSubDateDatetimeDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDatetimeDecimal)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETString:
 		sig = &builtinSubDateDurationStringSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDurationString)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETInt:
 		sig = &builtinSubDateDurationIntSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDurationInt)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETReal:
 		sig = &builtinSubDateDurationRealSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDurationReal)
 	case dateEvalTp == types.ETDuration && intervalEvalTp == types.ETDecimal:
 		sig = &builtinSubDateDurationDecimalSig{
 			baseBuiltinFunc:      bf,
 			baseDateArithmitical: newDateArighmeticalUtil(),
 		}
+		sig.setPbCode(tipb.ScalarFuncSig_SubDateDurationDecimal)
 	}
 	return sig, nil
 }
@@ -4161,6 +4241,7 @@ func (c *timestampDiffFunctionClass) getFunction(ctx sessionctx.Context, args []
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETString, types.ETDatetime, types.ETDatetime)
 	sig := &builtinTimestampDiffSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_TimestampDiff)
 	return sig, nil
 }
 
@@ -4261,10 +4342,13 @@ func (c *unixTimestampFunctionClass) getFunction(ctx sessionctx.Context, args []
 	var sig builtinFunc
 	if len(args) == 0 {
 		sig = &builtinUnixTimestampCurrentSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampCurrent)
 	} else if retTp == types.ETInt {
 		sig = &builtinUnixTimestampIntSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampInt)
 	} else if retTp == types.ETDecimal {
 		sig = &builtinUnixTimestampDecSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UnixTimestampDec)
 	}
 	return sig, nil
 }
@@ -4430,8 +4514,10 @@ func (c *timestampFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	var sig builtinFunc
 	if argLen == 2 {
 		sig = &builtinTimestamp2ArgsSig{bf, isFloat}
+		sig.setPbCode(tipb.ScalarFuncSig_Timestamp2Args)
 	} else {
 		sig = &builtinTimestamp1ArgSig{bf, isFloat}
+		sig.setPbCode(tipb.ScalarFuncSig_Timestamp1Arg)
 	}
 	return sig, nil
 }
@@ -4727,37 +4813,49 @@ func (c *addTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinAddDatetimeAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDatetimeAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinAddTimeDateTimeNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddTimeDateTimeNull)
 		default:
 			sig = &builtinAddDatetimeAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDatetimeAndString)
 		}
 	case mysql.TypeDate:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinAddDateAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDateAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinAddTimeStringNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddTimeStringNull)
 		default:
 			sig = &builtinAddDateAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDateAndString)
 		}
 	case mysql.TypeDuration:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinAddDurationAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDurationAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinAddTimeDurationNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddTimeDurationNull)
 		default:
 			sig = &builtinAddDurationAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddDurationAndString)
 		}
 	default:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinAddStringAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddStringAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinAddTimeStringNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddTimeStringNull)
 		default:
 			sig = &builtinAddStringAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_AddStringAndString)
 		}
 	}
 	return sig, nil
@@ -5142,6 +5240,7 @@ func (c *convertTzFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 		baseBuiltinFunc: bf,
 		timezoneRegex:   tzRegex,
 	}
+	sig.setPbCode(tipb.ScalarFuncSig_ConvertTz)
 	return sig, nil
 }
 
@@ -5227,6 +5326,7 @@ func (c *makeDateFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	tp := bf.tp
 	tp.Tp, tp.Flen, tp.Decimal = mysql.TypeDate, mysql.MaxDateWidth, 0
 	sig := &builtinMakeDateSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MakeDate)
 	return sig, nil
 }
 
@@ -5315,6 +5415,7 @@ func (c *makeTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, arg0Type, arg1Type, types.ETReal)
 	bf.tp.Flen, bf.tp.Decimal = flen, decimal
 	sig := &builtinMakeTimeSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_MakeTime)
 	return sig, nil
 }
 
@@ -5537,6 +5638,7 @@ func (c *quarterFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	bf.tp.Flen = 1
 
 	sig := &builtinQuarterSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Quarter)
 	return sig, nil
 }
 
@@ -5602,6 +5704,7 @@ func (c *secToTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDuration, types.ETReal)
 	bf.tp.Flen, bf.tp.Decimal = retFlen, retFsp
 	sig := &builtinSecToTimeSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_SecToTime)
 	return sig, nil
 }
 
@@ -5674,37 +5777,49 @@ func (c *subTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinSubDatetimeAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDatetimeAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinSubTimeDateTimeNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubTimeDateTimeNull)
 		default:
 			sig = &builtinSubDatetimeAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDatetimeAndString)
 		}
 	case mysql.TypeDate:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinSubDateAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDateAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinSubTimeStringNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubTimeStringNull)
 		default:
 			sig = &builtinSubDateAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDateAndString)
 		}
 	case mysql.TypeDuration:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinSubDurationAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDurationAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinSubTimeDurationNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubTimeDurationNull)
 		default:
 			sig = &builtinSubDurationAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubDurationAndString)
 		}
 	default:
 		switch tp2.Tp {
 		case mysql.TypeDuration:
 			sig = &builtinSubStringAndDurationSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubStringAndDuration)
 		case mysql.TypeDatetime, mysql.TypeTimestamp:
 			sig = &builtinSubTimeStringNullSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubTimeStringNull)
 		default:
 			sig = &builtinSubStringAndStringSig{bf}
+			sig.setPbCode(tipb.ScalarFuncSig_SubStringAndString)
 		}
 	}
 	return sig, nil
@@ -6070,6 +6185,7 @@ func (c *timeFormatFunctionClass) getFunction(ctx sessionctx.Context, args []Exp
 	// worst case: formatMask=%r%r%r...%r, each %r takes 11 characters
 	bf.tp.Flen = (args[1].GetType().Flen + 1) / 2 * 11
 	sig := &builtinTimeFormatSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_TimeFormat)
 	return sig, nil
 }
 
@@ -6123,6 +6239,7 @@ func (c *timeToSecFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDuration)
 	bf.tp.Flen = 10
 	sig := &builtinTimeToSecSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_TimeToSec)
 	return sig, nil
 }
 
@@ -6163,6 +6280,7 @@ func (c *timestampAddFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETString, types.ETInt, types.ETDatetime)
 	bf.tp = &types.FieldType{Tp: mysql.TypeString, Flen: mysql.MaxDatetimeWidthNoFsp, Decimal: types.UnspecifiedLength}
 	sig := &builtinTimestampAddSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_TimestampAdd)
 	return sig, nil
 
 }
@@ -6255,6 +6373,7 @@ func (c *toDaysFunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	sig := &builtinToDaysSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_ToDays)
 	return sig, nil
 }
 
@@ -6293,6 +6412,7 @@ func (c *toSecondsFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETDatetime)
 	sig := &builtinToSecondsSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_ToSeconds)
 	return sig, nil
 }
 
@@ -6361,8 +6481,10 @@ func (c *utcTimeFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	var sig builtinFunc
 	if len(args) == 1 {
 		sig = &builtinUTCTimeWithArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UTCTimeWithArg)
 	} else {
 		sig = &builtinUTCTimeWithoutArgSig{bf}
+		sig.setPbCode(tipb.ScalarFuncSig_UTCTimeWithoutArg)
 	}
 	return sig, nil
 }
@@ -6430,6 +6552,7 @@ func (c *lastDayFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETDatetime, types.ETDatetime)
 	bf.tp.Tp, bf.tp.Flen, bf.tp.Decimal = mysql.TypeDate, mysql.MaxDateWidth, int(types.DefaultFsp)
 	sig := &builtinLastDaySig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_LastDay)
 	return sig, nil
 }
 

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
@@ -228,7 +229,10 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 
 	// check whether this function has ProtoBuf signature.
 	pbCode := expr.Function.PbCode()
-	if pbCode < 0 {
+	if pbCode <= tipb.ScalarFuncSig_Unspecified {
+		failpoint.Inject("PanicIfPbCodeUnspecified", func() {
+			panic(errors.Errorf("%T does not set the PbCode", expr.Function))
+		})
 		return nil
 	}
 

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -226,7 +226,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	pbCode := expr.Function.PbCode()
 	if pbCode <= tipb.ScalarFuncSig_Unspecified {
 		failpoint.Inject("PanicIfPbCodeUnspecified", func() {
-			panic(errors.Errorf("%T does not set the PbCode", expr.Function))
+			panic(errors.Errorf("unspecified PbCode: %T", expr.Function))
 		})
 		return nil
 	}

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -222,7 +222,7 @@ func (pc PbConverter) columnToPBExpr(column *Column) *tipb.Expr {
 }
 
 func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
-	// check whether this function has ProtoBuf signature.
+	// Check whether this function has ProtoBuf signature.
 	pbCode := expr.Function.PbCode()
 	if pbCode <= tipb.ScalarFuncSig_Unspecified {
 		failpoint.Inject("PanicIfPbCodeUnspecified", func() {
@@ -231,12 +231,12 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 		return nil
 	}
 
-	// check whether this function can be pushed.
+	// Check whether this function can be pushed.
 	if !pc.canFuncBePushed(expr) {
 		return nil
 	}
 
-	// check whether all of its parameters can be pushed.
+	// Check whether all of its parameters can be pushed.
 	children := make([]*tipb.Expr, 0, len(expr.GetArgs()))
 	for _, arg := range expr.GetArgs() {
 		pbArg := pc.ExprToPB(arg)
@@ -256,7 +256,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 		implicitArgs = encoded
 	}
 
-	// construct expression ProtoBuf.
+	// Construct expression ProtoBuf.
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
 		Val:       implicitArgs,

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -222,17 +222,17 @@ func (pc PbConverter) columnToPBExpr(column *Column) *tipb.Expr {
 }
 
 func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
-	// check whether this function can be pushed.
-	if !pc.canFuncBePushed(expr) {
-		return nil
-	}
-
 	// check whether this function has ProtoBuf signature.
 	pbCode := expr.Function.PbCode()
 	if pbCode <= tipb.ScalarFuncSig_Unspecified {
 		failpoint.Inject("PanicIfPbCodeUnspecified", func() {
 			panic(errors.Errorf("%T does not set the PbCode", expr.Function))
 		})
+		return nil
+	}
+
+	// check whether this function can be pushed.
+	if !pc.canFuncBePushed(expr) {
 		return nil
 	}
 

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
@@ -29,6 +30,14 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tipb/go-tipb"
 )
+
+func init() {
+	fpname := "github.com/pingcap/tidb/expression/PanicIfPbCodeUnspecified"
+	err := failpoint.Enable(fpname, "return(true)")
+	if err != nil {
+		panic(errors.Errorf("enable global failpoint `%s` failed: %v", fpname, err))
+	}
+}
 
 type dataGen4Expr2PbTest struct {
 }

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -443,7 +443,7 @@ func (s *testEvaluatorSerialSuites) TestPanicIfPbCodeUnspecified(c *C) {
 	c.Assert(fn.Function.PbCode(), Equals, tipb.ScalarFuncSig_Unspecified)
 
 	pc := PbConverter{client: new(mock.Client), sc: new(stmtctx.StatementContext)}
-	c.Assert(func() { pc.ExprToPB(fn) }, PanicMatches, "*expression.builtinBitAndSig does not set the PbCode")
+	c.Assert(func() { pc.ExprToPB(fn) }, PanicMatches, "unspecified PbCode: *expression.builtinBitAndSig")
 }
 
 func (s *testEvaluatorSerialSuites) TestPushDownSwitcher(c *C) {

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -443,7 +443,7 @@ func (s *testEvaluatorSerialSuites) TestPanicIfPbCodeUnspecified(c *C) {
 	c.Assert(fn.Function.PbCode(), Equals, tipb.ScalarFuncSig_Unspecified)
 
 	pc := PbConverter{client: new(mock.Client), sc: new(stmtctx.StatementContext)}
-	c.Assert(func() { pc.ExprToPB(fn) }, PanicMatches, "unspecified PbCode: *expression.builtinBitAndSig")
+	c.Assert(func() { pc.ExprToPB(fn) }, PanicMatches, "unspecified PbCode: .*")
 }
 
 func (s *testEvaluatorSerialSuites) TestPushDownSwitcher(c *C) {

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20191107084102-68af6554dec7
 	github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible
-	github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004
+	github.com/pingcap/tipb v0.0.0-20191112054303-0b0ad0d4a92e
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 // indirect

--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20191107084102-68af6554dec7
 	github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible
-	github.com/pingcap/tipb v0.0.0-20191105120856-bd4b782c8393
+	github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90
 	github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0 h1:GIEq+wZfrl2bc
 github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0/go.mod h1:G/6rJpnYwM0LKMec2rI82/5Kg6GaZMvlfB+e6/tvYmI=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible h1:H1jg0aDWz2SLRh3hNBo2HFtnuHtudIUvBumU7syRkic=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004 h1:pqi/6y2DxVWmNStLnR/Zq4DTE3Q7UXGvHp61KNDfbB4=
-github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pingcap/tipb v0.0.0-20191112054303-0b0ad0d4a92e h1:TWwzCfLrj9GH5uaT0VcvdSnrHuwEntUfoHDTYdOzNNI=
+github.com/pingcap/tipb v0.0.0-20191112054303-0b0ad0d4a92e/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -200,8 +200,8 @@ github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0 h1:GIEq+wZfrl2bc
 github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0/go.mod h1:G/6rJpnYwM0LKMec2rI82/5Kg6GaZMvlfB+e6/tvYmI=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible h1:H1jg0aDWz2SLRh3hNBo2HFtnuHtudIUvBumU7syRkic=
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
-github.com/pingcap/tipb v0.0.0-20191105120856-bd4b782c8393 h1:8XcpRME085GsIe3eiJGhmuDPAjG8CUa8VE/QnQAwmfM=
-github.com/pingcap/tipb v0.0.0-20191105120856-bd4b782c8393/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004 h1:pqi/6y2DxVWmNStLnR/Zq4DTE3Q7UXGvHp61KNDfbB4=
+github.com/pingcap/tipb v0.0.0-20191109171753-a594830fb004/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/server/conn.go
+++ b/server/conn.go
@@ -618,7 +618,7 @@ func (cc *clientConn) Run(ctx context.Context) {
 			buf = buf[:stackSize]
 			logutil.Logger(ctx).Error("connection running loop panic",
 				zap.Stringer("lastSQL", getLastStmtInConn{cc}),
-				zap.Reflect("err", r),
+				zap.String("err", fmt.Sprintf("%v", r)),
 				zap.String("stack", string(buf)),
 			)
 			metrics.PanicCounter.WithLabelValues(metrics.LabelSession).Inc()


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Update the `tipb` to the latest version which makes detect missing PbCode easily.
2. Panic in test mode if builtin function's PbCode unspecified

### What is changed and how it works?

Update go.mod and add a fail point to build expression to Protobuf.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - No need.
