### PR TITLE
executor: support abort the cluster log retriever

### DIFF
--- a/executor/cluster_reader.go
+++ b/executor/cluster_reader.go
@@ -47,10 +47,15 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-const clusterLogBatchSize = 1024
+const clusterLogBatchSize = 256
+
+type dummyClose struct{}
+
+func (dummyClose) close() error { return nil }
 
 type clusterRetriever interface {
 	retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error)
+	close() error
 }
 
 // ClusterReaderExec executes cluster information retrieving from the cluster components
@@ -80,7 +85,13 @@ func (e *ClusterReaderExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	return nil
 }
 
+// Close implements the Executor Close interface.
+func (e *ClusterReaderExec) Close() error {
+	return e.retriever.close()
+}
+
 type clusterConfigRetriever struct {
+	dummyClose
 	retrieved bool
 	extractor *plannercore.ClusterTableExtractor
 }
@@ -207,6 +218,7 @@ func (e *clusterConfigRetriever) retrieve(_ context.Context, sctx sessionctx.Con
 }
 
 type clusterServerInfoRetriever struct {
+	dummyClose
 	retrieved      bool
 	extractor      *plannercore.ClusterTableExtractor
 	serverInfoType diagnosticspb.ServerInfoType
@@ -370,6 +382,7 @@ type clusterLogRetriever struct {
 	retrieving bool
 	heap       *logResponseHeap
 	extractor  *plannercore.ClusterLogTableExtractor
+	cancel     func()
 }
 
 type logStreamResult struct {
@@ -479,6 +492,9 @@ func (e *clusterLogRetriever) startRetrieving(ctx context.Context, sctx sessionc
 		Levels:    levels,
 		Patterns:  patterns,
 	}
+
+	// The retrieve progress may be abort
+	ctx, e.cancel = context.WithCancel(ctx)
 
 	var results []chan logStreamResult
 	for _, srv := range serversInfo {
@@ -594,4 +610,9 @@ func (e *clusterLogRetriever) retrieve(ctx context.Context, sctx sessionctx.Cont
 	e.isDrained = e.heap.Len() == 0
 
 	return finalRows, nil
+}
+
+func (e *clusterLogRetriever) close() error {
+	e.cancel()
+	return nil
 }

--- a/executor/cluster_reader.go
+++ b/executor/cluster_reader.go
@@ -49,9 +49,9 @@ import (
 
 const clusterLogBatchSize = 256
 
-type dummyClose struct{}
+type dummyCloser struct{}
 
-func (dummyClose) close() error { return nil }
+func (dummyCloser) close() error { return nil }
 
 type clusterRetriever interface {
 	retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error)
@@ -91,7 +91,7 @@ func (e *ClusterReaderExec) Close() error {
 }
 
 type clusterConfigRetriever struct {
-	dummyClose
+	dummyCloser
 	retrieved bool
 	extractor *plannercore.ClusterTableExtractor
 }
@@ -218,7 +218,7 @@ func (e *clusterConfigRetriever) retrieve(_ context.Context, sctx sessionctx.Con
 }
 
 type clusterServerInfoRetriever struct {
-	dummyClose
+	dummyCloser
 	retrieved      bool
 	extractor      *plannercore.ClusterTableExtractor
 	serverInfoType diagnosticspb.ServerInfoType
@@ -382,7 +382,7 @@ type clusterLogRetriever struct {
 	retrieving bool
 	heap       *logResponseHeap
 	extractor  *plannercore.ClusterLogTableExtractor
-	cancel     func()
+	cancel     context.CancelFunc
 }
 
 type logStreamResult struct {

--- a/executor/diagnostics.go
+++ b/executor/diagnostics.go
@@ -52,6 +52,7 @@ var inspectionRules = []inspectionRule{
 }
 
 type inspectionRetriever struct {
+	dummyClose
 	retrieved bool
 	extractor *plannercore.InspectionResultTableExtractor
 }

--- a/executor/diagnostics.go
+++ b/executor/diagnostics.go
@@ -52,7 +52,7 @@ var inspectionRules = []inspectionRule{
 }
 
 type inspectionRetriever struct {
-	dummyClose
+	dummyCloser
 	retrieved bool
 	extractor *plannercore.InspectionResultTableExtractor
 }

--- a/executor/metric_reader.go
+++ b/executor/metric_reader.go
@@ -38,6 +38,7 @@ const promReadTimeout = time.Second * 10
 
 // MetricRetriever uses to read metric data.
 type MetricRetriever struct {
+	dummyClose
 	table     *model.TableInfo
 	tblDef    *metricschema.MetricTableDef
 	extractor *plannercore.MetricTableExtractor

--- a/executor/metric_reader.go
+++ b/executor/metric_reader.go
@@ -38,7 +38,7 @@ const promReadTimeout = time.Second * 10
 
 // MetricRetriever uses to read metric data.
 type MetricRetriever struct {
-	dummyClose
+	dummyCloser
 	table     *model.TableInfo
 	tblDef    *metricschema.MetricTableDef
 	extractor *plannercore.MetricTableExtractor


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR adds support abort retrieve log from the remote component.

### What is changed and how it works?

Binding cancel function with context and cancel the subsequent progress while the retriever closed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
