### PR TITLE
session,store: remove TestRetryPreparedSleep and TestInsertSleepOverMaxTxnTime

### DIFF
--- a/store/tikv/sql_fail_test.go
+++ b/store/tikv/sql_fail_test.go
@@ -53,23 +53,6 @@ func (s *testSQLSuite) TearDownSuite(c *C) {
 	s.OneByOneSuite.TearDownSuite(c)
 }
 
-func (s *testSQLSuite) TestInsertSleepOverMaxTxnTime(c *C) {
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tmpMaxTxnTime"), IsNil)
-	}()
-	se, err := session.CreateSession4Test(s.store)
-	c.Assert(err, IsNil)
-	_, err = se.Execute(context.Background(), "drop table if exists test.t")
-	c.Assert(err, IsNil)
-	_, err = se.Execute(context.Background(), "create table test.t(a int)")
-	c.Assert(err, IsNil)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tmpMaxTxnTime", `return(2)->return(0)`), IsNil)
-	start := time.Now()
-	_, err = se.Execute(context.Background(), "insert into test.t (a) select sleep(3)")
-	c.Assert(err, IsNil)
-	c.Assert(time.Since(start) < time.Second*5, IsTrue)
-}
-
 func (s *testSQLSuite) TestFailBusyServerCop(c *C) {
 	se, err := session.CreateSession4Test(s.store)
 	c.Assert(err, IsNil)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Those two tests are stale as `tmpMaxTxnTime` has been deleted.

https://github.com/pingcap/tidb/commit/f1461858701e609e2793a7f5777fb6cdf31977cc#diff-499c236856cd9ce3300d3f5ccde41a23L1037-L1043

`TestRetryPreparedSleep` now has no practical use except making our CI slow:

```
PASS: session_fail_test.go:117: testSessionSuite.TestRetryPreparedSleep	3.162s
```

### What is changed and how it works?

Remove staled code.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
