### PR TITLE
server: improve test coverage for `/mvcc/key` API

### DIFF
--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -379,6 +379,17 @@ func (ts *HTTPHandlerTestSuite) TestGetTableMVCC(c *C) {
 	err = decoder.Decode(&data2)
 	c.Assert(err, IsNil)
 	c.Assert(data2, DeepEquals, data)
+
+	resp, err = http.Get(fmt.Sprintf("http://127.0.0.1:10090/mvcc/key/tidb/test/1?decode=true"))
+	c.Assert(err, IsNil)
+	decoder = json.NewDecoder(resp.Body)
+	var data3 map[string]interface{}
+	err = decoder.Decode(&data3)
+	c.Assert(err, IsNil)
+	c.Assert(data3["key"], NotNil)
+	c.Assert(data3["info"], NotNil)
+	c.Assert(data3["data"], NotNil)
+	c.Assert(data3["decode_error"], IsNil)
 }
 
 func (ts *HTTPHandlerTestSuite) TestGetMVCCNotFound(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Improving test coverage for `/mvcc/key` api in `server` module.

Related PR #9932

### What is changed and how it works?

Adding test cases for

https://github.com/pingcap/tidb/blob/d438c860a660f00c755094e1d6c9e61c18715edf/server/http_handler.go#L1446-L1498
```
➜  tidb git:(mvcc-decode-key) ✗ go test ./server -cover
ok      github.com/pingcap/tidb/server  20.581s coverage: 63.8% of statements

➜  tidb git:(mvcc-decode-key) ✗ go test ./server -cover
ok      github.com/pingcap/tidb/server  20.642s coverage: 64.8% of statements
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
