### PR TITLE
executor: refine the check of onlyFullGroupBy when groupByItem is parenthesesExpr or UnaryPlusExpr

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -566,6 +566,16 @@ func (s *testSuiteAgg) TestOnlyFullGroupBy(c *C) {
 	c.Assert(terror.ErrorEqual(err, plannercore.ErrAmbiguous), IsTrue, Commentf("err %v", err))
 }
 
+func (s *testSuiteAgg) TestIssue13652(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set sql_mode = 'ONLY_FULL_GROUP_BY'")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a real)")
+	tk.MustQuery("select a from t group by (a)")
+	tk.MustQuery("select a from t group by ((a))")
+}
+
 func (s *testSuiteAgg) TestHaving(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -574,6 +574,10 @@ func (s *testSuiteAgg) TestIssue13652(c *C) {
 	tk.MustExec("create table t(a real)")
 	tk.MustQuery("select a from t group by (a)")
 	tk.MustQuery("select a from t group by ((a))")
+	tk.MustQuery("select a from t group by +a")
+	tk.MustQuery("select a from t group by ((+a))")
+	_, err := tk.Exec("select a from t group by (-a)")
+	c.Assert(err.Error(), Equals, "[planner:1055]Expression #1 of SELECT list is not in GROUP BY clause and contains nonaggregated column 'test.t.a' which is not functionally dependent on columns in GROUP BY clause; this is incompatible with sql_mode=only_full_group_by")
 }
 
 func (s *testSuiteAgg) TestHaving(c *C) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1910,7 +1910,11 @@ func (b *PlanBuilder) checkOnlyFullGroupByWithGroupClause(p LogicalPlan, sel *as
 	gbyColNames := make(map[*types.FieldName]struct{}, len(sel.Fields.Fields))
 	gbyExprs := make([]ast.ExprNode, 0, len(sel.Fields.Fields))
 	for _, byItem := range sel.GroupBy.Items {
-		if colExpr, ok := byItem.Expr.(*ast.ColumnNameExpr); ok {
+		expr := byItem.Expr
+		if pe, ok := expr.(*ast.ParenthesesExpr); ok {
+			expr = getInnerFromParenthesesAndUnaryPlus(pe)
+		}
+		if colExpr, ok := expr.(*ast.ColumnNameExpr); ok {
 			idx, err := expression.FindFieldName(p.OutputNames(), colExpr.Name)
 			if err != nil || idx < 0 {
 				continue

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1921,7 +1921,7 @@ func (b *PlanBuilder) checkOnlyFullGroupByWithGroupClause(p LogicalPlan, sel *as
 			}
 			gbyColNames[p.OutputNames()[idx]] = struct{}{}
 		} else {
-			gbyExprs = append(gbyExprs, byItem.Expr)
+			gbyExprs = append(gbyExprs, expr)
 		}
 	}
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1910,10 +1910,7 @@ func (b *PlanBuilder) checkOnlyFullGroupByWithGroupClause(p LogicalPlan, sel *as
 	gbyColNames := make(map[*types.FieldName]struct{}, len(sel.Fields.Fields))
 	gbyExprs := make([]ast.ExprNode, 0, len(sel.Fields.Fields))
 	for _, byItem := range sel.GroupBy.Items {
-		expr := byItem.Expr
-		if pe, ok := expr.(*ast.ParenthesesExpr); ok {
-			expr = getInnerFromParenthesesAndUnaryPlus(pe)
-		}
+		expr := getInnerFromParenthesesAndUnaryPlus(byItem.Expr)
 		if colExpr, ok := expr.(*ast.ColumnNameExpr); ok {
 			idx, err := expression.FindFieldName(p.OutputNames(), colExpr.Name)
 			if err != nil || idx < 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix issue #13652  

### What is changed and how it works?
Add the check for ParenthesesExpr and UnaryPlusExpr in checkOnlyFullGroupByWithGroupClause

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change


Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch


Release note

Make the check of SQL Mode only_full_group_by correct when the group by items is wrapped with parentheses.