### PR TITLE
*: update the forUpdateTS for insert/replace into select statements

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -674,7 +674,8 @@ func (b *executorBuilder) buildSet(v *plannercore.Set) Executor {
 func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
 	if v.SelectPlan != nil {
 		// Try to update the forUpdateTS for insert/replace into select statements.
-		if b.err = b.updateForUpdateTSIfNeeded(v.SelectPlan); b.err != nil {
+		// Set the selectPlan parameter to nil to make it always update the forUpdateTS.
+		if b.err = b.updateForUpdateTSIfNeeded(nil); b.err != nil {
 			return nil
 		}
 	}
@@ -1437,8 +1438,6 @@ func (b *executorBuilder) updateForUpdateTSIfNeeded(selectPlan plannercore.Physi
 	if !txnCtx.IsPessimistic {
 		return nil
 	}
-	// For insert/replace select statements, we should always update forUpdateTS, whether it is a PointGetPlan or not.
-	// But it seems the selectPlan could not be a PointGetPlan in these statements.
 	if _, ok := selectPlan.(*plannercore.PointGetPlan); ok {
 		return nil
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -672,6 +672,12 @@ func (b *executorBuilder) buildSet(v *plannercore.Set) Executor {
 }
 
 func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
+	if v.SelectPlan != nil {
+		// Try to update the forUpdateTS for insert/replace into select statements.
+		if b.err = b.updateForUpdateTSIfNeeded(v.SelectPlan); b.err != nil {
+			return nil
+		}
+	}
 	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 	selectExec := b.build(v.SelectPlan)
 	if b.err != nil {
@@ -1431,6 +1437,8 @@ func (b *executorBuilder) updateForUpdateTSIfNeeded(selectPlan plannercore.Physi
 	if !txnCtx.IsPessimistic {
 		return nil
 	}
+	// For insert/replace select statements, we should always update forUpdateTS, whether it is a PointGetPlan or not.
+	// But it seems the selectPlan could not be a PointGetPlan in these statements.
 	if _, ok := selectPlan.(*plannercore.PointGetPlan); ok {
 		return nil
 	}

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -579,6 +579,7 @@ func (s *testPessimisticSuite) TestConcurrentInsert(c *C) {
 	tk.MustExec("drop table if exists tk")
 	tk.MustExec("create table tk (c1 int primary key, c2 int)")
 	tk.MustExec("insert tk values (1, 1)")
+	tk.MustExec("create table tk1 (c1 int, c2 int)")
 
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk1.MustExec("begin pessimistic")
@@ -599,6 +600,16 @@ func (s *testPessimisticSuite) TestConcurrentInsert(c *C) {
 	tk2.MustExec("insert tk values (4, 4)")
 	tk1.MustExec("delete from tk")
 	c.Assert(tk1.Se.AffectedRows(), Equals, uint64(4))
+	tk2.MustExec("insert tk values (5, 5)")
+	tk1.MustExec("insert into tk1 select * from tk")
+	c.Assert(tk1.Se.AffectedRows(), Equals, uint64(1))
+	tk2.MustExec("insert tk values (6, 6)")
+	tk1.MustExec("replace into tk1 select * from tk")
+	c.Assert(tk1.Se.AffectedRows(), Equals, uint64(2))
+	tk2.MustExec("insert tk values (7, 7)")
+	// This test is used to test when the selectPlan is a PointGetPlan, and we didn't update its forUpdateTS.
+	tk1.MustExec("insert into tk1 select * from tk where c1 = 7")
+	c.Assert(tk1.Se.AffectedRows(), Equals, uint64(1))
 	tk1.MustExec("commit")
 }
 


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The forUpdateTS should be updated for the statements like "insert into t1 select * from t;".

### What is changed and how it works?
Update the forUpdateTS for insert/replace into select statements.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
