### PR TITLE
implement builtinUnixTimestampDecSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1939,31 +1939,11 @@ func (b *builtinTimestampDiffSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 }
 
 func (b *builtinUnixTimestampIntSig) vectorized() bool {
-	return true
+	return false
 }
 
 func (b *builtinUnixTimestampIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	n := input.NumRows()
-	buf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(buf)
-
-	if err := b.args[0].VecEvalTime(b.ctx, input, buf); err != nil {
-		return err
-	}
-	result.ResizeInt64(n, false)
-	i64s := result.Int64s()
-	for i := 0; i < n; i++ {
-		t, err := buf.GetTime(i).Time.GoTime(getTimeZone(b.ctx))
-		if buf.IsNull(i) || t.IsZero() || err != nil {
-			result.AppendInt64(0)
-			continue
-		}
-		i64s[i] = t.Unix()
-	}
-	return nil
+	return errors.Errorf("not implemented")
 }
 
 func (b *builtinAddDateDurationDecimalSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -125,6 +125,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.TimestampDiff:    {},
 	ast.TimestampLiteral: {},
+	ast.UnixTimestamp: {
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
+	},
 	ast.SubDate:          {},
 	ast.AddDate:          {},
 	ast.SubTime:          {},

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -128,9 +128,9 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.UnixTimestamp: {
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDatetime}},
 	},
-	ast.SubDate:          {},
-	ast.AddDate:          {},
-	ast.SubTime:          {},
+	ast.SubDate: {},
+	ast.AddDate: {},
+	ast.SubTime: {},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.
 		// arg1 has BinaryFlag here.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinUnixTimestampDecSig #12103
### What is changed and how it works?
```
BenchmarkVectorizedBuiltinTimeFunc/builtinUnixTimestampDecSig-VecBuiltinFunc-8                        	9495	    128101 ns/op	   38640 B/op	     805 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinUnixTimestampDecSig-NonVecBuiltinFunc-8                     	    7442	    156446 ns/op	   49152 B/op	    1024 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

