### PR TITLE
[WIP]implement inline projection for sort

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -1107,11 +1107,12 @@ func (tc sortCase) columns() []*expression.Column {
 	return []*expression.Column{
 		{UniqueID: 0, Index: 0, RetType: types.NewFieldType(mysql.TypeLonglong)},
 		{UniqueID: 1, Index: 1, RetType: types.NewFieldType(mysql.TypeLonglong)},
+		{UniqueID: 2, Index: 2, RetType: types.NewFieldType(mysql.TypeLonglong)},
 	}
 }
 
 func (tc sortCase) String() string {
-	return fmt.Sprintf("(rows:%v, orderBy:%v)", tc.rows, tc.orderByIdx)
+	return fmt.Sprintf("(rows:%v, orderBy:%v, output:%v)", tc.rows, tc.orderByIdx, tc.outputIdx)
 }
 
 func defaultSortTestCase() *sortCase {
@@ -1171,6 +1172,14 @@ func benchmarkSortExec(b *testing.B, cas *sortCase) {
 func BenchmarkSortExec(b *testing.B) {
 	b.ReportAllocs()
 	cas := defaultSortTestCase()
+	cas.orderByIdx = []int{0}
+	cas.outputIdx = []int{1, 2} // for inline projection.
+	b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
+		benchmarkSortExec(b, cas)
+	})
+
+	b.ReportAllocs()
+	cas = defaultSortTestCase()
 	cas.orderByIdx = []int{0}
 	cas.outputIdx = []int{1} // for inline projection.
 	b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {

--- a/planner/cascades/implementation_rules.go
+++ b/planner/cascades/implementation_rules.go
@@ -274,6 +274,7 @@ func (r *ImplSort) OnImplement(expr *memo.GroupExpr, reqProp *property.PhysicalP
 		ls.SelectBlockOffset(),
 		&property.PhysicalProperty{ExpectedCnt: math.MaxFloat64},
 	)
+	ps.SetSchema(expr.Schema().Clone())
 	return impl.NewSortImpl(ps), nil
 }
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1698,6 +1698,7 @@ func (p *LogicalUnionAll) exhaustPhysicalPlans(prop *property.PhysicalProperty) 
 
 func (ls *LogicalSort) getPhysicalSort(prop *property.PhysicalProperty) *PhysicalSort {
 	ps := PhysicalSort{ByItems: ls.ByItems}.Init(ls.ctx, ls.stats.ScaleByExpectCnt(prop.ExpectedCnt), ls.blockOffset, &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64})
+	ps.SetSchema(ls.schema.Clone())
 	return ps
 }
 

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -796,7 +796,7 @@ type LogicalUnionAll struct {
 
 // LogicalSort stands for the order by plan.
 type LogicalSort struct {
-	baseLogicalPlan
+	logicalSchemaProducer
 
 	ByItems []*ByItems
 }

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -467,7 +467,7 @@ type PhysicalStreamAgg struct {
 
 // PhysicalSort is the physical operator of sort, which implements a memory sort.
 type PhysicalSort struct {
-	basePhysicalPlan
+	physicalSchemaProducer
 
 	ByItems []*ByItems
 }

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -338,7 +338,7 @@ func (p *basePhysicalAgg) ResolveIndices() (err error) {
 
 // ResolveIndices implements Plan interface.
 func (p *PhysicalSort) ResolveIndices() (err error) {
-	err = p.basePhysicalPlan.ResolveIndices()
+	err = p.physicalSchemaProducer.ResolveIndices()
 	if err != nil {
 		return err
 	}

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
@@ -101,6 +102,13 @@ func (p *LogicalSelection) BuildKeyInfo(selfSchema *expression.Schema, childSche
 			}
 		}
 	}
+}
+
+// BuildKeyInfo implements LogicalPlan BuildKeyInfo interface.
+func (p *LogicalSort) BuildKeyInfo(selfSchema *expression.Schema, childSchema []*expression.Schema) {
+	p.logicalSchemaProducer.schema.Keys = make([]expression.KeyInfo, len(childSchema[0].Keys))
+	copy(p.logicalSchemaProducer.schema.Keys, childSchema[0].Keys)
+	p.baseLogicalPlan.BuildKeyInfo(selfSchema, childSchema)
 }
 
 // BuildKeyInfo implements LogicalPlan BuildKeyInfo interface.

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -104,7 +104,7 @@ func (p *LogicalSelection) BuildKeyInfo(selfSchema *expression.Schema, childSche
 	}
 }
 
