### PR TITLE
expression: implement vectorized evaluation for `SubXXXAndYYY`

### DIFF
--- a/expression/builtin_time_vec_generated_test.go
+++ b/expression/builtin_time_vec_generated_test.go
@@ -48,7 +48,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 	ast.AddTime: {
 		// builtinAddDatetimeAndDurationSig
 		{
-			retEvalType:   types.ETDatetime,
+			retEvalType: types.ETDatetime,
+
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDuration},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
@@ -57,7 +58,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddDatetimeAndStringSig
 		{
-			retEvalType:   types.ETDatetime,
+			retEvalType: types.ETDatetime,
+
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
@@ -66,7 +68,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddDurationAndDurationSig
 		{
-			retEvalType:   types.ETDuration,
+			retEvalType: types.ETDuration,
+
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETDuration},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
@@ -75,7 +78,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddDurationAndStringSig
 		{
-			retEvalType:   types.ETDuration,
+			retEvalType: types.ETDuration,
+
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETString},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
@@ -84,7 +88,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddStringAndDurationSig
 		{
-			retEvalType:   types.ETString,
+			retEvalType: types.ETString,
+
 			childrenTypes: []types.EvalType{types.ETString, types.ETDuration},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
@@ -93,7 +98,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddStringAndStringSig
 		{
-			retEvalType:   types.ETString,
+			retEvalType: types.ETString,
+
 			childrenTypes: []types.EvalType{types.ETString, types.ETString},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
@@ -102,7 +108,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddDateAndDurationSig
 		{
-			retEvalType:        types.ETString,
+			retEvalType: types.ETString,
+
 			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDuration},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDuration)},
 			geners: []dataGenerator{
@@ -112,7 +119,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddDateAndStringSig
 		{
-			retEvalType:        types.ETString,
+			retEvalType: types.ETString,
+
 			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETString},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeString)},
 			geners: []dataGenerator{
@@ -122,7 +130,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddTimeDateTimeNullSig
 		{
-			retEvalType:   types.ETDatetime,
+			retEvalType: types.ETDatetime,
+
 			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDatetime},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
@@ -131,7 +140,8 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddTimeStringNullSig
 		{
-			retEvalType:        types.ETString,
+			retEvalType: types.ETString,
+
 			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
 			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
 			geners: []dataGenerator{
@@ -141,7 +151,124 @@ var vecBuiltinTimeGeneratedCases = map[string][]vecExprBenchCase{
 		},
 		// builtinAddTimeDurationNullSig
 		{
-			retEvalType:   types.ETDuration,
+			retEvalType: types.ETDuration,
+
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDatetime},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+			},
+		},
+	},
+
+	ast.SubTime: {
+		// builtinSubDatetimeAndDurationSig
+		{
+			retEvalType: types.ETDatetime,
+
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDuration},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
+		// builtinSubDatetimeAndStringSig
+		{
+			retEvalType: types.ETDatetime,
+
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETString},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+			},
+		},
+		// builtinSubDurationAndDurationSig
+		{
+			retEvalType: types.ETDuration,
+
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETDuration},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
+		// builtinSubDurationAndStringSig
+		{
+			retEvalType: types.ETDuration,
+
+			childrenTypes: []types.EvalType{types.ETDuration, types.ETString},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+			},
+		},
+		// builtinSubStringAndDurationSig
+		{
+			retEvalType: types.ETString,
+
+			childrenTypes: []types.EvalType{types.ETString, types.ETDuration},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
+		// builtinSubStringAndStringSig
+		{
+			retEvalType: types.ETString,
+
+			childrenTypes: []types.EvalType{types.ETString, types.ETString},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+			},
+		},
+		// builtinSubDateAndDurationSig
+		{
+			retEvalType: types.ETString,
+
+			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDuration},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDuration)},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},
+			},
+		},
+		// builtinSubDateAndStringSig
+		{
+			retEvalType: types.ETString,
+
+			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETString},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeString)},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETString, nullRation: 0.2}},
+			},
+		},
+		// builtinSubTimeDateTimeNullSig
+		{
+			retEvalType: types.ETDatetime,
+
+			childrenTypes: []types.EvalType{types.ETDatetime, types.ETDatetime},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+			},
+		},
+		// builtinSubTimeStringNullSig
+		{
+			retEvalType: types.ETString,
+
+			childrenTypes:      []types.EvalType{types.ETDatetime, types.ETDatetime},
+			childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
+			geners: []dataGenerator{
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+			},
+		},
+		// builtinSubTimeDurationNullSig
+		{
+			retEvalType: types.ETDuration,
+
 			childrenTypes: []types.EvalType{types.ETDuration, types.ETDatetime},
 			geners: []dataGenerator{
 				gener{defaultGener{eType: types.ETDuration, nullRation: 0.2}},

--- a/expression/generator/time_vec.go
+++ b/expression/generator/time_vec.go
@@ -26,7 +26,9 @@ import (
 	. "github.com/pingcap/tidb/expression/generator/helper"
 )
 
-var addTime = template.Must(template.New("").Parse(`// Copyright 2019 PingCAP, Inc.
+var addOrSubTime = template.Must(template.New("").Parse(`
+{{ if eq $.FuncName "AddTime" }}
+// Copyright 2019 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -49,10 +51,10 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 )
-
+{{ end }}
 {{ define "SetNull" }}{{if .Output.Fixed}}result.SetNull(i, true){{else}}result.AppendNull(){{end}} // fixed: {{.Output.Fixed }}{{ end }}
 {{ define "ConvertStringToDuration" }}
-		{{ if ne .SigName "builtinAddStringAndStringSig" }}
+		{{ if (and (eq .TypeA.TypeName "String") (eq .TypeB.TypeName "String")) }}
 		if !isDuration(arg1) {
 			{{ template "SetNull" . }}
 			continue
@@ -68,27 +70,8 @@ import (
 			return err
 		}
 {{ end }}
-{{ define "strDurationAddDuration" }}
-		var output string
-		if isDuration(arg0) {
-			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
-			if err != nil {
-				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
-					sc.AppendWarning(err)
-					{{ template "SetNull" . }}
-					continue
-				}
-				return err
-			}
-		} else {
-			output, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
-			if err != nil {
-				return err
-			}
-		}
-{{ end }}
 
-{{ range . }}
+{{ range .Sigs }}
 {{ if .AllNull}}
 func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
@@ -120,7 +103,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(input *chunk.Chunk, result 
 	}
 {{ end }}
 
-{{ if eq .SigName "builtinAddStringAndStringSig" }}
+{{ if or (eq .SigName "builtinAddStringAndStringSig") (eq .SigName "builtinSubStringAndStringSig") }}
 	arg1Type := b.args[1].GetType()
 	if mysql.HasBinaryFlag(arg1Type.Flag) {
 		result.Reserve{{ .Output.TypeNameInColumn }}(n)
@@ -183,49 +166,159 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(input *chunk.Chunk, result 
 		{{ end }}
 
 		// calculate
-	{{ if eq .SigName "builtinAddDatetimeAndDurationSig" }}
+	{{ if or (eq .SigName "builtinAddDatetimeAndDurationSig") (eq .SigName "builtinSubDatetimeAndDurationSig") }}
+		{{ if eq $.FuncName "AddTime" }}
 		output, err := arg0.Add(b.ctx.GetSessionVars().StmtCtx, types.Duration{Duration: arg1, Fsp: -1})
+		{{ else }}
+		sc := b.ctx.GetSessionVars().StmtCtx
+		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
+		arg1time, err := arg1Duration.ConvertToTime(sc, mysql.TypeDatetime)
 		if err != nil {
 			return err
 		}
-	{{ else if eq .SigName "builtinAddDatetimeAndStringSig" }}
+		tmpDuration := arg0.Sub(sc, &arg1time)
+		output, err := tmpDuration.ConvertToTime(sc, arg0.Type)
+		{{ end }}
+		if err != nil {
+			return err
+		}
+		
+	{{ else if or (eq .SigName "builtinAddDatetimeAndStringSig") (eq .SigName "builtinSubDatetimeAndStringSig") }}
+		{{ if eq $.FuncName "AddTime" }}
 		{{ template "ConvertStringToDuration" . }}
 		output, err := arg0.Add(sc, arg1Duration)
+		{{ else }}
+		if !isDuration(arg1) {
+			result.SetNull(i, true) // fixed: true
+			continue
+		}
+		sc := b.ctx.GetSessionVars().StmtCtx
+		arg1Duration, err := types.ParseDuration(sc, arg1, types.GetFsp(arg1))
+		if err != nil {
+			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+				sc.AppendWarning(err)
+				result.SetNull(i, true) // fixed: true
+				continue
+			}
+			return err
+		}
+		arg1time, err := arg1Duration.ConvertToTime(sc, mysql.TypeDatetime)
 		if err != nil {
 			return err
 		}
-	{{ else if eq .SigName "builtinAddDurationAndDurationSig" }}
+		tmpDuration := arg0.Sub(sc, &arg1time)
+		output, err := tmpDuration.ConvertToTime(sc, mysql.TypeDatetime)
+		{{ end }}
+		if err != nil {
+			return err
+		}
+	{{ else if or (eq .SigName "builtinAddDurationAndDurationSig") (eq .SigName "builtinSubDurationAndDurationSig") }}
+		{{ if eq $.FuncName "AddTime" }}
 		output, err := types.AddDuration(arg0, arg1)
 		if err != nil {
 			return err
 		}
-	{{ else if eq .SigName "builtinAddDurationAndStringSig" }}
+		{{ else }}
+		arg0Duration := types.Duration{Duration: arg0, Fsp: -1}
+		arg1Duration := types.Duration{Duration: arg1, Fsp: -1}
+		outputDuration, err := arg0Duration.Sub(arg1Duration)
+		if err != nil {
+			return err
+		}
+		output := outputDuration.Duration
+		{{ end }}
+	{{ else if or (eq .SigName "builtinAddDurationAndStringSig") (eq .SigName "builtinSubDurationAndStringSig") }}
 		{{ template "ConvertStringToDuration" . }}
+		{{ if eq $.FuncName "AddTime" }}
 		output, err := types.AddDuration(arg0, arg1Duration.Duration)
 		if err != nil {
 			return err
 		}
-	{{ else if eq .SigName "builtinAddStringAndDurationSig" }}
+		{{ else }}
+		arg0Duration := types.Duration{Duration: arg0, Fsp: -1}
+		outputDuration, err := arg0Duration.Sub(arg1Duration)
+		if err != nil {
+			return err
+		}
+		output := outputDuration.Duration
+		{{ end }}
+	{{ else if or (eq .SigName "builtinAddStringAndDurationSig") (eq .SigName "builtinSubStringAndDurationSig") }}
 		sc := b.ctx.GetSessionVars().StmtCtx
 		fsp1 := int8(b.args[1].GetType().Decimal)
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
-		{{ template "strDurationAddDuration" . }}
-	{{ else if eq .SigName "builtinAddStringAndStringSig" }}
+		var output string
+		if isDuration(arg0) {
+			{{ if eq $.FuncName "AddTime" }}
+			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			{{ else }}
+			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			{{ end }}
+			if err != nil {
+				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+					sc.AppendWarning(err)
+					{{ template "SetNull" . }}
+					continue
+				}
+				return err
+			}
+		} else {
+			{{ if eq $.FuncName "AddTime" }}
+			output, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			{{ else }}
+			output, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			{{ end }}
+			if err != nil {
+				return err
+			}
+		}
+	{{ else if or (eq .SigName "builtinAddStringAndStringSig") (eq .SigName "builtinSubStringAndStringSig") }}
 		{{ template "ConvertStringToDuration" . }}
-		{{ template "strDurationAddDuration" . }}
-	{{ else if eq .SigName "builtinAddDateAndDurationSig" }}
+		var output string
+		if isDuration(arg0) {
+			{{ if eq $.FuncName "AddTime" }}
+			output, err = strDurationAddDuration(sc, arg0, arg1Duration)
+			{{ else }}
+			output, err = strDurationSubDuration(sc, arg0, arg1Duration)
+			{{ end }}
+			if err != nil {
+				if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {
+					sc.AppendWarning(err)
+					{{ template "SetNull" . }}
+					continue
+				}
+				return err
+			}
+		} else {
+			{{ if eq $.FuncName "AddTime" }}
+			output, err = strDatetimeAddDuration(sc, arg0, arg1Duration)
+			{{ else }}
+			output, err = strDatetimeSubDuration(sc, arg0, arg1Duration)
+			{{ end }}
+			if err != nil {
+				return err
+			}
+		}
+	{{ else if or (eq .SigName "builtinAddDateAndDurationSig") (eq .SigName "builtinSubDateAndDurationSig") }}
 		fsp0 := int8(b.args[0].GetType().Decimal)
 		fsp1 := int8(b.args[1].GetType().Decimal)
 		arg1Duration := types.Duration{Duration: arg1, Fsp: fsp1}
+		{{ if eq $.FuncName "AddTime" }}
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
+		{{ else }}
+		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Sub(arg1Duration)
+		{{ end }}
 		if err != nil {
 			return err
 		}
 		output := sum.String()
-	{{ else if eq .SigName "builtinAddDateAndStringSig" }}
+	{{ else if or (eq .SigName "builtinAddDateAndStringSig") (eq .SigName "builtinSubDateAndStringSig") }}
 		{{ template "ConvertStringToDuration" . }}
 		fsp0 := int8(b.args[0].GetType().Decimal)
+		{{ if eq $.FuncName "AddTime" }}
 		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Add(arg1Duration)
+		{{ else }}
+		sum, err := types.Duration{Duration: arg0, Fsp: fsp0}.Sub(arg1Duration)
+		{{ end }}
 		if err != nil {
 			return err
 		}
@@ -234,7 +327,7 @@ func (b *{{.SigName}}) vecEval{{ .Output.TypeName }}(input *chunk.Chunk, result 
 
 		// commit result
 	{{ if .Output.Fixed }}
-		resultSlice[i] = output
+		resultSlice[i] = output	
 	{{ else }}
 		result.Append{{ .Output.TypeNameInColumn }}(output)
 	{{ end }}
@@ -248,6 +341,7 @@ func (b *{{.SigName}}) vectorized() bool {
 }
 {{ end }}{{/* range */}}
 `))
+
 
 var timeDiff = template.Must(template.New("").Parse(`
 {{ define "BufAllocator0" }}
@@ -612,33 +706,54 @@ func (g gener) gen() interface{} {
 	{{- end }}
 {{ end }}
 
+{{ define "addOrSubTimeCases" }}
+	{{- range $sig := .Sigs }}
+		// {{ $sig.SigName }}
+			{
+				retEvalType:   types.ET{{ $sig.Output.ETName }},
+				{{ if or (eq $sig.SigName "builtinAddDateAndDurationSig") (eq $sig.SigName "builtinSubDateAndDurationSig") }}
+				childrenTypes: []types.EvalType{types.ET{{ $sig.TestTypeA }}, types.ET{{ $sig.TestTypeB }}},
+				childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDuration)},
+				geners: []dataGenerator{
+					gener{defaultGener{eType: types.ET{{ $sig.TestTypeA }}, nullRation: 0.2}},
+					gener{defaultGener{eType: types.ET{{ $sig.TestTypeB }}, nullRation: 0.2}},
+				},
+				{{ else if or (eq $sig.SigName "builtinAddDateAndStringSig") (eq $sig.SigName "builtinSubDateAndStringSig") }}
+				childrenTypes: []types.EvalType{types.ET{{ $sig.TestTypeA }}, types.ET{{ $sig.TestTypeB }}},
+				childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeString)},
+				geners: []dataGenerator{
+					gener{defaultGener{eType: types.ET{{ $sig.TestTypeA }}, nullRation: 0.2}},
+					gener{defaultGener{eType: types.ET{{ $sig.TestTypeB }}, nullRation: 0.2}},
+				},
+				{{ else if or (eq $sig.SigName "builtinAddTimeStringNullSig") (eq $sig.SigName "builtinSubTimeStringNullSig") }}
+				childrenTypes: []types.EvalType{types.ETDatetime, types.ETDatetime},
+				childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.TypeDate), types.NewFieldType(mysql.TypeDatetime)},
+				geners: []dataGenerator{
+					gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+					gener{defaultGener{eType: types.ETDatetime, nullRation: 0.2}},
+				},
+				{{ else }}
+				childrenTypes: []types.EvalType{types.ET{{ $sig.TypeA.ETName }}, types.ET{{ $sig.TypeB.ETName }}},
+				geners: []dataGenerator{
+					gener{defaultGener{eType: types.ET{{ $sig.TypeA.ETName }}, nullRation: 0.2}},
+					gener{defaultGener{eType: types.ET{{ $sig.TypeB.ETName }}, nullRation: 0.2}},
+				},
+				{{ end }}
+			},
+	{{- end }}
+{{ end }}
+
 {{/* Add more test cases here if we have more functions in this file */}}
 var vecBuiltin{{.Category}}GeneratedCases = map[string][]vecExprBenchCase{
 {{- range .Functions }}
 	{{- if eq .FuncName "AddTime" }}
 		ast.AddTime: {
-		{{ range .Sigs }} // {{ .SigName }}
-			{
-				retEvalType: types.ET{{ .Output.ETName }},
-				{{- if eq .TestTypeA "" }}
-				childrenTypes: []types.EvalType{types.ET{{ .TypeA.ETName }}, types.ET{{ .TypeB.ETName }}},
-				{{- else }}
-				childrenTypes: []types.EvalType{types.ET{{ .TestTypeA }}, types.ET{{ .TestTypeB }}},
-				{{- end }}
-				{{- if ne .FieldTypeA "" }}
-				childrenFieldTypes: []*types.FieldType{types.NewFieldType(mysql.Type{{.FieldTypeA}}), types.NewFieldType(mysql.Type{{.FieldTypeB}})},
-				{{- end }}
-				geners: []dataGenerator{
-					{{- if eq .TestTypeA "" }}
-					gener{defaultGener{eType: types.ET{{.TypeA.ETName}}, nullRation: 0.2}},
-					gener{defaultGener{eType: types.ET{{.TypeB.ETName}}, nullRation: 0.2}},
-					{{- else }}
-					gener{defaultGener{eType: types.ET{{ .TestTypeA }}, nullRation: 0.2}},
-					gener{defaultGener{eType: types.ET{{ .TestTypeB }}, nullRation: 0.2}},
-					{{- end }}
-				},
-			},
-		{{ end }}
+			{{- template "addOrSubTimeCases" . -}}
+		},
+	{{ end }}
+	{{- if eq .FuncName "SubTime" }}
+		ast.SubTime: {
+			{{- template "addOrSubTimeCases" . -}}
 		},
 	{{ end }}
 	{{- if eq .FuncName "TimeDiff" }}
@@ -722,6 +837,21 @@ var addTimeSigsTmpl = []sig{
 	{SigName: "builtinAddTimeDurationNullSig", TypeA: TypeDuration, TypeB: TypeDatetime, Output: TypeDuration, AllNull: true},
 }
 
+var subTimeSigsTmpl = []sig{
+	{SigName: "builtinSubDatetimeAndDurationSig", TypeA: TypeDatetime, TypeB: TypeDuration, Output: TypeDatetime},
+	{SigName: "builtinSubDatetimeAndStringSig", TypeA: TypeDatetime, TypeB: TypeString, Output: TypeDatetime},
+	{SigName: "builtinSubDurationAndDurationSig", TypeA: TypeDuration, TypeB: TypeDuration, Output: TypeDuration},
+	{SigName: "builtinSubDurationAndStringSig", TypeA: TypeDuration, TypeB: TypeString, Output: TypeDuration},
+	{SigName: "builtinSubStringAndDurationSig", TypeA: TypeString, TypeB: TypeDuration, Output: TypeString},
+	{SigName: "builtinSubStringAndStringSig", TypeA: TypeString, TypeB: TypeString, Output: TypeString},
+	{SigName: "builtinSubDateAndDurationSig", TypeA: TypeDuration, TypeB: TypeDuration, Output: TypeString, FieldTypeA: "Date", FieldTypeB: "Duration", TestTypeA: "Datetime", TestTypeB: "Duration"},
+	{SigName: "builtinSubDateAndStringSig", TypeA: TypeDuration, TypeB: TypeString, Output: TypeString, FieldTypeA: "Date", FieldTypeB: "String", TestTypeA: "Datetime", TestTypeB: "String"},
+
+	{SigName: "builtinSubTimeDateTimeNullSig", TypeA: TypeDatetime, TypeB: TypeDatetime, Output: TypeDatetime, AllNull: true},
+	{SigName: "builtinSubTimeStringNullSig", TypeA: TypeDatetime, TypeB: TypeDatetime, Output: TypeString, AllNull: true, FieldTypeA: "Date", FieldTypeB: "Datetime"},
+	{SigName: "builtinSubTimeDurationNullSig", TypeA: TypeDuration, TypeB: TypeDatetime, Output: TypeDuration, AllNull: true},
+}
+
 var timeDiffSigsTmpl = []sig{
 	{SigName: "builtinNullTimeDiffSig", Output: TypeDuration},
 	{SigName: "builtinTimeStringTimeDiffSig", TypeA: TypeDatetime, TypeB: TypeString, Output: TypeDuration},
@@ -791,6 +921,7 @@ var tmplVal = struct {
 	Category: "Time",
 	Functions: []function{
 		{FuncName: "AddTime", Sigs: addTimeSigsTmpl},
+		{FuncName: "SubTime", Sigs: subTimeSigsTmpl},
 		{FuncName: "TimeDiff", Sigs: timeDiffSigsTmpl},
 		{FuncName: "AddDate", Sigs: addDataSigsTmpl},
 		{FuncName: "SubDate", Sigs: subDataSigsTmpl},
@@ -799,7 +930,11 @@ var tmplVal = struct {
 
 func generateDotGo(fileName string) error {
 	w := new(bytes.Buffer)
-	err := addTime.Execute(w, addTimeSigsTmpl)
+	err := addOrSubTime.Execute(w, function{FuncName: "AddTime", Sigs: addTimeSigsTmpl})
+	if err != nil {
+		return err
+	}
+	err = addOrSubTime.Execute(w, function{FuncName: "SubTime", Sigs: subTimeSigsTmpl})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Use go template to generate vectorized  11 SUBTIME functions from #12176 

- builtinSubDatetimeAndDurationSig

- builtinSubDatetimeAndStringSig

- builtinSubDurationAndDurationSig

- builtinSubDurationAndStringSig

- builtinSubStringAndDurationSig

- builtinSubStringAndStringSig

- builtinSubDateAndDurationSig

- builtinSubDateAndStringSig

- builtinSubTimeDateTimeNullSig

- builtinSubTimeStringNullSig

- builtinSubTimeDurationNullSig

### What is changed and how it works?





    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDatetimeAndDurationSig-VecBuiltinFunc-4               3999            293371 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDatetimeAndDurationSig-NonVecBuiltinFunc-4            3459            339815 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDatetimeAndStringSig-VecBuiltinFunc-4                  586           2057947 ns/op           97826 B/op       6012 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDatetimeAndStringSig-NonVecBuiltinFunc-4               568           2100321 ns/op           98006 B/op       6012 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDurationAndDurationSig-VecBuiltinFunc-4             114855             10493 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDurationAndDurationSig-NonVecBuiltinFunc-4           32994             36492 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDurationAndStringSig-VecBuiltinFunc-4                 1057           1147146 ns/op           97517 B/op       6093 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDurationAndStringSig-NonVecBuiltinFunc-4               694           1796017 ns/op           99094 B/op       6093 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubStringAndDurationSig-VecBuiltinFunc-4                  518           2241379 ns/op          188826 B/op       9155 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubStringAndDurationSig-NonVecBuiltinFunc-4               537           2221352 ns/op          188730 B/op       9155 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubStringAndStringSig-VecBuiltinFunc-4                    326           3704692 ns/op          278973 B/op      14604 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubStringAndStringSig-NonVecBuiltinFunc-4                 363           3348957 ns/op          278401 B/op      14604 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDateAndDurationSig-VecBuiltinFunc-4                   2476            431365 ns/op           95126 B/op       3919 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDateAndDurationSig-NonVecBuiltinFunc-4                2412            463982 ns/op           95126 B/op       3919 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDateAndStringSig-VecBuiltinFunc-4                      692           1679502 ns/op          182640 B/op       9654 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubDateAndStringSig-NonVecBuiltinFunc-4                   525           2236717 ns/op          185652 B/op       9655 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeDateTimeNullSig-VecBuiltinFunc-4              13765372                83.4 ns/op             0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeDateTimeNullSig-NonVecBuiltinFunc-4              75445             15781 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeStringNullSig-VecBuiltinFunc-4                  397507              2921 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeStringNullSig-NonVecBuiltinFunc-4               177312              6657 ns/op               0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeDurationNullSig-VecBuiltinFunc-4              13544961                85.4 ns/op             0 B/op          0 allocs/op
    BenchmarkVectorizedBuiltinTimeFuncGenerated/builtinSubTimeDurationNullSig-NonVecBuiltinFunc-4             115204             10282 ns/op               0 B/op          0 allocs/op






### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
