### PR TITLE
expression: implement vectorized evaluation for `builtinAddDateDurationIntSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -800,11 +800,55 @@ func (b *builtinSysDateWithFspSig) vecEvalTime(input *chunk.Chunk, result *chunk
 }
 
 func (b *builtinAddDateDurationIntSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	buf2, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf2)
+	buf, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf)
+	buf1, err := b.bufAllocator.get(types.ETInt, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(buf1)
+	if err := b.args[2].VecEvalString(b.ctx, input, buf2); err != nil {
+		return err
+	}
+	if err := b.args[0].VecEvalDuration(b.ctx, input, buf); err != nil {
+		return err
+	}
+	if err := b.args[1].VecEvalInt(b.ctx, input, buf1); err != nil {
+		return err
+	}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(buf1, buf, buf2)
+	res := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			res[i] = types.ZeroDuration.Duration
+			continue
+		}
+		unit := buf2.GetString(i)
+		dur := buf.GetDuration(i, b.args[0].GetType().Decimal)
+		temp := buf1.GetInt64(i)
+		interval := strconv.FormatInt(temp, 10)
+		respoint, isNull, err := b.addDuration(b.ctx, dur, interval, unit)
+		if err != nil {
+			return nil
+		}
+		result.SetNull(i, isNull)
+		res[i] = respoint.Duration
+	}
+	return nil
 }
 
 func (b *builtinSubDateIntStringSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -131,7 +131,13 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
+	ast.AddDate: {
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			constants:     []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+	},
 	ast.SubTime: {
 		{
 			retEvalType:   types.ETString,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12101 
### What problem does this PR solve? <!--add issue link with summary if exists-->
expression: implement vectorized evaluation for `builtinAddDateDurationIntSig

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateDurationIntSig-VecBuiltinFunc-8                                     560           2003717 ns/op          303752 B/op      4069 allocs/op

BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateDurationIntSig-NonVecBuiltinFunc-8                                  411           2920615 ns/op          303744 B/op      4068 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
