### PR TITLE
planner: TIDB_INLJ hint does not work for smaller left table

### DIFF
--- a/cmd/explaintest/r/explain_complex.result
+++ b/cmd/explaintest/r/explain_complex.result
@@ -152,14 +152,15 @@ explain select dt.id as id, dt.aid as aid, dt.pt as pt, dt.dic as dic, dt.cm as 
 id	count	task	operator info
 Projection_10	0.00	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test.dt.cm, test.rr.gid, test.rr.acd, test.rr.t, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5
 └─Limit_13	0.00	root	offset:0, count:2000
-  └─IndexJoin_19	0.00	root	inner join, inner:IndexLookUp_18, outer key:test.dt.aid, test.dt.dic, inner key:test.rr.aid, test.rr.dic
-    ├─TableReader_43	0.00	root	data:Selection_42
-    │ └─Selection_42	0.00	cop[tikv]	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
-    │   └─TableScan_41	10000.00	cop[tikv]	table:dt, range:[0,+inf], keep order:false, stats:pseudo
-    └─IndexLookUp_18	1.00	root	
-      ├─IndexScan_15	1.00	cop[tikv]	table:rr, index:aid, dic, range: decided by [eq(test.rr.aid, test.dt.aid) eq(test.rr.dic, test.dt.dic)], keep order:false, stats:pseudo
-      └─Selection_17	1.00	cop[tikv]	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
-        └─TableScan_16	1.00	cop[tikv]	table:rr, keep order:false, stats:pseudo
+  └─IndexMergeJoin_41	0.00	root	inner join, inner:IndexLookUp_39, outer key:test.rr.aid, test.rr.dic, inner key:test.dt.aid, test.dt.dic
+    ├─IndexLookUp_39	0.00	root	
+    │ ├─Selection_37	1.00	cop[tikv]	not(isnull(test.dt.dic))
+    │ │ └─IndexScan_35	1.00	cop[tikv]	table:dt, index:aid, dic, range: decided by [eq(test.dt.aid, test.rr.aid) eq(test.dt.dic, test.rr.dic)], keep order:true, stats:pseudo
+    │ └─Selection_38	0.00	cop[tikv]	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592)
+    │   └─TableScan_36	1.00	cop[tikv]	table:dt, keep order:false, stats:pseudo
+    └─TableReader_61	3.33	root	data:Selection_60
+      └─Selection_60	3.33	cop[tikv]	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)
+        └─TableScan_59	10000.00	cop[tikv]	table:rr, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select pc,cr,count(DISTINCT uid) as pay_users,count(oid) as pay_times,sum(am) as am from pp where ps=2  and ppt>=1478188800 and ppt<1478275200  and pi in ('510017','520017') and uid in ('18089709','18090780') group by pc,cr;
 id	count	task	operator info
 Projection_5	1.00	root	test.pp.pc, test.pp.cr, Column#22, Column#23, Column#24

--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -161,9 +161,9 @@ id	count	task	operator info
 Projection_10	428.32	root	test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, test.dt.cm, test.rr.gid, test.rr.acd, test.rr.t, test.dt.p1, test.dt.p2, test.dt.p3, test.dt.p4, test.dt.p5, test.dt.p6_md5, test.dt.p7_md5
 └─Limit_13	428.32	root	offset:0, count:2000
   └─IndexJoin_19	428.32	root	inner join, inner:IndexLookUp_18, outer key:test.dt.aid, test.dt.dic, inner key:test.rr.aid, test.rr.dic
-    ├─TableReader_43	428.32	root	data:Selection_42
-    │ └─Selection_42	428.32	cop[tikv]	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
-    │   └─TableScan_41	2000.00	cop[tikv]	table:dt, range:[0,+inf], keep order:false
+    ├─TableReader_58	428.32	root	data:Selection_57
+    │ └─Selection_57	428.32	cop[tikv]	eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
+    │   └─TableScan_56	2000.00	cop[tikv]	table:dt, range:[0,+inf], keep order:false
     └─IndexLookUp_18	1.00	root	
       ├─IndexScan_15	1.00	cop[tikv]	table:rr, index:aid, dic, range: decided by [eq(test.rr.aid, test.dt.aid) eq(test.rr.dic, test.dt.dic)], keep order:false
       └─Selection_17	1.00	cop[tikv]	eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -350,13 +350,13 @@ Projection_11	5.00	root	Column#11
   ├─TableReader_15	5.00	root	data:TableScan_14
   │ └─TableScan_14	5.00	cop[tikv]	table:t, range:[-inf,+inf], keep order:false
   └─StreamAgg_20	1.00	root	funcs:count(1)->Column#10
