### PR TITLE
expression: add setPbCode for Sign Sqrt 

### DIFF
--- a/expression/builtin_math.go
+++ b/expression/builtin_math.go
@@ -1233,6 +1233,7 @@ func (c *signFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETInt, types.ETReal)
 	sig := &builtinSignSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Sign)
 	return sig, nil
 }
 
@@ -1272,6 +1273,7 @@ func (c *sqrtFunctionClass) getFunction(ctx sessionctx.Context, args []Expressio
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETReal, types.ETReal)
 	sig := &builtinSqrtSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Sqrt)
 	return sig, nil
 }
 

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"github.com/pingcap/tipb/go-tipb"
 	"math"
 	"math/rand"
 	"runtime"
@@ -602,6 +603,7 @@ func (s *testEvaluatorSuite) TestSign(c *C) {
 		fc := funcs[ast.Sign]
 		f, err := fc.getFunction(s.ctx, s.primitiveValsToConstants(t.num))
 		c.Assert(err, IsNil, Commentf("%v", t))
+		c.Assert(f.PbCode(), Equals, tipb.ScalarFuncSig_Sign)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		c.Assert(err, IsNil, Commentf("%v", t))
 		c.Assert(v, testutil.DatumEquals, types.NewDatum(t.ret), Commentf("%v", t))
@@ -665,6 +667,7 @@ func (s *testEvaluatorSuite) TestSqrt(c *C) {
 		fc := funcs[ast.Sqrt]
 		f, err := fc.getFunction(s.ctx, s.primitiveValsToConstants(t.Arg))
 		c.Assert(err, IsNil)
+		c.Assert(f.PbCode(), Equals, tipb.ScalarFuncSig_Sqrt)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		c.Assert(err, IsNil)
 		c.Assert(v, testutil.DatumEquals, types.NewDatum(t.Ret), Commentf("%v", t))


### PR DESCRIPTION
Relate to https://github.com/tikv/tikv/pull/5839

Signed-off-by: Fullstop000 <fullstop1005@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
push down `Sign` and `Sqrt`

### What is changed and how it works?
`Sign` and `Sqrt` should be pushed down to TiKV

### Check List <!--REMOVE the items that are not applicable-->

 - Tests
   - integration test with copr-test
