### PR TITLE
expression: implement vectorized evaluation for `builtinBitNegSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -190,11 +190,19 @@ func (b *builtinUnaryMinusRealSig) vecEvalReal(input *chunk.Chunk, result *chunk
 }
 
 func (b *builtinBitNegSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinBitNegSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	args := result.Int64s()
+	for i := 0; i < n; i++ {
+		args[i] = ^args[i]
+	}
+	return nil
 }
 
 func (b *builtinUnaryMinusDecimalSig) vectorized() bool {

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -47,6 +47,9 @@ var vecBuiltinOpCases = map[string][]vecExprBenchCase{
 	ast.Or: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt, types.ETInt}, geners: makeBinaryLogicOpDataGeners()},
 	},
+	ast.BitNeg: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 	ast.UnaryNot: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETDecimal}},


### PR DESCRIPTION
PCP #12103
### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinBitNegSig

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOpFunc/builtinBitNegSig-VecBuiltinFunc-56              2170525               602 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOpFunc/builtinBitNegSig-NonVecBuiltinFunc-56             47398             28934 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 