### PR TITLE
test: make several slow package unit test support run parallel 

### DIFF
--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -36,8 +36,12 @@ import (
 )
 
 var _ = Suite(&testPrepareSuite{})
+var _ = SerialSuites(&testPrepareSerialSuite{})
 
 type testPrepareSuite struct {
+}
+
+type testPrepareSerialSuite struct {
 }
 
 func (s *testPrepareSuite) TestPrepareCache(c *C) {
@@ -311,7 +315,7 @@ func (s *testPrepareSuite) TestPrepareOverMaxPreparedStmtCount(c *C) {
 }
 
 // unit test for issue https://github.com/pingcap/tidb/issues/8518
-func (s *testPrepareSuite) TestPrepareTableAsNameOnGroupByWithCache(c *C) {
+func (s *testPrepareSerialSuite) TestPrepareTableAsNameOnGroupByWithCache(c *C) {
 	defer testleak.AfterTest(c)()
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/pingcap/tidb/util/testleak"
 )
 
-var _ = Suite(&testPessimisticSuite{})
+var _ = SerialSuites(&testPessimisticSuite{})
 
 type testPessimisticSuite struct {
 	cluster   *mocktikv.Cluster

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -51,7 +51,7 @@ import (
 	"google.golang.org/grpc"
 )
 
-var _ = Suite(&testSessionSuite{})
+var _ = SerialSuites(&testSessionSuite{})
 
 type testSessionSuite struct {
 	cluster   *mocktikv.Cluster


### PR DESCRIPTION
### What problem does this PR solve?
make several package unit test support run unit test parallel to speed up unit test running

### What is changed and how it works?
some unit test need to change global variables to set up running environment, thus make it impossible to run in parallel. By move these test into independent test suite and use `SerialSuites` instead of `Suite`, we can make sure they will still run in serial, so it will be safe to open the parallel flag for other tests.

Here is the result:
Before change:
```
>  go test -v -vet=off -p 10 -race github.com/pingcap/tidb/planner/core
ok  	github.com/pingcap/tidb/planner/core	110.140s

> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/session
ok  	github.com/pingcap/tidb/session	123.002s
```

After change:
```
> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/planner/core -check.p=true
ok  	github.com/pingcap/tidb/planner/core	41.524s

> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/session -check.p=true
ok  	github.com/pingcap/tidb/session	95.673s
```

### Check List
Tests

- unit tests

Code changes

Side effects

Related changes