### PR TITLE
server: improve test coverage of server/conn.go

### DIFF
--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -472,3 +472,28 @@ func (ts *ConnTestSuite) TestShutDown(c *C) {
 	c.Assert(err, Equals, executor.ErrQueryInterrupted)
 	c.Assert(rs.closed, Equals, int32(1))
 }
+
+func (ts *ConnTestSuite) TestShutdownOrNotify(c *C) {
+	c.Parallel()
+	se, err := session.CreateSession4Test(ts.store)
+	c.Assert(err, IsNil)
+	tc := &TiDBContext{
+		session: se,
+		stmts:   make(map[int]*TiDBStatement),
+	}
+	cc := &clientConn{
+		connectionID: 1,
+		server: &Server{
+			capability: defaultCapability,
+		},
+		status: connStatusShutdown,
+		ctx:    tc,
+	}
+	c.Assert(cc.ShutdownOrNotify(), IsFalse)
+	cc.status = connStatusReading
+	c.Assert(cc.ShutdownOrNotify(), IsTrue)
+	c.Assert(cc.status, Equals, connStatusShutdown)
+	cc.status = connStatusDispatching
+	c.Assert(cc.ShutdownOrNotify(), IsFalse)
+	c.Assert(cc.status, Equals, connStatusWaitShutdown)
+}

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -486,7 +486,7 @@ func (ts *ConnTestSuite) TestShutdownOrNotify(c *C) {
 		server: &Server{
 			capability: defaultCapability,
 		},
-		status: connStatusShutdown,
+		status: connStatusWaitShutdown,
 		ctx:    tc,
 	}
 	c.Assert(cc.ShutdownOrNotify(), IsFalse)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Improving test coverage of `server` package

### What is changed and how it works?
A new test case like `TestShutdownOrNotify `has been added for [tidb/server/conn.go](https://github.com/pingcap/tidb/blob/b274eb2079dcbe9166825e677d4496046c494856/server/conn.go)
before: ` coverage: 63.2% of statements`
<img width="307" alt="0" src="https://user-images.githubusercontent.com/30926443/69414334-797b7b80-0d4d-11ea-8aa0-b5ca58a09365.png">

after: ` coverage: 63.4% of statements`
<img width="306" alt="1" src="https://user-images.githubusercontent.com/30926443/69414356-8304e380-0d4d-11ea-9ad5-8e1e3751cb48.png">


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
