### PR TITLE
planner/cascades: inject Projection below TopN when ByItems contain ScalarFunctions

### DIFF
--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -37,7 +37,8 @@
       "select a from t limit 2",
       "select a from t limit 1 offset 2",
       "select b from t order by b limit 3",
-      "select a from t order by a limit 1 offset 2"
+      "select a from t order by a limit 1 offset 2",
+      "select b from t order by a + b limit 3"
     ]
   },
   {

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -301,6 +301,23 @@
         "Result": [
           "3"
         ]
+      },
+      {
+        "SQL": "select b from t order by a + b limit 3",
+        "Plan": [
+          "Projection_9 3.00 root Column#2",
+          "└─Projection_14 3.00 root Column#2, Column#1",
+          "  └─TopN_10 3.00 root Column#4:asc, offset:0, count:3",
+          "    └─Projection_15 10000.00 root Column#2, Column#1, plus(Column#1, Column#2)",
+          "      └─Projection_11 10000.00 root Column#2, Column#1",
+          "        └─TableReader_12 10000.00 root data:TableScan_13",
+          "          └─TableScan_13 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "11",
+          "22",
+          "33"
+        ]
       }
     ]
   },

--- a/planner/implementation/simple_plans.go
+++ b/planner/implementation/simple_plans.go
@@ -144,8 +144,8 @@ func (impl *TiDBTopNImpl) CalcCost(outCount float64, children ...memo.Implementa
 func (impl *TiDBTopNImpl) AttachChildren(children ...memo.Implementation) memo.Implementation {
 	topN := impl.plan.(*plannercore.PhysicalTopN)
 	topN.SetChildren(children[0].GetPlan())
-	// If the topN.ByItems contains ScalarFunctions, we need to inject Projections
-	// below and above TopN for the them.
+	// If the topN.ByItems contains ScalarFunctions, we need to inject extra Projections
+	// below and above TopN for them.
 	impl.plan = plannercore.InjectProjBelowSort(topN, topN.ByItems)
 	return impl
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Similar to Sort, TiDB cannot deal with TopN with ScalarFunctions either. So we have to inject a Projection for it.

### What is changed and how it works?

 Inject Projection below TopN when ByItems contain ScalarFunctions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
