### PR TITLE
executor: implement the CLUSTER_LOG retriever

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1292,6 +1292,13 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 				serverInfoTP: diagnosticspb.ServerInfoType_SystemInfo,
 			},
 		}
+	case strings.ToLower(infoschema.TableClusterLog):
+		e = &ClusterReaderExec{
+			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
+			retriever: &clusterLogRetriever{
+				extractor: v.Extractor.(*plannercore.ClusterLogTableExtractor),
+			},
+		}
 	default:
 		tb, _ := b.is.TableByID(v.Table.ID)
 		e = &TableScanExec{

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1272,24 +1272,24 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 		e = &ClusterReaderExec{
 			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 			retriever: &clusterServerInfoRetriever{
-				extractor:    v.Extractor.(*plannercore.ClusterTableExtractor),
-				serverInfoTP: diagnosticspb.ServerInfoType_LoadInfo,
+				extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
+				serverInfoType: diagnosticspb.ServerInfoType_LoadInfo,
 			},
 		}
 	case strings.ToLower(infoschema.TableClusterHardware):
 		e = &ClusterReaderExec{
 			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 			retriever: &clusterServerInfoRetriever{
-				extractor:    v.Extractor.(*plannercore.ClusterTableExtractor),
-				serverInfoTP: diagnosticspb.ServerInfoType_HardwareInfo,
+				extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
+				serverInfoType: diagnosticspb.ServerInfoType_HardwareInfo,
 			},
 		}
 	case strings.ToLower(infoschema.TableClusterSystemInfo):
 		e = &ClusterReaderExec{
 			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 			retriever: &clusterServerInfoRetriever{
-				extractor:    v.Extractor.(*plannercore.ClusterTableExtractor),
-				serverInfoTP: diagnosticspb.ServerInfoType_SystemInfo,
+				extractor:      v.Extractor.(*plannercore.ClusterTableExtractor),
+				serverInfoType: diagnosticspb.ServerInfoType_SystemInfo,
 			},
 		}
 	case strings.ToLower(infoschema.TableClusterLog):

--- a/executor/cluster_reader.go
+++ b/executor/cluster_reader.go
@@ -97,10 +97,18 @@ func (e *clusterConfigRetriever) retrieve(ctx sessionctx.Context) ([][]types.Dat
 		rows [][]types.Datum
 		err  error
 	}
-	serversInfo, err := getClusterServerInfoWithFilter(ctx, "mockClusterServerInfo", e.extractor.NodeTypes, e.extractor.Addresses)
+
+	serversInfo, err := infoschema.GetClusterServerInfo(ctx)
+	failpoint.Inject("mockClusterConfigServerInfo", func(val failpoint.Value) {
+		if s := val.(string); len(s) > 0 {
+			// erase the error
+			serversInfo, err = parseFailpointServerInfo(s), nil
+		}
+	})
 	if err != nil {
 		return nil, err
 	}
+	serversInfo = filterClusterServerInfo(serversInfo, e.extractor.NodeTypes, e.extractor.Addresses)
 
 	var finalRows [][]types.Datum
 	wg := sync.WaitGroup{}
@@ -200,21 +208,24 @@ func (e *clusterConfigRetriever) retrieve(ctx sessionctx.Context) ([][]types.Dat
 }
 
 type clusterServerInfoRetriever struct {
+	retrieved      bool
 	extractor      *plannercore.ClusterTableExtractor
 	serverInfoType diagnosticspb.ServerInfoType
 }
 
 // retrieve implements the clusterRetriever interface
 func (e *clusterServerInfoRetriever) retrieve(ctx sessionctx.Context) ([][]types.Datum, error) {
-	if e.extractor.SkipRequest {
+	if e.extractor.SkipRequest || e.retrieved {
 		return nil, nil
 	}
+	e.retrieved = true
 
-	infoTp := e.serverInfoType
-	serversInfo, err := getClusterServerInfoWithFilter(ctx, "mockClusterServerInfo", e.extractor.NodeTypes, e.extractor.Addresses)
+	serversInfo, err := infoschema.GetClusterServerInfo(ctx)
 	if err != nil {
 		return nil, err
 	}
+	serversInfo = filterClusterServerInfo(serversInfo, e.extractor.NodeTypes, e.extractor.Addresses)
+
 	type result struct {
 		idx  int
 		rows [][]types.Datum
@@ -223,6 +234,7 @@ func (e *clusterServerInfoRetriever) retrieve(ctx sessionctx.Context) ([][]types
 	wg := sync.WaitGroup{}
 	ch := make(chan result, len(serversInfo))
 	ipMap := make(map[string]struct{}, len(serversInfo))
+	infoTp := e.serverInfoType
 	finalRows := make([][]types.Datum, 0, len(serversInfo)*10)
 	for i, srv := range serversInfo {
 		address := srv.Address
@@ -319,42 +331,40 @@ func getServerInfoByGRPC(address string, tp diagnosticspb.ServerInfoType) ([]*di
 	return r.Items, nil
 }
 
-func getClusterServerInfoWithFilter(ctx sessionctx.Context, fpName string, nodeTypes, addresses set.StringSet) ([]infoschema.ServerInfo, error) {
-	serversInfo, err := infoschema.GetClusterServerInfo(ctx)
-	failpoint.Inject(fpName, func(val failpoint.Value) {
-		if s := val.(string); len(s) > 0 {
-			serversInfo = serversInfo[:0]
-			servers := strings.Split(s, ";")
-			for _, server := range servers {
-				parts := strings.Split(server, ",")
-				serversInfo = append(serversInfo, infoschema.ServerInfo{
-					ServerType: parts[0],
-					Address:    parts[1],
-					StatusAddr: parts[2],
-				})
-			}
-			// erase the error
-			err = nil
-		}
-	})
-	if err != nil {
-		return nil, err
+func parseFailpointServerInfo(s string) []infoschema.ServerInfo {
+	var serversInfo []infoschema.ServerInfo
+	servers := strings.Split(s, ";")
+	for _, server := range servers {
+		parts := strings.Split(server, ",")
+		serversInfo = append(serversInfo, infoschema.ServerInfo{
+			ServerType: parts[0],
+			Address:    parts[1],
+			StatusAddr: parts[2],
+		})
 	}
+	return serversInfo
+}
+
+func filterClusterServerInfo(serversInfo []infoschema.ServerInfo, nodeTypes, addresses set.StringSet) []infoschema.ServerInfo {
+	if len(nodeTypes) == 0 && len(addresses) == 0 {
+		return serversInfo
+	}
+
 	filterServers := make([]infoschema.ServerInfo, 0, len(serversInfo))
 	for _, srv := range serversInfo {
-		// Skip some node type which has been filtered in WHERE cluase
+		// Skip some node type which has been filtered in WHERE clause
 		// e.g: SELECT * FROM cluster_config WHERE type='tikv'
 		if len(nodeTypes) > 0 && !nodeTypes.Exist(srv.ServerType) {
 			continue
 		}
-		// Skip some node address which has been filtered in WHERE cluase
+		// Skip some node address which has been filtered in WHERE clause
 		// e.g: SELECT * FROM cluster_config WHERE address='192.16.8.12:2379'
 		if len(addresses) > 0 && !addresses.Exist(srv.Address) {
 			continue
 		}
 		filterServers = append(filterServers, srv)
 	}
-	return filterServers, nil
+	return filterServers
 }
 
 type clusterLogRetriever struct {
@@ -405,15 +415,21 @@ func (h *logResponseHeap) Pop() interface{} {
 
 func (e *clusterLogRetriever) startRetrieving(ctx sessionctx.Context) ([]chan logStreamResult, error) {
 	isFailpointTestMode := false
-	addresses := e.extractor.Addresses
-	nodeTypes := e.extractor.NodeTypes
-	serversInfo, err := getClusterServerInfoWithFilter(ctx, "mockClusterLogServerInfo", nodeTypes, addresses)
-	failpoint.Inject("mockClusterLogServerInfo", func() {
+	serversInfo, err := infoschema.GetClusterServerInfo(ctx)
+	failpoint.Inject("mockClusterLogServerInfo", func(val failpoint.Value) {
+		if s := val.(string); len(s) > 0 {
+			// erase the error
+			serversInfo, err = parseFailpointServerInfo(s), nil
+		}
 		isFailpointTestMode = true
 	})
 	if err != nil {
 		return nil, err
 	}
+
+	addresses := e.extractor.Addresses
+	nodeTypes := e.extractor.NodeTypes
+	serversInfo = filterClusterServerInfo(serversInfo, nodeTypes, addresses)
 
 	// gRPC options
 	opt := grpc.WithInsecure()

--- a/executor/cluster_reader.go
+++ b/executor/cluster_reader.go
@@ -469,17 +469,7 @@ func (e *clusterLogRetriever) startRetrieving(ctx sessionctx.Context) ([]chan lo
 	var results []chan logStreamResult
 	for _, srv := range serversInfo {
 		typ := srv.ServerType
-		// Skip some node type which has been filtered in WHERE cluase
-		// e.g: SELECT * FROM cluster_log WHERE type='tikv'
-		if len(nodeTypes) > 0 && !nodeTypes.Exist(typ) {
-			continue
-		}
 		address := srv.Address
-		// Skip some node address which has been filtered in WHERE cluase
-		// e.g: SELECT * FROM cluster_log WHERE address='192.16.8.12:2379'
-		if len(addresses) > 0 && !addresses.Exist(address) {
-			continue
-		}
 		statusAddr := srv.StatusAddr
 		if len(statusAddr) == 0 {
 			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("%s node %s does not contain status address", typ, address))

--- a/executor/cluster_reader_test.go
+++ b/executor/cluster_reader_test.go
@@ -106,7 +106,7 @@ func (s *testClusterReaderSuite) TestTiDBClusterConfig(c *C) {
 		}
 	}
 
-	fpName := "github.com/pingcap/tidb/executor/mockClusterServerInfo"
+	fpName := "github.com/pingcap/tidb/executor/mockClusterConfigServerInfo"
 	fpExpr := strings.Join(servers, ";")
 	c.Assert(failpoint.Enable(fpName, fmt.Sprintf(`return("%s")`, fpExpr)), IsNil)
 	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()

--- a/executor/cluster_reader_test.go
+++ b/executor/cluster_reader_test.go
@@ -15,18 +15,27 @@ package executor_test
 
 import (
 	"fmt"
+	"io/ioutil"
+	"log"
+	"net"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
+	"time"
 
 	"github.com/gorilla/mux"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/fn"
+	"github.com/pingcap/kvproto/pkg/diagnosticspb"
+	"github.com/pingcap/sysutil"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/pdapi"
 	"github.com/pingcap/tidb/util/testkit"
+	"google.golang.org/grpc"
 )
 
 type testClusterReaderSuite struct {
@@ -339,5 +348,442 @@ func (s *testClusterReaderSuite) TestTiDBClusterConfig(c *C) {
 		warnings := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
 		c.Assert(len(warnings), Equals, 0, Commentf("unexpected warnigns: %+v", warnings))
 		c.Assert(requestCounter, Equals, ca.reqCount, Commentf("SQL: %s", ca.sql))
+	}
+}
+
+func (s *testClusterReaderSuite) writeTmpFile(c *C, dir, filename string, lines []string) {
+	err := ioutil.WriteFile(filepath.Join(dir, filename), []byte(strings.Join(lines, "\n")), os.ModePerm)
+	c.Assert(err, IsNil, Commentf("write tmp file %s failed", filename))
+}
+
+func (s *testClusterReaderSuite) TestTiDBClusterLog(c *C) {
+	type testServer struct {
+		typ     string
+		server  *grpc.Server
+		address string
+		tmpDir  string
+		logFile string
+	}
+	// typ => testServer
+	testServers := map[string]*testServer{}
+
+	// create gRPC servers
+	for _, typ := range []string{"tidb", "tikv", "pd"} {
+		tmpDir, err := ioutil.TempDir("", typ)
+		c.Assert(err, IsNil)
+
+		server := grpc.NewServer()
+		logFile := filepath.Join(tmpDir, fmt.Sprintf("%s.log", typ))
+		diagnosticspb.RegisterDiagnosticsServer(server, sysutil.NewDiagnosticsServer(logFile))
+
+		// Find a available port
+		listener, err := net.Listen("tcp", ":0")
+		c.Assert(err, IsNil, Commentf("cannot find available port"))
+
+		testServers[typ] = &testServer{
+			typ:     typ,
+			server:  server,
+			address: fmt.Sprintf("127.0.0.1:%d", listener.Addr().(*net.TCPAddr).Port),
+			tmpDir:  tmpDir,
+			logFile: logFile,
+		}
+		go func() {
+			if err := server.Serve(listener); err != nil {
+				log.Fatalf("failed to serve: %v", err)
+			}
+		}()
+	}
+
+	defer func() {
+		for _, s := range testServers {
+			s.server.Stop()
+			c.Assert(os.RemoveAll(s.tmpDir), IsNil, Commentf("remove tmpDir %v failed", s.tmpDir))
+		}
+	}()
+
+	// time format of log file
+	var logtime = func(s string) string {
+		t, err := time.ParseInLocation("2006/01/02 15:04:05.000", s, time.Local)
+		c.Assert(err, IsNil)
+		return t.Format("[2006/01/02 15:04:05.000 -07:00]")
+	}
+
+	// time format of query output
+	var restime = func(s string) string {
+		t, err := time.ParseInLocation("2006/01/02 15:04:05.000", s, time.Local)
+		c.Assert(err, IsNil)
+		return t.Format("2006/01/02 15:04:05.000")
+	}
+
+	// prepare log files
+	// TiDB
+	s.writeTmpFile(c, testServers["tidb"].tmpDir, "tidb.log", []string{
+		logtime(`2019/08/26 06:19:13.011`) + ` [INFO] [test log message tidb 1, foo]`,
+		logtime(`2019/08/26 06:19:14.011`) + ` [DEBUG] [test log message tidb 2, foo]`,
+		logtime(`2019/08/26 06:19:15.011`) + ` [error] [test log message tidb 3, foo]`,
+		logtime(`2019/08/26 06:19:16.011`) + ` [trace] [test log message tidb 4, foo]`,
+		logtime(`2019/08/26 06:19:17.011`) + ` [CRITICAL] [test log message tidb 5, foo]`,
+	})
+	s.writeTmpFile(c, testServers["tidb"].tmpDir, "tidb.log.1", []string{
+		logtime(`2019/08/26 06:25:13.011`) + ` [info] [test log message tidb 10, bar]`,
+		logtime(`2019/08/26 06:25:14.011`) + ` [debug] [test log message tidb 11, bar]`,
+		logtime(`2019/08/26 06:25:15.011`) + ` [ERROR] [test log message tidb 12, bar]`,
+		logtime(`2019/08/26 06:25:16.011`) + ` [TRACE] [test log message tidb 13, bar]`,
+		logtime(`2019/08/26 06:25:17.011`) + ` [critical] [test log message tidb 14, bar]`,
+	})
+
+	// TiKV
+	s.writeTmpFile(c, testServers["tikv"].tmpDir, "tikv.log", []string{
+		logtime(`2019/08/26 06:19:13.011`) + ` [INFO] [test log message tikv 1, foo]`,
+		logtime(`2019/08/26 06:20:14.011`) + ` [DEBUG] [test log message tikv 2, foo]`,
+		logtime(`2019/08/26 06:21:15.011`) + ` [error] [test log message tikv 3, foo]`,
+		logtime(`2019/08/26 06:22:16.011`) + ` [trace] [test log message tikv 4, foo]`,
+		logtime(`2019/08/26 06:23:17.011`) + ` [CRITICAL] [test log message tikv 5, foo]`,
+	})
+	s.writeTmpFile(c, testServers["tikv"].tmpDir, "tikv.log.1", []string{
+		logtime(`2019/08/26 06:24:15.011`) + ` [info] [test log message tikv 10, bar]`,
+		logtime(`2019/08/26 06:25:16.011`) + ` [debug] [test log message tikv 11, bar]`,
+		logtime(`2019/08/26 06:26:17.011`) + ` [ERROR] [test log message tikv 12, bar]`,
+		logtime(`2019/08/26 06:27:18.011`) + ` [TRACE] [test log message tikv 13, bar]`,
+		logtime(`2019/08/26 06:28:19.011`) + ` [critical] [test log message tikv 14, bar]`,
+	})
+
+	// PD
+	s.writeTmpFile(c, testServers["pd"].tmpDir, "pd.log", []string{
+		logtime(`2019/08/26 06:18:13.011`) + ` [INFO] [test log message pd 1, foo]`,
+		logtime(`2019/08/26 06:19:14.011`) + ` [DEBUG] [test log message pd 2, foo]`,
+		logtime(`2019/08/26 06:20:15.011`) + ` [error] [test log message pd 3, foo]`,
+		logtime(`2019/08/26 06:21:16.011`) + ` [trace] [test log message pd 4, foo]`,
+		logtime(`2019/08/26 06:22:17.011`) + ` [CRITICAL] [test log message pd 5, foo]`,
+	})
+	s.writeTmpFile(c, testServers["pd"].tmpDir, "pd.log.1", []string{
+		logtime(`2019/08/26 06:23:13.011`) + ` [info] [test log message pd 10, bar]`,
+		logtime(`2019/08/26 06:24:14.011`) + ` [debug] [test log message pd 11, bar]`,
+		logtime(`2019/08/26 06:25:15.011`) + ` [ERROR] [test log message pd 12, bar]`,
+		logtime(`2019/08/26 06:26:16.011`) + ` [TRACE] [test log message pd 13, bar]`,
+		logtime(`2019/08/26 06:27:17.011`) + ` [critical] [test log message pd 14, bar]`,
+	})
+
+	fullLogs := [][]string{
+		{"2019/08/26 06:18:13.011", "pd", "INFO", "[test log message pd 1, foo]"},
+		{"2019/08/26 06:19:13.011", "tidb", "INFO", "[test log message tidb 1, foo]"},
+		{"2019/08/26 06:19:13.011", "tikv", "INFO", "[test log message tikv 1, foo]"},
+		{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+		{"2019/08/26 06:19:14.011", "tidb", "DEBUG", "[test log message tidb 2, foo]"},
+		{"2019/08/26 06:19:15.011", "tidb", "error", "[test log message tidb 3, foo]"},
+		{"2019/08/26 06:19:16.011", "tidb", "trace", "[test log message tidb 4, foo]"},
+		{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+		{"2019/08/26 06:20:14.011", "tikv", "DEBUG", "[test log message tikv 2, foo]"},
+		{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+		{"2019/08/26 06:21:15.011", "tikv", "error", "[test log message tikv 3, foo]"},
+		{"2019/08/26 06:21:16.011", "pd", "trace", "[test log message pd 4, foo]"},
+		{"2019/08/26 06:22:16.011", "tikv", "trace", "[test log message tikv 4, foo]"},
+		{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+		{"2019/08/26 06:23:13.011", "pd", "info", "[test log message pd 10, bar]"},
+		{"2019/08/26 06:23:17.011", "tikv", "CRITICAL", "[test log message tikv 5, foo]"},
+		{"2019/08/26 06:24:14.011", "pd", "debug", "[test log message pd 11, bar]"},
+		{"2019/08/26 06:24:15.011", "tikv", "info", "[test log message tikv 10, bar]"},
+		{"2019/08/26 06:25:13.011", "tidb", "info", "[test log message tidb 10, bar]"},
+		{"2019/08/26 06:25:14.011", "tidb", "debug", "[test log message tidb 11, bar]"},
+		{"2019/08/26 06:25:15.011", "pd", "ERROR", "[test log message pd 12, bar]"},
+		{"2019/08/26 06:25:15.011", "tidb", "ERROR", "[test log message tidb 12, bar]"},
+		{"2019/08/26 06:25:16.011", "tidb", "TRACE", "[test log message tidb 13, bar]"},
+		{"2019/08/26 06:25:16.011", "tikv", "debug", "[test log message tikv 11, bar]"},
+		{"2019/08/26 06:25:17.011", "tidb", "critical", "[test log message tidb 14, bar]"},
+		{"2019/08/26 06:26:16.011", "pd", "TRACE", "[test log message pd 13, bar]"},
+		{"2019/08/26 06:26:17.011", "tikv", "ERROR", "[test log message tikv 12, bar]"},
+		{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+		{"2019/08/26 06:27:18.011", "tikv", "TRACE", "[test log message tikv 13, bar]"},
+		{"2019/08/26 06:28:19.011", "tikv", "critical", "[test log message tikv 14, bar]"},
+	}
+
+	var cases = []struct {
+		conditions []string
+		expected   [][]string
+	}{
+		// all log items
+		{
+			conditions: []string{},
+			expected:   fullLogs,
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+			},
+			expected: fullLogs,
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+				"time<='2019/08/26 06:28:19.011'",
+			},
+			expected: fullLogs,
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+				"time<='2099/08/26 06:28:19.011'",
+			},
+			expected: fullLogs,
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tidb", "INFO", "[test log message tidb 1, foo]"},
+				{"2019/08/26 06:19:13.011", "tikv", "INFO", "[test log message tikv 1, foo]"},
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+				{"2019/08/26 06:19:14.011", "tidb", "DEBUG", "[test log message tidb 2, foo]"},
+				{"2019/08/26 06:19:15.011", "tidb", "error", "[test log message tidb 3, foo]"},
+				{"2019/08/26 06:19:16.011", "tidb", "trace", "[test log message tidb 4, foo]"},
+				{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+				{"2019/08/26 06:20:14.011", "tikv", "DEBUG", "[test log message tikv 2, foo]"},
+				{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+				{"2019/08/26 06:21:15.011", "tikv", "error", "[test log message tikv 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				"type='pd'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+				{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+				"time>='2019/08/26 06:19:13.011'",
+				"time>='2019/08/26 06:19:14.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				"type='pd'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+				{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:18:13.011'",
+				"time>='2019/08/26 06:19:13.011'",
+				"time='2019/08/26 06:19:14.011'",
+				"type='pd'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				"type='tidb'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tidb", "INFO", "[test log message tidb 1, foo]"},
+				{"2019/08/26 06:19:14.011", "tidb", "DEBUG", "[test log message tidb 2, foo]"},
+				{"2019/08/26 06:19:15.011", "tidb", "error", "[test log message tidb 3, foo]"},
+				{"2019/08/26 06:19:16.011", "tidb", "trace", "[test log message tidb 4, foo]"},
+				{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				"type='tikv'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tikv", "INFO", "[test log message tikv 1, foo]"},
+				{"2019/08/26 06:20:14.011", "tikv", "DEBUG", "[test log message tikv 2, foo]"},
+				{"2019/08/26 06:21:15.011", "tikv", "error", "[test log message tikv 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				fmt.Sprintf("address='%s'", testServers["pd"].address),
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+				{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				fmt.Sprintf("address='%s'", testServers["tidb"].address),
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tidb", "INFO", "[test log message tidb 1, foo]"},
+				{"2019/08/26 06:19:14.011", "tidb", "DEBUG", "[test log message tidb 2, foo]"},
+				{"2019/08/26 06:19:15.011", "tidb", "error", "[test log message tidb 3, foo]"},
+				{"2019/08/26 06:19:16.011", "tidb", "trace", "[test log message tidb 4, foo]"},
+				{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				fmt.Sprintf("address='%s'", testServers["tikv"].address),
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tikv", "INFO", "[test log message tikv 1, foo]"},
+				{"2019/08/26 06:20:14.011", "tikv", "DEBUG", "[test log message tikv 2, foo]"},
+				{"2019/08/26 06:21:15.011", "tikv", "error", "[test log message tikv 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"time>='2019/08/26 06:19:13.011'",
+				"time<='2019/08/26 06:21:15.011'",
+				fmt.Sprintf("address in ('%s', '%s')", testServers["pd"].address, testServers["tidb"].address),
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:13.011", "tidb", "INFO", "[test log message tidb 1, foo]"},
+				{"2019/08/26 06:19:14.011", "pd", "DEBUG", "[test log message pd 2, foo]"},
+				{"2019/08/26 06:19:14.011", "tidb", "DEBUG", "[test log message tidb 2, foo]"},
+				{"2019/08/26 06:19:15.011", "tidb", "error", "[test log message tidb 3, foo]"},
+				{"2019/08/26 06:19:16.011", "tidb", "trace", "[test log message tidb 4, foo]"},
+				{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+				{"2019/08/26 06:20:15.011", "pd", "error", "[test log message pd 3, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:19:17.011", "tidb", "CRITICAL", "[test log message tidb 5, foo]"},
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+				{"2019/08/26 06:23:17.011", "tikv", "CRITICAL", "[test log message tikv 5, foo]"},
+				{"2019/08/26 06:25:17.011", "tidb", "critical", "[test log message tidb 14, bar]"},
+				{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+				{"2019/08/26 06:28:19.011", "tikv", "critical", "[test log message tikv 14, bar]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"type in ('pd', 'tikv')",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+				{"2019/08/26 06:23:17.011", "tikv", "CRITICAL", "[test log message tikv 5, foo]"},
+				{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+				{"2019/08/26 06:28:19.011", "tikv", "critical", "[test log message tikv 14, bar]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"(type='pd' or type='tikv')",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+				{"2019/08/26 06:23:17.011", "tikv", "CRITICAL", "[test log message tikv 5, foo]"},
+				{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+				{"2019/08/26 06:28:19.011", "tikv", "critical", "[test log message tikv 14, bar]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message like '%pd%'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+				{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message like '%pd%'",
+				"message like '%5%'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message like '%pd%'",
+				"message like '%5%'",
+				"message like '%x%'",
+			},
+			expected: [][]string{},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message regexp '.*pd.*'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+				{"2019/08/26 06:27:17.011", "pd", "critical", "[test log message pd 14, bar]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message regexp '.*pd.*'",
+				"message regexp '.*foo]$'",
+			},
+			expected: [][]string{
+				{"2019/08/26 06:22:17.011", "pd", "CRITICAL", "[test log message pd 5, foo]"},
+			},
+		},
+		{
+			conditions: []string{
+				"level='critical'",
+				"message regexp '.*pd.*'",
+				"message regexp '.*5.*'",
+				"message regexp '.*x.*'",
+			},
+			expected: [][]string{},
+		},
+	}
+
+	var servers []string
+	for _, s := range testServers {
+		servers = append(servers, strings.Join([]string{s.typ, s.address, s.address}, ","))
+	}
+	fpName := "github.com/pingcap/tidb/executor/mockClusterLogServerInfo"
+	fpExpr := strings.Join(servers, ";")
+	c.Assert(failpoint.Enable(fpName, fmt.Sprintf(`return("%s")`, fpExpr)), IsNil)
+	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
+
+	tk := testkit.NewTestKit(c, s.store)
+	for _, cas := range cases {
+		sql := "select * from information_schema.cluster_log"
+		if len(cas.conditions) > 0 {
+			sql = fmt.Sprintf("%s where %s", sql, strings.Join(cas.conditions, " and "))
+		}
+		result := tk.MustQuery(sql)
+		warnings := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+		c.Assert(len(warnings), Equals, 0, Commentf("unexpected warnigns: %+v", warnings))
+		var expected []string
+		for _, row := range cas.expected {
+			expectedRow := []string{
+				restime(row[0]),             // time column
+				row[1],                      // type column
+				testServers[row[1]].address, // address column
+				strings.ToUpper(sysutil.ParseLogLevel(row[2]).String()), // level column
+				row[3], // message column
+			}
+			expected = append(expected, strings.Join(expectedRow, " "))
+		}
+		result.Check(testkit.Rows(expected...))
 	}
 }

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,7 @@ github.com/opentracing/opentracing-go v1.0.2 h1:3jA2P6O1F9UOrWVpwrIo17pu01KWvNWg
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
 github.com/pelletier/go-toml v1.3.0/go.mod h1:PN7xzY2wHTK0K9p34ErDQMlFxa51Fk0OUruD3k1mMwo=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
+github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12 h1:rfD9v3+ppLPzoQBgZev0qYCpegrwyFx/BUpkApEiKdY=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/errcode v0.0.0-20180921232412-a1a7271709d9 h1:KH4f4Si9XK6/IW50HtoaiLIFHGkapOM6w83za47UYik=

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -90,7 +90,7 @@ type testClusterTableSuite struct {
 func (s *testClusterTableSuite) SetUpSuite(c *C) {
 	s.testTableSuite.SetUpSuite(c)
 	s.rpcserver, s.listenAddr = s.setUpRPCService(c, ":0")
-	s.httpServer, s.mockAddr = setUpMockPDHTTPSercer()
+	s.httpServer, s.mockAddr = s.setUpMockPDHTTPServer()
 }
 
 func (s *testClusterTableSuite) setUpRPCService(c *C, addr string) (*grpc.Server, string) {
@@ -105,7 +105,7 @@ func (s *testClusterTableSuite) setUpRPCService(c *C, addr string) (*grpc.Server
 		Command: mysql.ComQuery,
 	}
 	srv := server.NewRPCServer(config.GetGlobalConfig(), s.dom, sm)
-	addr = fmt.Sprintf(":%d", lis.Addr().(*net.TCPAddr).Port)
+	addr = fmt.Sprintf("127.0.0.1:%d", lis.Addr().(*net.TCPAddr).Port)
 	go func() {
 		err = srv.Serve(lis)
 		c.Assert(err, IsNil)
@@ -113,7 +113,7 @@ func (s *testClusterTableSuite) setUpRPCService(c *C, addr string) (*grpc.Server
 	return srv, addr
 }
 
-func setUpMockPDHTTPSercer() (*httptest.Server, string) {
+func (s *testClusterTableSuite) setUpMockPDHTTPServer() (*httptest.Server, string) {
 	// mock PD http server
 	router := mux.NewRouter()
 	server := httptest.NewServer(router)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- [x] merge  https://github.com/pingcap/tidb/pull/14018 first

This PR is the subsequent task of https://github.com/pingcap/tidb/pull/14018 and part of issue #13567.

### What is changed and how it works?

Implement the `ClusterLogRetriver`, which is used to search cluster log via SQL.

e.g:
1. Search all `DDL` related log: `select * from cluster_log where message like '%ddl%'` or  `select * from cluster_log where message regexp '.*ddl.*'`
2. Filter log by level: `select * from cluster_log where level='info'`.
3. Search log between time range: `select * from cluster_log where time > '2019-10-14 15:30:39'` and time < '2019-10-19 15:30:39'`.
4. Select log in target cluster component type: `select * from cluster_log where type='tikv'`
5. Select log in target address: `select * from cluster_log where address='192.168.15.2' or  address='192.168.15.2'` or `select * from cluster_log where address in ('192.168.15.2', '192.168.15.2')`.

All the above-mentioned predicates will be pushed down to the memory table to eliminate the log search request amount. e.g: `select * from cluster_log where address in ('192.168.15.2', '192.168.15.2')` only send requests to `'192.168.15.2', '192.168.15.2'` instead of all cluster nodes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test
```
mysql> select * from cluster_log where type='pd' and level='warn' and message like '%';
+-------------------------+------+-----------------+-------+---------------------------------------------------------------------------------------------------------------------------+
| TIME                    | TYPE | ADDRESS         | LEVEL | MESSAGE                                                                                                                   |
+-------------------------+------+-----------------+-------+---------------------------------------------------------------------------------------------------------------------------+
| 2019/12/16 16:28:28.357 | pd   | 127.0.0.1:49901 | Warn  | [store.go:1288] ["simple token is not cryptographically signed"]                                                          |
| 2019/12/16 16:28:29.852 | pd   | 127.0.0.1:49901 | Warn  | [history_buffer.go:138] ["load history index failed"] [error="leveldb: not found"]                                        |
| 2019/12/16 16:29:03.773 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283320320] |
| 2019/12/16 16:29:13.774 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:29:23.775 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:29:33.776 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:29:43.777 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:29:53.778 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:30:03.779 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:30:13.780 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283267072] |
| 2019/12/16 16:30:23.781 | pd   | 127.0.0.1:49901 | Warn  | [cluster.go:383] ["store does not have enough disk space"] [store-id=1] [capacity=1574498656256] [available=280283262976] |
+-------------------------+------+-----------------+-------+---------------------------------------------------------------------------------------------------------------------------+
11 rows in set (0.00 sec)
```

```
mysql> select * from cluster_log where type='pd' and message like '%scheduler%' and message regexp '.*coordinator.*';
+-------------------------+------+-----------------+-------+-----------------------------------------------------------------------------------------+
| TIME                    | TYPE | ADDRESS         | LEVEL | MESSAGE                                                                                 |
+-------------------------+------+-----------------+-------+-----------------------------------------------------------------------------------------+
| 2019/12/16 16:28:56.764 | pd   | 127.0.0.1:49901 | Info  | [coordinator.go:172] ["coordinator starts to run schedulers"]                           |
| 2019/12/16 16:28:56.765 | pd   | 127.0.0.1:49901 | Info  | [coordinator.go:236] ["create scheduler"] [scheduler-name=balance-region-scheduler]     |
| 2019/12/16 16:28:56.766 | pd   | 127.0.0.1:49901 | Info  | [coordinator.go:236] ["create scheduler"] [scheduler-name=balance-leader-scheduler]     |
| 2019/12/16 16:28:56.766 | pd   | 127.0.0.1:49901 | Info  | [coordinator.go:236] ["create scheduler"] [scheduler-name=balance-hot-region-scheduler] |
| 2019/12/16 16:28:56.767 | pd   | 127.0.0.1:49901 | Info  | [coordinator.go:236] ["create scheduler"] [scheduler-name=label-scheduler]              |
+-------------------------+------+-----------------+-------+-----------------------------------------------------------------------------------------+
5 rows in set (0.01 sec)
```

Release note

 - Support search log via SQL, e.g: `SELECT * FROM cluster_log WHERE level='debug' AND message REGEXP '.*coprocessor.*'`
