### PR TITLE
planner/core: fix cannot record test of plan suite

### DIFF
--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -39,29 +39,33 @@ var _ = SerialSuites(&testPlanSerialSuite{})
 type testPlanSuiteBase struct {
 	*parser.Parser
 	is infoschema.InfoSchema
-
-	testData testutil.TestData
-}
-
-type testPlanSuite struct {
-	testPlanSuiteBase
-}
-
-type testPlanSerialSuite struct {
-	testPlanSuiteBase
 }
 
 func (s *testPlanSuiteBase) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable(), core.MockUnsignedTable()})
 	s.Parser = parser.New()
 	s.Parser.EnableWindowFunc(true)
+}
+
+type testPlanSerialSuite struct {
+	testPlanSuiteBase
+}
+
+type testPlanSuite struct {
+	testPlanSuiteBase
+
+	testData testutil.TestData
+}
+
+func (s *testPlanSuite) SetUpSuite(c *C) {
+	s.testPlanSuiteBase.SetUpSuite(c)
 
 	var err error
 	s.testData, err = testutil.LoadTestSuiteData("testdata", "plan_suite")
 	c.Assert(err, IsNil)
 }
 
-func (s *testPlanSuiteBase) TearDownSuite(c *C) {
+func (s *testPlanSuite) TearDownSuite(c *C) {
 	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Run `go test --record` would leave outputs of `plan_suite.out` as null.

### What is changed and how it works?

We should not put the `LoadTestData` and `GenerateOutputIfNeeded` of same suite mulitply names, they should not be put in base struct.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Run `go test --record` and nothing changed.

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
