### PR TITLE
builtinBitCountSig

### DIFF
--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -79,11 +79,23 @@ func (b *builtinValuesJSONSig) vecEvalJSON(input *chunk.Chunk, result *chunk.Col
 }
 
 func (b *builtinBitCountSig) vectorized() bool {
-	return false
+	return true
 }
 
 func (b *builtinBitCountSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
-	return errors.Errorf("not implemented")
+	if err := b.args[0].VecEvalInt(b.ctx, input, result); err != nil {
+		return err
+	}
+	i64s := result.Int64s()
+	for i := range i64s {
+		var count int64
+		n := i64s[i]
+		for ; n != 0; n = (n - 1) & n {
+			count++
+		}
+		i64s[i] = count
+	}
+	return nil
 }
 
 func (b *builtinGetParamStringSig) vectorized() bool {

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -28,7 +28,9 @@ var vecBuiltinOtherCases = map[string][]vecExprBenchCase{
 	ast.GetVar: {
 		{retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETString}},
 	},
-	ast.BitCount: {},
+	ast.BitCount: {
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
+	},
 	ast.GetParam: {
 		{
 			retEvalType: types.ETString, childrenTypes: []types.EvalType{types.ETInt},


### PR DESCRIPTION
### What problem does this PR solve?
Implement vectorized evaluation for builtinBitCountSig.
Issue #12103

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinOtherFuncGenerated-4   	1000000000	         0.0100 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOtherFunc/builtinBitCountSig-VecBuiltinFunc-4            50288	     23415 ns/op	       0 B/op	       0 allocs/op
BenchmarkVectorizedBuiltinOtherFunc/builtinBitCountSig-NonVecBuiltinFunc-4         31467	     38341 ns/op	       0 B/op	       0 allocs/op
PASS
```

### Check List
Tests
* Unit test