### PR TITLE
expression: implement vectorized evaluation for 'builtinSubDurationAndDurationSig'

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1492,16 +1492,13 @@ func (b *builtinSubDurationAndDurationSig) vecEvalDuration(input *chunk.Chunk, r
 		if result.IsNull(i) {
 			continue
 		}
-		// get arg0 & arg1
-		arg0 := arg0s[i]
-		arg1 := arg1s[i]
 		// calculate
-		output, err := types.AddDuration(arg0, -arg1)
+		output, err := types.SubInt64(int64(arg0s[i]), int64(arg1s[i]))
 		if err != nil {
 			return err
 		}
 		// commit result
-		resultSlice[i] = output
+		resultSlice[i] = time.Duration(output)
 	}
 	return nil
 }

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -179,6 +179,15 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
 		},
+		// builtinSubDurationAndDurationSig
+		{
+			retEvalType:   types.ETDuration,
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDuration},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
 	},
 	ast.AddTime: {
 		// builtinAddStringAndStringSig, a special case written by hand.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinSubDurationAndDurationSig  from #12176 

### What is changed and how it works?

77% faster than before:




    BenchmarkVectorizedBuiltinTimeFunc/builtinSubDurationAndDurationSig-VecBuiltinFunc-4              144088              8238 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFunc/builtinSubDurationAndDurationSig-NonVecBuiltinFunc-4            33532             35975 ns/op               0 B/op          0 allocs/op




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test