### PR TITLE
expression: implement vectorized evaluation for builtinFindInSetSig

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -800,15 +800,13 @@ func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 		return err
 	}
 	result.ResizeInt64(n, false)
+	result.MergeNulls(str, strlist)
 	res := result.Int64s()
 	for i := 0; i < n; i++ {
-		if str.IsNull(i) || strlist.IsNull(i) {
-			result.SetNull(i, true)
-			continue
-		}
 		strlistI := strlist.GetString(i)
 		if len(strlistI) == 0 {
 			res[i] = 0
+			continue
 		}
 		for j, strInSet := range strings.Split(strlistI, ",") {
 			if str.GetString(i) == strInSet {

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -806,11 +806,11 @@ func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 			result.SetNull(i, true)
 			continue
 		}
-		strlist_i := strlist.GetString(i)
-		if len(strlist_i) == 0 {
+		strlistI := strlist.GetString(i)
+		if len(strlistI) == 0 {
 			res[i] = 0
 		}
-		for j, strInSet := range strings.Split(strlist_i, ",") {
+		for j, strInSet := range strings.Split(strlistI, ",") {
 			if str.GetString(i) == strInSet {
 				res[i] = int64(j + 1)
 			}

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -778,7 +778,41 @@ func (b *builtinLpadSig) vecEvalString(input *chunk.Chunk, result *chunk.Column)
 }
 
 func (b *builtinFindInSetSig) vectorized() bool {
-	return false
+	n := input.NumRows()
+	str, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(str)
+	if err := b.args[0].VecEvalString(b.ctx, input, str); err != nil {
+		return err
+	}
+	strlist, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(strlist)
+	if err := b.args[1].VecEvalString(b.ctx, input, strlist); err != nil {
+		return err
+	}
+	result.ResizeInt64(n, false)
+	res := result.Int64s()
+	for i := 0; i < n; i++ {
+		if str.IsNull(i) || strlist.IsNull(i) {
+			result.SetNull(i, true)
+			continue
+		}
+		strlist_i := strlist.GetString(i)
+		if len(strlist_i) == 0 {
+			res[i] = 0
+		}
+		for j, strInSet := range strings.Split(strlist_i, ",") {
+			if str.GetString(i) == strInSet {
+				res[i] = int64(j + 1)
+			}
+		}
+	}
+	return nil
 }
 
 func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -803,6 +803,9 @@ func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 	result.MergeNulls(str, strlist)
 	res := result.Int64s()
 	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
 		strlistI := strlist.GetString(i)
 		if len(strlistI) == 0 {
 			res[i] = 0

--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -778,6 +778,10 @@ func (b *builtinLpadSig) vecEvalString(input *chunk.Chunk, result *chunk.Column)
 }
 
 func (b *builtinFindInSetSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	str, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
@@ -813,10 +817,6 @@ func (b *builtinFindInSetSig) vectorized() bool {
 		}
 	}
 	return nil
-}
-
-func (b *builtinFindInSetSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinLeftBinarySig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -168,6 +168,8 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	},
 	ast.FindInSet: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 1}, &randLenStrGener{0, 10}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 10}, &randLenStrGener{0, 1}}},
 	},
 	ast.MakeSet: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString}},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -166,7 +166,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.BitLength: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},
-	ast.FindInSet: {},
+	ast.FindInSet: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
+	},
 	ast.MakeSet: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString}},
 	},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -167,9 +167,10 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},
 	ast.FindInSet: {
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 1}, &randLenStrGener{0, 10}}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&randLenStrGener{0, 10}, &randLenStrGener{0, 1}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"case"}, &constStrGener{"test,case"}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"testcase"}, &constStrGener{"test,case"}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{""}, &constStrGener{"test,case"}}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"test"}, &constStrGener{""}}},
 	},
 	ast.MakeSet: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString}},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -167,10 +167,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},
 	ast.FindInSet: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"case"}, &constStrGener{"test,case"}}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"testcase"}, &constStrGener{"test,case"}}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{""}, &constStrGener{"test,case"}}},
-		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&constStrGener{"test"}, &constStrGener{""}}},
 	},
 	ast.MakeSet: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString, types.ETString}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12103
### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinFindInSetSig

### What is changed and how it works?

```
BenchmarkVectorizedBuiltinStringFunc/builtinFindInSetSig-VecBuiltinFunc-8         	   21078	     56566 ns/op	   10640 B/op	     665 allocs/op

BenchmarkVectorizedBuiltinStringFunc/builtinFindInSetSig-NonVecBuiltinFunc-8      	   10000	    101829 ns/op	   10640 B/op	     665 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 