### PR TITLE
executor: speed up `TestMemoryAndDiskUsageAfterClose`

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -162,7 +162,7 @@ func (s *testSuite1) TestMemoryAndDiskUsageAfterClose(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (v int, k int, key(k))")
 	batch := 128
-	limit := tk.Se.GetSessionVars().MaxChunkSize * 5
+	limit := tk.Se.GetSessionVars().MaxChunkSize*2 + 10
 	var buf bytes.Buffer
 	for i := 0; i < limit; {
 		buf.Reset()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Speed up `TestMemoryAndDiskUsageAfterClose` by inserting records in a batch way and reducing the size of test data.

After this PR:
```
PASS: explain_test.go:160: testSuite1.TestMemoryAndDiskUsageAfterClose	5.868s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test