### PR TITLE
distsql: use low priority for admin checksum

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -104,6 +104,7 @@ func (builder *RequestBuilder) SetChecksumRequest(checksum *tipb.ChecksumRequest
 		builder.Request.StartTs = checksum.StartTs
 		builder.Request.Data, builder.err = checksum.Marshal()
 		builder.Request.NotFillCache = true
+		builder.Request.Priority = kv.PriorityLow
 	}
 
 	return builder

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -555,7 +555,7 @@ func (s *testSuite) TestRequestBuilder6(c *C) {
 		Desc:           false,
 		Concurrency:    concurrency,
 		IsolationLevel: 0,
-		Priority:       0,
+		Priority:       kv.PriorityLow,
 		NotFillCache:   true,
 		SyncLog:        false,
 		Streaming:      false,


### PR DESCRIPTION

### What problem does this PR solve? <!--add issue link with summary if exists-->

Use low priority for admin checksum to reduce admin-checksum impact on online QPS.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch
