### PR TITLE
test: fix race of TestSkipWithGrant

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -748,7 +748,7 @@ func (s *testSessionSuite) TestSessionAuth(c *C) {
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "Any not exist username with zero password!", Hostname: "anyhost"}, []byte(""), []byte("")), IsFalse)
 }
 
-func (s *testSessionSuite) TestSkipWithGrant(c *C) {
+func (s *testSessionSerialSuite) TestSkipWithGrant(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	save2 := privileges.SkipWithGrant
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
```
[2019-12-05T06:52:07.294Z] ==================

[2019-12-05T06:52:07.294Z] WARNING: DATA RACE

[2019-12-05T06:52:07.294Z] Read at 0x0000055f4d0a by goroutine 222:

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/privilege/privileges.(*UserPrivileges).RequestVerification()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/privilege/privileges/privileges.go:43 +0x4f

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/planner/core.CheckPrivilege()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/optimizer.go:92 +0x1bf

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/planner.optimize()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:129 +0xae0

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/planner.Optimize()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:53 +0x25a

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/executor.(*Compiler).Compile()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:61 +0x298

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/session.(*session).execute()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1118 +0x887

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/session.(*session).Execute()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1072 +0xee

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:144 +0x103

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:182 +0x91

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite2).TestUnique()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1611 +0xfa1

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite2).TestUnique()

[2019-12-05T06:52:07.294Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1591 +0xbff

[2019-12-05T06:52:07.294Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite2).TestUnique()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1590 +0xbc8

[2019-12-05T06:52:07.295Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite2).TestUnique()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:1570 +0x308

[2019-12-05T06:52:07.295Z]   runtime.call32()

[2019-12-05T06:52:07.295Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2019-12-05T06:52:07.295Z]   reflect.Value.Call()

[2019-12-05T06:52:07.295Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:854 +0x9aa

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:739 +0x113

[2019-12-05T06:52:07.295Z] 

[2019-12-05T06:52:07.295Z] Previous write at 0x0000055f4d0a by goroutine 342:

[2019-12-05T06:52:07.295Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite).TestSkipWithGrant()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:766 +0x7d9

[2019-12-05T06:52:07.295Z]   github.com/pingcap/tidb/session_test.(*testSessionSuite).TestSkipWithGrant()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session_test.go:761 +0x6ed

[2019-12-05T06:52:07.295Z]   runtime.call32()

[2019-12-05T06:52:07.295Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2019-12-05T06:52:07.295Z]   reflect.Value.Call()

[2019-12-05T06:52:07.295Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:854 +0x9aa

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:739 +0x113

[2019-12-05T06:52:07.295Z] 

[2019-12-05T06:52:07.295Z] Goroutine 222 (running) created at:

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkCall()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:734 +0x4a3

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkTest()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:836 +0x1b9

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).doRun()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:666 +0x13a

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:650 +0xae

[2019-12-05T06:52:07.295Z] 

[2019-12-05T06:52:07.295Z] Goroutine 342 (running) created at:

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkCall()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:734 +0x4a3

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).forkTest()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:836 +0x1b9

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).doRun()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:666 +0x13a

[2019-12-05T06:52:07.295Z]   github.com/pingcap/check.(*suiteRunner).asyncRun.func1()

[2019-12-05T06:52:07.295Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/tiancaiamao/check@v0.0.0-20191119042138-8e73d07b629d/check.go:650 +0xae

[2019-12-05T06:52:07.295Z] ==================
```
