### PR TITLE
expression: implement vectorized evaluation for builtinAddDateStringRealSig

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2615,12 +2615,7 @@ func newDateArighmeticalUtil() baseDateArithmitical {
 	}
 }
 
-func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
-	dateStr, isNull, err := args[0].EvalString(ctx, row)
-	if isNull || err != nil {
-		return types.Time{}, true, err
-	}
-
+func getDateFromString(ctx sessionctx.Context, dateStr string, unit string) (types.Time, bool, error) {
 	dateTp := mysql.TypeDate
 	if !types.IsDateFormat(dateStr) || types.IsClockUnit(unit) {
 		dateTp = mysql.TypeDatetime
@@ -2629,6 +2624,14 @@ func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args [
 	sc := ctx.GetSessionVars().StmtCtx
 	date, err := types.ParseTime(sc, dateStr, dateTp, types.MaxFsp)
 	return date, err != nil, handleInvalidTimeError(ctx, err)
+}
+
+func (du *baseDateArithmitical) getDateFromString(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {
+	dateStr, isNull, err := args[0].EvalString(ctx, row)
+	if isNull || err != nil {
+		return types.Time{}, true, err
+	}
+	return getDateFromString(ctx, dateStr, unit)
 }
 
 func (du *baseDateArithmitical) getDateFromInt(ctx sessionctx.Context, args []Expression, row chunk.Row, unit string) (types.Time, bool, error) {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -122,8 +122,14 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.TimestampDiff:    {},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
-	ast.SubTime:          {},
+	ast.AddDate: {
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners:        []dataGenerator{&dateStrGener{}, &rangeRealGener{1, 31, 1.0}, &unitStrGener{}},
+		},
+	},
+	ast.SubTime: {},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.
 		// arg1 has BinaryFlag here.


### PR DESCRIPTION
PCP #12101

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR implements vectorized `builtinAddDateStringRealSig`

### What is changed and how it works?

```sh
➜ make vectorized-bench VB_FILE=Time VB_FUNC=builtinAddDateStringRealSig
cd ./expression && \
	go test -v -benchmem \
		-bench=BenchmarkVectorizedBuiltinTimeFunc \
		-run=BenchmarkVectorizedBuiltinTimeFunc \
		-args "builtinAddDateStringRealSig"
goos: linux
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.0741 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringRealSig-VecBuiltinFunc-12         	  360562	      3322 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateStringRealSig-NonVecBuiltinFunc-12      	     300	   3627110 ns/op	  672719 B/op	   17259 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	5.370s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
