### PR TITLE
ddl: throw warning when `ALTER TABLE ORDER BY` on table with primary key

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4248,7 +4248,7 @@ func (s *testDBSuite1) TestAlterOrderBy(c *C) {
 	// Test order by with primary key
 	s.tk.MustExec("alter table ob order by c")
 	c.Assert(s.tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(1))
-	s.tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|ORDER BY ignored as there is a user-defined clustered index in the table '%s'", "ob"))
+	s.tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|ORDER BY ignored as there is a user-defined clustered index in the table 'ob'"))
 
 	// Test order by with no primary key
 	s.tk.MustExec("drop table if exists ob")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4243,18 +4243,19 @@ func (s *testDBSuite2) TestDDLWithInvalidTableInfo(c *C) {
 func (s *testDBSuite1) TestAlterOrderBy(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
-	s.tk.MustExec("create table ob (pk int primary key, c int default 1, c1 int default 1, KEY cl(cl))")
+	s.tk.MustExec("create table ob (pk int primary key, c int default 1, c1 int default 1, KEY cl(c1))")
 
 	// Test order by with primary key
 	s.tk.MustExec("alter table ob order by c")
 	c.Assert(s.tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(1))
 	s.tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1105|ORDER BY ignored as there is a user-defined clustered index in the table '%s'", "ob"))
 
-	//Test order by with no primary key
-	s.tk.MustExec("alter table ob drop primary key")
+	// Test order by with no primary key
+	s.tk.MustExec("drop table if exists ob")
+	s.tk.MustExec("create table ob (c int default 1, c1 int default 1, KEY cl(c1))")
 	s.tk.MustExec("alter table ob order by c")
 	c.Assert(s.tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(0))
-	s.tk.MustExec("drop table ob")
+	s.tk.MustExec("drop table if exists ob")
 }
 
 func init() {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -4151,11 +4151,8 @@ func (d *ddl) AlterTableOrderBy(ctx sessionctx.Context, ident ast.Ident) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	for _, item := range tb.Cols() {
-		if item.Flag&mysql.PriKeyFlag != 0 {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("ORDER BY ignored as there is a user-defined clustered index in the table '%s'", ident.Name))
-			break
-		}
+	if tb.Meta().GetPkColInfo() != nil {
+		ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("ORDER BY ignored as there is a user-defined clustered index in the table '%s'", ident.Name))
 	}
 	return nil
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2067,7 +2067,7 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 		case ast.AlterTableSetTiFlashReplica:
 			err = d.AlterTableSetTiFlashReplica(ctx, ident, spec.TiFlashReplica)
 		case ast.AlterTableOrderByColumns:
-			err = d.AlterTableOrderBy(ctx, ident)
+			err = d.OrderByColumns(ctx, ident)
 		default:
 			// Nothing to do now.
 		}
@@ -4146,7 +4146,7 @@ func (d *ddl) RepairTable(ctx sessionctx.Context, table *ast.TableName, createSt
 	return errors.Trace(err)
 }
 
-func (d *ddl) AlterTableOrderBy(ctx sessionctx.Context, ident ast.Ident) error {
+func (d *ddl) OrderByColumns(ctx sessionctx.Context, ident ast.Ident) error {
 	_, tb, err := d.getSchemaAndTableByIdent(ctx, ident)
 	if err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
  Fix pingcap/parser#608
  Throw a warning if a table has the primary key when do a `alter order by` ddl.

### What is changed and how it works?

tidb> create table t(id int primary key not null);
tidb> alter table t order by id;
tidb> show warnings;
+---------+------+------------------------------------------------------------------------------+
| Level   | Code | Message                                                                      |
+---------+------+------------------------------------------------------------------------------+
| Warning | 1105 | ORDER BY ignored as there is a user-defined clustered index in the table 't' |
+---------+------+------------------------------------------------------------------------------+

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
