### PR TITLE
ddl: make the error message more readable when dropping primary key

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1405,6 +1405,9 @@ func (s *testDBSuite5) TestAlterPrimaryKey(c *C) {
 	s.tk.MustExec("alter table test_add_pk add primary key idx(e)")
 	s.tk.MustExec("alter table test_add_pk drop primary key")
 
+	// Check if the primary key exists before checking the table's pkIsHandle.
+	s.tk.MustGetErrCode("alter table test_add_pk drop primary key", tmysql.ErrCantDropFieldOrKey)
+
 	// for the limit of name
 	validName := strings.Repeat("a", mysql.MaxIndexIdentifierLen)
 	invalidName := strings.Repeat("b", mysql.MaxIndexIdentifierLen+1)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3607,13 +3607,15 @@ func (d *ddl) dropIndex(ctx sessionctx.Context, ti ast.Ident, isPK bool, indexNa
 
 	indexInfo := t.Meta().FindIndexByName(indexName.L)
 	if isPK {
-		if !config.GetGlobalConfig().AlterPrimaryKey || t.Meta().PKIsHandle {
-			return ErrUnsupportedModifyPrimaryKey.GenWithStack(fmt.Sprintf(
-				"Unsupported drop primary key when alter-primary-key is %v and the table's pkIsHandle is %v",
-				config.GetGlobalConfig().AlterPrimaryKey, t.Meta().PKIsHandle))
+		if !config.GetGlobalConfig().AlterPrimaryKey {
+			return ErrUnsupportedModifyPrimaryKey.GenWithStack("Unsupported drop primary key when alter-primary-key is false")
+
 		}
 		if indexInfo == nil {
 			return ErrCantDropFieldOrKey.GenWithStack("Can't DROP 'PRIMARY'; check that column/key exists")
+		}
+		if t.Meta().PKIsHandle {
+			return ErrUnsupportedModifyPrimaryKey.GenWithStack("Unsupported drop primary key when the table's pkIsHandle is true")
 		}
 	}
 	if indexInfo == nil {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -90,7 +90,7 @@ func (s *testSerialSuite) TestPrimaryKey(c *C) {
 	_, err := tk.Exec("alter table primary_key_test add primary key(a)")
 	c.Assert(ddl.ErrUnsupportedModifyPrimaryKey.Equal(err), IsTrue)
 	_, err = tk.Exec("alter table primary_key_test drop primary key")
-	c.Assert(ddl.ErrUnsupportedModifyPrimaryKey.Equal(err), IsTrue)
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported drop primary key when alter-primary-key is false")
 }
 
 func (s *testSerialSuite) TestMultiRegionGetTableEndHandle(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If the value of alter-primary-key is false.
```
create table t(a int);
alter table t drop primary key;
Error 8200: Unsupported drop primary key when alter-primary-key is false and the table's pkIsHandle is true
```
The better error msg:
```
Error 8200: Unsupported drop primary key when alter-primary-key is false
```

### What is changed and how it works?
Split the error message.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

- mysql test: pingcap/tidb-test#951


Related changes

 - Need to cherry-pick to the release branch

Release note

 - Make the error message more readable when dropping primary key
