### PR TITLE
expression: implement vectorized evaluation for `builtinSubDateAndStringSig`

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -175,6 +175,16 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 				&timeStrGener{},
 			},
 		},
+		// builtinSubDateAndStringSig
+		{
+			retEvalType:        types.ETString,
+			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETString},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeString)},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+			},
+		},
 		// builtinSubTimeStringNullSig
 		{
 			retEvalType:        types.ETString,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinSubDateAndStringSig , for #12106

### What is changed and how it works?

	$go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args "builtinSubDateAndStringSig"
	goos: darwin
	goarch: amd64
	pkg: github.com/pingcap/tidb/expression
	BenchmarkVectorizedBuiltinTimeFuncGenerated-4           1000000000               0.0203 ns/op          0 B/op          0 allocs/op
	BenchmarkVectorizedBuiltinTimeFunc/builtinSubDateAndStringSig-VecBuiltinFunc-4               655           1736516 ns/op          190230 B/op       9903 allocs/op
	BenchmarkVectorizedBuiltinTimeFunc/builtinSubDateAndStringSig-NonVecBuiltinFunc-4            607           1879569 ns/op          190025 B/op       9903 allocs/op
	PASS
	ok      github.com/pingcap/tidb/expression      2.888s

Tests <!-- At least one of them must be included. -->

 - Unit test