### PR TITLE
privilege: check whether table and db exist before executing grant

### DIFF
--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/meta"
 	"strings"
 
 	. "github.com/pingcap/check"
@@ -236,4 +237,14 @@ func (s *testSuite3) TestGrantUnderANSIQuotes(c *C) {
 	tk.MustExec(`GRANT ALL PRIVILEGES ON video_ulimit.* TO web@'%' IDENTIFIED BY 'eDrkrhZ>l2sV'`)
 	tk.MustExec(`REVOKE ALL PRIVILEGES ON video_ulimit.* FROM web@'%';`)
 	tk.MustExec(`DROP USER IF EXISTS 'web'@'%'`)
+}
+
+func (s *testSuite3) TestGrantUnexistObject(c *C)  {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("CREATE USER 'unexist'@'%';")
+	_, err := tk.Exec("grant select, update on unkown_db.* to unexist;")
+	c.Assert(meta.ErrDBNotExists.Equal(err), IsTrue)
+	_, err = tk.Exec("grant select, update on unkown_db.unknown_table to unexist;")
+	c.Assert(meta.ErrTableNotExists.Equal(err), IsTrue)
+	tk.MustExec("DROP USER 'unexist'@'%';")
 }

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -15,13 +15,13 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/meta"
 	"strings"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/executor"
+	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
@@ -239,7 +239,7 @@ func (s *testSuite3) TestGrantUnderANSIQuotes(c *C) {
 	tk.MustExec(`DROP USER IF EXISTS 'web'@'%'`)
 }
 
-func (s *testSuite3) TestGrantUnexistObject(c *C)  {
+func (s *testSuite3) TestGrantUnexistObject(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("CREATE USER 'unexist'@'%';")
 	_, err := tk.Exec("grant select, update on unkown_db.* to unexist;")

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -242,9 +242,9 @@ func (s *testSuite3) TestGrantUnderANSIQuotes(c *C) {
 func (s *testSuite3) TestGrantUnexistObject(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("CREATE USER 'unexist'@'%';")
-	_, err := tk.Exec("grant select, update on unkown_db.* to unexist;")
+	_, err := tk.Exec("grant select, update on unknown_db.* to unexist;")
 	c.Assert(meta.ErrDBNotExists.Equal(err), IsTrue)
-	_, err = tk.Exec("grant select, update on unkown_db.unknown_table to unexist;")
+	_, err = tk.Exec("grant select, update on unknown_db.unknown_table to unexist;")
 	c.Assert(meta.ErrTableNotExists.Equal(err), IsTrue)
 	tk.MustExec("DROP USER 'unexist'@'%';")
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB doesn't check whether target table or db exist when executing `GRANT`. User can grant privileges on tables that was not created before.

### What is changed and how it works?
add `checkIfDBExist` and `checkIfTableExist` which will looking for table and db information in `infoschema` and make sure target table is an existed table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

- None

Side effects

 - none

Related changes

 - Need to cherry-pick to the release branch

