### PR TITLE
expression: use new metadata instead of implicit_args

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -61,10 +61,10 @@ func (b *baseBuiltinFunc) PbCode() tipb.ScalarFuncSig {
 	return b.pbCode
 }
 
-// implicitArgs returns the implicit arguments of this function.
-// implicit arguments means some functions contain extra inner fields which will not
+// metadata returns the metadata of a function.
+// metadata means some functions contain extra inner fields which will not
 // contain in `tipb.Expr.children` but must be pushed down to coprocessor
-func (b *baseBuiltinFunc) implicitArgs() proto.Message {
+func (b *baseBuiltinFunc) metadata() proto.Message {
 	// We will not use a field to store them because of only
 	// a few functions contain implicit parameters
 	return nil
@@ -350,8 +350,8 @@ type baseBuiltinCastFunc struct {
 	inUnion bool
 }
 
-// implicitArgs returns the implicit arguments of cast functions
-func (b *baseBuiltinCastFunc) implicitArgs() proto.Message {
+// metadata returns the metadata of cast functions
+func (b *baseBuiltinCastFunc) metadata() proto.Message {
 	args := &tipb.InUnionMetadata{
 		InUnion: b.inUnion,
 	}
@@ -443,10 +443,10 @@ type builtinFunc interface {
 	setPbCode(tipb.ScalarFuncSig)
 	// PbCode returns PbCode of this signature.
 	PbCode() tipb.ScalarFuncSig
-	// implicitArgs returns the implicit parameters of a function.
-	// implicit arguments means some functions contain extra inner fields which will not
+	// metadata returns the metadata of a function.
+	// metadata means some functions contain extra inner fields which will not
 	// contain in `tipb.Expr.children` but must be pushed down to coprocessor
-	implicitArgs() proto.Message
+	metadata() proto.Message
 	// Clone returns a copy of itself.
 	Clone() builtinFunc
 }

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -267,20 +267,20 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 		children = append(children, pbArg)
 	}
 
-	var metadata []byte
-	if args := expr.Function.metadata(); args != nil {
-		encoded, err := proto.Marshal(args)
+	var encoded []byte
+	if metadata := expr.Function.metadata(); metadata != nil {
+		var err error
+		encoded, err = proto.Marshal(metadata)
 		if err != nil {
-			logutil.BgLogger().Error("encode metadata", zap.Any("metadata", args), zap.Error(err))
+			logutil.BgLogger().Error("encode metadata", zap.Any("metadata", metadata), zap.Error(err))
 			return nil
 		}
-		metadata = encoded
 	}
 
 	// Construct expression ProtoBuf.
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
-		Val:       metadata,
+		Val:       encoded,
 		Sig:       pbCode,
 		Children:  children,
 		FieldType: ToPBFieldType(expr.RetType),

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -271,7 +271,7 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	if args := expr.Function.metadata(); args != nil {
 		encoded, err := proto.Marshal(args)
 		if err != nil {
-			logutil.BgLogger().Error("encode implicit parameters", zap.Any("implicit_args", args), zap.Error(err))
+			logutil.BgLogger().Error("encode metadata", zap.Any("metadata", args), zap.Error(err))
 			return nil
 		}
 		metadata = encoded

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -267,20 +267,20 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 		children = append(children, pbArg)
 	}
 
-	var implicitArgs []byte
-	if args := expr.Function.implicitArgs(); args != nil {
+	var metadata []byte
+	if args := expr.Function.metadata(); args != nil {
 		encoded, err := proto.Marshal(args)
 		if err != nil {
 			logutil.BgLogger().Error("encode implicit parameters", zap.Any("implicit_args", args), zap.Error(err))
 			return nil
 		}
-		implicitArgs = encoded
+		metadata = encoded
 	}
 
 	// Construct expression ProtoBuf.
 	return &tipb.Expr{
 		Tp:        tipb.ExprType_ScalarFunc,
-		Val:       implicitArgs,
+		Val:       metadata,
 		Sig:       pbCode,
 		Children:  children,
 		FieldType: ToPBFieldType(expr.RetType),

--- a/expression/expr_to_pb.go
+++ b/expression/expr_to_pb.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"sync/atomic"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/ast"
@@ -267,10 +268,10 @@ func (pc PbConverter) scalarFuncToPBExpr(expr *ScalarFunction) *tipb.Expr {
 	}
 
 	var implicitArgs []byte
-	if args := expr.Function.implicitArgs(); len(args) > 0 {
-		encoded, err := codec.EncodeValue(pc.sc, nil, args...)
+	if args := expr.Function.implicitArgs(); args != nil {
+		encoded, err := proto.Marshal(args)
 		if err != nil {
-			logutil.BgLogger().Error("encode implicit parameters", zap.Any("datums", args), zap.Error(err))
+			logutil.BgLogger().Error("encode implicit parameters", zap.Any("implicit_args", args), zap.Error(err))
 			return nil
 		}
 		implicitArgs = encoded

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -629,7 +629,7 @@ func (s *testEvaluatorSuite) TestSortByItem2Pb(c *C) {
 	c.Assert(string(js), Equals, "{\"expr\":{\"tp\":201,\"val\":\"gAAAAAAAAAE=\",\"sig\":0,\"field_type\":{\"tp\":5,\"flag\":0,\"flen\":-1,\"decimal\":-1,\"collate\":46,\"charset\":\"\"}},\"desc\":true}")
 }
 
-func (s *testEvaluatorSerialSuites) TestImplicitArgs(c *C) {
+func (s *testEvaluatorSerialSuites) TestMetadata(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -641,21 +641,21 @@ func (s *testEvaluatorSerialSuites) TestImplicitArgs(c *C) {
 
 	// InUnion flag is false in `BuildCastFunction` when `ScalarFuncSig_CastStringAsInt`
 	cast := BuildCastFunction(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
-	c.Assert(cast.(*ScalarFunction).Function.implicitArgs(), DeepEquals, &tipb.InUnionMetadata{InUnion: false})
+	c.Assert(cast.(*ScalarFunction).Function.metadata(), DeepEquals, &tipb.InUnionMetadata{InUnion: false})
 	expr := pc.ExprToPB(cast)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)
 
 	// InUnion flag is nil in `BuildCastFunction4Union` when `ScalarFuncSig_CastIntAsString`
 	castInUnion := BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeLonglong, 1), types.NewFieldType(mysql.TypeString))
-	c.Assert(castInUnion.(*ScalarFunction).Function.implicitArgs(), IsNil)
+	c.Assert(castInUnion.(*ScalarFunction).Function.metadata(), IsNil)
 	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastIntAsString)
 	c.Assert(len(expr.Val), Equals, 0)
 
 	// InUnion flag is true in `BuildCastFunction4Union` when `ScalarFuncSig_CastStringAsInt`
 	castInUnion = BuildCastFunction4Union(mock.NewContext(), dg.genColumn(mysql.TypeString, 1), types.NewFieldType(mysql.TypeLonglong))
-	c.Assert(castInUnion.(*ScalarFunction).Function.implicitArgs(), DeepEquals, &tipb.InUnionMetadata{InUnion: true})
+	c.Assert(castInUnion.(*ScalarFunction).Function.metadata(), DeepEquals, &tipb.InUnionMetadata{InUnion: true})
 	expr = pc.ExprToPB(castInUnion)
 	c.Assert(expr.Sig, Equals, tipb.ScalarFuncSig_CastStringAsInt)
 	c.Assert(len(expr.Val), Greater, 0)

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	github.com/pingcap/pd v1.1.0-beta.0.20190923032047-5c648dc365e0
 	github.com/pingcap/sysutil v0.0.0-20191126040022-986c5b3ed9a3
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible
-	github.com/pingcap/tipb v0.0.0-20191203131953-a35f738b4796
+	github.com/pingcap/tipb v0.0.0-20191208102537-b1be44fee017
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/remyoudompheng/bigfft v0.0.0-20190512091148-babf20351dd7 // indirect
@@ -77,5 +77,3 @@ require (
 go 1.13
 
 replace github.com/pingcap/check => github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d
-
-replace github.com/pingcap/tipb => github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 go 1.13
 
 replace github.com/pingcap/check => github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d
+
+replace github.com/pingcap/tipb => github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/TennyZhuang/tipb v0.0.0-20191207151924-18900263e752 h1:14fJDo3nyjre5WoXN3bfrtkS5mRLmV5mzLHn6ji5wT0=
-github.com/TennyZhuang/tipb v0.0.0-20191207151924-18900263e752/go.mod h1:tno+hfkjxdOKSo6WMnSg9GsniRS8Dw5RzLcC7c/kGMg=
-github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727 h1:RAYDRP/cCYCkj0JhBux9C7Rca0iT2SF8YkuKfJvVBcM=
-github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727/go.mod h1:tno+hfkjxdOKSo6WMnSg9GsniRS8Dw5RzLcC7c/kGMg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -71,7 +67,6 @@ github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -202,6 +197,8 @@ github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible 
 github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20191203131953-a35f738b4796 h1:VNxsATjjGSXYbLXYdwJMj4ah5oxkMbKtOg/kaoXUX64=
 github.com/pingcap/tipb v0.0.0-20191203131953-a35f738b4796/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pingcap/tipb v0.0.0-20191208102537-b1be44fee017 h1:oz1muRVhhYhGiHgI4owcWSTDfGQHyIRhVEhb3YjBfpM=
+github.com/pingcap/tipb v0.0.0-20191208102537-b1be44fee017/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
@@ -259,8 +256,6 @@ github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d h1:4J9HCZVpvDmj2t
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tiancaiamao/check v0.0.0-20161104095106-5ebf485998c8 h1:aFvEDJPdbkkIeIPCjgzLLah2e+RSEttbtqbf+chnjnk=
-github.com/tiancaiamao/check v0.0.0-20161104095106-5ebf485998c8/go.mod h1:LmMhDQ7nI0MXViivwJKc2kx9c8ISRoLSWKYKgOYPIbI=
 github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d h1:TMYOU9yCm2egiuzypRgFlVDw/5LzkJZaTmT26GPyFtE=
 github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,10 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/TennyZhuang/tipb v0.0.0-20191207151924-18900263e752 h1:14fJDo3nyjre5WoXN3bfrtkS5mRLmV5mzLHn6ji5wT0=
+github.com/TennyZhuang/tipb v0.0.0-20191207151924-18900263e752/go.mod h1:tno+hfkjxdOKSo6WMnSg9GsniRS8Dw5RzLcC7c/kGMg=
+github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727 h1:RAYDRP/cCYCkj0JhBux9C7Rca0iT2SF8YkuKfJvVBcM=
+github.com/TennyZhuang/tipb v0.0.0-20191207154638-8bf980d92727/go.mod h1:tno+hfkjxdOKSo6WMnSg9GsniRS8Dw5RzLcC7c/kGMg=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -67,6 +71,7 @@ github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7a
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
+github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -254,6 +259,8 @@ github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d h1:4J9HCZVpvDmj2t
 github.com/syndtr/goleveldb v0.0.0-20180815032940-ae2bd5eed72d/go.mod h1:Z4AUp2Km+PwemOoO/VB5AOx9XSsIItzFjoJlOSiYmn0=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
+github.com/tiancaiamao/check v0.0.0-20161104095106-5ebf485998c8 h1:aFvEDJPdbkkIeIPCjgzLLah2e+RSEttbtqbf+chnjnk=
+github.com/tiancaiamao/check v0.0.0-20161104095106-5ebf485998c8/go.mod h1:LmMhDQ7nI0MXViivwJKc2kx9c8ISRoLSWKYKgOYPIbI=
 github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d h1:TMYOU9yCm2egiuzypRgFlVDw/5LzkJZaTmT26GPyFtE=
 github.com/tiancaiamao/check v0.0.0-20191119042138-8e73d07b629d/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
Signed-off-by: TennyZhuang <zty0826@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, implicit_args can only pass data with `[]Datum` format, it's not reasonable for structured metadata, such as for `in` optimization, we need some metadata format like https://github.com/TennyZhuang/tikv/blob/fdb0bb3777f2bb32716a10beb776cc5e1c55125f/components/tidb_query/src/rpn_expr/impl_compare_in.rs#L125

### What is changed and how it works?

This PR introduce arbitrary metadata format defined with protobuf in tipb, encoding in TiDB and decoding in TiKV.

Related to https://github.com/pingcap/tipb/pull/161

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

This feature will break the implicit_args format, but will not break anything really, because only `cast` use implicit_args, and the pushdown switch of `cast` is never open before.

Related changes

 - Need to merge https://github.com/pingcap/tipb/pull/161 first.

Release note

 - Introduce new implicit_args format
