### PR TITLE
planner: support point get by `_tidb_rowid` (#13360)

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -609,9 +609,7 @@ drop table if exists t;
 create table t(a int);
 explain select * from t where _tidb_rowid = 0;
 id	count	task	operator info
-Projection_4	8000.00	root	test.t.a
-└─TableReader_6	10000.00	root	data:TableScan_5
-  └─TableScan_5	10000.00	cop	table:t, range:[0,0], keep order:false, stats:pseudo
+Point_Get_1	1.00	root	table:t, handle:0
 explain select * from t where _tidb_rowid > 0;
 id	count	task	operator info
 Projection_4	8000.00	root	test.t.a

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -564,3 +564,14 @@ func (s *testPointGetSuite) TestForUpdateRetry(c *C) {
 	_, err := tk.Exec("commit")
 	c.Assert(session.ErrForUpdateCantRetry.Equal(err), IsTrue)
 }
+
+func (s *testPointGetSuite) TestPointGetByRowID(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a varchar(20), b int)")
+	tk.MustExec("insert into t values(\"aaa\", 12)")
+	tk.MustQuery("explain select * from t where t._tidb_rowid = 1").Check(testkit.Rows(
+		"Point_Get_1 1.00 root table:t, handle:1"))
+	tk.MustQuery("select * from t where t._tidb_rowid = 1").Check(testkit.Rows("aaa 12"))
+}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -438,6 +438,10 @@ func getNameValuePairs(nvPairs []nameValuePair, tblName model.CIStr, expr ast.Ex
 
 func findPKHandle(tblInfo *model.TableInfo, pairs []nameValuePair) (handlePair nameValuePair, fieldType *types.FieldType) {
 	if !tblInfo.PKIsHandle {
+		rowIDIdx := findInPairs("_tidb_rowid", pairs)
+		if rowIDIdx != -1 {
+			return pairs[rowIDIdx], types.NewFieldType(mysql.TypeLonglong)
+		}
 		return handlePair, nil
 	}
 	for _, col := range tblInfo.Columns {


### PR DESCRIPTION
cherry-pick 3.0: planner: support point get by `_tidb_rowid` (#13360)