### PR TITLE
tikv: check lock timeout again after resolving lock

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -785,8 +785,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			} else if action.LockWaitTime == kv.LockAlwaysWait {
 				// do nothing but keep wait
 			} else {
-				// the lockWaitTime is set, check the lock wait timeout or not
-				// the pessimistic lock found could be invalid locks which is timeout but not recycled yet
+				// the lockWaitTime is set, we should return wait timeout if we are still blocked by a lock
 				if time.Since(lockWaitStartTime).Milliseconds() >= action.LockWaitTime {
 					return ErrLockWaitTimeout
 				}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -745,27 +745,6 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			if err1 != nil {
 				return errors.Trace(err1)
 			}
-			// Check lock conflict error for nowait, if nowait set and key locked by others,
-			// report error immediately and do no more resolve locks.
-			// if the lock left behind whose related txn is already committed or rollbacked,
-			// (eg secondary locks not committed or rollbacked yet)
-			// we cant return "nowait conflict" directly
-			if action.LockWaitTime == kv.LockNoWait {
-				// the pessimistic lock found could be invalid locks which is timeout but not recycled yet
-				if !c.store.oracle.IsExpired(lock.TxnID, lock.TTL) {
-					return ErrLockAcquireFailAndNoWaitSet
-				}
-			} else if action.LockWaitTime == kv.LockAlwaysWait {
-				// do nothing but keep wait
-			} else {
-				// the lockWaitTime is set, check the lock wait timeout or not
-				// the pessimistic lock found could be invalid locks which is timeout but not recycled yet
-				if !c.store.oracle.IsExpired(lock.TxnID, lock.TTL) {
-					if time.Since(lockWaitStartTime).Milliseconds() >= action.LockWaitTime {
-						return ErrLockWaitTimeout
-					}
-				}
-			}
 			locks = append(locks, lock)
 		}
 		// Because we already waited on tikv, no need to Backoff here.
@@ -775,10 +754,8 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			return errors.Trace(err)
 		}
 
-		// Before resolving locks, we checked whether the locks are expired according to its own TTL.
-		// However, it's not accurate because heartbeat only updates the TTL of the primary key.
 		// If msBeforeTxnExpired is not zero, it means there are still locks blocking us acquiring
-		// the pessimistic lock. We should return timeout error if necessary.
+		// the pessimistic lock. We should return acquire fail with nowait set or timeout error if necessary.
 		if msBeforeTxnExpired > 0 {
 			if action.LockWaitTime == kv.LockNoWait {
 				return ErrLockAcquireFailAndNoWaitSet

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -674,7 +674,7 @@ func (s *testCommitterSuite) TestAcquireFalseTimeoutLock(c *C) {
 	err = txn2.LockKeys(context.Background(), lockCtx, k2)
 	elapsed := time.Now().Sub(startTime)
 	// cannot acquire lock immediately thus error
-	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, ErrLockAcquireFailAndNoWaitSet.Error())
 	// it should return immediately
 	c.Assert(elapsed, Less, 50*time.Millisecond)
 
@@ -683,8 +683,8 @@ func (s *testCommitterSuite) TestAcquireFalseTimeoutLock(c *C) {
 	startTime = time.Now()
 	err = txn2.LockKeys(context.Background(), lockCtx, k2)
 	elapsed = time.Now().Sub(startTime)
-	// cannot acquire lock immediately thus error
-	c.Assert(err, NotNil)
+	// cannot acquire lock in time thus error
+	c.Assert(err.Error(), Equals, ErrLockWaitTimeout.Error())
 	// it should return after about 300ms
 	c.Assert(elapsed, Less, 350*time.Millisecond)
 }

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -642,6 +642,53 @@ func (s *testCommitterSuite) TestElapsedTTL(c *C) {
 	c.Assert(lockInfo.LockTtl-ManagedLockTTL, Less, uint64(150))
 }
 
+// TestAcquireFalseTimeoutLock tests acquiring a key which is a secondary key of another transaction.
+// The lock's own TTL is expired but the primary key is still alive due to heartbeats.
+func (s *testCommitterSuite) TestAcquireFalseTimeoutLock(c *C) {
+	// k1 is the primary lock of txn1
+	k1 := kv.Key("k1")
+	// k2 is a secondary lock of txn1 and a key txn2 wants to lock
+	k2 := kv.Key("k2")
+
+	txn1 := s.begin(c)
+	txn1.SetOption(kv.Pessimistic, true)
+	// lock the primary key
+	lockCtx := &kv.LockCtx{ForUpdateTS: txn1.startTS, WaitStartTime: time.Now()}
+	err := txn1.LockKeys(context.Background(), lockCtx, k1)
+	c.Assert(err, IsNil)
+	// lock the secondary key
+	lockCtx = &kv.LockCtx{ForUpdateTS: txn1.startTS, WaitStartTime: time.Now()}
+	err = txn1.LockKeys(context.Background(), lockCtx, k2)
+	c.Assert(err, IsNil)
+
+	// Heartbeats will increase the TTL of the primary key
+
+	// wait until secondary key exceeds its own TTL
+	time.Sleep(time.Duration(ManagedLockTTL) * time.Millisecond)
+	txn2 := s.begin(c)
+	txn2.SetOption(kv.Pessimistic, true)
+
+	// test no wait
+	lockCtx = &kv.LockCtx{ForUpdateTS: txn2.startTS, LockWaitTime: kv.LockNoWait, WaitStartTime: time.Now()}
+	startTime := time.Now()
+	err = txn2.LockKeys(context.Background(), lockCtx, k2)
+	elapsed := time.Now().Sub(startTime)
+	// cannot acquire lock immediately thus error
+	c.Assert(err, NotNil)
+	// it should return immediately
+	c.Assert(elapsed, Less, 50*time.Millisecond)
+
+	// test for wait limited time (300ms)
+	lockCtx = &kv.LockCtx{ForUpdateTS: txn2.startTS, LockWaitTime: 300, WaitStartTime: time.Now()}
+	startTime = time.Now()
+	err = txn2.LockKeys(context.Background(), lockCtx, k2)
+	elapsed = time.Now().Sub(startTime)
+	// cannot acquire lock immediately thus error
+	c.Assert(err, NotNil)
+	// it should return after about 300ms
+	c.Assert(elapsed, Less, 350*time.Millisecond)
+}
+
 func (s *testCommitterSuite) getLockInfo(c *C, key []byte) *kvrpcpb.LockInfo {
 	txn := s.begin(c)
 	err := txn.Set(key, key)


### PR DESCRIPTION
Signed-off-by: Yilin Chen <sticnarf@gmail.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #14063 

### What is changed and how it works?

Before resolving locks, we checked whether the locks are expired according to its own TTL. However, it's not accurate because heartbeat only updates the TTL of the primary key.

So we still fetch `msBeforeTxnExpired` from `ResolveLocks`. If `msBeforeTxnExpired` is not zero, it means there are still locks blocking us acquiring the pessimistic lock. We should return timeout error if necessary.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
