### PR TITLE
Cherry pick follower read to TiDB (#11347)

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -153,12 +153,13 @@ func (builder *RequestBuilder) getKVPriority(sv *variable.SessionVars) int {
 }
 
 // SetFromSessionVars sets the following fields for "kv.Request" from session variables:
-// "Concurrency", "IsolationLevel", "NotFillCache".
+// "Concurrency", "IsolationLevel", "NotFillCache", "ReplicaRead".
 func (builder *RequestBuilder) SetFromSessionVars(sv *variable.SessionVars) *RequestBuilder {
 	builder.Request.Concurrency = sv.DistSQLScanConcurrency
 	builder.Request.IsolationLevel = builder.getIsolationLevel()
 	builder.Request.NotFillCache = sv.StmtCtx.NotFillCache
 	builder.Request.Priority = builder.getKVPriority(sv)
+	builder.Request.ReplicaRead = sv.ReplicaRead
 	return builder
 }
 

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -311,6 +311,7 @@ func (s *testSuite) TestRequestBuilder1(c *C) {
 		NotFillCache:   false,
 		SyncLog:        false,
 		Streaming:      false,
+		ReplicaRead:    kv.ReplicaReadLeader,
 	}
 	c.Assert(actual, DeepEquals, expect)
 }
@@ -385,6 +386,7 @@ func (s *testSuite) TestRequestBuilder2(c *C) {
 		NotFillCache:   false,
 		SyncLog:        false,
 		Streaming:      false,
+		ReplicaRead:    kv.ReplicaReadLeader,
 	}
 	c.Assert(actual, DeepEquals, expect)
 }
@@ -429,6 +431,7 @@ func (s *testSuite) TestRequestBuilder3(c *C) {
 		NotFillCache:   false,
 		SyncLog:        false,
 		Streaming:      false,
+		ReplicaRead:    kv.ReplicaReadLeader,
 	}
 	c.Assert(actual, DeepEquals, expect)
 }
@@ -474,6 +477,7 @@ func (s *testSuite) TestRequestBuilder4(c *C) {
 		Streaming:      true,
 		NotFillCache:   false,
 		SyncLog:        false,
+		ReplicaRead:    kv.ReplicaReadLeader,
 	}
 	c.Assert(actual, DeepEquals, expect)
 }
@@ -550,6 +554,35 @@ func (s *testSuite) TestRequestBuilder6(c *C) {
 		NotFillCache:   true,
 		SyncLog:        false,
 		Streaming:      false,
+	}
+
+	c.Assert(actual, DeepEquals, expect)
+}
+
+func (s *testSuite) TestRequestBuilder7(c *C) {
+	vars := variable.NewSessionVars()
+	vars.ReplicaRead = kv.ReplicaReadFollower
+
+	concurrency := 10
+
+	actual, err := (&RequestBuilder{}).
+		SetFromSessionVars(vars).
+		SetConcurrency(concurrency).
+		Build()
+	c.Assert(err, IsNil)
+
+	expect := &kv.Request{
+		Tp:             0,
+		StartTs:        0x0,
+		KeepOrder:      false,
+		Desc:           false,
+		Concurrency:    concurrency,
+		IsolationLevel: 0,
+		Priority:       0,
+		NotFillCache:   false,
+		SyncLog:        false,
+		Streaming:      false,
+		ReplicaRead:    kv.ReplicaReadFollower,
 	}
 
 	c.Assert(actual, DeepEquals, expect)

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -106,6 +106,16 @@ PARTITION BY RANGE ( a ) (
 	}
 }
 
+func (s *testSuite1) TestAnalyzeReplicaReadFollower(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int)")
+	ctx := tk.Se.(sessionctx.Context)
+	ctx.GetSessionVars().ReplicaRead = kv.ReplicaReadFollower
+	tk.MustExec("analyze table t")
+}
+
 func (s *testSuite1) TestAnalyzeParameters(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -93,6 +93,9 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 	if err != nil {
 		return err
 	}
+	if e.ctx.GetSessionVars().ReplicaRead.IsFollowerRead() {
+		e.snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
+	}
 	if e.idxInfo != nil {
 		idxKey, err1 := e.encodeIndexKey()
 		if err1 != nil && !kv.ErrNotExist.Equal(err1) {

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -232,3 +232,6 @@ func (s *mockSnapshot) Iter(k Key, upperBound Key) (Iterator, error) {
 func (s *mockSnapshot) IterReverse(k Key) (Iterator, error) {
 	return s.store.IterReverse(k)
 }
+
+func (s *mockSnapshot) SetOption(opt Option, val interface{}) {}
+func (s *mockSnapshot) DelOption(opt Option)                  {}

--- a/session/session.go
+++ b/session/session.go
@@ -186,6 +186,9 @@ type session struct {
 	statsCollector *handle.SessionStatsCollector
 	// ddlOwnerChecker is used in `select tidb_is_ddl_owner()` statement;
 	ddlOwnerChecker owner.DDLOwnerChecker
+
+	// shared coprocessor client per session
+	client kv.Client
 }
 
 // DDLOwnerChecker returns s.ddlOwnerChecker.
@@ -495,7 +498,7 @@ func (s *session) RollbackTxn(ctx context.Context) {
 }
 
 func (s *session) GetClient() kv.Client {
-	return s.store.GetClient()
+	return s.client
 }
 
 func (s *session) String() string {
@@ -1271,6 +1274,9 @@ func (s *session) Txn(active bool) (kv.Transaction, error) {
 		if !s.sessionVars.IsAutocommit() {
 			s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
 		}
+		if s.sessionVars.ReplicaRead.IsFollowerRead() {
+			s.txn.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
+		}
 	}
 	return &s.txn, nil
 }
@@ -1294,6 +1300,9 @@ func (s *session) NewTxn(ctx context.Context) error {
 	}
 	txn.SetCap(s.getMembufCap())
 	txn.SetVars(s.sessionVars.KVVars)
+	if s.GetSessionVars().ReplicaRead.IsFollowerRead() {
+		txn.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
+	}
 	s.txn.changeInvalidToValid(txn)
 	is := domain.GetDomain(s).InfoSchema()
 	s.sessionVars.TxnCtx = &variable.TransactionContext{
@@ -1573,6 +1582,7 @@ func createSession(store kv.Storage) (*session, error) {
 		parser:          parser.New(),
 		sessionVars:     variable.NewSessionVars(),
 		ddlOwnerChecker: dom.DDL().OwnerManager(),
+		client:          store.GetClient(),
 	}
 	if plannercore.PreparedPlanCacheEnabled() {
 		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity,
@@ -1596,6 +1606,7 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 		store:       store,
 		parser:      parser.New(),
 		sessionVars: variable.NewSessionVars(),
+		client:      store.GetClient(),
 	}
 	if plannercore.PreparedPlanCacheEnabled() {
 		s.preparedPlanCache = kvcache.NewSimpleLRUCache(plannercore.PreparedPlanCacheCapacity,

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2714,3 +2714,15 @@ func (s *testSessionSuite) TestGrantViewRelated(c *C) {
 	tkUser.MustQuery("select current_user();").Check(testkit.Rows("u_version29@%"))
 	tkUser.MustExec("create view v_version29_c as select * from v_version29;")
 }
+
+func (s *testSessionSuite) TestReplicaRead(c *C) {
+	var err error
+	tk := testkit.NewTestKit(c, s.store)
+	tk.Se, err = session.CreateSession4Test(s.store)
+	c.Assert(err, IsNil)
+	c.Assert(tk.Se.GetSessionVars().ReplicaRead, Equals, kv.ReplicaReadLeader)
+	tk.MustExec("set @@tidb_replica_read = 'follower';")
+	c.Assert(tk.Se.GetSessionVars().ReplicaRead, Equals, kv.ReplicaReadFollower)
+	tk.MustExec("set @@tidb_replica_read = 'leader';")
+	c.Assert(tk.Se.GetSessionVars().ReplicaRead, Equals, kv.ReplicaReadLeader)
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -393,6 +393,9 @@ type SessionVars struct {
 	// ConnectionInfo indicates current connection info used by current session, only be lazy assigned by plugin.
 	ConnectionInfo *ConnectionInfo
 
+	// ReplicaRead is used for reading data from replicas, only follower is supported at this time.
+	ReplicaRead kv.ReplicaReadType
+
 	// StartTime is the start time of the last query.
 	StartTime time.Time
 
@@ -473,6 +476,7 @@ func NewSessionVars() *SessionVars {
 		SlowQueryFile:               config.GetGlobalConfig().Log.SlowQueryFile,
 		WaitSplitRegionFinish:       DefTiDBWaitSplitRegionFinish,
 		WaitSplitRegionTimeout:      DefWaitSplitRegionTimeout,
+		ReplicaRead:                 kv.ReplicaReadLeader,
 		AllowRemoveAutoInc:          DefTiDBAllowRemoveAutoInc,
 		LockWaitTimeout:             DefInnodbLockWaitTimeout * 1000,
 	}
@@ -846,6 +850,12 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	// It's a global variable, but it also wants to be cached in server.
 	case TiDBMaxDeltaSchemaCount:
 		SetMaxDeltaSchemaCount(tidbOptInt64(val, DefTiDBMaxDeltaSchemaCount))
+	case TiDBReplicaRead:
+		if strings.EqualFold(val, "follower") {
+			s.ReplicaRead = kv.ReplicaReadFollower
+		} else if strings.EqualFold(val, "leader") || len(val) == 0 {
+			s.ReplicaRead = kv.ReplicaReadLeader
+		}
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -712,6 +712,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBWaitSplitRegionTimeout, strconv.Itoa(DefWaitSplitRegionTimeout)},
 	{ScopeSession, TiDBLowResolutionTSO, "0"},
 	{ScopeSession, TiDBExpensiveQueryTimeThreshold, strconv.Itoa(DefTiDBExpensiveQueryTimeThreshold)},
+	{ScopeSession, TiDBReplicaRead, "leader"},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
 	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, "0"},
 }

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -46,6 +46,9 @@ func (*testSysVarSuite) TestSysVar(c *C) {
 
 	f = GetSysVar("tidb_low_resolution_tso")
 	c.Assert(f.Value, Equals, "0")
+
+	f = GetSysVar("tidb_replica_read")
+	c.Assert(f.Value, Equals, "leader")
 }
 
 func (*testSysVarSuite) TestTxnMode(c *C) {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -146,6 +146,9 @@ const (
 	// TiDBLowResolutionTSO is used for reading data with low resolution TSO which is updated once every two seconds
 	TiDBLowResolutionTSO = "tidb_low_resolution_tso"
 
+	// TiDBReplicaRead is used for reading data from replicas, followers for example.
+	TiDBReplicaRead = "tidb_replica_read"
+
 	// TiDBAllowRemoveAutoInc indicates whether a user can drop the auto_increment column attribute or not.
 	TiDBAllowRemoveAutoInc = "tidb_allow_remove_auto_inc"
 )

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -585,6 +585,13 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		default:
 			return value, ErrWrongValueForVar.GenWithStackByArgs(TiDBTxnMode, value)
 		}
+	case TiDBReplicaRead:
+		if strings.EqualFold(value, "follower") {
+			return "follower", nil
+		} else if strings.EqualFold(value, "leader") || len(value) == 0 {
+			return "leader", nil
+		}
+		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
 	case TiDBAllowRemoveAutoInc:
 		switch {
 		case strings.EqualFold(value, "ON") || value == "1":

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testleak"
 )
@@ -294,6 +295,17 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 	c.Assert(v.CorrelationThreshold, Equals, float64(0))
+
+	SetSessionSystemVar(v, TiDBReplicaRead, types.NewStringDatum("follower"))
+	val, err = GetSessionSystemVar(v, TiDBReplicaRead)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "follower")
+	c.Assert(v.ReplicaRead, Equals, kv.ReplicaReadFollower)
+	SetSessionSystemVar(v, TiDBReplicaRead, types.NewStringDatum("leader"))
+	val, err = GetSessionSystemVar(v, TiDBReplicaRead)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "leader")
+	c.Assert(v.ReplicaRead, Equals, kv.ReplicaReadLeader)
 }
 
 func (s *testVarsutilSuite) TestValidate(c *C) {
@@ -348,6 +360,7 @@ func (s *testVarsutilSuite) TestValidate(c *C) {
 		{TiDBTxnMode, "pessimistic", false},
 		{TiDBTxnMode, "optimistic", false},
 		{TiDBTxnMode, "", false},
+		{TiDBReplicaRead, "invalid", true},
 	}
 
 	for _, t := range tests {

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -21,6 +21,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/coreos/etcd/clientv3"
@@ -145,6 +146,8 @@ type tikvStore struct {
 	spTime    time.Time
 	spMutex   sync.RWMutex  // this is used to update safePoint and spTime
 	closed    chan struct{} // this is used to nofity when the store is closed
+
+	replicaReadSeed uint32 // this is used to load balance followers / learners when replica read is enabled
 }
 
 func (s *tikvStore) UpdateSPCache(cachedSP uint64, cachedTime time.Time) {
@@ -180,16 +183,17 @@ func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Clie
 		return nil, errors.Trace(err)
 	}
 	store := &tikvStore{
-		clusterID:   pdClient.GetClusterID(context.TODO()),
-		uuid:        uuid,
-		oracle:      o,
-		client:      client,
-		pdClient:    pdClient,
-		regionCache: NewRegionCache(pdClient),
-		kv:          spkv,
-		safePoint:   0,
-		spTime:      time.Now(),
-		closed:      make(chan struct{}),
+		clusterID:       pdClient.GetClusterID(context.TODO()),
+		uuid:            uuid,
+		oracle:          o,
+		client:          client,
+		pdClient:        pdClient,
+		regionCache:     NewRegionCache(pdClient),
+		kv:              spkv,
+		safePoint:       0,
+		spTime:          time.Now(),
+		closed:          make(chan struct{}),
+		replicaReadSeed: rand.Uint32(),
 	}
 	store.lockResolver = newLockResolver(store)
 	store.enableGC = enableGC
@@ -263,7 +267,7 @@ func (s *tikvStore) Begin() (kv.Transaction, error) {
 
 // BeginWithStartTS begins a transaction with startTS.
 func (s *tikvStore) BeginWithStartTS(startTS uint64) (kv.Transaction, error) {
-	txn, err := newTikvTxnWithStartTS(s, startTS)
+	txn, err := newTikvTxnWithStartTS(s, startTS, s.nextReplicaReadSeed())
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -272,7 +276,7 @@ func (s *tikvStore) BeginWithStartTS(startTS uint64) (kv.Transaction, error) {
 }
 
 func (s *tikvStore) GetSnapshot(ver kv.Version) (kv.Snapshot, error) {
-	snapshot := newTiKVSnapshot(s, ver)
+	snapshot := newTiKVSnapshotWithReplicaReadSeed(s, ver, s.nextReplicaReadSeed())
 	metrics.TiKVSnapshotCounter.Inc()
 	return snapshot, nil
 }
@@ -336,9 +340,14 @@ func (s *tikvStore) getTimestampWithRetry(bo *Backoffer) (uint64, error) {
 	}
 }
 
+func (s *tikvStore) nextReplicaReadSeed() uint32 {
+	return atomic.AddUint32(&s.replicaReadSeed, 1)
+}
+
 func (s *tikvStore) GetClient() kv.Client {
 	return &CopClient{
-		store: s,
+		store:           s,
+		replicaReadSeed: s.nextReplicaReadSeed(),
 	}
 }
 

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/pd/client"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
@@ -85,6 +86,26 @@ func (r *RegionStore) clone() *RegionStore {
 		stores:       r.stores,
 		storeFails:   storeFails,
 	}
+}
+
+// return next follower store's index
+func (r *RegionStore) follower(seed uint32) int32 {
+	l := uint32(len(r.stores))
+	if l <= 1 {
+		return r.workStoreIdx
+	}
+
+	for retry := l - 1; retry > 0; retry-- {
+		followerIdx := int32(seed % (l - 1))
+		if followerIdx >= r.workStoreIdx {
+			followerIdx++
+		}
+		if r.storeFails[followerIdx] == atomic.LoadUint32(&r.stores[followerIdx].fail) {
+			return followerIdx
+		}
+		seed++
+	}
+	return r.workStoreIdx
 }
 
 // init initializes region after constructed.
@@ -258,7 +279,7 @@ func (c *RPCContext) String() string {
 
 // GetRPCContext returns RPCContext for a region. If it returns nil, the region
 // must be out of date and already dropped from cache.
-func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID) (*RPCContext, error) {
+func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID, replicaRead kv.ReplicaReadType, followerStoreSeed uint32) (*RPCContext, error) {
 	ts := time.Now().Unix()
 
 	cachedRegion := c.getCachedRegionWithRLock(id)
@@ -271,7 +292,15 @@ func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID) (*RPCContext,
 	}
 
 	regionStore := cachedRegion.getStore()
-	store, peer, storeIdx := cachedRegion.WorkStorePeer(regionStore)
+	var store *Store
+	var peer *metapb.Peer
+	var storeIdx int
+	switch replicaRead {
+	case kv.ReplicaReadFollower:
+		store, peer, storeIdx = cachedRegion.FollowerStorePeer(regionStore, followerStoreSeed)
+	default:
+		store, peer, storeIdx = cachedRegion.WorkStorePeer(regionStore)
+	}
 	addr, err := c.getStoreAddr(bo, cachedRegion, store, storeIdx)
 	if err != nil {
 		return nil, err
@@ -289,7 +318,7 @@ func (c *RegionCache) GetRPCContext(bo *Backoffer, id RegionVerID) (*RPCContext,
 	}
 
 	storeFailEpoch := atomic.LoadUint32(&store.fail)
-	if storeFailEpoch != regionStore.storeFails[regionStore.workStoreIdx] {
+	if storeFailEpoch != regionStore.storeFails[storeIdx] {
 		cachedRegion.invalidate()
 		logutil.Logger(context.Background()).Info("invalidate current region, because others failed on same store",
 			zap.Uint64("region", id.GetID()),
@@ -841,12 +870,21 @@ func (r *Region) GetLeaderStoreID() uint64 {
 	return r.meta.Peers[int(r.getStore().workStoreIdx)].StoreId
 }
 
+func (r *Region) getStorePeer(rs *RegionStore, pidx int32) (store *Store, peer *metapb.Peer, idx int) {
+	store = rs.stores[pidx]
+	peer = r.meta.Peers[pidx]
+	idx = int(pidx)
+	return
+}
+
 // WorkStorePeer returns current work store with work peer.
 func (r *Region) WorkStorePeer(rs *RegionStore) (store *Store, peer *metapb.Peer, idx int) {
-	idx = int(rs.workStoreIdx)
-	store = rs.stores[rs.workStoreIdx]
-	peer = r.meta.Peers[rs.workStoreIdx]
-	return
+	return r.getStorePeer(rs, rs.workStoreIdx)
+}
+
+// FollowerStorePeer returns a follower store with follower peer.
+func (r *Region) FollowerStorePeer(rs *RegionStore, followerStoreSeed uint32) (store *Store, peer *metapb.Peer, idx int) {
+	return r.getStorePeer(rs, rs.follower(followerStoreSeed))
 }
 
 // RegionVerID is a unique ID that can identify a Region at a specific version.
@@ -890,17 +928,18 @@ func (c *RegionCache) switchToPeer(r *Region, targetStoreID uint64) (found bool)
 
 func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
 	rs := r.getStore()
-	if int(rs.workStoreIdx) != currentPeerIdx {
-		return
-	}
 
 	if err != nil { // TODO: refine err, only do this for some errors.
-		s := rs.stores[rs.workStoreIdx]
-		epoch := rs.storeFails[rs.workStoreIdx]
+		s := rs.stores[currentPeerIdx]
+		epoch := rs.storeFails[currentPeerIdx]
 		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
 			logutil.Logger(context.Background()).Info("mark store's regions need be refill", zap.String("store", s.addr))
 			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
 		}
+	}
+
+	if int(rs.workStoreIdx) != currentPeerIdx {
+		return
 	}
 
 	nextIdx := (currentPeerIdx + 1) % len(rs.stores)

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -17,22 +17,24 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
 	"github.com/google/btree"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testRegionCacheSuite struct {
 	OneByOneSuite
 	cluster *mocktikv.Cluster
-	store1  uint64
-	store2  uint64
-	peer1   uint64
-	peer2   uint64
+	store1  uint64 // store1 is leader
+	store2  uint64 // store2 is follower
+	peer1   uint64 // peer1 is leader
+	peer2   uint64 // peer2 is follower
 	region1 uint64
 	cache   *RegionCache
 	bo      *Backoffer
@@ -105,10 +107,10 @@ func (s *testRegionCacheSuite) getRegionWithEndKey(c *C, key []byte) *Region {
 	return r
 }
 
-func (s *testRegionCacheSuite) getAddr(c *C, key []byte) string {
+func (s *testRegionCacheSuite) getAddr(c *C, key []byte, replicaRead kv.ReplicaReadType, seed uint32) string {
 	loc, err := s.cache.LocateKey(s.bo, key)
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region, replicaRead, seed)
 	c.Assert(err, IsNil)
 	if ctx == nil {
 		return ""
@@ -117,10 +119,12 @@ func (s *testRegionCacheSuite) getAddr(c *C, key []byte) string {
 }
 
 func (s *testRegionCacheSuite) TestSimple(c *C) {
+	seed := rand.Uint32()
 	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 	s.checkCache(c, 1)
 	c.Assert(r.GetMeta(), DeepEquals, r.meta)
 	c.Assert(r.GetLeaderID(), Equals, r.meta.Peers[r.getStore().workStoreIdx].Id)
@@ -134,7 +138,10 @@ func (s *testRegionCacheSuite) TestDropStore(c *C) {
 	s.cluster.RemoveStore(s.store1)
 	loc, err := s.cache.LocateKey(bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetRPCContext(bo, loc.Region)
+	ctx, err := s.cache.GetRPCContext(bo, loc.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ctx, IsNil)
+	ctx, err = s.cache.GetRPCContext(bo, loc.Region, kv.ReplicaReadFollower, rand.Uint32())
 	c.Assert(err, IsNil)
 	c.Assert(ctx, IsNil)
 	s.checkCache(c, 0)
@@ -155,6 +162,7 @@ func (s *testRegionCacheSuite) TestDropStoreRetry(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
+	seed := rand.Uint32()
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// tikv-server reports `NotLeader`
@@ -163,15 +171,18 @@ func (s *testRegionCacheSuite) TestUpdateLeader(c *C) {
 	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(s.store2))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store2))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store1))
 
 	r = s.getRegionWithEndKey(c, []byte("z"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("z")), Equals, s.storeAddr(s.store2))
+	c.Assert(s.getAddr(c, []byte("z"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store2))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store1))
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
+	seed := rand.Uint32()
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// new store3 becomes leader
@@ -186,7 +197,20 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store1))
+	follower := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
+	if seed%2 == 0 {
+		c.Assert(follower, Equals, s.storeAddr(s.store2))
+	} else {
+		c.Assert(follower, Equals, s.storeAddr(store3))
+	}
+	follower2 := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
+	if (seed+1)%2 == 0 {
+		c.Assert(follower2, Equals, s.storeAddr(s.store2))
+	} else {
+		c.Assert(follower2, Equals, s.storeAddr(store3))
+	}
+	c.Assert(follower, Not(Equals), follower2)
 
 	// tikv-server notifies new leader to pd-server.
 	s.cluster.ChangeLeader(s.region1, peer3)
@@ -195,10 +219,24 @@ func (s *testRegionCacheSuite) TestUpdateLeader2(c *C) {
 	r = s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(store3))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(store3))
+	follower = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
+	if seed%2 == 0 {
+		c.Assert(follower, Equals, s.storeAddr(s.store1))
+	} else {
+		c.Assert(follower, Equals, s.storeAddr(s.store2))
+	}
+	follower2 = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
+	if (seed+1)%2 == 0 {
+		c.Assert(follower2, Equals, s.storeAddr(s.store1))
+	} else {
+		c.Assert(follower2, Equals, s.storeAddr(s.store2))
+	}
+	c.Assert(follower, Not(Equals), follower2)
 }
 
 func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
+	seed := rand.Uint32()
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 	// store2 becomes leader
@@ -219,11 +257,16 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	addr := s.getAddr(c, []byte("a"))
+	addr := s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0)
 	c.Assert(addr, Equals, "")
 	s.getRegion(c, []byte("a"))
 	// pd-server should return the new leader.
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(store3))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(store3))
+	addr = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
+	c.Assert(addr == s.storeAddr(s.store1) || len(addr) == 0, IsTrue)
+	addr2 := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
+	c.Assert(addr2 == s.storeAddr(s.store1) || len(addr2) == 0, IsTrue)
+	c.Assert((len(addr2) == 0 && len(addr) == 0) || addr != addr2, IsTrue)
 }
 
 func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
@@ -236,22 +279,74 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
+	// verify follower to be one of store2 and store3
+	seed := rand.Uint32()
+	ctxFollower1, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
+
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
+	// verify follower to be one of store1 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
+
 	// access 1 it will return NotLeader, leader back to 2 again
 	s.cache.UpdateLeader(loc.Region, s.store2, ctx.PeerIdx)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
+
+	// verify follower to be one of store1 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 }
 
 func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
@@ -264,30 +359,100 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
+	// verify follower to be one of store2 and store3
+	seed := rand.Uint32()
+	ctxFollower1, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
+
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
+	// verify follower to be one of store1 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id == s.peer1 || ctxFollower1.Peer.Id == peer3, IsTrue)
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
+
 	// access 2, it's in hibernate and return 0 leader, so switch to 3
 	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
 
+	// verify follower to be one of store1 and store2
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
+
 	// again peer back to 1
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
+
+	// verify follower to be one of store2 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 }
 
 func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
@@ -305,12 +470,12 @@ func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
 	c.Assert(loc2.Region.id, Equals, region2)
 
 	// Send fail on region1
-	ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region)
+	ctx, _ := s.cache.GetRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	s.checkCache(c, 2)
 	s.cache.OnSendFail(s.bo, ctx, false, errors.New("test error"))
 
 	// Get region2 cache will get nil then reload.
-	ctx2, err := s.cache.GetRPCContext(s.bo, loc2.Region)
+	ctx2, err := s.cache.GetRPCContext(s.bo, loc2.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(ctx2, IsNil)
 	c.Assert(err, IsNil)
 }
@@ -325,34 +490,106 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
-	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
 	c.Assert(len(ctx.Meta.Peers), Equals, 3)
 
+	// verify follower to be one of store2 and store3
+	seed := rand.Uint32()
+	ctxFollower1, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
+
 	// send fail leader switch to 2
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
 
+	// verify follower to be one of store1 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
+
 	// send 2 fail leader switch to 3
 	s.cache.OnSendFail(s.bo, ctx, false, nil)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
 
+	// verify follower to be one of store1 and store2
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	}
+	c.Assert(ctxFollower1.Peer.Id == s.peer1 || ctxFollower1.Peer.Id == s.peer2, IsTrue)
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer1)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
+
 	// 3 can be access, so switch to 1
 	s.cache.UpdateLeader(loc.Region, s.store1, ctx.PeerIdx)
