### PR TITLE
store/tikv: move `batchConn` out of `connArray` and go over the `recycleIdleConn` code

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -638,7 +638,7 @@ func (c *rpcClient) recycleIdleConn() {
 	for _, addr := range addrs {
 		c.Lock()
 		conn, ok := c.batchConns[addr]
-		if ok {
+		if ok && conn.isIdle() {
 			delete(c.batchConns, addr)
 			logutil.BgLogger().Info("recycle idle connection",
 				zap.String("target", addr))

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -639,7 +639,7 @@ func (c *rpcClient) recycleIdleConn() {
 		c.Lock()
 		conn, ok := c.batchConns[addr]
 		if ok {
-			delete(c.conns, addr)
+			delete(c.batchConns, addr)
 			logutil.BgLogger().Info("recycle idle connection",
 				zap.String("target", addr))
 		}

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -91,7 +91,7 @@ func (s *testClientSuite) TestRemoveCanceledRequests(c *C) {
 
 func (s *testClientSuite) TestCancelTimeoutRetErr(c *C) {
 	req := new(tikvpb.BatchCommandsRequest_Request)
-	a := newBatchConn(1, 1, nil)
+	a := &batchConn{}
 
 	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
@@ -108,11 +108,11 @@ func (s *testClientSuite) TestSendWhenReconnect(c *C) {
 
 	rpcClient := newRPCClient(config.Security{})
 	addr := fmt.Sprintf("%s:%d", "127.0.0.1", port)
-	conn, err := rpcClient.getConnArray(addr)
+	conn, err := rpcClient.getBatchConn(addr)
 	c.Assert(err, IsNil)
 
 	// Suppose all connections are re-establishing.
-	for _, client := range conn.batchConn.batchCommandsClients {
+	for _, client := range conn.batchCommandsClients {
 		client.lockForRecreate()
 	}
 


### PR DESCRIPTION


<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

I find a case where TiDB can't recover from TiKV's crash.
Some clues indicate that the `batchClient` retry sending forever.

```
goroutine 193 [select]:
github.com/pingcap/tidb/store/tikv.sendBatchRequest(0x27cb540, 0xc001822e10, 0xc0000546e0, 0x11, 0xc0001a37a0, 0xc008730ab0, 0x4a817c800, 0x0, 0x0, 0x0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/client_batch.go:566 +0x65b
github.com/pingcap/tidb/store/tikv.(*rpcClient).SendRequest(0xc00067c0a0, 0x27cb540, 0xc001822e10, 0xc0000546e0, 0x11, 0xc000b78460, 0x4a817c800, 0x0, 0x0, 0x0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/client.go:293 +0xa00
github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).sendReqToRegion(0xc00083ae30, 0xc00a26e600, 0xc001392050, 0xc000b78460, 0x4a817c800, 0x0, 0x0, 0x0, 0x0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:180 +0x103
github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).SendReqCtx(0xc00083ae30, 0xc00a26e600, 0xc000b78460, 0x8, 0x5, 0x2, 0x4a817c800, 0x0, 0xc0040a9920, 0x0, ...)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:143 +0x264
github.com/pingcap/tidb/store/tikv.(*clientHelper).SendReqCtx(0xc00083af58, 0xc00a26e600, 0xc000b78460, 0x8, 0x5, 0x2, 0x4a817c800, 0x0, 0xc001ae8d20, 0x0, ...)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:781 +0x126
github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).get(0xc00704f3b0, 0xc00a26e600, 0xc009ecd0b0, 0x1b, 0x23, 0xc0084c1b38, 0x27cb540, 0xc001822e10, 0x106e141, 0x2246dc0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:326 +0x334
github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).Get(0xc00704f3b0, 0x27cb4c0, 0xc000050080, 0xc009ecd0b0, 0x1b, 0x23, 0x0, 0x0, 0x0, 0x0, ...)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:282 +0x1c1
github.com/pingcap/tidb/kv.(*unionStore).Get(0xc00145eea0, 0x27cb4c0, 0xc000050080, 0xc009ecd0b0, 0x1b, 0x23, 0x0, 0x167a957, 0xc009ecd0bc, 0xc0001ec4f0, ...)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/kv/union_store.go:201 +0x38c
github.com/pingcap/tidb/store/tikv.(*tikvTxn).Get(0xc000828000, 0x27cb4c0, 0xc000050080, 0xc009ecd0b0, 0x1b, 0x23, 0x0, 0x0, 0x0, 0x0, ...)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/store/tikv/txn.go:136 +0x119
github.com/pingcap/tidb/structure.(*TxStructure).loadListMeta(0xc003c0be40, 0xc009ecd0b0, 0x1b, 0x23, 0xc009ecd0b0, 0x1b, 0x23, 0xd54c96)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/structure/list.go:217 +0x79
github.com/pingcap/tidb/structure.(*TxStructure).LIndex(0xc003c0be40, 0x385cfd0, 0xa, 0xa, 0x0, 0x3477e272e04c41, 0x7fda1bdc66d5, 0x1bdc66d500000000, 0x5df779de, 0xc00083b4d0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/structure/list.go:163 +0x7f
github.com/pingcap/tidb/meta.(*Meta).getDDLJob(0xc001822db0, 0x385cfd0, 0xa, 0xa, 0x0, 0xc001822db0, 0xc000828000, 0x7fda8cd04168)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/meta/meta.go:499 +0x69
github.com/pingcap/tidb/meta.(*Meta).GetDDLJobByIdx(0xc001822db0, 0x0, 0x0, 0x0, 0x0, 0xc001822db0, 0x24, 0x0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/meta/meta.go:528 +0xdd
github.com/pingcap/tidb/ddl.(*worker).getFirstDDLJob(0xc0006b8420, 0xc001822db0, 0x24b0798, 0x7, 0xc001822db0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:228 +0x38
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1(0x27f7300, 0xc000828000, 0xc000828000, 0x0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:385 +0xe4
github.com/pingcap/tidb/kv.RunInNewTxn(0x27ef200, 0xc0004480f0, 0xdb7900, 0xc00083bc98, 0xc000b74d80, 0x6)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/kv/txn.go:47 +0xde
github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue(0xc0006b8420, 0xc000282c80, 0x24, 0xc00710ba80)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:376 +0x13f
github.com/pingcap/tidb/ddl.(*worker).start(0xc0006b8420, 0xc000282c80)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:140 +0x24f
github.com/pingcap/tidb/ddl.(*ddl).start.func1()
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl.go:438 +0x37
github.com/pingcap/tidb/util.WithRecovery(0xc0004384a0, 0xc0004384c0)
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/util/misc.go:81 +0x57
created by github.com/pingcap/tidb/ddl.(*ddl).start
        /home/jenkins/agent/workspace/uild_tiflash_multi_branch_master/go/src/github.com/pingcap/tidb/ddl/ddl.go:437 +0x624
```

This log comes along when the error happen:

```
[2019/12/16 20:40:09.750 +08:00] [INFO] [region_cache.go:669] ["switch region leader to specific leader due to kv return NotLeader"] [regionID=8] [currIdx=1] [leaderStoreID=5]
[2019/12/16 20:40:09.765 +08:00] [INFO] [region_cache.go:330] ["invalidate current region, because others failed on same store"] [region=8] [store=172.16.5.34:32173]
[2019/12/16 20:40:10.475 +08:00] [INFO] [client_batch.go:298] ["batchRecvLoop re-create streaming fail"] [target=172.16.5.34:32171] [error="context deadline exceeded"]
[2019/12/16 20:40:11.352 +08:00] [INFO] [client_batch.go:298] ["batchRecvLoop re-create streaming fail"] [target=172.16.5.34:32171] [error="context deadline exceeded"]
[2019/12/16 20:40:11.589 +08:00] [WARN] [client_batch.go:223] ["init create streaming fail"] [target=172.16.5.34:32173] [error="context deadline exceeded"]
[2019/12/16 20:40:11.589 +08:00] [INFO] [region_cache.go:1106] ["mark store's regions need be refill"] [store=172.16.5.34:32173]
[2019/12/16 20:40:11.589 +08:00] [INFO] [region_cache.go:500] ["switch region peer to next due to send request fail"] [current="region ID: 72, meta: id:72 
```

The `batchRecvLoop` code is trying to re-create the stream, but it always gets a "context deadline exceeded" error.

I'm still not sure how it happens but it must have something to do with `recycleIdleConn`.
Before TiDB start to print the error log in `client_batch.go`, there are something logs like this:

```
[2019/12/11 16:38:51.776 +08:00] [WARN] [client_batch.go:223] ["init create streaming fail"] [target=172.16.5.34:32171] [error="context deadline exceeded"]
[2019/12/11 17:32:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 17:42:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 17:52:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:02:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:12:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:22:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:32:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:42:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 18:52:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:02:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:12:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:22:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:32:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:42:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
[2019/12/11 19:52:09.938 +08:00] [INFO] [client_batch.go:595] ["recycle idle connection"] [target=172.16.5.34:32173]
```

For the bug to reproduce, I can conclude at least those steps should be met:

* TiDB idle for a while, "recycle idle connection"
* The `grpc.ClientConn` is somehow closed, "batchRecvLoop re-create streaming fail"
* TiKV crash and batchClient never recover

### What is changed and how it works?

Tiny refactor

- move `batchConn` out of `connArray` so the don't share the same `grpc.ClientConn`.
- check the `recycleIdleConn` related code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

