### PR TITLE
privilege: fix privilege check of `GRANT ROLE`

### DIFF
--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -192,7 +192,6 @@ func (s *testSuite3) TestRoleAdmin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("CREATE USER 'testRoleAdmin';")
 	tk.MustExec("CREATE ROLE 'targetRole';")
-	tk.MustExec("GRANT SUPER ON *.* TO `testRoleAdmin`;")
 
 	// Create a new session.
 	se, err := session.CreateSession4Test(s.store)
@@ -201,6 +200,10 @@ func (s *testSuite3) TestRoleAdmin(c *C) {
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "testRoleAdmin", Hostname: "localhost"}, nil, nil), IsTrue)
 
 	ctx := context.Background()
+	_, err = se.Execute(ctx, "GRANT `targetRole` TO `testRoleAdmin`;")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("GRANT SUPER ON *.* TO `testRoleAdmin`;")
 	_, err = se.Execute(ctx, "GRANT `targetRole` TO `testRoleAdmin`;")
 	c.Assert(err, IsNil)
 	_, err = se.Execute(ctx, "REVOKE `targetRole` FROM `testRoleAdmin`;")

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -188,6 +188,28 @@ func (s *testSuite3) TestRole(c *C) {
 	tk.MustExec("SET ROLE NONE")
 }
 
+func (s *testSuite3) TestRoleAdmin(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("CREATE USER 'testRoleAdmin';")
+	tk.MustExec("CREATE ROLE 'targetRole';")
+	tk.MustExec("GRANT SUPER ON *.* TO `testRoleAdmin`;")
+
+	// Create a new session.
+	se, err := session.CreateSession4Test(s.store)
+	c.Check(err, IsNil)
+	defer se.Close()
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "testRoleAdmin", Hostname: "localhost"}, nil, nil), IsTrue)
+
+	ctx := context.Background()
+	_, err = se.Execute(ctx, "GRANT `targetRole` TO `testRoleAdmin`;")
+	c.Assert(err, IsNil)
+	_, err = se.Execute(ctx, "REVOKE `targetRole` FROM `testRoleAdmin`;")
+	c.Assert(err, IsNil)
+
+	tk.MustExec("DROP USER 'testRoleAdmin';")
+	tk.MustExec("DROP ROLE 'targetRole';")
+}
+
 func (s *testSuite3) TestDefaultRole(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1620,11 +1620,12 @@ func (b *PlanBuilder) buildSimple(node ast.StmtNode) (Plan, error) {
 		}
 		b.visitInfo = collectVisitInfoFromGrantStmt(b.ctx, b.visitInfo, raw)
 	case *ast.GrantRoleStmt:
-		err := ErrSpecificAccessDenied.GenWithStackByArgs("GRANT ROLE")
+		err := ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", err)
 	case *ast.RevokeStmt:
 		b.visitInfo = collectVisitInfoFromRevokeStmt(b.ctx, b.visitInfo, raw)
 	case *ast.RevokeRoleStmt:
+		err := ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", nil)
 	case *ast.KillStmt:
 		// If you have the SUPER privilege, you can kill all threads and statements.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1626,7 +1626,7 @@ func (b *PlanBuilder) buildSimple(node ast.StmtNode) (Plan, error) {
 		b.visitInfo = collectVisitInfoFromRevokeStmt(b.ctx, b.visitInfo, raw)
 	case *ast.RevokeRoleStmt:
 		err := ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", nil)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", err)
 	case *ast.KillStmt:
 		// If you have the SUPER privilege, you can kill all threads and statements.
 		// Otherwise, you can kill only your own threads and statements.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1621,7 +1621,7 @@ func (b *PlanBuilder) buildSimple(node ast.StmtNode) (Plan, error) {
 		b.visitInfo = collectVisitInfoFromGrantStmt(b.ctx, b.visitInfo, raw)
 	case *ast.GrantRoleStmt:
 		err := ErrSpecificAccessDenied.GenWithStackByArgs("GRANT ROLE")
-		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.GrantPriv, "", "", "", err)
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", err)
 	case *ast.RevokeStmt:
 		b.visitInfo = collectVisitInfoFromRevokeStmt(b.ctx, b.visitInfo, raw)
 	case *ast.RevokeRoleStmt:


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In MySQL, `GRANT roles TO users` require `ROLE_ADMIN` or `SUPER` privilege, But TiDB use `GrantPriv` to check `GRANT ROLE`.

### What is changed and how it works?
fix this bug and add test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix privilege check rule for `GRANT ROLE`
