### PR TITLE
expression: implement vectorized evaluation for builtinNowWithoutArgSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1031,11 +1031,27 @@ func (b *builtinSecondSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinNowWithoutArgSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinNowWithoutArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+
+	result.ResizeTime(n, false)
+	times := result.Times()
+	t, isNull, err := evalNowWithFsp(b.ctx, int8(0))
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < n; i++ {
+		if isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		times[i] = t
+	}
+	return nil
 }
 
 func (b *builtinStringDurationTimeDiffSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -69,7 +69,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
 	ast.MicroSecond: {},
-	ast.Now:         {},
+	ast.Now: {
+		{retEvalType: types.ETDatetime},
+	},
 	ast.DayOfWeek: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},


### PR DESCRIPTION
PCP #12101

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinNowWithoutArgSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=Time VB_FUNC=builtinNowWithoutArgSig                           
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinTimeFunc \
		-run=BenchmarkVectorizedBuiltinTimeFunc \
		-args "builtinNowWithoutArgSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.00780 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinNowWithoutArgSig-VecBuiltinFunc-12         	  622129	      1731 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinNowWithoutArgSig-NonVecBuiltinFunc-12      	    3333	    343405 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.189s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
