### PR TITLE
expression: implement vectorized evaluation for `builtinSubStringAndDurationSig `

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -175,6 +175,15 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 				&timeStrGener{},
 			},
 		},
+		// builtinSubStringAndDurationSig
+		{
+			retEvalType:   types.ETString,
+			childrenTypes: []types.EvalType{types.ETString, types.ETDuration},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
 		// builtinSubTimeStringNullSig
 		{
 			retEvalType:        types.ETString,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement vectorized evaluation for builtinSubStringAndDurationSig , for #12106

### What is changed and how it works?

	$go test -v -benchmem -bench=BenchmarkVectorizedBuiltinTimeFunc -run=BenchmarkVectorizedBuiltinTimeFunc -args "builtinSubStringAndDurationSig"
	goos: darwin
	goarch: amd64
	pkg: github.com/pingcap/tidb/expression
	BenchmarkVectorizedBuiltinTimeFuncGenerated-4           1000000000               0.0332 ns/op          0 B/op          0 allocs/op
	BenchmarkVectorizedBuiltinTimeFunc/builtinSubStringAndDurationSig-VecBuiltinFunc-4                   518           2692707 ns/op          184037 B/op       8932 allocs/op
	BenchmarkVectorizedBuiltinTimeFunc/builtinSubStringAndDurationSig-NonVecBuiltinFunc-4                386           2679383 ns/op          184583 B/op       8932 allocs/op
	PASS
	ok      github.com/pingcap/tidb/expression      4.340s

Tests <!-- At least one of them must be included. -->

 - Unit test