### PR TITLE
tidb-server: introduce `go.uber.org/automaxprocs`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	github.com/unrolled/render v0.0.0-20180914162206-b9786414de4d // indirect
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738
 	go.uber.org/atomic v1.5.0
+	go.uber.org/automaxprocs v1.2.0
 	go.uber.org/zap v1.12.0
 	golang.org/x/crypto v0.0.0-20191029031824-8986dd9e96cf // indirect
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b

--- a/go.sum
+++ b/go.sum
@@ -291,6 +291,8 @@ go.etcd.io/etcd v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXw
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
+go.uber.org/automaxprocs v1.2.0 h1:+RUihKM+nmYUoB9w0D0Ov5TJ2PpFO2FgenTxMJiZBZA=
+go.uber.org/automaxprocs v1.2.0/go.mod h1:YfO3fm683kQpzETxlTGZhGIVmXAhaw3gxeBADbpZtnU=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.3.0/go.mod h1:VgVr7evmIr6uPjLBxg28wmKNXyqE9akIJ5XnfpiKl+4=
 go.uber.org/multierr v1.4.0 h1:f3WCSC2KzAcBXGATIxAB1E2XuCpNU255wNKZ505qi3E=

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -59,6 +59,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/struCoder/pidusage"
+	_ "go.uber.org/automaxprocs"
 	"go.uber.org/zap"
 )
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR closes #13337 to allow auto set `GOMAXPROCS` to the CPUs tidb-server can use.

### What is changed and how it works?

Introducing the package `go.uber.org/automaxprocs`, this package will read cgroup system to get the CPU the process can use and adjust the `GOMAXPROCS` to the CPU limit. When users already explicitly set `performance.max-procs` to non-zero, then the value provided by users will override the default value, so it does not have break change.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
 
Run tidb-server inside a kubernetes pod which has cpu limit by `GODEBUG=schedtrace=1000 ./tidb-server`, the reported `GOMAXPROCS` is exactly the cpu limits set by pod resources.

Code changes

None

Side effects

None

Related changes

 - Need to cherry-pick to the release 2.1 and 3.0
 - Need to update the documentation

Release note

Auto set GOMAXPROCS in Docker container environment.
