### PR TITLE
infoschema: show query disk usage in `information_schema.processlist`

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -628,6 +628,7 @@ var tableProcesslistCols = []columnInfo{
 	{"STATE", mysql.TypeVarchar, 7, 0, nil, nil},
 	{"INFO", mysql.TypeString, 512, 0, nil, nil},
 	{"MEM", mysql.TypeLonglong, 21, 0, nil, nil},
+	{"DISK", mysql.TypeLonglong, 21, 0, nil, nil},
 	{"TxnStart", mysql.TypeVarchar, 64, mysql.NotNullFlag, "", nil},
 }
 

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -565,8 +565,8 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 	tk.Se.SetSessionManager(sm)
 	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Sort().Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "do something"),
-			fmt.Sprintf("2 user-2 localhost test Init DB 9223372036 2 %s 0 ", strings.Repeat("x", 101)),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 0 ", "do something"),
+			fmt.Sprintf("2 user-2 localhost test Init DB 9223372036 2 %s 0 0 ", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("SHOW PROCESSLIST;").Sort().Check(
 		testkit.Rows(
@@ -603,8 +603,8 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 	tk.Se.GetSessionVars().TimeZone = time.UTC
 	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "<nil>"),
-			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 0 ", "<nil>"),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("SHOW PROCESSLIST;").Sort().Check(
 		testkit.Rows(
@@ -618,11 +618,11 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 		))
 	tk.MustQuery("select * from information_schema.PROCESSLIST where db is null;").Check(
 		testkit.Rows(
-			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("select * from information_schema.PROCESSLIST where Info is null;").Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "<nil>"),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 0 ", "<nil>"),
 		))
 }
 

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -992,7 +992,7 @@ func (s *testClusterTableSuite) TestSelectClusterTable(c *C) {
 	tk.MustExec("use information_schema")
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("1"))
 	tk.MustQuery("select count(*) from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1"))
-	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0  :10080"))
+	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1 root 127.0.0.1 <nil> Query 9223372036 0 0 <nil> 0  :10080"))
 	tk.MustQuery("select query_time, conn_id from `CLUSTER_SLOW_QUERY` order by time limit 1").Check(testkit.Rows("4.895492 6"))
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1"))
 	tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -992,7 +992,7 @@ func (s *testClusterTableSuite) TestSelectClusterTable(c *C) {
 	tk.MustExec("use information_schema")
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("1"))
 	tk.MustQuery("select count(*) from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1"))
-	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1 root 127.0.0.1 <nil> Query 9223372036 0 0 <nil> 0  :10080"))
+	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0  :10080"))
 	tk.MustQuery("select query_time, conn_id from `CLUSTER_SLOW_QUERY` order by time limit 1").Check(testkit.Rows("4.895492 6"))
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1"))
 	tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -82,10 +82,17 @@ func (pi *ProcessInfo) txnStartTs(tz *time.Location) (txnStart string) {
 // "SELECT * FROM INFORMATION_SCHEMA.PROCESSLIST".
 func (pi *ProcessInfo) ToRow(tz *time.Location) []interface{} {
 	bytesConsumed := int64(0)
-	if pi.StmtCtx != nil && pi.StmtCtx.MemTracker != nil {
-		bytesConsumed = pi.StmtCtx.MemTracker.BytesConsumed()
+	diskConsumed := int64(0)
+	if pi.StmtCtx != nil {
+		if pi.StmtCtx.MemTracker != nil {
+			bytesConsumed = pi.StmtCtx.MemTracker.BytesConsumed()
+		}
+		if pi.StmtCtx.DiskTracker != nil {
+			diskConsumed = pi.StmtCtx.DiskTracker.BytesConsumed()
+		}
 	}
-	return append(pi.ToRowForShow(true), bytesConsumed, pi.txnStartTs(tz))
+	return append(pi.ToRowForShow(true), bytesConsumed, diskConsumed, pi.txnStartTs(tz))
+
 }
 
 // SessionManager is an interface for session manage. Show processlist and


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fixes: https://github.com/pingcap/tidb/issues/13931

### What is changed and how it works?
```
mysql> select * from INFORMATION_SCHEMA.PROCESSLIST;
+------+------+-----------+------+---------+------+-------+----------------------------------------------+------+------+----------+
| ID   | USER | HOST      | DB   | COMMAND | TIME | STATE | INFO                                         | MEM  | DISK | TxnStart |
+------+------+-----------+------+---------+------+-------+----------------------------------------------+------+------+----------+
|    2 | root | 127.0.0.1 | NULL | Query   |    0 | 2     | select * from INFORMATION_SCHEMA.PROCESSLIST |    0 |    0 |          |
+------+------+-----------+------+---------+------+-------+----------------------------------------------+------+------+----------+
1 row in set (0.00 sec)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
