### PR TITLE
expression: fix incompatible problems in vectorized `builtinUnaryMinusIntSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -488,6 +488,9 @@ func (b *builtinUnaryMinusIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 	args := result.Int64s()
 	if mysql.HasUnsignedFlag(b.args[0].GetType().Flag) {
 		for i := 0; i < n; i++ {
+			if result.IsNull(i) {
+				continue
+			}
 			if uint64(args[i]) > uint64(-math.MinInt64) {
 				return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("-%v", uint64(args[i])))
 			}
@@ -495,6 +498,9 @@ func (b *builtinUnaryMinusIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 		}
 	} else {
 		for i := 0; i < n; i++ {
+			if result.IsNull(i) {
+				continue
+			}
 			if args[i] == math.MinInt64 {
 				return types.ErrOverflow.GenWithStackByArgs("BIGINT", fmt.Sprintf("-%v", args[i]))
 			}

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -14,8 +14,6 @@
 package expression
 
 import (
-	"github.com/pingcap/tidb/util/chunk"
-	"github.com/pingcap/tidb/util/mock"
 	"math"
 	"testing"
 
@@ -23,6 +21,8 @@ import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
 )
 
 var vecBuiltinOpCases = map[string][]vecExprBenchCase{

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -14,6 +14,8 @@
 package expression
 
 import (
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
 	"math"
 	"testing"
 
@@ -151,4 +153,38 @@ func (s *testEvaluatorSuite) TestVectorizedBuiltinOpFunc(c *C) {
 
 func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {
 	benchmarkVectorizedBuiltinFunc(b, vecBuiltinOpCases)
+}
+
+func (s *testEvaluatorSuite) TestBuiltinUnaryMinusIntSig(c *C) {
+	ctx := mock.NewContext()
+	ft := eType2FieldType(types.ETInt)
+	col0 := &Column{RetType: ft, Index: 0}
+	f, err := funcs[ast.UnaryMinus].getFunction(ctx, []Expression{col0})
+	c.Assert(err, IsNil)
+	input := chunk.NewChunkWithCapacity([]*types.FieldType{ft}, 1024)
+	result := chunk.NewColumn(ft, 1024)
+
+	c.Assert(mysql.HasUnsignedFlag(col0.GetType().Flag), IsFalse)
+	input.AppendInt64(0, 233333)
+	c.Assert(f.vecEvalInt(input, result), IsNil)
+	c.Assert(result.GetInt64(0), Equals, int64(-233333))
+	input.Reset()
+	input.AppendInt64(0, math.MinInt64)
+	c.Assert(f.vecEvalInt(input, result), NotNil)
+	input.Column(0).SetNull(0, true)
+	c.Assert(f.vecEvalInt(input, result), IsNil)
+	c.Assert(result.IsNull(0), IsTrue)
+
+	col0.GetType().Flag |= mysql.UnsignedFlag
+	c.Assert(mysql.HasUnsignedFlag(col0.GetType().Flag), IsTrue)
+	input.Reset()
+	input.AppendUint64(0, 233333)
+	c.Assert(f.vecEvalInt(input, result), IsNil)
+	c.Assert(result.GetInt64(0), Equals, int64(-233333))
+	input.Reset()
+	input.AppendUint64(0, -(math.MinInt64)+1)
+	c.Assert(f.vecEvalInt(input, result), NotNil)
+	input.Column(0).SetNull(0, true)
+	c.Assert(f.vecEvalInt(input, result), IsNil)
+	c.Assert(result.IsNull(0), IsTrue)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In vectorized `builtinUnaryMinusIntSig`, it skips checking nulls, which may cause some incompatible problems, see the unit test in the PR.

### What is changed and how it works?
Checking if this row is null before doing minus operation.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test