### PR TITLE
planner: apply max/min elimination when other aggregations exist (#14376)

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -263,3 +263,25 @@ func (s *testIntegrationSuite) TestErrNoDB(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("grant select on test1111 to test@'%'")
 }
+
+func (s *testIntegrationSuite) TestMaxMinEliminate(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key)")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -34,6 +34,9 @@ func (a *maxMinEliminator) optimize(ctx context.Context, p LogicalPlan) (Logical
 
 // Try to convert max/min to Limit+Sort operators.
 func (a *maxMinEliminator) eliminateMaxMin(p LogicalPlan) {
+	for _, child := range p.Children() {
+		a.eliminateMaxMin(child)
+	}
 	// We don't need to guarantee that the child of it is a data source. This transformation won't be worse than previous.
 	if agg, ok := p.(*LogicalAggregation); ok {
 		// We only consider case with single max/min function.
@@ -78,10 +81,6 @@ func (a *maxMinEliminator) eliminateMaxMin(p LogicalPlan) {
 		// Since now it's almost one row returned, a agg operator is okay to do this.
 		p.SetChildren(li)
 		return
-	}
-
-	for _, child := range p.Children() {
-		a.eliminateMaxMin(child)
 	}
 }
 

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -27,6 +27,12 @@
     ]
   },
   {
+    "name": "TestMaxMinEliminate",
+    "cases": [
+      "explain (select max(a) from t) union (select min(a) from t)"
+    ]
+  },
+  {
     "name": "TestPartitionTableStats",
     "cases": [
       "explain select * from t order by a",

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -38,6 +38,28 @@
     ]
   },
   {
+    "Name": "TestMaxMinEliminate",
+    "Cases": [
+      {
+        "SQL": "explain (select max(a) from t) union (select min(a) from t)",
+        "Plan": [
+          "HashAgg_19 2.00 root group by:max(a), funcs:firstrow(max(a))",
+          "└─Union_20 2.00 root ",
+          "  ├─StreamAgg_26 1.00 root funcs:max(test.t.a)",
+          "  │ └─Limit_30 1.00 root offset:0, count:1",
+          "  │   └─TableReader_40 1.00 root data:Limit_39",
+          "  │     └─Limit_39 1.00 cop offset:0, count:1",
+          "  │       └─TableScan_38 1.00 cop table:t, range:[-inf,+inf], keep order:true, desc, stats:pseudo",
+          "  └─StreamAgg_48 1.00 root funcs:min(test.t.a)",
+          "    └─Limit_52 1.00 root offset:0, count:1",
+          "      └─TableReader_62 1.00 root data:Limit_61",
+          "        └─Limit_61 1.00 cop offset:0, count:1",
+          "          └─TableScan_60 1.00 cop table:t, range:[-inf,+inf], keep order:true, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestPartitionTableStats",
     "Cases": [
       {


### PR DESCRIPTION

cherry-pick #14376

 Conflicts:
	planner/core/integration_test.go
	planner/core/rule_max_min_eliminate.go
	planner/core/testdata/integration_suite_in.json
	planner/core/testdata/integration_suite_out.json