### PR TITLE
expression: implement vectorized evaluation for `builtinLikeSig`

### DIFF
--- a/expression/builtin_like_vec_test.go
+++ b/expression/builtin_like_vec_test.go
@@ -22,7 +22,11 @@ import (
 )
 
 var vecBuiltinLikeCases = map[string][]vecExprBenchCase{
-	ast.Like: {},
+	ast.Like: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETInt},
+			geners: []dataGenerator{nil, nil, &rangeInt64Gener{int('\\'), int('\\') + 1}},
+		},
+	},
 	ast.Regexp: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETString}},
 	},


### PR DESCRIPTION
PCP #12103 

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for `builtinLikeSig` at #12103

### What is changed and how it works?
It gets faster about 44%.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
```
GO111MODULE=on go test -check.f TestVectorizedBuiltinLikeFunc
PASS: builtin_like_vec_test.go:35: testEvaluatorSuite.TestVectorizedBuiltinLikeFunc	0.012s
OK: 1 passed
PASS
ok  	github.com/pingcap/tidb/expression	0.038s
```

 - Benchmark
```
> go test -v -benchmem -bench=BenchmarkVectorizedBuiltinLikeFunc -run=BenchmarkVectorizedBuiltinLikeFunc -args builtinLikeSig
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinLikeFunc/builtinLikeSig-VecBuiltinFunc-12         	   19312	     61934 ns/op	   27456 B/op	    1302 allocs/op
BenchmarkVectorizedBuiltinLikeFunc/builtinLikeSig-NonVecBuiltinFunc-12      	   13378	     88762 ns/op	   27456 B/op	    1302 allocs/op
PASS
ok  	github.com/pingcap/tidb/expression	3.949s
```
