### PR TITLE
tikv: fix store addr cannot update bug after change new store addr and old addr be offline (#13495)

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -902,6 +902,7 @@ func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
 			logutil.Logger(context.Background()).Info("mark store's regions need be refill", zap.String("store", s.addr))
 			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
 		}
+		s.markNeedCheck(c.notifyCheckCh)
 	}
 
 	nextIdx := (currentPeerIdx + 1) % len(rs.stores)

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -530,7 +530,7 @@ func (s *testRegionCacheSuite) TestReplaceNewAddrAndOldOfflineImmediately(c *C) 
 	// pre-load store2's address into cache via follower-read.
 	loc, err := client.regionCache.LocateKey(s.bo, testKey)
 	c.Assert(err, IsNil)
-	fctx, err := client.regionCache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	fctx, err := client.regionCache.GetRPCContext(s.bo, loc.Region)
 	c.Assert(err, IsNil)
 	c.Assert(fctx.Store.storeID, Equals, s.store2)
 	c.Assert(fctx.Addr, Equals, "store2")

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -504,10 +504,46 @@ func (s *testRegionCacheSuite) TestReplaceAddrWithNewStore(c *C) {
 	s.cluster.UpdateStoreAddr(s.store2, store1Addr)
 	s.cluster.RemoveStore(s.store1)
 	s.cluster.ChangeLeader(s.region1, s.peer2)
-	s.cluster.RemovePeer(s.region1, s.store1)
+	s.cluster.RemovePeer(s.region1, s.peer1)
 
 	getVal, err := client.Get(testKey)
 
+	c.Assert(err, IsNil)
+	c.Assert(getVal, BytesEquals, testValue)
+}
+
+func (s *testRegionCacheSuite) TestReplaceNewAddrAndOldOfflineImmediately(c *C) {
+	mvccStore := mocktikv.MustNewMVCCStore()
+	defer mvccStore.Close()
+
+	client := &RawKVClient{
+		clusterID:   0,
+		regionCache: NewRegionCache(mocktikv.NewPDClient(s.cluster)),
+		rpcClient:   mocktikv.NewRPCClient(s.cluster, mvccStore),
+	}
+	defer client.Close()
+	testKey := []byte("test_key")
+	testValue := []byte("test_value")
+	err := client.Put(testKey, testValue)
+	c.Assert(err, IsNil)
+
+	// pre-load store2's address into cache via follower-read.
+	loc, err := client.regionCache.LocateKey(s.bo, testKey)
+	c.Assert(err, IsNil)
+	fctx, err := client.regionCache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
+	c.Assert(err, IsNil)
+	c.Assert(fctx.Store.storeID, Equals, s.store2)
+	c.Assert(fctx.Addr, Equals, "store2")
+
+	// make store2 using store1's addr and store1 offline
+	store1Addr := s.storeAddr(s.store1)
+	s.cluster.UpdateStoreAddr(s.store1, s.storeAddr(s.store2))
+	s.cluster.UpdateStoreAddr(s.store2, store1Addr)
+	s.cluster.RemoveStore(s.store1)
+	s.cluster.ChangeLeader(s.region1, s.peer2)
+	s.cluster.RemovePeer(s.region1, s.peer1)
+
+	getVal, err := client.Get(testKey)
 	c.Assert(err, IsNil)
 	c.Assert(getVal, BytesEquals, testValue)
 }


### PR DESCRIPTION
cherry-pick #13495 to 3.0

conflict:

- on region_cache.go, 3.0 without tiflash logic
- on region_cache_test.go, 3.0 without follower-read, so need use another way to pre-load store2 into store cache


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/13576)
<!-- Reviewable:end -->
