### PR TITLE
planner/cascades: Add the transformation rule PushSelDownWindow

### DIFF
--- a/planner/cascades/testdata/transformation_rules_suite_in.json
+++ b/planner/cascades/testdata/transformation_rules_suite_in.json
@@ -16,7 +16,7 @@
       "select a, f from t where g > 1 and f > 1",
       "select t1.a, t1.b from t t1, t t2 where t1.a = t2.a and t1.a = 10 and t2.a = 5",
       "select a, b from ((select a, b from t) union all(select c as a, d as b from t)) as t1 where a > 1",
-      "select a, b, row_number()over(partition by a order by b desc) as n from t"
+      "select a, b from (select a, b, min(a) over(partition by b) as min_a from t)as tt where a < 10 and b > 10 and b = min_a"
     ]
   },
   {

--- a/planner/cascades/testdata/transformation_rules_suite_in.json
+++ b/planner/cascades/testdata/transformation_rules_suite_in.json
@@ -15,7 +15,8 @@
       "select a, f from (select a, f, g from t where f = 1) t1 where g > 1",
       "select a, f from t where g > 1 and f > 1",
       "select t1.a, t1.b from t t1, t t2 where t1.a = t2.a and t1.a = 10 and t2.a = 5",
-      "select a, b from ((select a, b from t) union all(select c as a, d as b from t)) as t1 where a > 1"
+      "select a, b from ((select a, b from t) union all(select c as a, d as b from t)) as t1 where a > 1",
+      "select a, b, row_number()over(partition by a order by b desc) as n from t"
     ]
   },
   {

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -234,6 +234,10 @@
           "Group#10 Schema:[test.t.c,test.t.d]",
           "    IndexScan_24 table:t, index:c, d, e, cond:[gt(test.t.c, 1)]"
         ]
