### PR TITLE
executor: add metric to trace tikvTxn LockKeys time consume

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -194,10 +194,12 @@ type Transaction interface {
 
 // LockCtx contains information for LockKeys method.
 type LockCtx struct {
-	Killed        *uint32
-	ForUpdateTS   uint64
-	LockWaitTime  int64
-	WaitStartTime time.Time
+	Killed                *uint32
+	ForUpdateTS           uint64
+	LockWaitTime          int64
+	WaitStartTime         time.Time
+	PessimisticLockWaited int32
+	LockTimeWaited        time.Duration
 }
 
 // Client is used to send request to KV layer.

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -237,7 +237,7 @@ var (
 			Namespace: "tidb",
 			Subsystem: "tikvclient",
 			Name:      "pessimistic_lock_keys_duration",
-			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 30), // 1ms ~ 1073741s
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 24), // 1ms ~ 16777s
 			Help:      "tidb txn pessimistic lock keys duration",
 		})
 )

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -232,4 +232,12 @@ var (
 			Help:      "Bucketed histogram of the txn_heartbeat request duration.",
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 18), // 1ms ~ 292s
 		}, []string{LblType})
+	TiKVPessimisticLockKeysDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "pessimistic_lock_keys_duration",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 30), // 1ms ~ 1073741s
+			Help:      "tidb txn pessimistic lock keys duration",
+		})
 )

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -767,6 +767,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 					return ErrLockWaitTimeout
 				}
 			}
+			atomic.StoreInt32(&action.LockCtx.PessimisticLockWaited, 1)
 		}
 
 		// Handle the killed flag when waiting for the pessimistic lock.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Add metric to trace pessimistic lock `LockKeys` time consume

### What is changed and how it works?



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported variable/fields change


Side effects



Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Write release note for bug-fix or new feature.
