### PR TITLE
expression: Revert vectorized builtinFormatSig (#13215)

### DIFF
--- a/expression/builtin_string_vec.go
+++ b/expression/builtin_string_vec.go
@@ -2199,91 +2199,11 @@ func (b *builtinBinSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) 
 }
 
 func (b *builtinFormatSig) vectorized() bool {
-	return true
+	return false
 }
 
-// vecEvalNumDecArgsForFormat evaluates first 2 arguments, i.e, x and d, for function `format`.
-func vecEvalNumDecArgsForFormat(b *baseBuiltinFunc, input *chunk.Chunk) ([]string, []string, []bool, error) {
-	n := input.NumRows()
-	isDecimal := b.args[0].GetType().EvalType() == types.ETDecimal
-	var buf0 *chunk.Column
-	buf0, err := b.bufAllocator.get(b.args[0].GetType().EvalType(), n)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	defer b.bufAllocator.put(buf0)
-	buf1, err := b.bufAllocator.get(types.ETInt, n)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-	defer b.bufAllocator.put(buf1)
-	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
-		return nil, nil, nil, err
-	}
-
-	xStrBuf := make([]string, n)
-	if isDecimal {
-		if err := b.args[0].VecEvalDecimal(b.ctx, input, buf0); err != nil {
-			return nil, nil, nil, err
-		}
-		buf1.MergeNulls(buf0)
-		d64s := buf0.Decimals()
-		for i := 0; i < n; i++ {
-			if buf1.IsNull(i) {
-				continue
-			}
-			xStrBuf[i] = d64s[i].String()
-		}
-	} else {
-		if err := b.args[0].VecEvalReal(b.ctx, input, buf0); err != nil {
-			return nil, nil, nil, err
-		}
-		buf1.MergeNulls(buf0)
-		f64s := buf0.Float64s()
-		for i := 0; i < n; i++ {
-			if buf1.IsNull(i) {
-				continue
-			}
-			xStrBuf[i] = fmt.Sprintf(strconv.FormatFloat(f64s[i], 'f', -1, 64))
-		}
-	}
-
-	d64s := buf1.Int64s()
-	isNulls := make([]bool, n)
-	dStrBuf := make([]string, n)
-	for i := 0; i < n; i++ {
-		if buf1.IsNull(i) {
-			isNulls[i] = true
-			continue
-		}
-		isNulls[i] = false
-		dStrBuf[i] = strconv.FormatInt(d64s[i], 10)
-	}
-	return xStrBuf, dStrBuf, isNulls, nil
-}
-
-// evalString evals FORMAT(X,D).
-// See https://dev.mysql.com/doc/refman/5.7/en/string-functions.html#function_format
 func (b *builtinFormatSig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
-	xStrBuf, dStrBuf, isNulls, err := vecEvalNumDecArgsForFormat(&b.baseBuiltinFunc, input)
-	if err != nil {
-		return err
-	}
-	n := input.NumRows()
-	result.ReserveString(n)
-	var formatString string
-	for i := 0; i < n; i++ {
-		if isNulls[i] {
-			result.AppendNull()
-			continue
-		}
-		formatString, err = mysql.GetLocaleFormatFunction("en_US")(xStrBuf[i], dStrBuf[i])
-		if err != nil {
-			return err
-		}
-		result.AppendString(formatString)
-	}
-	return nil
+	return errors.Errorf("not implemented")
 }
 
 func (b *builtinRightBinarySig) vectorized() bool {

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -331,10 +331,6 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 			},
 		}},
 	},
-	ast.Format: {
-		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal, types.ETInt}, geners: []dataGenerator{&rangeDecimalGener{}, &rangeInt64Gener{0, 30}}},
-		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETReal, types.ETInt}, geners: []dataGenerator{&rangeRealGener{}, &rangeInt64Gener{0, 30}}},
-	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinStringEvalOneVec(c *C) {


### PR DESCRIPTION
PR #13215 causes CI run very slow and TiDB failed to execute much more SQLs than before:

After reverting the PR:

```
Test summary: non-matching queries: 0, success queries: 2687, skipped queries: 312
Test summary(sql/randgen/7_str_2.sql): Test case PASS
```

Before reverting the PR:

```
Test summary: non-matching queries: 0, success queries: 1476, skipped queries: 1523
Test summary(sql/randgen/7_str_2.sql): Test case PASS
```