### PR TITLE
expression: implement vectorized evaluation for `builtinValuesIntSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -985,6 +985,10 @@ func genVecBuiltinFuncBenchCase(ctx sessionctx.Context, funcName string, testCas
 			fc = &castAsStringFunctionClass{baseFunctionClass{ast.Cast, 1, 1}, tp}
 		}
 		baseFunc, err = fc.getFunction(ctx, cols)
+	} else if funcName == ast.Values {
+		tp := eType2FieldType(testCase.retEvalType)
+		fc := &valuesFunctionClass{baseFunctionClass{ast.Values, 0, 0}, 1, tp}
+		baseFunc, err = fc.getFunction(ctx, cols)
 	} else {
 		baseFunc, err = funcs[funcName].getFunction(ctx, cols)
 	}
@@ -1057,6 +1061,11 @@ func testVectorizedBuiltinFunc(c *C, vecExprCases vecExprBenchCases) {
 					types.NewMysqlBitDatum(types.BinaryLiteral([]byte{1})),
 					types.NewMysqlEnumDatum(types.Enum{Name: "n", Value: 2}),
 				}
+			}
+			if funcName == ast.Values {
+				ctx.GetSessionVars().StmtCtx.InInsertStmt = true
+				currInsertValues := types.MakeDatums("1", "2")
+				ctx.GetSessionVars().CurrInsertValues = chunk.MutRowFromDatums(currInsertValues).ToRow()
 			}
 			baseFunc, fts, input, output := genVecBuiltinFuncBenchCase(ctx, funcName, testCase)
 			baseFuncName := fmt.Sprintf("%v", reflect.TypeOf(baseFunc))

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -28,6 +28,9 @@ var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
 	ast.GetVar: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
 	},
+	ast.Values: {
+		{retEvalType: types.ETInt},
+	},
 	ast.BitCount: {},
 	ast.GetParam: {
 		{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinValuesIntSig.
Issue: #12103

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinOtherFunc/builtinValuesIntSig-VecBuiltinFunc-4                  747039              2898 ns/op               0 B/op            0 allocs/op
BenchmarkVectorizedBuiltinOtherFunc/builtinValuesIntSig-NonVecBuiltinFunc-4                49257             40616 ns/op               0 B/op            0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test