### PR TITLE
rowcodec: fix use origin default value when decode

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2678,9 +2678,14 @@ func newRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model
 			Elems:   col.RetType.Elems,
 		}
 	}
-	defVal := func(i int) (types.Datum, error) {
+	defVal := func(i int, chk *chunk.Chunk) error {
 		ci := getColInfoByID(tbl, reqCols[i].ID)
-		return table.GetColDefaultValue(ctx, ci)
+		d, err := table.GetColOriginDefaultValue(ctx, ci)
+		if err != nil {
+			return err
+		}
+		chk.AppendDatum(i, &d)
+		return nil
 	}
 	return rowcodec.NewChunkDecoder(reqCols, handleColID, defVal, ctx.GetSessionVars().TimeZone)
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5153,3 +5153,14 @@ func (s *testSuite1) TestPartitionHashCode(c *C) {
 	}
 	wg.Wait()
 }
+
+func (s *testSuite1) TestAlterDefaultValue(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(a int, primary key(a))")
+	tk.MustExec("insert into t(a) values(1)")
+	tk.MustExec("alter table t add column b int default 1")
+	tk.MustExec("alter table t alter b set default 2")
+	tk.MustQuery("select b from t where a = 1").Check(testkit.Rows("1"))
+}

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -184,11 +184,11 @@ func (decoder *DatumMapDecoder) decodeColDatum(col *ColInfo, colData []byte) (ty
 // ChunkDecoder decodes the row to chunk.Chunk.
 type ChunkDecoder struct {
 	decoder
-	defDatum func(i int) (types.Datum, error)
+	defDatum func(i int, chk *chunk.Chunk) error
 }
 
 // NewChunkDecoder creates a NewChunkDecoder.
-func NewChunkDecoder(columns []ColInfo, handleColID int64, defDatum func(i int) (types.Datum, error), loc *time.Location) *ChunkDecoder {
+func NewChunkDecoder(columns []ColInfo, handleColID int64, defDatum func(i int, chk *chunk.Chunk) error, loc *time.Location) *ChunkDecoder {
 	return &ChunkDecoder{
 		decoder: decoder{
 			columns:     columns,
@@ -232,12 +232,10 @@ func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, handle int64, chk *ch
 			continue
 		}
 
-		defDatum, err := decoder.defDatum(colIdx)
+		err := decoder.defDatum(colIdx, chk)
 		if err != nil {
 			return err
 		}
-
-		chk.AppendDatum(colIdx, &defDatum)
 	}
 	return nil
 }

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -442,14 +442,16 @@ func (s *testSuite) TestNilAndDefault(c *C) {
 				Elems:      t.ft.Elems,
 			})
 		}
-		ddf := func(i int) (types.Datum, error) {
+		ddf := func(i int, chk *chunk.Chunk) error {
 			t := testData[i]
 			if t.def == nil {
 				var d types.Datum
 				d.SetNull()
-				return d, nil
+				chk.AppendDatum(i, &d)
+				return nil
 			}
-			return *t.def, nil
+			chk.AppendDatum(i, t.def)
+			return nil
 		}
 		bdf := func(i int) ([]byte, error) {
 			t := testData[i]

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -445,9 +445,7 @@ func (s *testSuite) TestNilAndDefault(c *C) {
 		ddf := func(i int, chk *chunk.Chunk) error {
 			t := testData[i]
 			if t.def == nil {
-				var d types.Datum
-				d.SetNull()
-				chk.AppendDatum(i, &d)
+				chk.AppendNull(i)
 				return nil
 			}
 			chk.AppendDatum(i, t.def)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

see test-case `TestAlterDefaultValue`

### What is changed and how it works?

use column's origin default value instead default value when decoding

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - change ChunkDecoder 

Side effects

 - n/a

Related changes

 - n/a

Release note

 - fix use origin default value when decode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/14327)
<!-- Reviewable:end -->
