### PR TITLE
store: fix potential panic in GC worker

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -153,9 +153,6 @@ func (w *GCWorker) start(ctx context.Context, wg *sync.WaitGroup) {
 	logutil.Logger(ctx).Info("[gc worker] start",
 		zap.String("uuid", w.uuid))
 
-	se := createSession(w.store)
-	defer se.Close()
-
 	w.tick(ctx) // Immediately tick once to initialize configs.
 	wg.Done()
 

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -55,8 +55,6 @@ type GCWorker struct {
 	lastFinish  time.Time
 	cancel      context.CancelFunc
 	done        chan error
-
-	session session.Session
 }
 
 // NewGCWorker creates a GCWorker instance.
@@ -155,7 +153,8 @@ func (w *GCWorker) start(ctx context.Context, wg *sync.WaitGroup) {
 	logutil.Logger(ctx).Info("[gc worker] start",
 		zap.String("uuid", w.uuid))
 
-	w.session = createSession(w.store)
+	se := createSession(w.store)
+	defer se.Close()
 
 	w.tick(ctx) // Immediately tick once to initialize configs.
 	wg.Done()
@@ -274,18 +273,20 @@ func (w *GCWorker) prepare() (bool, uint64, error) {
 	// 4. GC update `tikv_gc_safe_point` value to t2, continue do GC in this round.
 	// Then the data record that has been dropped between time t1 and t2, will be cleaned by GC, but the user thinks the data after t1 won't be clean by GC.
 	ctx := context.Background()
-	_, err := w.session.Execute(ctx, "BEGIN")
+	se := createSession(w.store)
+	defer se.Close()
+	_, err := se.Execute(ctx, "BEGIN")
 	if err != nil {
 		return false, 0, errors.Trace(err)
 	}
 	doGC, safePoint, err := w.checkPrepare(ctx)
 	if doGC {
-		err = w.session.CommitTxn(ctx)
+		err = se.CommitTxn(ctx)
 		if err != nil {
 			return false, 0, errors.Trace(err)
 		}
 	} else {
-		w.session.RollbackTxn(ctx)
+		se.RollbackTxn(ctx)
 	}
 	return doGC, safePoint, errors.Trace(err)
 }
@@ -1067,39 +1068,42 @@ func (w *GCWorker) doGC(ctx context.Context, safePoint uint64, concurrency int) 
 
 func (w *GCWorker) checkLeader() (bool, error) {
 	metrics.GCWorkerCounter.WithLabelValues("check_leader").Inc()
+	se := createSession(w.store)
+	defer se.Close()
+
 	ctx := context.Background()
-	_, err := w.session.Execute(ctx, "BEGIN")
+	_, err := se.Execute(ctx, "BEGIN")
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	leader, err := w.loadValueFromSysTable(gcLeaderUUIDKey)
 	if err != nil {
-		w.session.RollbackTxn(ctx)
+		se.RollbackTxn(ctx)
 		return false, errors.Trace(err)
 	}
 	logutil.BgLogger().Debug("[gc worker] got leader", zap.String("uuid", leader))
 	if leader == w.uuid {
 		err = w.saveTime(gcLeaderLeaseKey, time.Now().Add(gcWorkerLease))
 		if err != nil {
-			w.session.RollbackTxn(ctx)
+			se.RollbackTxn(ctx)
 			return false, errors.Trace(err)
 		}
-		err = w.session.CommitTxn(ctx)
+		err = se.CommitTxn(ctx)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
 		return true, nil
 	}
 
-	w.session.RollbackTxn(ctx)
+	se.RollbackTxn(ctx)
 
-	_, err = w.session.Execute(ctx, "BEGIN")
+	_, err = se.Execute(ctx, "BEGIN")
 	if err != nil {
 		return false, errors.Trace(err)
 	}
 	lease, err := w.loadTime(gcLeaderLeaseKey)
 	if err != nil {
-		w.session.RollbackTxn(ctx)
+		se.RollbackTxn(ctx)
 		return false, errors.Trace(err)
 	}
 	if lease == nil || lease.Before(time.Now()) {
@@ -1109,26 +1113,26 @@ func (w *GCWorker) checkLeader() (bool, error) {
 
 		err = w.saveValueToSysTable(gcLeaderUUIDKey, w.uuid)
 		if err != nil {
-			w.session.RollbackTxn(ctx)
+			se.RollbackTxn(ctx)
 			return false, errors.Trace(err)
 		}
 		err = w.saveValueToSysTable(gcLeaderDescKey, w.desc)
 		if err != nil {
-			w.session.RollbackTxn(ctx)
+			se.RollbackTxn(ctx)
 			return false, errors.Trace(err)
 		}
 		err = w.saveTime(gcLeaderLeaseKey, time.Now().Add(gcWorkerLease))
 		if err != nil {
-			w.session.RollbackTxn(ctx)
+			se.RollbackTxn(ctx)
 			return false, errors.Trace(err)
 		}
-		err = w.session.CommitTxn(ctx)
+		err = se.CommitTxn(ctx)
 		if err != nil {
 			return false, errors.Trace(err)
 		}
 		return true, nil
 	}
-	w.session.RollbackTxn(ctx)
+	se.RollbackTxn(ctx)
 	return false, nil
 }
 
@@ -1199,8 +1203,10 @@ func (w *GCWorker) loadDurationWithDefault(key string, def time.Duration) (*time
 
 func (w *GCWorker) loadValueFromSysTable(key string) (string, error) {
 	ctx := context.Background()
+	se := createSession(w.store)
+	defer se.Close()
 	stmt := fmt.Sprintf(`SELECT HIGH_PRIORITY (variable_value) FROM mysql.tidb WHERE variable_name='%s' FOR UPDATE`, key)
-	rs, err := w.session.Execute(ctx, stmt)
+	rs, err := se.Execute(ctx, stmt)
 	if len(rs) > 0 {
 		defer terror.Call(rs[0].Close)
 	}
@@ -1229,10 +1235,9 @@ func (w *GCWorker) saveValueToSysTable(key, value string) error {
 			       ON DUPLICATE KEY
 			       UPDATE variable_value = '%[2]s', comment = '%[3]s'`,
 		key, value, gcVariableComments[key])
-	if w.session == nil {
-		return errors.New("[saveValueToSysTable session is nil]")
-	}
-	_, err := w.session.Execute(context.Background(), stmt)
+	se := createSession(w.store)
+	defer se.Close()
+	_, err := se.Execute(context.Background(), stmt)
 	logutil.BgLogger().Debug("[gc worker] save kv",
 		zap.String("key", key),
 		zap.String("value", value),
@@ -1323,13 +1328,6 @@ func NewMockGCWorker(store tikv.Storage) (*MockGCWorker, error) {
 		lastFinish:  time.Now(),
 		done:        make(chan error),
 	}
-	worker.session, err = session.CreateSession(worker.store)
-	if err != nil {
-		logutil.BgLogger().Error("initialize MockGCWorker session fail", zap.Error(err))
-		return nil, errors.Trace(err)
-	}
-	privilege.BindPrivilegeManager(worker.session, nil)
-	worker.session.GetSessionVars().InRestrictedSQL = true
 	return &MockGCWorker{worker: worker}, nil
 }
 

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -445,7 +445,9 @@ const (
 
 func (s *testGCWorkerSuite) testDeleteRangesFailureImpl(c *C, failType int) {
 	// Put some delete range tasks.
-	_, err := s.gcWorker.session.Execute(context.Background(), `INSERT INTO mysql.gc_delete_range VALUES
+	se := createSession(s.gcWorker.store)
+	defer se.Close()
+	_, err := se.Execute(context.Background(), `INSERT INTO mysql.gc_delete_range VALUES
 		("1", "2", "31", "32", "10"),
 		("3", "4", "33", "34", "10"),
 		("5", "6", "35", "36", "10")`)
@@ -473,7 +475,6 @@ func (s *testGCWorkerSuite) testDeleteRangesFailureImpl(c *C, failType int) {
 	}
 
 	// Check the delete range tasks.
-	se := createSession(s.gcWorker.store)
 	preparedRanges, err := util.LoadDeleteRanges(se, 20)
 	se.Close()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Try to fix
```
goroutine 5109074295 [running]:
github.com/pingcap/tidb/executor.(*ExecStmt).Exec.func1(0xc01b732830, 0x23b8c60, 0xc000138000, 0xc7ef2ca7e0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:229 +0x48c
panic(0x1ebe500, 0x31c4a60)
	/usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/pingcap/tidb/session.(*TxnState).LockKeys(0xc2e81aa1f0, 0x23b8c60, 0xc000138000, 0xc03018ab30, 0x5bd729875b001b6, 0xc350, 0xc817a17540, 0x1, 0x1, 0xc0638be8c0, ...)
	<autogenerated>:1 +0x36
github.com/pingcap/tidb/executor.doLockKeys(0x23b8c60, 0xc000138000, 0x23effa0, 0xc2e81aa1e0, 0xc350, 0xc817a17540, 0x1, 0x1, 0x13, 0xc2bdd5e300)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/executor.go:800 +0x185
github.com/pingcap/tidb/executor.(*SelectLockExec).Next(0xc33d69de60, 0x23b8c60, 0xc000138000, 0xca6dc03680, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/executor.go:789 +0x5a8
github.com/pingcap/tidb/executor.Next(0x23b8c60, 0xc000138000, 0x23bf820, 0xc33d69de60, 0xca6dc03680, 0x0, 0x203000)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/executor.go:192 +0xbd
github.com/pingcap/tidb/executor.(*ProjectionExec).unParallelExecute(0xc0148a7100, 0x23b8c60, 0xc000138000, 0xca27605ce0, 0xc3a2a6, 0xc013663180)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/projection.go:182 +0x8d
github.com/pingcap/tidb/executor.(*ProjectionExec).Next(0xc0148a7100, 0x23b8c60, 0xc000138000, 0xca27605ce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/projection.go:169 +0xf4
github.com/pingcap/tidb/executor.Next(0x23b8c60, 0xc000138000, 0x23bf660, 0xc0148a7100, 0xca27605ce0, 0xca2698aa98, 0xc00b0e9080)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/executor.go:192 +0xbd
github.com/pingcap/tidb/executor.(*recordSet).Next(0xc01b732578, 0x23b8c60, 0xc000138000, 0xca27605ce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:113 +0xc7
github.com/pingcap/tidb/executor.(*ExecStmt).runPessimisticSelectForUpdate(0xc7ef2ca7e0, 0x23b8c60, 0xc000138000, 0x23bf660, 0xc0148a7100, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:387 +0x303
github.com/pingcap/tidb/executor.(*ExecStmt).handlePessimisticSelectForUpdate(0xc7ef2ca7e0, 0x23b8c60, 0xc000138000, 0x23bf660, 0xc0148a7100, 0x355a9c0, 0xc1a4df2b00, 0x0, 0xc03018a800)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:362 +0x5d
github.com/pingcap/tidb/executor.(*ExecStmt).Exec(0xc7ef2ca7e0, 0x23b8c60, 0xc000138000, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:287 +0x70c
github.com/pingcap/tidb/session.runStmt(0x23b8c60, 0xc000138000, 0x23effa0, 0xc2e81aa1e0, 0x23bf1e0, 0xc7ef2ca7e0, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/session/tidb.go:249 +0x1cb
github.com/pingcap/tidb/session.(*session).executeStatement(0xc2e81aa1e0, 0x23b8c60, 0xc000138000, 0x0, 0x23beba0, 0xc0183f58c0, 0x23bf1e0, 0xc7ef2ca7e0, 0x0, 0x0, ...)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/session/session.go:976 +0x1ce
github.com/pingcap/tidb/session.(*session).execute(0xc2e81aa1e0, 0x23b8c60, 0xc000138000, 0xc1a4df2b60, 0x63, 0xc9c65c, 0x31c8260, 0xc0176dc880, 0x11, 0xc01b733190)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/session/session.go:1091 +0x96a
github.com/pingcap/tidb/session.(*session).Execute(0xc2e81aa1e0, 0x23b8c60, 0xc000138000, 0xc1a4df2b60, 0x63, 0x0, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/session/session.go:1014 +0xdb
github.com/pingcap/tidb/store/tikv/gcworker.(*GCWorker).loadValueFromSysTable(0xc002626200, 0x2104528, 0xc, 0x0, 0x0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1274 +0x119
github.com/pingcap/tidb/store/tikv/gcworker.(*GCWorker).checkUseDistributedGC(0xc002626200, 0x23b8c20, 0xc003ae2400, 0x5bd722345b00000)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:749 +0x55
github.com/pingcap/tidb/store/tikv/gcworker.(*GCWorker).runGCJob(0xc002626200, 0x23b8c20, 0xc003ae2400, 0x5bd722345b00000, 0xc)
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:534 +0x1451
created by github.com/pingcap/tidb/store/tikv/gcworker.(*GCWorker).leaderTick
	/home/jenkins/agent/workspace/tidb_release-3.0/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:281 +0xd96
```

### What is changed and how it works?
Do not create a private session for `checkLeader`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch
