### PR TITLE
store/tikv: refine grpc config

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -137,7 +137,12 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 			grpc.WithStreamInterceptor(streamInterceptor),
 			grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxRecvMsgSize)),
 			grpc.WithConnectParams(grpc.ConnectParams{
-				Backoff:           backoff.Config{MaxDelay: time.Second * 3},
+				Backoff: backoff.Config{
+					BaseDelay:  100 * time.Millisecond, // Default was 1s.
+					Multiplier: 1.6,                    // Default
+					Jitter:     0.2,                    // Default
+					MaxDelay:   3 * time.Second,        // Default was 120s.
+				},
 				MinConnectTimeout: dialTimeout,
 			}),
 			grpc.WithKeepaliveParams(keepalive.ClientParameters{


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The old `backoff.Config` not completely set, the result backoff delay would always be 0.

### What is changed and how it works?
Set all the `backoff.Config` fields.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
