### PR TITLE
executor: refactor union_scan executor by using txn_mem_buffer_reader (#10673)

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -833,25 +833,20 @@ func (b *executorBuilder) buildUnionScanExec(v *plannercore.PhysicalUnionScan) E
 	if b.err != nil {
 		return nil
 	}
-	us, err := b.buildUnionScanFromReader(reader, v)
-	if err != nil {
-		b.err = err
-		return nil
-	}
-	return us
+	return b.buildUnionScanFromReader(reader, v)
 }
 
 // buildUnionScanFromReader builds union scan executor from child executor.
 // Note that this function may be called by inner workers of index lookup join concurrently.
 // Be careful to avoid data race.
-func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannercore.PhysicalUnionScan) (Executor, error) {
-	var err error
+func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannercore.PhysicalUnionScan) Executor {
 	us := &UnionScanExec{baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID(), reader)}
 	// Get the handle column index of the below plannercore.
 	// We can guarantee that there must be only one col in the map.
 	for _, cols := range v.Children()[0].Schema().TblID2Handle {
 		us.belowHandleIndex = cols[0].Index
 	}
+	us.mutableRow = chunk.MutRowFromTypes(retTypes(us))
 	switch x := reader.(type) {
 	case *TableReaderExecutor:
 		us.desc = x.desc
@@ -866,7 +861,7 @@ func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannerco
 		us.dirty = GetDirtyDB(b.ctx).GetDirtyTable(physicalTableID)
 		us.conditions = v.Conditions
 		us.columns = x.columns
-		err = us.buildAndSortAddedRows(x.table)
+		us.table = x.table
 	case *IndexReaderExecutor:
 		us.desc = x.desc
 		for _, ic := range x.index.Columns {
@@ -881,7 +876,7 @@ func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannerco
 		us.dirty = GetDirtyDB(b.ctx).GetDirtyTable(physicalTableID)
 		us.conditions = v.Conditions
 		us.columns = x.columns
-		err = us.buildAndSortAddedRows(x.table)
+		us.table = x.table
 	case *IndexLookUpExecutor:
 		us.desc = x.desc
 		for _, ic := range x.index.Columns {
@@ -896,15 +891,12 @@ func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannerco
 		us.dirty = GetDirtyDB(b.ctx).GetDirtyTable(physicalTableID)
 		us.conditions = v.Conditions
 		us.columns = x.columns
-		err = us.buildAndSortAddedRows(x.table)
+		us.table = x.table
 	default:
 		// The mem table will not be written by sql directly, so we can omit the union scan to avoid err reporting.
-		return reader, nil
+		return reader
 	}
-	if err != nil {
-		return nil, err
-	}
-	return us, nil
+	return us
 }
 
 // buildMergeJoin builds MergeJoinExec executor.
@@ -1960,6 +1952,7 @@ func buildNoRangeIndexReader(b *executorBuilder, v *plannercore.PhysicalIndexRea
 		idxCols:         is.IdxCols,
 		colLens:         is.IdxColLens,
 		plans:           v.IndexPlans,
+		outputColumns:   v.OutputColumns,
 	}
 	if containsLimit(dagReq.Executors) {
 		e.feedback = statistics.NewQueryFeedback(0, nil, 0, is.Desc)
@@ -2108,13 +2101,9 @@ func (builder *dataReaderBuilder) buildUnionScanForIndexJoin(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	e, err := builder.buildUnionScanFromReader(reader, v)
-	if err != nil {
-		return nil, err
-	}
-	us := e.(*UnionScanExec)
-	us.snapshotChunkBuffer = newFirstChunk(us)
-	return us, nil
+	us := builder.buildUnionScanFromReader(reader, v).(*UnionScanExec)
+	err = us.open(ctx)
+	return us, err
 }
 
 func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Context, v *plannercore.PhysicalTableReader, lookUpContents []*indexJoinLookUpContent) (Executor, error) {
@@ -2147,6 +2136,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Contex
 	if err != nil {
 		return nil, err
 	}
+	e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
 	e.resultHandler = &tableResultHandler{}
 	result, err := builder.SelectResult(ctx, builder.ctx, kvReq, retTypes(e), e.feedback, getPhysicalPlanIDs(e.plans))
 	if err != nil {

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -240,14 +240,18 @@ type IndexReaderExecutor struct {
 	keepOrder       bool
 	desc            bool
 	ranges          []*ranger.Range
-	dagPB           *tipb.DAGRequest
+	// kvRanges are only used for union scan.
+	kvRanges []kv.KeyRange
+	dagPB    *tipb.DAGRequest
 
 	// result returns one or more distsql.PartialResult and each PartialResult is returned by one region.
 	result distsql.SelectResult
 	// columns are only required by union scan.
-	columns   []*model.ColumnInfo
-	streaming bool
-	feedback  *statistics.QueryFeedback
+	columns []*model.ColumnInfo
+	// outputColumns are only required by union scan.
+	outputColumns []*expression.Column
+	streaming     bool
+	feedback      *statistics.QueryFeedback
 
 	corColInFilter bool
 	corColInAccess bool
@@ -319,6 +323,7 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		collExec := true
 		e.dagPB.CollectExecutionSummaries = &collExec
 	}
+	e.kvRanges = kvRanges
 
 	e.memTracker = memory.NewTracker(e.id, e.ctx.GetSessionVars().MemQuotaDistSQL)
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1406,7 +1406,9 @@ func (e *UnionExec) Next(ctx context.Context, req *chunk.Chunk) error {
 
 // Close implements the Executor Close interface.
 func (e *UnionExec) Close() error {
-	close(e.finished)
+	if e.finished != nil {
+		close(e.finished)
+	}
 	e.childrenResults = nil
 	if e.resultPool != nil {
 		for range e.resultPool {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2811,6 +2811,7 @@ func (s *testSuite) TestHandleTransfer(c *C) {
 	tk.MustExec("insert into t values(4)")
 	// test single read whose result need handle
 	tk.MustQuery("select * from t use index(idx)").Check(testkit.Rows("1", "2", "3", "4"))
+	tk.MustQuery("select * from t use index(idx) order by a desc").Check(testkit.Rows("4", "3", "2", "1"))
 	tk.MustExec("update t set a = 5 where a = 3")
 	tk.MustQuery("select * from t use index(idx)").Check(testkit.Rows("1", "2", "4", "5"))
 	tk.MustExec("commit")

--- a/executor/mem_reader.go
+++ b/executor/mem_reader.go
@@ -1,0 +1,307 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/set"
+)
+
+type memIndexReader struct {
+	ctx           sessionctx.Context
+	index         *model.IndexInfo
+	table         *model.TableInfo
+	kvRanges      []kv.KeyRange
+	desc          bool
+	conditions    []expression.Expression
+	addedRows     [][]types.Datum
+	retFieldTypes []*types.FieldType
+	outputOffset  []int
+	// cache for decode handle.
+	handleBytes []byte
+	// memIdxHandles is uses to store the handle ids that has been read by memIndexReader.
+	memIdxHandles set.Int64Set
+	// belowHandleIndex is the handle's position of the below scan plan.
+	belowHandleIndex int
+}
+
+func buildMemIndexReader(us *UnionScanExec, idxReader *IndexReaderExecutor) *memIndexReader {
+	kvRanges := idxReader.kvRanges
+	outputOffset := make([]int, 0, len(us.columns))
+	for _, col := range idxReader.outputColumns {
+		outputOffset = append(outputOffset, col.Index)
+	}
+	return &memIndexReader{
+		ctx:              us.ctx,
+		index:            idxReader.index,
+		table:            idxReader.table.Meta(),
+		kvRanges:         kvRanges,
+		desc:             us.desc,
+		conditions:       us.conditions,
+		addedRows:        make([][]types.Datum, 0, len(us.dirty.addedRows)),
+		retFieldTypes:    retTypes(us),
+		outputOffset:     outputOffset,
+		handleBytes:      make([]byte, 0, 16),
+		memIdxHandles:    set.NewInt64Set(),
+		belowHandleIndex: us.belowHandleIndex,
+	}
+}
+
+func (m *memIndexReader) getMemRows() ([][]types.Datum, error) {
+	tps := make([]*types.FieldType, 0, len(m.index.Columns)+1)
+	cols := m.table.Columns
+	for _, col := range m.index.Columns {
+		tps = append(tps, &cols[col.Offset].FieldType)
+	}
+	if m.table.PKIsHandle {
+		for _, col := range m.table.Columns {
+			if mysql.HasPriKeyFlag(col.Flag) {
+				tps = append(tps, &col.FieldType)
+				break
+			}
+		}
+	} else {
+		// ExtraHandle Column tp.
+		tps = append(tps, types.NewFieldType(mysql.TypeLonglong))
+	}
+
+	mutableRow := chunk.MutRowFromTypes(m.retFieldTypes)
+	err := iterTxnMemBuffer(m.ctx, m.kvRanges, func(key, value []byte) error {
+		data, err := m.decodeIndexKeyValue(key, value, tps)
+		if err != nil {
+			return err
+		}
+		handle := data[m.belowHandleIndex].GetInt64()
+		m.memIdxHandles.Insert(handle)
+
+		mutableRow.SetDatums(data...)
+		matched, _, err := expression.EvalBool(m.ctx, m.conditions, mutableRow.ToRow())
+		if err != nil || !matched {
+			return err
+		}
+		m.addedRows = append(m.addedRows, data)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+	// TODO: After refine `IterReverse`, remove below logic and use `IterReverse` when do reverse scan.
+	if m.desc {
+		reverseDatumSlice(m.addedRows)
+	}
+	return m.addedRows, nil
+}
+
+func (m *memIndexReader) decodeIndexKeyValue(key, value []byte, tps []*types.FieldType) ([]types.Datum, error) {
+	pkStatus := tablecodec.PrimaryKeyIsSigned
+	if mysql.HasUnsignedFlag(tps[len(tps)-1].Flag) {
+		pkStatus = tablecodec.PrimaryKeyIsUnsigned
+	}
+	values, err := tablecodec.DecodeIndexKV(key, value, len(m.index.Columns), pkStatus)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	ds := make([]types.Datum, 0, len(m.outputOffset))
+	for _, offset := range m.outputOffset {
+		d, err := tablecodec.DecodeColumnValue(values[offset], tps[offset], m.ctx.GetSessionVars().TimeZone)
+		if err != nil {
+			return nil, err
+		}
+		ds = append(ds, d)
+	}
+	return ds, nil
+}
+
+type memTableReader struct {
+	ctx           sessionctx.Context
+	table         *model.TableInfo
+	columns       []*model.ColumnInfo
+	kvRanges      []kv.KeyRange
+	desc          bool
+	conditions    []expression.Expression
+	addedRows     [][]types.Datum
+	retFieldTypes []*types.FieldType
+	colIDs        map[int64]int
+	// cache for decode handle.
+	handleBytes []byte
+}
+
+func buildMemTableReader(us *UnionScanExec, tblReader *TableReaderExecutor) *memTableReader {
+	kvRanges := tblReader.kvRanges
+	colIDs := make(map[int64]int)
+	for i, col := range tblReader.columns {
+		colIDs[col.ID] = i
+	}
+
+	return &memTableReader{
+		ctx:           us.ctx,
+		table:         tblReader.table.Meta(),
+		columns:       us.columns,
+		kvRanges:      kvRanges,
+		desc:          us.desc,
+		conditions:    us.conditions,
+		addedRows:     make([][]types.Datum, 0, len(us.dirty.addedRows)),
+		retFieldTypes: retTypes(us),
+		colIDs:        colIDs,
+		handleBytes:   make([]byte, 0, 16),
+	}
+}
+
+// TODO: Try to make memXXXReader lazy, There is no need to decode many rows when parent operator only need 1 row.
+func (m *memTableReader) getMemRows() ([][]types.Datum, error) {
+	mutableRow := chunk.MutRowFromTypes(m.retFieldTypes)
+	err := iterTxnMemBuffer(m.ctx, m.kvRanges, func(key, value []byte) error {
+		row, err := m.decodeRecordKeyValue(key, value)
+		if err != nil {
+			return err
+		}
+
+		mutableRow.SetDatums(row...)
+		matched, _, err := expression.EvalBool(m.ctx, m.conditions, mutableRow.ToRow())
+		if err != nil || !matched {
+			return err
+		}
+		m.addedRows = append(m.addedRows, row)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: After refine `IterReverse`, remove below logic and use `IterReverse` when do reverse scan.
+	if m.desc {
+		reverseDatumSlice(m.addedRows)
+	}
+	return m.addedRows, nil
+}
+
+func (m *memTableReader) decodeRecordKeyValue(key, value []byte) ([]types.Datum, error) {
+	handle, err := tablecodec.DecodeRowKey(key)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return decodeRowData(m.ctx, m.table, m.columns, m.colIDs, handle, m.handleBytes, value)
+}
+
+// decodeRowData uses to decode row data value.
+func decodeRowData(ctx sessionctx.Context, tb *model.TableInfo, columns []*model.ColumnInfo, colIDs map[int64]int, handle int64, cacheBytes, value []byte) ([]types.Datum, error) {
+	values, err := getRowData(ctx.GetSessionVars().StmtCtx, tb, columns, colIDs, handle, cacheBytes, value)
+	if err != nil {
+		return nil, err
+	}
+	ds := make([]types.Datum, 0, len(columns))
+	for _, col := range columns {
+		offset := colIDs[col.ID]
+		d, err := tablecodec.DecodeColumnValue(values[offset], &col.FieldType, ctx.GetSessionVars().TimeZone)
+		if err != nil {
+			return nil, err
+		}
+		ds = append(ds, d)
+	}
+	return ds, nil
+}
+
+// getRowData decodes raw byte slice to row data.
+func getRowData(ctx *stmtctx.StatementContext, tb *model.TableInfo, columns []*model.ColumnInfo, colIDs map[int64]int, handle int64, cacheBytes, value []byte) ([][]byte, error) {
+	pkIsHandle := tb.PKIsHandle
+	values, err := tablecodec.CutRowNew(value, colIDs)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if values == nil {
+		values = make([][]byte, len(colIDs))
+	}
+	// Fill the handle and null columns.
+	for _, col := range columns {
+		id := col.ID
+		offset := colIDs[id]
+		if (pkIsHandle && mysql.HasPriKeyFlag(col.Flag)) || id == model.ExtraHandleID {
+			var handleDatum types.Datum
+			if mysql.HasUnsignedFlag(col.Flag) {
+				// PK column is Unsigned.
+				handleDatum = types.NewUintDatum(uint64(handle))
+			} else {
+				handleDatum = types.NewIntDatum(handle)
+			}
+			handleData, err1 := codec.EncodeValue(ctx, cacheBytes, handleDatum)
+			if err1 != nil {
+				return nil, errors.Trace(err1)
+			}
+			values[offset] = handleData
+			continue
+		}
+		if hasColVal(values, colIDs, id) {
+			continue
+		}
+		// no need to fill default value.
+		values[offset] = []byte{codec.NilFlag}
+	}
+
+	return values, nil
+}
+
+func hasColVal(data [][]byte, colIDs map[int64]int, id int64) bool {
+	offset, ok := colIDs[id]
+	if ok && data[offset] != nil {
+		return true
+	}
+	return false
+}
+
+type processKVFunc func(key, value []byte) error
+
+func iterTxnMemBuffer(ctx sessionctx.Context, kvRanges []kv.KeyRange, fn processKVFunc) error {
+	txn, err := ctx.Txn(true)
+	if err != nil {
+		return err
+	}
+	for _, rg := range kvRanges {
+		iter, err := txn.GetMemBuffer().Iter(rg.StartKey, rg.EndKey)
+		if err != nil {
+			return err
+		}
+		for ; iter.Valid(); err = iter.Next() {
+			if err != nil {
+				return err
+			}
+			// check whether the key was been deleted.
+			if len(iter.Value()) == 0 {
+				continue
+			}
+			err = fn(iter.Key(), iter.Value())
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func reverseDatumSlice(rows [][]types.Datum) {
+	for i, j := 0, len(rows)-1; i < j; i, j = i+1, j-1 {
+		rows[i], rows[j] = rows[j], rows[i]
+	}
+}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -58,7 +58,9 @@ type TableReaderExecutor struct {
 	keepOrder bool
 	desc      bool
 	ranges    []*ranger.Range
-	dagPB     *tipb.DAGRequest
+	// kvRanges are only use for union scan.
+	kvRanges []kv.KeyRange
+	dagPB    *tipb.DAGRequest
 	// columns are only required by union scan.
 	columns []*model.ColumnInfo
 
@@ -154,7 +156,10 @@ func (e *TableReaderExecutor) Next(ctx context.Context, req *chunk.Chunk) error 
 
 // Close implements the Executor Close interface.
 func (e *TableReaderExecutor) Close() error {
-	err := e.resultHandler.Close()
+	var err error
+	if e.resultHandler != nil {
+		err = e.resultHandler.Close()
+	}
 	if e.runtimeStats != nil {
 		copStats := e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(e.plans[0].ExplainID().String())
 		copStats.SetRowNum(e.feedback.Actual())
@@ -178,6 +183,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	if err != nil {
 		return nil, err
 	}
+	e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
 	result, err := e.SelectResult(ctx, e.ctx, kvReq, retTypes(e), e.feedback, getPhysicalPlanIDs(e.plans))
 	if err != nil {
 		return nil, err

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -25,9 +25,9 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/set"
 )
 
 // DirtyDB stores uncommitted write operations for a transaction.
@@ -112,21 +112,44 @@ type UnionScanExec struct {
 	desc       bool
 	conditions []expression.Expression
 	columns    []*model.ColumnInfo
-
+	table      table.Table
 	// belowHandleIndex is the handle's position of the below scan plan.
 	belowHandleIndex int
 
-	addedRows           [][]types.Datum
+	addedRows [][]types.Datum
+	// memIdxHandles is uses to store the handle ids that has been read by memIndexReader.
+	memIdxHandles       set.Int64Set
 	cursor4AddRows      int
 	sortErr             error
 	snapshotRows        [][]types.Datum
 	cursor4SnapshotRows int
 	snapshotChunkBuffer *chunk.Chunk
+	mutableRow          chunk.MutRow
 }
 
 // Open implements the Executor Open interface.
 func (us *UnionScanExec) Open(ctx context.Context) error {
 	if err := us.baseExecutor.Open(ctx); err != nil {
+		return err
+	}
+	return us.open(ctx)
+}
+
+func (us *UnionScanExec) open(ctx context.Context) error {
+	var err error
+	reader := us.children[0]
+	switch x := reader.(type) {
+	case *TableReaderExecutor:
+		us.addedRows, err = buildMemTableReader(us, x).getMemRows()
+	case *IndexReaderExecutor:
+		mIdxReader := buildMemIndexReader(us, x)
+		us.addedRows, err = mIdxReader.getMemRows()
+		us.memIdxHandles = mIdxReader.memIdxHandles
+	case *IndexLookUpExecutor:
+		us.memIdxHandles = set.NewInt64Set()
+		err = us.buildAndSortAddedRows(x.table)
+	}
+	if err != nil {
 		return err
 	}
 	us.snapshotChunkBuffer = newFirstChunk(us)
@@ -219,17 +242,49 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) ([]types.Datum, err
 		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 			snapshotHandle := row.GetInt64(us.belowHandleIndex)
 			if _, ok := us.dirty.deletedRows[snapshotHandle]; ok {
+				err = us.getMissIndexRowsByHandle(snapshotHandle)
+				if err != nil {
+					return nil, err
+				}
 				continue
 			}
 			if _, ok := us.dirty.addedRows[snapshotHandle]; ok {
 				// If src handle appears in added rows, it means there is conflict and the transaction will fail to
 				// commit, but for simplicity, we don't handle it here.
+				err = us.getMissIndexRowsByHandle(snapshotHandle)
+				if err != nil {
+					return nil, err
+				}
 				continue
 			}
 			us.snapshotRows = append(us.snapshotRows, row.GetDatumRow(retTypes(us.children[0])))
 		}
 	}
 	return us.snapshotRows[0], nil
+}
+
+// For index reader and index look up reader, update doesn't write index to txn memBuffer when the idx column
+// is unchanged. So the `memIndexReader` and `memIndexLookUpReader` can't read the index from txn memBuffer.
+// This function is used to get the missing row by the handle if the handle is in dirtyTable.addedRows.
+func (us *UnionScanExec) getMissIndexRowsByHandle(handle int64) error {
+	reader := us.children[0]
+	switch reader.(type) {
+	case *TableReaderExecutor:
+		return nil
+	}
+	if _, ok := us.dirty.addedRows[handle]; !ok {
+		return nil
+	}
+	// Don't miss in memBuffer reader.
+	if us.memIdxHandles.Exist(handle) {
+		return nil
+	}
+	memRow, err := us.getMemRow(handle)
+	if memRow == nil || err != nil {
+		return err
+	}
+	us.snapshotRows = append(us.snapshotRows, memRow)
+	return nil
 }
 
 func (us *UnionScanExec) getAddedRow() []types.Datum {
@@ -288,7 +343,7 @@ func (us *UnionScanExec) compare(a, b []types.Datum) (int, error) {
 }
 
 // rowWithColsInTxn gets the row from the transaction buffer.
-func (us *UnionScanExec) rowWithColsInTxn(t table.Table, h int64, cols []*table.Column) ([]types.Datum, error) {
+func (us *UnionScanExec) rowWithColsInTxn(t table.Table, h int64) ([]types.Datum, error) {
 	key := t.RecordKey(h)
 	txn, err := us.ctx.Txn(true)
 	if err != nil {
@@ -298,29 +353,38 @@ func (us *UnionScanExec) rowWithColsInTxn(t table.Table, h int64, cols []*table.
 	if err != nil {
 		return nil, err
 	}
-	v, _, err := tables.DecodeRawRowData(us.ctx, t.Meta(), h, cols, value)
+	colIDs := make(map[int64]int)
+	for i, col := range us.columns {
+		colIDs[col.ID] = i
+	}
+	return decodeRowData(us.ctx, us.table.Meta(), us.columns, colIDs, h, []byte{}, value)
+}
+
+func (us *UnionScanExec) getMemRow(h int64) ([]types.Datum, error) {
+	data, err := us.rowWithColsInTxn(us.table, h)
 	if err != nil {
 		return nil, err
 	}
-	return v, nil
+	us.mutableRow.SetDatums(data...)
+	matched, _, err := expression.EvalBool(us.ctx, us.conditions, us.mutableRow.ToRow())
+	if err != nil {
+		return nil, err
+	}
+	if !matched {
+		return nil, nil
+	}
+	return data, nil
 }
 
+// TODO: remove `buildAndSortAddedRows` functions and `DirtyTable`.
 func (us *UnionScanExec) buildAndSortAddedRows(t table.Table) error {
 	us.addedRows = make([][]types.Datum, 0, len(us.dirty.addedRows))
 	mutableRow := chunk.MutRowFromTypes(retTypes(us))
-	cols := t.WritableCols()
 	for h := range us.dirty.addedRows {
-		newData := make([]types.Datum, 0, us.schema.Len())
-		data, err := us.rowWithColsInTxn(t, h, cols)
+		us.memIdxHandles.Insert(h)
+		newData, err := us.rowWithColsInTxn(t, h)
 		if err != nil {
 			return err
-		}
-		for _, col := range us.columns {
-			if col.ID == model.ExtraHandleID {
-				newData = append(newData, types.NewIntDatum(h))
-			} else {
-				newData = append(newData, data[col.Offset])
-			}
 		}
 		mutableRow.SetDatums(newData...)
 		matched, _, err := expression.EvalBool(us.ctx, us.conditions, mutableRow.ToRow())

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -216,17 +216,17 @@ func (h *rpcHandler) buildIndexScan(ctx *dagContext, executor *tipb.Executor) (*
 	columns := executor.IdxScan.Columns
 	ctx.evalCtx.setColumnInfo(columns)
 	length := len(columns)
-	pkStatus := pkColNotExists
+	pkStatus := tablecodec.PrimaryKeyNotExists
 	// The PKHandle column info has been collected in ctx.
 	if columns[length-1].GetPkHandle() {
 		if mysql.HasUnsignedFlag(uint(columns[length-1].GetFlag())) {
-			pkStatus = pkColIsUnsigned
+			pkStatus = tablecodec.PrimaryKeyIsUnsigned
 		} else {
-			pkStatus = pkColIsSigned
+			pkStatus = tablecodec.PrimaryKeyIsSigned
 		}
 		columns = columns[:length-1]
 	} else if columns[length-1].ColumnId == model.ExtraHandleID {
-		pkStatus = pkColIsSigned
+		pkStatus = tablecodec.PrimaryKeyIsSigned
 		columns = columns[:length-1]
 	}
 	ranges, err := h.extractKVRanges(ctx.keyRanges, executor.IdxScan.Desc)

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -14,6 +14,7 @@
 package tablecodec
 
 import (
+	"bytes"
 	"encoding/binary"
 	"math"
 	"time"
@@ -515,6 +516,57 @@ func CutIndexKeyNew(key kv.Key, length int) (values [][]byte, b []byte, err erro
 		values = append(values, val)
 	}
 	return
+}
+
+// PrimaryKeyStatus is the primary key column status.
+type PrimaryKeyStatus int
+
+const (
+	// PrimaryKeyNotExists means no need to decode primary key column value when DecodeIndexKV.
+	PrimaryKeyNotExists PrimaryKeyStatus = iota
+	// PrimaryKeyIsSigned means decode primary key column value as int64 when DecodeIndexKV.
+	PrimaryKeyIsSigned
+	// PrimaryKeyIsUnsigned means decode primary key column value as uint64 when DecodeIndexKV.
+	PrimaryKeyIsUnsigned
+)
+
+// DecodeIndexKV uses to decode index key values.
+func DecodeIndexKV(key, value []byte, colsLen int, pkStatus PrimaryKeyStatus) ([][]byte, error) {
+	values, b, err := CutIndexKeyNew(key, colsLen)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if len(b) > 0 {
+		if pkStatus != PrimaryKeyNotExists {
+			values = append(values, b)
+		}
+	} else if pkStatus != PrimaryKeyNotExists {
+		handle, err := DecodeIndexValueAsHandle(value)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		var handleDatum types.Datum
+		if pkStatus == PrimaryKeyIsUnsigned {
+			handleDatum = types.NewUintDatum(uint64(handle))
+		} else {
+			handleDatum = types.NewIntDatum(handle)
+		}
+		handleBytes := make([]byte, 0, 8)
+		handleBytes, err = codec.EncodeValue(nil, handleBytes, handleDatum)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		values = append(values, handleBytes)
+	}
+	return values, nil
+}
+
+// DecodeIndexValueAsHandle uses to decode index value as handle id.
+func DecodeIndexValueAsHandle(data []byte) (int64, error) {
+	var h int64
+	buf := bytes.NewBuffer(data)
+	err := binary.Read(buf, binary.BigEndian, &h)
+	return h, errors.Trace(err)
 }
 
 // EncodeTableIndexPrefix encodes index prefix with tableID and idxID.


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
cherry-pick https://github.com/pingcap/tidb/pull/10673/files

conflict file:
```
(use "git add <file>..." to mark resolution)

both modified:   executor/table_reader.go
both modified:   store/mockstore/mocktikv/executor.go
```

TODO: 
need cherry-pick 
* #11702
* https://github.com/pingcap/tidb/pull/12609
* https://github.com/pingcap/tidb/pull/14057   -- bug-fix
