### PR TITLE
Disable automaxprocs log

### DIFF
--- a/checkout-pr-branch.sh
+++ b/checkout-pr-branch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script is used to checkout a TiDB PR branch in a forked repo.
 if test -z $1; then

--- a/cmd/explaintest/run-tests.sh
+++ b/cmd/explaintest/run-tests.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TIDB_TEST_STORE_NAME=$TIDB_TEST_STORE_NAME
 TIKV_PATH=$TIKV_PATH

--- a/hooks/pre-commit
+++ b/hooks/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This file modified from k8s
 # https://github.com/kubernetes/kubernetes/blob/master/hooks/pre-commit
 # Now It's removed, The Reason is https://github.com/kubernetes/community/issues/729

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -571,7 +571,8 @@ func setupLog() {
 	terror.MustNil(err)
 	// Disable automaxprocs log
 	nopLog := func(string, ...interface{}) {}
-	maxprocs.Set(maxprocs.Logger(nopLog))
+	_, err = maxprocs.Set(maxprocs.Logger(nopLog))
+	terror.MustNil(err)
 }
 
 func printInfo() {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -60,7 +60,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/push"
 	"github.com/struCoder/pidusage"
-	_ "go.uber.org/automaxprocs"
+	"go.uber.org/automaxprocs/maxprocs"
 	"go.uber.org/zap"
 )
 
@@ -569,6 +569,9 @@ func setupLog() {
 
 	err = logutil.InitLogger(cfg.Log.ToLogConfig())
 	terror.MustNil(err)
+	// Disable automaxprocs log
+	nopLog := func(string, ...interface{}) {}
+	maxprocs.Set(maxprocs.Logger(nopLog))
 }
 
 func printInfo() {

--- a/tools/check/check_testSuite.sh
+++ b/tools/check/check_testSuite.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
Signed-off-by: tennix <ztennix@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
After introducing automaxprocs in #13340, now tidb-server will always log a message `2019/11/28 14:18:22 maxprocs: Leaving GOMAXPROCS=4: CPU quota undefined` at startup which is annoying. This PR resolves this problem.

### What is changed and how it works?
According to this https://github.com/uber-go/automaxprocs/issues/18 and https://github.com/uber-go/automaxprocs/issues/19. We can disable this annoying log by importing `go.uber.org/automaxprocs/maxprocs` and set the logger to a noplog.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Now the annoying log disappears whenever runs tidb-server. And the `GOMAXPROCS` is still set automatically.

Code changes

None

Side effects

None

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Removing the annoying automaxprocs log.
