### PR TITLE
expression: implement vectorized evaluation for `builtinStrToDateDateSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -583,12 +583,17 @@ func (g *dateTimeStrGener) gen() interface{} {
 
 // timeStrGener is used to generate strings which are time format
 type timeStrGener struct {
-	Year  int
-	Month int
-	Day   int
+	Year       int
+	Month      int
+	Day        int
+	NullRation float64
 }
 
 func (g *timeStrGener) gen() interface{} {
+	if g.NullRation > 1e-6 && rand.Float64() < g.NullRation {
+		return nil
+	}
+
 	if g.Year == 0 {
 		g.Year = 1970 + rand.Intn(100)
 	}

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -831,11 +831,11 @@ func (b *builtinStrToDateDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 	}
 
 	result.ResizeTime(n, false)
+	result.MergeNulls(bufStrings, bufFormats)
 	times := result.Times()
 	sc := b.ctx.GetSessionVars().StmtCtx
 	for i := 0; i < n; i++ {
-		if bufStrings.IsNull(i) || bufFormats.IsNull(i) {
-			result.SetNull(i, true)
+		if result.IsNull(i) {
 			continue
 		}
 		var t types.Time

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -266,6 +266,19 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
 			geners:        []dataGenerator{&timeStrGener{}, &constStrGener{"%y-%m-%d"}},
 		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString},
+			geners:        []dataGenerator{&timeStrGener{NullRation: 0.3}, nil},
+			constants:     []*Constant{nil, {Value: types.NewDatum("%Y-%m-%d"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString},
+			geners:        []dataGenerator{&timeStrGener{}, nil},
+			// "%y%m%d" is wrong format, STR_TO_DATE should be failed for all rows
+			constants: []*Constant{nil, {Value: types.NewDatum("%y%m%d"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
 	},
 	ast.GetFormat: {
 		{


### PR DESCRIPTION
PCP #12101 

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinStrToDateDateSig` at #12101 

### What is changed and how it works?
It gets faster aboult 5%.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
```
> GO111MODULE=on go test -check.f TestVectorizedBuiltinTimeFunc
PASS: builtin_time_vec_test.go:246: testEvaluatorSuite.TestVectorizedBuiltinTimeFunc	0.165s
PASS: builtin_time_vec_generated_test.go:192: testEvaluatorSuite.TestVectorizedBuiltinTimeFuncGenerated	0.102s
OK: 2 passed
PASS
ok  	github.com/pingcap/tidb/expression	0.290s
```

 - Benchmark
```
> go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args builtinStrToDateDateSig
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinTimeFuncGenerated-12    	1000000000	         0.0165 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinStrToDateDateSig-VecBuiltinFunc-12         	    2520	    468740 ns/op	   48279 B/op	    1464 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinStrToDateDateSig-NonVecBuiltinFunc-12      	    2402	    500521 ns/op	   48194 B/op	    1464 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinStrToDateDateSig-VecBuiltinFunc#01-12      	     405	   2743202 ns/op	  685807 B/op	   23552 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinStrToDateDateSig-NonVecBuiltinFunc#01-12   	     331	   3618155 ns/op	  685857 B/op	   23552 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	5.622s
```
