### PR TITLE
session: support 'GLOBAL SCOPE' for `tidb_enable_table_partition` (#14062)

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -142,6 +142,7 @@ var (
 	ErrUnsupportedPartitionByRangeColumns = terror.ClassDDL.New(codeUnsupportedPartitionByRangeColumns,
 		"unsupported partition by range columns")
 	errUnsupportedCreatePartition = terror.ClassDDL.New(codeUnsupportedCreatePartition, "unsupported partition type, treat as normal table")
+	errTablePartitionDisabled     = terror.ClassDDL.New(codeUnsupportedCreatePartition, "Partitions are ignored because Table Partition is disabled, please set 'tidb_enable_table_partition' if you need to need to enable it")
 
 	// ErrDupKeyName returns for duplicated key name
 	ErrDupKeyName = terror.ClassDDL.New(codeDupKeyName, "duplicate key name")

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -80,7 +80,7 @@ func buildTablePartitionInfo(ctx sessionctx.Context, d *ddl, s *ast.CreateTableS
 		}
 	}
 	if !enable {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errUnsupportedCreatePartition)
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errTablePartitionDisabled)
 	}
 
 	pi := &model.PartitionInfo{

--- a/session/session.go
+++ b/session/session.go
@@ -1715,6 +1715,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBRetryLimit,
 	variable.TiDBDisableTxnAutoRetry,
 	variable.TiDBEnableWindowFunction,
+	variable.TiDBEnableTablePartition,
 	variable.TiDBEnableFastAnalyze,
 	variable.TiDBExpensiveQueryTimeThreshold,
 	variable.TiDBTxnMode,

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2420,6 +2420,22 @@ func (s *testSessionSuite) TestCommitRetryCount(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *testSessionSuite2) TestEnablePartition(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("set tidb_enable_table_partition=off")
+	tk.MustQuery("show variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition off"))
+
+	tk.MustExec("set global tidb_enable_table_partition = on")
+
+	tk.MustQuery("show variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition off"))
+	tk.MustQuery("show global variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition on"))
+
+	// Disable global variable cache, so load global session variable take effect immediate.
+	s.dom.GetGlobalVarsCache().Disable()
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustQuery("show variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition on"))
+}
+
 func (s *testSessionSuite) TestTxnRetryErrMsg(c *C) {
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2420,7 +2420,7 @@ func (s *testSessionSuite) TestCommitRetryCount(c *C) {
 	c.Assert(err, NotNil)
 }
 
-func (s *testSessionSuite2) TestEnablePartition(c *C) {
+func (s *testSessionSuite) TestEnablePartition(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("set tidb_enable_table_partition=off")
 	tk.MustQuery("show variables like 'tidb_enable_table_partition'").Check(testkit.Rows("tidb_enable_table_partition off"))

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -676,7 +676,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TIDBMemQuotaNestedLoopApply, strconv.FormatInt(DefTiDBMemQuotaNestedLoopApply, 10)},
 	{ScopeSession, TiDBEnableStreaming, "0"},
 	{ScopeSession, TxnIsolationOneShot, ""},
-	{ScopeSession, TiDBEnableTablePartition, "auto"},
+	{ScopeGlobal | ScopeSession, TiDBEnableTablePartition, "auto"},
 	{ScopeGlobal | ScopeSession, TiDBHashJoinConcurrency, strconv.Itoa(DefTiDBHashJoinConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBProjectionConcurrency, strconv.Itoa(DefTiDBProjectionConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBHashAggPartialConcurrency, strconv.Itoa(DefTiDBHashAggPartialConcurrency)},


### PR DESCRIPTION
Cherry-pick #14062 

-----------------------------------------------------------------
### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to support global scope for TiDB system variable `tidb_enable_table_partition`. Sometimes users may need to disable `TABLE PARTITIONS` for a TiDB cluster, at this time, setting `tidb_enable_table_partition` to `off` at global scope will be convenient.

### What is changed and how it works?
Add missing scope.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)

```
tidb> show variables like '%partition%';                                                                                                                                                    +-----------------------------+-------+
| Variable_name               | Value |
+-----------------------------+-------+
| tidb_enable_table_partition | on    |
+-----------------------------+-------+
1 row in set (0.01 sec)

tidb> set global tidb_enable_table_partition=off;
Query OK, 0 rows affected (0.00 sec)

tidb> select @@global.tidb_enable_table_partition;
+--------------------------------------+
| @@global.tidb_enable_table_partition |
+--------------------------------------+
| off                                  |
+--------------------------------------+

tidb> select @@tidb_enable_table_partition;
+-------------------------------+
| @@tidb_enable_table_partition |
+-------------------------------+
| on                            |
+-------------------------------+
1 row in set (0.00 sec)

(Start a new session)
tidb> select @@tidb_enable_table_partition;
+-------------------------------+
| @@tidb_enable_table_partition |
+-------------------------------+
| off                           |
+-------------------------------+

tidb> CREATE TABLE e2 (
    ->     id INT NOT NULL,
    ->     fname VARCHAR(30),
    ->     lname VARCHAR(30),
    ->     hired DATE NOT NULL DEFAULT '1970-01-01',
    ->     separated DATE NOT NULL DEFAULT '9999-12-31',
    ->     job_code INT NOT NULL,
    ->     store_id INT NOT NULL
    -> )
    -> 
    -> PARTITION BY RANGE (store_id) (
    ->     PARTITION p0 VALUES LESS THAN (6),
    ->     PARTITION p1 VALUES LESS THAN (11),
    ->     PARTITION p2 VALUES LESS THAN (16),
    ->     PARTITION p3 VALUES LESS THAN (21)
    -> );
Query OK, 0 rows affected, 1 warning (0.02 sec)

tidb> show warnings;
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                                  |
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------+
| Warning | 8200 | Partitions are ignored because Table Partition is disabled, please set 'tidb_enable_table_partition' is if you need to need to enable it |
+---------+------+------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

tidb> explain select * from e2 where store_id > 15 ;
+---------------------+----------+-----------+-------------------------------------------------------------+
| id                  | count    | task      | operator info                                               |
+---------------------+----------+-----------+-------------------------------------------------------------+
| TableReader_7       | 3333.33  | root      | data:Selection_6                                            |
| └─Selection_6       | 3333.33  | cop[tikv] | gt(test.e2.store_id, 15)                                    |
|   └─TableScan_5     | 10000.00 | cop[tikv] | table:e2, range:[-inf,+inf], keep order:false, stats:pseudo |
+---------------------+----------+-----------+-------------------------------------------------------------+
3 rows in set (0.01 sec)
```

Code changes

 - Has exported variable/fields change

Side effects

 - NA

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release note

 - Support 'GLOBAL SCOPE' for `tidb_enable_table_partition`
