### PR TITLE
test: fix ddl test duplicated test cases due to wrong embedding struct

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -48,10 +48,14 @@ var _ = Suite(&testStateChangeSuite{})
 var _ = SerialSuites(&serialTestStateChangeSuite{})
 
 type serialTestStateChangeSuite struct {
-	testStateChangeSuite
+	testStateChangeSuiteBase
 }
 
 type testStateChangeSuite struct {
+	testStateChangeSuiteBase
+}
+
+type testStateChangeSuiteBase struct {
 	lease  time.Duration
 	store  kv.Storage
 	dom    *domain.Domain
@@ -60,7 +64,7 @@ type testStateChangeSuite struct {
 	preSQL string
 }
 
-func (s *testStateChangeSuite) SetUpSuite(c *C) {
+func (s *testStateChangeSuiteBase) SetUpSuite(c *C) {
 	s.lease = 200 * time.Millisecond
 	ddl.WaitTimeWhenErrorOccured = 1 * time.Microsecond
 	var err error
@@ -78,7 +82,7 @@ func (s *testStateChangeSuite) SetUpSuite(c *C) {
 	s.p = parser.New()
 }
 
-func (s *testStateChangeSuite) TearDownSuite(c *C) {
+func (s *testStateChangeSuiteBase) TearDownSuite(c *C) {
 	s.se.Execute(context.Background(), "drop database if exists test_db_state")
 	s.se.Close()
 	s.dom.Close()
@@ -541,7 +545,7 @@ func (s *testStateChangeSuite) TestDeleteOnly(c *C) {
 	s.runTestInSchemaState(c, model.StateDeleteOnly, "", dropColumnSQL, sqls, nil)
 }
 
-func (s *testStateChangeSuite) runTestInSchemaState(c *C, state model.SchemaState, tableName, alterTableSQL string,
+func (s *testStateChangeSuiteBase) runTestInSchemaState(c *C, state model.SchemaState, tableName, alterTableSQL string,
 	sqlWithErrs []sqlWithErr, expectQuery *expectQuery) {
 	_, err := s.se.Execute(context.Background(), `create table t (
 		c1 varchar(64),
@@ -599,7 +603,7 @@ func (s *testStateChangeSuite) runTestInSchemaState(c *C, state model.SchemaStat
 	}
 }
 
-func (s *testStateChangeSuite) execQuery(tk *testkit.TestKit, sql string, args ...interface{}) (*testkit.Result, error) {
+func (s *testStateChangeSuiteBase) execQuery(tk *testkit.TestKit, sql string, args ...interface{}) (*testkit.Result, error) {
 	comment := Commentf("sql:%s, args:%v", sql, args)
 	rs, err := tk.Exec(sql, args...)
 	if err != nil {
@@ -618,7 +622,7 @@ func checkResult(result *testkit.Result, expected [][]interface{}) error {
 	return nil
 }
 
-func (s *testStateChangeSuite) CheckResult(tk *testkit.TestKit, sql string, args ...interface{}) (*testkit.Result, error) {
+func (s *testStateChangeSuiteBase) CheckResult(tk *testkit.TestKit, sql string, args ...interface{}) (*testkit.Result, error) {
 	comment := Commentf("sql:%s, args:%v", sql, args)
 	rs, err := tk.Exec(sql, args...)
 	if err != nil {
@@ -836,7 +840,7 @@ func (s *testStateChangeSuite) TestParallelCreateAndRename(c *C) {
 
 type checkRet func(c *C, err1, err2 error)
 
-func (s *testStateChangeSuite) testControlParallelExecSQL(c *C, sql1, sql2 string, f checkRet) {
+func (s *testStateChangeSuiteBase) testControlParallelExecSQL(c *C, sql1, sql2 string, f checkRet) {
 	_, err := s.se.Execute(context.Background(), "use test_db_state")
 	c.Assert(err, IsNil)
 	_, err = s.se.Execute(context.Background(), "create table t(a int, b int, c int, d int auto_increment,e int, index idx1(d), index idx2(d,e))")


### PR DESCRIPTION
### What problem does this PR solve?
fix ddl test duplicated cases  due to wrong embedding struct

### What is changed and how it works?
The ddl test suite `serialTestStateChangeSuite` embedding another test suite `testStateChangeSuite`, so all the test cases under `testStateChangeSuite` will be implicitly auto-generated for `serialTestStateChangeSuite` thus make ddl test run slow and unnecessary .

result:
before changes: 
```
> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/ddl
ok  	github.com/pingcap/tidb/ddl	103.783s
```

after change:
```
> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/ddl
ok  	github.com/pingcap/tidb/ddl	87.718s
```

### Check List
Tests

- unit tests

Code changes

Side effects

Related changes