### PR TITLE
session: add auto_increment_offset to global variables' loading list.

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1805,6 +1805,7 @@ var builtinGlobalVariable = []string{
 	variable.QueryCacheSize,
 	variable.CharacterSetServer,
 	variable.AutoIncrementIncrement,
+	variable.AutoIncrementOffset,
 	variable.CollationServer,
 	variable.NetWriteTimeout,
 	variable.MaxExecutionTime,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
It's left code by #14301
add `auto_increment_offset` to global variables' load.

### What is changed and how it works?
add the variable name in `builtinGlobalVariable`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

0. start a tidb server:
1. set the global `auto_increment_offset` variable in one session.
2. open a new session and show the global variable changed.

Related changes

 - Need to cherry-pick to the release branch

Release note

 - add auto_increment_offset to global variables' loading list.
