### PR TITLE
config: Remove Coprocessor Cache config and disable it by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -554,11 +554,16 @@ var defaultConf = Config{
 		StoreLimit:     0,
 
 		CoprCache: CoprocessorCache{
+			//Enabled:               false,
+			//CapacityMB:            1000,
+			//AdmissionMaxResultMB:  10,
+			//AdmissionMinProcessMs: 5,
 			// WARNING: Currently Coprocessor Cache may lead to inconsistent result. Do not open it.
+			// These config items are hidden from user, so that fill them with zero value instead of default value.
 			Enabled:               false,
-			CapacityMB:            1000,
-			AdmissionMaxResultMB:  10,
-			AdmissionMinProcessMs: 5,
+			CapacityMB:            0,
+			AdmissionMaxResultMB:  0,
+			AdmissionMinProcessMs: 0,
 		},
 	},
 	Binlog: Binlog{

--- a/config/config.go
+++ b/config/config.go
@@ -554,7 +554,8 @@ var defaultConf = Config{
 		StoreLimit:     0,
 
 		CoprCache: CoprocessorCache{
-			Enabled:               true,
+			// WARNING: Currently Coprocessor Cache may lead to inconsistent result. Do not open it.
+			Enabled:               false,
 			CapacityMB:            1000,
 			AdmissionMaxResultMB:  10,
 			AdmissionMinProcessMs: 5,

--- a/config/config.go
+++ b/config/config.go
@@ -554,16 +554,18 @@ var defaultConf = Config{
 		StoreLimit:     0,
 
 		CoprCache: CoprocessorCache{
-			//Enabled:               false,
-			//CapacityMB:            1000,
-			//AdmissionMaxResultMB:  10,
-			//AdmissionMinProcessMs: 5,
 			// WARNING: Currently Coprocessor Cache may lead to inconsistent result. Do not open it.
 			// These config items are hidden from user, so that fill them with zero value instead of default value.
 			Enabled:               false,
 			CapacityMB:            0,
 			AdmissionMaxResultMB:  0,
 			AdmissionMinProcessMs: 0,
+
+			// If you still want to use Coprocessor Cache, here are some recommended configurations:
+			// Enabled:               true,
+			// CapacityMB:            1000,
+			// AdmissionMaxResultMB:  10,
+			// AdmissionMinProcessMs: 5,
 		},
 	},
 	Binlog: Binlog{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -316,19 +316,6 @@ region-cache-ttl = 600
 # default 0 means shutting off store limit.
 store-limit = 0
 
-[tikv-client.copr-cache]
-# Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
-# reuses the result when corresponding data in TiKV is unchanged, on a region basis.
-enabled = true
-
-# The capacity in MB of the cache.
-capacity-mb = 1000.0
-
-# Only cache requests whose result set is small.
-admission-max-result-mb = 10.0
-# Only cache requests takes notable time to process.
-admission-min-process-ms = 5
-
 [txn-local-latches]
 # Enable local latches for transactions. Enable it when
 # there are lots of conflicts between transactions.


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR removes the cache config so that user will not see them. Additionally this PR disables the cache by default becuase it has correctness issue now.

Correctness issue:
- Wall time 1: Write A with TS=10
- Wall time 2: Read A with TS=5 (read nothing, cached)
- Wall time 3: Read A with TS=15 (read nothing from cache, but should read A)

### What is changed and how it works?

Only config is changed. This PR does not solve the correctness issue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
