### PR TITLE
perfschema: support retrieve CPU/memory/mutex/block/allocs profile from PD via SQL

### DIFF
--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -43,10 +43,16 @@ var perfSchemaTables = []string{
 	tableTiDBProfileCPU,
 	tableTiDBProfileMemory,
 	tableTiDBProfileMutex,
-	tableTiDBAllocsProfile,
+	tableTiDBProfileAllocs,
 	tableTiDBProfileBlock,
 	tableTiDBProfileGoroutines,
 	tableTiKVProfileCPU,
+	tablePDProfileCPU,
+	tablePDProfileMemory,
+	tablePDProfileMutex,
+	tablePDProfileAllocs,
+	tablePDProfileBlock,
+	tablePDProfileGoroutines,
 }
 
 // tableGlobalStatus contains the column name definitions for table global_status, same as MySQL.
@@ -475,8 +481,8 @@ const tableTiDBProfileMutex = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfi
 	"DEPTH INT(8) NOT NULL," +
 	"FILE VARCHAR(512) NOT NULL);"
 
-// tableTiDBAllocsProfile contains the columns name definitions for table tidb_profile_allocs
-const tableTiDBAllocsProfile = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileAllocs + " (" +
+// tableTiDBProfileAllocs contains the columns name definitions for table tidb_profile_allocs
+const tableTiDBProfileAllocs = "CREATE TABLE IF NOT EXISTS " + tableNameTiDBProfileAllocs + " (" +
 	"FUNCTION VARCHAR(512) NOT NULL," +
 	"PERCENT_ABS VARCHAR(8) NOT NULL," +
 	"PERCENT_REL VARCHAR(8) NOT NULL," +
@@ -498,9 +504,9 @@ const tableTiDBProfileGoroutines = "CREATE TABLE IF NOT EXISTS " + tableNameTiDB
 	"FUNCTION VARCHAR(512) NOT NULL," +
 	"ID INT(8) NOT NULL," +
 	"STATE VARCHAR(16) NOT NULL," +
-	"LOCATION VARCHAR(512));"
+	"LOCATION VARCHAR(512) NOT NULL);"
 
-	// tableTiKVProfileCPU contains the columns name definitions for table tikv_profile_cpu
+// tableTiKVProfileCPU contains the columns name definitions for table tikv_profile_cpu
 const tableTiKVProfileCPU = "CREATE TABLE IF NOT EXISTS " + tableNameTiKVProfileCPU + " (" +
 	"ADDRESS VARCHAR(64) NOT NULL," +
 	"FUNCTION VARCHAR(512) NOT NULL," +
@@ -509,3 +515,61 @@ const tableTiKVProfileCPU = "CREATE TABLE IF NOT EXISTS " + tableNameTiKVProfile
 	"ROOT_CHILD INT(8) NOT NULL," +
 	"DEPTH INT(8) NOT NULL," +
 	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileCPU contains the columns name definitions for table pd_profile_cpu
+const tablePDProfileCPU = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileCPU + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileMemory contains the columns name definitions for table pd_profile_cpu_memory
+const tablePDProfileMemory = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileMemory + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileMutex contains the columns name definitions for table pd_profile_mutex
+const tablePDProfileMutex = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileMutex + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileAllocs contains the columns name definitions for table pd_profile_allocs
+const tablePDProfileAllocs = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileAllocs + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileBlock contains the columns name definitions for table pd_profile_block
+const tablePDProfileBlock = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileBlock + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"PERCENT_ABS VARCHAR(8) NOT NULL," +
+	"PERCENT_REL VARCHAR(8) NOT NULL," +
+	"ROOT_CHILD INT(8) NOT NULL," +
+	"DEPTH INT(8) NOT NULL," +
+	"FILE VARCHAR(512) NOT NULL);"
+
+// tablePDProfileGoroutines contains the columns name definitions for table pd_profile_goroutines
+const tablePDProfileGoroutines = "CREATE TABLE IF NOT EXISTS " + tableNamePDProfileGoroutines + " (" +
+	"ADDRESS VARCHAR(64) NOT NULL," +
+	"FUNCTION VARCHAR(512) NOT NULL," +
+	"ID INT(8) NOT NULL," +
+	"STATE VARCHAR(16) NOT NULL," +
+	"LOCATION VARCHAR(512) NOT NULL);"

