### PR TITLE
planner/cascades: add transformation rule MergeAdjacentProjection

### DIFF
--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -49,13 +49,12 @@
       {
         "SQL": "select a from t group by a having sum(b) > 4",
         "Plan": [
-          "Projection_11 6400.00 root test.t.a",
-          "└─Projection_12 6400.00 root test.t.a, Column#3",
-          "  └─Selection_13 6400.00 root gt(Column#3, 4)",
-          "    └─HashAgg_18 8000.00 root group by:test.t.a, funcs:sum(Column#5)->Column#3, funcs:firstrow(test.t.a)->test.t.a",
-          "      └─TableReader_19 8000.00 root data:HashAgg_20",
-          "        └─HashAgg_20 8000.00 cop[tikv] group by:test.t.a, funcs:sum(test.t.b)->Column#5",
-          "          └─TableScan_16 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
+          "Projection_12 6400.00 root test.t.a",
+          "└─Selection_13 6400.00 root gt(Column#3, 4)",
+          "  └─HashAgg_18 8000.00 root group by:test.t.a, funcs:sum(Column#5)->Column#3, funcs:firstrow(test.t.a)->test.t.a",
+          "    └─TableReader_19 8000.00 root data:HashAgg_20",
+          "      └─HashAgg_20 8000.00 cop[tikv] group by:test.t.a, funcs:sum(test.t.b)->Column#5",
+          "        └─TableScan_16 10000.00 cop[tikv] table:t, range:[-inf,+inf], keep order:false, stats:pseudo"
         ],
         "Result": [
           "5"

--- a/planner/cascades/testdata/transformation_rules_suite_in.json
+++ b/planner/cascades/testdata/transformation_rules_suite_in.json
@@ -35,7 +35,7 @@
       "select a+b from (select a, b from t) as t2",
       "select a from (select floor(a) as a from t) as t2",
       "select a from (select a, b from (select a, b, c from t) as t2) as t3",
-      "select a from (select floor(a) as a, b, c from t) as t2"
+      "select a+c from (select floor(a) as a, b, c from t) as t2"
     ]
   }
 ]

