### PR TITLE
plugin: fix plugin build and load with go 1.13 (#13455)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
 
 GO        := GO111MODULE=on go
-GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG) -trimpath
+GOBUILD   := CGO_ENABLED=1 $(GO) build $(BUILD_FLAG)
 GOBUILDCOVERAGE := GOPATH=$(GOPATH) CGO_ENABLED=1 cd tidb-server; $(GO) test -coverpkg="../..." -c .
 GOTEST    := CGO_ENABLED=1 $(GO) test -p 4
 OVERALLS  := CGO_ENABLED=1 GO111MODULE=on overalls

--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -155,10 +155,8 @@ func main() {
 	}
 
 	outputFile := filepath.Join(outDir, pluginName+"-"+version+".so")
-	pluginPath := `-pluginpath=` + pluginName + "-" + version
 	ctx := context.Background()
 	buildCmd := exec.CommandContext(ctx, "go", "build",
-		"-ldflags", pluginPath,
 		"-buildmode=plugin",
 		"-o", outputFile, pkgDir)
 	buildCmd.Dir = pkgDir


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

cherry-pick #13455 to 3.0

conflict at Makefile, just remove `-trimpath` from old file

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/13526)
<!-- Reviewable:end -->
