### PR TITLE
expression: implement vectorized evaluation for builtinSubTimeDurationNullSig

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -800,11 +800,13 @@ func (b *builtinAddDateDatetimeRealSig) vecEvalTime(input *chunk.Chunk, result *
 }
 
 func (b *builtinSubTimeDurationNullSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinSubTimeDurationNullSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	result.ResizeGoDuration(n, true)
+	return nil
 }
 
 func (b *builtinStrToDateDateSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -179,7 +179,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		{
 			retEvalType:        types.ETDuration,
 			childrenTypes:      []types.EvalType{types.ETDuration, types.ETDatetime},
-			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDuration), types.NewFieldType(mysql.TypeDatetime)},
 		},
 		// builtinSubTimeStringNullSig
 		{

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -178,7 +178,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 		// builtinSubTimeDurationNullSig
 		{
 			retEvalType:        types.ETDuration,
-			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
+			childrenTypes:      []types.EvalType{types.ETDuration, types.ETDatetime},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
 		},
 		// builtinSubTimeStringNullSig

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -175,6 +175,12 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 				&timeStrGener{},
 			},
 		},
+		// builtinSubTimeDurationNullSig
+		{
+			retEvalType:        types.ETDuration,
+			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
+		},
 		// builtinSubTimeStringNullSig
 		{
 			retEvalType:        types.ETString,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
### What problem does this PR solve?
implement vectorized evaluation for builtinSubTimeDurationNullSig, for [#12106](https://github.com/pingcap/tidb/issues/12106)

### What is changed and how it works?
according to benchmark, about 2 times faster than before:
```
BenchmarkVectorizedBuiltinTimeFunc/builtinSubTimeDurationNullSig-VecBuiltinFunc-4                BenchmarkVectorizedBuiltinTimeFunc/builtinSubTimeDurationNullSig-NonVecBuiltinFunc-4              
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test\