### PR TITLE
tikv: more uniform logic handle leader/follower-read/tiflash request

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -624,7 +624,7 @@ func (e *AnalyzeFastExec) getSampRegionsRowCount(bo *tikv.Backoffer, needRebuild
 		var resp *tikvrpc.Response
 		var rpcCtx *tikv.RPCContext
 		// we always use the first follower when follower read is enabled
-		rpcCtx, *err = e.cache.GetTiKVRPCContext(bo, loc.Region, e.ctx.GetSessionVars().GetReplicaRead(), 0)
+		rpcCtx, *err = e.cache.GetRPCContext(kv.TiKV, bo, loc.Region, e.ctx.GetSessionVars().GetReplicaRead(), 0)
 		if *err != nil {
 			return
 		}

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -265,12 +265,13 @@ func (c *RegionCache) checkAndResolve(needCheckStores []*Store) {
 
 // RPCContext contains data that is needed to send RPC to a region.
 type RPCContext struct {
-	Region  RegionVerID
-	Meta    *metapb.Region
-	Peer    *metapb.Peer
-	PeerIdx int
-	Store   *Store
-	Addr    string
+	Region      RegionVerID
+	Meta        *metapb.Region
+	Peer        *metapb.Peer
+	PeerIdx     int
+	Store       *Store
+	Addr        string
+	ForceLeader bool
 }
 
 // GetStoreID returns StoreID.
@@ -338,12 +339,13 @@ func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRe
 	}
 
 	return &RPCContext{
-		Region:  id,
-		Meta:    cachedRegion.meta,
-		Peer:    peer,
-		PeerIdx: storeIdx,
-		Store:   store,
-		Addr:    addr,
+		Region:      id,
+		Meta:        cachedRegion.meta,
+		Peer:        peer,
+		PeerIdx:     storeIdx,
+		Store:       store,
+		Addr:        addr,
+		ForceLeader: replicaRead != kv.ReplicaReadFollower,
 	}, nil
 }
 
