### PR TITLE
store/tikv: fix lockTTL too large if local time is behind timestamp.

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -648,6 +648,8 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 			}
 
 			newTTL := uptime + ManagedLockTTL
+			logutil.BgLogger().Info("send TxnHeartBeat",
+				zap.Uint64("startTS", c.startTS), zap.Uint64("newTTL", newTTL))
 			startTime := time.Now()
 			_, err = sendTxnHeartBeat(bo, c.store, c.primary(), c.startTS, newTTL)
 			if err != nil {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -675,9 +675,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		}
 		mutations[i] = mut
 	}
-
-	t0 := oracle.GetTimeFromTS(c.forUpdateTS)
-	elapsed := uint64(time.Since(t0) / time.Millisecond)
+	elapsed := uint64(time.Since(c.txn.startTime) / time.Millisecond)
 	req := tikvrpc.NewRequest(tikvrpc.CmdPessimisticLock, &pb.PessimisticLockRequest{
 		Mutations:    mutations,
 		PrimaryLock:  c.primary(),

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -626,11 +626,12 @@ func (s *testCommitterSuite) TestElapsedTTL(c *C) {
 	txn.startTS = oracle.ComposeTS(oracle.GetPhysical(time.Now().Add(time.Second*10)), 1)
 	txn.SetOption(kv.Pessimistic, true)
 	time.Sleep(time.Millisecond * 100)
-	err := txn.LockKeys(context.Background(), nil, txn.startTS, kv.LockAlwaysWait, key)
+	forUpdateTS := oracle.ComposeTS(oracle.ExtractPhysical(txn.startTS)+100, 1)
+	err := txn.LockKeys(context.Background(), nil, forUpdateTS, kv.LockAlwaysWait, key)
 	c.Assert(err, IsNil)
 	lockInfo := s.getLockInfo(c, key)
 	c.Assert(lockInfo.LockTtl-ManagedLockTTL, GreaterEqual, uint64(100))
-	c.Assert(lockInfo.LockTtl-ManagedLockTTL, Less, uint64(120))
+	c.Assert(lockInfo.LockTtl-ManagedLockTTL, Less, uint64(150))
 }
 
 func (s *testCommitterSuite) getLockInfo(c *C, key []byte) *kvrpcpb.LockInfo {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -619,6 +619,20 @@ func (s *testCommitterSuite) TestPessimisticTTL(c *C) {
 	c.Assert(false, IsTrue, Commentf("update pessimistic ttl fail"))
 }
 
+// TestElapsedTTL tests that elapsed time is correct even if ts physical time is greater than local time.
+func (s *testCommitterSuite) TestElapsedTTL(c *C) {
+	key := kv.Key("key")
+	txn := s.begin(c)
+	txn.startTS = oracle.ComposeTS(oracle.GetPhysical(time.Now().Add(time.Second*10)), 1)
+	txn.SetOption(kv.Pessimistic, true)
+	time.Sleep(time.Millisecond * 100)
+	err := txn.LockKeys(context.Background(), nil, txn.startTS, kv.LockAlwaysWait, key)
+	c.Assert(err, IsNil)
+	lockInfo := s.getLockInfo(c, key)
+	c.Assert(lockInfo.LockTtl-ManagedLockTTL, GreaterEqual, uint64(100))
+	c.Assert(lockInfo.LockTtl-ManagedLockTTL, Less, uint64(120))
+}
+
 func (s *testCommitterSuite) getLockInfo(c *C, key []byte) *kvrpcpb.LockInfo {
 	txn := s.begin(c)
 	err := txn.Set(key, key)


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
elapsed time should only be calculated by local time, otherwise it may be negative and cast to uint64, a value that is too large.

### What is changed and how it works?
Use `txn.startTime` to calculate elapsed time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix lockTTL too large if local time is behind pd timestamp.
