### PR TITLE
docs: fix two broken links in quickstart

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -23,7 +23,7 @@ Notice: OS X user may use `docker-machine ip` to connect it.
 
 #### __Or run TiDB on TiKV cluster__ 
 
-Read the documents for [Ansible deployment](https://github.com/pingcap/docs/blob/master/op-guide/ansible-deployment.md) or [docker deployment](https://github.com/pingcap/docs/blob/master/op-guide/docker-deployment.md).
+Read the documents for [Ansible deployment](https://pingcap.com/docs/stable/how-to/deploy/orchestrated/ansible/) or [Docker deployment](https://pingcap.com/docs/stable/how-to/deploy/orchestrated/docker/).
 
 #### __Pre-requirement__
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR fixes two broken links in `docs/QUICKSTART.md` by replacing them with two pingcap.com links. Links in the `pingcap/docs` repo might change, while links at pingcap.com will always work in most cases.

### What is changed and how it works?

Only two links