-// BuildKeyInfo implements LogicalPlan BuildKeyInfo interface.
+// BuildKeyInfo implements LogicalSort BuildKeyInfo interface.
 func (p *LogicalSort) BuildKeyInfo(selfSchema *expression.Schema, childSchema []*expression.Schema) {
 	p.logicalSchemaProducer.schema.Keys = make([]expression.KeyInfo, len(childSchema[0].Keys))
 	copy(p.logicalSchemaProducer.schema.Keys, childSchema[0].Keys)

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -143,6 +143,14 @@ func (la *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) 
 // If any expression can view as a constant in execution stage, such as correlated column, constant,
 // we do prune them. Note that we can't prune the expressions contain non-deterministic functions, such as rand().
 func (ls *LogicalSort) PruneColumns(parentUsedCols []*expression.Column) error {
+	// for inline projection
+	used := getUsedList(parentUsedCols, ls.schema)
+	for i := len(used) - 1; i >= 0; i-- {
+		if !used[i] {
+			ls.schema.Columns = append(ls.schema.Columns[:i], ls.schema.Columns[i+1:]...)
+		}
+	}
+
 	child := ls.children[0]
 	for i := len(ls.ByItems) - 1; i >= 0; i-- {
 		cols := expression.ExtractColumns(ls.ByItems[i].Expr)

--- a/planner/core/util.go
+++ b/planner/core/util.go
@@ -83,12 +83,15 @@ type logicalSchemaProducer struct {
 // Schema implements the Plan.Schema interface.
 func (s *logicalSchemaProducer) Schema() *expression.Schema {
 	if s.schema == nil {
-		s.schema = expression.NewSchema()
+		s.schema = s.baseLogicalPlan.children[0].Schema().Clone()
 	}
 	return s.schema
 }
 
 func (s *logicalSchemaProducer) OutputNames() types.NameSlice {
+	if s.names == nil {
+		s.names = s.baseLogicalPlan.children[0].OutputNames()
+	}
 	return s.names
 }
 
@@ -115,7 +118,7 @@ type physicalSchemaProducer struct {
 // Schema implements the Plan.Schema interface.
 func (s *physicalSchemaProducer) Schema() *expression.Schema {
 	if s.schema == nil {
-		s.schema = expression.NewSchema()
+		s.schema = s.basePhysicalPlan.children[0].Schema().Clone()
 	}
 	return s.schema
 }

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -167,6 +167,14 @@ func (c *Chunk) IsFull() bool {
 	return c.NumRows() >= c.requiredRows
 }
 
+// Prune prunes Columns and keep the usedColIdxs. usedColIdxs should be ascending.
+func (c *Chunk) Prune(usedColIdxs []int) {
+	for i, idx := range usedColIdxs {
+		c.columns[i] = c.columns[idx]
+	}
+	c.columns = c.columns[:len(usedColIdxs)]
+}
+
 // MakeRef makes Column in "dstColIdx" reference to Column in "srcColIdx".
 func (c *Chunk) MakeRef(srcColIdx, dstColIdx int) {
 	c.columns[dstColIdx] = c.columns[srcColIdx]
@@ -337,7 +345,7 @@ func (c *Chunk) AppendRow(row Row) {
 	c.numVirtualRows++
 }
 
-// AppendPartialRow appends a row to the chunk.
+// AppendPartialRow appends a row to the chunk, with a column offset of colIdx.
 func (c *Chunk) AppendPartialRow(colIdx int, row Row) {
 	c.appendSel(colIdx)
 	for i, rowCol := range row.c.columns {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

implement inline projection for sort
1. Planner: prune output columns  in `LogicalSort`
2. Executor: do not copy columns that output doesn't need in `SortExec`

### What is changed and how it works?

```
name                                                   old time/op    new time/op    delta
SortExec/(rows:3000000,_orderBy:[0],_output:[1_2])-12     4.27s ± 3%     4.04s ± 3%   -5.48%  (p=0.016 n=5+5)
SortExec/(rows:3000000,_orderBy:[0],_output:[1])-12       4.26s ± 2%     3.83s ± 3%  -10.02%  (p=0.008 n=5+5)

name                                                   old alloc/op   new alloc/op   delta
SortExec/(rows:3000000,_orderBy:[0],_output:[1_2])-12    27.9MB ± 0%    27.9MB ± 0%   -0.13%  (p=0.008 n=5+5)
SortExec/(rows:3000000,_orderBy:[0],_output:[1])-12      27.9MB ± 0%    27.8MB ± 0%   -0.26%  (p=0.008 n=5+5)

name                                                   old allocs/op  new allocs/op  delta
SortExec/(rows:3000000,_orderBy:[0],_output:[1_2])-12     41.1k ± 0%     41.1k ± 0%   -0.03%  (p=0.029 n=4+4)
SortExec/(rows:3000000,_orderBy:[0],_output:[1])-12       41.1k ± 0%     41.1k ± 0%   -0.07%  (p=0.029 n=4+4)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Write release note for bug-fix or new feature.
