### PR TITLE
implement vectoried builtinCastRealAsDecimalSig

### DIFF
--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -775,15 +775,17 @@ func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result 
 	resdecimal := result.Decimals()
 	if !b.inUnion {
 		for i := 0; i < n; i++ {
-			resdecimal[i].FromFloat64(bufreal[i])
+			if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
+				return err
+			}
 		}
 	} else {
 		for i := 0; i < n; i++ {
 			if bufreal[i] >= 0 {
-				err = resdecimal[i].FromFloat64(bufreal[i])
-				if err != nil {
+				if err = resdecimal[i].FromFloat64(bufreal[i]); err != nil {
 					return err
 				}
+
 			} else {
 				_, err = types.ProduceDecWithSpecifiedTp(&resdecimal[i], b.tp, b.ctx.GetSessionVars().StmtCtx)
 				if err != nil {

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -756,11 +756,43 @@ func (b *builtinCastStringAsJSONSig) vecEvalJSON(input *chunk.Chunk, result *chu
 }
 
 func (b *builtinCastRealAsDecimalSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinCastRealAsDecimalSig) vecEvalDecimal(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf, err := b.bufAllocator.get(types.ETReal, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	if err = b.args[0].VecEvalDecimal(b.ctx, input, buf); err != nil {
+		return err
+	}
+	result.ResizeDecimal(n, false)
+	result.MergeNulls(buf)
+	bufreal := buf.Float64s()
+	resdecimal := result.Decimals()
+	if !b.inUnion {
+		for i := 0; i < n; i++ {
+			resdecimal[i].FromFloat64(bufreal[i])
+		}
+	} else {
+		for i := 0; i < n; i++ {
+			if bufreal[i] >= 0 {
+				err = resdecimal[i].FromFloat64(bufreal[i])
+				if err != nil {
+					return err
+				}
+			} else {
+				_, err = types.ProduceDecWithSpecifiedTp(&resdecimal[i], b.tp, b.ctx.GetSessionVars().StmtCtx)
+				if err != nil {
+					return err
+				}
+			}
+		}
+	}
+	return nil
 }
 
 func (b *builtinCastStringAsIntSig) vectorized() bool {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -26,6 +26,7 @@ import (
 
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 	ast.Cast: {
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectoried builtinCastRealAsDecimalSig

### What is changed and how it works?

it improve speed 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

 - Manual test (add detailed scripts or steps below)

```
BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsDecimalSig-VecBuiltinFunc-8                     4531            266235 ns/op           64832 B/op       2048 allocs/op

BenchmarkVectorizedBuiltinCastFunc/builtinCastRealAsDecimalSig-NonVecBuiltinFunc-8                  3870            285807 ns/op           91376 B/op

Code changes
```
