### PR TITLE
session: fix CI data race in TestSchemaCheckerSQL

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -596,7 +596,7 @@ func (s *session) String() string {
 const sqlLogMaxLen = 1024
 
 // SchemaChangedWithoutRetry is used for testing.
-var SchemaChangedWithoutRetry bool
+var SchemaChangedWithoutRetry uint32
 
 func (s *session) getSQLLabel() string {
 	if s.sessionVars.InRestrictedSQL {
@@ -610,7 +610,7 @@ func (s *session) isInternal() bool {
 }
 
 func (s *session) isTxnRetryableError(err error) bool {
-	if SchemaChangedWithoutRetry {
+	if atomic.LoadUint32(&SchemaChangedWithoutRetry) == 1 {
 		return kv.IsTxnRetryableError(err)
 	}
 	return kv.IsTxnRetryableError(err) || domain.ErrInfoSchemaChanged.Equal(err)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1902,9 +1902,9 @@ func (s *testSchemaSerialSuite) TestSchemaCheckerSQL(c *C) {
 	tk.MustExec(`commit;`)
 
 	// The schema version is out of date in the first transaction, and the SQL can't be retried.
-	session.SchemaChangedWithoutRetry = true
+	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)
 	defer func() {
-		session.SchemaChangedWithoutRetry = false
+		atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 0)
 	}()
 	tk.MustExec(`begin;`)
 	tk1.MustExec(`alter table t modify column c bigint;`)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
==================
[2019-12-02T10:30:29.974Z] WARNING: DATA RACE
[2019-12-02T10:30:29.974Z] Write at 0x000004b90b0b by goroutine 248:
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSchemaSuite).TestSchemaCheckerSQL()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1800 +0x37a
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSchemaSuite).TestSchemaCheckerSQL()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1795 +0x2fc
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSchemaSuite).TestSchemaCheckerSQL()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1788 +0x220
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSchemaSuite).TestSchemaCheckerSQL()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1787 +0x1e9
[2019-12-02T10:30:29.974Z]   runtime.call32()
[2019-12-02T10:30:29.974Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-12-02T10:30:29.974Z]   reflect.Value.Call()
[2019-12-02T10:30:29.974Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-12-02T10:30:29.974Z] 
[2019-12-02T10:30:29.974Z] Previous read at 0x000004b90b0b by goroutine 271:
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).isTxnRetryableError()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:561 +0x3e
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).doCommitWithRetry()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:424 +0xc6a
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).CommitTxn()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:483 +0x143
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.finishStmt()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:190 +0x562
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.runStmt()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:268 +0x385
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).executeStatement()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:976 +0x203
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).execute()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1091 +0xcfa
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session.(*session).Execute()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1014 +0xeb
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:141 +0x100
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite).TestErrorRollback.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:162 +0x1a7
[2019-12-02T10:30:29.974Z] 
[2019-12-02T10:30:29.974Z] Goroutine 248 (running) created at:
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkCall()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a3
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkTest()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).doRun()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x13a
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:643 +0xae
[2019-12-02T10:30:29.974Z] 
[2019-12-02T10:30:29.974Z] Goroutine 271 (running) created at:
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite).TestErrorRollback()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:157 +0x226
[2019-12-02T10:30:29.974Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite).TestErrorRollback()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:148 +0x152
[2019-12-02T10:30:29.974Z]   runtime.call32()
[2019-12-02T10:30:29.974Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-12-02T10:30:29.974Z]   reflect.Value.Call()
[2019-12-02T10:30:29.974Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-12-02T10:30:29.974Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-12-02T10:30:29.974Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-12-02T10:30:29.974Z] ==================
```
### What is changed and how it works?

Fix a data race in the CI.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



Related changes

 - Need to cherry-pick to the release branch

