### PR TITLE
ddl: check if the dropping index is primary key when doing "drop index `primary` on..."

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1396,7 +1396,7 @@ func (s *testDBSuite5) TestAlterPrimaryKey(c *C) {
 	s.tk.MustGetErrCode("alter table test_add_pk add primary key(d);", tmysql.ErrUnsupportedOnGeneratedColumn)
 	// The primary key name is the same as the existing index name.
 	s.tk.MustExec("alter table test_add_pk add primary key idx(e)")
-	s.tk.MustExec("alter table test_add_pk drop primary key")
+	s.tk.MustExec("drop index `primary` on test_add_pk")
 
 	// for describing table
 	s.tk.MustExec("create table test_add_pk1(a int, index idx(a))")
@@ -1436,6 +1436,7 @@ func (s *testDBSuite5) TestAlterPrimaryKey(c *C) {
 	s.tk.MustExec("alter table test_add_pk drop primary key")
 	// for not existing primary key
 	s.tk.MustGetErrCode("alter table test_add_pk drop primary key", tmysql.ErrCantDropFieldOrKey)
+	s.tk.MustGetErrCode("drop index `primary` on test_add_pk", tmysql.ErrCantDropFieldOrKey)
 
 	// for too many key parts specified
 	s.tk.MustGetErrCode("alter table test_add_pk add primary key idx_test(f1,f2,f3,f4,f5,f6,f7,f8,f9,f10,f11,f12,f13,f14,f15,f16,f17);",

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1891,7 +1891,7 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 		case ast.AlterTableDropIndex:
 			err = d.DropIndex(ctx, ident, model.NewCIStr(spec.Name))
 		case ast.AlterTableDropPrimaryKey:
-			err = d.dropIndex(ctx, ident, true, model.NewCIStr(mysql.PrimaryKeyName))
+			err = d.DropIndex(ctx, ident, model.NewCIStr(mysql.PrimaryKeyName))
 		case ast.AlterTableRenameIndex:
 			err = d.RenameIndex(ctx, ident, spec)
 		case ast.AlterTableDropPartition:
@@ -3317,10 +3317,6 @@ func (d *ddl) DropForeignKey(ctx sessionctx.Context, ti ast.Ident, fkName model.
 }
 
 func (d *ddl) DropIndex(ctx sessionctx.Context, ti ast.Ident, indexName model.CIStr) error {
-	return d.dropIndex(ctx, ti, false, indexName)
-}
-
-func (d *ddl) dropIndex(ctx sessionctx.Context, ti ast.Ident, isPK bool, indexName model.CIStr) error {
 	is := d.infoHandle.Get()
 	schema, ok := is.SchemaByName(ti.Schema)
 	if !ok {
@@ -3332,6 +3328,12 @@ func (d *ddl) dropIndex(ctx sessionctx.Context, ti ast.Ident, isPK bool, indexNa
 	}
 
 	indexInfo := t.Meta().FindIndexByName(indexName.L)
+	var isPK bool
+	if indexName.L == strings.ToLower(mysql.PrimaryKeyName) &&
+		// Before we fixed #14243, there might be a general index named `primary` but not a primary key.
+		(indexInfo == nil || indexInfo.Primary) {
+		isPK = true
+	}
 	if isPK {
 		if !config.GetGlobalConfig().AlterPrimaryKey {
 			return ErrUnsupportedModifyPrimaryKey.GenWithStack("Unsupported drop primary key when alter-primary-key is false")

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -87,9 +87,15 @@ func (s *testSerialSuite) TestPrimaryKey(c *C) {
 	tk.MustExec("use test")
 
 	tk.MustExec("create table primary_key_test (a int, b varchar(10))")
+	tk.MustExec("create table primary_key_test_1 (a int, b varchar(10), primary key(a))")
 	_, err := tk.Exec("alter table primary_key_test add primary key(a)")
 	c.Assert(ddl.ErrUnsupportedModifyPrimaryKey.Equal(err), IsTrue)
 	_, err = tk.Exec("alter table primary_key_test drop primary key")
+	c.Assert(err.Error(), Equals, "[ddl:206]Unsupported drop primary key when alter-primary-key is false")
+	// for "drop index `primary` on ..." syntax
+	_, err = tk.Exec("drop index `primary` on primary_key_test")
+	c.Assert(err.Error(), Equals, "[ddl:206]Unsupported drop primary key when alter-primary-key is false")
+	_, err = tk.Exec("drop index `primary` on primary_key_test_1")
 	c.Assert(err.Error(), Equals, "[ddl:206]Unsupported drop primary key when alter-primary-key is false")
 
 	// Change the value of AlterPrimaryKey.
@@ -111,6 +117,18 @@ func (s *testSerialSuite) TestPrimaryKey(c *C) {
 	tk.MustExec("alter table primary_key_test2 drop primary key")
 	_, err = tk.Exec("alter table primary_key_test3 drop primary key")
 	c.Assert(err.Error(), Equals, "[ddl:1091]Can't DROP 'PRIMARY'; check that column/key exists")
+
+	// for "drop index `primary` on ..." syntax
+	tk.MustExec("create table primary_key_test4 (a int, b varchar(10), primary key(a))")
+	newCfg.AlterPrimaryKey = false
+	config.StoreGlobalConfig(&newCfg)
+	_, err = tk.Exec("drop index `primary` on primary_key_test4")
+	c.Assert(err.Error(), Equals, "[ddl:206]Unsupported drop primary key when alter-primary-key is false")
+	// for the index name is `primary`
+	tk.MustExec("create table tt(`primary` int);")
+	tk.MustExec("alter table tt add index (`primary`);")
+	_, err = tk.Exec("drop index `primary` on tt")
+	c.Assert(err.Error(), Equals, "[ddl:206]Unsupported drop primary key when alter-primary-key is false")
 }
 
 func (s *testSerialSuite) TestMultiRegionGetTableEndHandle(c *C) {


### PR DESCRIPTION
Cherry-pick #14122 to v3.0

Conflict:
 ddl/db_test.go
 ddl/ddl_api.go
 ddl/serial_test.go