--- a/infoschema/perfschema/tables.go
+++ b/infoschema/perfschema/tables.go
@@ -15,7 +15,6 @@ package perfschema
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -201,7 +200,7 @@ func dataForRemoteProfile(ctx sessionctx.Context, nodeType, uri string, isGrouti
 			servers = servers[:0]
 			for _, server := range strings.Split(s, ";") {
 				parts := strings.Split(server, ",")
-				if parts[1] != nodeType {
+				if parts[0] != nodeType {
 					continue
 				}
 				servers = append(servers, infoschema.ServerInfo{
@@ -256,11 +255,6 @@ func dataForRemoteProfile(ctx sessionctx.Context, nodeType, uri string, isGrouti
 					terror.Log(resp.Body.Close())
 				}()
 				if resp.StatusCode != http.StatusOK {
-					content, err := ioutil.ReadAll(resp.Body)
-					if err != nil {
-						panic(err)
-					}
-					fmt.Println("===>", string(content))
 					ch <- result{err: errors.Errorf("request %s failed: %s", url, resp.Status)}
 					return
 				}

--- a/infoschema/perfschema/tables.go
+++ b/infoschema/perfschema/tables.go
@@ -15,11 +15,11 @@ package perfschema
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -45,6 +45,12 @@ const (
 	tableNameTiDBProfileBlock                = "tidb_profile_block"
 	tableNameTiDBProfileGoroutines           = "tidb_profile_goroutines"
 	tableNameTiKVProfileCPU                  = "tikv_profile_cpu"
+	tableNamePDProfileCPU                    = "pd_profile_cpu"
+	tableNamePDProfileMemory                 = "pd_profile_memory"
+	tableNamePDProfileMutex                  = "pd_profile_mutex"
+	tableNamePDProfileAllocs                 = "pd_profile_allocs"
+	tableNamePDProfileBlock                  = "pd_profile_block"
+	tableNamePDProfileGoroutines             = "pd_profile_goroutines"
 )
 
 // perfSchemaTable stands for the fake table all its data is in the memory.
@@ -120,9 +126,21 @@ func (vt *perfSchemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 	case tableNameTiDBProfileBlock:
 		fullRows, err = (&profile.Collector{}).ProfileGraph("block")
 	case tableNameTiDBProfileGoroutines:
-		fullRows, err = (&profile.Collector{}).Goroutines()
+		fullRows, err = (&profile.Collector{}).ProfileGraph("goroutine")
 	case tableNameTiKVProfileCPU:
-		fullRows, err = dataForTiKVProfileCPU(ctx)
+		fullRows, err = dataForRemoteProfile(ctx, "tikv", "/debug/pprof/profile?seconds=30", false)
+	case tableNamePDProfileCPU:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/profile?seconds=30", false)
+	case tableNamePDProfileMemory:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/heap", false)
+	case tableNamePDProfileMutex:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/mutex", false)
+	case tableNamePDProfileAllocs:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/allocs", false)
+	case tableNamePDProfileBlock:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/block", false)
+	case tableNamePDProfileGoroutines:
+		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/goroutine?debug=2", true)
 	}
 	if err != nil {
 		return
@@ -163,15 +181,29 @@ func (vt *perfSchemaTable) IterRecords(ctx sessionctx.Context, startKey kv.Key, 
 	return nil
 }
 
-func dataForTiKVProfileCPU(ctx sessionctx.Context) ([][]types.Datum, error) {
-	servers, err := infoschema.GetTiKVServerInfo(ctx)
-	failpoint.Inject("mockTiKVNodeStatusAddress", func(val failpoint.Value) {
+func dataForRemoteProfile(ctx sessionctx.Context, nodeType, uri string, isGroutine bool) ([][]types.Datum, error) {
+	var (
+		servers []infoschema.ServerInfo
+		err     error
+	)
+	switch nodeType {
+	case "tikv":
+		servers, err = infoschema.GetTiKVServerInfo(ctx)
+	case "pd":
+		servers, err = infoschema.GetPDServerInfo(ctx)
+	default:
+		return nil, errors.Errorf("%s does not support profile remote component", nodeType)
+	}
+	failpoint.Inject("mockRemoteNodeStatusAddress", func(val failpoint.Value) {
 		// The cluster topology is injected by `failpoint` expression and
 		// there is no extra checks for it. (let the test fail if the expression invalid)
 		if s := val.(string); len(s) > 0 {
 			servers = servers[:0]
 			for _, server := range strings.Split(s, ";") {
 				parts := strings.Split(server, ",")
+				if parts[1] != nodeType {
+					continue
+				}
 				servers = append(servers, infoschema.ServerInfo{
 					ServerType: parts[0],
 					Address:    parts[1],
@@ -205,13 +237,15 @@ func dataForTiKVProfileCPU(ctx sessionctx.Context) ([][]types.Datum, error) {
 		go func(address string) {
 			util.WithRecovery(func() {
 				defer wg.Done()
-				interval := int(profile.CPUProfileInterval / time.Second)
-				url := fmt.Sprintf("http://%s/debug/pprof/profile?seconds=%d", statusAddr, interval)
+				url := fmt.Sprintf("http://%s%s", statusAddr, uri)
 				req, err := http.NewRequest(http.MethodGet, url, nil)
 				if err != nil {
 					ch <- result{err: errors.Trace(err)}
 					return
 				}
+				// Forbidden PD follower proxy
+				req.Header.Add("PD-Allow-follower-handle", "true")
+				// TiKV output svg format in default
 				req.Header.Add("Content-Type", "application/protobuf")
 				resp, err := http.DefaultClient.Do(req)
 				if err != nil {
@@ -222,11 +256,21 @@ func dataForTiKVProfileCPU(ctx sessionctx.Context) ([][]types.Datum, error) {
 					terror.Log(resp.Body.Close())
 				}()
 				if resp.StatusCode != http.StatusOK {
-					ch <- result{err: errors.Errorf("request %s failed: %s", statusAddr, resp.Status)}
+					content, err := ioutil.ReadAll(resp.Body)
+					if err != nil {
+						panic(err)
+					}
+					fmt.Println("===>", string(content))
+					ch <- result{err: errors.Errorf("request %s failed: %s", url, resp.Status)}
 					return
 				}
 				collector := profile.Collector{}
-				rows, err := collector.ProfileReaderToDatums(resp.Body)
+				var rows [][]types.Datum
+				if isGroutine {
+					rows, err = collector.ParseGoroutines(resp.Body)
+				} else {
+					rows, err = collector.ProfileReaderToDatums(resp.Body)
+				}
 				if err != nil {
 					ch <- result{err: errors.Trace(err)}
 					return

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"runtime/pprof"
 	"strings"
 	"testing"
 
@@ -222,8 +223,12 @@ func (s *testTableSuite) TestTiKVProfileCPU(c *C) {
 	})
 
 	// failpoint setting
-	fpExpr := strings.Join([]string{"tikv", mockAddr, mockAddr}, ",")
-	fpName := "github.com/pingcap/tidb/infoschema/perfschema/mockTiKVNodeStatusAddress"
+	servers := []string{
+		strings.Join([]string{"tikv", mockAddr, mockAddr}, ","),
+		strings.Join([]string{"pd", mockAddr, mockAddr}, ","),
+	}
+	fpExpr := strings.Join(servers, ";")
+	fpName := "github.com/pingcap/tidb/infoschema/perfschema/mockRemoteNodeStatusAddress"
 	c.Assert(failpoint.Enable(fpName, fmt.Sprintf(`return("%s")`, fpExpr)), IsNil)
 	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
 
@@ -256,4 +261,61 @@ func (s *testTableSuite) TestTiKVProfileCPU(c *C) {
 		"│ └─core::iter::range::<impl core::iter::traits::iterator::Iterator for core::ops::range::Range<A>>::next::hdb23ceb766e7a91f 0.89% 100%",
 		"└─<hashbrown::raw::bitmask::BitMaskIter as core::iter::traits::iterator::Iterator>::next::he129c78b3deb639d 0.89% 0.89%",
 		"  └─Unknown 0.89% 100%"))
+
+	// We can use current processe profile to mock profile of PD because the PD has the
+	// same way of retrieving profile with TiDB. And the purpose of this test case is used
+	// to make sure all profile HTTP API have been accessed.
+	accessed := map[string]struct{}{}
+	handlerFactory := func(name string, debug ...int) func(w http.ResponseWriter, _ *http.Request) {
+		debugLevel := 0
+		if len(debug) > 0 {
+			debugLevel = debug[0]
+		}
+		return func(w http.ResponseWriter, _ *http.Request) {
+			profile := pprof.Lookup(name)
+			if profile == nil {
+				http.Error(w, fmt.Sprintf("profile %s not found", name), http.StatusBadRequest)
+				return
+			}
+			if err := profile.WriteTo(w, debugLevel); err != nil {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+				return
+			}
+			accessed[name] = struct{}{}
+		}
+	}
+
+	// mock PD profile
+	router.HandleFunc("/pd/api/v1/debug/pprof/profile", handlerFactory("profile"))
+	router.HandleFunc("/pd/api/v1/debug/pprof/heap", handlerFactory("heap"))
+	router.HandleFunc("/pd/api/v1/debug/pprof/mutex", handlerFactory("mutex"))
+	router.HandleFunc("/pd/api/v1/debug/pprof/allocs", handlerFactory("allocs"))
+	router.HandleFunc("/pd/api/v1/debug/pprof/block", handlerFactory("block"))
+	router.HandleFunc("/pd/api/v1/debug/pprof/goroutine", handlerFactory("goroutine", 2))
+
+	tk.MustQuery("select * from pd_profile_cpu where depth < 3")
+	warnings := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	tk.MustQuery("select * from pd_profile_memory where depth < 3")
+	warnings = tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	tk.MustQuery("select * from pd_profile_mutex where depth < 3")
+	warnings = tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	tk.MustQuery("select * from pd_profile_allocs where depth < 3")
+	warnings = tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	tk.MustQuery("select * from pd_profile_block where depth < 3")
+	warnings = tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	tk.MustQuery("select * from pd_profile_goroutines")
+	warnings = tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Assert(len(warnings), Equals, 0, Commentf("expect no warnings, but found: %+v", warnings))
+
+	c.Assert(len(accessed), Equals, 5, Commentf("expect all HTTP API had been accessed, but found: %v", accessed))
 }

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -111,7 +111,6 @@ func (c *Collector) ParseGoroutines(reader io.Reader) ([][]types.Datum, error) {
 
 		headers := strings.SplitN(strings.TrimSpace(goroutine[len("goroutine")+1:colIndex]), " ", 2)
 		if len(headers) != 2 {
-			fmt.Println(string(content))
 			return nil, errors.Errorf("incompatible goroutine headers: %s", goroutine[len("goroutine")+1:colIndex])
 		}
 		id, err := strconv.Atoi(strings.TrimSpace(headers[0]))

--- a/util/profile/profile.go
+++ b/util/profile/profile.go
@@ -15,7 +15,6 @@ package profile
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"runtime/pprof"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

perfschema: support retrieve CPU/memory/mutex/block/allocs profile from PD via SQL

### What is changed and how it works?

Add system tables in `PERFORMANCE_SCHEMA`
```
pd_profile_cpu
pd_profile_memory
pd_profile_mutex
pd_profile_allocs
pd_profile_block
pd_profile_goroutines
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - Support retrieve CPU/memory/mutex/block/allocs profile from PD via SQL (eg: `select * from performance_schema.pd_profile_memory`).
