### PR TITLE
 implement vectorized evaluation for `builtinCharSig`

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -550,6 +550,29 @@ func (g *dateTimeGener) gen() interface{} {
 	return t
 }
 
+// charInt64Gener is used to generate int which is equal to char's ascii
+type charInt64Gener struct{}
+
+func (g *charInt64Gener) gen() interface{} {
+	rand := time.Now().Nanosecond()
+	rand = rand % 128
+	return int64(rand)
+}
+
+// charsetStringGener is used to generate "ascii" or "gbk"
+type charsetStringGener struct{}
+
+func (g *charsetStringGener) gen() interface{} {
+	rand := time.Now().Nanosecond() % 3
+	if rand == 0 {
+		return "ascii"
+	}
+	if rand == 1 {
+		return "utf8"
+	}
+	return "gbk"
+}
+
 // dateTimeStrGener is used to generate strings which are dataTime format
 type dateTimeStrGener struct {
 	Fsp   int

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -26,6 +26,7 @@ import (
 
 var vecBuiltinCastCases = map[string][]vecExprBenchCase{
 	ast.Cast: {
+		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETDuration}},
 		{retEvalType: types.ETDecimal, childrenTypes: []types.EvalType{types.ETReal}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETInt}},
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETReal}},

--- a/expression/builtin_string_vec_test.go
+++ b/expression/builtin_string_vec_test.go
@@ -178,6 +178,13 @@ var vecBuiltinStringCases = map[string][]vecExprBenchCase{
 			childrenFieldTypes: []*types.FieldType{{Tp: mysql.TypeString, Flag: mysql.BinaryFlag, Collate: charset.CollationBin}},
 		},
 	},
+	ast.CharFunc: {
+		{
+			retEvalType:   types.ETString,
+			childrenTypes: []types.EvalType{types.ETInt, types.ETInt, types.ETString},
+			geners:        []dataGenerator{&charInt64Gener{}, &charInt64Gener{}, &charsetStringGener{}},
+		},
+	},
 	ast.BitLength: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString}},
 	},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
PCP #12106 
### What problem does this PR solve? <!--add issue link with summary if exists-->

 implement vectorized evaluation for `builtinCharSig`
### What is changed and how it works?

```BenchmarkVectorizedBuiltinStringFunc/builtinCharSig-VecBuiltinFunc-8                4639            241188 ns/op           22954 B/op       4097 allocs/op

BenchmarkVectorizedBuiltinStringFunc/builtinCharSig-NonVecBuiltinFunc-8             4228            272857 ns/op           22937 B/op       4096 allocs/op
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
