### PR TITLE
expression: implement vectorized evaluation for `builtinBitCountSig`

### DIFF
--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -79,11 +79,24 @@ func (b *builtinValuesJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinBitCountSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinBitCountSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	n := input.NumRows()
+	args := result.Int64s()
+	for i := 0; i < n; i++ {
+		val := args[i]
+		count := int64(0)
+		for ; val != 0; val = (val - 1) & val {
+			count++
+		}
+		args[i] = count
+	}
+	return nil
 }
 
 func (b *builtinGetParamStringSig) vectorized() bool {

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -28,7 +28,9 @@ var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
 	ast.GetVar: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
 	},
-	ast.BitCount: {},
+	ast.BitCount: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 	ast.GetParam: {},
 }
 


### PR DESCRIPTION
Signed-off-by: AerysNan <aerysnan@gmail.com>

PCP #12103

### What problem does this PR solve? <!--add issue link with summary if exists-->

Implement vectorized evaluation for builtinBitNegSig.

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOtherFunc/builtinBitCountSig-VecBuiltinFunc-56                   31857             36541 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinOtherFunc/builtinBitCountSig-NonVecBuiltinFunc-56                15096             70084 ns/op               0 B/op          0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
