### PR TITLE
infoschema: add plan field to the statement summary tables

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -546,7 +546,7 @@ var defaultConf = Config{
 		MaxRetryCount: 256,
 	},
 	StmtSummary: StmtSummary{
-		Enable:          true,
+		Enable:          false,
 		MaxStmtCount:    200,
 		MaxSQLLength:    4096,
 		RefreshInterval: 1800,

--- a/config/config.go
+++ b/config/config.go
@@ -547,7 +547,7 @@ var defaultConf = Config{
 	},
 	StmtSummary: StmtSummary{
 		Enable:          true,
-		MaxStmtCount:    100,
+		MaxStmtCount:    200,
 		MaxSQLLength:    4096,
 		RefreshInterval: 1800,
 		HistorySize:     24,

--- a/config/config.go
+++ b/config/config.go
@@ -546,7 +546,7 @@ var defaultConf = Config{
 		MaxRetryCount: 256,
 	},
 	StmtSummary: StmtSummary{
-		Enable:          false,
+		Enable:          true,
 		MaxStmtCount:    100,
 		MaxSQLLength:    4096,
 		RefreshInterval: 1800,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -351,7 +351,7 @@ max-retry-count = 256
 enable = false
 
 # max number of statements kept in memory.
-max-stmt-count = 100
+max-stmt-count = 200
 
 # max length of displayed normalized sql and sample sql.
 max-sql-length = 4096

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -876,7 +876,10 @@ func (a *ExecStmt) SummaryStmt() {
 	}
 	sessVars.SetPrevStmtDigest(digest)
 
-	plan := plannercore.EncodePlan(a.Plan)
+	// No need to encode every time, so encode lazily.
+	planGenerator := func() string {
+		return plannercore.EncodePlan(a.Plan)
+	}
 	_, planDigest := getPlanDigest(a.Ctx, a.Plan)
 
 	execDetail := stmtCtx.GetExecDetails()
@@ -894,7 +897,7 @@ func (a *ExecStmt) SummaryStmt() {
 		Digest:         digest,
 		PrevSQL:        prevSQL,
 		PrevSQLDigest:  prevSQLDigest,
-		Plan:           plan,
+		PlanGenerator:  planGenerator,
 		PlanDigest:     planDigest,
 		User:           userString,
 		TotalLatency:   costTime,

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -876,6 +876,9 @@ func (a *ExecStmt) SummaryStmt() {
 	}
 	sessVars.SetPrevStmtDigest(digest)
 
+	plan := plannercore.EncodePlan(a.Plan)
+	_, planDigest := getPlanDigest(a.Ctx, a.Plan)
+
 	execDetail := stmtCtx.GetExecDetails()
 	copTaskInfo := stmtCtx.CopTasksDetails()
 	memMax := stmtCtx.MemTracker.MaxConsumed()
@@ -891,6 +894,8 @@ func (a *ExecStmt) SummaryStmt() {
 		Digest:         digest,
 		PrevSQL:        prevSQL,
 		PrevSQLDigest:  prevSQLDigest,
+		Plan:           plan,
+		PlanDigest:     planDigest,
 		User:           userString,
 		TotalLatency:   costTime,
 		ParseLatency:   sessVars.DurationParse,

--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -447,7 +447,9 @@ const fieldsInEventsStatementsSummary = " (" +
 	"FIRST_SEEN TIMESTAMP(6) NOT NULL," +
 	"LAST_SEEN TIMESTAMP(6) NOT NULL," +
 	"QUERY_SAMPLE_TEXT LONGTEXT DEFAULT NULL," +
-	"PREV_SAMPLE_TEXT LONGTEXT DEFAULT NULL);"
+	"PREV_SAMPLE_TEXT LONGTEXT DEFAULT NULL," +
+	"PLAN_DIGEST VARCHAR(64) DEFAULT NULL," +
+	"PLAN LONGTEXT DEFAULT NULL);"
 
 // tableEventsStatementsSummaryByDigest contains the column name definitions for table
 // events_statements_summary_by_digest, same as MySQL.

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -106,27 +106,29 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustExec("/**/insert into t values(4, 'd')")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'insert into t%'`,
-	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd')"))
+	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
 
 	// Test SELECT.
 	tk.MustQuery("select * from t where a=2")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2"))
+	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
+		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
 
 	// select ... order by
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		order by exec_count desc limit 1`,
-	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd')"))
+	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
 
 	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
@@ -141,7 +143,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	// The table should be cleared.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest`,
 	).Check(testkit.Rows())
 
@@ -153,24 +155,26 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustExec("commit")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text, prev_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, prev_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'insert into t%'`,
-	).Check(testkit.Rows("insert test test.t <nil> 1 0 0 0 0 0 0 0 0 0 1 insert into t values(1, 'a') "))
+	).Check(testkit.Rows("insert test test.t <nil> 1 0 0 0 0 0 0 0 0 0 1 insert into t values(1, 'a')  "))
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text, prev_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, prev_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text='commit'`,
-	).Check(testkit.Rows("commit test <nil> <nil> 1 0 0 0 0 0 2 2 1 1 0 commit insert into t values(1, 'a')"))
+	).Check(testkit.Rows("commit test <nil> <nil> 1 0 0 0 0 0 2 2 1 1 0 commit insert into t values(1, 'a') "))
 
 	tk.MustQuery("select * from t where a=2")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2"))
+	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
+		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it in global scope.
 	tk.MustExec("set global tidb_enable_stmt_summary = off")
@@ -183,10 +187,12 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	// Statement summary is still enabled.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2"))
+	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
+		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
 
 	// Unset session variable.
 	tk.MustExec("set session tidb_enable_stmt_summary = ''")
@@ -195,7 +201,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	// Statement summary is disabled.
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest`,
 	).Check(testkit.Rows())
 }
@@ -232,15 +238,15 @@ func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 	tk.MustExec("/**/insert into t values(4, 'd')")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest_history
 		where digest_text like 'insert into t%'`,
-	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd')"))
+	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
 
 	tk.MustExec("set global tidb_stmt_summary_history_size = 0")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
-		max_prewrite_regions, avg_affected_rows, query_sample_text 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest_history`,
 	).Check(testkit.Rows())
 }

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -131,7 +131,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		order by exec_count desc limit 1`,
-	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
+	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 insert into t values(1, 'a') "))
 
 	// Test different plans with same digest.
 	c.Assert(failpoint.Enable(failpointName, "return(1000)"), IsNil)

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -120,9 +120,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
-		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
+	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t100\t\n" +
+		"\t├─IndexScan_8 \tcop \t100\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t100\ttable:t, keep order:false, stats:pseudo"))
 
 	// select ... order by
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
@@ -140,9 +140,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 2 2 0 0 0 0 0 0 0 0 0 select * from t where a=3 \tIndexLookUp_10\troot\t10\t\n" +
-		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[3,3], keep order:false, stats:pseudo\n" +
-		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
+	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=3 \tIndexLookUp_10\troot\t1000\t\n" +
+		"\t├─IndexScan_8 \tcop \t1000\ttable:t, index:a, range:[3,3], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t1000\ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
@@ -186,9 +186,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
-		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
+	).Check(testkit.Rows("select test test.t t:k 1 2 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t1000\t\n" +
+		"\t├─IndexScan_8 \tcop \t1000\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t1000\ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it in global scope.
 	tk.MustExec("set global tidb_enable_stmt_summary = off")
@@ -204,9 +204,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
 		from performance_schema.events_statements_summary_by_digest
 		where digest_text like 'select * from t%'`,
-	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t10\t\n" +
-		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
-		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
+	).Check(testkit.Rows("select test test.t t:k 2 4 0 0 0 0 0 0 0 0 0 select * from t where a=2 \tIndexLookUp_10\troot\t1000\t\n" +
+		"\t├─IndexScan_8 \tcop \t1000\ttable:t, index:a, range:[2,2], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t1000\ttable:t, keep order:false, stats:pseudo"))
 
 	// Unset session variable.
 	tk.MustExec("set session tidb_enable_stmt_summary = ''")

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -112,6 +112,8 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
 
 	// Test SELECT.
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/planner/core/mockPlanRowCount", "return(100)"), IsNil)
+	defer func() { c.Assert(failpoint.Disable("github.com/pingcap/tidb/planner/core/mockPlanRowCount"), IsNil) }()
 	tk.MustQuery("select * from t where a=2")
 	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
 		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
@@ -129,6 +131,18 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		from performance_schema.events_statements_summary_by_digest
 		order by exec_count desc limit 1`,
 	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 /**/insert into t values(4, 'd') "))
+
+	// Test different plans with same digest.
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/planner/core/mockPlanRowCount", "return(1000)"), IsNil)
+	tk.MustQuery("select * from t where a=3")
+	tk.MustQuery(`select stmt_type, schema_name, table_names, index_names, exec_count, cop_task_num, avg_total_keys, 
+		max_total_keys, avg_processed_keys, max_processed_keys, avg_write_keys, max_write_keys, avg_prewrite_regions, 
+		max_prewrite_regions, avg_affected_rows, query_sample_text, plan 
+		from performance_schema.events_statements_summary_by_digest
+		where digest_text like 'select * from t%'`,
+	).Check(testkit.Rows("select test test.t t:k 2 2 0 0 0 0 0 0 0 0 0 select * from t where a=3 \tIndexLookUp_10\troot\t10\t\n" +
+		"\t├─IndexScan_8 \tcop \t10\ttable:t, index:a, range:[3,3], keep order:false, stats:pseudo\n" +
+		"\t└─TableScan_9 \tcop \t10\ttable:t, keep order:false, stats:pseudo"))
 
 	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -20,6 +20,7 @@ import (
 	"hash"
 	"sync"
 
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/util/plancodec"
 )
 
@@ -42,6 +43,9 @@ func EncodePlan(p Plan) string {
 	if selectPlan == nil {
 		return ""
 	}
+	failpoint.Inject("mockPlanRowCount", func(val failpoint.Value) {
+		selectPlan.statsInfo().RowCount = float64(val.(int))
+	})
 	return pn.encodePlanTree(selectPlan)
 }
 

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -783,7 +783,7 @@ func (ssElement *stmtSummaryByDigestElement) toDatum(ssbd *stmtSummaryByDigest) 
 
 	plan, err := plancodec.DecodePlan(ssElement.samplePlan)
 	if err != nil {
-		logutil.BgLogger().Error("decode plan in slow log failed", zap.String("plan", ssElement.samplePlan), zap.Error(err))
+		logutil.BgLogger().Error("decode plan in statement summary failed", zap.String("plan", ssElement.samplePlan), zap.Error(err))
 		plan = ""
 	}
 

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -581,7 +581,7 @@ func (s *testStmtSummarySuite) TestToDatum(c *C) {
 		stmtExecInfo1.ExecDetail.CommitDetail.PrewriteRegionNum, stmtExecInfo1.ExecDetail.CommitDetail.PrewriteRegionNum,
 		stmtExecInfo1.ExecDetail.CommitDetail.TxnRetry, stmtExecInfo1.ExecDetail.CommitDetail.TxnRetry, 1,
 		"txnLock:1", stmtExecInfo1.MemMax, stmtExecInfo1.MemMax, stmtExecInfo1.StmtCtx.AffectedRows(),
-		t, t, stmtExecInfo1.OriginalSQL, stmtExecInfo1.PrevSQL}
+		t, t, stmtExecInfo1.OriginalSQL, stmtExecInfo1.PrevSQL, "", ""}
 	match(c, datums[0], expectedDatum...)
 
 	datums = s.ssMap.ToHistoryDatum()

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -698,8 +698,6 @@ func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 	stmtExecInfo1 := generateAnyExecInfo()
 	stmtExecInfo1.OriginalSQL = str
 	stmtExecInfo1.NormalizedSQL = str
-	stmtExecInfo1.PrevSQLDigest = "prevSQLDigest"
-	stmtExecInfo1.PrevSQL = str
 	s.ssMap.AddStatement(stmtExecInfo1)
 
 	key := &stmtSummaryByDigestKey{
@@ -710,12 +708,12 @@ func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 	}
 	value, ok := s.ssMap.summaryMap.Get(key)
 	c.Assert(ok, IsTrue)
-	// Length of normalizedSQL and sampleSQL should be maxSQLLength.
+
+	expectedSQL := fmt.Sprintf("%s(len:%d)", strings.Repeat("a", int(maxSQLLength)), length)
 	summary := value.(*stmtSummaryByDigest)
-	c.Assert(len(summary.normalizedSQL), Equals, int(maxSQLLength))
+	c.Assert(summary.normalizedSQL, Equals, expectedSQL)
 	ssElement := summary.history.Back().Value.(*stmtSummaryByDigestElement)
-	c.Assert(len(ssElement.sampleSQL), Equals, int(maxSQLLength))
-	c.Assert(len(ssElement.prevSQL), Equals, int(maxSQLLength))
+	c.Assert(ssElement.sampleSQL, Equals, expectedSQL)
 }
 
 // Test setting EnableStmtSummary to 0.

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -36,6 +36,10 @@ type testStmtSummarySuite struct {
 	ssMap *stmtSummaryByDigestMap
 }
 