--- a/planner/cascades/testdata/transformation_rules_suite_in.json
+++ b/planner/cascades/testdata/transformation_rules_suite_in.json
@@ -33,7 +33,9 @@
     "cases": [
       "select a, b from (select a, b from t) as t2",
       "select a+b from (select a, b from t) as t2",
-      "select a from (select floor(a) as a from t) as t2"
+      "select a from (select floor(a) as a from t) as t2",
+      "select a from (select a, b from (select a, b, c from t) as t2) as t3",
+      "select a from (select floor(a) as a, b, c from t) as t2"
     ]
   }
 ]

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -253,6 +253,7 @@
         "SQL": "select a from (select floor(a) as a from t) as t2",
         "Result": [
           "Group#0 Schema:[Column#13]",
+          "    Projection_4 input:[Group#1], floor(test.t.a)->Column#13",
           "    Projection_2 input:[Group#1], floor(test.t.a)->Column#13",
           "Group#1 Schema:[test.t.a]",
           "    TableScan_1 table:t"
@@ -261,10 +262,8 @@
       {
         "SQL": "select a from (select a, b from (select a, b, c from t) as t2) as t3",
         "Result": [
-          "Group#0 Schema:[test.t.a], UniqueKey:[test.t.a]",
-          "    Projection_6 input:[Group#1], test.t.a",
-          "Group#1 Schema:[test.t.a], UniqueKey:[test.t.a]",
-          "    TableScan_1 table:t, pk col:test.t.a"
+          "Group#0 Schema:[test.t.a]",
+          "    TableScan_1 table:t"
         ]
       },
       {
@@ -272,8 +271,8 @@
         "Result": [
           "Group#0 Schema:[Column#14]",
           "    Projection_4 input:[Group#1], plus(floor(test.t.a), test.t.c)->Column#14",
-          "Group#1 Schema:[test.t.a,test.t.c], UniqueKey:[test.t.a]",
-          "    TableScan_1 table:t, pk col:test.t.a"
+          "Group#1 Schema:[test.t.a,test.t.c]",
+          "    TableScan_1 table:t"
         ]
       }
     ]

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -262,19 +262,17 @@
         "SQL": "select a from (select a, b from (select a, b, c from t) as t2) as t3",
         "Result": [
           "Group#0 Schema:[test.t.a], UniqueKey:[test.t.a]",
-          "    Projection_4 input:[Group#1], test.t.a",
+          "    Projection_6 input:[Group#1], test.t.a",
           "Group#1 Schema:[test.t.a], UniqueKey:[test.t.a]",
           "    TableScan_1 table:t, pk col:test.t.a"
         ]
       },
       {
-        "SQL": "select a from (select floor(a) as a, b, c from t) as t2",
+        "SQL": "select a+c from (select floor(a) as a, b, c from t) as t2",
         "Result": [
-          "Group#0 Schema:[Column#13]",
-          "    Projection_3 input:[Group#1], Column#13",
-          "Group#1 Schema:[Column#13]",
-          "    Projection_2 input:[Group#2], floor(test.t.a)->Column#13",
-          "Group#2 Schema:[test.t.a], UniqueKey:[test.t.a]",
+          "Group#0 Schema:[Column#14]",
+          "    Projection_4 input:[Group#1], plus(floor(test.t.a), test.t.c)->Column#14",
+          "Group#1 Schema:[test.t.a,test.t.c], UniqueKey:[test.t.a]",
           "    TableScan_1 table:t, pk col:test.t.a"
         ]
       }

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -257,6 +257,26 @@
           "Group#1 Schema:[test.t.a]",
           "    TableScan_1 table:t"
         ]
+      },
+      {
+        "SQL": "select a from (select a, b from (select a, b, c from t) as t2) as t3",
+        "Result": [
+          "Group#0 Schema:[test.t.a], UniqueKey:[test.t.a]",
+          "    Projection_4 input:[Group#1], test.t.a",
+          "Group#1 Schema:[test.t.a], UniqueKey:[test.t.a]",
+          "    TableScan_1 table:t, pk col:test.t.a"
+        ]
+      },
+      {
+        "SQL": "select a from (select floor(a) as a, b, c from t) as t2",
+        "Result": [
+          "Group#0 Schema:[Column#13]",
+          "    Projection_3 input:[Group#1], Column#13",
+          "Group#1 Schema:[Column#13]",
+          "    Projection_2 input:[Group#2], floor(test.t.a)->Column#13",
+          "Group#2 Schema:[test.t.a], UniqueKey:[test.t.a]",
+          "    TableScan_1 table:t, pk col:test.t.a"
+        ]
       }
     ]
   }

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -62,6 +62,7 @@ var defaultTransformationMap = map[memo.Operand][]Transformation{
 	},
 	memo.OperandProjection: {
 		NewRuleEliminateProjection(),
+		NewRuleMergeAdjacentProjection(),
 	},
 }
 
@@ -646,8 +647,8 @@ func NewRuleMergeAdjacentProjection() Transformation {
 	rule := &MergeAdjacentProjection{}
 	rule.pattern = memo.BuildPattern(
 		memo.OperandProjection,
-		memo.EngineAll,
-		memo.NewPattern(memo.OperandProjection, memo.EngineAll),
+		memo.EngineTiDBOnly,
+		memo.NewPattern(memo.OperandProjection, memo.EngineTiDBOnly),
 	)
 	return rule
 }
