### PR TITLE
expression: implement vectorized for `builtinCastStringAsRealSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -330,6 +330,12 @@ func (g *decimalStringGener) gen() interface{} {
 	return tempDecimal.String()
 }
 
+type realStringGener struct{}
+
+func (g *realStringGener) gen() interface{} {
+	return fmt.Sprintf("%f", rand.Float64())
+}
+
 type jsonTimeGener struct{}
 
 func (g *jsonTimeGener) gen() interface{} {

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -54,6 +54,7 @@ var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETJson}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETDecimal}},
+		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETString}, geners: []dataGenerator{&realStringGener{}}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETDatetime}},
 		{retEvalType: types.ETReal, childrenTypes: []types.EvalType{types.ETDuration}, geners: []dataGenerator{&rangeDurationGener{nullRation: 0.5}}},
 		{retEvalType: types.ETDuration, childrenTypes: []types.EvalType{types.ETDatetime},


### PR DESCRIPTION
PCP #12105

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. Add vectorized expression: `builtinCastStringAsRealSig`
2. Add the corresponding test case
3. Add the corresponding  generator: `realStringGener`

### What is changed and how it works?
```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/expression
BenchmarkVectorizedBuiltinCastFunc/builtinCastStringAsRealSig-VecBuiltinFunc-8             10000            102142 ns/op               0 B/op          0 allocs/op
BenchmarkVectorizedBuiltinCastFunc/builtinCastStringAsRealSig-NonVecBuiltinFunc-8           8454            132102 ns/op               0 B/op          0 allocs/op
PASS
ok      github.com/pingcap/tidb/expression      2.785s
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change
 - Has interface methods change

Side effects

- No

Related changes

- No

Release note

 - No
