### PR TITLE
session: delay to print general log to make general log contain the transaction tso.

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1027,9 +1027,9 @@ func (s *session) executeStatement(ctx context.Context, connID uint64, stmtNode 
 	} else {
 		s.ClearValue(sessionctx.LastExecuteDDL)
 	}
-	logStmt(stmtNode, s.sessionVars)
 	startTime := time.Now()
 	recordSet, err := runStmt(ctx, s, stmt)
+	logStmt(stmtNode, s.sessionVars)
 	if err != nil {
 		if !kv.ErrKeyExists.Equal(err) {
 			logutil.Logger(ctx).Warn("run statement failed",


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this PR:
```log
[2019/12/05 15:26:33.155 +08:00] [INFO] [session.go:2041] [GENERAL_LOG] [conn=1] [user=root@127.0.0.1] [schemaVersion=153] [txnStartTS=0] [current_db=test] [sql="insert into t values(\"a\", 4)"]
```

This PR：
```
[2019/12/05 15:24:57.894 +08:00] [INFO] [session.go:2041] [GENERAL_LOG] [conn=1] [user=root@127.0.0.1] [schemaVersion=153] [txnStartTS=413015919256141825] [current_db=test] [sql="insert into t values(\"a\", 3)"]
```

The difference is `txnStartTS`.

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


Code changes


Side effects


Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