@@ -657,63 +658,28 @@ func NewRuleMergeAdjacentProjection() Transformation {
 // or just keep the selection unchanged.
 func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
 	proj := old.GetExpr().ExprNode.(*plannercore.LogicalProjection)
+	childGroup := old.Children[0].Group
 	child := old.Children[0].GetExpr().ExprNode.(*plannercore.LogicalProjection)
 	if plannercore.ExprsHasSideEffects(child.Exprs) {
 		return nil, false, false, nil
 	}
 
 	replace := make(map[string]*expression.Column)
-	for i, col := range child.Schema().Columns {
-		if col1, ok := child.Exprs[i].(*expression.Column); ok {
-			replace[string(col.HashCode(nil))] = col1
-		} else {
-			return nil, false, false, nil
+	for i, col := range childGroup.Prop.Schema.Columns {
+		if colOrigin, ok := child.Exprs[i].(*expression.Column); ok {
+			replace[string(col.HashCode(nil))] = colOrigin
 		}
 	}
 
-	for i, expr := range proj.Exprs {
-		resolveExprAndReplace(expr, replace)
-		proj.Exprs[i] = replaceColumnOfExpr(proj.Exprs[i], child)
+	newProj := plannercore.LogicalProjection{Exprs: make([]expression.Expression, len(proj.Exprs))}.Init(proj.SCtx(), proj.SelectBlockOffset())
+	copy(newProj.Exprs, proj.Exprs)
+	newProj.SetSchema(old.GetExpr().Group.Prop.Schema.Clone())
+	for i, expr := range newProj.Exprs {
+		plannercore.ResolveExprAndReplace(expr, replace)
+		newProj.Exprs[i] = plannercore.ReplaceColumnOfExpr(newProj.Exprs[i], child, childGroup.Prop.Schema)
 	}
 
-	childGroup := old.Children[0].GetExpr().Children[0]
-	old.GetExpr().SetChildren(childGroup)
-	return nil, false, false, nil
-}
-
-func resolveColumnAndReplace(origin *expression.Column, replace map[string]*expression.Column) {
-	dst := replace[string(origin.HashCode(nil))]
-	if dst != nil {
-		retType, inOperand := origin.RetType, origin.InOperand
-		*origin = *dst
-		origin.RetType, origin.InOperand = retType, inOperand
-	}
-}
-
-func resolveExprAndReplace(origin expression.Expression, replace map[string]*expression.Column) {
-	switch expr := origin.(type) {
-	case *expression.Column:
-		resolveColumnAndReplace(expr, replace)
-	case *expression.CorrelatedColumn:
-		resolveColumnAndReplace(&expr.Column, replace)
-	case *expression.ScalarFunction:
-		for _, arg := range expr.GetArgs() {
-			resolveExprAndReplace(arg, replace)
-		}
-	}
-}
-
-func replaceColumnOfExpr(expr expression.Expression, proj *plannercore.LogicalProjection) expression.Expression {
-	switch v := expr.(type) {
-	case *expression.Column:
-		idx := proj.Schema().ColumnIndex(v)
-		if idx != -1 && idx < len(proj.Exprs) {
-			return proj.Exprs[idx]
-		}
-	case *expression.ScalarFunction:
-		for i := range v.GetArgs() {
-			v.GetArgs()[i] = replaceColumnOfExpr(v.GetArgs()[i], proj)
-		}
-	}
-	return expr
+	newProjExpr := memo.NewGroupExpr(newProj)
+	newProjExpr.SetChildren(old.Children[0].GetExpr().Children[0])
+	return []*memo.GroupExpr{newProjExpr}, true, false, nil
 }

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -671,7 +671,8 @@ func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*m
 		}
 	}
 
-	newProj := plannercore.LogicalProjection{Exprs: proj.Exprs}.Init(proj.SCtx(), proj.SelectBlockOffset())
+	newProj := plannercore.LogicalProjection{Exprs: make([]expression.Expression, len(proj.Exprs))}.Init(proj.SCtx(), proj.SelectBlockOffset())
+	copy(newProj.Exprs, proj.Exprs)
 	newProj.SetSchema(old.GetExpr().Group.Prop.Schema)
 	for i, expr := range newProj.Exprs {
 		plannercore.ResolveExprAndReplace(expr, replace)

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -672,7 +672,7 @@ func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*m
 	}
 
 	newProj := plannercore.LogicalProjection{Exprs: proj.Exprs}.Init(proj.SCtx(), proj.SelectBlockOffset())
-	newProj.SetSchema(old.GetExpr().Group.Prop.Schema.Clone())
+	newProj.SetSchema(old.GetExpr().Group.Prop.Schema)
 	for i, expr := range newProj.Exprs {
 		plannercore.ResolveExprAndReplace(expr, replace)
 		newProj.Exprs[i] = plannercore.ReplaceColumnOfExpr(newProj.Exprs[i], child, childGroup.Prop.Schema)

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -672,11 +672,11 @@ func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*m
 	}
 
 	newProj := plannercore.LogicalProjection{Exprs: make([]expression.Expression, len(proj.Exprs))}.Init(proj.SCtx(), proj.SelectBlockOffset())
-	copy(newProj.Exprs, proj.Exprs)
 	newProj.SetSchema(old.GetExpr().Group.Prop.Schema)
-	for i, expr := range newProj.Exprs {
-		plannercore.ResolveExprAndReplace(expr, replace)
-		newProj.Exprs[i] = plannercore.ReplaceColumnOfExpr(newProj.Exprs[i], child, childGroup.Prop.Schema)
+	for i, expr := range proj.Exprs {
+		newExpr := expr.Clone()
+		plannercore.ResolveExprAndReplace(newExpr, replace)
+		newProj.Exprs[i] = plannercore.ReplaceColumnOfExpr(newExpr, child, childGroup.Prop.Schema)
 	}
 
 	newProjExpr := memo.NewGroupExpr(newProj)

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -655,7 +655,7 @@ func NewRuleMergeAdjacentProjection() Transformation {
 
 // OnTransform implements Transformation interface.
 // It will transform `proj->proj->x` to `proj->x`
-// or just keep the selection unchanged.
+// or just keep the adjacent projections unchanged.
 func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
 	proj := old.GetExpr().ExprNode.(*plannercore.LogicalProjection)
 	childGroup := old.Children[0].Group
@@ -671,8 +671,7 @@ func (r *MergeAdjacentProjection) OnTransform(old *memo.ExprIter) (newExprs []*m
 		}
 	}
 
-	newProj := plannercore.LogicalProjection{Exprs: make([]expression.Expression, len(proj.Exprs))}.Init(proj.SCtx(), proj.SelectBlockOffset())
-	copy(newProj.Exprs, proj.Exprs)
+	newProj := plannercore.LogicalProjection{Exprs: proj.Exprs}.Init(proj.SCtx(), proj.SelectBlockOffset())
 	newProj.SetSchema(old.GetExpr().Group.Prop.Schema.Clone())
 	for i, expr := range newProj.Exprs {
 		plannercore.ResolveExprAndReplace(expr, replace)

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -162,6 +162,7 @@ func (s *testTransformationRuleSuite) TestProjectionElimination(c *C) {
 	s.optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandProjection: {
 			NewRuleEliminateProjection(),
+			NewRuleMergeAdjacentProjection(),
 		},
 	})
 	defer func() {

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -51,6 +51,11 @@ func exprsHasSideEffects(exprs []expression.Expression) bool {
 	return false
 }
 
+// ExprsHasSideEffects checks if any of the expressions has side effects.
+func ExprsHasSideEffects(exprs []expression.Expression) bool {
+	return exprsHasSideEffects(exprs)
+}
+
 // exprHasSetVarOrSleep checks if the expression has SetVar function or Sleep function.
 func exprHasSetVarOrSleep(expr expression.Expression) bool {
 	scalaFunc, isScalaFunc := expr.(*expression.ScalarFunction)

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -41,19 +41,14 @@ func getUsedList(usedCols []*expression.Column, schema *expression.Schema) []boo
 	return used
 }
 
-// exprsHasSideEffects checks if any of the expressions has side effects.
-func exprsHasSideEffects(exprs []expression.Expression) bool {
+// ExprsHasSideEffects checks if any of the expressions has side effects.
+func ExprsHasSideEffects(exprs []expression.Expression) bool {
 	for _, expr := range exprs {
 		if exprHasSetVarOrSleep(expr) {
 			return true
 		}
 	}
 	return false
-}
-
-// ExprsHasSideEffects checks if any of the expressions has side effects.
-func ExprsHasSideEffects(exprs []expression.Expression) bool {
-	return exprsHasSideEffects(exprs)
 }
 
 // exprHasSetVarOrSleep checks if the expression has SetVar function or Sleep function.

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -63,7 +63,7 @@ func resolveColumnAndReplace(origin *expression.Column, replace map[string]*expr
 	}
 }
 
-// ResolveExprAndReplace replaces columns fields of expressions by children logical plans
+// ResolveExprAndReplace replaces columns fields of expressions by children logical plans.
 func ResolveExprAndReplace(origin expression.Expression, replace map[string]*expression.Column) {
 	switch expr := origin.(type) {
 	case *expression.Column:
@@ -160,7 +160,7 @@ func (pe *projectionEliminator) eliminate(p LogicalPlan, replace map[string]*exp
 	return p.Children()[0]
 }
 
-// ReplaceColumnOfExpr replaces column of expression by another LogicalProjection
+// ReplaceColumnOfExpr replaces column of expression by another LogicalProjection.
 func ReplaceColumnOfExpr(expr expression.Expression, proj *LogicalProjection, schema *expression.Schema) expression.Expression {
 	switch v := expr.(type) {
 	case *expression.Column:

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -63,7 +63,8 @@ func resolveColumnAndReplace(origin *expression.Column, replace map[string]*expr
 	}
 }
 
-func resolveExprAndReplace(origin expression.Expression, replace map[string]*expression.Column) {
+// ResolveExprAndReplace replaces columns fields of expressions by children logical plans
+func ResolveExprAndReplace(origin expression.Expression, replace map[string]*expression.Column) {
 	switch expr := origin.(type) {
 	case *expression.Column:
 		resolveColumnAndReplace(expr, replace)
@@ -71,7 +72,7 @@ func resolveExprAndReplace(origin expression.Expression, replace map[string]*exp
 		resolveColumnAndReplace(&expr.Column, replace)
 	case *expression.ScalarFunction:
 		for _, arg := range expr.GetArgs() {
-			resolveExprAndReplace(arg, replace)
+			ResolveExprAndReplace(arg, replace)
 		}
 	}
 }
@@ -141,9 +142,9 @@ func (pe *projectionEliminator) eliminate(p LogicalPlan, replace map[string]*exp
 	}
 	p.replaceExprColumns(replace)
 	if isProj {
-		if child, ok := p.Children()[0].(*LogicalProjection); ok && !exprsHasSideEffects(child.Exprs) {
+		if child, ok := p.Children()[0].(*LogicalProjection); ok && !ExprsHasSideEffects(child.Exprs) {
 			for i := range proj.Exprs {
-				proj.Exprs[i] = replaceColumnOfExpr(proj.Exprs[i], child)
+				proj.Exprs[i] = ReplaceColumnOfExpr(proj.Exprs[i], child, child.Schema())
 			}
 			p.Children()[0] = child.Children()[0]
 		}
@@ -159,16 +160,17 @@ func (pe *projectionEliminator) eliminate(p LogicalPlan, replace map[string]*exp
 	return p.Children()[0]
 }
 
-func replaceColumnOfExpr(expr expression.Expression, proj *LogicalProjection) expression.Expression {
+// ReplaceColumnOfExpr replaces column of expression by another LogicalProjection
+func ReplaceColumnOfExpr(expr expression.Expression, proj *LogicalProjection, schema *expression.Schema) expression.Expression {
 	switch v := expr.(type) {
 	case *expression.Column:
-		idx := proj.Schema().ColumnIndex(v)
+		idx := schema.ColumnIndex(v)
 		if idx != -1 && idx < len(proj.Exprs) {
 			return proj.Exprs[idx]
 		}
 	case *expression.ScalarFunction:
 		for i := range v.GetArgs() {
-			v.GetArgs()[i] = replaceColumnOfExpr(v.GetArgs()[i], proj)
+			v.GetArgs()[i] = ReplaceColumnOfExpr(v.GetArgs()[i], proj, schema)
 		}
 	}
 	return expr
@@ -176,40 +178,40 @@ func replaceColumnOfExpr(expr expression.Expression, proj *LogicalProjection) ex
 
 func (p *LogicalJoin) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, equalExpr := range p.EqualConditions {
-		resolveExprAndReplace(equalExpr, replace)
+		ResolveExprAndReplace(equalExpr, replace)
 	}
 	for _, leftExpr := range p.LeftConditions {
-		resolveExprAndReplace(leftExpr, replace)
+		ResolveExprAndReplace(leftExpr, replace)
 	}
 	for _, rightExpr := range p.RightConditions {
-		resolveExprAndReplace(rightExpr, replace)
+		ResolveExprAndReplace(rightExpr, replace)
 	}
 	for _, otherExpr := range p.OtherConditions {
-		resolveExprAndReplace(otherExpr, replace)
+		ResolveExprAndReplace(otherExpr, replace)
 	}
 }
 
 func (p *LogicalProjection) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, expr := range p.Exprs {
-		resolveExprAndReplace(expr, replace)
+		ResolveExprAndReplace(expr, replace)
 	}
 }
 
 func (la *LogicalAggregation) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, agg := range la.AggFuncs {
 		for _, aggExpr := range agg.Args {
-			resolveExprAndReplace(aggExpr, replace)
+			ResolveExprAndReplace(aggExpr, replace)
 		}
 	}
 	for _, gbyItem := range la.GroupByItems {
-		resolveExprAndReplace(gbyItem, replace)
+		ResolveExprAndReplace(gbyItem, replace)
 	}
 	la.collectGroupByColumns()
 }
 
 func (p *LogicalSelection) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, expr := range p.Conditions {
-		resolveExprAndReplace(expr, replace)
+		ResolveExprAndReplace(expr, replace)
 	}
 }
 
@@ -225,20 +227,20 @@ func (la *LogicalApply) replaceExprColumns(replace map[string]*expression.Column
 
 func (ls *LogicalSort) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, byItem := range ls.ByItems {
-		resolveExprAndReplace(byItem.Expr, replace)
+		ResolveExprAndReplace(byItem.Expr, replace)
 	}
 }
 
 func (lt *LogicalTopN) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, byItem := range lt.ByItems {
-		resolveExprAndReplace(byItem.Expr, replace)
+		ResolveExprAndReplace(byItem.Expr, replace)
 	}
 }
 
 func (p *LogicalWindow) replaceExprColumns(replace map[string]*expression.Column) {
 	for _, desc := range p.WindowFuncDescs {
 		for _, arg := range desc.Args {
-			resolveExprAndReplace(arg, replace)
+			ResolveExprAndReplace(arg, replace)
 		}
 	}
 	for _, item := range p.PartitionBy {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR adds Transformation rule MergeAdjacentProjection which implements `merge the adjacent projection` of `Projection elimination` (#13709) in cascades planner.

### What is changed and how it works?
The logic is the same with `planner/core/rule_eliminate_projection.go/(*projectionEliminator).eliminate`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
Exports `ExprsHasSideEffects` from `planner/core/rule_column_pruning.go`, to avoid duplicated codes.