### PR TITLE
expression: use generator to implement vectorized evaluation for `builtinAddDate*Sig` and `builtinSubDate*Sig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1057,9 +1057,7 @@ func removeTestOptions(args []string) []string {
 	// args contains '-test.timeout=' option for example
 	// excluding it to be able to run all tests
 	for _, arg := range args {
-		if strings.HasPrefix(arg, "builtin") {
-			argList = append(argList, arg)
-		} else if IsFunctionSupported(arg) {
+		if strings.HasPrefix(arg, "builtin") || IsFunctionSupported(arg) {
 			argList = append(argList, arg)
 		}
 	}

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -639,7 +639,7 @@ func (g *dateStrGener) gen() interface{} {
 }
 
 // timeStrGener is used to generate strings which are time format
-type timeStrGener struct{
+type timeStrGener struct {
 	nullRation float64
 }
 

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1059,7 +1059,7 @@ func removeTestOptions(args []string) []string {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "builtin") {
 			argList = append(argList, arg)
-		} else if _, ok := funcs[arg]; ok {
+		} else if IsFunctionSupported(arg) {
 			argList = append(argList, arg)
 		}
 	}

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1059,6 +1059,8 @@ func removeTestOptions(args []string) []string {
 	for _, arg := range args {
 		if strings.HasPrefix(arg, "builtin") {
 			argList = append(argList, arg)
+		} else if _, ok := funcs[arg]; ok {
+			argList = append(argList, arg)
 		}
 	}
 	return argList
@@ -1109,7 +1111,7 @@ func testVectorizedBuiltinFunc(c *C, vecExprCases vecExprBenchCases) {
 			tmp := strings.Split(baseFuncName, ".")
 			baseFuncName = tmp[len(tmp)-1]
 
-			if !testAll && testFunc[baseFuncName] != true {
+			if !testAll && (testFunc[baseFuncName] != true && testFunc[funcName] != true) {
 				continue
 			}
 			// do not forget to implement the vectorized method.
@@ -1329,7 +1331,7 @@ func benchmarkVectorizedBuiltinFunc(b *testing.B, vecExprCases vecExprBenchCases
 			tmp := strings.Split(baseFuncName, ".")
 			baseFuncName = tmp[len(tmp)-1]
 
-			if !testAll && testFunc[baseFuncName] != true {
+			if !testAll && testFunc[baseFuncName] != true && testFunc[funcName] != true {
 				continue
 			}
 

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -612,15 +612,15 @@ func (g *dateTimeStrGener) gen() interface{} {
 	return dataTimeStr
 }
 
-// timeStrGener is used to generate strings which are time format
-type timeStrGener struct {
+// dateStrGener is used to generate strings which are date format
+type dateStrGener struct {
 	Year       int
 	Month      int
 	Day        int
 	NullRation float64
 }
 
-func (g *timeStrGener) gen() interface{} {
+func (g *dateStrGener) gen() interface{} {
 	if g.NullRation > 1e-6 && rand.Float64() < g.NullRation {
 		return nil
 	}
@@ -638,12 +638,12 @@ func (g *timeStrGener) gen() interface{} {
 	return fmt.Sprintf("%d-%d-%d", g.Year, g.Month, g.Day)
 }
 
-// dateStrGener is used to generate strings which are data format
-type dateStrGener struct {
+// timeStrGener is used to generate strings which are time format
+type timeStrGener struct{
 	nullRation float64
 }
 
-func (g *dateStrGener) gen() interface{} {
+func (g *timeStrGener) gen() interface{} {
 	if g.nullRation > 1e-6 && rand.Float64() < g.nullRation {
 		return nil
 	}
@@ -652,6 +652,24 @@ func (g *dateStrGener) gen() interface{} {
 	second := rand.Intn(60)
 
 	return fmt.Sprintf("%d:%d:%d", hour, minute, second)
+}
+
+type dateTimeIntGener struct {
+	dateTimeGener
+	nullRation float64
+}
+
+func (g *dateTimeIntGener) gen() interface{} {
+	if rand.Float64() < g.nullRation {
+		return nil
+	}
+
+	t := g.dateTimeGener.gen().(types.Time)
+	num, err := t.ToNumber().ToInt()
+	if err != nil {
+		panic(err)
+	}
+	return num
 }
 
 // constStrGener always returns the given string

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -87,8 +87,8 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString},
 			geners: []dataGenerator{
 				&dateTimeStrGener{},
-				&timeStrGener{},
 				&dateStrGener{},
+				&timeStrGener{},
 			}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDuration}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDatetime}},

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2870,10 +2870,17 @@ func (du *baseDateArithmitical) vecGetDateFromInt(b *baseBuiltinFunc, input *chu
 		if result.IsNull(i) {
 			continue
 		}
+
 		date, err := types.ParseTimeFromInt64(sc, i64s[i])
 		if err != nil {
-			return err
+			err = handleInvalidTimeError(b.ctx, err)
+			if err != nil {
+				return err
+			}
+			result.SetNull(i, true)
+			continue
 		}
+
 		dateTp := mysql.TypeDate
 		if date.Type == mysql.TypeDatetime || date.Type == mysql.TypeTimestamp || isClockUnit {
 			dateTp = mysql.TypeDatetime

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2924,6 +2924,28 @@ func (du *baseDateArithmitical) vecGetDateFromString(b *baseBuiltinFunc, input *
 	return nil
 }
 
+func (du *baseDateArithmitical) vecGetDateFromDatetime(b *baseBuiltinFunc, input *chunk.Chunk, unit *chunk.Column, result *chunk.Column) error {
+	n := input.NumRows()
+	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(unit)
+	dates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		dateTp := mysql.TypeDate
+		if dates[i].Type == mysql.TypeDatetime || dates[i].Type == mysql.TypeTimestamp || types.IsClockUnit(unit.GetString(i)) {
+			dateTp = mysql.TypeDatetime
+		}
+		dates[i].Type = dateTp
+	}
+	return nil
+}
+
 func (du *baseDateArithmitical) vecGetIntervalFromString(b *baseBuiltinFunc, input *chunk.Chunk, unit *chunk.Column, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get(types.ETString, n)

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2935,6 +2935,7 @@ func (du *baseDateArithmitical) vecGetDateFromString(b *baseBuiltinFunc, input *
 
 func (du *baseDateArithmitical) vecGetDateFromDatetime(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {
 	n := input.NumRows()
+	result.ResizeTime(n, false)
 	if err := b.args[0].VecEvalTime(b.ctx, input, result); err != nil {
 		return err
 	}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2966,6 +2966,20 @@ func (du *baseDateArithmitical) vecGetIntervalFromString(b *baseBuiltinFunc, inp
 		return err
 	}
 
+	amendInterval := func(val string) string {
+		return val
+	}
+	if unitLower := strings.ToLower(unit); unitLower == "day" || unitLower == "hour" {
+		amendInterval = func(val string) string {
+			if intervalLower := strings.ToLower(val); intervalLower == "true" {
+				return "1"
+			} else if intervalLower == "false" {
+				return "0"
+			}
+			return du.intervalRegexp.FindString(val)
+		}
+	}
+
 	result.ReserveString(n)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
@@ -2973,17 +2987,7 @@ func (du *baseDateArithmitical) vecGetIntervalFromString(b *baseBuiltinFunc, inp
 			continue
 		}
 
-		interval := buf.GetString(i)
-		if unitLower := strings.ToLower(unit); unitLower == "day" || unitLower == "hour" {
-			if intervalLower := strings.ToLower(interval); intervalLower == "true" {
-				interval = "1"
-			} else if intervalLower == "false" {
-				interval = "0"
-			} else {
-				interval = du.intervalRegexp.FindString(interval)
-			}
-		}
-		result.AppendString(interval)
+		result.AppendString(amendInterval(buf.GetString(i)))
 	}
 	return nil
 }

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2788,6 +2788,30 @@ func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, int
 	return date, false, nil
 }
 
+func (du *baseDateArithmitical) addDuration(ctx sessionctx.Context, d types.Duration, interval string, unit string) (types.Duration, bool, error) {
+	dur, err := types.ExtractDurationValue(unit, interval)
+	if err != nil {
+		return types.ZeroDuration, true, handleInvalidTimeError(ctx, err)
+	}
+	retDur, err := d.Add(dur)
+	if err != nil {
+		return types.ZeroDuration, true, err
+	}
+	return retDur, false, nil
+}
+
+func (du *baseDateArithmitical) subDuration(ctx sessionctx.Context, d types.Duration, interval string, unit string) (types.Duration, bool, error) {
+	dur, err := types.ExtractDurationValue(unit, interval)
+	if err != nil {
+		return types.ZeroDuration, true, handleInvalidTimeError(ctx, err)
+	}
+	retDur, err := d.Sub(dur)
+	if err != nil {
+		return types.ZeroDuration, true, err
+	}
+	return retDur, false, nil
+}
+
 func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, interval string, unit string) (types.Time, bool, error) {
 	year, month, day, nano, err := types.ParseDurationValue(unit, interval)
 	if err := handleInvalidTimeError(ctx, err); err != nil {
@@ -2823,30 +2847,6 @@ func (du *baseDateArithmitical) sub(ctx sessionctx.Context, date types.Time, int
 		return types.Time{}, true, handleInvalidTimeError(ctx, types.ErrDatetimeFunctionOverflow.GenWithStackByArgs("datetime"))
 	}
 	return date, false, nil
-}
-
-func (du *baseDateArithmitical) addDuration(ctx sessionctx.Context, d types.Duration, interval string, unit string) (types.Duration, bool, error) {
-	dur, err := types.ExtractDurationValue(unit, interval)
-	if err != nil {
-		return types.ZeroDuration, true, handleInvalidTimeError(ctx, err)
-	}
-	retDur, err := d.Add(dur)
-	if err != nil {
-		return types.ZeroDuration, true, err
-	}
-	return retDur, false, nil
-}
-
-func (du *baseDateArithmitical) subDuration(ctx sessionctx.Context, d types.Duration, interval string, unit string) (types.Duration, bool, error) {
-	dur, err := types.ExtractDurationValue(unit, interval)
-	if err != nil {
-		return types.ZeroDuration, true, handleInvalidTimeError(ctx, err)
-	}
-	retDur, err := d.Sub(dur)
-	if err != nil {
-		return types.ZeroDuration, true, err
-	}
-	return retDur, false, nil
 }
 
 func (du *baseDateArithmitical) vecGetDateFromInt(b *baseBuiltinFunc, input *chunk.Chunk, unit string, result *chunk.Column) error {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -244,14 +244,6 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(input *chunk.Chunk, result *chunk
 	return nil
 }
 
-func (b *builtinAddDateIntIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
 	return false
 }
@@ -545,14 +537,6 @@ func (b *builtinYearWeekWithoutModeSig) vecEvalInt(input *chunk.Chunk, result *c
 	return nil
 }
 
-func (b *builtinAddDateStringRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinSubDateStringDecimalSig) vectorized() bool {
 	return false
 }
@@ -784,14 +768,6 @@ func (b *builtinLastDaySig) vecEvalTime(input *chunk.Chunk, result *chunk.Column
 	return nil
 }
 
-func (b *builtinAddDateStringDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinAddDateDatetimeRealSig) vectorized() bool {
 	return false
 }
@@ -860,14 +836,6 @@ func (b *builtinStrToDateDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		times[i] = t
 	}
 	return nil
-}
-
-func (b *builtinAddDateStringIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSysDateWithFspSig) vectorized() bool {
@@ -1354,14 +1322,6 @@ func (b *builtinTimestampLiteralSig) vecEvalTime(input *chunk.Chunk, result *chu
 	return errors.Errorf("not implemented")
 }
 
-func (b *builtinAddDateIntDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinMakeDateSig) vectorized() bool {
 	return true
 }
@@ -1508,14 +1468,6 @@ func (b *builtinUTCTimestampWithArgSig) vecEvalTime(input *chunk.Chunk, result *
 		t64s[i] = res
 	}
 	return nil
-}
-
-func (b *builtinAddDateIntRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubDurationAndDurationSig) vectorized() bool {
@@ -2140,22 +2092,6 @@ func (b *builtinCurrentDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Co
 		times[i] = timeValue
 	}
 	return nil
-}
-
-func (b *builtinAddDateStringStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinAddDateIntStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinAddDateDatetimeStringSig) vectorized() bool {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -447,14 +447,6 @@ func (b *builtinUTCTimeWithArgSig) vecEvalDuration(input *chunk.Chunk, result *c
 	return nil
 }
 
-func (b *builtinSubDateIntIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinUnixTimestampCurrentSig) vectorized() bool {
 	return true
 }
@@ -477,14 +469,6 @@ func (b *builtinUnixTimestampCurrentSig) vecEvalInt(input *chunk.Chunk, result *
 		intRes[i] = intVal
 	}
 	return nil
-}
-
-func (b *builtinSubDateIntRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinYearWeekWithoutModeSig) vectorized() bool {
@@ -527,14 +511,6 @@ func (b *builtinYearWeekWithoutModeSig) vecEvalInt(input *chunk.Chunk, result *c
 		}
 	}
 	return nil
-}
-
-func (b *builtinSubDateStringDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinPeriodDiffSig) vectorized() bool {
@@ -616,22 +592,6 @@ func (b *builtinNowWithArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Col
 		times[i] = t
 	}
 	return nil
-}
-
-func (b *builtinSubDateStringRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinSubDateDatetimeIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubDateDurationDecimalSig) vectorized() bool {
@@ -866,14 +826,6 @@ func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, resul
 	return errors.Errorf("not implemented")
 }
 
-func (b *builtinSubDateIntStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinTidbParseTsoSig) vectorized() bool {
 	return true
 }
@@ -991,14 +943,6 @@ func (b *builtinSubDatetimeAndStringSig) vectorized() bool {
 }
 
 func (b *builtinSubDatetimeAndStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinSubDateStringStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	return errors.Errorf("not implemented")
 }
 
@@ -1995,14 +1939,6 @@ func (b *builtinUTCTimeWithoutArgSig) vecEvalDuration(input *chunk.Chunk, result
 	return nil
 }
 
-func (b *builtinSubDateIntDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinDateDiffSig) vectorized() bool {
 	return true
 }
@@ -2303,14 +2239,6 @@ func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, r
 	return errors.Errorf("not implemented")
 }
 
-func (b *builtinSubDateDatetimeRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinSubDateDurationRealSig) vectorized() bool {
 	return false
 }
@@ -2389,14 +2317,6 @@ func (b *builtinTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Colum
 		ds[i] = res.Duration
 	}
 	return nil
-}
-
-func (b *builtinSubDateStringIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinDateLiteralSig) vectorized() bool {
@@ -2486,22 +2406,6 @@ func (b *builtinMonthNameSig) vecEvalString(input *chunk.Chunk, result *chunk.Co
 
 func (b *builtinMonthNameSig) vectorized() bool {
 	return true
-}
-
-func (b *builtinSubDateDatetimeStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinSubDateDatetimeDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubDatetimeAndDurationSig) vectorized() bool {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -244,14 +244,6 @@ func (b *builtinExtractDatetimeSig) vecEvalInt(input *chunk.Chunk, result *chunk
 	return nil
 }
 
-func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinDayNameSig) vectorized() bool {
 	return true
 }
@@ -766,14 +758,6 @@ func (b *builtinLastDaySig) vecEvalTime(input *chunk.Chunk, result *chunk.Column
 		}
 	}
 	return nil
-}
-
-func (b *builtinAddDateDatetimeRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubTimeDurationNullSig) vectorized() bool {
@@ -2094,14 +2078,6 @@ func (b *builtinCurrentDateSig) vecEvalTime(input *chunk.Chunk, result *chunk.Co
 	return nil
 }
 
-func (b *builtinAddDateDatetimeStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinMakeTimeSig) vectorized() bool {
 	return false
 }
@@ -2413,14 +2389,6 @@ func (b *builtinTimeSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Colum
 		ds[i] = res.Duration
 	}
 	return nil
-}
-
-func (b *builtinAddDateDatetimeIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubDateStringIntSig) vectorized() bool {

--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -594,14 +594,6 @@ func (b *builtinNowWithArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.Col
 	return nil
 }
 
-func (b *builtinSubDateDurationDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinGetFormatSig) vectorized() bool {
 	return true
 }
@@ -818,14 +810,6 @@ func (b *builtinSysDateWithFspSig) vecEvalTime(input *chunk.Chunk, result *chunk
 	return nil
 }
 
-func (b *builtinAddDateDurationIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinTidbParseTsoSig) vectorized() bool {
 	return true
 }
@@ -864,14 +848,6 @@ func (b *builtinTidbParseTsoSig) vecEvalTime(input *chunk.Chunk, result *chunk.C
 		times[i] = r
 	}
 	return nil
-}
-
-func (b *builtinAddDateDurationStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
 }
 
 func (b *builtinSubStringAndDurationSig) vectorized() bool {
@@ -1782,14 +1758,6 @@ func (b *builtinHourSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) er
 	return nil
 }
 
-func (b *builtinAddDateDurationRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinSecToTimeSig) vectorized() bool {
 	return true
 }
@@ -2102,14 +2070,6 @@ func (b *builtinFromUnixTime1ArgSig) vecEvalTime(input *chunk.Chunk, result *chu
 	return nil
 }
 
-func (b *builtinSubDateDurationIntSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinYearWeekWithModeSig) vectorized() bool {
 	return true
 }
@@ -2231,22 +2191,6 @@ func (b *builtinUnixTimestampIntSig) vecEvalInt(input *chunk.Chunk, result *chun
 	return errors.Errorf("not implemented")
 }
 
-func (b *builtinAddDateDurationDecimalSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinSubDateDurationRealSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
 func (b *builtinCurrentTime0ArgSig) vectorized() bool {
 	return true
 }
@@ -2346,14 +2290,6 @@ func (b *builtinTimeLiteralSig) vectorized() bool {
 }
 
 func (b *builtinTimeLiteralSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
-}
-
-func (b *builtinSubDateDurationStringSig) vectorized() bool {
-	return false
-}
-
-func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	return errors.Errorf("not implemented")
 }
 

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1020,12 +1020,12 @@ func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1039,21 +1039,21 @@ func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1075,12 +1075,12 @@ func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1094,21 +1094,21 @@ func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1130,12 +1130,12 @@ func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1149,21 +1149,21 @@ func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1185,12 +1185,12 @@ func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1204,21 +1204,21 @@ func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1240,12 +1240,12 @@ func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1259,21 +1259,21 @@ func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1295,12 +1295,12 @@ func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1314,21 +1314,21 @@ func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1350,12 +1350,12 @@ func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1369,21 +1369,21 @@ func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1405,12 +1405,12 @@ func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1424,21 +1424,21 @@ func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1460,12 +1460,12 @@ func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1479,21 +1479,21 @@ func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1515,12 +1515,12 @@ func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1534,21 +1534,21 @@ func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1570,12 +1570,12 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1589,21 +1589,21 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1625,12 +1625,12 @@ func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1644,27 +1644,255 @@ func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
 }
 
 func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDurationStringSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDurationIntSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDurationRealSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDurationDecimalSig) vectorized() bool {
 	return true
 }
 
@@ -1680,12 +1908,12 @@ func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1699,21 +1927,21 @@ func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1735,12 +1963,12 @@ func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1754,21 +1982,21 @@ func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1790,12 +2018,12 @@ func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1809,21 +2037,21 @@ func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1845,12 +2073,12 @@ func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1864,21 +2092,21 @@ func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1900,12 +2128,12 @@ func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1919,21 +2147,21 @@ func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -1955,12 +2183,12 @@ func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -1974,21 +2202,21 @@ func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2010,12 +2238,12 @@ func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2029,21 +2257,21 @@ func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2065,12 +2293,12 @@ func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2084,21 +2312,21 @@ func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2120,12 +2348,12 @@ func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2139,21 +2367,21 @@ func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2175,12 +2403,12 @@ func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2194,21 +2422,21 @@ func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2230,12 +2458,12 @@ func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2249,21 +2477,21 @@ func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
@@ -2285,12 +2513,12 @@ func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return err
 	}
 
-	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	defer b.bufAllocator.put(timeCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
 		return err
 	}
 
@@ -2304,26 +2532,254 @@ func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, dateCol, intervalCol)
-	orgDates := dateCol.Times()
-	resDates := result.Times()
+	result.MergeNulls(unitCol, timeCol, intervalCol)
+	oriTimes := timeCol.Times()
+	resTimes := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		date, isNull, err := b.sub(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDates[i] = date
+			resTimes[i] = time
 		}
 	}
 	return nil
 }
 
 func (b *builtinSubDateDatetimeDecimalSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinSubDateDurationStringSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinSubDateDurationIntSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinSubDateDurationRealSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(durationCol)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	stubDuration := types.Duration{Fsp: types.MaxFsp}
+	result.ResizeGoDuration(n, false)
+	result.MergeNulls(unitCol, durationCol, intervalCol)
+	oriDurations := durationCol.GoDurations()
+	resDurations := result.GoDurations()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+		stubDuration.Duration = oriDurations[i]
+		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDurations[i] = duration.Duration
+		}
+	}
+	return nil
+}
+
+func (b *builtinSubDateDurationDecimalSig) vectorized() bool {
 	return true
 }

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1028,24 +1028,17 @@ func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1082,24 +1075,17 @@ func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1136,24 +1122,17 @@ func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1190,24 +1169,17 @@ func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1244,24 +1216,17 @@ func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1298,24 +1263,17 @@ func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1352,24 +1310,17 @@ func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1406,24 +1357,17 @@ func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1460,7 +1404,6 @@ func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -1508,7 +1451,6 @@ func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -1556,7 +1498,6 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -1604,7 +1545,6 @@ func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -1852,24 +1792,17 @@ func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1906,24 +1839,17 @@ func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1960,24 +1886,17 @@ func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2014,24 +1933,17 @@ func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2068,24 +1980,17 @@ func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2122,24 +2027,17 @@ func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2176,24 +2074,17 @@ func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2230,24 +2121,17 @@ func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return err
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
 
-	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2284,7 +2168,6 @@ func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -2332,7 +2215,6 @@ func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -2380,7 +2262,6 @@ func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}
@@ -2428,7 +2309,6 @@ func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return err
 	}
 
-	result.ResizeTime(n, false)
 	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
 		return err
 	}

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1007,3 +1007,451 @@ func (b *builtinTimeTimeTimeDiffSig) vecEvalDuration(input *chunk.Chunk, result 
 func (b *builtinTimeTimeTimeDiffSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateStringStringSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateStringIntSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateStringRealSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateStringDecimalSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateIntStringSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateIntIntSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateIntRealSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateIntDecimalSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1455,3 +1455,227 @@ func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 func (b *builtinAddDateIntDecimalSig) vectorized() bool {
 	return true
 }
+
+func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDatetimeStringSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDatetimeIntSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDatetimeRealSig) vectorized() bool {
+	return true
+}
+
+func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
+	n := input.NumRows()
+
+	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unitCol)
+	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
+		return err
+	}
+
+	dateCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateCol)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+		return err
+	}
+
+	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(intervalCol)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+		return err
+	}
+
+	result.ResizeTime(n, false)
+	result.MergeNulls(unitCol, dateCol, intervalCol)
+	orgDates := dateCol.Times()
+	resDates := result.Times()
+	for i := 0; i < n; i++ {
+		if result.IsNull(i) {
+			continue
+		}
+
+		date, isNull, err := b.add(b.ctx, orgDates[i], intervalCol.GetString(i), unitCol.GetString(i))
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+		} else {
+			resDates[i] = date
+		}
+	}
+	return nil
+}
+
+func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
+	return true
+}

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1010,50 +1010,49 @@ func (b *builtinTimeTimeTimeDiffSig) vectorized() bool {
 
 func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1065,50 +1064,49 @@ func (b *builtinAddDateStringStringSig) vectorized() bool {
 
 func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1120,50 +1118,49 @@ func (b *builtinAddDateStringIntSig) vectorized() bool {
 
 func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1175,50 +1172,49 @@ func (b *builtinAddDateStringRealSig) vectorized() bool {
 
 func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1230,50 +1226,49 @@ func (b *builtinAddDateStringDecimalSig) vectorized() bool {
 
 func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1285,50 +1280,49 @@ func (b *builtinAddDateIntStringSig) vectorized() bool {
 
 func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1340,50 +1334,49 @@ func (b *builtinAddDateIntIntSig) vectorized() bool {
 
 func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1395,50 +1388,49 @@ func (b *builtinAddDateIntRealSig) vectorized() bool {
 
 func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1450,50 +1442,49 @@ func (b *builtinAddDateIntDecimalSig) vectorized() bool {
 
 func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1505,50 +1496,49 @@ func (b *builtinAddDateDatetimeStringSig) vectorized() bool {
 
 func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1560,50 +1550,49 @@ func (b *builtinAddDateDatetimeIntSig) vectorized() bool {
 
 func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1615,50 +1604,49 @@ func (b *builtinAddDateDatetimeRealSig) vectorized() bool {
 
 func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.add(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1670,52 +1658,51 @@ func (b *builtinAddDateDatetimeDecimalSig) vectorized() bool {
 
 func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -1727,52 +1714,51 @@ func (b *builtinAddDateDurationStringSig) vectorized() bool {
 
 func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -1784,52 +1770,51 @@ func (b *builtinAddDateDurationIntSig) vectorized() bool {
 
 func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -1841,52 +1826,51 @@ func (b *builtinAddDateDurationRealSig) vectorized() bool {
 
 func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.addDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -1898,50 +1882,49 @@ func (b *builtinAddDateDurationDecimalSig) vectorized() bool {
 
 func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -1953,50 +1936,49 @@ func (b *builtinSubDateStringStringSig) vectorized() bool {
 
 func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2008,50 +1990,49 @@ func (b *builtinSubDateStringIntSig) vectorized() bool {
 
 func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2063,50 +2044,49 @@ func (b *builtinSubDateStringRealSig) vectorized() bool {
 
 func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2118,50 +2098,49 @@ func (b *builtinSubDateStringDecimalSig) vectorized() bool {
 
 func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2173,50 +2152,49 @@ func (b *builtinSubDateIntStringSig) vectorized() bool {
 
 func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2228,50 +2206,49 @@ func (b *builtinSubDateIntIntSig) vectorized() bool {
 
 func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2283,50 +2260,49 @@ func (b *builtinSubDateIntRealSig) vectorized() bool {
 
 func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2338,50 +2314,49 @@ func (b *builtinSubDateIntDecimalSig) vectorized() bool {
 
 func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2393,50 +2368,49 @@ func (b *builtinSubDateDatetimeStringSig) vectorized() bool {
 
 func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2448,50 +2422,49 @@ func (b *builtinSubDateDatetimeIntSig) vectorized() bool {
 
 func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2503,50 +2476,49 @@ func (b *builtinSubDateDatetimeRealSig) vectorized() bool {
 
 func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeTime(n, true)
+		return nil
 	}
 
-	timeCol, err := b.bufAllocator.get(types.ETDatetime, n)
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(timeCol)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unitCol, timeCol); err != nil {
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(unitCol, timeCol, intervalCol)
-	oriTimes := timeCol.Times()
-	resTimes := result.Times()
+	result.MergeNulls(dateBuf, intervalBuf)
+	oriDates := dateBuf.Times()
+	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		time, isNull, err := b.sub(b.ctx, oriTimes[i], intervalCol.GetString(i), unitCol.GetString(i))
+		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resTimes[i] = time
+			resDates[i] = resDate
 		}
 	}
 	return nil
@@ -2558,52 +2530,51 @@ func (b *builtinSubDateDatetimeDecimalSig) vectorized() bool {
 
 func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -2615,52 +2586,51 @@ func (b *builtinSubDateDurationStringSig) vectorized() bool {
 
 func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -2672,52 +2642,51 @@ func (b *builtinSubDateDurationIntSig) vectorized() bool {
 
 func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil
@@ -2729,52 +2698,51 @@ func (b *builtinSubDateDurationRealSig) vectorized() bool {
 
 func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
-
-	unitCol, err := b.bufAllocator.get(types.ETString, n)
+	unit, isNull, err := b.args[2].EvalString(b.ctx, chunk.Row{})
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(unitCol)
-	if err := b.args[2].VecEvalString(b.ctx, input, unitCol); err != nil {
-		return err
+	if isNull {
+		result.ResizeGoDuration(n, true)
+		return nil
 	}
 
-	durationCol, err := b.bufAllocator.get(types.ETDuration, n)
+	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(durationCol)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationCol); err != nil {
+	defer b.bufAllocator.put(durationBuf)
+	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
 		return err
 	}
 
-	intervalCol, err := b.bufAllocator.get(types.ETString, n)
+	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
-	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	defer b.bufAllocator.put(intervalBuf)
+	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
 		return err
 	}
 
-	stubDuration := types.Duration{Fsp: types.MaxFsp}
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(unitCol, durationCol, intervalCol)
-	oriDurations := durationCol.GoDurations()
+	result.MergeNulls(durationBuf, intervalBuf)
+	oriDurations := durationBuf.GoDurations()
 	resDurations := result.GoDurations()
+	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		stubDuration.Duration = oriDurations[i]
-		duration, isNull, err := b.subDuration(b.ctx, stubDuration, intervalCol.GetString(i), unitCol.GetString(i))
+		iterDuration.Duration = oriDurations[i]
+		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
 		if isNull {
 			result.SetNull(i, true)
 		} else {
-			resDurations[i] = duration.Duration
+			resDurations[i] = resDuration.Duration
 		}
 	}
 	return nil

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -1019,21 +1019,21 @@ func (b *builtinAddDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1073,21 +1073,21 @@ func (b *builtinAddDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1127,21 +1127,21 @@ func (b *builtinAddDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1181,21 +1181,21 @@ func (b *builtinAddDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1235,21 +1235,21 @@ func (b *builtinAddDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1289,21 +1289,21 @@ func (b *builtinAddDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1343,21 +1343,21 @@ func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1397,21 +1397,21 @@ func (b *builtinAddDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1451,15 +1451,6 @@ func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1470,14 +1461,17 @@ func (b *builtinAddDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1505,15 +1499,6 @@ func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1524,14 +1509,17 @@ func (b *builtinAddDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1559,15 +1547,6 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1578,14 +1557,17 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1613,15 +1595,6 @@ func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1632,14 +1605,17 @@ func (b *builtinAddDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.add(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.add(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -1667,15 +1643,6 @@ func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, re
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1686,15 +1653,18 @@ func (b *builtinAddDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, re
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -1723,15 +1693,6 @@ func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, resul
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1742,15 +1703,18 @@ func (b *builtinAddDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, resul
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -1779,15 +1743,6 @@ func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, resu
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1798,15 +1753,18 @@ func (b *builtinAddDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, resu
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -1835,15 +1793,6 @@ func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, r
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -1854,15 +1803,18 @@ func (b *builtinAddDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, r
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.addDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -1891,21 +1843,21 @@ func (b *builtinSubDateStringStringSig) vecEvalTime(input *chunk.Chunk, result *
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1945,21 +1897,21 @@ func (b *builtinSubDateStringIntSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -1999,21 +1951,21 @@ func (b *builtinSubDateStringRealSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2053,21 +2005,21 @@ func (b *builtinSubDateStringDecimalSig) vecEvalTime(input *chunk.Chunk, result 
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromString(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2107,21 +2059,21 @@ func (b *builtinSubDateIntStringSig) vecEvalTime(input *chunk.Chunk, result *chu
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromString(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2161,21 +2113,21 @@ func (b *builtinSubDateIntIntSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromInt(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2215,21 +2167,21 @@ func (b *builtinSubDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromReal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2269,21 +2221,21 @@ func (b *builtinSubDateIntDecimalSig) vecEvalTime(input *chunk.Chunk, result *ch
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
 	}
 	defer b.bufAllocator.put(intervalBuf)
 	if err := b.vecGetIntervalFromDecimal(&b.baseBuiltinFunc, input, unit, intervalBuf); err != nil {
+		return err
+	}
+
+	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(dateBuf)
+	if err := b.vecGetDateFromInt(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
 		return err
 	}
 
@@ -2323,15 +2275,6 @@ func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2342,14 +2285,17 @@ func (b *builtinSubDateDatetimeStringSig) vecEvalTime(input *chunk.Chunk, result
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2377,15 +2323,6 @@ func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2396,14 +2333,17 @@ func (b *builtinSubDateDatetimeIntSig) vecEvalTime(input *chunk.Chunk, result *c
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2431,15 +2371,6 @@ func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2450,14 +2381,17 @@ func (b *builtinSubDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2485,15 +2419,6 @@ func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 		return nil
 	}
 
-	dateBuf, err := b.bufAllocator.get(types.ETDatetime, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(dateBuf)
-	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, dateBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2504,14 +2429,17 @@ func (b *builtinSubDateDatetimeDecimalSig) vecEvalTime(input *chunk.Chunk, resul
 	}
 
 	result.ResizeTime(n, false)
-	result.MergeNulls(dateBuf, intervalBuf)
-	oriDates := dateBuf.Times()
+	if err := b.vecGetDateFromDatetime(&b.baseBuiltinFunc, input, unit, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDates := result.Times()
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		resDate, isNull, err := b.sub(b.ctx, oriDates[i], intervalBuf.GetString(i), unit)
+		resDate, isNull, err := b.sub(b.ctx, resDates[i], intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
 		}
@@ -2539,15 +2467,6 @@ func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, re
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2558,15 +2477,18 @@ func (b *builtinSubDateDurationStringSig) vecEvalDuration(input *chunk.Chunk, re
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -2595,15 +2517,6 @@ func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, resul
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2614,15 +2527,18 @@ func (b *builtinSubDateDurationIntSig) vecEvalDuration(input *chunk.Chunk, resul
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -2651,15 +2567,6 @@ func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, resu
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2670,15 +2577,18 @@ func (b *builtinSubDateDurationRealSig) vecEvalDuration(input *chunk.Chunk, resu
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err
@@ -2707,15 +2617,6 @@ func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, r
 		return nil
 	}
 
-	durationBuf, err := b.bufAllocator.get(types.ETDuration, n)
-	if err != nil {
-		return err
-	}
-	defer b.bufAllocator.put(durationBuf)
-	if err := b.args[0].VecEvalDuration(b.ctx, input, durationBuf); err != nil {
-		return err
-	}
-
 	intervalBuf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
 		return err
@@ -2726,15 +2627,18 @@ func (b *builtinSubDateDurationDecimalSig) vecEvalDuration(input *chunk.Chunk, r
 	}
 
 	result.ResizeGoDuration(n, false)
-	result.MergeNulls(durationBuf, intervalBuf)
-	oriDurations := durationBuf.GoDurations()
+	if err := b.args[0].VecEvalDuration(b.ctx, input, result); err != nil {
+		return err
+	}
+
+	result.MergeNulls(intervalBuf)
 	resDurations := result.GoDurations()
 	iterDuration := types.Duration{Fsp: types.MaxFsp}
 	for i := 0; i < n; i++ {
 		if result.IsNull(i) {
 			continue
 		}
-		iterDuration.Duration = oriDurations[i]
+		iterDuration.Duration = resDurations[i]
 		resDuration, isNull, err := b.subDuration(b.ctx, iterDuration, intervalBuf.GetString(i), unit)
 		if err != nil {
 			return err

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -305,6 +305,46 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&intervalUnitStrGener{nullRation: 0.05},
 			},
 		},
+		// builtinAddDateDurationStringSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDurationIntSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDurationRealSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDurationDecimalSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
 	},
 
 	ast.SubDate: {
@@ -424,6 +464,46 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDurationStringSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDurationIntSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDurationRealSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDurationDecimalSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
 				&intervalUnitStrGener{nullRation: 0.05},
 			},

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -192,8 +192,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringIntSig
 		{
@@ -202,8 +203,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringRealSig
 		{
@@ -212,8 +214,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringDecimalSig
 		{
@@ -222,8 +225,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntStringSig
 		{
@@ -232,8 +236,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntIntSig
 		{
@@ -242,8 +247,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntRealSig
 		{
@@ -252,8 +258,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntDecimalSig
 		{
@@ -262,8 +269,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeStringSig
 		{
@@ -272,8 +280,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeIntSig
 		{
@@ -282,8 +291,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeRealSig
 		{
@@ -292,8 +302,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeDecimalSig
 		{
@@ -302,8 +313,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationStringSig
 		{
@@ -312,8 +324,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationIntSig
 		{
@@ -322,8 +335,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationRealSig
 		{
@@ -332,8 +346,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationDecimalSig
 		{
@@ -342,8 +357,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 	},
 
@@ -355,8 +371,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringIntSig
 		{
@@ -365,8 +382,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringRealSig
 		{
@@ -375,8 +393,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringDecimalSig
 		{
@@ -385,8 +404,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntStringSig
 		{
@@ -395,8 +415,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntIntSig
 		{
@@ -405,8 +426,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntRealSig
 		{
@@ -415,8 +437,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntDecimalSig
 		{
@@ -425,8 +448,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeStringSig
 		{
@@ -435,8 +459,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeIntSig
 		{
@@ -445,8 +470,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeRealSig
 		{
@@ -455,8 +481,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeDecimalSig
 		{
@@ -465,8 +492,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationStringSig
 		{
@@ -475,8 +503,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationIntSig
 		{
@@ -485,8 +514,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationRealSig
 		{
@@ -495,8 +525,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationDecimalSig
 		{
@@ -505,8 +536,9 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
-				&intervalUnitStrGener{nullRation: 0.05},
+				nil,
 			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 	},
 }

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -195,6 +195,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -204,6 +205,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -213,6 +215,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -222,6 +225,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -231,6 +235,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -240,6 +245,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -249,6 +255,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -258,6 +265,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -267,6 +275,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -276,6 +285,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -285,6 +295,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -294,6 +305,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -303,6 +315,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -312,6 +325,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -321,6 +335,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -330,6 +345,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -339,6 +355,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -348,6 +365,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -357,6 +375,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -366,6 +385,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateStringIntSig
 		{
@@ -376,6 +396,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -385,6 +406,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -394,6 +416,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -403,6 +426,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -412,6 +436,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -421,6 +446,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -430,6 +456,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -439,6 +466,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -448,6 +476,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -457,6 +486,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -466,6 +496,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -475,6 +506,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -484,6 +516,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -493,6 +526,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -502,6 +536,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -511,6 +546,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -520,6 +556,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -529,6 +566,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -538,6 +576,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -547,6 +586,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateStringRealSig
 		{
@@ -557,6 +597,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -566,6 +607,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -575,6 +617,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -584,6 +627,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -593,6 +637,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -602,6 +647,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -611,6 +657,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -620,6 +667,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -629,6 +677,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -638,6 +687,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -647,6 +697,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -656,6 +707,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -665,6 +717,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -674,6 +727,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -683,6 +737,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -692,6 +747,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -701,6 +757,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -710,6 +767,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -719,6 +777,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -728,6 +787,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateStringDecimalSig
 		{
@@ -738,6 +798,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -747,6 +808,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -756,6 +818,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -765,6 +828,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -774,6 +838,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -783,6 +848,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -792,6 +858,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -801,6 +868,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -810,6 +878,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -819,6 +888,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -828,6 +898,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -837,6 +908,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -846,6 +918,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -855,6 +928,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -864,6 +938,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -873,6 +948,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -882,6 +958,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -891,6 +968,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -900,6 +978,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -909,6 +988,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateIntStringSig
 		{
@@ -919,6 +999,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -928,6 +1009,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -937,6 +1019,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -946,6 +1029,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -955,6 +1039,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -964,6 +1049,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -973,6 +1059,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -982,6 +1069,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -991,6 +1079,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1000,6 +1089,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1009,6 +1099,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1018,6 +1109,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1027,6 +1119,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1036,6 +1129,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1045,6 +1139,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1054,6 +1149,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1063,6 +1159,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1072,6 +1169,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1081,6 +1179,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1090,6 +1189,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateIntIntSig
 		{
@@ -1100,6 +1200,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1109,6 +1210,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1118,6 +1220,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1127,6 +1230,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1136,6 +1240,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1145,6 +1250,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1154,6 +1260,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1163,6 +1270,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1172,6 +1280,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1181,6 +1290,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1190,6 +1300,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1199,6 +1310,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1208,6 +1320,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1217,6 +1330,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1226,6 +1340,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1235,6 +1350,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1244,6 +1360,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1253,6 +1370,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1262,6 +1380,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1271,6 +1390,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateIntRealSig
 		{
@@ -1281,6 +1401,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1290,6 +1411,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1299,6 +1421,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1308,6 +1431,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1317,6 +1441,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1326,6 +1451,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1335,6 +1461,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1344,6 +1471,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1353,6 +1481,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1362,6 +1491,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1371,6 +1501,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1380,6 +1511,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1389,6 +1521,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1398,6 +1531,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1407,6 +1541,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1416,6 +1551,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1425,6 +1561,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1434,6 +1571,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1443,6 +1581,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1452,6 +1591,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateIntDecimalSig
 		{
@@ -1462,6 +1602,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1471,6 +1612,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1480,6 +1622,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1489,6 +1632,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1498,6 +1642,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1507,6 +1652,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1516,6 +1662,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1525,6 +1672,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1534,6 +1682,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1543,6 +1692,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1552,6 +1702,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1561,6 +1712,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1570,6 +1722,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1579,6 +1732,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1588,6 +1742,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1597,6 +1752,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1606,6 +1762,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1615,6 +1772,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1624,6 +1782,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1633,6 +1792,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDatetimeStringSig
 		{
@@ -1643,6 +1803,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1652,6 +1813,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1661,6 +1823,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1670,6 +1833,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1679,6 +1843,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1688,6 +1853,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1697,6 +1863,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1706,6 +1873,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1715,6 +1883,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1724,6 +1893,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1733,6 +1903,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1742,6 +1913,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1751,6 +1923,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1760,6 +1933,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1769,6 +1943,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1778,6 +1953,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1787,6 +1963,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1796,6 +1973,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1805,6 +1983,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1814,6 +1993,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDatetimeIntSig
 		{
@@ -1824,6 +2004,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1833,6 +2014,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1842,6 +2024,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1851,6 +2034,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1860,6 +2044,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1869,6 +2054,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1878,6 +2064,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1887,6 +2074,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1896,6 +2084,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1905,6 +2094,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1914,6 +2104,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1923,6 +2114,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1932,6 +2124,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1941,6 +2134,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1950,6 +2144,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1959,6 +2154,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1968,6 +2164,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1977,6 +2174,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1986,6 +2184,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -1995,6 +2194,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDatetimeRealSig
 		{
@@ -2005,6 +2205,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2014,6 +2215,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2023,6 +2225,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2032,6 +2235,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2041,6 +2245,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2050,6 +2255,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2059,6 +2265,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2068,6 +2275,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2077,6 +2285,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2086,6 +2295,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2095,6 +2305,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2104,6 +2315,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2113,6 +2325,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2122,6 +2335,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2131,6 +2345,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2140,6 +2355,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2149,6 +2365,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2158,6 +2375,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2167,6 +2385,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2176,6 +2395,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDatetimeDecimalSig
 		{
@@ -2186,6 +2406,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2195,6 +2416,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2204,6 +2426,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2213,6 +2436,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2222,6 +2446,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2231,6 +2456,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2240,6 +2466,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2249,6 +2476,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2258,6 +2486,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2267,6 +2496,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2276,6 +2506,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2285,6 +2516,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2294,6 +2526,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2303,6 +2536,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2312,6 +2546,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2321,6 +2556,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2330,6 +2566,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2339,6 +2576,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2348,6 +2586,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -2357,6 +2596,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDurationStringSig
 		{
@@ -2367,6 +2607,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2376,6 +2617,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2385,6 +2627,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2394,6 +2637,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2403,6 +2647,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2412,6 +2657,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2421,6 +2667,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2430,6 +2677,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2439,6 +2687,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2448,6 +2697,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2457,6 +2707,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2466,6 +2717,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2475,6 +2727,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2484,6 +2737,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2493,6 +2747,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2502,6 +2757,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2511,6 +2767,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2520,6 +2777,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2529,6 +2787,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2538,6 +2797,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDurationIntSig
 		{
@@ -2548,6 +2808,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2557,6 +2818,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2566,6 +2828,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2575,6 +2838,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2584,6 +2848,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2593,6 +2858,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2602,6 +2868,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2611,6 +2878,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2620,6 +2888,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2629,6 +2898,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2638,6 +2908,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2647,6 +2918,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2656,6 +2928,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2665,6 +2938,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2674,6 +2948,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2683,6 +2958,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2692,6 +2968,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2701,6 +2978,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2710,6 +2988,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2719,6 +2998,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDurationRealSig
 		{
@@ -2729,6 +3009,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2738,6 +3019,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2747,6 +3029,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2756,6 +3039,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2765,6 +3049,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2774,6 +3059,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2783,6 +3069,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2792,6 +3079,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2801,6 +3089,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2810,6 +3099,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2819,6 +3109,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2828,6 +3119,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2837,6 +3129,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2846,6 +3139,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2855,6 +3149,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2864,6 +3159,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2873,6 +3169,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2882,6 +3179,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2891,6 +3189,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2900,6 +3199,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinAddDateDurationDecimalSig
 		{
@@ -2910,6 +3210,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2919,6 +3220,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2928,6 +3230,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2937,6 +3240,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2946,6 +3250,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2955,6 +3260,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2964,6 +3270,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2973,6 +3280,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2982,6 +3290,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -2991,6 +3300,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3000,6 +3310,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3009,6 +3320,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3018,6 +3330,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3027,6 +3340,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3036,6 +3350,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3045,6 +3360,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3054,6 +3370,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3063,6 +3380,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3072,6 +3390,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -3081,6 +3400,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 	},
 
@@ -3094,6 +3414,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3103,6 +3424,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3112,6 +3434,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3121,6 +3444,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3130,6 +3454,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3139,6 +3464,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3148,6 +3474,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3157,6 +3484,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3166,6 +3494,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3175,6 +3504,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3184,6 +3514,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3193,6 +3524,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3202,6 +3534,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3211,6 +3544,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3220,6 +3554,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3229,6 +3564,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3238,6 +3574,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3247,6 +3584,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3256,6 +3594,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3265,6 +3604,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateStringIntSig
 		{
@@ -3275,6 +3615,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3284,6 +3625,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3293,6 +3635,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3302,6 +3645,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3311,6 +3655,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3320,6 +3665,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3329,6 +3675,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3338,6 +3685,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3347,6 +3695,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3356,6 +3705,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3365,6 +3715,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3374,6 +3725,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3383,6 +3735,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3392,6 +3745,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3401,6 +3755,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3410,6 +3765,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3419,6 +3775,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3428,6 +3785,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3437,6 +3795,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3446,6 +3805,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateStringRealSig
 		{
@@ -3456,6 +3816,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3465,6 +3826,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3474,6 +3836,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3483,6 +3846,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3492,6 +3856,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3501,6 +3866,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3510,6 +3876,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3519,6 +3886,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3528,6 +3896,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3537,6 +3906,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3546,6 +3916,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3555,6 +3926,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3564,6 +3936,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3573,6 +3946,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3582,6 +3956,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3591,6 +3966,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3600,6 +3976,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3609,6 +3986,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3618,6 +3996,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3627,6 +4006,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateStringDecimalSig
 		{
@@ -3637,6 +4017,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3646,6 +4027,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3655,6 +4037,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3664,6 +4047,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3673,6 +4057,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3682,6 +4067,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3691,6 +4077,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3700,6 +4087,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3709,6 +4097,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3718,6 +4107,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3727,6 +4117,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3736,6 +4127,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3745,6 +4137,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3754,6 +4147,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3763,6 +4157,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3772,6 +4167,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3781,6 +4177,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3790,6 +4187,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3799,6 +4197,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3808,6 +4207,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateIntStringSig
 		{
@@ -3818,6 +4218,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3827,6 +4228,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3836,6 +4238,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3845,6 +4248,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3854,6 +4258,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3863,6 +4268,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3872,6 +4278,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3881,6 +4288,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3890,6 +4298,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3899,6 +4308,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3908,6 +4318,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3917,6 +4328,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3926,6 +4338,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3935,6 +4348,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3944,6 +4358,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3953,6 +4368,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3962,6 +4378,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3971,6 +4388,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3980,6 +4398,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -3989,6 +4408,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateIntIntSig
 		{
@@ -3999,6 +4419,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4008,6 +4429,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4017,6 +4439,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4026,6 +4449,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4035,6 +4459,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4044,6 +4469,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4053,6 +4479,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4062,6 +4489,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4071,6 +4499,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4080,6 +4509,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4089,6 +4519,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4098,6 +4529,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4107,6 +4539,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4116,6 +4549,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4125,6 +4559,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4134,6 +4569,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4143,6 +4579,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4152,6 +4589,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4161,6 +4599,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4170,6 +4609,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateIntRealSig
 		{
@@ -4180,6 +4620,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4189,6 +4630,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4198,6 +4640,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4207,6 +4650,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4216,6 +4660,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4225,6 +4670,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4234,6 +4680,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4243,6 +4690,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4252,6 +4700,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4261,6 +4710,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4270,6 +4720,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4279,6 +4730,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4288,6 +4740,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4297,6 +4750,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4306,6 +4760,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4315,6 +4770,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4324,6 +4780,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4333,6 +4790,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4342,6 +4800,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4351,6 +4810,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateIntDecimalSig
 		{
@@ -4361,6 +4821,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4370,6 +4831,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4379,6 +4841,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4388,6 +4851,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4397,6 +4861,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4406,6 +4871,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4415,6 +4881,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4424,6 +4891,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4433,6 +4901,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4442,6 +4911,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4451,6 +4921,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4460,6 +4931,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4469,6 +4941,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4478,6 +4951,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4487,6 +4961,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4496,6 +4971,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4505,6 +4981,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4514,6 +4991,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4523,6 +5001,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4532,6 +5011,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDatetimeStringSig
 		{
@@ -4542,6 +5022,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4551,6 +5032,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4560,6 +5042,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4569,6 +5052,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4578,6 +5062,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4587,6 +5072,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4596,6 +5082,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4605,6 +5092,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4614,6 +5102,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4623,6 +5112,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4632,6 +5122,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4641,6 +5132,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4650,6 +5142,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4659,6 +5152,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4668,6 +5162,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4677,6 +5172,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4686,6 +5182,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4695,6 +5192,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4704,6 +5202,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4713,6 +5212,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDatetimeIntSig
 		{
@@ -4723,6 +5223,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4732,6 +5233,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4741,6 +5243,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4750,6 +5253,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4759,6 +5263,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4768,6 +5273,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4777,6 +5283,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4786,6 +5293,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4795,6 +5303,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4804,6 +5313,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4813,6 +5323,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4822,6 +5333,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4831,6 +5343,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4840,6 +5353,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4849,6 +5363,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4858,6 +5373,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4867,6 +5383,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4876,6 +5393,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4885,6 +5403,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4894,6 +5413,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDatetimeRealSig
 		{
@@ -4904,6 +5424,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4913,6 +5434,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4922,6 +5444,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4931,6 +5454,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4940,6 +5464,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4949,6 +5474,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4958,6 +5484,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4967,6 +5494,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4976,6 +5504,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4985,6 +5514,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -4994,6 +5524,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5003,6 +5534,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5012,6 +5544,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5021,6 +5554,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5030,6 +5564,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5039,6 +5574,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5048,6 +5584,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5057,6 +5594,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5066,6 +5604,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5075,6 +5614,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDatetimeDecimalSig
 		{
@@ -5085,6 +5625,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5094,6 +5635,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5103,6 +5645,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5112,6 +5655,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5121,6 +5665,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5130,6 +5675,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5139,6 +5685,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5148,6 +5695,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5157,6 +5705,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5166,6 +5715,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5175,6 +5725,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5184,6 +5735,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5193,6 +5745,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5202,6 +5755,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5211,6 +5765,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5220,6 +5775,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5229,6 +5785,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5238,6 +5795,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5247,6 +5805,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDatetime,
@@ -5256,6 +5815,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDurationStringSig
 		{
@@ -5266,6 +5826,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5275,6 +5836,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5284,6 +5846,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5293,6 +5856,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5302,6 +5866,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5311,6 +5876,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5320,6 +5886,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5329,6 +5896,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5338,6 +5906,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5347,6 +5916,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5356,6 +5926,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5365,6 +5936,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5374,6 +5946,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5383,6 +5956,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5392,6 +5966,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5401,6 +5976,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5410,6 +5986,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5419,6 +5996,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5428,6 +6006,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5437,6 +6016,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDurationIntSig
 		{
@@ -5447,6 +6027,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5456,6 +6037,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5465,6 +6047,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5474,6 +6057,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5483,6 +6067,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5492,6 +6077,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5501,6 +6087,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5510,6 +6097,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5519,6 +6107,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5528,6 +6117,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5537,6 +6127,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5546,6 +6137,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5555,6 +6147,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5564,6 +6157,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5573,6 +6167,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5582,6 +6177,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5591,6 +6187,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5600,6 +6197,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5609,6 +6207,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5618,6 +6217,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDurationRealSig
 		{
@@ -5628,6 +6228,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5637,6 +6238,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5646,6 +6248,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5655,6 +6258,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5664,6 +6268,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5673,6 +6278,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5682,6 +6288,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5691,6 +6298,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5700,6 +6308,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5709,6 +6318,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5718,6 +6328,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5727,6 +6338,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5736,6 +6348,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5745,6 +6358,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5754,6 +6368,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5763,6 +6378,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5772,6 +6388,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5781,6 +6398,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5790,6 +6408,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5799,6 +6418,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		// builtinSubDateDurationDecimalSig
 		{
@@ -5809,6 +6429,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5818,6 +6439,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5827,6 +6449,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5836,6 +6459,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5845,6 +6469,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5854,6 +6479,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5863,6 +6489,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5872,6 +6499,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5881,6 +6509,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5890,6 +6519,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5899,6 +6529,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5908,6 +6539,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5917,6 +6549,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5926,6 +6559,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5935,6 +6569,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5944,6 +6579,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5953,6 +6589,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5962,6 +6599,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5971,6 +6609,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 		{
 			retEvalType:   types.ETDuration,
@@ -5980,6 +6619,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+			chunkSize: 128,
 		},
 	},
 }

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -193,9 +193,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringIntSig
 		{
@@ -204,9 +374,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringRealSig
 		{
@@ -215,9 +555,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateStringDecimalSig
 		{
@@ -226,9 +736,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntStringSig
 		{
@@ -237,9 +917,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntIntSig
 		{
@@ -248,9 +1098,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntRealSig
 		{
@@ -259,9 +1279,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateIntDecimalSig
 		{
@@ -270,9 +1460,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeStringSig
 		{
@@ -281,9 +1641,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeIntSig
 		{
@@ -292,9 +1822,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeRealSig
 		{
@@ -303,9 +2003,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDatetimeDecimalSig
 		{
@@ -314,9 +2184,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationStringSig
 		{
@@ -325,9 +2365,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationIntSig
 		{
@@ -336,9 +2546,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationRealSig
 		{
@@ -347,9 +2727,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinAddDateDurationDecimalSig
 		{
@@ -358,9 +2908,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 	},
 
@@ -372,9 +3092,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringIntSig
 		{
@@ -383,9 +3273,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringRealSig
 		{
@@ -394,9 +3454,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateStringDecimalSig
 		{
@@ -405,9 +3635,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntStringSig
 		{
@@ -416,9 +3816,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntIntSig
 		{
@@ -427,9 +3997,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntRealSig
 		{
@@ -438,9 +4178,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateIntDecimalSig
 		{
@@ -449,9 +4359,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeStringSig
 		{
@@ -460,9 +4540,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeIntSig
 		{
@@ -471,9 +4721,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeRealSig
 		{
@@ -482,9 +4902,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDatetimeDecimalSig
 		{
@@ -493,9 +5083,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationStringSig
 		{
@@ -504,9 +5264,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationIntSig
 		{
@@ -515,9 +5445,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETInt, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationRealSig
 		{
@@ -526,9 +5626,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETReal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		// builtinSubDateDurationDecimalSig
 		{
@@ -537,9 +5807,179 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
 				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
-				nil,
 			},
-			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("WEEK"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("QUARTER"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("SECOND_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("MINUTE_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("HOUR_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MICROSECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_SECOND"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_MINUTE"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("DAY_HOUR"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
+			},
+			constants: []*Constant{nil, nil, {Value: types.NewStringDatum("YEAR_MONTH"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 	},
 }

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -306,6 +306,129 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			},
 		},
 	},
+
+	ast.SubDate: {
+		// builtinSubDateStringStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateStringIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateStringRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateStringDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateIntStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateIntIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateIntRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateIntDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDatetimeStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDatetimeIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDatetimeRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinSubDateDatetimeDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+	},
 }
 
 func (s *testEvaluatorSuite) TestVectorizedBuiltinTimeEvalOneVecGenerated(c *C) {

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -265,6 +265,46 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 				&intervalUnitStrGener{nullRation: 0.05},
 			},
 		},
+		// builtinAddDateDatetimeStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDatetimeIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDatetimeRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateDatetimeDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
 	},
 }
 

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -158,7 +158,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		// builtinDurationDurationTimeDiffSig
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration, types.ETDuration}},
 		// builtinDurationStringTimeDiffSig
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration, types.ETString}, geners: []dataGenerator{nil, &timeStrGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration, types.ETString}, geners: []dataGenerator{nil, &dateStrGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration, types.ETString}, geners: []dataGenerator{nil, &dateTimeStrGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration, types.ETString}, geners: []dataGenerator{nil, &dateTimeStrGener{Year: 2019, Month: 10, Fsp: 4}}},
 		// builtinTimeTimeTimeDiffSig
@@ -167,21 +167,104 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETTimestamp, types.ETTimestamp}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETTimestamp, types.ETDatetime}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
 		// builtinTimeStringTimeDiffSig
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDatetime, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &timeStrGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDatetime, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateStrGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDatetime, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateTimeStrGener{Year: 2019, Month: 10}}},
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETTimestamp, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &timeStrGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETTimestamp, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateStrGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETTimestamp, types.ETString}, geners: []dataGenerator{&dateTimeGener{Year: 2019, Month: 10}, &dateTimeStrGener{Year: 2019, Month: 10}}},
 		// builtinStringDurationTimeDiffSig
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}, geners: []dataGenerator{&timeStrGener{Year: 2019, Month: 10}, nil}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}, geners: []dataGenerator{&dateStrGener{Year: 2019, Month: 10}, nil}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}, geners: []dataGenerator{&dateTimeStrGener{Year: 2019, Month: 10}, nil}},
 		// builtinStringTimeTimeDiffSig
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDatetime}, geners: []dataGenerator{&timeStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDatetime}, geners: []dataGenerator{&dateStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETDatetime}, geners: []dataGenerator{&dateTimeStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETTimestamp}, geners: []dataGenerator{&timeStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETTimestamp}, geners: []dataGenerator{&dateStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETTimestamp}, geners: []dataGenerator{&dateTimeStrGener{Year: 2019, Month: 10}, &dateTimeGener{Year: 2019, Month: 10}}},
 		// builtinStringStringTimeDiffSig
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&timeStrGener{Year: 2019, Month: 10}, &dateTimeStrGener{Year: 2019, Month: 10}}},
-		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&dateTimeStrGener{Year: 2019, Month: 10}, &timeStrGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&dateStrGener{Year: 2019, Month: 10}, &dateTimeStrGener{Year: 2019, Month: 10}}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString, types.ETString}, geners: []dataGenerator{&dateTimeStrGener{Year: 2019, Month: 10}, &dateStrGener{Year: 2019, Month: 10}}},
+	},
+
+	ast.AddDate: {
+		// builtinAddDateStringStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateStringIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateStringRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateStringDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateStrGener{NullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateIntStringSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateIntIntSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateIntRealSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
+		// builtinAddDateIntDecimalSig
+		{
+			retEvalType:   types.ETDatetime,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
+			geners: []dataGenerator{
+				&dateTimeIntGener{nullRation: 0.2},
+				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&intervalUnitStrGener{nullRation: 0.05},
+			},
+		},
 	},
 }
 

--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -16,6 +16,7 @@
 package expression
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -191,7 +192,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -202,7 +203,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -213,7 +214,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -224,7 +225,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -235,7 +236,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -246,7 +247,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -257,7 +258,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -268,7 +269,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -279,7 +280,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -290,7 +291,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -301,7 +302,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -312,7 +313,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -323,7 +324,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -334,7 +335,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -345,7 +346,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -356,7 +357,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -370,7 +371,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -381,7 +382,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -392,7 +393,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -403,7 +404,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&dateStrGener{NullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -414,7 +415,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -425,7 +426,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -436,7 +437,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -447,7 +448,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETInt, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&dateTimeIntGener{nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -458,7 +459,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -469,7 +470,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -480,7 +481,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -491,7 +492,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -502,7 +503,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETString, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -513,7 +514,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETInt, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETInt, nullRation: 0.2}},
+				&defaultGener{eType: types.ETInt, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -524,7 +525,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETReal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETReal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETReal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
@@ -535,7 +536,7 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETDecimal, types.ETString},
 			geners: []dataGenerator{
 				&defaultGener{eType: types.ETDuration, nullRation: 0.2},
-				gener{defaultGener{eType: types.ETDecimal, nullRation: 0.2}},
+				&defaultGener{eType: types.ETDecimal, nullRation: 0.2},
 				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -72,6 +72,41 @@ func (g *dateTimeUnitStrGener) gen() interface{} {
 	return dateTimes[n]
 }
 
+type intervalUnitStrGener struct {
+	nullRation float64
+}
+
+func (g *intervalUnitStrGener) gen() interface{} {
+	if rand.Float64() < g.nullRation {
+		return nil
+	}
+	unitList := []string{
+		"MICROSECOND",
+		"SECOND",
+		"MINUTE",
+		"HOUR",
+		"DAY",
+		"WEEK",
+		"MONTH",
+		"QUARTER",
+		"YEAR",
+		"SECOND_MICROSECOND",
+		"MINUTE_MICROSECOND",
+		"MINUTE_SECOND",
+		"HOUR_MICROSECOND",
+		"HOUR_SECOND",
+		"HOUR_MINUTE",
+		"DAY_MICROSECOND",
+		"DAY_SECOND",
+		"DAY_MINUTE",
+		"DAY_HOUR",
+		"YEAR_MONTH",
+	}
+
+	n := rand.Int() % len(unitList)
+	return unitList[n]
+}
+
 var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.DateLiteral: {
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDatetime},
@@ -176,8 +211,8 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 				Flag:    mysql.BinaryFlag,
 			}},
 			geners: []dataGenerator{
-				&timeStrGener{},
-				&timeStrGener{},
+				&dateStrGener{},
+				&dateStrGener{},
 			},
 		},
 		// builtinSubTimeStringNullSig
@@ -220,15 +255,15 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.Timestamp: {
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{new(dateTimeStrGener)}},
-		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{new(timeStrGener)}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{new(dateStrGener)}},
+		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{new(timeStrGener)}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners: []dataGenerator{new(dateTimeStrGener), new(dateStrGener)}},
+			geners: []dataGenerator{new(dateTimeStrGener), new(timeStrGener)}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString, types.ETString},
 			geners: []dataGenerator{new(dateTimeStrGener), nil}},
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners: []dataGenerator{nil, new(dateStrGener)}},
+			geners: []dataGenerator{nil, new(timeStrGener)}},
 	},
 	ast.MonthName: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDatetime}},
@@ -278,31 +313,31 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		{
 			retEvalType:   types.ETDatetime,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners:        []dataGenerator{&timeStrGener{}, &constStrGener{"%y-%m-%d"}},
+			geners:        []dataGenerator{&dateStrGener{}, &constStrGener{"%y-%m-%d"}},
 		},
 		{
 			retEvalType:   types.ETDatetime,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners:        []dataGenerator{&timeStrGener{NullRation: 0.3}, nil},
+			geners:        []dataGenerator{&dateStrGener{NullRation: 0.3}, nil},
 			constants:     []*Constant{nil, {Value: types.NewDatum("%Y-%m-%d"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		{
 			retEvalType:   types.ETDatetime,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners:        []dataGenerator{&timeStrGener{}, nil},
+			geners:        []dataGenerator{&dateStrGener{}, nil},
 			// "%y%m%d" is wrong format, STR_TO_DATE should be failed for all rows
 			constants: []*Constant{nil, {Value: types.NewDatum("%y%m%d"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		{
 			retEvalType:   types.ETDuration,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners:        []dataGenerator{&dateStrGener{nullRation: 0.3}, nil},
+			geners:        []dataGenerator{&timeStrGener{nullRation: 0.3}, nil},
 			constants:     []*Constant{nil, {Value: types.NewDatum("%H:%i:%s"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 		{
 			retEvalType:   types.ETDuration,
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
-			geners:        []dataGenerator{&dateStrGener{nullRation: 0.3}, nil},
+			geners:        []dataGenerator{&timeStrGener{nullRation: 0.3}, nil},
 			// "%H%i%s" is wrong format, STR_TO_DATE should be failed for all rows
 			constants: []*Constant{nil, {Value: types.NewDatum("%H%i%s"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -72,41 +72,6 @@ func (g *dateTimeUnitStrGener) gen() interface{} {
 	return dateTimes[n]
 }
 
-type intervalUnitStrGener struct {
-	nullRation float64
-}
-
-func (g *intervalUnitStrGener) gen() interface{} {
-	if rand.Float64() < g.nullRation {
-		return nil
-	}
-	unitList := []string{
-		"MICROSECOND",
-		"SECOND",
-		"MINUTE",
-		"HOUR",
-		"DAY",
-		"WEEK",
-		"MONTH",
-		"QUARTER",
-		"YEAR",
-		"SECOND_MICROSECOND",
-		"MINUTE_MICROSECOND",
-		"MINUTE_SECOND",
-		"HOUR_MICROSECOND",
-		"HOUR_SECOND",
-		"HOUR_MINUTE",
-		"DAY_MICROSECOND",
-		"DAY_SECOND",
-		"DAY_MINUTE",
-		"DAY_HOUR",
-		"YEAR_MONTH",
-	}
-
-	n := rand.Int() % len(unitList)
-	return unitList[n]
-}
-
 var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	ast.DateLiteral: {
 		{retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETDatetime},

--- a/expression/generator/time_vec.go
+++ b/expression/generator/time_vec.go
@@ -606,6 +606,7 @@ func (g gener) gen() interface{} {
 					{{- end }}
 				},
 				constants: []*Constant{nil, nil, {Value: types.NewStringDatum("{{$unit}}"), RetType: types.NewFieldType(mysql.TypeString)}},
+				chunkSize: 128,
 			},
 		{{- end }}
 	{{- end }}

--- a/expression/generator/time_vec.go
+++ b/expression/generator/time_vec.go
@@ -600,15 +600,9 @@ func (g gener) gen() interface{} {
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.Type{{.FieldTypeA}}), types.NewFieldType(mysql.Type{{.FieldTypeB}})},
 			{{- end }}
 			geners: []dataGenerator{
-				{{- if eq .TestTypeA "" }}
-					{{- template "datetimeGener" . -}}
-					{{- template "intervalGener" . -}}
-					nil,
-				{{- else }}
-					{{- template "datetimeGener" . -}}
-					{{- template "intervalGener" . -}}
-					nil,
-				{{- end }}
+				{{- template "datetimeGener" . -}}
+				{{- template "intervalGener" . -}}
+				nil,
 			},
 			constants: []*Constant{nil, nil, {Value: types.NewStringDatum((&intervalUnitStrGener{}).gen().(string)), RetType: types.NewFieldType(mysql.TypeString)}},
 		},

--- a/expression/generator/time_vec.go
+++ b/expression/generator/time_vec.go
@@ -438,7 +438,7 @@ func (b *{{.SigName}}) vecEvalTime(input *chunk.Chunk, result *chunk.Column) err
 		return err
 	}
 	defer b.bufAllocator.put(dateCol)
-	if err := b.vecGetDateFrom{{.TypeA.TypeName}}(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
+	if err := b.vecGetDateFrom{{.TypeA.ETName}}(&b.baseBuiltinFunc, input, unitCol, dateCol); err != nil {
 		return err
 	}
 
@@ -447,7 +447,7 @@ func (b *{{.SigName}}) vecEvalTime(input *chunk.Chunk, result *chunk.Column) err
 		return err
 	}
 	defer b.bufAllocator.put(intervalCol)
-	if err := b.vecGetIntervalFrom{{.TypeB.TypeName}}(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
+	if err := b.vecGetIntervalFrom{{.TypeB.ETName}}(&b.baseBuiltinFunc, input, unitCol, intervalCol); err != nil {
 		return err
 	}
 
@@ -527,8 +527,10 @@ func (g gener) gen() interface{} {
 {{ define "strOrIntDateGener" }}
 	{{- if eq .TypeA.ETName "String"}}
 		&dateStrGener{NullRation: 0.2},
-	{{- else }}
+	{{- else if eq .TypeA.ETName "Int"}}
 		&dateTimeIntGener{nullRation: 0.2},
+	{{- else }}
+		&defaultGener{eType: types.ETDatetime, nullRation: 0.2},
 	{{- end }}
 {{ end }}
 
@@ -680,6 +682,10 @@ var addDataSigsTmpl = []sig{
 	{SigName: "builtinAddDateIntIntSig", TypeA: TypeInt, TypeB: TypeInt, Output: TypeDatetime},
 	{SigName: "builtinAddDateIntRealSig", TypeA: TypeInt, TypeB: TypeReal, Output: TypeDatetime},
 	{SigName: "builtinAddDateIntDecimalSig", TypeA: TypeInt, TypeB: TypeDecimal, Output: TypeDatetime},
+	{SigName: "builtinAddDateDatetimeStringSig", TypeA: TypeDatetime, TypeB: TypeString, Output: TypeDatetime},
+	{SigName: "builtinAddDateDatetimeIntSig", TypeA: TypeDatetime, TypeB: TypeInt, Output: TypeDatetime},
+	{SigName: "builtinAddDateDatetimeRealSig", TypeA: TypeDatetime, TypeB: TypeReal, Output: TypeDatetime},
+	{SigName: "builtinAddDateDatetimeDecimalSig", TypeA: TypeDatetime, TypeB: TypeDecimal, Output: TypeDatetime},
 }
 
 type sig struct {

--- a/expression/generator/time_vec.go
+++ b/expression/generator/time_vec.go
@@ -541,6 +541,7 @@ var testFile = template.Must(template.New("").Parse(`// Copyright 2019 PingCAP, 
 package expression
 
 import (
+	"math"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -578,6 +579,14 @@ func (g gener) gen() interface{} {
 	{{- end }}
 {{ end }}
 
+{{ define "intervalGener" }}
+	{{- if eq .TypeB.ETName "String" -}}
+		&numStrGener{rangeInt64Gener{math.MinInt32 + 1, math.MaxInt32}},
+	{{- else -}}
+		&defaultGener{eType: types.ET{{.TypeB.ETName}}, nullRation: 0.2},
+	{{- end }}
+{{ end }}
+
 {{ define "addOrSubDateCases" }}
 	{{ range .Sigs }} // {{ .SigName }}
 		{
@@ -593,11 +602,11 @@ func (g gener) gen() interface{} {
 			geners: []dataGenerator{
 				{{- if eq .TestTypeA "" }}
 					{{- template "datetimeGener" . -}}
-					gener{defaultGener{eType: types.ET{{.TypeB.ETName}}, nullRation: 0.2}},
+					{{- template "intervalGener" . -}}
 					nil,
 				{{- else }}
 					{{- template "datetimeGener" . -}}
-					gener{defaultGener{eType: types.ET{{ .TestTypeB }}, nullRation: 0.2}},
+					{{- template "intervalGener" . -}}
 					nil,
 				{{- end }}
 			},


### PR DESCRIPTION
PCP #12101

### What problem does this PR solve?
1. use generator to  implement vectorized evaluation for `builtinAddDate*Sig` and `builtinSubDate*Sig`
2. fix the following  errors caused by calling `ADDDATE`:
```bash
mysql> select * from `interval`;
+-------+------+------+--------------------+
| str   | int  | dec  | real               |
+-------+------+------+--------------------+
| 77.89 |   96 |    5 | 2.1426728997115996 |
| 72.14 |   25 |    5 | 1.0116074468331964 |
| 14.51 |    7 |    6 |  7.730443335527452 |
| 94.09 |   45 |    1 |  9.796964383311114 |
| 1.59  |   23 |    8 | 6.7950140907766965 |
+-------+------+------+--------------------+
5 rows in set (0.00 sec)

// ----- ERROR1: cast decimal to string with unit 'YEAR'
mysql> select `interval`.dec, ADDDATE(20190101120000,INTERVAL `interval`.dec YEAR) from `interval`;
ERROR 1105 (HY000): baseBuiltinFunc.evalString() should never be called, please contact the TiDB team for help

// ----- ERROR2: cast decimal to string with unit 'SECOND'
mysql> select `interval`.dec, ADDDATE(20190101120000,INTERVAL `interval`.dec SECOND) from `interval`;
ERROR 2006 (HY000): MySQL server has gone away
No connection. Trying to reconnect...
Connection id:    3
Current database: test

ERROR 2013 (HY000): Lost connection to MySQL server during query
```

### What is changed and how it works?

### Check List
Tests 
 - Unit test -- PASS
 - Integration test -- PASS
 - Manual test (add detailed scripts or steps below) -- PASS
    - re-execute the statements that caused the above errors