### PR TITLE
*: fix the wrong check for key-need-lock of pessimistic transaction

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -758,3 +758,33 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeoutWaitStart(c *C) {
 	tk2.MustExec("rollback")
 	tk3.MustExec("commit")
 }
+
+func (s *testPessimisticSuite) TestPessimisticReadCommitted(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test")
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("use test")
+
+	tk.MustExec("set tidb_txn_mode = 'pessimistic'")
+	tk1.MustExec("set tidb_txn_mode = 'pessimistic'")
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t(i int key);")
+	tk.MustExec("insert into t values (1);")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
+
+	tk.MustExec("begin;")
+	tk1.MustExec("begin;")
+	tk.MustExec("update t set i = -i;")
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		tk1.MustExec("update t set i = -i;")
+		wg.Done()
+	}()
+	tk.MustExec("commit;")
+	wg.Wait()
+
+	tk1.MustExec("commit;")
+}

--- a/session/txn.go
+++ b/session/txn.go
@@ -349,7 +349,7 @@ func keyNeedToLock(k, v []byte) bool {
 	if tablecodec.IsUntouchedIndexKValue(k, v) {
 		return false
 	}
-	isNonUniqueIndex := len(v) == 1
+	isNonUniqueIndex := tablecodec.IsIndexKey(k) && len(v) == 1
 	// Put row key and unique index need to lock.
 	return !isNonUniqueIndex
 }

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -678,11 +678,16 @@ func GenTableIndexPrefix(tableID int64) kv.Key {
 	return appendTableIndexPrefix(buf, tableID)
 }
 
+// IsIndexKey is used to check whether the key is an index key.
+func IsIndexKey(k []byte) bool {
+	return len(k) > 11 && k[0] == 't' && k[10] == 'i'
+}
+
 // IsUntouchedIndexKValue uses to check whether the key is index key, and the value is untouched,
 // since the untouched index key/value is no need to commit.
 func IsUntouchedIndexKValue(k, v []byte) bool {
 	vLen := len(v)
-	return (len(k) > 11 && k[0] == 't' && k[10] == 'i') &&
+	return IsIndexKey(k) &&
 		((vLen == 1 || vLen == 9) && v[vLen-1] == kv.UnCommitIndexKVFlag)
 }
 


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The pessimistic transaction does not lock the key if it is a table key with only one column and the column is the primary key with type int. See the test case for more details.

### What is changed and how it works?
Verify the key is an index key first and then check it is a unique index or not.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
