### PR TITLE
statistics: fix row count estimation of unique composite index

### DIFF
--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -570,3 +570,26 @@ func (s *testStatsSuite) TestColumnIndexNullEstimation(c *C) {
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i]...))
 	}
 }
+
+func (s *testStatsSuite) TestUniqCompEqualEst(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	testKit := testkit.NewTestKit(c, s.store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec("create table t(a int, b int, primary key(a, b))")
+	testKit.MustExec("insert into t values(1,1),(1,2),(1,3),(1,4),(1,5),(1,6),(1,7),(1,8),(1,9),(1,10)")
+	h := s.do.StatsHandle()
+	c.Assert(h.DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	testKit.MustExec("analyze table t")
+	var (
+		input  []string
+		output [][]string
+	)
+	s.testData.GetTestCases(c, &input, &output)
+	for i := 0; i < 1; i++ {
+		s.testData.OnRecord(func() {
+			output[i] = s.testData.ConvertRowsToStrings(testKit.MustQuery(input[i]).Rows())
+		})
+		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i]...))
+	}
+}

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -391,7 +391,7 @@ func isSingleColIdxNullRange(idx *Index, ran *ranger.Range) bool {
 func (coll *HistColl) getEqualCondSelectivity(idx *Index, bytes []byte, coverAll bool, unique bool) float64 {
 	// In this case, the row count is at most 1.
 	if unique && coverAll {
-		return 1.0 / float64(idx.TotalCount())
+		return 1.0 / float64(idx.TotalRowCount())
 	}
 	val := types.NewBytesDatum(bytes)
 	if idx.outOfRange(val) {

--- a/statistics/testdata/stats_suite_in.json
+++ b/statistics/testdata/stats_suite_in.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "TestUniqCompEqualEst",
+    "cases": [
+      "explain select * from t where a = 1 and b = 5 and 1 = 1"
+    ]
+  },
+  {
     "name": "TestColumnIndexNullEstimation",
     "cases": [
       "explain select b from t where b is null",

--- a/statistics/testdata/stats_suite_out.json
+++ b/statistics/testdata/stats_suite_out.json
@@ -1,5 +1,14 @@
 [
   {
+    "Name": "TestUniqCompEqualEst",
+    "Cases": [
+      [
+        "IndexReader_6 1.00 root index:IndexScan_5",
+        "└─IndexScan_5 1.00 cop[tikv] table:t, index:a, b, range:[1 5,1 5], keep order:false"
+      ]
+    ]
+  },
+  {
     "Name": "TestColumnIndexNullEstimation",
     "Cases": [
       [


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/14075
### What is changed and how it works?

Change `TotalCount()` to `TotalRowCount` when estimating row count of unique composite index.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch


Release note
