### PR TITLE
session: move the failpoint test to testSessionSerialSuite

### DIFF
--- a/session/session_fail_test.go
+++ b/session/session_fail_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/util/testkit"
 )
 
-func (s *testSessionSuite2) TestFailStatementCommit(c *C) {
+func (s *testSessionSerialSuite) TestFailStatementCommit(c *C) {
 
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
@@ -58,7 +58,7 @@ func (s *testSessionSuite2) TestFailStatementCommit(c *C) {
 	tk.MustQuery(`select * from t`).Check(testkit.Rows("1", "2"))
 }
 
-func (s *testSessionSuite2) TestFailStatementCommitInRetry(c *C) {
+func (s *testSessionSerialSuite) TestFailStatementCommitInRetry(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
 
@@ -78,7 +78,7 @@ func (s *testSessionSuite2) TestFailStatementCommitInRetry(c *C) {
 	tk.MustQuery(`select * from t`).Check(testkit.Rows("6"))
 }
 
-func (s *testSessionSuite2) TestGetTSFailDirtyState(c *C) {
+func (s *testSessionSerialSuite) TestGetTSFailDirtyState(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (id int)")
 
@@ -96,7 +96,7 @@ func (s *testSessionSuite2) TestGetTSFailDirtyState(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/mockGetTSFail"), IsNil)
 }
 
-func (s *testSessionSuite2) TestGetTSFailDirtyStateInretry(c *C) {
+func (s *testSessionSerialSuite) TestGetTSFailDirtyStateInretry(c *C) {
 	defer func() {
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/mockCommitError"), IsNil)
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/mockGetTSErrorInRetry"), IsNil)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2425,7 +2425,7 @@ func (s *testSessionSuite2) TestDBUserNameLength(c *C) {
 	tk.MustExec(`grant all privileges on test.t to 'abcddfjakldfjaldddds'@'%'`)
 }
 
-func (s *testSessionSuite2) TestKVVars(c *C) {
+func (s *testSessionSerialSuite) TestKVVars(c *C) {
 	c.Skip("there is no backoff here in the large txn, so this test is stale")
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table kvvars (a int, b int)")
@@ -2509,7 +2509,7 @@ func (s *testSessionSuite2) TestEnablePartition(c *C) {
 	tk1.MustQuery("show variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition on"))
 }
 
-func (s *testSessionSuite2) TestTxnRetryErrMsg(c *C) {
+func (s *testSessionSerialSuite) TestTxnRetryErrMsg(c *C) {
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)
 	tk1.MustExec("create table no_retry (id int)")


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The failpoint tests will affect the behavior of other tests.

### What is changed and how it works?
Move them to `testSessionSerialSuite`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test