-    └─MergeJoin_51	2.40	root	inner join, left key:test.t.a, right key:test.t.a
-      ├─IndexReader_38	2.40	root	index:Selection_37
-      │ └─Selection_37	2.40	cop[tikv]	eq(3, test.t.a)
-      │   └─IndexScan_36	3.00	cop[tikv]	table:s, index:b, range:[3,3], keep order:true
-      └─TableReader_41	4.00	root	data:Selection_40
-        └─Selection_40	4.00	cop[tikv]	eq(3, test.t.a)
-          └─TableScan_39	5.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:true
+    └─MergeJoin_62	2.40	root	inner join, left key:test.t.a, right key:test.t.a
+      ├─IndexReader_49	2.40	root	index:Selection_48
+      │ └─Selection_48	2.40	cop[tikv]	eq(3, test.t.a)
+      │   └─IndexScan_47	3.00	cop[tikv]	table:s, index:b, range:[3,3], keep order:true
+      └─TableReader_52	4.00	root	data:Selection_51
+        └─Selection_51	4.00	cop[tikv]	eq(3, test.t.a)
+          └─TableScan_50	5.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:true
 explain select t.c in (select count(*) from t s left join t t1 on s.a = t1.a where 3 = t.a and s.b = 3) from t;
 id	count	task	operator info
 Projection_10	5.00	root	Column#11

--- a/cmd/explaintest/r/explain_join_stats.result
+++ b/cmd/explaintest/r/explain_join_stats.result
@@ -7,13 +7,13 @@ load stats 's/explain_join_stats_lo.json';
 explain select count(*) from e, lo where lo.a=e.a and e.b=22336;
 id	count	task	operator info
 StreamAgg_13	1.00	root	funcs:count(1)->Column#5
-└─HashRightJoin_71	19977.00	root	inner join, inner:TableReader_41, equal:[eq(test.lo.a, test.e.a)]
-  ├─TableReader_41	250.00	root	data:TableScan_40
-  │ └─TableScan_40	250.00	cop[tikv]	table:lo, range:[-inf,+inf], keep order:false
-  └─IndexLookUp_52	19977.00	root	
-    ├─IndexScan_49	19977.00	cop[tikv]	table:e, index:b, range:[22336,22336], keep order:false
-    └─Selection_51	19977.00	cop[tikv]	not(isnull(test.e.a))
-      └─TableScan_50	19977.00	cop[tikv]	table:e, keep order:false
+└─HashRightJoin_89	19977.00	root	inner join, inner:TableReader_50, equal:[eq(test.lo.a, test.e.a)]
+  ├─TableReader_50	250.00	root	data:TableScan_49
+  │ └─TableScan_49	250.00	cop[tikv]	table:lo, range:[-inf,+inf], keep order:false
+  └─IndexLookUp_61	19977.00	root	
+    ├─IndexScan_58	19977.00	cop[tikv]	table:e, index:b, range:[22336,22336], keep order:false
+    └─Selection_60	19977.00	cop[tikv]	not(isnull(test.e.a))
+      └─TableScan_59	19977.00	cop[tikv]	table:e, keep order:false
 explain select /*+ TIDB_INLJ(e) */ count(*) from e, lo where lo.a=e.a and e.b=22336;
 id	count	task	operator info
 StreamAgg_12	1.00	root	funcs:count(1)->Column#5

--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -76,19 +76,19 @@ IndexJoin_26	5.00	root	inner join, inner:IndexLookUp_25, outer key:test.sgc2.a, 
 │ ├─Selection_24	5.00	cop[tikv]	not(isnull(test.sgc1.a))
 │ │ └─IndexScan_22	5.00	cop[tikv]	table:sgc1, index:a, range: decided by [eq(test.sgc1.a, test.sgc2.a)], keep order:false
 │ └─TableScan_23	5.00	cop[tikv]	table:sgc1, keep order:false
