### PR TITLE
executor: avoid `ProjectoinExec`'s goroutine leak 

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -74,7 +74,7 @@ func (e *ExplainExec) Next(ctx context.Context, req *chunk.Chunk) error {
 func (e *ExplainExec) generateExplainInfo(ctx context.Context) (rows [][]string, err error) {
 	closed := false
 	defer func() {
-		if !closed {
+		if !closed && e.analyzeExec != nil {
 			err = e.analyzeExec.Close()
 			closed = true
 		}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -74,8 +74,7 @@ func (e *ExplainExec) Next(ctx context.Context, req *chunk.Chunk) error {
 func (e *ExplainExec) generateExplainInfo(ctx context.Context) (rows [][]string, err error) {
 	closed := false
 	defer func() {
-		// handle panic
-		if panicErr := recover(); panicErr != nil && !closed {
+		if !closed {
 			err = e.analyzeExec.Close()
 			closed = true
 		}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -75,8 +75,7 @@ func (e *ExplainExec) generateExplainInfo(ctx context.Context) (rows [][]string,
 	closed := false
 	defer func() {
 		// handle panic
-		recover()
-		if !closed {
+		if panicErr := recover(); panicErr != nil && !closed {
 			err = e.analyzeExec.Close()
 			closed = true
 		}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -15,11 +15,11 @@ package executor
 
 import (
 	"context"
-	"github.com/pingcap/errors"
 
+	"github.com/cznic/mathutil"
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/util/chunk"
-	"github.com/pingcap/tidb/util/mathutil"
 )
 
 // ExplainExec represents an explain executor.

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -15,7 +15,6 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/pingcap/failpoint"
 	"strings"
 
 	. "github.com/pingcap/check"
@@ -105,23 +104,6 @@ func (s *testSuite1) TestExplainWrite(c *C) {
 	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
 	tk.MustExec("explain analyze insert into t select 1")
 	tk.MustQuery("select * from t order by a").Check(testkit.Rows("1", "2"))
-}
-
-func (s *testSuite1) TestGoroutineLeakInExplainAnalyzeForProjection(c *C) {
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/mockErrorsInNextOfProjection", `return(true)`), IsNil)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/mockErrorsInCloseOfProjection", `return(true)`), IsNil)
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/mockErrorsInNextOfProjection"), IsNil)
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/mockErrorsInCloseOfProjection"), IsNil)
-
-	}()
-	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t (a int)")
-	tk.MustExec("insert into t values(1),(2),(3),(4)")
-	tk.MustExec("set @@tidb_projection_concurrency = 4")
-	err := tk.QueryToErr("explain analyze select a*200 from t")
-	c.Assert(err.Error(), Equals, "goroutines leak in next() of projection, An error in close() of projection")
 }
 
 func (s *testSuite1) TestExplainAnalyzeMemory(c *C) {

--- a/executor/explain_unit_test.go
+++ b/executor/explain_unit_test.go
@@ -71,16 +71,17 @@ func TestExplainAnalyzeInvokeNextAndClose(t *testing.T) {
 		explain:      nil,
 	}
 	// mockErrorOperator returns errors
-	explainExec.analyzeExec = &mockErrorOperator{baseExec, false, false}
+	mockOper := mockErrorOperator{baseExec, false, false}
+	explainExec.analyzeExec = &mockOper
 	tmpCtx := context.Background()
 	_, err := explainExec.generateExplainInfo(tmpCtx)
 
 	expectedStr := "next error, close error"
-	if err.Error() != expectedStr {
+	if err.Error() != expectedStr || !mockOper.closed {
 		t.Errorf(err.Error())
 	}
 	// mockErrorOperator panic
-	mockOper := mockErrorOperator{baseExec, true, false}
+	mockOper = mockErrorOperator{baseExec, true, false}
 	explainExec.analyzeExec = &mockOper
 	defer func() {
 		if panicErr := recover(); panicErr != nil && !mockOper.closed {

--- a/executor/explain_unit_test.go
+++ b/executor/explain_unit_test.go
@@ -84,10 +84,9 @@ func TestExplainAnalyzeInvokeNextAndClose(t *testing.T) {
 	mockOper = mockErrorOperator{baseExec, true, false}
 	explainExec.analyzeExec = &mockOper
 	defer func() {
-		if panicErr := recover(); panicErr != nil && !mockOper.closed {
-			t.Errorf(err.Error())
+		if panicErr := recover(); panicErr == nil || !mockOper.closed {
+			t.Errorf("panic test failed: without panic or close() is not called")
 		}
 	}()
 	_, err = explainExec.generateExplainInfo(tmpCtx)
-
 }

--- a/executor/explain_unit_test.go
+++ b/executor/explain_unit_test.go
@@ -1,0 +1,74 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+	"errors"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+	"testing"
+)
+
+var (
+	_ Executor = &mockErrorOperator{}
+)
+
+type mockErrorOperator struct {
+	baseExecutor
+}
+
+func (e *mockErrorOperator) Open(ctx context.Context) error {
+	return nil
+}
+
+func (e *mockErrorOperator) Next(ctx context.Context, req *chunk.Chunk) error {
+	return errors.New("next error")
+}
+
+func (e *mockErrorOperator) Close() error {
+	return errors.New("close error")
+}
+
+func getColumns() []*expression.Column {
+	return []*expression.Column{
+		{Index: 1, RetType: types.NewFieldType(mysql.TypeLonglong)},
+	}
+}
+
+// close() must be called after next() to avoid goroutines leak
+func TestExplainAnalyzeInvokeNextAndClose(t *testing.T) {
+	ctx := mock.NewContext()
+	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
+	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
+	schema := expression.NewSchema(getColumns()...)
+	baseExec := newBaseExecutor(ctx, schema, nil)
+	explainExec := &ExplainExec{
+		baseExecutor: baseExec,
+		explain:      nil,
+	}
+	explainExec.analyzeExec = &mockErrorOperator{baseExec}
+	tmpCtx := context.Background()
+	_, err := explainExec.generateExplainInfo(tmpCtx)
+
+	expectedStr := "next error, close error"
+	if err.Error() != expectedStr {
+		t.Errorf(err.Error())
+	}
+}

--- a/executor/explain_unit_test.go
+++ b/executor/explain_unit_test.go
@@ -16,6 +16,7 @@ package executor
 import (
 	"context"
 	"errors"
+	"testing"
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -23,7 +24,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
-	"testing"
 )
 
 var (


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix #14125

### What is changed and how it works?
invoke close() even next() errors in explain statements

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - N/A

Side effects

 - N/A

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
