### PR TITLE
ddl, test : fix CI with adding new tk to execute additional sql. (#13447)

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -84,6 +84,10 @@ func (s *testStateChangeSuite) TestShowCreateTable(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t (id int)")
 	tk.MustExec("create table t2 (a int, b varchar(10)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
+	// tkInternal is used to execute additional sql (here show create table) in ddl change callback.
+	// Using same `tk` in different goroutines may lead to data race.
+	tkInternal := testkit.NewTestKit(c, s.store)
+	tkInternal.MustExec("use test")
 
 	var checkErr error
 	testCases := []struct {
@@ -112,14 +116,26 @@ func (s *testStateChangeSuite) TestShowCreateTable(c *C) {
 			currTestCaseOffset++
 		}
 		if job.SchemaState != model.StatePublic {
-			var result *testkit.Result
-			tbl2 := testGetTableByName(c, tk.Se, "test", "t2")
+			var result sqlexec.RecordSet
+			tbl2 := testGetTableByName(c, tkInternal.Se, "test", "t2")
 			if job.TableID == tbl2.Meta().ID {
-				result = tk.MustQuery("show create table t2")
+				// Try to do not use mustQuery in hook func, cause assert fail in mustQuery will cause ddl job hung.
+				result, checkErr = tkInternal.Exec("show create table t2")
+				if checkErr != nil {
+					return
+				}
 			} else {
-				result = tk.MustQuery("show create table t")
+				result, checkErr = tkInternal.Exec("show create table t")
+				if checkErr != nil {
+					return
+				}
 			}
-			got := result.Rows()[0][1]
+			req := result.NewChunk()
+			checkErr = result.Next(context.Background(), req)
+			if checkErr != nil {
+				return
+			}
+			got := req.GetRow(0).GetString(1)
 			expected := testCases[currTestCaseOffset].expectedRet
 			if got != expected {
 				checkErr = errors.Errorf("got %s, expected %s", got, expected)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #13447 to release-2.1

### What is changed and how it works?
**Background**:
 In the ddl state change callback, we conduct additional sql to show create table, in order to make sure the schema state is the same with what we want it to be.  

**Root Cause** : 
This will cause `resetContextOfStmt` of the same `tk`, consequently, causing data race.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix CI with adding new tk to execute additional sql in `TestShowCreateTable`.
