### PR TITLE
expression:implement vectorized evaluation for builtinAddDateIntStringSig

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -157,7 +157,16 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
+	ast.AddDate: {
+		{
+			retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				nil,
+				nil,
+				&constStrGener{"MICROSECOND"},
+			},
+		},
+	},
 	ast.SubTime: {
 		{
 			retEvalType:   types.ETString,


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12101 
### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinAddDateIntStringSig

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateIntStringSig-VecBuiltinFunc-8         	     374	   2924720 ns/op	  352354 B/op	    5182 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateIntStringSig-NonVecBuiltinFunc-8      	     291	   3941496 ns/op	  352356 B/op	    5182 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 