### PR TITLE
ddl: make ddl test more stable

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -107,6 +107,7 @@ func setUpSuite(s *testDBSuite, c *C) {
 
 	_, err = s.s.Execute(context.Background(), "create database test_db")
 	c.Assert(err, IsNil)
+	s.s.Execute(context.Background(), "set @@global.tidb_max_delta_schema_count= 4096")
 
 	s.tk = testkit.NewTestKit(c, s.store)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```go
[2019-12-31T07:47:54.687Z] ----------------------------------------------------------------------
[2019-12-31T07:47:54.687Z] FAIL: db_test.go:1262: testDBSuite3.TestCancelDropColumn
[2019-12-31T07:47:54.687Z] 
[2019-12-31T07:47:54.687Z] db_test.go:1333:
[2019-12-31T07:47:54.687Z]     c.Assert(err1.Error(), Equals, "[ddl:8214]Cancelled DDL job")
[2019-12-31T07:47:54.687Z] ... obtained string = "[domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later]"
```

### What is changed and how it works?
Increasing `tidb_max_delta_schema_count` in ddl test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

