### PR TITLE
session: fix `show variable` result of `tidb_enable_window_function` after upgrade

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1736,7 +1736,7 @@ func createSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = version36
+	currentBootstrapVersion = version37
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {


### PR DESCRIPTION
…

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

`tidb_enable_window_function` will display as `1` in `show variables `'s result  after upgrade from old version, but real `tidb_enable_window_function` value will keep 0 due to [keep syntax compatibility](https://pingcap.com/docs/stable/reference/sql/functions-and-operators/window-functions/#window-functions)， on another hand, new cluster can safe use `1` as default value.

### What is changed and how it works?

when upgrade from old version, insert a default 0 value if no exists record in` GLOBAL_VARIABLES`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test : upgrade from old version

Code changes

 - add upgrade logic

Side effects

 - n/a

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix `show variable` result of `tidb_enable_window_function` after upgrade

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/13866)
<!-- Reviewable:end -->