+      },
+      {
+        "SQL": "",
+        "Result": null
       }
     ]
   },

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -236,8 +236,27 @@
         ]
       },
       {
-        "SQL": "",
-        "Result": null
+        "SQL": "select a, b from (select a, b, min(a) over(partition by b) as min_a from t)as tt where a < 10 and b > 10 and b = min_a",
+        "Result": [
+          "Group#0 Schema:[test.t.a,test.t.b]",
+          "    Projection_7 input:[Group#1], test.t.a, test.t.b",
+          "Group#1 Schema:[test.t.a,test.t.b,Column#14]",
+          "    Projection_5 input:[Group#2], test.t.a, test.t.b, Column#14",
+          "Group#2 Schema:[test.t.a,test.t.b,Column#14]",
+          "    Selection_12 input:[Group#3], eq(test.t.b, Column#14), lt(test.t.a, 10)",
+          "Group#3 Schema:[test.t.a,test.t.b,Column#14]",
+          "    Window_4 input:[Group#4]",
+          "Group#4 Schema:[test.t.a,test.t.b]",
+          "    Projection_3 input:[Group#5], test.t.a, test.t.b",
+          "Group#5 Schema:[test.t.a,test.t.b]",
+          "    Projection_2 input:[Group#6], test.t.a, test.t.b",
+          "Group#6 Schema:[test.t.a,test.t.b]",
+          "    TiKVSingleGather_9 input:[Group#7], table:t",
+          "Group#7 Schema:[test.t.a,test.t.b]",
+          "    Selection_15 input:[Group#8], gt(test.t.b, 10)",
+          "Group#8 Schema:[test.t.a,test.t.b]",
+          "    TableScan_8 table:t, pk col:test.t.a"
+        ]
       }
     ]
   },

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -598,11 +598,7 @@ func (r *PushSelDownWindow) OnTransform(old *memo.ExprIter) (newExprs []*memo.Gr
 	canNotBePushed := make([]expression.Expression, 0, len(sel.Conditions))
 
 	// get partition Columns' Schema
-	partitionCols := make([]*expression.Column, 0, len(window.PartitionBy))
-	for _, partitionItem := range window.PartitionBy {
-		partitionCols = append(partitionCols, partitionItem.Col)
-	}
-	partitionColsSchema := expression.NewSchema(partitionCols...)
+	partitionColsSchema := expression.NewSchema(window.GetPartitionByCols()...)
 
 	for _, cond := range sel.Conditions {
 		if expression.ExprFromSchema(cond, partitionColsSchema) {

--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -52,6 +52,7 @@ var defaultTransformationMap = map[memo.Operand][]Transformation{
 		NewRulePushSelDownJoin(),
 		NewRulePushSelDownIndexScan(),
 		NewRulePushSelDownUnionAll(),
+		NewRulePushSelDownWindow(),
 	},
 	memo.OperandDataSource: {
 		NewRuleEnumeratePaths(),
@@ -564,6 +565,73 @@ func (r *PushSelDownAggregation) OnTransform(old *memo.ExprIter) (newExprs []*me
 	remainedGroupExpr := memo.NewGroupExpr(remainedSel)
 	remainedGroupExpr.SetChildren(aggGroup)
 	return []*memo.GroupExpr{remainedGroupExpr}, true, false, nil
+}
+
+// PushSelDownWindow pushes Selection down to the child of Window.
+type PushSelDownWindow struct {
+	baseRule
+}
+
+// NewRulePushSelDownWindow creates a new Transformation PushSelDownWindow.
+// The pattern of this rule is `Selection -> Window`.
+func NewRulePushSelDownWindow() Transformation {
+	rule := &PushSelDownWindow{}
+	rule.pattern = memo.BuildPattern(
+		memo.OperandSelection,
+		memo.EngineTiDBOnly,
+		memo.NewPattern(memo.OperandWindow, memo.EngineAll),
+	)
+	return rule
+}
+
+// OnTransform implements Transformation interface.
+// This rule will transform `sel -> window -> x` to
+// 1. `window -> sel -> x` or
+// 2. `sel -> window -> sel -> x` or
+// 3. just keep unchanged.
+func (r *PushSelDownWindow) OnTransform(old *memo.ExprIter) (newExprs []*memo.GroupExpr, eraseOld bool, eraseAll bool, err error) {
+	sel := old.GetExpr().ExprNode.(*plannercore.LogicalSelection)
+	window := old.Children[0].GetExpr().ExprNode.(*plannercore.LogicalWindow)
+	windowSchema := old.Children[0].Prop.Schema
+	childGroup := old.Children[0].GetExpr().Children[0]
+	canBePushed := make([]expression.Expression, 0, len(sel.Conditions))
+	canNotBePushed := make([]expression.Expression, 0, len(sel.Conditions))
+
+	// get partition Columns' Schema
+	partitionCols := make([]*expression.Column, 0, len(window.PartitionBy))
+	for _, partitionItem := range window.PartitionBy {
+		partitionCols = append(partitionCols, partitionItem.Col)
+	}
+	partitionColsSchema := expression.NewSchema(partitionCols...)
+
+	for _, cond := range sel.Conditions {
+		if expression.ExprFromSchema(cond, partitionColsSchema) {
+			canBePushed = append(canBePushed, cond)
+		} else {
+			canNotBePushed = append(canNotBePushed, cond)
+		}
+	}
+	// Nothing can be pushed!
+	if len(canBePushed) == 0 {
+		return nil, false, false, nil
+	}
+
+	// construct return GroupExpr
+	newBottomSel := plannercore.LogicalSelection{Conditions: canBePushed}.Init(sel.SCtx(), sel.SelectBlockOffset())
+	newBottomSelExpr := memo.NewGroupExpr(newBottomSel)
+	newBottomSelExpr.SetChildren(childGroup)
+	newBottomSelGroup := memo.NewGroupWithSchema(newBottomSelExpr, childGroup.Prop.Schema)
+	newWindowExpr := memo.NewGroupExpr(window)
+	newWindowExpr.SetChildren(newBottomSelGroup)
+	if len(canNotBePushed) == 0 {
+		return []*memo.GroupExpr{newWindowExpr}, true, false, nil
+	}
+
+	newWindowGroup := memo.NewGroupWithSchema(newWindowExpr, windowSchema)
+	newTopSel := plannercore.LogicalSelection{Conditions: canNotBePushed}.Init(sel.SCtx(), sel.SelectBlockOffset())
+	newTopSelExpr := memo.NewGroupExpr(newTopSel)
+	newTopSelExpr.SetChildren(newWindowGroup)
+	return []*memo.GroupExpr{newTopSelExpr}, true, false, nil
 }
 
 // TransformLimitToTopN transforms Limit+Sort to TopN.

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -44,6 +44,7 @@ func (s *testTransformationRuleSuite) SetUpSuite(c *C) {
 	var err error
 	s.testData, err = testutil.LoadTestSuiteData("testdata", "transformation_rules_suite")
 	c.Assert(err, IsNil)
+	s.Parser.EnableWindowFunc(true)
 }
 
 func (s *testTransformationRuleSuite) TearDownSuite(c *C) {

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -125,6 +125,7 @@ func (s *testTransformationRuleSuite) TestPredicatePushDown(c *C) {
 			NewRulePushSelDownJoin(),
 			NewRulePushSelDownIndexScan(),
 			NewRulePushSelDownUnionAll(),
+			NewRulePushSelDownWindow(),
 		},
 		memo.OperandDataSource: {
 			NewRuleEnumeratePaths(),

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -551,8 +551,8 @@ func (p *LogicalJoin) outerJoinPropConst(predicates []expression.Expression) []e
 	return predicates
 }
 
-// getPartitionByCols extracts 'partition by' columns from the Window.
-func (p *LogicalWindow) getPartitionByCols() []*expression.Column {
+// GetPartitionByCols extracts 'partition by' columns from the Window.
+func (p *LogicalWindow) GetPartitionByCols() []*expression.Column {
 	partitionCols := make([]*expression.Column, 0, len(p.PartitionBy))
 	for _, partitionItem := range p.PartitionBy {
 		partitionCols = append(partitionCols, partitionItem.Col)
@@ -564,7 +564,7 @@ func (p *LogicalWindow) getPartitionByCols() []*expression.Column {
 func (p *LogicalWindow) PredicatePushDown(predicates []expression.Expression) ([]expression.Expression, LogicalPlan) {
 	canBePushed := make([]expression.Expression, 0, len(predicates))
 	canNotBePushed := make([]expression.Expression, 0, len(predicates))
-	partitionCols := expression.NewSchema(p.getPartitionByCols()...)
+	partitionCols := expression.NewSchema(p.GetPartitionByCols()...)
 	for _, cond := range predicates {
 		// We can push predicate beneath Window, only if all of the
 		// extractedCols are part of partitionBy columns.

--- a/planner/memo/pattern.go
+++ b/planner/memo/pattern.go
@@ -63,6 +63,8 @@ const (
 	OperandIndexScan
 	// OperandShow is the operand for Show.
 	OperandShow
+	// OperandWindow is the operand for window function.
+	OperandWindow
 	// OperandUnsupported is the operand for unsupported operators.
 	OperandUnsupported
 )
@@ -106,6 +108,8 @@ func GetOperand(p plannercore.LogicalPlan) Operand {
 		return OperandIndexScan
 	case *plannercore.LogicalShow:
 		return OperandShow
+	case *plannercore.LogicalWindow:
+		return OperandWindow
 	default:
 		return OperandUnsupported
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR adds Transformation rule PushSelDownWindow which is a part of predicate push down in cascades planner(#13709).

### What is changed and how it works?
The logic is the same with `planner/core/rule_predicate_push_down.go/LogicalWindow.PredicatePushdown`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
