### PR TITLE
infoschema: place INFORMATION_SCHEMA in new virtual table framework

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -166,9 +166,6 @@ github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKw
 github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg4X946/Y5Zwg=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
-github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
-github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4 h1:iRtOAQ6FXkY/BGvst3CDfTva4nTqh6CL8WXvanLdbu0=
-github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9 h1:KH4f4Si9XK6/IW50HtoaiLIFHGkapOM6w83za47UYik=
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9/go.mod h1:4b2X8xSqxIroj/IZ9MX/VGZhAwc11wB9wRIzHvz6SeM=
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
@@ -197,6 +194,7 @@ github.com/pingcap/tipb v0.0.0-20191120020146-6161b015e21e/go.mod h1:RtkHW8WbcNx
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -323,8 +323,8 @@ func (b *Builder) InitWithDBInfos(dbInfos []*model.DBInfo, schemaVersion int64) 
 			return nil, errors.Trace(err)
 		}
 	}
-	// TODO: Update INFORMATION_SCHEMA schema to use virtual table.
-	b.createSchemaTablesForInfoSchemaDB()
+
+	// Sort all tables by `ID`
 	for _, v := range info.sortedTablesBuckets {
 		sort.Sort(v)
 	}
@@ -364,20 +364,6 @@ var drivers []*virtualTableDriver
 // RegisterVirtualTable register virtual tables to the builder.
 func RegisterVirtualTable(dbInfo *model.DBInfo, tableFromMeta tableFromMetaFunc) {
 	drivers = append(drivers, &virtualTableDriver{dbInfo, tableFromMeta})
-}
-
-func (b *Builder) createSchemaTablesForInfoSchemaDB() {
-	infoSchemaSchemaTables := &schemaTables{
-		dbInfo: infoSchemaDB,
-		tables: make(map[string]table.Table, len(infoSchemaDB.Tables)),
-	}
-	b.is.schemaMap[infoSchemaDB.Name.L] = infoSchemaSchemaTables
-	for _, t := range infoSchemaDB.Tables {
-		tbl := createInfoSchemaTable(b.handle, t)
-		infoSchemaSchemaTables.tables[t.Name.L] = tbl
-		bucketIdx := tableBucketIdx(t.ID)
-		b.is.sortedTablesBuckets[bucketIdx] = append(b.is.sortedTablesBuckets[bucketIdx], tbl)
-	}
 }
 
 // Build sets new InfoSchema to the handle in the Builder.

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -372,14 +372,8 @@ func init() {
 		codeTableLocked:               mysql.ErrTableLocked,
 	}
 	terror.ErrClassToMySQLCodes[terror.ClassSchema] = schemaMySQLErrCodes
-	initInfoSchemaDB()
-}
 
-var (
-	infoSchemaDB *model.DBInfo
-)
-
-func initInfoSchemaDB() {
+	// Initialize the information shema database and register the driver to `drivers`
 	dbID := autoid.GenLocalSchemaID()
 	infoSchemaTables := make([]*model.TableInfo, 0, len(tableNameToColumns))
 	for name, cols := range tableNameToColumns {
@@ -390,20 +384,18 @@ func initInfoSchemaDB() {
 			c.ID = autoid.GenLocalSchemaID()
 		}
 	}
-	infoSchemaDB = &model.DBInfo{
+	infoSchemaDB := &model.DBInfo{
 		ID:      dbID,
 		Name:    model.NewCIStr(Name),
 		Charset: mysql.DefaultCharset,
 		Collate: mysql.DefaultCollationName,
 		Tables:  infoSchemaTables,
 	}
+	RegisterVirtualTable(infoSchemaDB, createInfoSchemaTable)
 }
 
 // IsMemoryDB checks if the db is in memory.
 func IsMemoryDB(dbName string) bool {
-	if dbName == "information_schema" {
-		return true
-	}
 	for _, driver := range drivers {
 		if driver.DBInfo.Name.L == dbName {
 			return true

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -2200,23 +2200,19 @@ var tableNameToColumns = map[string][]columnInfo{
 	tableTiFlashReplica:                     tableTableTiFlashReplicaCols,
 }
 
-func createInfoSchemaTable(handle *Handle, meta *model.TableInfo) *infoschemaTable {
+func createInfoSchemaTable(_ autoid.Allocator, meta *model.TableInfo) (table.Table, error) {
 	columns := make([]*table.Column, len(meta.Columns))
 	for i, col := range meta.Columns {
 		columns[i] = table.ToColumn(col)
 	}
-	return &infoschemaTable{
-		handle: handle,
-		meta:   meta,
-		cols:   columns,
-	}
+	return &infoschemaTable{meta: meta, cols: columns}, nil
 }
 
 type infoschemaTable struct {
-	handle *Handle
-	meta   *model.TableInfo
-	cols   []*table.Column
-	rows   [][]types.Datum
+	// handle *Handle
+	meta *model.TableInfo
+	cols []*table.Column
+	rows [][]types.Datum
 }
 
 // schemasSorter implements the sort.Interface interface, sorts DBInfo by name.

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -2209,7 +2209,6 @@ func createInfoSchemaTable(_ autoid.Allocator, meta *model.TableInfo) (table.Tab
 }
 
 type infoschemaTable struct {
-	// handle *Handle
 	meta *model.TableInfo
 	cols []*table.Column
 	rows [][]types.Datum


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix issue #13694
 
The `informaction_schema` should be placed in the new virtual table framework. See: 
https://github.com/pingcap/tidb/blob/71e19a730831119bbab81178bdf57eb4eb2af217/infoschema/builder.go#L326

### What is changed and how it works?

Refactor it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - No need.
