### PR TITLE
*: lock unchanged rows for pessimistic transaction (#14045)

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -451,6 +451,7 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 		if err1 != nil {
 			return err1
 		}
+		keys = txnCtx.CollectUnchangedRowKeys(keys)
 		if len(keys) == 0 {
 			return nil
 		}

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -359,23 +359,24 @@ func (s *testPessimisticSuite) TestLockUnchangedRowKey(c *C) {
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("update unchanged set c = 1 where id < 2")
 
+	tk2.Se.GetSessionVars().LockWaitTimeout = 1
 	tk2.MustExec("begin pessimistic")
-	err := tk2.ExecToErr("select * from unchanged where id = 1 for update nowait")
+	err := tk2.ExecToErr("select * from unchanged where id = 1 for update")
 	c.Assert(err, NotNil)
 
 	tk.MustExec("rollback")
 
-	tk2.MustQuery("select * from unchanged where id = 1 for update nowait")
+	tk2.MustQuery("select * from unchanged where id = 1 for update")
 
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("insert unchanged values (2, 2) on duplicate key update c = values(c)")
 
-	err = tk2.ExecToErr("select * from unchanged where id = 2 for update nowait")
+	err = tk2.ExecToErr("select * from unchanged where id = 2 for update")
 	c.Assert(err, NotNil)
 
 	tk.MustExec("commit")
 
-	tk2.MustQuery("select * from unchanged where id = 1 for update nowait")
+	tk2.MustQuery("select * from unchanged where id = 1 for update")
 	tk2.MustExec("rollback")
 }
 

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -349,6 +349,36 @@ func (s *testPessimisticSuite) TestBankTransfer(c *C) {
 	tk.MustQuery("select sum(c) from accounts").Check(testkit.Rows("300"))
 }
 
+func (s *testPessimisticSuite) TestLockUnchangedRowKey(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists unchanged")
+	tk.MustExec("create table unchanged (id int primary key, c int)")
+	tk.MustExec("insert unchanged values (1, 1), (2, 2)")
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("update unchanged set c = 1 where id < 2")
+
+	tk2.MustExec("begin pessimistic")
+	err := tk2.ExecToErr("select * from unchanged where id = 1 for update nowait")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("rollback")
+
+	tk2.MustQuery("select * from unchanged where id = 1 for update nowait")
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert unchanged values (2, 2) on duplicate key update c = values(c)")
+
+	err = tk2.ExecToErr("select * from unchanged where id = 2 for update nowait")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("commit")
+
+	tk2.MustQuery("select * from unchanged where id = 1 for update nowait")
+	tk2.MustExec("rollback")
+}
+
 func (s *testPessimisticSuite) TestOptimisticConflicts(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)


### PR DESCRIPTION
cherry-pick #14045 to release-3.0

---


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The pessimistic lock is not acquired if a row is unchanged.

### What is changed and how it works?
Add the unchanged row key to TxnCtx, later collect them before calling LockKeys.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the issue that unchanged rows are not locked for a pessimistic transaction.
