### PR TITLE
stats: fix merge cm sketch panic

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -310,6 +310,8 @@ func (s *testFastAnalyze) TestFastAnalyze(c *C) {
 
 	// Test CM Sketch built from fast analyze.
 	tk.MustExec("create table t1(a int, b int, index idx(a, b))")
+	// Should not panic.
+	tk.MustExec("analyze table t1")
 	tk.MustExec("insert into t1 values (1,1),(1,1),(1,2),(1,2)")
 	tk.MustExec("analyze table t1")
 	tk.MustQuery("explain select a from t1 where a = 1").Check(testkit.Rows(

--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -336,6 +336,9 @@ func (c *CMSketch) mergeTopN(lTopN map[uint64][]*TopNMeta, rTopN map[uint64][]*T
 
 // MergeCMSketch merges two CM Sketch.
 func (c *CMSketch) MergeCMSketch(rc *CMSketch, numTopN uint32) error {
+	if c == nil || rc == nil {
+		return nil
+	}
 	if c.depth != rc.depth || c.width != rc.width {
 		return errors.New("Dimensions of Count-Min Sketch should be the same")
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fast analyze on multi-column indexes will panic when merge cm sketches when there are no samples.

### What is changed and how it works?

Check if the cm sketch is nil when merging them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix panic when fast analyze on multi-column indexes