### PR TITLE
executor: add log for commit work

### DIFF
--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -243,11 +244,17 @@ func (e *LoadDataInfo) CommitWork(ctx context.Context) error {
 			break
 		case commitTask, ok := <-e.commitTaskQueue:
 			if ok {
+				start := time.Now()
 				err = e.CommitOneTask(ctx, commitTask)
 				if err != nil {
 					break
 				}
 				tasks++
+				logutil.Logger(ctx).Info("commit one task success",
+					zap.Duration("commit time usage", time.Since(start)),
+					zap.Uint64("keys processed", commitTask.cnt),
+					zap.Uint64("tasks processed", tasks),
+					zap.Int("tasks in queue", len(e.commitTaskQueue)))
 			} else {
 				end = true
 				break
@@ -485,6 +492,7 @@ func (e *LoadDataInfo) addRecordLD(ctx context.Context, row []types.Datum) (int6
 	h, err := e.addRecord(ctx, row)
 	if err != nil {
 		e.handleWarning(err)
+		return 0, err
 	}
 	return h, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The original `AddRecordLd` function used in `load data` statement, will not report error to caller.

Problem:
Loading 300 millon rows in tpch lineitem table into tidb,  after loaded row counts over 50800000, the load data commit goroutine will always write zero rows processing one commit task, because of error "[autoid:1467]Failed to read auto-increment value from storage engine" from `AddRecord`. (related to #13648, need more investigation on this), add this error not reported, so  the loading process seems  got stuck

### What is changed and how it works?

- Do report error in `AddRecordLd` function if `AddRecord` failed
- Add some info log for commit processing

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below), retrying loading `tpch.lineitem` data with 300million rows


Code changes



Side effects


Related changes

 - Need to cherry-pick to the release branch ?


Release note

