### PR TITLE
bindinfo: remove last semicolon of bind sqls

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -496,9 +496,9 @@ func (s *testSuite) TestUseMultiplyBindings(c *C) {
 	tk.MustExec("create binding for select * from t where a >= 1 and b >= 1 and c = 0 using select * from t use index(idx_a) where a >= 1 and b >= 1 and c = 0")
 	tk.MustExec("create binding for select * from t where a >= 1 and b >= 1 and c = 0 using select * from t use index(idx_b) where a >= 1 and b >= 1 and c = 0")
 	// It cannot choose table path although it has lowest cost.
-	tk.MustQuery("select * from t where a >= 4 and b >= 1 and c = 0")
+	tk.MustQuery("select * from t where a >= 4 and b >= 1 and c = 0;")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.IndexNames[0], Equals, "t:idx_a")
-	tk.MustQuery("select * from t where a >= 1 and b >= 4 and c = 0")
+	tk.MustQuery("select * from t where a >= 1 and b >= 4 and c = 0;")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.IndexNames[0], Equals, "t:idx_b")
 }
 

--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -572,18 +572,18 @@ func (s *testSuite) TestBindingCache(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, index idx(a))")
-	tk.MustExec("create global binding for select * from t using select * from t use index(idx)")
+	tk.MustExec("create global binding for select * from t using select * from t use index(idx);")
 	tk.MustExec("create database tmp")
 	tk.MustExec("use tmp")
 	tk.MustExec("create table t(a int, b int, index idx(a))")
-	tk.MustExec("create global binding for select * from t using select * from t use index(idx)")
+	tk.MustExec("create global binding for select * from t using select * from t use index(idx);")
 
 	c.Assert(s.domain.BindHandle().Update(false), IsNil)
 	c.Assert(s.domain.BindHandle().Update(false), IsNil)
 	res := tk.MustQuery("show global bindings")
 	c.Assert(len(res.Rows()), Equals, 2)
 
-	tk.MustExec("drop global binding for select * from t")
+	tk.MustExec("drop global binding for select * from t;")
 	c.Assert(s.domain.BindHandle().Update(false), IsNil)
 	c.Assert(len(s.domain.BindHandle().GetAllBindRecord()), Equals, 1)
 }

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -120,13 +120,13 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	case *ast.Join:
 		p.checkNonUniqTableAlias(node)
 	case *ast.CreateBindingStmt:
-		eraseLastSemicolon(node.OriginSel)
-		eraseLastSemicolon(node.HintedSel)
+		EraseLastSemicolon(node.OriginSel)
+		EraseLastSemicolon(node.HintedSel)
 		p.checkBindGrammar(node.OriginSel, node.HintedSel)
 	case *ast.DropBindingStmt:
-		eraseLastSemicolon(node.OriginSel)
+		EraseLastSemicolon(node.OriginSel)
 		if node.HintedSel != nil {
-			eraseLastSemicolon(node.HintedSel)
+			EraseLastSemicolon(node.HintedSel)
 			p.checkBindGrammar(node.OriginSel, node.HintedSel)
 		}
 	case *ast.RecoverTableStmt, *ast.FlashBackTableStmt:
@@ -144,9 +144,10 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 	return in, p.err != nil
 }
 
-func eraseLastSemicolon(stmt ast.StmtNode) {
+// EraseLastSemicolon removes last semicolon of sql.
+func EraseLastSemicolon(stmt ast.StmtNode) {
 	sql := stmt.Text()
-	if sql[len(sql)-1] == ';' {
+	if len(sql) > 0 && sql[len(sql)-1] == ';' {
 		stmt.SetText(sql[:len(sql)-1])
 	}
 }

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -163,6 +163,7 @@ func extractSelectAndNormalizeDigest(stmtNode ast.StmtNode) (*ast.SelectStmt, st
 	case *ast.ExplainStmt:
 		switch x.Stmt.(type) {
 		case *ast.SelectStmt:
+			plannercore.EraseLastSemicolon(x)
 			normalizeExplainSQL := parser.Normalize(x.Text())
 			idx := strings.Index(normalizeExplainSQL, "select")
 			normalizeSQL := normalizeExplainSQL[idx:]
@@ -170,6 +171,7 @@ func extractSelectAndNormalizeDigest(stmtNode ast.StmtNode) (*ast.SelectStmt, st
 			return x.Stmt.(*ast.SelectStmt), normalizeSQL, hash
 		}
 	case *ast.SelectStmt:
+		plannercore.EraseLastSemicolon(x)
 		normalizedSQL, hash := parser.NormalizeDigest(x.Text())
 		return x, normalizedSQL, hash
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When the bind sqls are ended by ';', we cannot create or drop bindings, since after normalize ';' is only in the bind sql, not in the original sql.

### What is changed and how it works?

Remove last semicolon of bind sqls

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch

Release note

 - remove last semicolon of bind sqls
