### PR TITLE
proposal: run Discourse on TiDB

### DIFF
--- a/docs/design/2019-11-28-discourse-on-tidb.md
+++ b/docs/design/2019-11-28-discourse-on-tidb.md
@@ -1,0 +1,33 @@
+# Proposal: Migrate Discourse's db from PostgreSQL to TiDB
+
+- Author(s): EE-Team
+- Last updated:  Nov 19, 2019
+- Discussion at: https://github.com/pingcap-incubator/discourse/issues/
+
+## Abstract
+
+The proposal aim at:
+
+1. **Eat our own dog food**;
+2. Connect TiDB Community with Discourse Community and Ruby On Rails Community;
+
+## Background
+
+The TiDB User Group Website: [AskTUG](https://asktug.com) is running on Discourse, and Discourse is running on PostgreSQL, we want to migrate it to TiDB. Then we can frequently test TiDB before each release.
+
+## Proposal
+
+We will make these changes:
+
+1. Make Discourse's most sql statemennt run on MySQL;
+2. Add new component elastic search instead of PostgreSQL's fulltext search;
+3. Migrate from MySQL to TiDB, fix potential compatible problems;
+
+## Rationale
+
+## Compatibility
+
+## Implementation
+
+## Open issues (if applicable)
+


### PR DESCRIPTION
Signed-off-by: sykp241095@gmail.com

## Summary
This is a proposal about migration of Discourse's database from PostgreSQL to MySQL.

## Motivation
1. Eat our own dog food before release;
2. This migration is a big event in both TiDB community and Discourse(Rails) Community;
