### PR TITLE
config, infoschema: enable statement summary by default

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/stmtsummary"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	dto "github.com/prometheus/client_model/go"
@@ -469,10 +470,9 @@ func (s *testSuite) TestPreparedStmt(c *C) {
 func (s *testSuite) TestCapturePlanBaseline(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	s.cleanBindingEnv(tk)
-	tk.MustExec("set @@tidb_enable_stmt_summary = on")
+	stmtsummary.StmtSummaryByDigestMap.Clear()
 	tk.MustExec(" set @@tidb_capture_plan_baselines = on")
 	defer func() {
-		tk.MustExec("set @@tidb_enable_stmt_summary = off")
 		tk.MustExec(" set @@tidb_capture_plan_baselines = off")
 	}()
 	tk.MustExec("use test")

--- a/config/config.go
+++ b/config/config.go
@@ -577,7 +577,7 @@ var defaultConf = Config{
 		MaxRetryCount: 256,
 	},
 	StmtSummary: StmtSummary{
-		Enable:          false,
+		Enable:          true,
 		MaxStmtCount:    200,
 		MaxSQLLength:    4096,
 		RefreshInterval: 1800,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -348,7 +348,7 @@ max-retry-count = 256
 
 [stmt-summary]
 # enable statement summary.
-enable = false
+enable = true
 
 # max number of statements kept in memory.
 max-stmt-count = 200

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -191,7 +191,7 @@ max-batch-size=128
 region-cache-ttl=6000
 store-limit=0
 [stmt-summary]
-enable=true
+enable=false
 max-stmt-count=1000
 max-sql-length=1024
 refresh-interval=100
@@ -223,7 +223,7 @@ allow-auto-random = true
 	c.Assert(conf.EnableTableLock, IsTrue)
 	c.Assert(conf.DelayCleanTableLock, Equals, uint64(5))
 	c.Assert(conf.SplitRegionMaxNum, Equals, uint64(10000))
-	c.Assert(conf.StmtSummary.Enable, Equals, true)
+	c.Assert(conf.StmtSummary.Enable, Equals, false)
 	c.Assert(conf.StmtSummary.MaxStmtCount, Equals, uint(1000))
 	c.Assert(conf.StmtSummary.MaxSQLLength, Equals, uint(1024))
 	c.Assert(conf.StmtSummary.RefreshInterval, Equals, 100)

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -82,11 +82,6 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b varchar(10), key k(a))")
 
-	// Statement summary is disabled by default.
-	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
-	tk.MustExec("insert into t values(1, 'a')")
-	tk.MustQuery("select * from performance_schema.events_statements_summary_by_digest").Check(testkit.Rows())
-
 	tk.MustExec("set global tidb_enable_stmt_summary = 1")
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("1"))
 
@@ -147,6 +142,9 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 
 	// Disable it again.
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
+	tk.MustExec("set session tidb_enable_stmt_summary = false")
+	defer tk.MustExec("set global tidb_enable_stmt_summary = 1")
+	defer tk.MustExec("set session tidb_enable_stmt_summary = 1")
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
 
 	// Create a new session to test
@@ -227,11 +225,6 @@ func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b varchar(10), key k(a))")
-
-	// Statement summary is disabled by default.
-	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
-	tk.MustExec("insert into t values(1, 'a')")
-	tk.MustQuery("select * from performance_schema.events_statements_summary_by_digest_history").Check(testkit.Rows())
 
 	tk.MustExec("set global tidb_enable_stmt_summary = 1")
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("1"))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Enable statement summary by default.
It's enabled only in master, not release versions.

### What is changed and how it works?
Modify config files to set the default value to `true`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Possible performance regression

Related changes

N/A

Release note

 - Enable statement summary by default.
