### PR TITLE
expression: implement vectorized evaluation for builtinAddDateStringStringSig

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -122,8 +122,14 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.TimestampDiff:    {},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
-	ast.SubTime:          {},
+	ast.AddDate: {
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners:        []dataGenerator{&dateStrGener{}, &numStrGener{rangeInt64Gener{1, 31}}, &unitStrGener{}},
+		},
+	},
+	ast.SubTime: {},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.
 		// arg1 has BinaryFlag here.


### PR DESCRIPTION
PCP #12101

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinAddDateStringStringSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=Time VB_FUNC=builtinAddDateStringStringSig                    
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinTimeFunc \
		-run=BenchmarkVectorizedBuiltinTimeFunc \
		-args "builtinAddDateStringStringSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.0192 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringStringSig-VecBuiltinFunc-12         	     378	   2892838 ns/op	  713578 B/op	   17877 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringStringSig-NonVecBuiltinFunc-12      	     294	   4297390 ns/op	  712456 B/op	   17867 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.274s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
