### PR TITLE
expression: implement vectorized evaluation for `builtinExtractDurationSig`

### DIFF
--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -358,6 +358,7 @@ var vecBuiltinTimeCases = map[string][]vecExprBenchCase{
 	},
 	ast.Extract: {
 		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETDatetime}, geners: []dataGenerator{&dateTimeUnitStrGener{}, nil}},
+		{retEvalType: types.ETInt, childrenTypes: []types.EvalType{types.ETString, types.ETDuration}, geners: []dataGenerator{&dateTimeUnitStrGener{}, &rangeDurationGener{0.2}}},
 	},
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
expression: implemented vectorized  “builtinExtractDurationSig”

### What is changed and how it works?
	BenchmarkVectorizedBuiltinTimeFuncGenerated-8           1000000000               0.0997 ns/op          0 B/op          0 allocs/op

	BenchmarkVectorizedBuiltinTimeFunc-8                    1000000000               0.0219 ns/op          0 B/op          0 allocs/op
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
