### PR TITLE
planner: apply max/min elimination when other aggregations exist (#14376)

### DIFF
--- a/planner/core/rule_max_min_eliminate.go
+++ b/planner/core/rule_max_min_eliminate.go
@@ -32,6 +32,9 @@ func (a *maxMinEliminator) optimize(p LogicalPlan) (LogicalPlan, error) {
 
 // Try to convert max/min to Limit+Sort operators.
 func (a *maxMinEliminator) eliminateMaxMin(p LogicalPlan) {
+	for _, child := range p.Children() {
+		a.eliminateMaxMin(child)
+	}
 	// We don't need to guarantee that the child of it is a data source. This transformation won't be worse than previous.
 	if agg, ok := p.(*LogicalAggregation); ok {
 		// We only consider case with single max/min function.
@@ -76,9 +79,5 @@ func (a *maxMinEliminator) eliminateMaxMin(p LogicalPlan) {
 		// Since now it's almost one row returned, a agg operator is okay to do this.
 		p.SetChildren(li)
 		return
-	}
-
-	for _, child := range p.Children() {
-		a.eliminateMaxMin(child)
 	}
 }

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -25,5 +25,11 @@
       // LeftOuterJoin should no be simplified to InnerJoin.
       "explain select * from t t1 left join t t2 on t1.a = t2.a where cast(t1.b as date) >= '2019-01-01'"
     ]
+  },
+  {
+    "name": "TestMaxMinEliminate",
+    "cases": [
+      "explain (select max(a) from t) union (select min(a) from t)"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -34,5 +34,27 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestMaxMinEliminate",
+    "Cases": [
+      {
+        "SQL": "explain (select max(a) from t) union (select min(a) from t)",
+        "Plan": [
+          "HashAgg_19 2.00 root group by:max(a), funcs:firstrow(max(a))",
+          "└─Union_20 2.00 root ",
+          "  ├─StreamAgg_26 1.00 root funcs:max(test.t.a)",
+          "  │ └─Limit_30 1.00 root offset:0, count:1",
+          "  │   └─TableReader_40 1.00 root data:Limit_39",
+          "  │     └─Limit_39 1.00 cop offset:0, count:1",
+          "  │       └─TableScan_38 1.00 cop table:t, range:[-inf,+inf], keep order:true, desc, stats:pseudo",
+          "  └─StreamAgg_48 1.00 root funcs:min(test.t.a)",
+          "    └─Limit_52 1.00 root offset:0, count:1",
+          "      └─TableReader_62 1.00 root data:Limit_61",
+          "        └─Limit_61 1.00 cop offset:0, count:1",
+          "          └─TableScan_60 1.00 cop table:t, range:[-inf,+inf], keep order:true, stats:pseudo"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
cherry-pick #14376

Conflicts:
	planner/core/integration_test.go
	planner/core/rule_max_min_eliminate.go
	planner/core/testdata/integration_suite_in.json
	planner/core/testdata/integration_suite_out.json