### PR TITLE
ddl: fix the error message for dropping primary key (#13665)

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3323,7 +3323,8 @@ func (d *ddl) dropIndex(ctx sessionctx.Context, ti ast.Ident, isPK bool, indexNa
 			return ErrUnsupportedModifyPrimaryKey.GenWithStack("Unsupported drop primary key when alter-primary-key is false")
 
 		}
-		if indexInfo == nil {
+		// If the table's PKIsHandle is true, we can't find the index from the table. So we check the value of PKIsHandle.
+		if indexInfo == nil && !t.Meta().PKIsHandle {
 			return ErrCantDropFieldOrKey.GenWithStack("Can't DROP 'PRIMARY'; check that column/key exists")
 		}
 		if t.Meta().PKIsHandle {


### PR DESCRIPTION
Cherry-pick #13665 to v3.0

Conflicts:

- ddl/serial_test.go

Release note

 - Fix the error message for dropping the primary key.