-└─TableReader_38	1.00	root	data:Selection_37
-  └─Selection_37	1.00	cop[tikv]	not(isnull(test.sgc2.a))
-    └─TableScan_36	1.00	cop[tikv]	table:sgc2, range:[-inf,+inf], keep order:false
+└─TableReader_47	1.00	root	data:Selection_46
+  └─Selection_46	1.00	cop[tikv]	not(isnull(test.sgc2.a))
+    └─TableScan_45	1.00	cop[tikv]	table:sgc2, range:[-inf,+inf], keep order:false
 EXPLAIN SELECT * from sgc1 join sgc2 on sgc1.a=sgc2.a;
 id	count	task	operator info
 Projection_6	5.00	root	test.sgc1.j1, test.sgc1.j2, test.sgc1.a, test.sgc1.b, test.sgc2.j1, test.sgc2.j2, test.sgc2.a, test.sgc2.b
-└─HashRightJoin_24	5.00	root	inner join, inner:TableReader_43, equal:[eq(test.sgc2.a, test.sgc1.a)]
-  ├─TableReader_43	1.00	root	data:Selection_42
-  │ └─Selection_42	1.00	cop[tikv]	not(isnull(test.sgc2.a))
-  │   └─TableScan_41	1.00	cop[tikv]	table:sgc2, range:[-inf,+inf], keep order:false
-  └─TableReader_52	5.00	root	data:Selection_51
-    └─Selection_51	5.00	cop[tikv]	not(isnull(test.sgc1.a))
-      └─TableScan_50	5.00	cop[tikv]	table:sgc1, range:[-inf,+inf], keep order:false
+└─HashRightJoin_38	5.00	root	inner join, inner:TableReader_57, equal:[eq(test.sgc2.a, test.sgc1.a)]
+  ├─TableReader_57	1.00	root	data:Selection_56
+  │ └─Selection_56	1.00	cop[tikv]	not(isnull(test.sgc2.a))
+  │   └─TableScan_55	1.00	cop[tikv]	table:sgc2, range:[-inf,+inf], keep order:false
+  └─TableReader_66	5.00	root	data:Selection_65
+    └─Selection_65	5.00	cop[tikv]	not(isnull(test.sgc1.a))
+      └─TableScan_64	5.00	cop[tikv]	table:sgc1, range:[-inf,+inf], keep order:false
 DROP TABLE IF EXISTS sgc3;
 CREATE TABLE sgc3 (
 j JSON,

--- a/cmd/explaintest/r/index_join.result
+++ b/cmd/explaintest/r/index_join.result
@@ -13,19 +13,19 @@ IndexJoin_25	5.00	root	inner join, inner:IndexLookUp_24, outer key:test.t2.a, in
 │ ├─Selection_23	5.00	cop[tikv]	not(isnull(test.t1.a))
 │ │ └─IndexScan_21	5.00	cop[tikv]	table:t1, index:a, range: decided by [eq(test.t1.a, test.t2.a)], keep order:false
 │ └─TableScan_22	5.00	cop[tikv]	table:t1, keep order:false
-└─TableReader_37	1.00	root	data:Selection_36
-  └─Selection_36	1.00	cop[tikv]	not(isnull(test.t2.a))
-    └─TableScan_35	1.00	cop[tikv]	table:t2, range:[-inf,+inf], keep order:false
+└─TableReader_43	1.00	root	data:Selection_42
+  └─Selection_42	1.00	cop[tikv]	not(isnull(test.t2.a))
+    └─TableScan_41	1.00	cop[tikv]	table:t2, range:[-inf,+inf], keep order:false
 explain select * from t1 join t2 on t1.a=t2.a;
 id	count	task	operator info
 Projection_6	5.00	root	test.t1.a, test.t1.b, test.t2.a, test.t2.b
-└─HashRightJoin_23	5.00	root	inner join, inner:TableReader_34, equal:[eq(test.t2.a, test.t1.a)]
-  ├─TableReader_34	1.00	root	data:Selection_33
-  │ └─Selection_33	1.00	cop[tikv]	not(isnull(test.t2.a))
-  │   └─TableScan_32	1.00	cop[tikv]	table:t2, range:[-inf,+inf], keep order:false
-  └─TableReader_40	5.00	root	data:Selection_39
-    └─Selection_39	5.00	cop[tikv]	not(isnull(test.t1.a))
-      └─TableScan_38	5.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false
+└─HashRightJoin_37	5.00	root	inner join, inner:TableReader_48, equal:[eq(test.t2.a, test.t1.a)]
+  ├─TableReader_48	1.00	root	data:Selection_47
+  │ └─Selection_47	1.00	cop[tikv]	not(isnull(test.t2.a))
+  │   └─TableScan_46	1.00	cop[tikv]	table:t2, range:[-inf,+inf], keep order:false
+  └─TableReader_54	5.00	root	data:Selection_53
+    └─Selection_53	5.00	cop[tikv]	not(isnull(test.t1.a))
+      └─TableScan_52	5.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false
 drop table if exists t1, t2;
 create table t1(a int not null, b int not null);
 create table t2(a int not null, b int not null, key a(a));

--- a/cmd/explaintest/r/topn_push_down.result
+++ b/cmd/explaintest/r/topn_push_down.result
@@ -170,11 +170,11 @@ id	count	task	operator info
 Projection_12	0.00	root	test.te.expect_time
 └─TopN_15	0.00	root	test.te.expect_time:asc, offset:0, count:5
   └─IndexJoin_24	0.00	root	inner join, inner:IndexLookUp_23, outer key:test.tr.id, inner key:test.te.trade_id
-    ├─IndexLookUp_67	0.00	root	
-    │ ├─Selection_65	0.00	cop[tikv]	eq(test.tr.business_type, 18), eq(test.tr.trade_type, 1)
-    │ │ └─IndexScan_63	10.00	cop[tikv]	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false, stats:pseudo
-    │ └─Selection_66	0.00	cop[tikv]	eq(test.tr.brand_identy, 32314), eq(test.tr.domain_type, 2)
-    │   └─TableScan_64	0.00	cop[tikv]	table:tr, keep order:false, stats:pseudo
+    ├─IndexLookUp_78	0.00	root	
+    │ ├─Selection_76	0.00	cop[tikv]	eq(test.tr.business_type, 18), eq(test.tr.trade_type, 1)
+    │ │ └─IndexScan_74	10.00	cop[tikv]	table:tr, index:shop_identy, trade_status, business_type, trade_pay_status, trade_type, delivery_type, source, biz_date, range:[810094178,810094178], keep order:false, stats:pseudo
+    │ └─Selection_77	0.00	cop[tikv]	eq(test.tr.brand_identy, 32314), eq(test.tr.domain_type, 2)
+    │   └─TableScan_75	0.00	cop[tikv]	table:tr, keep order:false, stats:pseudo
     └─IndexLookUp_23	1.25	root	
       ├─IndexScan_20	50.00	cop[tikv]	table:te, index:trade_id, range: decided by [eq(test.te.trade_id, test.tr.id)], keep order:false, stats:pseudo
       └─Selection_22	1.25	cop[tikv]	ge(test.te.expect_time, 2018-04-23 00:00:00.000000), le(test.te.expect_time, 2018-04-23 23:59:59.000000)

--- a/cmd/explaintest/r/tpch.result
+++ b/cmd/explaintest/r/tpch.result
@@ -767,12 +767,12 @@ l_shipmode;
 id	count	task	operator info
 Sort_9	1.00	root	tpch.lineitem.l_shipmode:asc
 └─Projection_11	1.00	root	tpch.lineitem.l_shipmode, Column#27, Column#28
-  └─HashAgg_14	1.00	root	group by:Column#35, funcs:sum(Column#32)->Column#27, funcs:sum(Column#33)->Column#28, funcs:firstrow(Column#34)->tpch.lineitem.l_shipmode
-    └─Projection_40	10023369.01	root	cast(case(or(eq(tpch.orders.o_orderpriority, 1-URGENT), eq(tpch.orders.o_orderpriority, 2-HIGH)), 1, 0))->Column#32, cast(case(and(ne(tpch.orders.o_orderpriority, 1-URGENT), ne(tpch.orders.o_orderpriority, 2-HIGH)), 1, 0))->Column#33, tpch.lineitem.l_shipmode, tpch.lineitem.l_shipmode
+  └─HashAgg_14	1.00	root	group by:Column#40, funcs:sum(Column#37)->Column#27, funcs:sum(Column#38)->Column#28, funcs:firstrow(Column#39)->tpch.lineitem.l_shipmode
+    └─Projection_54	10023369.01	root	cast(case(or(eq(tpch.orders.o_orderpriority, 1-URGENT), eq(tpch.orders.o_orderpriority, 2-HIGH)), 1, 0))->Column#37, cast(case(and(ne(tpch.orders.o_orderpriority, 1-URGENT), ne(tpch.orders.o_orderpriority, 2-HIGH)), 1, 0))->Column#38, tpch.lineitem.l_shipmode, tpch.lineitem.l_shipmode
       └─IndexMergeJoin_22	10023369.01	root	inner join, inner:TableReader_20, outer key:tpch.lineitem.l_orderkey, inner key:tpch.orders.o_orderkey
-        ├─TableReader_36	10023369.01	root	data:Selection_35
-        │ └─Selection_35	10023369.01	cop[tikv]	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
-        │   └─TableScan_34	300005811.00	cop[tikv]	table:lineitem, range:[-inf,+inf], keep order:false
+        ├─TableReader_50	10023369.01	root	data:Selection_49
+        │ └─Selection_49	10023369.01	cop[tikv]	ge(tpch.lineitem.l_receiptdate, 1997-01-01 00:00:00.000000), in(tpch.lineitem.l_shipmode, "RAIL", "FOB"), lt(tpch.lineitem.l_commitdate, tpch.lineitem.l_receiptdate), lt(tpch.lineitem.l_receiptdate, 1998-01-01), lt(tpch.lineitem.l_shipdate, tpch.lineitem.l_commitdate)
+        │   └─TableScan_48	300005811.00	cop[tikv]	table:lineitem, range:[-inf,+inf], keep order:false
         └─TableReader_20	1.00	root	data:TableScan_19
           └─TableScan_19	1.00	cop[tikv]	table:orders, range: decided by [tpch.lineitem.l_orderkey], keep order:true
 /*
@@ -929,16 +929,16 @@ id	count	task	operator info
 Sort_13	3863988.24	root	Column#23:desc, tpch.part.p_brand:asc, tpch.part.p_type:asc, tpch.part.p_size:asc
 └─Projection_15	3863988.24	root	tpch.part.p_brand, tpch.part.p_type, tpch.part.p_size, Column#23
   └─HashAgg_18	3863988.24	root	group by:tpch.part.p_brand, tpch.part.p_size, tpch.part.p_type, funcs:count(distinct tpch.partsupp.ps_suppkey)->Column#23, funcs:firstrow(tpch.part.p_brand)->tpch.part.p_brand, funcs:firstrow(tpch.part.p_type)->tpch.part.p_type, funcs:firstrow(tpch.part.p_size)->tpch.part.p_size
-    └─HashLeftJoin_30	3863988.24	root	anti semi join, inner:TableReader_57, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
+    └─HashLeftJoin_30	3863988.24	root	anti semi join, inner:TableReader_68, equal:[eq(tpch.partsupp.ps_suppkey, tpch.supplier.s_suppkey)]
       ├─IndexMergeJoin_38	4829985.30	root	inner join, inner:IndexReader_36, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
-      │ ├─TableReader_50	1200618.43	root	data:Selection_49
-      │ │ └─Selection_49	1200618.43	cop[tikv]	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
-      │ │   └─TableScan_48	10000000.00	cop[tikv]	table:part, range:[-inf,+inf], keep order:false
+      │ ├─TableReader_61	1200618.43	root	data:Selection_60
+      │ │ └─Selection_60	1200618.43	cop[tikv]	in(tpch.part.p_size, 48, 19, 12, 4, 41, 7, 21, 39), ne(tpch.part.p_brand, "Brand#34"), not(like(tpch.part.p_type, "LARGE BRUSHED%", 92))
+      │ │   └─TableScan_59	10000000.00	cop[tikv]	table:part, range:[-inf,+inf], keep order:false
       │ └─IndexReader_36	4.02	root	index:IndexScan_35
       │   └─IndexScan_35	4.02	cop[tikv]	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:true
-      └─TableReader_57	400000.00	root	data:Selection_56
-        └─Selection_56	400000.00	cop[tikv]	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
-          └─TableScan_55	500000.00	cop[tikv]	table:supplier, range:[-inf,+inf], keep order:false
+      └─TableReader_68	400000.00	root	data:Selection_67
+        └─Selection_67	400000.00	cop[tikv]	like(tpch.supplier.s_comment, "%Customer%Complaints%", 92)
+          └─TableScan_66	500000.00	cop[tikv]	table:supplier, range:[-inf,+inf], keep order:false
 /*
 Q17 Small-Quantity-Order Revenue Query
 This query determines how much average yearly revenue would be lost if orders were no longer filled for small
@@ -1159,15 +1159,15 @@ Sort_28	20000.00	root	tpch.supplier.s_name:asc
           └─HashAgg_58	80007.93	root	group by:tpch.partsupp.ps_partkey, tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_partkey)->tpch.partsupp.ps_partkey, funcs:firstrow(tpch.partsupp.ps_suppkey)->tpch.partsupp.ps_suppkey, funcs:firstrow(tpch.partsupp.ps_availqty)->tpch.partsupp.ps_availqty, funcs:firstrow(tpch.part.p_partkey)->tpch.part.p_partkey, funcs:sum(tpch.lineitem.l_quantity)->Column#44
             └─HashLeftJoin_62	9711455.06	root	left outer join, inner:IndexHashJoin_75 (REVERSED), equal:[eq(tpch.partsupp.ps_partkey, tpch.lineitem.l_partkey) eq(tpch.partsupp.ps_suppkey, tpch.lineitem.l_suppkey)]
               ├─IndexHashJoin_75	321865.05	root	inner join, inner:IndexLookUp_66, outer key:tpch.part.p_partkey, inner key:tpch.partsupp.ps_partkey
-              │ ├─TableReader_87	80007.93	root	data:Selection_86
-              │ │ └─Selection_86	80007.93	cop[tikv]	like(tpch.part.p_name, "green%", 92)
-              │ │   └─TableScan_85	10000000.00	cop[tikv]	table:part, range:[-inf,+inf], keep order:false
+              │ ├─TableReader_98	80007.93	root	data:Selection_97
+              │ │ └─Selection_97	80007.93	cop[tikv]	like(tpch.part.p_name, "green%", 92)
+              │ │   └─TableScan_96	10000000.00	cop[tikv]	table:part, range:[-inf,+inf], keep order:false
               │ └─IndexLookUp_66	4.02	root	
               │   ├─IndexScan_64	4.02	cop[tikv]	table:partsupp, index:PS_PARTKEY, PS_SUPPKEY, range: decided by [eq(tpch.partsupp.ps_partkey, tpch.part.p_partkey)], keep order:false
               │   └─TableScan_65	4.02	cop[tikv]	table:partsupp, keep order:false
-              └─TableReader_92	44189356.65	root	data:Selection_91
-                └─Selection_91	44189356.65	cop[tikv]	ge(tpch.lineitem.l_shipdate, 1993-01-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1994-01-01)
-                  └─TableScan_90	300005811.00	cop[tikv]	table:lineitem, range:[-inf,+inf], keep order:false
+              └─TableReader_103	44189356.65	root	data:Selection_102
+                └─Selection_102	44189356.65	cop[tikv]	ge(tpch.lineitem.l_shipdate, 1993-01-01 00:00:00.000000), lt(tpch.lineitem.l_shipdate, 1994-01-01)
+                  └─TableScan_101	300005811.00	cop[tikv]	table:lineitem, range:[-inf,+inf], keep order:false
 /*
 Q21 Suppliers Who Kept Orders Waiting Query
 This query identifies certain suppliers who were not able to ship required parts in a timely manner.

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -292,3 +292,16 @@ func (s *testIntegrationSuite) TestErrNoDB(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("grant select on test1111 to test@'%'")
 }
+
+func (s *testIntegrationSuite) TestINLJHintSmallTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int not null, b int, key(a))")
+	tk.MustExec("insert into t1 values(1,1),(2,2)")
+	tk.MustExec("create table t2(a int not null, b int, key(a))")
+	tk.MustExec("insert into t2 values(1,1),(2,2),(3,3),(4,4),(5,5)")
+	tk.MustExec("analyze table t1, t2")
+	tk.MustExec("explain select /*+ TIDB_INLJ(t1) */ * from t1 join t2 on t1.a = t2.a")
+	tk.MustQuery("show warnings").Check(testkit.Rows())
+}

