### PR TITLE
expression: implement vectorized evaluation for `builtinCurrentRoleSig`

### DIFF
--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
@@ -126,18 +127,12 @@ func (b *builtinCurrentRoleSig) vecEvalString(input *chunk.Chunk, result *chunk.
 		return nil
 	}
 
-	res := ""
 	sortedRes := make([]string, 0, 10)
 	for _, r := range data.ActiveRoles {
 		sortedRes = append(sortedRes, r.String())
 	}
 	sort.Strings(sortedRes)
-	for i, r := range sortedRes {
-		res += r
-		if i != len(data.ActiveRoles)-1 {
-			res += ","
-		}
-	}
+	res := strings.Join(sortedRes, ",")
 	for i := 0; i < n; i++ {
 		result.AppendString(res)
 	}

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -123,6 +123,7 @@ func (b *builtinCurrentRoleSig) vecEvalString(input *chunk.Chunk, result *chunk.
 		for i := 0; i < n; i++ {
 			result.AppendString("")
 		}
+		return nil
 	}
 
 	res := ""

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -71,7 +71,9 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	ast.RowCount: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
 	},
-	ast.CurrentRole: {},
+	ast.CurrentRole: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{}},
+	},
 	ast.TiDBIsDDLOwner: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinCurrentRoleSig , for #12106

### What is changed and how it works?

	$go test -v -benchmem -bench=BenchmarkVectorizedBuiltinInfoFunc -run=BenchmarkVectorizedBuiltinInfoFunc -args "builtinCurrentRoleSig"
	goos: darwin
	goarch: amd64
	pkg: github.com/pingcap/tidb/expression
	BenchmarkVectorizedBuiltinInfoFunc/builtinCurrentRoleSig-VecBuiltinFunc-4         	   81760	     15292 ns/op	     192 B/op	       2 allocs/op
	BenchmarkVectorizedBuiltinInfoFunc/builtinCurrentRoleSig-NonVecBuiltinFunc-4      	   79507	     14121 ns/op	       0 B/op	       0 allocs/op
	PASS
	ok  	github.com/pingcap/tidb/expression	2.812s

Tests <!-- At least one of them must be included. -->

 - Unit test