@@ -491,11 +493,7 @@ func (c *RegionCache) OnSendFail(bo *Backoffer, ctx *RPCContext, scheduleReload 
 	tikvRegionCacheCounterWithSendFail.Inc()
 	r := c.getCachedRegionWithRLock(ctx.Region)
 	if r != nil {
-		if ctx.Store.storeType == kv.TiKV {
-			c.switchNextPeer(ctx.Store.storeType, r, ctx.PeerIdx, err)
-		} else {
-			c.switchNextFlashPeer(ctx.Store.storeType, r, ctx.PeerIdx, err)
-		}
+		c.switchPeerForNextRetry(ctx.Store.storeType, ctx.ForceLeader, r, ctx.PeerIdx, err)
 		if scheduleReload {
 			r.scheduleReload()
 		}
@@ -654,7 +652,7 @@ func (c *RegionCache) UpdateLeader(regionID RegionVerID, leaderStoreID uint64, c
 	}
 
 	if leaderStoreID == 0 {
-		c.switchNextPeer(kv.TiKV, r, currentPeerIdx, nil)
+		c.switchPeerForNextRetry(kv.TiKV, true, r, currentPeerIdx, nil)
 		logutil.BgLogger().Info("switch region peer to next due to NotLeader with NULL leader",
 			zap.Int("currIdx", currentPeerIdx),
 			zap.Uint64("regionID", regionID.GetID()))
@@ -1084,9 +1082,10 @@ func (c *RegionCache) switchToPeer(r *Region, targetStoreID uint64) (found bool)
 	return
 }
 
-func (c *RegionCache) switchNextFlashPeer(engine kv.StoreType, r *Region, currentPeerIdx int, err error) {
+func (c *RegionCache) switchPeerForNextRetry(engine kv.StoreType, forceLeader bool, r *Region, currentPeerIdx int, err error) {
 	rs := r.getStore()
 
+	// notify other region's request this store has meet failure.
 	if err != nil { // TODO: refine err, only do this for some errors.
 		s := rs.stores[engine][currentPeerIdx]
 		epoch := rs.storeFails[engine][currentPeerIdx]
@@ -1096,32 +1095,13 @@ func (c *RegionCache) switchNextFlashPeer(engine kv.StoreType, r *Region, curren
 		}
 	}
 
-	nextIdx := (currentPeerIdx + 1) % len(rs.stores[engine])
-	newRegionStore := rs.clone()
-	newRegionStore.currIdx[engine] = int32(nextIdx)
-	r.compareAndSwapStore(rs, newRegionStore)
-}
-
-func (c *RegionCache) switchNextPeer(engine kv.StoreType, r *Region, currentPeerIdx int, err error) {
-	rs := r.getStore()
-
-	if err != nil { // TODO: refine err, only do this for some errors.
-		s := rs.stores[engine][currentPeerIdx]
-		epoch := rs.storeFails[engine][currentPeerIdx]
-		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
-			logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
-			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
-		}
-	}
-
-	if int(rs.currIdx[engine]) != currentPeerIdx {
+	// send follower read request fail no need to change work index.
+	if !forceLeader {
 		return
 	}
 
+	// change work index(leader index for TiKV).
 	nextIdx := (currentPeerIdx + 1) % len(rs.stores[engine])
-	for rs.stores[engine][nextIdx].storeType == kv.TiFlash {
-		nextIdx = (nextIdx + 1) % len(rs.stores[engine])
-	}
 	newRegionStore := rs.clone()
 	newRegionStore.currIdx[engine] = int32(nextIdx)
 	r.compareAndSwapStore(rs, newRegionStore)

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -102,8 +102,7 @@ func (r *RegionStore) clone() *RegionStore {
 }
 
 // return next follower store's index
-func (r *RegionStore) follower(seed uint32) int32 {
-	engine := kv.TiKV
+func (r *RegionStore) follower(engine kv.StoreType, seed uint32) int32 {
 	l := uint32(len(r.stores[engine]))
 	if l <= 1 {
 		return r.currIdx[engine]
@@ -309,9 +308,9 @@ func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRe
 	var storeIdx int
 	switch replicaRead {
 	case kv.ReplicaReadFollower:
-		store, peer, storeIdx = cachedRegion.FollowerStorePeer(regionStore, followerStoreSeed)
+		store, peer, storeIdx = cachedRegion.FollowerStorePeer(engine, regionStore, followerStoreSeed)
 	default:
-		store, peer, storeIdx = cachedRegion.WorkStorePeer(regionStore)
+		store, peer, storeIdx = cachedRegion.WorkStorePeer(engine, regionStore)
 	}
 	addr, err := c.getStoreAddr(bo, cachedRegion, store, storeIdx)
 	if err != nil {
@@ -493,9 +492,9 @@ func (c *RegionCache) OnSendFail(bo *Backoffer, ctx *RPCContext, scheduleReload 
 	r := c.getCachedRegionWithRLock(ctx.Region)
 	if r != nil {
 		if ctx.Store.storeType == kv.TiKV {
-			c.switchNextPeer(r, ctx.PeerIdx, err)
+			c.switchNextPeer(ctx.Store.storeType, r, ctx.PeerIdx, err)
 		} else {
-			c.switchNextFlashPeer(r, ctx.PeerIdx, err)
+			c.switchNextFlashPeer(ctx.Store.storeType, r, ctx.PeerIdx, err)
 		}
 		if scheduleReload {
 			r.scheduleReload()
@@ -655,7 +654,7 @@ func (c *RegionCache) UpdateLeader(regionID RegionVerID, leaderStoreID uint64, c
 	}
 
 	if leaderStoreID == 0 {
-		c.switchNextPeer(r, currentPeerIdx, nil)
+		c.switchNextPeer(kv.TiKV, r, currentPeerIdx, nil)
 		logutil.BgLogger().Info("switch region peer to next due to NotLeader with NULL leader",
 			zap.Int("currIdx", currentPeerIdx),
 			zap.Uint64("regionID", regionID.GetID()))
@@ -1028,8 +1027,7 @@ func (r *Region) GetLeaderStoreID() uint64 {
 	return r.meta.Peers[int(r.getStore().currIdx[engine])].StoreId
 }
 
-func (r *Region) getStorePeer(rs *RegionStore, pidx int32) (store *Store, peer *metapb.Peer, idx int) {
-	engine := kv.TiKV
+func (r *Region) getStorePeer(engine kv.StoreType, rs *RegionStore, pidx int32) (store *Store, peer *metapb.Peer, idx int) {
 	store = rs.stores[engine][pidx]
 	peer = r.meta.Peers[pidx]
 	idx = int(pidx)
@@ -1037,14 +1035,13 @@ func (r *Region) getStorePeer(rs *RegionStore, pidx int32) (store *Store, peer *
 }
 
 // WorkStorePeer returns current work store with work peer.
-func (r *Region) WorkStorePeer(rs *RegionStore) (store *Store, peer *metapb.Peer, idx int) {
-	engine := kv.TiKV
-	return r.getStorePeer(rs, rs.currIdx[engine])
+func (r *Region) WorkStorePeer(engine kv.StoreType, rs *RegionStore) (store *Store, peer *metapb.Peer, idx int) {
+	return r.getStorePeer(engine, rs, rs.currIdx[engine])
 }
 
 // FollowerStorePeer returns a follower store with follower peer.
-func (r *Region) FollowerStorePeer(rs *RegionStore, followerStoreSeed uint32) (*Store, *metapb.Peer, int) {
-	return r.getStorePeer(rs, rs.follower(followerStoreSeed))
+func (r *Region) FollowerStorePeer(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32) (*Store, *metapb.Peer, int) {
+	return r.getStorePeer(engine, rs, rs.follower(engine, followerStoreSeed))
 }
 
 // RegionVerID is a unique ID that can identify a Region at a specific version.
@@ -1082,12 +1079,12 @@ func (r *Region) EndKey() []byte {
 // false if no peer matches the storeID.
 func (c *RegionCache) switchToPeer(r *Region, targetStoreID uint64) (found bool) {
 	leaderIdx, found := c.getPeerStoreIndex(r, targetStoreID)
-	c.switchWorkIdx(r, leaderIdx)
+	engine := kv.TiKV // now, we only support leader in TiKV store.
+	c.switchWorkIdx(engine, r, leaderIdx)
 	return
 }
 
-func (c *RegionCache) switchNextFlashPeer(r *Region, currentPeerIdx int, err error) {
-	engine := kv.TiFlash
+func (c *RegionCache) switchNextFlashPeer(engine kv.StoreType, r *Region, currentPeerIdx int, err error) {
 	rs := r.getStore()
 
 	if err != nil { // TODO: refine err, only do this for some errors.
@@ -1105,9 +1102,8 @@ func (c *RegionCache) switchNextFlashPeer(r *Region, currentPeerIdx int, err err
 	r.compareAndSwapStore(rs, newRegionStore)
 }
 
-func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
+func (c *RegionCache) switchNextPeer(engine kv.StoreType, r *Region, currentPeerIdx int, err error) {
 	rs := r.getStore()
-	engine := kv.TiKV
 
 	if err != nil { // TODO: refine err, only do this for some errors.
 		s := rs.stores[engine][currentPeerIdx]
@@ -1145,8 +1141,7 @@ func (c *RegionCache) getPeerStoreIndex(r *Region, id uint64) (idx int, found bo
 	return
 }
 
-func (c *RegionCache) switchWorkIdx(r *Region, leaderIdx int) {
-	engine := kv.TiKV
+func (c *RegionCache) switchWorkIdx(engine kv.StoreType, r *Region, leaderIdx int) {
 retry:
 	// switch to new leader.
 	oldRegionStore := r.getStore()

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -287,11 +287,9 @@ func (c *RPCContext) String() string {
 		c.Region.GetID(), c.Meta, c.Peer, c.Addr, c.PeerIdx)
 }
 
-// GetTiKVRPCContext returns RPCContext for a region. If it returns nil, the region
+// GetRPCContext returns RPCContext for a region. If it returns nil, the region
 // must be out of date and already dropped from cache.
-func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRead kv.ReplicaReadType, followerStoreSeed uint32) (*RPCContext, error) {
-
-	engine := kv.TiKV
+func (c *RegionCache) GetRPCContext(engine kv.StoreType, bo *Backoffer, id RegionVerID, replicaRead kv.ReplicaReadType, followerStoreSeed uint32) (*RPCContext, error) {
 	ts := time.Now().Unix()
 
 	cachedRegion := c.getCachedRegionWithRLock(id)
@@ -304,15 +302,15 @@ func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRe
 	}
 
 	regionStore := cachedRegion.getStore()
-	var store *Store
-	var peer *metapb.Peer
-	var storeIdx int
+	var sg RouteStrategy
 	switch replicaRead {
 	case kv.ReplicaReadFollower:
-		store, peer, storeIdx = cachedRegion.FollowerStorePeer(engine, regionStore, followerStoreSeed)
+		sg = cachedRegion.KeepSendLast
 	default:
-		store, peer, storeIdx = cachedRegion.WorkStorePeer(engine, regionStore)
+		sg = cachedRegion.SendCurrRetryNextOnFail
 	}
+
+	store, peer, storeIdx := cachedRegion.WorkStorePeer(engine, regionStore, followerStoreSeed, sg)
 	addr, err := c.getStoreAddr(bo, cachedRegion, store, storeIdx)
 	if err != nil {
 		return nil, err
@@ -1032,14 +1030,29 @@ func (r *Region) getStorePeer(engine kv.StoreType, rs *RegionStore, pidx int32) 
 	return
 }
 
-// WorkStorePeer returns current work store with work peer.
-func (r *Region) WorkStorePeer(engine kv.StoreType, rs *RegionStore) (store *Store, peer *metapb.Peer, idx int) {
-	return r.getStorePeer(engine, rs, rs.currIdx[engine])
+// SendCurrRetryNextOnFail is a RouteStrategy that try route request to currIndex node.
+// if send fail will try next node for current engine in OnSendFail method.
+//
+// TiKV normal request will use this to send request to region leader and try next node on failure.
+// TiFlash request also use this to send curr node and round-robin others on failure.
+func (r *Region) SendCurrRetryNextOnFail(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32) int32 {
+	return rs.currIdx[engine]
 }
 
-// FollowerStorePeer returns a follower store with follower peer.
-func (r *Region) FollowerStorePeer(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32) (*Store, *metapb.Peer, int) {
-	return r.getStorePeer(engine, rs, rs.follower(engine, followerStoreSeed))
+// KeepSendLast is a RouteStrategy that try route request to last send node via followerStoreSeed.
+// it will find next available node for current engine in current method.
+//
+// TiKV follower read will use this.
+func (r *Region) KeepSendLast(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32) int32 {
+	return rs.follower(engine, followerStoreSeed)
+}
+
+// RouteStrategy defines how choose a store from region's store lists.
+type RouteStrategy func(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32) int32
+
+// WorkStorePeer returns current work store with work peer.
+func (r *Region) WorkStorePeer(engine kv.StoreType, rs *RegionStore, followerStoreSeed uint32, strategy RouteStrategy) (store *Store, peer *metapb.Peer, idx int) {
+	return r.getStorePeer(engine, rs, strategy(engine, rs, followerStoreSeed))
 }
 
 // RegionVerID is a unique ID that can identify a Region at a specific version.
@@ -1096,7 +1109,7 @@ func (c *RegionCache) switchPeerForNextRetry(engine kv.StoreType, forceLeader bo
 	}
 
 	// send follower read request fail no need to change work index.
-	if !forceLeader {
+	if !forceLeader && int(rs.currIdx[engine]) != currentPeerIdx {
 		return
 	}
 

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -127,7 +127,7 @@ func (s *testRegionCacheSuite) TestSimple(c *C) {
 	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 	s.checkCache(c, 1)
 	c.Assert(r.GetMeta(), DeepEquals, r.meta)
-	c.Assert(r.GetLeaderID(), Equals, r.meta.Peers[r.getStore().workTiKVIdx].Id)
+	c.Assert(r.GetLeaderID(), Equals, r.meta.Peers[r.getStore().currIdx[kv.TiKV]].Id)
 	s.cache.mu.regions[r.VerID()].lastAccess = 0
 	r = s.cache.searchCachedRegion([]byte("a"), true)
 	c.Assert(r, IsNil)

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -789,7 +789,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 5)
 	for i := 0; i < 5; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -800,7 +800,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 3)
 	for i := 1; i < 4; i++ {
 		r := scannedRegions[i-1]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -811,7 +811,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 1)
 
 	r0 := scannedRegions[0]
-	_, p0, _ := r0.WorkStorePeer(r0.getStore())
+	_, p0, _ := r0.WorkStorePeer(kv.TiKV, r0.getStore())
 	c.Assert(r0.meta.Id, Equals, regions[1])
 	c.Assert(p0.Id, Equals, peers[1][0])
 
@@ -822,7 +822,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(err, IsNil)
 	for i := 0; i < 3; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i*2])
 		c.Assert(p.Id, Equals, peers[i*2][0])
@@ -953,7 +953,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	region := cache.getRegionByIDFromCache(loc.Region.id)
 	b.ResetTimer()
 	regionStore := region.getStore()
-	store, peer, idx := region.WorkStorePeer(regionStore)
+	store, peer, idx := region.WorkStorePeer(kv.TiKV, regionStore)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			rpcCtx := &RPCContext{
@@ -965,7 +965,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
 			if r == nil {
-				cache.switchNextPeer(r, rpcCtx.PeerIdx, nil)
+				cache.switchNextPeer(kv.TiKV, r, rpcCtx.PeerIdx, nil)
 			}
 		}
 	})

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -267,8 +267,10 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	// pd-server should return the new leader.
 	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(store3))
 	addr = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
+	//c.Assert(addr == s.storeAddr(s.store1) || len(addr) == 0, IsTrue)
 	addr2 := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
-	//c.Assert(addr2 == s.storeAddr(s.store1) || len(addr2) == 0, IsTrue)
+	//a1 := s.storeAddr(s.store1)
+	//c.Assert(addr2 == a1 || len(addr2) == 0, IsTrue)
 	c.Assert((len(addr2) == 0 && len(addr) == 0) || addr != addr2, IsTrue)
 }
 

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -965,7 +965,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
 			if r == nil {
-				cache.switchNextPeer(kv.TiKV, r, rpcCtx.PeerIdx, nil)
+				cache.switchPeerForNextRetry(kv.TiKV, true, r, rpcCtx.PeerIdx, nil)
 			}
 		}
 	})

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -110,7 +110,7 @@ func (s *testRegionCacheSuite) getRegionWithEndKey(c *C, key []byte) *Region {
 func (s *testRegionCacheSuite) getAddr(c *C, key []byte, replicaRead kv.ReplicaReadType, seed uint32) string {
 	loc, err := s.cache.LocateKey(s.bo, key)
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, replicaRead, seed)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, replicaRead, seed)
 	c.Assert(err, IsNil)
 	if ctx == nil {
 		return ""
@@ -138,10 +138,10 @@ func (s *testRegionCacheSuite) TestDropStore(c *C) {
 	s.cluster.RemoveStore(s.store1)
 	loc, err := s.cache.LocateKey(bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx, IsNil)
-	ctx, err = s.cache.GetTiKVRPCContext(bo, loc.Region, kv.ReplicaReadFollower, rand.Uint32())
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, bo, loc.Region, kv.ReplicaReadFollower, rand.Uint32())
 	c.Assert(err, IsNil)
 	c.Assert(ctx, IsNil)
 	s.checkCache(c, 0)
@@ -279,21 +279,21 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
 	// verify follower to be one of store2 and store3
 	seed := rand.Uint32()
-	ctxFollower1, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower2, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
@@ -304,19 +304,19 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
 	// verify follower to be one of store1 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -327,19 +327,19 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 
 	// access 1 it will return NotLeader, leader back to 2 again
 	s.cache.UpdateLeader(loc.Region, s.store2, ctx.PeerIdx)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
 	// verify follower to be one of store1 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -359,21 +359,21 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
 	// verify follower to be one of store2 and store3
 	seed := rand.Uint32()
-	ctxFollower1, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower2, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
@@ -384,12 +384,12 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
 	// verify follower to be one of store1 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
@@ -397,7 +397,7 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
 	c.Assert(ctxFollower1.Peer.Id == s.peer1 || ctxFollower1.Peer.Id == peer3, IsTrue)
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -408,19 +408,19 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 
 	// access 2, it's in hibernate and return 0 leader, so switch to 3
 	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
 
 	// verify follower to be one of store1 and store2
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -430,22 +430,22 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// again peer back to 1
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 
 	// verify follower to be one of store2 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
@@ -470,12 +470,12 @@ func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
 	c.Assert(loc2.Region.id, Equals, region2)
 
 	// Send fail on region1
-	ctx, _ := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
+	ctx, _ := s.cache.GetRPCContext(kv.TiKV, s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	s.checkCache(c, 2)
 	s.cache.OnSendFail(s.bo, ctx, false, errors.New("test error"))
 
 	// Get region2 cache will get nil then reload.
-	ctx2, err := s.cache.GetTiKVRPCContext(s.bo, loc2.Region, kv.ReplicaReadLeader, 0)
+	ctx2, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc2.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(ctx2, IsNil)
 	c.Assert(err, IsNil)
 }
@@ -490,21 +490,21 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
 	// verify follower to be one of store2 and store3
 	seed := rand.Uint32()
-	ctxFollower1, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower2, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
@@ -515,19 +515,19 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
 	// verify follower to be one of store1 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -538,12 +538,12 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 
 	// send 2 fail leader switch to 3
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
 
 	// verify follower to be one of store1 and store2
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
@@ -551,7 +551,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	}
 	c.Assert(ctxFollower1.Peer.Id == s.peer1 || ctxFollower1.Peer.Id == s.peer2, IsTrue)
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
@@ -562,19 +562,19 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 
 	// 3 can be access, so switch to 1
 	s.cache.UpdateLeader(loc.Region, s.store1, ctx.PeerIdx)
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 
 	// verify follower to be one of store2 and store3
-	ctxFollower1, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	ctxFollower1, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed)
 	c.Assert(err, IsNil)
 	if seed%2 == 0 {
 		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
 	} else {
 		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
 	}
-	ctxFollower2, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	ctxFollower2, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
 	c.Assert(err, IsNil)
 	if (seed+1)%2 == 0 {
 		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
@@ -789,7 +789,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 5)
 	for i := 0; i < 5; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore(), 0, r.SendCurrRetryNextOnFail)
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -800,7 +800,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 3)
 	for i := 1; i < 4; i++ {
 		r := scannedRegions[i-1]
-		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore(), 0, r.SendCurrRetryNextOnFail)
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -811,7 +811,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 1)
 
 	r0 := scannedRegions[0]
-	_, p0, _ := r0.WorkStorePeer(kv.TiKV, r0.getStore())
+	_, p0, _ := r0.WorkStorePeer(kv.TiKV, r0.getStore(), 0, r0.SendCurrRetryNextOnFail)
 	c.Assert(r0.meta.Id, Equals, regions[1])
 	c.Assert(p0.Id, Equals, peers[1][0])
 
@@ -822,7 +822,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(err, IsNil)
 	for i := 0; i < 3; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore())
+		_, p, _ := r.WorkStorePeer(kv.TiKV, r.getStore(), 0, r.SendCurrRetryNextOnFail)
 
 		c.Assert(r.meta.Id, Equals, regions[i*2])
 		c.Assert(p.Id, Equals, peers[i*2][0])
@@ -876,23 +876,23 @@ func (s *testRegionCacheSuite) TestFollowerReadFallback(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	ctx, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
 	// verify follower to be store2 and store3
-	ctxFollower1, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	ctxFollower1, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
-	ctxFollower2, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 1)
+	ctxFollower2, err := s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, 1)
 	c.Assert(err, IsNil)
 	c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// send fail on store2, next follower read is going to fallback to store3
 	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
-	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	ctx, err = s.cache.GetRPCContext(kv.TiKV, s.bo, loc.Region, kv.ReplicaReadFollower, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
 }
@@ -953,7 +953,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	region := cache.getRegionByIDFromCache(loc.Region.id)
 	b.ResetTimer()
 	regionStore := region.getStore()
-	store, peer, idx := region.WorkStorePeer(kv.TiKV, regionStore)
+	store, peer, idx := region.WorkStorePeer(kv.TiKV, regionStore, 0, region.SendCurrRetryNextOnFail)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			rpcCtx := &RPCContext{

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -114,14 +114,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		replicaRead = kv.ReplicaReadLeader
 	}
 	for {
-		switch sType {
-		case kv.TiKV:
-			rpcCtx, err = s.regionCache.GetTiKVRPCContext(bo, regionID, replicaRead, req.ReplicaReadSeed)
-		case kv.TiFlash:
-			rpcCtx, err = s.regionCache.GetTiFlashRPCContext(bo, regionID)
-		default:
-			err = errors.Errorf("unsupported storage type: %v", sType)
-		}
+		rpcCtx, err = s.regionCache.GetRPCContext(sType, bo, regionID, replicaRead, req.ReplicaReadSeed)
 		if err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

there are three different but similar logic for leader/follower-read/tiflash request, this pr try to move then into a more uniform one.

- leader request: normal tidb request will send to region's leader node and try next node to get new leader if leader be unreachable(via NotLeader error from TiKV).
- follower read: will random send to region's follower or leader and keep first tried node as possible as he can in following request, it will try next node if meet fail.
- tiflash: will send request to tiflash node and try next next node if meet failure.

there are some duplicate code for them, and we'd better use uniform form logic with different strategy to handle it, it will be easier to add new strategy in future

for example: add locality strategy to tiflash and follower read at same time; add label based route filter

### What is changed and how it works?

(1) split engine store in different store lists for a region

current, tikv/tiflash node are mixed in `regionStore.stores`, so for tikv request we need filter tikv node out, and for tiflash find tiflash node in list

it seems we have no requirement for "try tidb then try tiflash logic", if we split them into two different slice will make TiKV request  and TiFlash request can reuse same logic:

send request to currIdx node(leader idx for kv, round-robin idx for tiflash) and try next node(redirect to leader if tikv, success or retry next for tiflash)

(2) using same `GetRPCContext`  and `switchToNextPeer` 

after tikv leader/tiflash can using same logic, so we can use one `GetRPCContext` to handle tiflash and tikv leader request, the remain question is follower-read.

the only difference between follower-read and other is `RouteStragegy`:

- tikv leader request and tiflash: always route to currIdx 
- follower read: route to last access node and try others if failure

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - refactor code

Side effects

 - n/a

Related changes

 - no need to cherry-pick to the release, and target 4.0

Release note

 - more uniform logic handle leader/follower-read/tiflash request

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/13398)
<!-- Reviewable:end -->