-	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region)
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
+
+	// verify follower to be one of store2 and store3
+	ctxFollower1, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed)
+	c.Assert(err, IsNil)
+	if seed%2 == 0 {
+		c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower1.Peer.Id, Equals, peer3)
+	}
+	ctxFollower2, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, seed+1)
+	c.Assert(err, IsNil)
+	if (seed+1)%2 == 0 {
+		c.Assert(ctxFollower2.Peer.Id, Equals, s.peer2)
+	} else {
+		c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	}
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 }
 
 func (s *testRegionCacheSuite) TestSplit(c *C) {
+	seed := rand.Uint32()
 	r := s.getRegion(c, []byte("x"))
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("x")), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("x"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("x"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 
 	// split to ['' - 'm' - 'z']
 	region2 := s.cluster.AllocID()
@@ -365,7 +602,8 @@ func (s *testRegionCacheSuite) TestSplit(c *C) {
 
 	r = s.getRegion(c, []byte("x"))
 	c.Assert(r.GetID(), Equals, region2)
-	c.Assert(s.getAddr(c, []byte("x")), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("x"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("x"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 	s.checkCache(c, 1)
 
 	r = s.getRegionWithEndKey(c, []byte("m"))
@@ -397,6 +635,7 @@ func (s *testRegionCacheSuite) TestMerge(c *C) {
 }
 
 func (s *testRegionCacheSuite) TestReconnect(c *C) {
+	seed := rand.Uint32()
 	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)
 
@@ -406,7 +645,8 @@ func (s *testRegionCacheSuite) TestReconnect(c *C) {
 	r := s.getRegion(c, []byte("a"))
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
-	c.Assert(s.getAddr(c, []byte("a")), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(s.store1))
+	c.Assert(s.getAddr(c, []byte("x"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 	s.checkCache(c, 1)
 }
 
@@ -528,6 +768,37 @@ func (s *testRegionCacheSuite) TestListRegionIDsInCache(c *C) {
 	regionIDs, err = s.cache.ListRegionIDsInKeyRange(s.bo, []byte("a"), []byte("m"))
 	c.Assert(err, IsNil)
 	c.Assert(regionIDs, DeepEquals, []uint64{s.region1, region2})
+}
+
+func (s *testRegionCacheSuite) TestFollowerReadFallback(c *C) {
+	// 3 nodes and no.1 is leader.
+	store3 := s.cluster.AllocID()
+	peer3 := s.cluster.AllocID()
+	s.cluster.AddStore(store3, s.storeAddr(store3))
+	s.cluster.AddPeer(s.region1, store3, peer3)
+	s.cluster.ChangeLeader(s.region1, s.peer1)
+
+	loc, err := s.cache.LocateKey(s.bo, []byte("a"))
+	c.Assert(err, IsNil)
+	ctx, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ctx.Peer.Id, Equals, s.peer1)
+	c.Assert(len(ctx.Meta.Peers), Equals, 3)
+
+	// verify follower to be store2 and store3
+	ctxFollower1, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ctxFollower1.Peer.Id, Equals, s.peer2)
+	ctxFollower2, err := s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 1)
+	c.Assert(err, IsNil)
+	c.Assert(ctxFollower2.Peer.Id, Equals, peer3)
+	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
+
+	// send fail on store2, next follower read is going to fallback to store3
+	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
+	ctx, err = s.cache.GetRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	c.Assert(err, IsNil)
+	c.Assert(ctx.Peer.Id, Equals, peer3)
 }
 
 func createSampleRegion(startKey, endKey []byte) *Region {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -96,8 +96,14 @@ func (s *RegionRequestSender) SendReqCtx(bo *Backoffer, req *tikvrpc.Request, re
 		}
 	})
 
+	var replicaRead kv.ReplicaReadType
+	if req.ReplicaRead {
+		replicaRead = kv.ReplicaReadFollower
+	} else {
+		replicaRead = kv.ReplicaReadLeader
+	}
 	for {
-		ctx, err := s.regionCache.GetRPCContext(bo, regionID)
+		ctx, err := s.regionCache.GetRPCContext(bo, regionID, replicaRead, req.ReplicaReadSeed)
 		if err != nil {
 			return nil, nil, errors.Trace(err)
 		}

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -144,6 +144,11 @@ func (s *testRegionRequestSuite) TestSendReqCtx(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(resp.RawPut, NotNil)
 	c.Assert(ctx, NotNil)
+	req.ReplicaRead = true
+	resp, ctx, err = s.regionRequestSender.SendReqCtx(s.bo, req, region.Region, time.Second)
+	c.Assert(err, IsNil)
+	c.Assert(resp.RawPut, NotNil)
+	c.Assert(ctx, NotNil)
 }
 
 func (s *testRegionRequestSuite) TestOnSendFailedWithCancelled(c *C) {
@@ -253,6 +258,9 @@ func (s *mockTikvGrpcServer) KvPessimisticLock(context.Context, *kvrpcpb.Pessimi
 func (s *mockTikvGrpcServer) KVPessimisticRollback(context.Context, *kvrpcpb.PessimisticRollbackRequest) (*kvrpcpb.PessimisticRollbackResponse, error) {
 	return nil, errors.New("unreachable")
 }
+func (s *mockTikvGrpcServer) KvTxnHeartBeat(ctx context.Context, in *kvrpcpb.TxnHeartBeatRequest) (*kvrpcpb.TxnHeartBeatResponse, error) {
+	return nil, errors.New("unreachable")
+}
 func (s *mockTikvGrpcServer) KvGC(context.Context, *kvrpcpb.GCRequest) (*kvrpcpb.GCResponse, error) {
 	return nil, errors.New("unreachable")
 }
@@ -317,9 +325,6 @@ func (s *mockTikvGrpcServer) BatchCommands(tikvpb.Tikv_BatchCommandsServer) erro
 	return errors.New("unreachable")
 }
 func (s *mockTikvGrpcServer) ReadIndex(context.Context, *kvrpcpb.ReadIndexRequest) (*kvrpcpb.ReadIndexResponse, error) {
-	return nil, errors.New("unreachable")
-}
-func (s *mockTikvGrpcServer) KvTxnHeartBeat(ctx context.Context, in *kvrpcpb.TxnHeartBeatRequest) (*kvrpcpb.TxnHeartBeatResponse, error) {
 	return nil, errors.New("unreachable")
 }
 

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -197,7 +197,9 @@ func (s *Scanner) getData(bo *Backoffer) error {
 			Context: pb.Context{
 				Priority:     s.snapshot.priority,
 				NotFillCache: s.snapshot.notFillCache,
+				ReplicaRead:  s.snapshot.replicaRead.IsFollowerRead(),
 			},
+			ReplicaReadSeed: s.snapshot.replicaReadSeed,
 		}
 		if s.reverse {
 			req.Scan.StartKey = s.nextEndKey

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -57,6 +57,9 @@ type tikvSnapshot struct {
 	keyOnly      bool
 	vars         *kv.Variables
 
+	replicaRead     kv.ReplicaReadType
+	replicaReadSeed uint32
+
 	// Cache the result of BatchGet.
 	// The invariance is that calling BatchGet multiple times using the same start ts,
 	// the result should not change.
@@ -70,10 +73,22 @@ type tikvSnapshot struct {
 // newTiKVSnapshot creates a snapshot of an TiKV store.
 func newTiKVSnapshot(store *tikvStore, ver kv.Version) *tikvSnapshot {
 	return &tikvSnapshot{
-		store:    store,
-		version:  ver,
-		priority: pb.CommandPri_Normal,
-		vars:     kv.DefaultVars,
+		store:           store,
+		version:         ver,
+		priority:        pb.CommandPri_Normal,
+		vars:            kv.DefaultVars,
+		replicaReadSeed: 0,
+	}
+}
+
+// newTiKVSnapshot creates a snapshot of an TiKV store with replicaReadSeed.
+func newTiKVSnapshotWithReplicaReadSeed(store *tikvStore, ver kv.Version, replicaReadSeed uint32) *tikvSnapshot {
+	return &tikvSnapshot{
+		store:           store,
+		version:         ver,
+		priority:        pb.CommandPri_Normal,
+		vars:            kv.DefaultVars,
+		replicaReadSeed: replicaReadSeed,
 	}
 }
 
@@ -202,7 +217,9 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 			Context: pb.Context{
 				Priority:     s.priority,
 				NotFillCache: s.notFillCache,
+				ReplicaRead:  s.replicaRead.IsFollowerRead(),
 			},
+			ReplicaReadSeed: s.replicaReadSeed,
 		}
 		resp, err := sender.SendReq(bo, req, batch.region, ReadTimeoutMedium)
 		if err != nil {
@@ -295,7 +312,9 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 		Context: pb.Context{
 			Priority:     s.priority,
 			NotFillCache: s.notFillCache,
+			ReplicaRead:  s.replicaRead.IsFollowerRead(),
 		},
+		ReplicaReadSeed: s.replicaReadSeed,
 	}
 	for {
 		loc, err := s.store.regionCache.LocateKey(bo, k)
@@ -353,6 +372,23 @@ func (s *tikvSnapshot) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 func (s *tikvSnapshot) IterReverse(k kv.Key) (kv.Iterator, error) {
 	scanner, err := newScanner(s, nil, k, scanBatchSize, true)
 	return scanner, errors.Trace(err)
+}
+
+// SetOption sets an option with a value, when val is nil, uses the default
+// value of this option. Only ReplicaRead is supported for snapshot
+func (s *tikvSnapshot) SetOption(opt kv.Option, val interface{}) {
+	switch opt {
+	case kv.ReplicaRead:
+		s.replicaRead = val.(kv.ReplicaReadType)
+	}
+}
+
+// ClearFollowerRead disables follower read on current transaction
+func (s *tikvSnapshot) DelOption(opt kv.Option) {
+	switch opt {
+	case kv.ReplicaRead:
+		s.replicaRead = kv.ReplicaReadLeader
+	}
 }
 
 func extractLockFromKeyErr(keyErr *pb.KeyError) (*Lock, error) {

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -169,6 +169,8 @@ type Request struct {
 
 	DebugGetRegionProperties *debugpb.GetRegionPropertiesRequest
 
+	ReplicaReadSeed uint32
+
 	Empty        *tikvpb.BatchCommandsEmptyRequest
 	TxnHeartBeat *kvrpcpb.TxnHeartBeatRequest
 }

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -78,13 +78,13 @@ func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	return newTikvTxnWithStartTS(store, startTS)
+	return newTikvTxnWithStartTS(store, startTS, store.nextReplicaReadSeed())
 }
 
 // newTikvTxnWithStartTS creates a txn with startTS.
-func newTikvTxnWithStartTS(store *tikvStore, startTS uint64) (*tikvTxn, error) {
+func newTikvTxnWithStartTS(store *tikvStore, startTS uint64, replicaReadSeed uint32) (*tikvTxn, error) {
 	ver := kv.NewVersion(startTS)
-	snapshot := newTiKVSnapshot(store, ver)
+	snapshot := newTiKVSnapshotWithReplicaReadSeed(store, ver, replicaReadSeed)
 	return &tikvTxn{
 		snapshot:  snapshot,
 		us:        kv.NewUnionStore(snapshot),

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -560,6 +560,10 @@ func ScanSnapshotTableRecord(sessCtx sessionctx.Context, store kv.Storage, ver k
 		return nil, 0, errors.Trace(err)
 	}
 
+	if sessCtx.GetSessionVars().ReplicaRead.IsFollowerRead() {
+		snap.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
+	}
+
 	records, nextHandle, err := ScanTableRecord(sessCtx, snap, t, startHandle, limit)
 
 	return records, nextHandle, errors.Trace(err)


### PR DESCRIPTION
cherry pick #11347 to 3.1

Fix code conflicts from 4.0 to 3.1. Users can use tidb_replica_read session variable to choose reading from leader or follower. To make it consistent with existing behavior, leader will be used by default unless follower is explicitly specified otherwise.

Add a session scope variable tidb_replica_read to specify if TiDB should read data from leader or follower.
