### PR TITLE
util/printer: get `GoVersion` from runtime variable instead of shell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ LDFLAGS += -X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=$(shell git de
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.GoVersion=$(shell go version)"
 
 TEST_LDFLAGS =  -X "github.com/pingcap/tidb/config.checkBeforeDropLDFlag=1"
 COVERAGE_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/tidb-server.isCoverageServer=1"

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	_ "unsafe"
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
@@ -30,7 +31,6 @@ var (
 	TiDBBuildTS   = "None"
 	TiDBGitHash   = "None"
 	TiDBGitBranch = "None"
-	GoVersion     = "None"
 	// TiKVMinVersion is the minimum version of TiKV that can be compatible with the current TiDB.
 	TiKVMinVersion = "v3.0.0-60965b006877ca7234adaced7890d7b029ed1306"
 )
@@ -42,7 +42,7 @@ func PrintTiDBInfo() {
 		zap.String("Git Commit Hash", TiDBGitHash),
 		zap.String("Git Branch", TiDBGitBranch),
 		zap.String("UTC Build Time", TiDBBuildTS),
-		zap.String("GoVersion", GoVersion),
+		zap.String("GoVersion", buildVersion),
 		zap.Bool("Race Enabled", israce.RaceEnabled),
 		zap.Bool("Check Table Before Drop", config.CheckTableBeforeDrop),
 		zap.String("TiKV Min Version", TiKVMinVersion))
@@ -67,7 +67,7 @@ func GetTiDBInfo() string {
 		TiDBGitHash,
 		TiDBGitBranch,
 		TiDBBuildTS,
-		GoVersion,
+		buildVersion,
 		israce.RaceEnabled,
 		TiKVMinVersion,
 		config.CheckTableBeforeDrop)
@@ -167,3 +167,6 @@ func GetPrintResult(cols []string, datas [][]string) (string, bool) {
 	value = append(value, getPrintDivLine(maxColLen)...)
 	return string(value), true
 }
+
+//go:linkname buildVersion runtime.buildVersion
+var buildVersion string

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	_ "runtime" // import link package
-	_ "unsafe" // required by go:linkname
+	_ "unsafe"  // required by go:linkname
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	_ "runtime" // import link package
 	_ "unsafe" // required by go:linkname
 
 	"github.com/pingcap/parser/mysql"

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -17,7 +17,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	_ "unsafe"
+	_ "unsafe" // required by go:linkname
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If we build `tidb-server` with a different go binary rather than the default go, the `GoVersion` may be wrong.

### What is changed and how it works?
link runtime `buildVersion` variable in `printer` to get the `GoVersion`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
`make server` and run `tidb-server -V`
