### PR TITLE
*: fix condition check push down for pessimistic transaction (#14141)

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -595,6 +595,22 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 	tk.MustExec("drop table if exists tk")
 }
 
+func (s *testPessimisticSuite) TestPushConditionCheckForPessimisticTxn(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	defer tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (i int key)")
+	tk.MustExec("insert into t values (1)")
+
+	tk.MustExec("set tidb_txn_mode = 'pessimistic'")
+	tk.MustExec("begin")
+	tk1.MustExec("delete from t where i = 1")
+	tk.MustExec("insert into t values (1) on duplicate key update i = values(i)")
+	tk.MustExec("commit")
+	tk.MustQuery("select * from t").Check(testkit.Rows("1"))
+}
+
 func (s *testPessimisticSuite) TestInnodbLockWaitTimeoutWaitStart(c *C) {
 	// prepare work
 	tk := testkit.NewTestKitWithInit(c, s.store)


### PR DESCRIPTION
 Conflicts:
	store/mockstore/mocktikv/mvcc_leveldb.go

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Cherry pick #14141 to release 3.0.
