### PR TITLE
config: add configuration entry make TiDB version string configurable (#13775)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/util/logutil"
 	tracing "github.com/uber/jaeger-client-go/config"
 )
@@ -67,8 +68,8 @@ type Config struct {
 	TxnLocalLatches  TxnLocalLatches `toml:"txn-local-latches" json:"txn-local-latches"`
 	// Set sys variable lower-case-table-names, ref: https://dev.mysql.com/doc/refman/5.7/en/identifier-case-sensitivity.html.
 	// TODO: We actually only support mode 2, which keeps the original case, but the comparison is case-insensitive.
-	LowerCaseTableNames int `toml:"lower-case-table-names" json:"lower-case-table-names"`
-
+	LowerCaseTableNames int               `toml:"lower-case-table-names" json:"lower-case-table-names"`
+	ServerVersion       string            `toml:"server-version" json:"server-version"`
 	Log                 Log               `toml:"log" json:"log"`
 	Security            Security          `toml:"security" json:"security"`
 	Status              Status            `toml:"status" json:"status"`
@@ -308,6 +309,7 @@ var defaultConf = Config{
 		Capacity: 10240000,
 	},
 	LowerCaseTableNames: 2,
+	ServerVersion:       "",
 	Log: Log{
 		Level:              "info",
 		Format:             "text",
@@ -388,6 +390,9 @@ func (c *Config) Load(confFile string) error {
 	metaData, err := toml.DecodeFile(confFile, c)
 	if c.TokenLimit <= 0 {
 		c.TokenLimit = 1000
+	}
+	if len(c.ServerVersion) > 0 {
+		mysql.ServerVersion = c.ServerVersion
 	}
 
 	// If any items in confFile file are not mapped into the Config struct, issue

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -60,23 +60,11 @@ treat-old-version-utf8-as-utf8mb4 = true
 # Maximum number of the splitting region, which is used by the split region statement.
 split-region-max-num = 1000
 
-# alter-primary-key is used to control alter primary key feature. Default is false, indicate the alter primary key feature is disabled.
-# If it is true, we can add the primary key by "alter table", but we may not be able to drop the primary key.
-# In order to support "drop primary key" operation , this flag must be true and the table does not have the pkIsHandle flag.
-alter-primary-key = false
-
 # server-version is used to change the version string of TiDB in the following scenarios:
 # 1. the server version returned by builtin-function `VERSION()`.
 # 2. the server version filled in handshake packets of MySQL Connection Protocol, see https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake for more details.
 # if server-version = "", the default value(original TiDB version string) is used.
 server-version = ""
-
-# repair mode is used to repair the broken table meta in TiKV in extreme cases.
-repair-mode = false
-
-# Repair table list is used to list the tables in repair mode with the format like ["db.table",].
-# In repair mode, repairing table which is not in repair list will get wrong database or wrong table error.
-repair-table-list = []
 
 [log]
 # Log level: debug, info, warn, error, fatal.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -60,6 +60,24 @@ treat-old-version-utf8-as-utf8mb4 = true
 # Maximum number of the splitting region, which is used by the split region statement.
 split-region-max-num = 1000
 
+# alter-primary-key is used to control alter primary key feature. Default is false, indicate the alter primary key feature is disabled.
+# If it is true, we can add the primary key by "alter table", but we may not be able to drop the primary key.
+# In order to support "drop primary key" operation , this flag must be true and the table does not have the pkIsHandle flag.
+alter-primary-key = false
+
+# server-version is used to change the version string of TiDB in the following scenarios:
+# 1. the server version returned by builtin-function `VERSION()`.
+# 2. the server version filled in handshake packets of MySQL Connection Protocol, see https://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::Handshake for more details.
+# if server-version = "", the default value(original TiDB version string) is used.
+server-version = ""
+
+# repair mode is used to repair the broken table meta in TiKV in extreme cases.
+repair-mode = false
+
+# Repair table list is used to list the tables in repair mode with the format like ["db.table",].
+# In repair mode, repairing table which is not in repair list will get wrong database or wrong table error.
+repair-table-list = []
+
 [log]
 # Log level: debug, info, warn, error, fatal.
 level = "info"

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -63,9 +63,7 @@ unrecognized-option-test = true
 	_, err = f.WriteString(`
 token-limit = 0
 split-region-max-num=10000
-enable-batch-dml = true
 server-version = "test_version"
-repair-mode = true
 [performance]
 txn-entry-count-limit=2000
 txn-total-size-limit=2000

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
 )
 
 var _ = Suite(&testConfigSuite{})
@@ -62,6 +63,9 @@ unrecognized-option-test = true
 	_, err = f.WriteString(`
 token-limit = 0
 split-region-max-num=10000
+enable-batch-dml = true
+server-version = "test_version"
+repair-mode = true
 [performance]
 txn-entry-count-limit=2000
 txn-total-size-limit=2000
@@ -74,6 +78,8 @@ commit-timeout="41s"
 
 	c.Assert(conf.Load(configFile), IsNil)
 
+	c.Assert(conf.ServerVersion, Equals, "test_version")
+	c.Assert(mysql.ServerVersion, Equals, conf.ServerVersion)
 	// Test that the original value will not be clear by load the config file that does not contain the option.
 	c.Assert(conf.Binlog.Enable, Equals, true)
 	c.Assert(conf.Binlog.BinlogSocket, Equals, "/tmp/socket")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick #13775  to release-2.1

It can improve the hard-coding of `serverVersion `property. 

### What is changed and how it works?
add the `serverVersion `in `config/config.go` and `config/config.toml.example`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported variable/fields change

Release note

 - add a configuration entry `server-version` which make TiDB version string configurable, this PR closes #13802 