### PR TITLE
statistics,domain: release statistics session periodically to avoid memory leak

### DIFF
--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -62,7 +62,7 @@ func (h *Handle) initStatsMeta(is infoschema.InfoSchema) (statsCache, error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	sql := "select HIGH_PRIORITY version, table_id, modify_count, count from mysql.stats_meta"
-	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -142,7 +142,7 @@ func (h *Handle) initStatsHistograms(is infoschema.InfoSchema, cache *statsCache
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, correlation, flag, last_analyze_pos from mysql.stats_histograms"
-	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -214,7 +214,7 @@ func (h *Handle) initStatsBuckets(cache *statsCache) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 	sql := "select HIGH_PRIORITY table_id, is_index, hist_id, count, repeats, lower_bound, upper_bound from mysql.stats_buckets order by table_id, is_index, hist_id, bucket_id"
-	rc, err := h.mu.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
+	rc, err := h.ctx.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(rc) > 0 {
 		defer terror.Call(rc[0].Close)
 	}
@@ -231,7 +231,7 @@ func (h *Handle) initStatsBuckets(cache *statsCache) error {
 		if req.NumRows() == 0 {
 			break
 		}
-		initStatsBuckets4Chunk(h.mu.ctx, cache, iter)
+		initStatsBuckets4Chunk(h.ctx, cache, iter)
 	}
 	lastVersion := uint64(0)
 	for _, table := range cache.tables {

--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -99,7 +99,7 @@ func (h *Handle) deleteHistStatsFromKV(physicalID int64, histID int64, isIndex i
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	exec := h.mu.ctx.(sqlexec.SQLExecutor)
+	exec := h.ctx.(sqlexec.SQLExecutor)
 	_, err = exec.Execute(context.Background(), "begin")
 	if err != nil {
 		return errors.Trace(err)
@@ -107,7 +107,7 @@ func (h *Handle) deleteHistStatsFromKV(physicalID int64, histID int64, isIndex i
 	defer func() {
 		err = finishTransaction(context.Background(), exec, err)
 	}()
-	txn, err := h.mu.ctx.Txn(true)
+	txn, err := h.ctx.Txn(true)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -128,7 +128,7 @@ func (h *Handle) deleteHistStatsFromKV(physicalID int64, histID int64, isIndex i
 func (h *Handle) DeleteTableStatsFromKV(physicalID int64) (err error) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	exec := h.mu.ctx.(sqlexec.SQLExecutor)
+	exec := h.ctx.(sqlexec.SQLExecutor)
 	_, err = exec.Execute(context.Background(), "begin")
 	if err != nil {
 		return errors.Trace(err)
@@ -136,7 +136,7 @@ func (h *Handle) DeleteTableStatsFromKV(physicalID int64) (err error) {
 	defer func() {
 		err = finishTransaction(context.Background(), exec, err)
 	}()
-	txn, err := h.mu.ctx.Txn(true)
+	txn, err := h.ctx.Txn(true)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/statistics/handle/update_list_test.go
+++ b/statistics/handle/update_list_test.go
@@ -23,7 +23,7 @@ type testUpdateListSuite struct {
 }
 
 func (s *testUpdateListSuite) TestInsertAndDelete(c *C) {
-	h := Handle{listHead: &SessionStatsCollector{mapper: make(tableDeltaMap)}}
+	h := Handle{HandleShare: &HandleShare{listHead: &SessionStatsCollector{mapper: make(tableDeltaMap)}}}
 	var items []*SessionStatsCollector
 	for i := 0; i < 5; i++ {
 		items = append(items, h.NewSessionStatsCollector())


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/13883

Statistics worker goroutines use system session to execute SQL, that system session is never recycled. 
When executing a large transaction, statistic workers may come to work. After that some variables are referenced by the `sessionVars` in the system session and can't be released, leading to memory leaks.

### What is changed and how it works?

Refactor the `Handle` struct, extract the shared part out, provide `sessionctx.Context` for each worker goroutine.
In the `updateStatsWorker`, I'll recycle the session to avoid memory leak.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Run a large transaction and observe the memory footprint.

Code changes

 - Has exported function/method change
