### PR TITLE
table, executor: extract two functions for ShowCreateTable/DB (#13907)

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -38,9 +38,11 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta/autoid"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/plugin"
 	"github.com/pingcap/tidb/privilege"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
@@ -636,53 +638,45 @@ func escape(cis model.CIStr, sqlMode mysql.SQLMode) string {
 	return quote + strings.Replace(cis.O, quote, quote+quote, -1) + quote
 }
 
-func (e *ShowExec) fetchShowCreateTable() error {
-	tb, err := e.getTable()
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	sqlMode := e.ctx.GetSessionVars().SQLMode
-
-	// TODO: let the result more like MySQL.
-	var buf bytes.Buffer
-	if tb.Meta().IsView() {
-		e.fetchShowCreateTable4View(tb.Meta(), &buf)
-		e.appendRow([]interface{}{tb.Meta().Name.O, buf.String(), tb.Meta().Charset, tb.Meta().Collate})
+// ConstructResultOfShowCreateTable constructs the result for show create table.
+func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.TableInfo, allocator autoid.Allocator, buf *bytes.Buffer) (err error) {
+	if tableInfo.IsView() {
+		fetchShowCreateTable4View(ctx, tableInfo, buf)
 		return nil
 	}
 
-	tblCharset := tb.Meta().Charset
+	tblCharset := tableInfo.Charset
 	if len(tblCharset) == 0 {
 		tblCharset = mysql.DefaultCharset
 	}
-	tblCollate := tb.Meta().Collate
+	tblCollate := tableInfo.Collate
 	// Set default collate if collate is not specified.
 	if len(tblCollate) == 0 {
 		tblCollate = getDefaultCollate(tblCharset)
 	}
 
-	fmt.Fprintf(&buf, "CREATE TABLE %s (\n", escape(tb.Meta().Name, sqlMode))
-	var pkCol *table.Column
+	sqlMode := ctx.GetSessionVars().SQLMode
+	fmt.Fprintf(buf, "CREATE TABLE %s (\n", escape(tableInfo.Name, sqlMode))
+	var pkCol *model.ColumnInfo
 	var hasAutoIncID bool
-	for i, col := range tb.Cols() {
-		fmt.Fprintf(&buf, "  %s %s", escape(col.Name, sqlMode), col.GetTypeDesc())
+	for i, col := range tableInfo.Cols() {
+		fmt.Fprintf(buf, "  %s %s", escape(col.Name, sqlMode), col.GetTypeDesc())
 		if col.Charset != "binary" {
 			if col.Charset != tblCharset {
-				fmt.Fprintf(&buf, " CHARACTER SET %s", col.Charset)
+				fmt.Fprintf(buf, " CHARACTER SET %s", col.Charset)
 			}
 			if col.Collate != tblCollate {
-				fmt.Fprintf(&buf, " COLLATE %s", col.Collate)
+				fmt.Fprintf(buf, " COLLATE %s", col.Collate)
 			} else {
 				defcol, err := charset.GetDefaultCollation(col.Charset)
 				if err == nil && defcol != col.Collate {
-					fmt.Fprintf(&buf, " COLLATE %s", col.Collate)
+					fmt.Fprintf(buf, " COLLATE %s", col.Collate)
 				}
 			}
 		}
 		if col.IsGenerated() {
 			// It's a generated column.
-			fmt.Fprintf(&buf, " GENERATED ALWAYS AS (%s)", col.GeneratedExprString)
+			fmt.Fprintf(buf, " GENERATED ALWAYS AS (%s)", col.GeneratedExprString)
 			if col.GeneratedStored {
 				buf.WriteString(" STORED")
 			} else {
@@ -716,7 +710,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 					defaultValStr := fmt.Sprintf("%v", defaultValue)
 					// If column is timestamp, and default value is not current_timestamp, should convert the default value to the current session time zone.
 					if col.Tp == mysql.TypeTimestamp && defaultValStr != types.ZeroDatetimeStr {
-						timeValue, err := table.GetColDefaultValue(e.ctx, col.ToInfo())
+						timeValue, err := table.GetColDefaultValue(ctx, col)
 						if err != nil {
 							return errors.Trace(err)
 						}
@@ -725,9 +719,9 @@ func (e *ShowExec) fetchShowCreateTable() error {
 
 					if col.Tp == mysql.TypeBit {
 						defaultValBinaryLiteral := types.BinaryLiteral(defaultValStr)
-						fmt.Fprintf(&buf, " DEFAULT %s", defaultValBinaryLiteral.ToBitLiteralString(true))
+						fmt.Fprintf(buf, " DEFAULT %s", defaultValBinaryLiteral.ToBitLiteralString(true))
 					} else {
-						fmt.Fprintf(&buf, " DEFAULT '%s'", format.OutputFormat(defaultValStr))
+						fmt.Fprintf(buf, " DEFAULT '%s'", format.OutputFormat(defaultValStr))
 					}
 				}
 			}
@@ -737,12 +731,12 @@ func (e *ShowExec) fetchShowCreateTable() error {
 			}
 		}
 		if len(col.Comment) > 0 {
-			fmt.Fprintf(&buf, " COMMENT '%s'", format.OutputFormat(col.Comment))
+			fmt.Fprintf(buf, " COMMENT '%s'", format.OutputFormat(col.Comment))
 		}
-		if i != len(tb.Cols())-1 {
+		if i != len(tableInfo.Cols())-1 {
 			buf.WriteString(",\n")
 		}
-		if tb.Meta().PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {
+		if tableInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {
 			pkCol = col
 		}
 	}
@@ -750,12 +744,12 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	if pkCol != nil {
 		// If PKIsHanle, pk info is not in tb.Indices(). We should handle it here.
 		buf.WriteString(",\n")
-		fmt.Fprintf(&buf, "  PRIMARY KEY (%s)", escape(pkCol.Name, sqlMode))
+		fmt.Fprintf(buf, "  PRIMARY KEY (%s)", escape(pkCol.Name, sqlMode))
 	}
 
-	publicIndices := make([]table.Index, 0, len(tb.Indices()))
-	for _, idx := range tb.Indices() {
-		if idx.Meta().State == model.StatePublic {
+	publicIndices := make([]*model.IndexInfo, 0, len(tableInfo.Indices))
+	for _, idx := range tableInfo.Indices {
+		if idx.State == model.StatePublic {
 			publicIndices = append(publicIndices, idx)
 		}
 	}
@@ -763,14 +757,13 @@ func (e *ShowExec) fetchShowCreateTable() error {
 		buf.WriteString(",\n")
 	}
 
-	for i, idx := range publicIndices {
-		idxInfo := idx.Meta()
+	for i, idxInfo := range publicIndices {
 		if idxInfo.Primary {
 			buf.WriteString("  PRIMARY KEY ")
 		} else if idxInfo.Unique {
-			fmt.Fprintf(&buf, "  UNIQUE KEY %s ", escape(idxInfo.Name, sqlMode))
+			fmt.Fprintf(buf, "  UNIQUE KEY %s ", escape(idxInfo.Name, sqlMode))
 		} else {
-			fmt.Fprintf(&buf, "  KEY %s ", escape(idxInfo.Name, sqlMode))
+			fmt.Fprintf(buf, "  KEY %s ", escape(idxInfo.Name, sqlMode))
 		}
 
 		cols := make([]string, 0, len(idxInfo.Columns))
@@ -781,7 +774,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 			}
 			cols = append(cols, colInfo)
 		}
-		fmt.Fprintf(&buf, "(%s)", strings.Join(cols, ","))
+		fmt.Fprintf(buf, "(%s)", strings.Join(cols, ","))
 		if i != len(publicIndices)-1 {
 			buf.WriteString(",\n")
 		}
@@ -795,40 +788,60 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	if len(tblCollate) == 0 {
 		// If we can not find default collate for the given charset,
 		// do not show the collate part.
-		fmt.Fprintf(&buf, " DEFAULT CHARSET=%s", tblCharset)
+		fmt.Fprintf(buf, " DEFAULT CHARSET=%s", tblCharset)
 	} else {
-		fmt.Fprintf(&buf, " DEFAULT CHARSET=%s COLLATE=%s", tblCharset, tblCollate)
+		fmt.Fprintf(buf, " DEFAULT CHARSET=%s COLLATE=%s", tblCharset, tblCollate)
 	}
 
 	// Displayed if the compression typed is set.
-	if len(tb.Meta().Compression) != 0 {
-		fmt.Fprintf(&buf, " COMPRESSION='%s'", tb.Meta().Compression)
+	if len(tableInfo.Compression) != 0 {
+		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
 	if hasAutoIncID {
-		autoIncID, err := tb.Allocator(e.ctx).NextGlobalAutoID(tb.Meta().ID)
+		autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		// It's campatible with MySQL.
+		// It's compatible with MySQL.
 		if autoIncID > 1 {
-			fmt.Fprintf(&buf, " AUTO_INCREMENT=%d", autoIncID)
+			fmt.Fprintf(buf, " AUTO_INCREMENT=%d", autoIncID)
 		}
 	}
 
-	if tb.Meta().ShardRowIDBits > 0 {
-		fmt.Fprintf(&buf, "/*!90000 SHARD_ROW_ID_BITS=%d ", tb.Meta().ShardRowIDBits)
-		if tb.Meta().PreSplitRegions > 0 {
-			fmt.Fprintf(&buf, "PRE_SPLIT_REGIONS=%d ", tb.Meta().PreSplitRegions)
+	if tableInfo.ShardRowIDBits > 0 {
+		fmt.Fprintf(buf, "/*!90000 SHARD_ROW_ID_BITS=%d ", tableInfo.ShardRowIDBits)
+		if tableInfo.PreSplitRegions > 0 {
+			fmt.Fprintf(buf, "PRE_SPLIT_REGIONS=%d ", tableInfo.PreSplitRegions)
 		}
 		buf.WriteString("*/")
 	}
 
-	if len(tb.Meta().Comment) > 0 {
-		fmt.Fprintf(&buf, " COMMENT='%s'", format.OutputFormat(tb.Meta().Comment))
+	if len(tableInfo.Comment) > 0 {
+		fmt.Fprintf(buf, " COMMENT='%s'", format.OutputFormat(tableInfo.Comment))
 	}
 	// add partition info here.
-	appendPartitionInfo(tb.Meta().Partition, &buf)
+	appendPartitionInfo(tableInfo.Partition, buf)
+	return nil
+}
+
+func (e *ShowExec) fetchShowCreateTable() error {
+	tb, err := e.getTable()
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	tableInfo := tb.Meta()
+	allocator := tb.Allocator(e.ctx)
+	var buf bytes.Buffer
+	// TODO: let the result more like MySQL.
+	if err = ConstructResultOfShowCreateTable(e.ctx, tb.Meta(), allocator, &buf); err != nil {
+		return err
+	}
+	if tableInfo.IsView() {
+		e.appendRow([]interface{}{tableInfo.Name.O, buf.String(), tableInfo.Charset, tableInfo.Collate})
+		return nil
+	}
 
 	e.appendRow([]interface{}{tb.Meta().Name.O, buf.String()})
 	return nil
@@ -850,13 +863,13 @@ func (e *ShowExec) fetchShowCreateView() error {
 	}
 
 	var buf bytes.Buffer
-	e.fetchShowCreateTable4View(tb.Meta(), &buf)
+	fetchShowCreateTable4View(e.ctx, tb.Meta(), &buf)
 	e.appendRow([]interface{}{tb.Meta().Name.O, buf.String(), tb.Meta().Charset, tb.Meta().Collate})
 	return nil
 }
 
-func (e *ShowExec) fetchShowCreateTable4View(tb *model.TableInfo, buf *bytes.Buffer) {
-	sqlMode := e.ctx.GetSessionVars().SQLMode
+func fetchShowCreateTable4View(ctx sessionctx.Context, tb *model.TableInfo, buf *bytes.Buffer) {
+	sqlMode := ctx.GetSessionVars().SQLMode
 
 	fmt.Fprintf(buf, "CREATE ALGORITHM=%s ", tb.View.Algorithm.String())
 	fmt.Fprintf(buf, "DEFINER=%s@%s ", escape(model.NewCIStr(tb.View.Definer.Username), sqlMode), escape(model.NewCIStr(tb.View.Definer.Hostname), sqlMode))
@@ -905,6 +918,20 @@ func appendPartitionInfo(partitionInfo *model.PartitionInfo, buf *bytes.Buffer) 
 	buf.WriteString(")")
 }
 
+// ConstructResultOfShowCreateDatabase constructs the result for show create database.
+func ConstructResultOfShowCreateDatabase(ctx sessionctx.Context, dbInfo *model.DBInfo, ifNotExists bool, buf *bytes.Buffer) (err error) {
+	sqlMode := ctx.GetSessionVars().SQLMode
+	var ifNotExistsStr string
+	if ifNotExists {
+		ifNotExistsStr = "/*!32312 IF NOT EXISTS*/ "
+	}
+	fmt.Fprintf(buf, "CREATE DATABASE %s%s", ifNotExistsStr, escape(dbInfo.Name, sqlMode))
+	if s := dbInfo.Charset; len(s) > 0 {
+		fmt.Fprintf(buf, " /*!40100 DEFAULT CHARACTER SET %s */", s)
+	}
+	return nil
+}
+
 // fetchShowCreateDatabase composes show create database result.
 func (e *ShowExec) fetchShowCreateDatabase() error {
 	checker := privilege.GetPrivilegeManager(e.ctx)
@@ -913,24 +940,17 @@ func (e *ShowExec) fetchShowCreateDatabase() error {
 			return e.dbAccessDenied()
 		}
 	}
-	db, ok := e.is.SchemaByName(e.DBName)
+	dbInfo, ok := e.is.SchemaByName(e.DBName)
 	if !ok {
 		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(e.DBName.O)
 	}
 
-	sqlMode := e.ctx.GetSessionVars().SQLMode
-
 	var buf bytes.Buffer
-	var ifNotExists string
-	if e.IfNotExists {
-		ifNotExists = "/*!32312 IF NOT EXISTS*/ "
+	err := ConstructResultOfShowCreateDatabase(e.ctx, dbInfo, e.IfNotExists, &buf)
+	if err != nil {
+		return err
 	}
-	fmt.Fprintf(&buf, "CREATE DATABASE %s%s", ifNotExists, escape(db.Name, sqlMode))
-	if s := db.Charset; len(s) > 0 {
-		fmt.Fprintf(&buf, " /*!40100 DEFAULT CHARACTER SET %s */", s)
-	}
-
-	e.appendRow([]interface{}{db.Name.O, buf.String()})
+	e.appendRow([]interface{}{dbInfo.Name.O, buf.String()})
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8
 	github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd
-	github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa
+	github.com/pingcap/parser v0.0.0-20191205054626-288fe5207ce6
 	github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e
 	github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible
 	github.com/pingcap/tipb v0.0.0-20191126033718-169898888b24

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8
 	github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd
-	github.com/pingcap/parser v0.0.0-20191121045207-8b5639e42f59
+	github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa
 	github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e
 	github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible
 	github.com/pingcap/tipb v0.0.0-20191126033718-169898888b24

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,8 @@ github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8 h1:P9jGgwVkLHlbEGt
 github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20191121045207-8b5639e42f59 h1:D422KNsb0XuoDX0XZtmO0FYJ/KT4opcXHEc44hgYNQo=
-github.com/pingcap/parser v0.0.0-20191121045207-8b5639e42f59/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa h1:z6F4Hvr5unVOvR6Ed6Wurk9Sl5rREv7iBz18MwFIIh0=
+github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e h1:6En0+9KDJ6CjkuzbGwHgo+P1YjEt22jn+nujl6cSAXA=
 github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e/go.mod h1:ribyi6AyFNOElWgb6VnUsky4JFciEoGApSUzIcJxGSI=
 github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible h1:I8HirWsu1MZp6t9G/g8yKCEjJJxtHooKakEgccvdJ4M=

--- a/go.sum
+++ b/go.sum
@@ -171,6 +171,8 @@ github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+87
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
 github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa h1:z6F4Hvr5unVOvR6Ed6Wurk9Sl5rREv7iBz18MwFIIh0=
 github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20191205054626-288fe5207ce6 h1:KrJorS9gGYMhsQjENNWAeB5ho28xbowZ74pfJWkOmFc=
+github.com/pingcap/parser v0.0.0-20191205054626-288fe5207ce6/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e h1:6En0+9KDJ6CjkuzbGwHgo+P1YjEt22jn+nujl6cSAXA=
 github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e/go.mod h1:ribyi6AyFNOElWgb6VnUsky4JFciEoGApSUzIcJxGSI=
 github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible h1:I8HirWsu1MZp6t9G/g8yKCEjJJxtHooKakEgccvdJ4M=

--- a/go.sum
+++ b/go.sum
@@ -169,8 +169,6 @@ github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8 h1:P9jGgwVkLHlbEGt
 github.com/pingcap/kvproto v0.0.0-20191113105027-4f292e1801d8/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa h1:z6F4Hvr5unVOvR6Ed6Wurk9Sl5rREv7iBz18MwFIIh0=
-github.com/pingcap/parser v0.0.0-20191205031633-e66a9d180ffa/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/parser v0.0.0-20191205054626-288fe5207ce6 h1:KrJorS9gGYMhsQjENNWAeB5ho28xbowZ74pfJWkOmFc=
 github.com/pingcap/parser v0.0.0-20191205054626-288fe5207ce6/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191115131715-6b7dc037010e h1:6En0+9KDJ6CjkuzbGwHgo+P1YjEt22jn+nujl6cSAXA=

--- a/table/column.go
+++ b/table/column.go
@@ -224,18 +224,6 @@ type ColDesc struct {
 
 const defaultPrivileges = "select,insert,update,references"
 
-// GetTypeDesc gets the description for column type.
-func (c *Column) GetTypeDesc() string {
-	desc := c.FieldType.CompactStr()
-	if mysql.HasUnsignedFlag(c.Flag) && c.Tp != mysql.TypeBit && c.Tp != mysql.TypeYear {
-		desc += " unsigned"
-	}
-	if mysql.HasZerofillFlag(c.Flag) && c.Tp != mysql.TypeYear {
-		desc += " zerofill"
-	}
-	return desc
-}
-
 // NewColDesc returns a new ColDesc for a column.
 func NewColDesc(col *Column) *ColDesc {
 	// TODO: if we have no primary key and a unique index which's columns are all not null


### PR DESCRIPTION
cherry-pick #13907 
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Extract two core functions for ShowCreateTable/Database to make them easy to be called by the backup feature.
related PR:https://github.com/pingcap/parser/pull/659

### What is changed and how it works?
N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

N/A

Release note

N/A