### PR TITLE
expression: implement vectorized evaluation for `builtinCastJSONAsDecimalSig`

### DIFF
--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -82,6 +82,10 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 				&jsonTimeGener{},
 			}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDecimal}},
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETJson},
+			geners: []dataGenerator{
+				&decimalJSONGener{nullRation: 0.1},
+			}},
 	},
 }
 
@@ -123,6 +127,27 @@ func (g *datetimeJSONGener) gen() interface{} {
 		Fsp:  3,
 	}
 	return json.CreateBinary(d.String())
+}
+
+type decimalJSONGener struct {
+	nullRation float64
+}
+
+func (g *decimalJSONGener) gen() interface{} {
+	if rand.Float64() < g.nullRation {
+		return nil
+	}
+
+	var f float64
+	if rand.Float64() < 0.5 {
+		f = rand.Float64() * 100000
+	} else {
+		f = -rand.Float64() * 100000
+	}
+	if err := (&types.MyDecimal{}).FromFloat64(f); err != nil {
+		panic(err)
+	}
+	return json.CreateBinary(f)
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinCastEvalOneVec(c *C) {


### PR DESCRIPTION
PCP #12102

## What have you changed?

implement vectorized evaluation for `builtinCastJSONAsDecimalSig`

## What is changed and how it works?
bench output:
```bash
$$ go test -v -benchmem -bench=BenchmarkVectorizedBuiltinCastFunc -run=BenchmarkVectorizedBuiltinCastFunc -args "builtinCastJSONAsDecimalSig"
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinCastFunc/builtinCastJSONAsDecimalSig-VecBuiltinFunc-8                     2840            370180 ns/op          104880 B/op       2826 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastJSONAsDecimalSig-NonVecBuiltinFunc-8                  2714            387725 ns/op          104880 B/op       2826 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      2.236s

```

## Check List

Tests
  - Unit test
