### PR TITLE
infoschema, util: refresh statement summary table periodically (#13680)

### DIFF
--- a/domain/global_vars_cache.go
+++ b/domain/global_vars_cache.go
@@ -44,7 +44,7 @@ func (gvc *GlobalVariableCache) Update(rows []chunk.Row, fields []*ast.ResultFie
 	gvc.fields = fields
 	gvc.Unlock()
 
-	checkEnableStmtSummary(rows, fields)
+	checkEnableServerGlobalVar(rows)
 }
 
 // Get gets the global variables from cache.
@@ -67,24 +67,22 @@ func (gvc *GlobalVariableCache) Disable() {
 	return
 }
 
-// checkEnableStmtSummary looks for TiDBEnableStmtSummary and notifies StmtSummary
-func checkEnableStmtSummary(rows []chunk.Row, fields []*ast.ResultField) {
+// checkEnableServerGlobalVar processes variables that acts in server and global level.
+func checkEnableServerGlobalVar(rows []chunk.Row) {
 	for _, row := range rows {
-		varName := row.GetString(0)
-		if varName == variable.TiDBEnableStmtSummary {
-			varVal := row.GetDatum(1, &fields[1].Column.FieldType)
-
+		switch row.GetString(0) {
+		case variable.TiDBEnableStmtSummary:
 			sVal := ""
-			if !varVal.IsNull() {
-				var err error
-				sVal, err = varVal.ToString()
-				if err != nil {
-					return
-				}
+			if !row.IsNull(1) {
+				sVal = row.GetString(1)
 			}
-
 			stmtsummary.StmtSummaryByDigestMap.SetEnabled(sVal, false)
-			break
+		case variable.TiDBStmtSummaryRefreshInterval:
+			sVal := ""
+			if !row.IsNull(1) {
+				sVal = row.GetString(1)
+			}
+			stmtsummary.StmtSummaryByDigestMap.SetRefreshInterval(sVal, false)
 		}
 	}
 }

--- a/executor/set.go
+++ b/executor/set.go
@@ -197,8 +197,11 @@ func (e *SetExecutor) setSysVariable(name string, v *expression.VarAssignment) e
 		}
 	}
 
-	if name == variable.TiDBEnableStmtSummary {
+	switch name {
+	case variable.TiDBEnableStmtSummary:
 		stmtsummary.StmtSummaryByDigestMap.SetEnabled(valStr, !v.IsGlobal)
+	case variable.TiDBStmtSummaryRefreshInterval:
+		stmtsummary.StmtSummaryByDigestMap.SetRefreshInterval(valStr, !v.IsGlobal)
 	}
 
 	return nil

--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -382,6 +382,7 @@ const tableStagesHistoryLong = "CREATE TABLE if not exists performance_schema.ev
 // tableEventsStatementsSummaryByDigest contains the column name definitions for table
 // events_statements_summary_by_digest, same as MySQL.
 const tableEventsStatementsSummaryByDigest = "CREATE TABLE if not exists events_statements_summary_by_digest (" +
+	"SUMMARY_BEGIN_TIME TIMESTAMP(6) NOT NULL," +
 	"STMT_TYPE VARCHAR(64) NOT NULL," +
 	"SCHEMA_NAME VARCHAR(64) DEFAULT NULL," +
 	"DIGEST VARCHAR(64) NOT NULL," +

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -64,14 +64,14 @@ func (s *testTableSuite) TestPerfSchemaTables(c *C) {
 	tk.MustQuery("select * from events_stages_history_long").Check(testkit.Rows())
 }
 
-// Test events_statements_summary_by_digest
+// Test events_statements_summary_by_digest.
 func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b varchar(10), key k(a))")
 
-	// Statement summary is disabled by default
+	// Statement summary is disabled by default.
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
 	tk.MustExec("insert into t values(1, 'a')")
 	tk.MustQuery("select * from performance_schema.events_statements_summary_by_digest").Check(testkit.Rows())
@@ -81,8 +81,11 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 
 	// Invalidate the cache manually so that tidb_enable_stmt_summary works immediately.
 	s.dom.GetGlobalVarsCache().Disable()
+	// Disable refreshing summary.
+	tk.MustExec("set global tidb_stmt_summary_refresh_interval = 999999999")
+	tk.MustQuery("select @@global.tidb_stmt_summary_refresh_interval").Check(testkit.Rows("999999999"))
 
-	// Create a new session to test
+	// Create a new session to test.
 	tk = testkit.NewTestKitWithInit(c, s.store)
 
 	// Test INSERT
@@ -97,7 +100,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		where digest_text like 'insert into t%'`,
 	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd')"))
 
-	// Test SELECT
+	// Test SELECT.
 	tk.MustQuery("select * from t where a=2")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
@@ -114,26 +117,26 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		order by exec_count desc limit 1`,
 	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd')"))
 
-	// Disable it again
+	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
 
 	// Create a new session to test
 	tk = testkit.NewTestKitWithInit(c, s.store)
 
-	// This statement shouldn't be summarized
+	// This statement shouldn't be summarized.
 	tk.MustQuery("select * from t where a=2")
 
-	// The table should be cleared
+	// The table should be cleared.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
 		max_prewrite_regions, avg_affected_rows, query_sample_text 
 		from performance_schema.events_statements_summary_by_digest`,
 	).Check(testkit.Rows())
 
-	// Enable it in session scope
+	// Enable it in session scope.
 	tk.MustExec("set session tidb_enable_stmt_summary = on")
-	// It should work immediately
+	// It should work immediately.
 	tk.MustExec("begin")
 	tk.MustExec("insert into t values(1, 'a')")
 	tk.MustExec("commit")
@@ -158,15 +161,15 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2"))
 
-	// Disable it in global scope
+	// Disable it in global scope.
 	tk.MustExec("set global tidb_enable_stmt_summary = off")
 
-	// Create a new session to test
+	// Create a new session to test.
 	tk = testkit.NewTestKitWithInit(c, s.store)
 
 	tk.MustQuery("select * from t where a=2")
 
-	// Statement summary is still enabled
+	// Statement summary is still enabled.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
 		max_prewrite_regions, avg_affected_rows, query_sample_text 
@@ -174,11 +177,11 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		where digest_text like 'select * from t%'`,
 	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2"))
 
-	// Unset session variable
+	// Unset session variable.
 	tk.MustExec("set session tidb_enable_stmt_summary = ''")
 	tk.MustQuery("select * from t where a=2")
 
-	// Statement summary is disabled
+	// Statement summary is disabled.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
 		max_prewrite_regions, avg_affected_rows, query_sample_text 

--- a/session/session.go
+++ b/session/session.go
@@ -1720,6 +1720,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBExpensiveQueryTimeThreshold,
 	variable.TiDBTxnMode,
 	variable.TiDBEnableStmtSummary,
+	variable.TiDBStmtSummaryRefreshInterval,
 	variable.TiDBMaxDeltaSchemaCount,
 	variable.TiDBStoreLimit,
 }

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -715,6 +715,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBExpensiveQueryTimeThreshold, strconv.Itoa(DefTiDBExpensiveQueryTimeThreshold)},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
 	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, "0"},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryRefreshInterval, strconv.Itoa(DefTiDBStmtSummaryRefreshInterval)},
 	{ScopeGlobal | ScopeSession, TiDBStoreLimit, strconv.FormatInt(atomic.LoadInt64(&config.GetGlobalConfig().TiKVClient.StoreLimit), 10)},
 }
 

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -295,6 +295,9 @@ const (
 	// TiDBEnableStmtSummary indicates whether the statement summary is enabled.
 	TiDBEnableStmtSummary = "tidb_enable_stmt_summary"
 
+	// TiDBStmtSummaryRefreshInterval indicates the refresh interval in seconds for each statement summary.
+	TiDBStmtSummaryRefreshInterval = "tidb_stmt_summary_refresh_interval"
+
 	// TiDBStoreLimit indicates the limit of sending request to a store, 0 means without limit.
 	TiDBStoreLimit = "tidb_store_limit"
 )
