### PR TITLE
expression: implement vectorized evaluation for builtinAddDateStringIntSig

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2615,20 +2615,22 @@ func newDateArighmeticalUtil() baseDateArithmitical {
 	}
 }
 
+func getDateFromString(ctx sessionctx.Context, dateStr string, unit string) (types.Time, bool, error) {
+	dateTp := mysql.TypeDate
+	if !types.IsDateFormat(dateStr) || types.IsClockUnit(unit) {
+		dateTp = mysql.TypeDatetime
+	}
+	sc := ctx.GetSessionVars().StmtCtx
+	date, err := types.ParseTime(sc, dateStr, dateTp, types.MaxFsp)
+	return date, err != nil, handleInvalidTimeError(ctx, err)
+}
+
 func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
 	dateStr, isNull, err := args[0].EvalString(ctx, row)
 	if isNull || err != nil {
 		return types.Time{}, true, err
 	}
-
-	dateTp := mysql.TypeDate
-	if !types.IsDateFormat(dateStr) || types.IsClockUnit(unit) {
-		dateTp = mysql.TypeDatetime
-	}
-
-	sc := ctx.GetSessionVars().StmtCtx
-	date, err := types.ParseTime(sc, dateStr, dateTp, types.MaxFsp)
-	return date, err != nil, handleInvalidTimeError(ctx, err)
+	return getDateFromString(ctx, dateStr, unit)
 }
 
 func (du *baseDateArithmitical) getDateFromInt(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -122,8 +122,14 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.TimestampDiff:    {},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
-	ast.SubTime:          {},
+	ast.AddDate: {
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners:        []dataGenerator{&dateStrGener{}, &rangeInt64Gener{1, 31}, &unitStrGener{}},
+		},
+	},
+	ast.SubTime: {},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.
 		// arg1 has BinaryFlag here.


### PR DESCRIPTION
PCP #12101

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinAddDateStringIntSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=Time VB_FUNC=builtinAddDateStringIntSig
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinTimeFunc \
		-run=BenchmarkVectorizedBuiltinTimeFunc \
		-args "builtinAddDateStringIntSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.0325 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringIntSig-VecBuiltinFunc-12         	     316	   3272690 ns/op	  707250 B/op	   17653 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringIntSig-NonVecBuiltinFunc-12      	     238	   4240392 ns/op	  707256 B/op	   17653 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	4.176s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
