### PR TITLE
executor: correctly handle panic for hashjoin build phase

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -672,13 +672,15 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 	if err != nil {
 		e.buildFinished <- errors.Trace(err)
 		close(doneCh)
+		doneCh = nil
 	}
 	// Wait fetchBuildSideRows be finished.
 	// 1. if buildHashTableForList fails
 	// 2. if probeSideResult.NumRows() == 0, fetchProbeSideChunks will not wait for the build side.
 	for range buildSideResultCh {
 	}
-	if err = <-fetchBuildSideRowsOk; err != nil {
+	// Check whether doneCh is nil to avoid sending redundant error into buildFinished.
+	if err = <-fetchBuildSideRowsOk; doneCh != nil && err != nil {
 		e.buildFinished <- err
 	}
 }

--- a/executor/join.go
+++ b/executor/join.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
@@ -247,6 +248,7 @@ func (e *HashJoinExec) fetchBuildSideRows(ctx context.Context, chkCh chan<- *chu
 			e.buildFinished <- errors.Trace(err)
 			return
 		}
+		failpoint.Inject("errorFetchBuildSideRowsMockOOMPanic", nil)
 		if chk.NumRows() == 0 {
 			return
 		}
@@ -654,7 +656,16 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 	// buildSideResultCh transfers build side chunk from build side fetch to build hash table.
 	buildSideResultCh := make(chan *chunk.Chunk, 1)
 	doneCh := make(chan struct{})
-	go util.WithRecovery(func() { e.fetchBuildSideRows(ctx, buildSideResultCh, doneCh) }, nil)
+	fetchBuildSideRowsOk := make(chan error, 1)
+	go util.WithRecovery(
+		func() { e.fetchBuildSideRows(ctx, buildSideResultCh, doneCh) },
+		func(r interface{}) {
+			if r != nil {
+				fetchBuildSideRowsOk <- errors.Errorf("%v", r)
+			}
+			close(fetchBuildSideRowsOk)
+		},
+	)
 
 	// TODO: Parallel build hash table. Currently not support because `rowHashMap` is not thread-safe.
 	err := e.buildHashTableForList(buildSideResultCh)
@@ -666,6 +677,9 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 	// 1. if buildHashTableForList fails
 	// 2. if probeSideResult.NumRows() == 0, fetchProbeSideChunks will not wait for the build side.
 	for range buildSideResultCh {
+	}
+	if err = <-fetchBuildSideRowsOk; err != nil {
+		e.buildFinished <- err
 	}
 }
 

--- a/executor/join.go
+++ b/executor/join.go
@@ -672,16 +672,17 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 	if err != nil {
 		e.buildFinished <- errors.Trace(err)
 		close(doneCh)
-		doneCh = nil
 	}
 	// Wait fetchBuildSideRows be finished.
 	// 1. if buildHashTableForList fails
 	// 2. if probeSideResult.NumRows() == 0, fetchProbeSideChunks will not wait for the build side.
 	for range buildSideResultCh {
 	}
-	// Check whether doneCh is nil to avoid sending redundant error into buildFinished.
-	if err = <-fetchBuildSideRowsOk; doneCh != nil && err != nil {
-		e.buildFinished <- err
+	// Check whether err is nil to avoid sending redundant error into buildFinished.
+	if err == nil {
+		if err = <-fetchBuildSideRowsOk; err != nil {
+			e.buildFinished <- err
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/14027

### What is changed and how it works?
handle the panic when OOM during build a hash table

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch
3.0.5

Release note

 - correctly output OOM errors when building a hash table
