### PR TITLE
server: set `system_time_zone` from `systemTZ` (#13934)

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -58,6 +58,7 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sys/linux"
+	"github.com/pingcap/tidb/util/timeutil"
 	"go.uber.org/zap"
 )
 
@@ -203,6 +204,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		stopListenerCh:    make(chan struct{}, 1),
 	}
 	s.loadTLSCertificates()
+	setSystemTimeZoneVariable()
 
 	s.capability = defaultCapability
 	if s.tlsConfig != nil {
@@ -611,6 +613,18 @@ func (s *Server) kickIdleConnection() {
 			logutil.Logger(context.Background()).Error("close connection", zap.Error(err))
 		}
 	}
+}
+
+func setSystemTimeZoneVariable() {
+	tz, err := timeutil.GetSystemTZ()
+	if err != nil {
+		logutil.Logger(context.Background()).Error(
+			"Error getting SystemTZ, use default value instead",
+			zap.Error(err),
+			zap.String("default system_time_zone", variable.SysVars["system_time_zone"].Value))
+		return
+	}
+	variable.SysVars["system_time_zone"].Value = tz
 }
 
 // Server error codes.

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/testkit"
 )
 
 type TidbTestSuite struct {
@@ -292,6 +293,19 @@ func registerTLSConfig(configName string, caCertPath string, clientCertPath stri
 	}
 	mysql.RegisterTLSConfig(configName, tlsConfig)
 	return nil
+}
+
+func (ts *TidbTestSuite) TestSystemTimeZone(c *C) {
+	tk := testkit.NewTestKit(c, ts.store)
+	cfg := config.NewConfig()
+	cfg.Port = 4002
+	cfg.Status.ReportStatus = false
+	server, err := NewServer(cfg, ts.tidbdrv)
+	c.Assert(err, IsNil)
+	defer server.Close()
+
+	tz1 := tk.MustQuery("select variable_value from mysql.tidb where variable_name = 'system_tz'").Rows()
+	tk.MustQuery("select @@system_time_zone").Check(tz1)
 }
 
 func (ts *TidbTestSuite) TestTLS(c *C) {

--- a/util/timeutil/time.go
+++ b/util/timeutil/time.go
@@ -127,6 +127,14 @@ func SetSystemTZ(name string) {
 	})
 }
 
+// GetSystemTZ gets the value of systemTZ, an error is returned if systemTZ is not properly set.
+func GetSystemTZ() (string, error) {
+	if systemTZ == "System" || systemTZ == "" {
+		return "", fmt.Errorf("variable `systemTZ` is not properly set")
+	}
+	return systemTZ, nil
+}
+
 // getLoc first trying to load location from a cache map. If nothing found in such map, then call
 // `time.LoadLocation` to get a timezone location. After trying both way, an error will be returned
 //  if valid Location is not found.


### PR DESCRIPTION
Cherry-pick #13934 without conflict.

-------------------------------------------------------------------------------------------------------------

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to close https://github.com/pingcap/tidb/issues/13894, by setting system variable `system_time_zone` from `system_tz` variable in `mysql.tidb` table.

### What is changed and how it works?
A `setSystemTimeZoneVariable()` is added to `server.NewServer()`, which get the value of `systemTZ` from exported function `GetSystemTZ()`

Please notice that this PR doesn't change any other behavior: all time-related calculations are not affected.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test
 - Manual test (add detailed scripts or steps below)
 
```
export TZ="Europe/London"
# Before the initial bootstrap of TiDB Server)

./bin/tidb-server
# TiDB bootstrapped and infer `systemTZ` from TZ environment variable.

tidb> select variable_value from mysql.tidb where variable_name = "system_tz"; 
+----------------+
| VARIABLE_VALUE |
+----------------+
| Europe/London  |
+----------------+
1 row in set (0.00 sec)

tidb> select @@system_time_zone;                                                  
+--------------------+
| @@system_time_zone |
+--------------------+
| Europe/London      |
+--------------------+
1 row in set (0.00 sec)
```

The scripts described in #13894 is also used for manual tests.

Code changes

 - Has exported function/method change
 
Side effects

 - NA

Related changes

 - Need to update the documentation

Release note

 - Fix the issue that `system_time_zone` is hard-coded as `CST` by setting this variable from `system_tz` in `mysql`.`tidb` table.