### PR TITLE
expression: implement vectorized evaluation for 'builtinSubTimeDurationNullSig'

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -800,11 +800,13 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 }
 
 func (b *builtinSubTimeDurationNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinSubTimeDurationNullSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	result.ResizeGoDuration(n, true)
+	return nil
 }
 
 func (b *builtinStrToDateDateSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -179,6 +179,11 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
 		},
+		// builtinSubTimeDurationNullSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDatetime},
+		},
 	},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinSubTimeDurationNullSig from #12176 

### What is changed and how it works?
99% faster than before:


    BenchmarkVectorizedBuiltinTimeFunc/builtinSubTimeDurationNullSig-VecBuiltinFunc-4               13122880                88.4 ns/op             0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFunc/builtinSubTimeDurationNullSig-NonVecBuiltinFunc-4              111243             11047 ns/op               0 B/op          0 allocs/op




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