+func emptyPlanGenerator() string {
+	return ""
+}
+
 func (s *testStmtSummarySuite) SetUpSuite(c *C) {
 	s.ssMap = newStmtSummaryByDigestMap()
 	s.ssMap.SetEnabled("1", false)
@@ -69,7 +73,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 		beginTime:            now + 60,
 		endTime:              now + 1860,
 		sampleSQL:            stmtExecInfo1.OriginalSQL,
-		samplePlan:           stmtExecInfo1.Plan,
+		samplePlan:           stmtExecInfo1.PlanGenerator(),
 		indexNames:           stmtExecInfo1.StmtCtx.IndexNames,
 		sampleUser:           stmtExecInfo1.User,
 		execCount:            1,
@@ -148,6 +152,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 		NormalizedSQL:  "normalized_sql",
 		Digest:         "digest",
 		PlanDigest:     "plan_digest",
+		PlanGenerator:  emptyPlanGenerator,
 		User:           "user2",
 		TotalLatency:   20000,
 		ParseLatency:   200,
@@ -200,9 +205,6 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 	}
 	stmtExecInfo2.StmtCtx.AddAffectedRows(200)
 	expectedSummaryElement.execCount++
-	expectedSummaryElement.indexNames = indexes
-	expectedSummaryElement.sampleSQL = stmtExecInfo2.OriginalSQL
-	expectedSummaryElement.sampleUser = stmtExecInfo2.User
 	expectedSummaryElement.sumLatency += stmtExecInfo2.TotalLatency
 	expectedSummaryElement.maxLatency = stmtExecInfo2.TotalLatency
 	expectedSummaryElement.sumParseLatency += stmtExecInfo2.ParseLatency
