### PR TITLE
planner, executor: build ColWithCmpFuncManager.TmpConstant for indexMergeJoin.innerWorker individually

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -1058,6 +1058,20 @@ func (s *testSuiteJoin1) TestIndexLookupJoin(c *C) {
 	tk.MustQuery("select /*+ TIDB_INLJ(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b").Check(testkit.Rows("64"))
 	tk.MustExec("set @@tidb_index_lookup_join_concurrency=1;")
 	tk.MustQuery("select /*+ TIDB_INLJ(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b").Check(testkit.Rows("64"))
+
+	tk.MustQuery("desc select /*+ INL_MERGE_JOIN(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b").Check(testkit.Rows(
+		"HashAgg_9 1.00 root funcs:count(1)",
+		"└─IndexMergeJoin_21 64.00 root inner join, inner:IndexReader_19, outer key:Column#1, inner key:Column#3, other cond:lt(Column#4, Column#2)",
+		"  ├─TableReader_26 64.00 root data:Selection_25",
+		"  │ └─Selection_25 64.00 cop[tikv] not(isnull(Column#2))",
+		"  │   └─TableScan_24 64.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false",
+		"  └─IndexReader_19 1.00 root index:Selection_18",
+		"    └─Selection_18 1.00 cop[tikv] not(isnull(Column#3)), not(isnull(Column#4))",
+		"      └─IndexScan_17 1.00 cop[tikv] table:s, index:a, b, range: decided by [eq(Column#3, Column#1) lt(Column#4, Column#2)], keep order:true",
+	))
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b").Check(testkit.Rows("64"))
+	tk.MustExec("set @@tidb_index_lookup_join_concurrency=1;")
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b").Check(testkit.Rows("64"))
 }
 
 func (s *testSuiteJoin1) TestIndexNestedLoopHashJoin(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

The same as https://github.com/pingcap/tidb/pull/13669

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit, the query result is not stable:
``` sql
drop table if exists t,s
create table t(a int primary key auto_increment, b time)
create table s(a int, b time)
alter table s add index idx(a,b)
set @@tidb_index_join_batch_size=4;set @@tidb_init_chunk_size=1;set @@tidb_max_chunk_size=32; set @@tidb_index_lookup_join_concurrency=15;
-- insert 64 rows into `t`
-- insert 64 rows into `s`
select /*+ INL_MERGE_JOIN(s) */ count(*) from t join s use index(idx) on s.a = t.a and s.b < t.b;
```

### What is changed and how it works?
Build ColWithCmpFuncManager.TmpConstant for indexMergeJoin.innerWorker individually.
Thus the modifications triggered by each inner worker will not affect the others.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Side effects

N/A

Related changes

N/A

Release note

N/A