### PR TITLE
*: support read consistency isolation level in the pessimistic transactions

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -548,8 +548,8 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 }
 
 // UpdateForUpdateTS updates the ForUpdateTS, if newForUpdateTS is 0, it obtain a new TS from PD.
-func UpdateForUpdateTS(seCtx sessionctx.Context, newForUpdateTS uint64, couldSame bool) error {
-	if newForUpdateTS == 0 && couldSame {
+func UpdateForUpdateTS(seCtx sessionctx.Context, newForUpdateTS uint64, useFuture bool) error {
+	if newForUpdateTS == 0 && useFuture {
 		future, cachedTS := seCtx.GetSessionVars().TxnCtx.GetStmtFuture()
 		if cachedTS != 0 {
 			newForUpdateTS = cachedTS
@@ -573,7 +573,7 @@ func UpdateForUpdateTS(seCtx sessionctx.Context, newForUpdateTS uint64, couldSam
 		return err
 	}
 	seCtx.GetSessionVars().TxnCtx.SetForUpdateTS(newForUpdateTS)
-	txn.SetOption(kv.SnapshotTS, newForUpdateTS)
+	txn.SetOption(kv.SnapshotTS, seCtx.GetSessionVars().TxnCtx.GetForUpdateTS())
 	return nil
 }
 

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -904,7 +904,7 @@ func (e *Explain) prepareTaskDot(p PhysicalPlan, taskTp string, buffer *bytes.Bu
 //  2. session is not InTxn
 //  3. plan is point get by pk, or point get by unique index (no double read)
 func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bool, error) {
-	if !isAutoCommitTxn(ctx) {
+	if !IsAutoCommitTxn(ctx) {
 		return false, nil
 	}
 
@@ -930,15 +930,15 @@ func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bo
 	}
 }
 
-// isAutoCommitTxn checks if session is in autocommit mode and not InTxn
+// IsAutoCommitTxn checks if session is in autocommit mode and not InTxn
 // used for fast plan like point get
-func isAutoCommitTxn(ctx sessionctx.Context) bool {
+func IsAutoCommitTxn(ctx sessionctx.Context) bool {
 	return ctx.GetSessionVars().IsAutocommit() && !ctx.GetSessionVars().InTxn()
 }
 
 // IsPointUpdateByAutoCommit checks if plan p is point update and is in autocommit context
 func IsPointUpdateByAutoCommit(ctx sessionctx.Context, p Plan) (bool, error) {
-	if !isAutoCommitTxn(ctx) {
+	if !IsAutoCommitTxn(ctx) {
 		return false, nil
 	}
 

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -269,7 +269,7 @@ func (e *paramMarkerChecker) Leave(in ast.Node) (ast.Node, bool) {
 //  1. ctx is auto commit tagged.
 //  2. plan is point get by pk.
 func isPointGetWithoutDoubleRead(ctx sessionctx.Context, p plannercore.Plan) bool {
-	if !ctx.GetSessionVars().IsAutocommit() {
+	if !plannercore.IsAutoCommitTxn(ctx) {
 		return false
 	}
 

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -43,12 +43,12 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 	fp := plannercore.TryFastPlan(sctx, node)
 	if fp != nil {
 		if !isPointGetWithoutDoubleRead(sctx, fp) {
-			sctx.PrepareTxnFuture(ctx)
+			sctx.PrepareTSFuture(ctx)
 		}
 		return fp, fp.OutputNames(), nil
 	}
 
-	sctx.PrepareTxnFuture(ctx)
+	sctx.PrepareTSFuture(ctx)
 
 	bestPlan, names, _, err := optimize(ctx, sctx, node, is)
 	if err != nil {

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -758,3 +758,35 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeoutWaitStart(c *C) {
 	tk2.MustExec("rollback")
 	tk3.MustExec("commit")
 }
+
+func (s *testPessimisticSuite) TestPessimisticReadCommitted(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("use test")
+
+	tk.MustExec("set tidb_txn_mode = 'pessimistic'")
+	tk1.MustExec("set tidb_txn_mode = 'pessimistic'")
+	// tk.MustExec("set tx_isolation = 'READ-COMMITTED'")
+	// tk1.MustExec("set tx_isolation = 'READ-COMMITTED'")
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t(i int key);")
+	tk.MustExec("insert into t values (1);")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
+
+	tk.MustExec("begin;")
+	tk1.MustExec("begin;")
+	tk.MustExec("update t set i = -i;")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		tk1.MustExec("update t set i = -i;")
+		wg.Done()
+	}()
+	tk.MustExec("commit;")
+	wg.Wait()
+
+	tk1.MustExec("commit;")
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1964,7 +1964,7 @@ func (s *session) PrepareTSFuture(ctx context.Context) {
 		txnFuture := s.getTxnFuture(ctx)
 		s.txn.changeInvalidToPending(txnFuture)
 		s.GetSessionVars().TxnCtx.SetStmtFuture(txnFuture.future, 0)
-	} else if s.txn.IsPessimistic() {
+	} else if s.GetSessionVars().TxnCtx.IsPessimistic {
 		s.GetSessionVars().TxnCtx.SetStmtFuture(s.getTxnFuture(ctx).future, 0)
 	}
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -53,6 +53,8 @@ import (
 
 var _ = Suite(&testSessionSuite{})
 var _ = Suite(&testSessionSuite2{})
+var _ = Suite(&testSchemaSuite{})
+var _ = SerialSuites(&testSchemaSerialSuite{})
 var _ = SerialSuites(&testSessionSerialSuite{})
 
 type testSessionSuiteBase struct {
@@ -1745,9 +1747,6 @@ func (s *testSessionSuite2) TestInformationSchemaCreateTime(c *C) {
 	r := t1.Compare(t)
 	c.Assert(r, Equals, 1)
 }
-
-var _ = Suite(&testSchemaSuite{})
-var _ = SerialSuites(&testSchemaSerialSuite{})
 
 type testSchemaSuiteBase struct {
 	cluster   *mocktikv.Cluster

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -97,8 +97,8 @@ type Context interface {
 	ReleaseAllTableLocks()
 	// HasLockedTables uses to check whether this session locked any tables.
 	HasLockedTables() bool
-	// PrepareTxnFuture uses to prepare txn by future.
-	PrepareTxnFuture(ctx context.Context)
+	// PrepareTSFuture uses to prepare timestamp by future.
+	PrepareTSFuture(ctx context.Context)
 }
 
 type basicCtxType int

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -710,6 +710,7 @@ func (s *SessionVars) IsAutocommit() bool {
 	return s.GetStatusFlag(mysql.ServerStatusAutocommit)
 }
 
+// IsReadConsistencyTxn if true it means the transaction is an read consistency (read committed) transaction.
 func (s *SessionVars) IsReadConsistencyTxn() bool {
 	var isoLevel string
 	if s.TxnIsolationLevelOneShot.State == 2 {

--- a/store/mockstore/mocktikv/errors.go
+++ b/store/mockstore/mocktikv/errors.go
@@ -70,9 +70,10 @@ func (e ErrAlreadyCommitted) Error() string {
 
 // ErrConflict is returned when the commitTS of key in the DB is greater than startTS.
 type ErrConflict struct {
-	StartTS    uint64
-	ConflictTS uint64
-	Key        []byte
+	StartTS          uint64
+	ConflictTS       uint64
+	ConflictCommitTS uint64
+	Key              []byte
 }
 
 func (e *ErrConflict) Error() string {

--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -655,9 +655,10 @@ func checkConflictValue(iter *Iterator, m *kvrpcpb.Mutation, startTS uint64) err
 	// Note that it's a write conflict here, even if the value is a rollback one.
 	if dec.value.commitTS >= startTS {
 		return &ErrConflict{
-			StartTS:    startTS,
-			ConflictTS: dec.value.commitTS,
-			Key:        m.Key,
+			StartTS:          startTS,
+			ConflictTS:       dec.value.startTS,
+			ConflictCommitTS: dec.value.commitTS,
+			Key:              m.Key,
 		}
 	}
 

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -73,9 +73,10 @@ func convertToKeyError(err error) *kvrpcpb.KeyError {
 	if writeConflict, ok := errors.Cause(err).(*ErrConflict); ok {
 		return &kvrpcpb.KeyError{
 			Conflict: &kvrpcpb.WriteConflict{
-				Key:        writeConflict.Key,
-				ConflictTs: writeConflict.ConflictTS,
-				StartTs:    writeConflict.StartTS,
+				Key:              writeConflict.Key,
+				ConflictTs:       writeConflict.ConflictTS,
+				ConflictCommitTs: writeConflict.ConflictCommitTS,
+				StartTs:          writeConflict.StartTS,
 			},
 		}
 	}

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -247,8 +247,8 @@ func (c *Context) HasLockedTables() bool {
 	return false
 }
 
-// PrepareTxnFuture implements the sessionctx.Context interface.
-func (c *Context) PrepareTxnFuture(ctx context.Context) {
+// PrepareTSFuture implements the sessionctx.Context interface.
+func (c *Context) PrepareTSFuture(ctx context.Context) {
 }
 
 // Close implements the sessionctx.Context interface.


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB does not support Oracle like read consistency isolation level.

### What is changed and how it works?
Support read consistency isolation level in the pessimistic transactions.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
