### PR TITLE
test: optimize expression unit test

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -47,17 +47,21 @@ import (
 var _ = Suite(&testIntegrationSuite{})
 var _ = Suite(&testIntegrationSuite2{})
 
-type testIntegrationSuite struct {
+type testIntegrationSuiteBase struct {
 	store kv.Storage
 	dom   *domain.Domain
 	ctx   sessionctx.Context
 }
 
-type testIntegrationSuite2 struct {
-	testIntegrationSuite
+type testIntegrationSuite struct {
+	testIntegrationSuiteBase
 }
 
-func (s *testIntegrationSuite) cleanEnv(c *C) {
+type testIntegrationSuite2 struct {
+	testIntegrationSuiteBase
+}
+
+func (s *testIntegrationSuiteBase) cleanEnv(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	r := tk.MustQuery("show tables")
@@ -67,14 +71,14 @@ func (s *testIntegrationSuite) cleanEnv(c *C) {
 	}
 }
 
-func (s *testIntegrationSuite) SetUpSuite(c *C) {
+func (s *testIntegrationSuiteBase) SetUpSuite(c *C) {
 	var err error
 	s.store, s.dom, err = newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 	s.ctx = mock.NewContext()
 }
 
-func (s *testIntegrationSuite) TearDownSuite(c *C) {
+func (s *testIntegrationSuiteBase) TearDownSuite(c *C) {
 	s.dom.Close()
 	s.store.Close()
 }


### PR DESCRIPTION
### What problem does this PR solve?
optimize expression unit test by fix duplicated cases  due to wrong embedding struct

### What is changed and how it works?
The expression test suite `testIntegrationSuite2` embedding another test suite `testIntegrationSuite`, so all the test cases under `testIntegrationSuite` will be implicitly auto-generated for `testIntegrationSuite2` thus make expression unit test run slow and unnecessary .

result:
before changes: 
```
> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/expression
[2019-12-18T02:23:57.925Z] OK: 470 passed, 1 skipped
[2019-12-18T02:23:57.925Z] --- PASS: TestT (88.37s)
[2019-12-18T02:23:59.292Z] ok  	github.com/pingcap/tidb/expression	89.517s
```

after change:
```
> go test -v -vet=off -p 10 -race github.com/pingcap/tidb/expression
[2019-12-18T02:23:07.926Z] OK: 406 passed, 1 skipped
[2019-12-18T02:23:07.926Z] --- PASS: TestT (76.40s)
[2019-12-18T02:23:08.854Z] ok  	github.com/pingcap/tidb/expression	77.532s
```

### Check List
Tests

- unit tests

Code changes

Side effects

Related changes