### PR TITLE
executor: fix 'shutdown' diffrent reaction with mysql

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1115,5 +1115,18 @@ func (e *SimpleExec) executeShutdown(s *ast.ShutdownStmt) error {
 	if err != nil {
 		return err
 	}
-	return p.Kill()
+
+	// Call with async
+	go asyncDelayShutdown(p, time.Second)
+
+	return nil
+}
+
+// #14239 - https://github.com/pingcap/tidb/issues/14239
+// Need repair 'shutdown' command behavior.
+// Response of TiDB is different to MySQL.
+// This function need to run with async model, otherwise it will block main coroutine
+func asyncDelayShutdown(p *os.Process, delay time.Duration) {
+	time.Sleep(delay)
+	p.Kill()
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- https://github.com/pingcap/tidb/issues/14239
- TiDB command "shutdown" reaction different with mysql

### What is changed and how it works?

- Delay kill time one second.
- Function return nil, to response an empty set.

Tests <!-- At least one of them must be included. -->

```
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.25-TiDB-None TiDB Server (Apache License 2.0), MySQL 5.7 compatible

Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql> shutdown;
Query OK, 0 rows affected (0.01 sec)
```

Code changes

 - Has exported function/method change
```
tidb/executor/simple.go

func (e *SimpleExec) executeShutdown(s *ast.ShutdownStmt) error {
	sessVars := e.ctx.GetSessionVars()
	logutil.BgLogger().Info("execute shutdown statement", zap.Uint64("conn", sessVars.ConnectionID))
	p, err := os.FindProcess(os.Getpid())
	if err != nil {
		return err
	}

	// Call with async
	go asyncDelayShutdown(p, time.Second)

	return nil
}

// #14239 - https://github.com/pingcap/tidb/issues/14239
// Need repair 'shutdown' command behavior.
// Response of TiDB is different to MySQL.
// This function need to run with async model, otherwise it will block main coroutine
func asyncDelayShutdown(p *os.Process, delay time.Duration) {
	time.Sleep(delay)
	p.Kill()
}
```

Side effects

- Delay shutdown 1s

Release note

 - bug-fix
