### PR TITLE
expression: implement vectorized evaluation for `builtinTimeLiteralSig`

### DIFF
--- a/expression/builtin_time_vec.go
+++ b/expression/builtin_time_vec.go
@@ -1347,11 +1347,17 @@ func (b *builtinNowWithoutArgSig) vecEvalTime(input *chunk.Chunk, result *chunk.
 }
 
 func (b *builtinTimestampLiteralSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinTimestampLiteralSig) vecEvalTime(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	n := input.NumRows()
+	result.ResizeTime(n, false)
+	times := result.Times()
+	for i := range times {
+		times[i] = b.tm
+	}
+	return nil
 }
 
 func (b *builtinAddDateIntDecimalSig) vectorized() bool {

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -161,14 +161,12 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			geners:        []dataGenerator{&unitStrGener{}, nil, nil}},
 	},
 	ast.TimestampLiteral: {
-		{
-			retEvalType: types.ETTimestamp,
-			childrenTypes: []types.EvalType{types.ETString},
+		{retEvalType: types.ETTimestamp, childrenTypes: []types.EvalType{types.ETString},
 			constants: []*Constant{{Value: types.NewStringDatum("2019-12-04 00:00:00"), RetType: types.NewFieldType(mysql.TypeString)}},
 		},
 	},
-	ast.SubDate:          {},
-	ast.AddDate:          {},
+	ast.SubDate: {},
+	ast.AddDate: {},
 	ast.SubTime: {
 		{
 			retEvalType:   types.ETString,

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -160,7 +160,13 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 			childrenTypes: []types.EvalType{types.ETString, types.ETDatetime, types.ETDatetime},
 			geners:        []dataGenerator{&unitStrGener{}, nil, nil}},
 	},
-	ast.TimestampLiteral: {},
+	ast.TimestampLiteral: {
+		{
+			retEvalType: types.ETTimestamp,
+			childrenTypes: []types.EvalType{types.ETString},
+			constants: []*Constant{{Value: types.NewStringDatum("2019-12-04 00:00:00"), RetType: types.NewFieldType(mysql.TypeString)}},
+		},
+	},
 	ast.SubDate:          {},
 	ast.AddDate:          {},
 	ast.SubTime: {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Implement vectorized evaluation for builtinTimeLiteralSig.
Issue: #12176

### What is changed and how it works?
```
BenchmarkVectorizedBuiltinTimeFunc/builtinTimestampLiteralSig-VecBuiltinFunc-4                          	 1062220	      1151 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinTimeFunc/builtinTimestampLiteralSig-NonVecBuiltinFunc-4                       	   46603	     24835 ns/op	       0 B/op	       0 allocs/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test