### PR TITLE
planner: support point get by `_tidb_rowid`

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -602,9 +602,7 @@ drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;
 id	count	task	operator info
-Projection_4	8000.00	root	Column#1
-└─TableReader_6	10000.00	root	data:TableScan_5
-  └─TableScan_5	10000.00	cop[tikv]	table:t, range:[0,0], keep order:false, stats:pseudo
+Point_Get_1	1.00	root	table:t, handle:0
 explain select * from t where _tidb_rowid > 0;
 id	count	task	operator info
 Projection_4	8000.00	root	Column#1

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -564,3 +564,14 @@ func (s *testPointGetSuite) TestForUpdateRetry(c *C) {
 	_, err := tk.Exec("commit")
 	c.Assert(session.ErrForUpdateCantRetry.Equal(err), IsTrue)
 }
+
+func (s *testPointGetSuite) TestPointGetByRowID(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a varchar(20), b int)")
+	tk.MustExec("insert into t values(\"aaa\", 12)")
+	tk.MustQuery("explain select * from t where t._tidb_rowid = 1").Check(testkit.Rows(
+		"Point_Get_1 1.00 root table:t, handle:1"))
+	tk.MustQuery("select * from t where t._tidb_rowid = 1").Check(testkit.Rows("aaa 12"))
+}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -783,6 +783,10 @@ func getNameValuePairs(nvPairs []nameValuePair, tblName model.CIStr, expr ast.Ex
 
 func findPKHandle(tblInfo *model.TableInfo, pairs []nameValuePair) (handlePair nameValuePair, fieldType *types.FieldType) {
 	if !tblInfo.PKIsHandle {
+		rowIDIdx := findInPairs("_tidb_rowid", pairs)
+		if rowIDIdx != -1 {
+			return pairs[rowIDIdx], types.NewFieldType(mysql.TypeLonglong)
+		}
 		return handlePair, nil
 	}
 	for _, col := range tblInfo.Columns {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
As the title says.

### What is changed and how it works?
When trying to build the point_get plan. Check where `_tidb_rowid` can build a point_get plan when the primary key is not the handle.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Side effects

 - Increased code complexity
