### PR TITLE
planner/core: fix CI data race in core_test.newStoreWithBootstrap

### DIFF
--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -42,6 +42,12 @@ import (
 
 var _ = Suite(&testAnalyzeSuite{})
 
+func init() {
+	// Init once here to avoid data race.
+	session.SetSchemaLease(0)
+	session.DisableStats4Test()
+}
+
 type testAnalyzeSuite struct {
 	testData testutil.TestData
 }
@@ -556,9 +562,6 @@ func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
 	if err != nil {
 		return nil, nil, errors.Trace(err)
 	}
-
-	session.SetSchemaLease(0)
-	session.DisableStats4Test()
 
 	dom, err := session.BootstrapSession(store)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
[2019-12-02T09:27:09.510Z] ==================
[2019-12-02T09:27:09.510Z] WARNING: DATA RACE
[2019-12-02T09:27:09.510Z] Write at 0x000003f46268 by goroutine 179:
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/planner/core_test.newStoreWithBootstrap()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:125 +0x7b
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/planner/core_test.(*testPlanSuite).TestAggEliminator()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/physical_plan_test.go:380 +0x89
[2019-12-02T09:27:09.510Z]   runtime.call32()
[2019-12-02T09:27:09.510Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-12-02T09:27:09.510Z]   reflect.Value.Call()
[2019-12-02T09:27:09.510Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-12-02T09:27:09.510Z] 
[2019-12-02T09:27:09.510Z] Previous read at 0x000003f46268 by goroutine 143:
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/session.(*domainMap).Get()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/tidb.go:68 +0x1b8
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/session.createSession()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1582 +0x7c
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/session.runInBootstrapSession()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1565 +0x60
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/session.BootstrapSession()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1486 +0xa00
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/planner/core_test.newStoreWithBootstrap()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/cbo_test.go:771 +0xba
[2019-12-02T09:27:09.510Z]   github.com/pingcap/tidb/planner/core_test.(*testAnalyzeSuite).TestAnalyze()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/cbo_test.go:454 +0x89
[2019-12-02T09:27:09.510Z]   runtime.call32()
[2019-12-02T09:27:09.510Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2019-12-02T09:27:09.510Z]   reflect.Value.Call()
[2019-12-02T09:27:09.510Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:836 +0x9aa
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:730 +0xc4
[2019-12-02T09:27:09.510Z] 
[2019-12-02T09:27:09.510Z] Goroutine 179 (running) created at:
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkCall()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a3
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkTest()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).doRun()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x13a
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:643 +0xae
[2019-12-02T09:27:09.510Z] 
[2019-12-02T09:27:09.510Z] Goroutine 143 (running) created at:
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkCall()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:727 +0x4a3
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).forkTest()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:818 +0x1b9
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).doRun()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:659 +0x13a
[2019-12-02T09:27:09.510Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()
[2019-12-02T09:27:09.510Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20190102082844-67f458068fc8/check.go:643 +0xae
[2019-12-02T09:27:09.510Z] ==================
```

### What is changed and how it works?

`session.SetSchemaLease()` is not thread safe.
Move it away from the `newStoreWithBootstrap` function.
Make sure it's only called once in the test package planner/core.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Related changes

 - Need to cherry-pick to the release branch
