### PR TITLE
*: use filepath instead of path for file operations (#13590)

### DIFF
--- a/cmd/benchfilesort/main.go
+++ b/cmd/benchfilesort/main.go
@@ -20,7 +20,7 @@ import (
 	"io/ioutil"
 	"math/rand"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime/pprof"
 	"time"
 
@@ -191,7 +191,7 @@ func decodeMeta(fd *os.File) error {
 func export() error {
 	var outputBytes []byte
 
-	fileName := path.Join(tmpDir, "data.out")
+	fileName := filepath.Join(tmpDir, "data.out")
 	outputFile, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
 	if err != nil {
 		return errors.Trace(err)
@@ -224,7 +224,7 @@ func load(ratio int) ([]*comparableRow, error) {
 		fd  *os.File
 	)
 
-	fileName := path.Join(tmpDir, "data.out")
+	fileName := filepath.Join(tmpDir, "data.out")
 	fd, err = os.Open(fileName)
 	if os.IsNotExist(err) {
 		return nil, errors.New("data file (data.out) does not exist")
@@ -284,7 +284,7 @@ func driveGenCmd() {
 	err = export()
 	terror.MustNil(err)
 	cLog("Done!")
-	cLogf("Data placed in: %s", path.Join(tmpDir, "data.out"))
+	cLogf("Data placed in: %s", filepath.Join(tmpDir, "data.out"))
 	cLog("Time used: ", time.Since(start))
 	cLog("=================================")
 }

--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -21,7 +21,6 @@ import (
 	"log"
 	"os"
 	"os/exec"
-	"path"
 	"path/filepath"
 	"strings"
 	"text/template"
@@ -89,7 +88,7 @@ func init() {
 }
 
 func usage() {
-	log.Printf("Usage: %s --pkg-dir [plugin source pkg folder] --out-dir [plugin packaged folder path]\n", path.Base(os.Args[0]))
+	log.Printf("Usage: %s --pkg-dir [plugin source pkg folder] --out-dir [plugin packaged folder path]\n", filepath.Base(os.Args[0]))
 	flag.PrintDefaults()
 	os.Exit(1)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -15,7 +15,7 @@ package config
 
 import (
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -44,7 +44,7 @@ func (s *testConfigSuite) TestConfig(c *C) {
 	conf.TiKVClient.RegionCacheTTL = 600
 	configFile := "config.toml"
 	_, localFile, _, _ := runtime.Caller(0)
-	configFile = path.Join(path.Dir(localFile), configFile)
+	configFile = filepath.Join(filepath.Dir(localFile), configFile)
 
 	f, err := os.Create(configFile)
 	c.Assert(err, IsNil)
@@ -105,7 +105,7 @@ max-sql-length=1024
 	c.Assert(f.Close(), IsNil)
 	c.Assert(os.Remove(configFile), IsNil)
 
-	configFile = path.Join(path.Dir(localFile), "config.toml.example")
+	configFile = filepath.Join(filepath.Dir(localFile), "config.toml.example")
 	c.Assert(conf.Load(configFile), IsNil)
 
 	// Make sure the example config is the same as default config.
@@ -124,7 +124,7 @@ max-sql-length=1024
 
 	// Test for TLS config.
 	certFile := "cert.pem"
-	certFile = path.Join(path.Dir(localFile), certFile)
+	certFile = filepath.Join(filepath.Dir(localFile), certFile)
 	f, err = os.Create(certFile)
 	c.Assert(err, IsNil)
 	_, err = f.WriteString(`-----BEGIN CERTIFICATE-----
@@ -150,7 +150,7 @@ c933WW1E0hCtvuGxWFIFtoJMQoyH0Pl4ACmY/6CokCCZKDInrPdhhf3MGRjkkw==
 	c.Assert(f.Sync(), IsNil)
 
 	keyFile := "key.pem"
-	keyFile = path.Join(path.Dir(localFile), keyFile)
+	keyFile = filepath.Join(filepath.Dir(localFile), keyFile)
 	f, err = os.Create(keyFile)
 	c.Assert(err, IsNil)
 	_, err = f.WriteString(`-----BEGIN RSA PRIVATE KEY-----

--- a/util/filesort/filesort.go
+++ b/util/filesort/filesort.go
@@ -18,7 +18,7 @@ import (
 	"encoding/binary"
 	"io"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"sync"
@@ -267,7 +267,7 @@ func (b *Builder) Build() (*FileSorter, error) {
 func (fs *FileSorter) getUniqueFileName() string {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
-	ret := path.Join(fs.tmpDir, strconv.Itoa(fs.nFiles))
+	ret := filepath.Join(fs.tmpDir, strconv.Itoa(fs.nFiles))
 	fs.nFiles++
 	return ret
 }

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -104,7 +104,7 @@ func (hook *contextHook) Fire(entry *log.Entry) error {
 		name := fu.Name()
 		if !isSkippedPackageName(name) {
 			file, line := fu.FileLine(pc[i] - 1)
-			entry.Data["file"] = path.Base(file)
+			entry.Data["file"] = filepath.Base(file)
 			entry.Data["line"] = line
 			break
 		}


### PR DESCRIPTION
Conflicts:
	config/config_test.go
	util/chunk/disk.go

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry-pick #13590 to release 3.0.