### PR TITLE
server: remove unused function `NewFrameItemFromRegionKey`

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -1312,50 +1312,6 @@ func (h regionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	writeData(w, regionDetail)
 }
 
-// NewFrameItemFromRegionKey creates a FrameItem with region's startKey or endKey,
-// returns err when key is illegal.
-func NewFrameItemFromRegionKey(key []byte) (frame *FrameItem, err error) {
-	frame = &FrameItem{}
-	frame.TableID, frame.IndexID, frame.IsRecord, err = tablecodec.DecodeKeyHead(key)
-	if err == nil {
-		if frame.IsRecord {
-			_, frame.RecordID, err = tablecodec.DecodeRecordKey(key)
-		} else {
-			_, _, frame.IndexValues, err = tablecodec.DecodeIndexKey(key)
-		}
-		log.Warnf("decode region key %q fail: %v", key, err)
-		// Ignore decode errors.
-		err = nil
-		return
-	}
-	if bytes.HasPrefix(key, tablecodec.TablePrefix()) {
-		// If SplitTable is enabled, the key may be `t{id}`.
-		if len(key) == tablecodec.TableSplitKeyLen {
-			frame.TableID = tablecodec.DecodeTableID(key)
-			return frame, nil
-		}
-		return nil, errors.Trace(err)
-	}
-
-	// key start with tablePrefix must be either record key or index key
-	// That's means table's record key and index key are always together
-	// in the continuous interval. And for key with prefix smaller than
-	// tablePrefix, is smaller than all tables. While for key with prefix
-	// bigger than tablePrefix, means is bigger than all tables.
-	err = nil
-	if bytes.Compare(key, tablecodec.TablePrefix()) < 0 {
-		frame.TableID = math.MinInt64
-		frame.IndexID = math.MinInt64
-		frame.IsRecord = false
-		return
-	}
-	// bigger than tablePrefix, means is bigger than all tables.
-	frame.TableID = math.MaxInt64
-	frame.IndexID = math.MaxInt64
-	frame.IsRecord = true
-	return
-}
-
 // parseQuery is used to parse query string in URL with shouldUnescape, due to golang http package can not distinguish
 // query like "?a=" and "?a". We rewrite it to separate these two queries. e.g.
 // "?a=" which means that a is an empty string "";


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Improving unit test coverage for `server` pkg.

### What is changed and how it works?

Remove unused function `NewFrameItemFromRegionKey` in `server/http_handler.go`

This function is duplicated with same name function in `store/helper/helper.go`, it's safety to remove it.

https://github.com/pingcap/tidb/blob/73d951d696ca1b051bb4396aabce55acf87b4c8e/store/helper/helper.go#L281-L283

```
(before)
➜  tidb git:(server-remove-func) ✗ go test ./server -cover
ok      github.com/pingcap/tidb/server  26.604s coverage: 64.4% of statements
(after)
➜  tidb git:(server-remove-func) ✗ go test ./server -cover
ok      github.com/pingcap/tidb/server  24.330s coverage: 64.9% of statements
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - None

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
