### PR TITLE
Changed version comment to include "TiDB Server"

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -407,7 +407,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "binlog_format", "STATEMENT"},
 	{ScopeGlobal | ScopeSession, "optimizer_trace", "enabled=off,one_line=off"},
 	{ScopeGlobal | ScopeSession, "read_rnd_buffer_size", "262144"},
-	{ScopeNone, "version_comment", "MySQL Community Server (Apache License 2.0)"},
+	{ScopeNone, "version_comment", "TiDB Server (Apache License 2.0), MySQL 5.7 compatible"},
 	{ScopeGlobal | ScopeSession, NetWriteTimeout, "60"},
 	{ScopeGlobal, InnodbBufferPoolLoadAbort, "0"},
 	{ScopeGlobal | ScopeSession, TxnIsolation, "REPEATABLE-READ"},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The version_comment system variable in TiDB currently reads "MySQL Community Server (Apache License 2.0)". This is simply false, since it is *not* an instance of MySQL Community Server. (That may actually be a copyright/trademark problem, misrepresenting our software as something else?)

### What is changed and how it works?

This patch changes the version_comment to read "TiDB Server (Apache License 2.0), MySQL 5.7 compatible". This communicates the actual server connected to, the license, and highlights its compatibility with MySQL 5.7.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

There is a very small chance that some client that expects a specific version comment string could have a problem. MariaDB has changed their version_comment string completely, apparently without any really serious problems, so I think this is not likely to be a problem.

Release note

 - Write release note for bug-fix or new feature.

version_comment system variable updated to better reflect that the user has connected to TiDB Server.