@@ -266,6 +268,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 		NormalizedSQL:  "normalized_sql",
 		Digest:         "digest",
 		PlanDigest:     "plan_digest",
+		PlanGenerator:  emptyPlanGenerator,
 		User:           "user3",
 		TotalLatency:   1000,
 		ParseLatency:   50,
@@ -318,8 +321,6 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 	}
 	stmtExecInfo3.StmtCtx.AddAffectedRows(20000)
 	expectedSummaryElement.execCount++
-	expectedSummaryElement.sampleUser = stmtExecInfo3.User
-	expectedSummaryElement.sampleSQL = stmtExecInfo3.OriginalSQL
 	expectedSummaryElement.sumLatency += stmtExecInfo3.TotalLatency
 	expectedSummaryElement.minLatency = stmtExecInfo3.TotalLatency
 	expectedSummaryElement.sumParseLatency += stmtExecInfo3.ParseLatency
@@ -514,7 +515,7 @@ func generateAnyExecInfo() *StmtExecInfo {
 		NormalizedSQL:  "normalized_sql",
 		Digest:         "digest",
 		PlanDigest:     "plan_digest",
-		Plan:           "",
+		PlanGenerator:  emptyPlanGenerator,
 		User:           "user",
 		TotalLatency:   10000,
 		ParseLatency:   100,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add plan and plan digest to the statement summary tables.
Same SQLs with different plans are summarized in different records in the tables.
Record the SQL and plan that appear at the first time in each summary, not the last time, to increase performance.

Since same SQL may be split into several records, `max-stmt-count` should increase.

### What is changed and how it works?
Add `plan_digest` and `plan` fields.
`schema_name` + `digest` + `prev_sql_digest` + `plan_digest` are combined as a key of the summary map.
Default value of `max-stmt-count` is increased to 200.
Record the SQL and plan that appear at the first time in each summary, not the last time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```
mysql> select * from performance_schema.events_statements_summary_by_digest where plan != ''\G
*************************** 1. row ***************************
       SUMMARY_BEGIN_TIME: 2019-12-22 16:00:00
         SUMMARY_END_TIME: 2019-12-22 16:30:00
                STMT_TYPE: select
              SCHEMA_NAME:
                   DIGEST: ff1ba2b3cf4f7452291642f6399447979825a310ef25a78f01288580f398a3c9
              DIGEST_TEXT: select table_id , is_index , hist_id , distinct_count , version , null_count , tot_col_size , stats_ver , flag , correlation , last_analyze_pos from mysql . stats_histograms where table_id = ?
              TABLE_NAMES: mysql.stats_histograms
              INDEX_NAMES: stats_histograms:tbl
              SAMPLE_USER: NULL
               EXEC_COUNT: 17
              SUM_LATENCY: 17842186
              MAX_LATENCY: 1417064
              MIN_LATENCY: 697887
              AVG_LATENCY: 1049540
        AVG_PARSE_LATENCY: 91016
        MAX_PARSE_LATENCY: 150406
      AVG_COMPILE_LATENCY: 309173
      MAX_COMPILE_LATENCY: 389786
             COP_TASK_NUM: 34
     AVG_COP_PROCESS_TIME: 0
     MAX_COP_PROCESS_TIME: 0
  MAX_COP_PROCESS_ADDRESS: NULL
        AVG_COP_WAIT_TIME: 0
        MAX_COP_WAIT_TIME: 0
     MAX_COP_WAIT_ADDRESS: NULL
         AVG_PROCESS_TIME: 0
         MAX_PROCESS_TIME: 0
            AVG_WAIT_TIME: 0
            MAX_WAIT_TIME: 0
         AVG_BACKOFF_TIME: 0
         MAX_BACKOFF_TIME: 0
           AVG_TOTAL_KEYS: 0
           MAX_TOTAL_KEYS: 0
       AVG_PROCESSED_KEYS: 0
       MAX_PROCESSED_KEYS: 0
        AVG_PREWRITE_TIME: 0
        MAX_PREWRITE_TIME: 0
          AVG_COMMIT_TIME: 0
          MAX_COMMIT_TIME: 0
   AVG_GET_COMMIT_TS_TIME: 0
   MAX_GET_COMMIT_TS_TIME: 0
  AVG_COMMIT_BACKOFF_TIME: 0
  MAX_COMMIT_BACKOFF_TIME: 0
    AVG_RESOLVE_LOCK_TIME: 0
    MAX_RESOLVE_LOCK_TIME: 0
AVG_LOCAL_LATCH_WAIT_TIME: 0
MAX_LOCAL_LATCH_WAIT_TIME: 0
           AVG_WRITE_KEYS: 0
           MAX_WRITE_KEYS: 0
           AVG_WRITE_SIZE: 0
           MAX_WRITE_SIZE: 0
     AVG_PREWRITE_REGIONS: 0
     MAX_PREWRITE_REGIONS: 0
            AVG_TXN_RETRY: 0
            MAX_TXN_RETRY: 0
        SUM_BACKOFF_TIMES: 0
            BACKOFF_TYPES: NULL
                  AVG_MEM: 16672
                  MAX_MEM: 16672
        AVG_AFFECTED_ROWS: 0
               FIRST_SEEN: 2019-12-22 16:18:25
                LAST_SEEN: 2019-12-22 16:19:13
        QUERY_SAMPLE_TEXT: select table_id, is_index, hist_id, distinct_count, version, null_count, tot_col_size, stats_ver, flag, correlation, last_analyze_pos from mysql.stats_histograms where table_id = 43
         PREV_SAMPLE_TEXT:
              PLAN_DIGEST: db05f9e134185031e52539c303d1930de3cf6e5d4881aee7ef97ba87a9a0a6d9
                     PLAN: 	Projection_4    	root	10	mysql.stats_histograms.table_id, mysql.stats_histograms.is_index, mysql.stats_histograms.hist_id, mysql.stats_histograms.distinct_count, mysql.stats_histograms.version, mysql.stats_histograms.null_count, mysql.stats_histograms.tot_col_size, mysql.stats_histograms.stats_ver, mysql.stats_histograms.flag, mysql.stats_histograms.correlation, mysql.stats_histograms.last_analyze_pos
	└─IndexLookUp_10	root	10
	  ├─IndexScan_8 	cop 	10	table:stats_histograms, index:table_id, is_index, hist_id, range:[43,43], keep order:false, stats:pseudo
	  └─TableScan_9 	cop 	10	table:stats_histograms, keep order:false, stats:pseudo
```

Code changes

 - N/A

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release note

 - And `plan` and `plan_digest` to the statement summary tables.
 - Change default value of configuration `max-stmt-count` in [stmt-summary] to 200.