### PR TITLE
session,store: make TestAsyncRollBackNoWait run faster to boost CI

### DIFF
--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -477,7 +477,7 @@ func (txn *tikvTxn) asyncPessimisticRollback(ctx context.Context, keys [][]byte)
 	wg.Add(1)
 	go func() {
 		failpoint.Inject("AsyncRollBackSleep", func() {
-			time.Sleep(2 * time.Second)
+			time.Sleep(100 * time.Millisecond)
 		})
 		err := committer.pessimisticRollbackKeys(NewBackoffer(ctx, pessimisticRollbackMaxBackoff), keys)
 		if err != nil {


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

`TestAsyncRollBackNoWait` slows our CI.

Before:
```
PASS: pessimistic_test.go:485: testPessimisticSuite.TestAsyncRollBackNoWait	5.070s
```
After:
```
PASS: pessimistic_test.go:485: testPessimisticSuite.TestAsyncRollBackNoWait	0.220s
```
### What is changed and how it works?

Reduce `time.Sleep`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

