### PR TITLE
executor: fix missing cached execution counter for point select

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -224,6 +224,7 @@ func (a *ExecStmt) PointGet(ctx context.Context, is infoschema.InfoSchema) (*rec
 		}
 		a.PsStmt.Executor = newExecutor
 	}
+	stmtNodeCounterSelect.Inc()
 	pointExecutor := a.PsStmt.Executor.(*PointGetExecutor)
 	if err = pointExecutor.Open(ctx); err != nil {
 		terror.Call(pointExecutor.Close)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The statement total counter is not used in point get the short path, since the `ExecutorExec.Build` will not be called in this path

### What is changed and how it works?

Add the missing counter usage


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Running sysbench point select and check the `statement OPS` tab

Code changes



Side effects



Related changes

 

Release note


