### PR TITLE
expression: implement vectorized evaluation for `builtinCastDecimalAsDecimalSig`

### DIFF
--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -79,6 +79,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&jsonTimeGener{},
 			}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal}},
 	},
 }
 


### PR DESCRIPTION
PCP #12102

## What have you changed?

implement vectorized evaluation for `builtinCastDecimalAsDecimalSig`

## What is changed and how it works?
```bash
$$ go test -check.f TestVectorizedBuiltinCastFunc
PASS: builtin_cast_vec_test.go:130: testEvaluatorSuite.TestVectorizedBuiltinCastFunc    0.150s
OK: 1 passed
PASS
ok      github.com/pingcap/tidb/expression      0.179s

$$ go test -v -benchmem -bench=BenchmarkVectorizedBuiltinCastFunc -run=BenchmarkVectorizedBuiltinCastFunc -args "builtinCastDecimalAsDecimalSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsDecimalSig-VecBuiltinFunc-8                 64309             18861 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastDecimalAsDecimalSig-NonVecBuiltinFunc-8              19194             62479 ns/op           39984 B/op        833 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      3.277s

```

## Check List

Tests
  - Unit test
