### PR TITLE
metrics,store: add a metric for ttlManager to record the lifetime reach events

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -153,4 +153,5 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVTokenWaitDuration)
 	prometheus.MustRegister(TiKVTxnHeartBeatHistogram)
 	prometheus.MustRegister(GRPCConnTransientFailureCounter)
+	prometheus.MustRegister(TiKVTTLLifeTimeReachCounter)
 }

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -216,4 +216,12 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 24), // 1ms ~ 16777s
 			Help:      "tidb txn pessimistic lock keys duration",
 		})
+
+	TiKVTTLLifeTimeReachCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "ttl_lifetime_reach_total",
+			Help:      "Counter of ttlManager live too long.",
+		})
 )

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -643,6 +643,7 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 				// the key will not be locked forever.
 				logutil.BgLogger().Info("ttlManager live up to its lifetime",
 					zap.Uint64("txnStartTS", c.startTS))
+				metrics.TiKVTTLLifeTimeReachCounter.Inc()
 				return
 			}
 


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Currently, we limit the pessimistic transaction to finish with 10min. It shouldn't take too long in general.
This commit adds a metric for that kind of event.

### What is changed and how it works?

Add a metric.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
