### PR TITLE
executor: replace the flag `CastStrToIntStrict` with `InSelectStmt` 

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1529,7 +1529,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	sc.OriginalSQL = s.Text()
 	if explainStmt, ok := s.(*ast.ExplainStmt); ok {
 		sc.InExplainStmt = true
-		sc.CastStrToIntStrict = true
 		s = explainStmt.Stmt
 	}
 	// TODO: Many same bool variables here.
@@ -1591,7 +1590,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 			sc.Priority = opts.Priority
 			sc.NotFillCache = !opts.SQLCache
 		}
-		sc.CastStrToIntStrict = true
 	case *ast.ShowStmt:
 		sc.IgnoreTruncate = true
 		sc.IgnoreZeroInDate = true

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -28,14 +28,17 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 )
 
-func (s *testEvaluatorSuite) TestCast(c *C) {
+func (s *testEvaluatorSuite) TestCastXXX(c *C) {
 	ctx, sc := s.ctx, s.ctx.GetSessionVars().StmtCtx
 
 	// Test `cast as char[(N)]` and `cast as binary[(N)]`.
 	originIgnoreTruncate := sc.IgnoreTruncate
-	sc.IgnoreTruncate = true
+	originTruncateAsWarning := sc.TruncateAsWarning
+	sc.IgnoreTruncate = false
+	sc.TruncateAsWarning = true
 	defer func() {
 		sc.IgnoreTruncate = originIgnoreTruncate
+		sc.TruncateAsWarning = originTruncateAsWarning
 	}()
 
 	tp := types.NewFieldType(mysql.TypeString)
@@ -150,7 +153,7 @@ func (s *testEvaluatorSuite) TestCast(c *C) {
 
 	warnings = sc.GetWarnings()
 	lastWarn = warnings[len(warnings)-1]
-	c.Assert(terror.ErrorEqual(types.ErrOverflow, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
+	c.Assert(terror.ErrorEqual(types.ErrTruncatedWrongVal, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
 
 	// cast('1e9223372036854775807' as unsigned)
 	f = BuildCastFunction(ctx, &Constant{Value: types.NewDatum("1e9223372036854775807"), RetType: types.NewFieldType(mysql.TypeString)}, tp1)
@@ -160,7 +163,7 @@ func (s *testEvaluatorSuite) TestCast(c *C) {
 
 	warnings = sc.GetWarnings()
 	lastWarn = warnings[len(warnings)-1]
-	c.Assert(terror.ErrorEqual(types.ErrOverflow, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
+	c.Assert(terror.ErrorEqual(types.ErrTruncatedWrongVal, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
 
 	// cast('18446744073709551616' as signed);
 	mask := ^mysql.UnsignedFlag
@@ -192,7 +195,7 @@ func (s *testEvaluatorSuite) TestCast(c *C) {
 
 	warnings = sc.GetWarnings()
 	lastWarn = warnings[len(warnings)-1]
-	c.Assert(terror.ErrorEqual(types.ErrOverflow, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
+	c.Assert(terror.ErrorEqual(types.ErrTruncatedWrongVal, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
 
 	// cast('1e9223372036854775807' as signed)
 	f = BuildCastFunction(ctx, &Constant{Value: types.NewDatum("1e9223372036854775807"), RetType: types.NewFieldType(mysql.TypeString)}, tp1)
@@ -202,7 +205,7 @@ func (s *testEvaluatorSuite) TestCast(c *C) {
 
 	warnings = sc.GetWarnings()
 	lastWarn = warnings[len(warnings)-1]
-	c.Assert(terror.ErrorEqual(types.ErrOverflow, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
+	c.Assert(terror.ErrorEqual(types.ErrTruncatedWrongVal, lastWarn.Err), IsTrue, Commentf("err %v", lastWarn.Err))
 
 	// create table t1(s1 time);
 	// insert into t1 values('11:11:11');

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -5207,3 +5207,22 @@ func (s *testIntegrationSuite) TestDecodetoChunkReuse(c *C) {
 	c.Assert(count, Equals, 200)
 	rs.Close()
 }
+
+func (s *testIntegrationSuite) TestCastStrToInt(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	cases := []struct {
+		sql    string
+		result int
+	}{
+		{"select cast('' as signed)", 0},
+		{"select cast('12345abcde' as signed)", 12345},
+		{"select cast('123e456' as signed)", 123},
+		{"select cast('-12345abcde' as signed)", -12345},
+		{"select cast('-123e456' as signed)", -123},
+	}
+	for _, ca := range cases {
+		tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
+		tk.MustQuery(ca.sql).Check(testkit.Rows(fmt.Sprintf("%v", ca.result)))
+		c.Assert(terror.ErrorEqual(tk.Se.GetSessionVars().StmtCtx.GetWarnings()[0].Err, types.ErrTruncatedWrongVal), IsTrue)
+	}
+}

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -71,11 +71,6 @@ type StatementContext struct {
 	BatchCheck             bool
 	InNullRejectCheck      bool
 	AllowInvalidDate       bool
-	// CastStrToIntStrict is used to control the way we cast float format string to int.
-	// If ConvertStrToIntStrict is false, we convert it to a valid float string first,
-	// then cast the float string to int string. Otherwise, we cast string to integer
-	// prefix in a strict way, only extract 0-9 and (+ or - in first bit).
-	CastStrToIntStrict bool
 
 	// mu struct holds variables that change during execution.
 	mu struct {

--- a/types/convert.go
+++ b/types/convert.go
@@ -371,7 +371,7 @@ func NumberToDuration(number int64, fsp int8) (Duration, error) {
 
 // getValidIntPrefix gets prefix of the string which can be successfully parsed as int.
 func getValidIntPrefix(sc *stmtctx.StatementContext, str string) (string, error) {
-	if !sc.CastStrToIntStrict {
+	if !sc.InSelectStmt {
 		floatPrefix, err := getValidFloatPrefix(sc, str)
 		if err != nil {
 			return floatPrefix, errors.Trace(err)

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -475,6 +475,7 @@ func testSelectUpdateDeleteEmptyStringError(c *C) {
 		{false, true},
 	}
 	sc := new(stmtctx.StatementContext)
+	sc.TruncateAsWarning = true
 	for _, tc := range testCases {
 		sc.InSelectStmt = tc.inSelect
 		sc.InDeleteStmt = tc.inDelete

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -753,7 +753,7 @@ func (s *testTypeConvertSuite) TestGetValidInt(c *C) {
 	}
 	sc := new(stmtctx.StatementContext)
 	sc.TruncateAsWarning = true
-	sc.CastStrToIntStrict = true
+	sc.InSelectStmt = true
 	warningCount := 0
 	for _, tt := range tests {
 		prefix, err := getValidIntPrefix(sc, tt.origin)
@@ -796,7 +796,7 @@ func (s *testTypeConvertSuite) TestGetValidInt(c *C) {
 		{"123de", "123", true},
 	}
 	sc.TruncateAsWarning = false
-	sc.CastStrToIntStrict = false
+	sc.InSelectStmt = false
 	for _, tt := range tests2 {
 		prefix, err := getValidIntPrefix(sc, tt.origin)
 		if tt.warning {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Replace the flag `CastStrToIntStrict` with `InSelectStmt` and remove it since it is too tricky to understand and causes some incompatible problems on `TiKV` and `MockTiKV`(see https://github.com/pingcap/tidb/pull/13970).

### What is changed and how it works?
+ Replace the flag with `InSelectStmt` since they have the same logic
+ Removing the definition of it in the `Ctx`
+ Add some UTs 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