--- a/planner/core/testdata/plan_normalized_suite_out.json
+++ b/planner/core/testdata/plan_normalized_suite_out.json
@@ -91,9 +91,9 @@
         "SQL": "SELECT /*+ TIDB_INLJ(t1, t2) */ * from t1, t2 where t1.a = t2.a and t1.c>1;",
         "Plan": [
           " IndexJoin_10       root inner join, inner:TableReader_9, outer key:test.t1.a, inner key:test.t2.a",
-          " ├─TableReader_19   root data:Selection_18",
-          " │ └─Selection_18   cop  gt(test.t1.c, ?)",
-          " │   └─TableScan_17 cop  table:t1, range:[?,?], keep order:false",
+          " ├─TableReader_30   root data:Selection_29",
+          " │ └─Selection_29   cop  gt(test.t1.c, ?)",
+          " │   └─TableScan_28 cop  table:t1, range:[?,?], keep order:false",
           " └─TableReader_9    root data:TableScan_8",
           "   └─TableScan_8    cop  table:t2, range: decided by [test.t1.a], keep order:false"
         ]
@@ -101,32 +101,32 @@
       {
         "SQL": "SELECT /*+ TIDB_HJ(t1, t2) */ * from t1, t2 where t1.a = t2.a and t1.c>1;",
         "Plan": [
-          " HashRightJoin_18   root inner join, inner:TableReader_21, equal:eq(test.t1.a, test.t2.a)",
-          " ├─TableReader_21   root data:Selection_20",
-          " │ └─Selection_20   cop  gt(test.t1.c, ?)",
-          " │   └─TableScan_19 cop  table:t1, range:[?,?], keep order:false",
-          " └─TableReader_23   root data:TableScan_22",
-          "   └─TableScan_22   cop  table:t2, range:[?,?], keep order:false"
+          " HashRightJoin_29   root inner join, inner:TableReader_32, equal:eq(test.t1.a, test.t2.a)",
+          " ├─TableReader_32   root data:Selection_31",
+          " │ └─Selection_31   cop  gt(test.t1.c, ?)",
+          " │   └─TableScan_30 cop  table:t1, range:[?,?], keep order:false",
+          " └─TableReader_34   root data:TableScan_33",
+          "   └─TableScan_33   cop  table:t2, range:[?,?], keep order:false"
         ]
       },
       {
         "SQL": "SELECT /*+ TIDB_HJ(t1, t2) */ * from t1, t2 where t1.a = t2.a and t1.c>1;",
         "Plan": [
-          " HashRightJoin_18   root inner join, inner:TableReader_21, equal:eq(test.t1.a, test.t2.a)",
-          " ├─TableReader_21   root data:Selection_20",
-          " │ └─Selection_20   cop  gt(test.t1.c, ?)",
-          " │   └─TableScan_19 cop  table:t1, range:[?,?], keep order:false",
-          " └─TableReader_23   root data:TableScan_22",
-          "   └─TableScan_22   cop  table:t2, range:[?,?], keep order:false"
+          " HashRightJoin_29   root inner join, inner:TableReader_32, equal:eq(test.t1.a, test.t2.a)",
+          " ├─TableReader_32   root data:Selection_31",
+          " │ └─Selection_31   cop  gt(test.t1.c, ?)",
+          " │   └─TableScan_30 cop  table:t1, range:[?,?], keep order:false",
+          " └─TableReader_34   root data:TableScan_33",
+          "   └─TableScan_33   cop  table:t2, range:[?,?], keep order:false"
         ]
       },
       {
         "SQL": "SELECT /*+ TIDB_INLJ(t1, t2) */ * from t1, t2 where t1.a = t2.a and t1.c>1;",
         "Plan": [
           " IndexJoin_10       root inner join, inner:TableReader_9, outer key:test.t1.a, inner key:test.t2.a",
-          " ├─TableReader_19   root data:Selection_18",
-          " │ └─Selection_18   cop  gt(test.t1.c, ?)",
-          " │   └─TableScan_17 cop  table:t1, range:[?,?], keep order:false",
+          " ├─TableReader_30   root data:Selection_29",
+          " │ └─Selection_29   cop  gt(test.t1.c, ?)",
+          " │   └─TableScan_28 cop  table:t1, range:[?,?], keep order:false",
           " └─TableReader_9    root data:TableScan_8",
           "   └─TableScan_8    cop  table:t2, range: decided by [test.t1.a], keep order:false"
         ]


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/14022

### What is changed and how it works?
correct code logic in `tryToGetIndexJoin` regarding hint.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

- Possible performance regression: plan of TPC-H Q12 has changed, because I removed the logic of choosing smaller table as IndexJoin outer child in `tryToGetIndexJoin`. It was reasonable in old cost model since we only considered outer row count in cost computing of IndexJoin then, but this logic is out of date for the current cost model.

Related changes

N/A

Release note

 - Write release note for bug-fix or new feature.

Fix cases where TIDB_INLJ hint does not work when specifying smaller left table as inner table.