@@ -362,7 +365,8 @@ const (
 	DefTiDBExpensiveQueryTimeThreshold = 60  // 60s
 	DefWaitSplitRegionTimeout          = 300 // 300s
 	DefTiDBAllowRemoveAutoInc          = false
-	DefInnodbLockWaitTimeout           = 50 // 50s
+	DefTiDBStmtSummaryRefreshInterval  = 1800 // 1800s
+	DefInnodbLockWaitTimeout           = 50   // 50s
 	DefTiDBStoreLimit                  = 0
 )
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -611,6 +611,11 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return "", nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
+	case TiDBStmtSummaryRefreshInterval:
+		if value == "" {
+			return "", nil
+		}
+		return checkUInt64SystemVar(name, value, 1, math.MaxUint32, vars)
 	}
 	return value, nil
 }

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -294,6 +294,16 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
 	c.Assert(v.CorrelationThreshold, Equals, float64(0))
+
+	SetSessionSystemVar(v, TiDBEnableStmtSummary, types.NewStringDatum("on"))
+	val, err = GetSessionSystemVar(v, TiDBEnableStmtSummary)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "1")
+
+	SetSessionSystemVar(v, TiDBStmtSummaryRefreshInterval, types.NewStringDatum("10"))
+	val, err = GetSessionSystemVar(v, TiDBStmtSummaryRefreshInterval)
+	c.Assert(err, IsNil)
+	c.Assert(val, Equals, "10")
 }
 
 func (s *testVarsutilSuite) TestValidate(c *C) {
@@ -348,6 +358,11 @@ func (s *testVarsutilSuite) TestValidate(c *C) {
 		{TiDBTxnMode, "pessimistic", false},
 		{TiDBTxnMode, "optimistic", false},
 		{TiDBTxnMode, "", false},
+		{TiDBEnableStmtSummary, "a", true},
+		{TiDBEnableStmtSummary, "-1", true},
+		{TiDBEnableStmtSummary, "", false},
+		{TiDBStmtSummaryRefreshInterval, "a", true},
+		{TiDBStmtSummaryRefreshInterval, "", false},
 	}
 
 	for _, t := range tests {

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -32,7 +33,7 @@ import (
 )
 
 // There're many types of statement summary tables in MySQL, but we have
-// only implemented events_statement_summary_by_digest for now.
+// only implemented events_statements_summary_by_digest for now.
 
 // stmtSummaryByDigestKey defines key for stmtSummaryByDigestMap.summaryMap.
 type stmtSummaryByDigestKey struct {
@@ -58,14 +59,23 @@ type stmtSummaryByDigestMap struct {
 	// It's rare to read concurrently, so RWMutex is not needed.
 	sync.Mutex
 	summaryMap *kvcache.SimpleLRUCache
+	// These fields are used for rolling summary.
+	beginTimeForCurInterval int64
+	lastCheckExpireTime     int64
 
-	// enabledWrapper encapsulates variables needed to judge whether statement summary is enabled.
-	enabledWrapper struct {
+	// sysVars encapsulates system variables needed to control statement summary.
+	sysVars struct {
 		sync.RWMutex
 		// enabled indicates whether statement summary is enabled in current server.
 		sessionEnabled string
 		// setInSession indicates whether statement summary has been set in any session.
 		globalEnabled string
+		// These variables indicate the refresh interval of summaries.
+		// They must be > 0.
+		sessionRefreshInterval string
+		globalRefreshInterval  string
+		// A cached result. It must be read atomically.
+		refreshInterval int64
 	}
 }
 
@@ -76,6 +86,8 @@ var StmtSummaryByDigestMap = newStmtSummaryByDigestMap()
 type stmtSummaryByDigest struct {
 	// It's rare to read concurrently, so RWMutex is not needed.
 	sync.Mutex
+	// Each summary is summarized between [beginTime, beginTime + interval].
+	beginTime int64
 	// basic
 	schemaName    string
 	digest        string
@@ -167,16 +179,21 @@ type StmtExecInfo struct {
 func newStmtSummaryByDigestMap() *stmtSummaryByDigestMap {
 	maxStmtCount := config.GetGlobalConfig().StmtSummary.MaxStmtCount
 	ssMap := &stmtSummaryByDigestMap{
-		summaryMap: kvcache.NewSimpleLRUCache(maxStmtCount, 0, 0),
+		summaryMap:              kvcache.NewSimpleLRUCache(maxStmtCount, 0, 0),
+		beginTimeForCurInterval: 0,
+		lastCheckExpireTime:     0,
 	}
-	// enabledWrapper.defaultEnabled will be initialized in package variable.
-	ssMap.enabledWrapper.sessionEnabled = ""
-	ssMap.enabledWrapper.globalEnabled = ""
+	// sysVars.defaultEnabled will be initialized in package variable.
+	ssMap.sysVars.sessionEnabled = ""
+	ssMap.sysVars.globalEnabled = ""
 	return ssMap
 }
 
 // AddStatement adds a statement to StmtSummaryByDigestMap.
 func (ssMap *stmtSummaryByDigestMap) AddStatement(sei *StmtExecInfo) {
+	// All times are counted in seconds.
+	now := time.Now().Unix()
+
 	key := &stmtSummaryByDigestKey{
 		schemaName: sei.SchemaName,
 		digest:     sei.Digest,
@@ -192,9 +209,29 @@ func (ssMap *stmtSummaryByDigestMap) AddStatement(sei *StmtExecInfo) {
 			return nil, false
 		}
 
+		// Check refreshing every second.
+		if now > ssMap.lastCheckExpireTime {
+			intervalSeconds := ssMap.RefreshInterval()
+			if intervalSeconds <= 0 {
+				return nil, false
+			}
+
+			if ssMap.beginTimeForCurInterval+intervalSeconds <= now {
+				// `beginTimeForCurInterval` is a multiple of intervalSeconds, so that when the interval is a multiple
+				// of 60 (or 600, 1800, 3600, etc), begin time shows 'XX:XX:00', not 'XX:XX:01'~'XX:XX:59'.
+				ssMap.beginTimeForCurInterval = now / intervalSeconds * intervalSeconds
+			}
+			ssMap.lastCheckExpireTime = now
+		}
+
 		value, ok := ssMap.summaryMap.Get(key)
+		// Replacing an element in LRU cache can only be `Delete` + `Put`.
+		if ok && (value.(*stmtSummaryByDigest).beginTime < ssMap.beginTimeForCurInterval) {
+			ssMap.summaryMap.Delete(key)
+			ok = false
+		}
 		if !ok {
-			newSummary := newStmtSummaryByDigest(sei)
+			newSummary := newStmtSummaryByDigest(sei, ssMap.beginTimeForCurInterval)
 			ssMap.summaryMap.Put(key, newSummary)
 		}
 		return value, ok
@@ -212,6 +249,8 @@ func (ssMap *stmtSummaryByDigestMap) Clear() {
 	defer ssMap.Unlock()
 
 	ssMap.summaryMap.DeleteAll()
+	ssMap.beginTimeForCurInterval = 0
+	ssMap.lastCheckExpireTime = 0
 }
 
 // ToDatum converts statement summary to datum.
@@ -223,8 +262,10 @@ func (ssMap *stmtSummaryByDigestMap) ToDatum() [][]types.Datum {
 	rows := make([][]types.Datum, 0, len(values))
 	for _, value := range values {
 		ssbd := value.(*stmtSummaryByDigest)
-		record := ssbd.toDatum()
-		rows = append(rows, record)
+		record := ssbd.toDatum(ssMap.beginTimeForCurInterval)
+		if record != nil {
+			rows = append(rows, record)
+		}
 	}
 	return rows
 }
@@ -256,15 +297,15 @@ func (ssMap *stmtSummaryByDigestMap) GetMoreThanOnceSelect() ([]string, []string
 func (ssMap *stmtSummaryByDigestMap) SetEnabled(value string, inSession bool) {
 	value = ssMap.normalizeEnableValue(value)
 
-	ssMap.enabledWrapper.Lock()
+	ssMap.sysVars.Lock()
 	if inSession {
-		ssMap.enabledWrapper.sessionEnabled = value
+		ssMap.sysVars.sessionEnabled = value
 	} else {
-		ssMap.enabledWrapper.globalEnabled = value
+		ssMap.sysVars.globalEnabled = value
 	}
-	sessionEnabled := ssMap.enabledWrapper.sessionEnabled
-	globalEnabled := ssMap.enabledWrapper.globalEnabled
-	ssMap.enabledWrapper.Unlock()
+	sessionEnabled := ssMap.sysVars.sessionEnabled
+	globalEnabled := ssMap.sysVars.globalEnabled
+	ssMap.sysVars.Unlock()
 
 	// Clear all summaries once statement summary is disabled.
 	var needClear bool
@@ -280,14 +321,14 @@ func (ssMap *stmtSummaryByDigestMap) SetEnabled(value string, inSession bool) {
 
 // Enabled returns whether statement summary is enabled.
 func (ssMap *stmtSummaryByDigestMap) Enabled() bool {
-	ssMap.enabledWrapper.RLock()
-	defer ssMap.enabledWrapper.RUnlock()
+	ssMap.sysVars.RLock()
+	defer ssMap.sysVars.RUnlock()
 
 	var enabled bool
-	if ssMap.isSet(ssMap.enabledWrapper.sessionEnabled) {
-		enabled = ssMap.isEnabled(ssMap.enabledWrapper.sessionEnabled)
+	if ssMap.isSet(ssMap.sysVars.sessionEnabled) {
+		enabled = ssMap.isEnabled(ssMap.sysVars.sessionEnabled)
 	} else {
-		enabled = ssMap.isEnabled(ssMap.enabledWrapper.globalEnabled)
+		enabled = ssMap.isEnabled(ssMap.sysVars.globalEnabled)
 	}
 	return enabled
 }
@@ -315,8 +356,44 @@ func (ssMap *stmtSummaryByDigestMap) isSet(value string) bool {
 	return value != ""
 }
 
+// SetRefreshInterval sets refreshing interval in ssMap.sysVars.
+func (ssMap *stmtSummaryByDigestMap) SetRefreshInterval(value string, inSession bool) {
+	ssMap.sysVars.Lock()
+	if inSession {
+		ssMap.sysVars.sessionRefreshInterval = value
+	} else {
+		ssMap.sysVars.globalRefreshInterval = value
+	}
+	sessionRefreshInterval := ssMap.sysVars.sessionRefreshInterval
+	globalRefreshInterval := ssMap.sysVars.globalRefreshInterval
+	ssMap.sysVars.Unlock()
+
+	// Calculate the cached `refreshInterval`.
+	var interval int
+	var err error
+	if ssMap.isSet(sessionRefreshInterval) {
+		interval, err = strconv.Atoi(sessionRefreshInterval)
+		if err != nil {
+			interval = 0
+		}
+	}
+	if interval <= 0 {
+		interval, err = strconv.Atoi(globalRefreshInterval)
+		if err != nil {
+			interval = 0
+		}
+	}
+	if interval > 0 {
+		atomic.StoreInt64(&ssMap.sysVars.refreshInterval, int64(interval))
+	}
+}
+
+func (ssMap *stmtSummaryByDigestMap) RefreshInterval() int64 {
+	return atomic.LoadInt64(&ssMap.sysVars.refreshInterval)
+}
+
 // newStmtSummaryByDigest creates a stmtSummaryByDigest from StmtExecInfo.
-func newStmtSummaryByDigest(sei *StmtExecInfo) *stmtSummaryByDigest {
+func newStmtSummaryByDigest(sei *StmtExecInfo, beginTime int64) *stmtSummaryByDigest {
 	// Trim SQL to size MaxSQLLength.
 	maxSQLLength := config.GetGlobalConfig().StmtSummary.MaxSQLLength
 	normalizedSQL := sei.NormalizedSQL
@@ -337,6 +414,7 @@ func newStmtSummaryByDigest(sei *StmtExecInfo) *stmtSummaryByDigest {
 	tableNames := buffer.String()
 
 	ssbd := &stmtSummaryByDigest{
+		beginTime:     beginTime,
 		schemaName:    sei.SchemaName,
 		digest:        sei.Digest,
 		stmtType:      strings.ToLower(sei.StmtCtx.StmtType),
@@ -492,11 +570,16 @@ func (ssbd *stmtSummaryByDigest) add(sei *StmtExecInfo) {
 	}
 }
 
-func (ssbd *stmtSummaryByDigest) toDatum() []types.Datum {
+func (ssbd *stmtSummaryByDigest) toDatum(oldestBeginTime int64) []types.Datum {
 	ssbd.Lock()
 	defer ssbd.Unlock()
 
+	if ssbd.beginTime < oldestBeginTime {
+		return nil
+	}
+
 	return types.MakeDatums(
+		types.Time{Time: types.FromGoTime(time.Unix(ssbd.beginTime, 0)), Type: mysql.TypeTimestamp},
 		ssbd.stmtType,
 		ssbd.schemaName,
 		ssbd.digest,

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -38,6 +38,7 @@ type testStmtSummarySuite struct {
 func (s *testStmtSummarySuite) SetUpSuite(c *C) {
 	s.ssMap = newStmtSummaryByDigestMap()
 	s.ssMap.SetEnabled("1", false)
+	s.ssMap.SetRefreshInterval("1800", false)
 }
 
 func TestT(t *testing.T) {
@@ -48,6 +49,10 @@ func TestT(t *testing.T) {
 // Test stmtSummaryByDigest.AddStatement.
 func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	s.ssMap.beginTimeForCurInterval = now
+	// to disable expiring
+	s.ssMap.lastCheckExpireTime = now + 60
 
 	tables := []stmtctx.TableEntry{{DB: "db1", Table: "tb1"}, {DB: "db2", Table: "tb2"}}
 	indexes := []string{"a"}
@@ -60,6 +65,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 		digest:     stmtExecInfo1.Digest,
 	}
 	expectedSummary := stmtSummaryByDigest{
+		beginTime:            now,
 		schemaName:           stmtExecInfo1.SchemaName,
 		stmtType:             stmtExecInfo1.StmtCtx.StmtType,
 		digest:               stmtExecInfo1.Digest,
@@ -360,8 +366,9 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 }
 
 func matchStmtSummaryByDigest(first, second *stmtSummaryByDigest) bool {
-	if first.schemaName != second.schemaName ||
-		strings.ToLower(first.stmtType) != strings.ToLower(second.stmtType) ||
+	if first.beginTime != second.beginTime ||
+		first.schemaName != second.schemaName ||
+		!strings.EqualFold(first.stmtType, second.stmtType) ||
 		first.digest != second.digest ||
 		first.normalizedSQL != second.normalizedSQL ||
 		first.sampleSQL != second.sampleSQL ||
@@ -509,13 +516,17 @@ func generateAnyExecInfo() *StmtExecInfo {
 // Test stmtSummaryByDigest.ToDatum.
 func (s *testStmtSummarySuite) TestToDatum(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	// to disable expiration
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	s.ssMap.AddStatement(stmtExecInfo1)
 	datums := s.ssMap.ToDatum()
 	c.Assert(len(datums), Equals, 1)
+	n := types.Time{Time: types.FromGoTime(time.Unix(s.ssMap.beginTimeForCurInterval, 0)), Type: mysql.TypeTimestamp}
 	t := types.Time{Time: types.FromGoTime(stmtExecInfo1.StartTime), Type: mysql.TypeTimestamp}
-	match(c, datums[0], "select", stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, stmtExecInfo1.NormalizedSQL,
+	match(c, datums[0], n, "select", stmtExecInfo1.SchemaName, stmtExecInfo1.Digest, stmtExecInfo1.NormalizedSQL,
 		"db1.tb1,db2.tb2", "a", stmtExecInfo1.User, 1, int64(stmtExecInfo1.TotalLatency),
 		int64(stmtExecInfo1.TotalLatency), int64(stmtExecInfo1.TotalLatency), int64(stmtExecInfo1.TotalLatency),
 		int64(stmtExecInfo1.ParseLatency), int64(stmtExecInfo1.ParseLatency), int64(stmtExecInfo1.CompileLatency),
@@ -543,6 +554,9 @@ func (s *testStmtSummarySuite) TestToDatum(c *C) {
 // Test AddStatement and ToDatum parallel.
 func (s *testStmtSummarySuite) TestAddStatementParallel(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	// to disable expiration
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	threads := 8
 	loops := 32
@@ -576,6 +590,9 @@ func (s *testStmtSummarySuite) TestAddStatementParallel(c *C) {
 // Test max number of statement count.
 func (s *testStmtSummarySuite) TestMaxStmtCount(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	// to disable expiration
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	maxStmtCount := config.GetGlobalConfig().StmtSummary.MaxStmtCount
@@ -605,6 +622,9 @@ func (s *testStmtSummarySuite) TestMaxStmtCount(c *C) {
 // Test max length of normalized and sample SQL.
 func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	// to disable expiration
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	// Create a long SQL
 	maxSQLLength := config.GetGlobalConfig().StmtSummary.MaxSQLLength
@@ -631,9 +651,11 @@ func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 // Test setting EnableStmtSummary to 0.
 func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
 
 	// Set false in global scope, it should work.
 	s.ssMap.SetEnabled("0", false)
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	s.ssMap.AddStatement(stmtExecInfo1)
@@ -649,6 +671,7 @@ func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 
 	// Set false in global scope, it shouldn't work.
 	s.ssMap.SetEnabled("0", false)
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	stmtExecInfo2 := stmtExecInfo1
 	stmtExecInfo2.OriginalSQL = "original_sql2"
@@ -660,12 +683,14 @@ func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 
 	// Unset in session scope.
 	s.ssMap.SetEnabled("", true)
+	s.ssMap.beginTimeForCurInterval = now + 60
 	s.ssMap.AddStatement(stmtExecInfo2)
 	datums = s.ssMap.ToDatum()
 	c.Assert(len(datums), Equals, 0)
 
 	// Unset in global scope.
 	s.ssMap.SetEnabled("", false)
+	s.ssMap.beginTimeForCurInterval = now + 60
 	s.ssMap.AddStatement(stmtExecInfo1)
 	datums = s.ssMap.ToDatum()
 	c.Assert(len(datums), Equals, 0)
@@ -677,6 +702,9 @@ func (s *testStmtSummarySuite) TestDisableStmtSummary(c *C) {
 // Test GetMoreThanOnceSelect.
 func (s *testStmtSummarySuite) TestGetMoreThenOnceSelect(c *C) {
 	s.ssMap.Clear()
+	now := time.Now().Unix()
+	// to disable expiration
+	s.ssMap.beginTimeForCurInterval = now + 60
 
 	stmtExecInfo1 := generateAnyExecInfo()
 	stmtExecInfo1.OriginalSQL = "insert 1"
@@ -711,4 +739,33 @@ func (s *testStmtSummarySuite) TestFormatBackoffTypes(c *C) {
 
 	backoffMap[tikv.BoTxnLock] = 2
 	c.Assert(formatBackoffTypes(backoffMap), Equals, "txnLock:2,pdRPC:1")
+}
+
+// Test refreshing current statement summary periodically.
+func (s *testStmtSummarySuite) TestRefreshCurrentSummary(c *C) {
+	s.ssMap.Clear()
+	now := time.Now().Unix()
+
+	s.ssMap.beginTimeForCurInterval = now + 10
+	stmtExecInfo1 := generateAnyExecInfo()
+	key := &stmtSummaryByDigestKey{
+		schemaName: stmtExecInfo1.SchemaName,
+		digest:     stmtExecInfo1.Digest,
+	}
+	s.ssMap.AddStatement(stmtExecInfo1)
+	c.Assert(s.ssMap.summaryMap.Size(), Equals, 1)
+	value, ok := s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	c.Assert(value.(*stmtSummaryByDigest).beginTime, Equals, s.ssMap.beginTimeForCurInterval)
+	c.Assert(value.(*stmtSummaryByDigest).execCount, Equals, int64(1))
+
+	s.ssMap.beginTimeForCurInterval = now - 1900
+	value.(*stmtSummaryByDigest).beginTime = now - 1900
+	s.ssMap.lastCheckExpireTime = now - 10
+	s.ssMap.AddStatement(stmtExecInfo1)
+	c.Assert(s.ssMap.summaryMap.Size(), Equals, 1)
+	value, ok = s.ssMap.summaryMap.Get(key)
+	c.Assert(ok, IsTrue)
+	c.Assert(value.(*stmtSummaryByDigest).beginTime, Greater, now-1900)
+	c.Assert(value.(*stmtSummaryByDigest).execCount, Equals, int64(1))
 }


### PR DESCRIPTION
conflicting files:
global_vars_cache.go
set.go
statement_summary_test.go
sysvar.go
tidb_vars.go
varsutil.go
varsutil_test.go

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Refresh the table `events_statements_summary_by_digest` periodically.

### What is changed and how it works?
If the current summary exists for over `tidb_stmt_summary_refresh_interval` seconds, then replace it with a new one.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```
mysql> select * from events_statements_summary_by_digest limit 1\G
*************************** 1. row ***************************
       SUMMARY_BEGIN_TIME: 2019-11-22 13:00:00
                STMT_TYPE: select
              SCHEMA_NAME: performance_schema
                   DIGEST: 688edff0859079e96540c6161b08dde9ab5f8654bd2755a0dbca27de5e06f93e
              DIGEST_TEXT: select * from events_statements_summary_by_digest
              TABLE_NAMES: performance_schema.events_statements_summary_by_digest
              INDEX_NAMES: NULL
              SAMPLE_USER: root@127.0.0.1
               EXEC_COUNT: 1
              SUM_LATENCY: 749473
              MAX_LATENCY: 749473
              MIN_LATENCY: 749473
              AVG_LATENCY: 749473
        AVG_PARSE_LATENCY: 56405
        MAX_PARSE_LATENCY: 56405
      AVG_COMPILE_LATENCY: 444081
      MAX_COMPILE_LATENCY: 444081
             COP_TASK_NUM: 0
     AVG_COP_PROCESS_TIME: 0
     MAX_COP_PROCESS_TIME: 0
  MAX_COP_PROCESS_ADDRESS: NULL
        AVG_COP_WAIT_TIME: 0
        MAX_COP_WAIT_TIME: 0
     MAX_COP_WAIT_ADDRESS: NULL
         AVG_PROCESS_TIME: 0
         MAX_PROCESS_TIME: 0
            AVG_WAIT_TIME: 0
            MAX_WAIT_TIME: 0
         AVG_BACKOFF_TIME: 0
         MAX_BACKOFF_TIME: 0
           AVG_TOTAL_KEYS: 0
           MAX_TOTAL_KEYS: 0
       AVG_PROCESSED_KEYS: 0
       MAX_PROCESSED_KEYS: 0
        AVG_PREWRITE_TIME: 0
        MAX_PREWRITE_TIME: 0
          AVG_COMMIT_TIME: 0
          MAX_COMMIT_TIME: 0
   AVG_GET_COMMIT_TS_TIME: 0
   MAX_GET_COMMIT_TS_TIME: 0
  AVG_COMMIT_BACKOFF_TIME: 0
  MAX_COMMIT_BACKOFF_TIME: 0
    AVG_RESOLVE_LOCK_TIME: 0
    MAX_RESOLVE_LOCK_TIME: 0
AVG_LOCAL_LATCH_WAIT_TIME: 0
MAX_LOCAL_LATCH_WAIT_TIME: 0
           AVG_WRITE_KEYS: 0
           MAX_WRITE_KEYS: 0
           AVG_WRITE_SIZE: 0
           MAX_WRITE_SIZE: 0
     AVG_PREWRITE_REGIONS: 0
     MAX_PREWRITE_REGIONS: 0
            AVG_TXN_RETRY: 0
            MAX_TXN_RETRY: 0
            BACKOFF_TYPES: NULL
                  AVG_MEM: 0
                  MAX_MEM: 0
        AVG_AFFECTED_ROWS: 0
               FIRST_SEEN: 2019-11-22 13:22:53
                LAST_SEEN: 2019-11-22 13:22:53
        QUERY_SAMPLE_TEXT: select * from events_statements_summary_by_digest
```

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression
 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release note

 - Refresh the system table `events_statements_summary_by_digest` periodically.
