### PR TITLE
expression: implement vectorized evaluation for `builtinCastStringAsDurationSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"math/rand"
 	"net"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -652,6 +653,12 @@ type randDurInt struct{}
 
 func (g *randDurInt) gen() interface{} {
 	return int64(rand.Intn(types.TimeMaxHour)*10000 + rand.Intn(60)*100 + rand.Intn(60))
+}
+
+type randDurString struct{}
+
+func (g *randDurString) gen() interface{} {
+	return strconv.FormatInt(int64(rand.Intn(types.TimeMaxHour)*10000+rand.Intn(60)*100+rand.Intn(60)), 10)
 }
 
 // locationGener is used to generate location for the built-in function GetFormat.

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -69,6 +69,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETDecimal}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETJson}, geners: []dataGenerator{&randJSONDuration{}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDuration}},
+		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{new(randDurString)}},
 		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETJson, childrenTypes: []types.EvalType{types.ETDuration}},


### PR DESCRIPTION




<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
implement vectorized evaluation for `builtinCastStringAsDurationSig` from #12176 

### What is changed and how it works?
4.1% faster than before:


    BenchmarkVectorizedBuiltinCastFunc/builtinCastStringAsDurationSig-VecBuiltinFunc-4                   740           1556465 ns/op          114716 B/op       9201 allocs/op
    BenchmarkVectorizedBuiltinCastFunc/builtinCastStringAsDurationSig-NonVecBuiltinFunc-4                734           1624636 ns/op          114717 B/op       9201 allocs/op




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test