### PR TITLE
expression : fix bug in insert select union select. (#13632)

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -658,7 +658,7 @@ func (s *testSuite) TestPartitionInsertOnDuplicate(c *C) {
 
 }
 
-func (s *testSuite3) TestJiraIssue5366(c *C) {
+func (s *testSuite) TestJiraIssue5366(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
 	tk.MustExec(`create table bug (a varchar(100))`)

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -657,3 +657,11 @@ func (s *testSuite) TestPartitionInsertOnDuplicate(c *C) {
 	tk.MustQuery(`select * from t2`).Check(testkit.Rows("1 1"))
 
 }
+
+func (s *testSuite3) TestJiraIssue5366(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`create table bug (a varchar(100))`)
+	tk.MustExec(` insert into bug select  ifnull(JSON_UNQUOTE(JSON_EXTRACT('[{"amount":2000,"feeAmount":0,"merchantNo":"20190430140319679394","shareBizCode":"20160311162_SECOND"}]', '$[0].merchantNo')),'') merchant_no union SELECT '20180531557' merchant_no;`)
+	tk.MustQuery(`select * from bug`).Sort().Check(testkit.Rows("20180531557", "20190430140319679394"))
+}

--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -16,6 +16,7 @@ package expression
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
@@ -170,6 +171,7 @@ func (c *jsonUnquoteFunctionClass) getFunction(ctx sessionctx.Context, args []Ex
 		return nil, errors.Trace(err)
 	}
 	bf := newBaseBuiltinFuncWithTp(ctx, args, types.ETString, types.ETJson)
+	bf.tp.Flen = mysql.MaxFieldVarCharLength
 	DisableParseJSONFlag4Expr(args[0])
 	sig := &builtinJSONUnquoteSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_JsonUnquoteSig)

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -1921,7 +1921,7 @@ func (s *testInferTypeSuite) createTestCase4JSONFuncs() []typeInferTestCase {
 	return []typeInferTestCase{
 		{"json_type(c_json)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 51, types.UnspecifiedLength},
 		// TODO: Flen of json_unquote doesn't follow MySQL now.
-		{"json_unquote(c_json)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 0, types.UnspecifiedLength},
+		{"json_unquote(c_json)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, mysql.MaxFieldVarCharLength, types.UnspecifiedLength},
 		{"json_extract(c_json, '')", mysql.TypeJSON, charset.CharsetUTF8MB4, mysql.BinaryFlag, mysql.MaxBlobWidth, 0},
 		{"json_set(c_json, '', 0)", mysql.TypeJSON, charset.CharsetUTF8MB4, mysql.BinaryFlag, mysql.MaxBlobWidth, 0},
 		{"json_insert(c_json, '', 0)", mysql.TypeJSON, charset.CharsetUTF8MB4, mysql.BinaryFlag, mysql.MaxBlobWidth, 0},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #13632 to release-2.1

conflict file:
```
insert_test.go
```

### What is changed and how it works?
This problem comes from `jsonUnquoteFunction` function.
We should fill the Flen in `jsonUnquoteFunctionClass.getFunction()`.
Cause return type `string` is an element set (maybe autowrapped as an array) of whole json, so here we set the flen with `mysql.MaxFieldVarCharLength`.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - fix bug in insert select union select, result from jsonUnquote function's flen.
