### PR TITLE
expression:implement vectorized evaluation for builtinAddDateIntRealSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1459,11 +1459,51 @@ func (b *builtinUTCTimestampWithArgSig) vecEvalTime(input *chunk.Chunk, result *
 }
 
 func (b *builtinAddDateIntRealSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinAddDateIntRealSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	unit, err := b.bufAllocator.get(types.ETString, n)
+	if err != nil {
+		return err
+	}
+	defer b.bufAllocator.put(unit)
+	if err = b.args[2].VecEvalString(b.ctx, input, unit); err != nil {
+		return err
+	}
+	result.ResizeTime(n, false)
+	times := result.Times()
+	for i := 0; i < n; i++ {
+		unitI := unit.GetString(i)
+		row := input.GetRow(i)
+		date, isNull, err := b.getDateFromInt(b.ctx, b.args, row, unitI)
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		interval, isNull, err := b.getIntervalFromReal(b.ctx, b.args, row, unitI)
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		resultI, isNull, err := b.add(b.ctx, date, interval, unitI)
+		if err != nil {
+			return err
+		}
+		if isNull {
+			result.SetNull(i, true)
+			continue
+		}
+		times[i] = resultI
+	}
+	return nil
 }
 
 func (b *builtinSubDurationAndDurationSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -157,7 +157,16 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.TimestampLiteral: {},
 	ast.SubDate:          {},
-	ast.AddDate:          {},
+	ast.AddDate: {
+		{
+			retEvalType: types.ETDatetime, childrenTypes: []types.EvalType{types.ETInt, types.ETReal, types.ETString},
+			geners: []dataGenerator{
+				nil,
+				nil,
+				&constStrGener{"MICROSECOND"},
+			},
+		},
+	},
 	ast.SubTime: {
 		{
 			retEvalType:   types.ETString,


### PR DESCRIPTION
PCP #12101 
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for builtinAddDateIntRealSig

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateIntRealSig-VecBuiltinFunc-8         	     100	  18749828 ns/op	  464849 B/op	    5096 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinAddDateIntRealSig-NonVecBuiltinFunc-8      	     100	  24523802 ns/op	  349377 B/op	    5096 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
