### PR TITLE
privilege: fix atomic problem of `DROP ROLE`

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -958,6 +958,9 @@ func (e *SimpleExec) executeDropUser(s *ast.DropUserStmt) error {
 	}
 
 	if len(failedUsers) > 0 {
+		if s.IsDropRole {
+			return ErrCannotUser.GenWithStackByArgs("DROP ROLE", strings.Join(failedUsers, ","))
+		}
 		return ErrCannotUser.GenWithStackByArgs("DROP USER", strings.Join(failedUsers, ","))
 	}
 	domain.GetDomain(e.ctx).NotifyUpdatePrivilege(e.ctx)

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -658,4 +658,3 @@ func (s *testSuite3) TestRoleAtomic(c *C) {
 	result.Check(testkit.Rows("r2"))
 	tk.MustExec("drop role r2;")
 }
-

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -395,9 +395,9 @@ func (s *testSuite3) TestUser(c *C) {
 	dropUserSQL = `DROP USER 'test1'@'localhost', 'test2'@'localhost', 'test3'@'localhost';`
 	tk.MustGetErrCode(dropUserSQL, mysql.ErrCannotUser)
 	dropUserSQL = `DROP USER 'test3'@'localhost';`
-	tk.MustGetErrCode(dropUserSQL, mysql.ErrCannotUser)
+	tk.MustExec(dropUserSQL)
 	dropUserSQL = `DROP USER 'test1'@'localhost';`
-	tk.MustGetErrCode(dropUserSQL, mysql.ErrCannotUser)
+	tk.MustExec(dropUserSQL)
 	// Test positive cases without IF EXISTS.
 	createUserSQL = `CREATE USER 'test1'@'localhost', 'test3'@'localhost';`
 	tk.MustExec(createUserSQL)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
TiDB has atomic problem at `DROP ROLE`, which can reproduce like this:
```
mysql root@127.0.0.1:test> select user, host from mysql.user where user in ('r1', 'r2', 'r3', 'r4');
+------+------+
| user | host |
+------+------+
0 rows in set
Time: 0.016s
mysql root@127.0.0.1:test> create role r2;
Query OK, 0 rows affected
Time: 0.004s
mysql root@127.0.0.1:test> create role r1, r2, r3
(1396, "Operation CREATE USER failed for 'r2'@'%'")
mysql root@127.0.0.1:test> select user, host from mysql.user where user in ('r1', 'r2', 'r3', 'r4');
+------+------+
| user | host |
+------+------+
| r2   | %    |
+------+------+
1 row in set
Time: 0.015s
mysql root@127.0.0.1:test> drop role 'r1', 'r2', 'r3';
(1396, 'Operation DROP USER failed for r1@%,r3@%')
mysql root@127.0.0.1:test> select user, host from mysql.user where user in ('r1', 'r2', 'r3', 'r4');
+------+------+
| user | host |
+------+------+
0 rows in set
Time: 0.012s
mysql root@127.0.0.1:test>
```

The problem was cause by error logic in `DROP ROLE`, which doesn't break loop when error occur.

### What is changed and how it works?
Break the loop when drop user/role failed. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix atomic problem of `DROP ROLE`
