### PR TITLE
expression: implement vectorized evaluation for `builtinConcatWSSig`

### DIFF
--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -57,7 +57,9 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 	ast.Concat: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString}},
 	},
-	ast.ConcatWS: {},
+	ast.ConcatWS: {
+		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString, types.ETString}},
+	},
 	ast.Convert: {
 		{
 			retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString, types.ETString},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinConcatWSSig.
Issue: #12106

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinStringFunc/builtinConcatWSSig-VecBuiltinFunc-4                                    6127            188824 ns/op    91888 B/op        1917 allocs/op
BenchmarkVectorizedBuiltinStringFunc/builtinConcatWSSig-NonVecBuiltinFunc-4                                 6003            202023 ns/op    76624 B/op        1570 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test