### PR TITLE
.github: add codeowner rules for planner related packages

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,5 @@
 /expression @pingcap/co-expression
+/planner @pingcap/co-planner
+/statistics @pingcap/co-planner
+/util/ranger  @pingcap/co-planner
+/bindinfo @pingcap/co-planner


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

make it possible to automatically assign reviewers for every planner related PR

### What is changed and how it works?

add a codeowner rule for planner related packages, 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code
