### PR TITLE
store/tikv: fix a memory leak in the batchClient for the large transactions

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -400,6 +400,22 @@ func (b *batchCommandsEntry) isCanceled() bool {
 
 const idleTimeout = 3 * time.Minute
 
+func resetEntries(entries []*batchCommandsEntry) []*batchCommandsEntry {
+	for i := 0; i < len(entries); i++ {
+		entries[i] = nil
+	}
+	entries = entries[:0]
+	return entries
+}
+
+func resetRequests(requests []*tikvpb.BatchCommandsRequest_Request) []*tikvpb.BatchCommandsRequest_Request {
+	for i := 0; i < len(requests); i++ {
+		requests[i] = nil
+	}
+	requests = requests[:0]
+	return requests
+}
+
 func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 	defer func() {
 		if r := recover(); r != nil {
@@ -418,8 +434,12 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 
 	var bestBatchWaitSize = cfg.BatchWaitSize
 	for {
-		entries = entries[:0]
-		requests = requests[:0]
+		// NOTE: We can't simply set entries = entries[:0] here.
+		// The data in the cap part of the slice would reference the prewrite keys whose
+		// underlying memory is borrowed from memdb. The reference cause GC can't release
+		// the memdb, leading to serious memory leak problems in the large transaction case.
+		entries = resetEntries(entries)
+		requests = resetRequests(requests)
 		requestIDs = requestIDs[:0]
 
 		a.pendingRequests.Set(float64(len(a.batchCommandsCh)))


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a memory leak.

### What is changed and how it works?

Change `xxx = xxx[:0]` to some deep reset operation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

Run some large transactions severals and observe the heap pprof.

```
mysql> truncate table sbtest2;                                                                                                                                                                        Query OK, 0 rows affected (1.15 sec)

mysql> insert into sbtest2 select * from sbtest1 limit 15000000;                                                                                                                                      Query OK, 15000000 rows affected (4 min 48.79 sec)
Records: 15000000  Duplicates: 0  Warnings: 0

mysql> truncate sbtest2;
Query OK, 0 rows affected (1.15 sec)

mysql> insert into sbtest2 select * from sbtest1 limit 10000000;
Query OK, 10000000 rows affected (2 min 59.24 sec)
Records: 10000000  Duplicates: 0  Warnings: 0

mysql> truncate sbtest2;
Query OK, 0 rows affected (1.04 sec)

mysql> insert into sbtest2 select * from sbtest1 limit 5000000;
Query OK, 5000000 rows affected (1 min 30.57 sec)
Records: 5000000  Duplicates: 0  Warnings: 0
```


Side effects

 - Possible performance regression
 
Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
