### PR TITLE
executor: fix a batch get executor bug inside a transaction

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1357,7 +1357,7 @@ func iterateSnapshotRows(store kv.Storage, priority int, t table.Table, version 
 	ver := kv.Version{Ver: version}
 
 	snap, err := store.GetSnapshot(ver)
-	snap.SetPriority(priority)
+	snap.SetOption(kv.Priority, priority)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -99,7 +99,7 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 			keys = append(keys, idxKey)
 		}
 
-		// Fetch all handles
+		// Fetch all handles.
 		handleVals, err1 := e.batchGet(ctx, keys)
 		if err1 != nil {
 			return err1
@@ -172,8 +172,6 @@ func (e *BatchPointGetExec) batchGet(ctx context.Context, keys []kv.Key) (res ma
 	}
 
 	res = make(map[string][]byte, len(keys))
-	// We cannot use txn.BatchGet directly here because the snapshot in txn and the
-	// snapshot of e.snapshot may be different for pessimistic transaction.
 	mb := txn.GetMemBuffer()
 	cacheMiss := make([]kv.Key, 0, len(keys))
 	for _, key := range keys {

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 h1:FUL3b97ZY
 github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.18.10+incompatible h1:cy84jW6EVRPa5g9HAHrlbxMSIjBhDSX0OFYyMYminYs=
 github.com/shirou/gopsutil v2.18.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -309,9 +309,6 @@ type Snapshot interface {
 	Retriever
 	// BatchGet gets a batch of values from snapshot.
 	BatchGet(ctx context.Context, keys []Key) (map[string][]byte, error)
-	// SetPriority snapshot set the priority
-	SetPriority(priority int)
-
 	// SetOption sets an option with a value, when val is nil, uses the default
 	// value of this option. Only ReplicaRead is supported for snapshot
 	SetOption(opt Option, val interface{})

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -34,7 +34,7 @@ func (s testMockSuite) TestInterface(c *C) {
 	c.Check(err, IsNil)
 	_, err = snapshot.BatchGet(context.Background(), []Key{Key("abc"), Key("def")})
 	c.Check(err, IsNil)
-	snapshot.SetPriority(0)
+	snapshot.SetOption(Priority, PriorityNormal)
 
 	transaction, err := storage.Begin()
 	c.Check(err, IsNil)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -89,10 +89,6 @@ func (s *tikvSnapshot) setSnapshotTS(ts uint64) {
 	s.cached = nil
 }
 
-func (s *tikvSnapshot) SetPriority(priority int) {
-	s.priority = pb.CommandPri(priority)
-}
-
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
 // The map will not contain nonexistent keys.
 func (s *tikvSnapshot) BatchGet(ctx context.Context, keys []kv.Key) (map[string][]byte, error) {
@@ -366,6 +362,8 @@ func (s *tikvSnapshot) SetOption(opt kv.Option, val interface{}) {
 	switch opt {
 	case kv.ReplicaRead:
 		s.replicaRead = val.(kv.ReplicaReadType)
+	case kv.Priority:
+		s.priority = kvPriorityToCommandPri(val.(int))
 	}
 }
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
mysql> create table t (id int primary key auto_increment, name varchar(30));  
Query OK, 0 rows affected (0.01 sec)
mysql> begin; 
Query OK, 0 rows affected (0.00 sec)
mysql> insert into t values (4, 'name'); 
Query OK, 1 row affected (0.01 sec)

mysql> select * from t where id in (4); 
Empty set (0.00 sec)           // This is a bug, should be (4, 'name')!        

mysql> explain select * from t where id in (4);
+-------------------+-------+------+---------------+
| id                | count | task | operator info |
+-------------------+-------+------+---------------+
| Batch_Point_Get_1 | 1.00  | root | table:t       |
+-------------------+-------+------+---------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?

When the BatchGetExec runs inside a transaction, it should consider the data changes
in the membuffer.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - Write release note for bug-fix or new feature.
