### PR TITLE
planner/core: fix bug when using generated column in aggregate statement

### DIFF
--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -172,3 +172,45 @@ Projection_4	10.00	root	test.person.name
 └─IndexLookUp_10	10.00	root	
   ├─IndexScan_8	10.00	cop[tikv]	table:person, index:city_no, range:[1,1], keep order:false, stats:pseudo
   └─TableScan_9	10.00	cop[tikv]	table:person, keep order:false, stats:pseudo
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a INT,
+b INT GENERATED ALWAYS AS (-a) VIRTUAL,
+c INT GENERATED ALWAYS AS (-a) STORED,
+index (c));
+INSERT INTO t1 (a) VALUES (2), (1), (1), (3), (NULL);
+EXPLAIN SELECT sum(a) FROM t1 GROUP BY b;
+id	count	task	operator info
+HashAgg_5	8000.00	root	group by:Column#7, funcs:sum(Column#6)->Column#5
+└─Projection_12	10000.00	root	cast(test.t1.a)->Column#6, test.t1.b
+  └─TableReader_9	10000.00	root	data:TableScan_8
+    └─TableScan_8	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+EXPLAIN SELECT sum(a) FROM t1 GROUP BY c;
+id	count	task	operator info
+HashAgg_11	8000.00	root	group by:test.t1.c, funcs:sum(Column#6)->Column#5
+└─TableReader_12	8000.00	root	data:HashAgg_5
+  └─HashAgg_5	8000.00	cop[tikv]	group by:test.t1.c, funcs:sum(test.t1.a)->Column#6
+    └─TableScan_10	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+EXPLAIN SELECT sum(b) FROM t1 GROUP BY a;
+id	count	task	operator info
+HashAgg_5	8000.00	root	group by:Column#7, funcs:sum(Column#6)->Column#5
+└─Projection_12	10000.00	root	cast(test.t1.b)->Column#6, test.t1.a
+  └─TableReader_9	10000.00	root	data:TableScan_8
+    └─TableScan_8	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+EXPLAIN SELECT sum(b) FROM t1 GROUP BY c;
+id	count	task	operator info
+HashAgg_5	8000.00	root	group by:Column#9, funcs:sum(Column#8)->Column#5
+└─Projection_18	10000.00	root	cast(test.t1.b)->Column#8, test.t1.c
+  └─TableReader_11	10000.00	root	data:TableScan_10
+    └─TableScan_10	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+EXPLAIN SELECT sum(c) FROM t1 GROUP BY a;
+id	count	task	operator info
+HashAgg_9	8000.00	root	group by:test.t1.a, funcs:sum(Column#6)->Column#5
+└─TableReader_10	8000.00	root	data:HashAgg_5
+  └─HashAgg_5	8000.00	cop[tikv]	group by:test.t1.a, funcs:sum(test.t1.c)->Column#6
+    └─TableScan_8	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+EXPLAIN SELECT sum(c) FROM t1 GROUP BY b;
+id	count	task	operator info
+HashAgg_5	8000.00	root	group by:Column#7, funcs:sum(Column#6)->Column#5
+└─Projection_12	10000.00	root	cast(test.t1.c)->Column#6, test.t1.b
+  └─TableReader_9	10000.00	root	data:TableScan_8
+    └─TableScan_8	10000.00	cop[tikv]	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/generated_columns.test
+++ b/cmd/explaintest/t/generated_columns.test
@@ -111,3 +111,20 @@ KEY(city_no));
 
 INSERT INTO person (name, address_info) VALUES ("John", CAST('{"city_no": 1}' AS JSON));
 EXPLAIN SELECT name FROM person where city_no=1;
+
+-- Virtual generated columns in aggregate statement
+-- ISSUE https://github.com/pingcap/tidb/issues/14072
+
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (a INT,
+                 b INT GENERATED ALWAYS AS (-a) VIRTUAL,
+                 c INT GENERATED ALWAYS AS (-a) STORED,
+                 index (c));
+INSERT INTO t1 (a) VALUES (2), (1), (1), (3), (NULL);
+
+EXPLAIN SELECT sum(a) FROM t1 GROUP BY b;
+EXPLAIN SELECT sum(a) FROM t1 GROUP BY c;
+EXPLAIN SELECT sum(b) FROM t1 GROUP BY a;
+EXPLAIN SELECT sum(b) FROM t1 GROUP BY c;
+EXPLAIN SELECT sum(c) FROM t1 GROUP BY a;
+EXPLAIN SELECT sum(c) FROM t1 GROUP BY b;

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -938,7 +938,7 @@ func (sel *PhysicalSelection) attach2Task(tasks ...task) task {
 	return t
 }
 
-// CheckAggCanPushCop checks whether the aggFuncs with groupByItems can
+// CheckAggCanPushCop checks whether the aggFuncs and groupByItems can
 // be pushed down to coprocessor.
 func CheckAggCanPushCop(sctx sessionctx.Context, aggFuncs []*aggregation.AggFuncDesc, groupByItems []expression.Expression, copToFlash bool) bool {
 	sc := sctx.GetSessionVars().StmtCtx
@@ -959,6 +959,9 @@ func CheckAggCanPushCop(sctx sessionctx.Context, aggFuncs []*aggregation.AggFunc
 		if pb == nil {
 			return false
 		}
+	}
+	if expression.ContainVirtualColumn(groupByItems) {
+		return false
 	}
 	_, _, remained := expression.ExpressionsToPB(sc, groupByItems, client)
 	if len(remained) > 0 {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix #14072 

### What is changed and how it works?

When checking if aggregate operator can be push-down, it should also check that if `groupByItem` contained generated columns, if true, current aggregate operator should not be push-down.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - None

Side effects

 - None
Related changes

 - None

Release note

 - None
