### PR TITLE
executor: vectorize the merge join executor by `vecGroupChecker`

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -1035,6 +1035,7 @@ func (e *vecGroupChecker) splitIntoGroups(chk *chunk.Chunk) (isFirstGroupSameAsP
 	e.nextGroupID = 0
 	if len(e.GroupByItems) == 0 {
 		e.groupOffset = append(e.groupOffset, numRows)
+		e.groupCount = 1
 		return true, nil
 	}
 

--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -1280,17 +1280,16 @@ func prepare4MergeJoin(tc *mergeJoinTestCase, leftExec, rightExec *mockDataSourc
 		isOuterJoin: false,
 	}
 
-	e.outerIdx = 0
-
-	e.innerTable = &mergeJoinInnerTable{
-		reader:   rightExec,
-		joinKeys: innerJoinKeys,
+	e.innerTable = &mergeJoinTable{
+		isInner:    true,
+		childIndex: 1,
+		joinKeys:   innerJoinKeys,
 	}
 
-	e.outerTable = &mergeJoinOuterTable{
-		reader: leftExec,
-		filter: nil,
-		keys:   outerJoinKeys,
+	e.outerTable = &mergeJoinTable{
+		childIndex: 0,
+		filters:    nil,
+		joinKeys:   outerJoinKeys,
 	}
 
 	return e

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -985,37 +985,29 @@ func (b *executorBuilder) buildMergeJoin(v *plannercore.PhysicalMergeJoin) Execu
 		desc:        v.Desc,
 	}
 
-	leftKeys := v.LeftJoinKeys
-	rightKeys := v.RightJoinKeys
-
-	e.outerIdx = 0
-	innerFilter := v.RightConditions
-
-	e.innerTable = &mergeJoinInnerTable{
-		reader:   rightExec,
-		joinKeys: rightKeys,
+	leftTable := &mergeJoinTable{
+		childIndex: 0,
+		joinKeys:   v.LeftJoinKeys,
+		filters:    v.LeftConditions,
 	}
-
-	e.outerTable = &mergeJoinOuterTable{
-		reader: leftExec,
-		filter: v.LeftConditions,
-		keys:   leftKeys,
+	rightTable := &mergeJoinTable{
+		childIndex: 1,
+		joinKeys:   v.RightJoinKeys,
+		filters:    v.RightConditions,
 	}
 
 	if v.JoinType == plannercore.RightOuterJoin {
-		e.outerIdx = 1
-		e.outerTable.reader = rightExec
-		e.outerTable.filter = v.RightConditions
-		e.outerTable.keys = rightKeys
-
-		innerFilter = v.LeftConditions
-		e.innerTable.reader = leftExec
-		e.innerTable.joinKeys = leftKeys
+		e.innerTable = leftTable
+		e.outerTable = rightTable
+	} else {
+		e.innerTable = rightTable
+		e.outerTable = leftTable
 	}
+	e.innerTable.isInner = true
 
 	// optimizer should guarantee that filters on inner table are pushed down
 	// to tikv or extracted to a Selection.
-	if len(innerFilter) != 0 {
+	if len(e.innerTable.filters) != 0 {
 		b.err = errors.Annotate(ErrBuildExecutor, "merge join's inner filter should be empty.")
 		return nil
 	}

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -17,13 +17,11 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/pingcap/errors"
-
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/stringutil"
 )
@@ -44,169 +42,224 @@ type MergeJoinExec struct {
 	isOuterJoin  bool
 	desc         bool
 
-	prepared bool
-	outerIdx int
+	innerTable *mergeJoinTable
+	outerTable *mergeJoinTable
 
-	innerTable *mergeJoinInnerTable
-	outerTable *mergeJoinOuterTable
-
-	innerIter4Row chunk.Iterator
-
-	childrenResults []*chunk.Chunk
-
-	memTracker *memory.Tracker
-}
-
-type mergeJoinOuterTable struct {
-	reader Executor
-	filter []expression.Expression
-	keys   []*expression.Column
-
-	chk      *chunk.Chunk
-	selected []bool
-
-	iter     *chunk.Iterator4Chunk
-	row      chunk.Row
 	hasMatch bool
 	hasNull  bool
+
+	memTracker  *memory.Tracker
+	diskTracker *disk.Tracker
 }
 
-// mergeJoinInnerTable represents the inner table of merge join.
-// All the inner rows which have the same join key are returned when function
-// "rowsWithSameKey()" being called.
-type mergeJoinInnerTable struct {
-	reader   Executor
-	joinKeys []*expression.Column
-	ctx      context.Context
+var (
+	innerTableLabel fmt.Stringer = stringutil.StringerStr("innerTable")
+	outerTableLabel fmt.Stringer = stringutil.StringerStr("outerTable")
+)
 
-	// for chunk executions
+type mergeJoinTable struct {
+	isInner    bool
+	childIndex int
+	joinKeys   []*expression.Column
+	filters    []expression.Expression
+
+	executed          bool
+	childChunk        *chunk.Chunk
+	childChunkIter    *chunk.Iterator4Chunk
+	groupChecker      *vecGroupChecker
+	groupRowsSelected []int
+	groupRowsIter     chunk.Iterator
+
+	// for inner table, an unbroken group may refer many chunks
 	rowContainer *chunk.RowContainer
-	keyCmpFuncs  []chunk.CompareFunc
-	firstRow4Key chunk.Row
-	curRow       chunk.Row
-	curChk       *chunk.Chunk
-	curSel       []int
-	curIter      *chunk.Iterator4Chunk
-	curChkInUse  bool
+
+	// for outer table, save result of filters
+	filtersSelected []bool
 
 	memTracker *memory.Tracker
 }
 
-func (t *mergeJoinInnerTable) init(ctx context.Context, sctx sessionctx.Context, chk4Reader *chunk.Chunk) (err error) {
-	if t.reader == nil || ctx == nil {
-		return errors.Errorf("Invalid arguments: Empty arguments detected.")
+func (t *mergeJoinTable) init(exec *MergeJoinExec) {
+	child := exec.children[t.childIndex]
+	t.childChunk = newFirstChunk(child)
+	t.childChunkIter = chunk.NewIterator4Chunk(t.childChunk)
+
+	items := make([]expression.Expression, 0, len(t.joinKeys))
+	for _, col := range t.joinKeys {
+		items = append(items, col)
 	}
-	t.ctx = ctx
-	t.curChk = chk4Reader
-	t.curIter = chunk.NewIterator4Chunk(t.curChk)
-	t.curRow = t.curIter.End()
-	t.curChkInUse = false
-	t.memTracker.Consume(chk4Reader.MemoryUsage())
-	// t.rowContainer needs to be closed when exit, it is done by the MergeJoinExec, see MergeJoinExec.Close
-	t.rowContainer = chunk.NewRowContainer(t.reader.base().retFieldTypes, t.curChk.Capacity())
-	t.rowContainer.GetMemTracker().AttachTo(sctx.GetSessionVars().StmtCtx.MemTracker)
-	t.rowContainer.GetDiskTracker().AttachTo(sctx.GetSessionVars().StmtCtx.DiskTracker)
-	if config.GetGlobalConfig().OOMUseTmpStorage {
-		actionSpill := t.rowContainer.ActionSpill()
-		sctx.GetSessionVars().StmtCtx.MemTracker.SetActionOnExceed(actionSpill)
+	t.groupChecker = newVecGroupChecker(exec.ctx, items)
+	t.groupRowsIter = chunk.NewIterator4Chunk(t.childChunk)
+
+	if t.isInner {
+		t.rowContainer = chunk.NewRowContainer(child.base().retFieldTypes, t.childChunk.Capacity())
+		t.rowContainer.GetMemTracker().AttachTo(exec.memTracker)
+		t.rowContainer.GetMemTracker().SetLabel(innerTableLabel)
+		t.rowContainer.GetDiskTracker().AttachTo(exec.diskTracker)
+		t.rowContainer.GetDiskTracker().SetLabel(innerTableLabel)
+		if config.GetGlobalConfig().OOMUseTmpStorage {
+			actionSpill := t.rowContainer.ActionSpill()
+			exec.ctx.GetSessionVars().StmtCtx.MemTracker.SetActionOnExceed(actionSpill)
+		}
+		t.memTracker = memory.NewTracker(innerTableLabel, -1)
+	} else {
+		t.filtersSelected = make([]bool, 0, exec.maxChunkSize)
+		t.memTracker = memory.NewTracker(outerTableLabel, -1)
 	}
-	t.firstRow4Key, err = t.nextRow()
-	t.keyCmpFuncs = make([]chunk.CompareFunc, 0, len(t.joinKeys))
-	for i := range t.joinKeys {
-		t.keyCmpFuncs = append(t.keyCmpFuncs, chunk.GetCompareFunc(t.joinKeys[i].RetType))
-	}
-	return err
+
+	t.memTracker.AttachTo(exec.memTracker)
+	t.memTracker.Consume(t.childChunk.MemoryUsage())
 }
 
-func (t *mergeJoinInnerTable) selectRow(row chunk.Row) {
-	t.curSel = append(t.curSel, row.Idx())
+func (t *mergeJoinTable) fini() error {
+	t.memTracker.Consume(-t.childChunk.MemoryUsage())
+
+	if t.isInner {
+		if err := t.rowContainer.Close(); err != nil {
+			return err
+		}
+	}
+
+	t.executed = false
+	t.childChunk = nil
+	t.childChunkIter = nil
+	t.groupChecker = nil
+	t.groupRowsSelected = nil
+	t.groupRowsIter = nil
+	t.rowContainer = nil
+	t.filtersSelected = nil
+	t.memTracker = nil
+	return nil
 }
 
-func (t *mergeJoinInnerTable) selectedRowsIter() chunk.Iterator {
-	var iters []chunk.Iterator
-	if t.rowContainer.NumChunks() != 0 {
-		iters = append(iters, chunk.NewIterator4RowContainer(t.rowContainer))
+func (t *mergeJoinTable) selectNextGroup() {
+	begin, end := t.groupChecker.getNextGroup()
+	if t.isInner && t.hasNullInJoinKey(t.childChunk.GetRow(begin)) {
+		return
 	}
-	if t.curSel != nil {
-		t.curChk.SetSel(t.curSel)
-		iters = append(iters, chunk.NewIterator4Chunk(t.curChk))
-		t.curSel = nil
+
+	for i := begin; i < end; i++ {
+		t.groupRowsSelected = append(t.groupRowsSelected, i)
 	}
-	if len(iters) == 1 {
-		return iters[0]
-	}
-	// If any of iters has zero length it will be discarded in the following function.
-	// If all of them are empty, the returned iterator is also empty.
-	// Check out the implementation of multiIterator for more details.
-	return chunk.NewMultiIterator(iters...)
+	t.childChunk.SetSel(t.groupRowsSelected)
 }
 
-func (t *mergeJoinInnerTable) rowsWithSameKeyIter() (chunk.Iterator, error) {
-	// t.curSel sets to nil, so that it won't overwrite Sel in chunks in RowContainer,
-	// it might be unnecessary since merge join only runs single thread. However since we want to hand
-	// over the management of a chunk to the RowContainer, to keep the semantic consistent, we set it
-	// to nil.
-	t.curSel = nil
-	t.curChk.SetSel(nil)
-	err := t.rowContainer.Reset()
+func (t *mergeJoinTable) fetchNextChunk(ctx context.Context, exec *MergeJoinExec) error {
+	oldMemUsage := t.childChunk.MemoryUsage()
+	err := Next(ctx, exec.children[t.childIndex], t.childChunk)
+	t.memTracker.Consume(t.childChunk.MemoryUsage() - oldMemUsage)
 	if err != nil {
-		return nil, err
+		return err
+	}
+	t.executed = t.childChunk.NumRows() == 0
+	return nil
+}
+
+func (t *mergeJoinTable) fetchNextInnerGroup(ctx context.Context, exec *MergeJoinExec) error {
+	t.groupRowsSelected = t.groupRowsSelected[:0]
+	t.childChunk.SetSel(nil)
+	if err := t.rowContainer.Reset(); err != nil {
+		return err
 	}
 
-	// no more data.
-	if t.firstRow4Key == t.curIter.End() {
-		// the iterator is a blank iterator only as a place holder
-		return chunk.NewIterator4Chunk(t.curChk), nil
+fetchNext:
+	if t.executed && t.groupChecker.isExhausted() {
+		// Ensure iter at the end, since sel of childChunk has been cleared.
+		t.groupRowsIter.ReachEnd()
+		return nil
 	}
-	t.selectRow(t.firstRow4Key)
-	for {
-		selectedRow, err := t.nextRow()
-		// error happens or no more data.
-		if err != nil || selectedRow == t.curIter.End() {
-			t.firstRow4Key = t.curIter.End()
-			return t.selectedRowsIter(), err
+
+	// For inner table, rows have null in join keys should be skip by selectNextGroup.
+	for len(t.groupRowsSelected) == 0 && !t.groupChecker.isExhausted() {
+		t.selectNextGroup()
+	}
+	isEmpty := len(t.groupRowsSelected) == 0
+
+	// For inner table, all the rows have the same join keys should be put into one group.
+	for !t.executed && t.groupChecker.isExhausted() {
+		if !isEmpty {
+			// Group is not empty, hand over the management of childChunk to t.rowContainer.
+			if err := t.rowContainer.Add(t.childChunk); err != nil {
+				return err
+			}
+			t.memTracker.Consume(-t.childChunk.MemoryUsage())
+			t.groupRowsSelected = nil
+
+			t.childChunk = t.rowContainer.AllocChunk()
+			t.memTracker.Consume(t.childChunk.MemoryUsage())
 		}
-		compareResult := compareChunkRow(t.keyCmpFuncs, selectedRow, t.firstRow4Key, t.joinKeys, t.joinKeys)
-		if compareResult == 0 {
-			t.selectRow(selectedRow)
+
+		if err := t.fetchNextChunk(ctx, exec); err != nil {
+			return err
+		}
+		if t.executed {
+			break
+		}
+
+		isFirstGroupSameAsPrev, err := t.groupChecker.splitIntoGroups(t.childChunk)
+		if err != nil {
+			return err
+		}
+		if isFirstGroupSameAsPrev && !isEmpty {
+			t.selectNextGroup()
+		}
+	}
+	if isEmpty {
+		goto fetchNext
+	}
+
+	// iterate all data in t.rowContainer and t.childChunk
+	var iter chunk.Iterator
+	if t.rowContainer.NumChunks() != 0 {
+		iter = chunk.NewIterator4RowContainer(t.rowContainer)
+	}
+	if len(t.groupRowsSelected) != 0 {
+		if iter != nil {
+			iter = chunk.NewMultiIterator(iter, t.childChunkIter)
 		} else {
-			t.firstRow4Key = selectedRow
-			return t.selectedRowsIter(), nil
+			iter = t.childChunkIter
 		}
 	}
+	t.groupRowsIter = iter
+	t.groupRowsIter.Begin()
+	return nil
 }
 
-func (t *mergeJoinInnerTable) nextRow() (chunk.Row, error) {
-	for {
-		if t.curRow == t.curIter.End() {
-			err := t.reallocCurChkForReader()
-			if err != nil {
-				t.curRow = t.curIter.End()
-				return t.curRow, err
-			}
-			oldMemUsage := t.curChk.MemoryUsage()
-			err = Next(t.ctx, t.reader, t.curChk)
-			// error happens or no more data.
-			if err != nil || t.curChk.NumRows() == 0 {
-				t.curRow = t.curIter.End()
-				return t.curRow, err
-			}
-			newMemUsage := t.curChk.MemoryUsage()
-			t.memTracker.Consume(newMemUsage - oldMemUsage)
-			t.curRow = t.curIter.Begin()
+func (t *mergeJoinTable) fetchNextOuterGroup(ctx context.Context, exec *MergeJoinExec, requiredRows int) error {
+	if t.executed && t.groupChecker.isExhausted() {
+		return nil
+	}
+
+	if !t.executed && t.groupChecker.isExhausted() {
+		// It's hard to calculate selectivity if there is any filter or it's inner join,
+		// so we just push the requiredRows down when it's outer join and has no filter.
+		if exec.isOuterJoin && len(t.filters) == 0 {
+			t.childChunk.SetRequiredRows(requiredRows, exec.maxChunkSize)
+		}
+		err := t.fetchNextChunk(ctx, exec)
+		if err != nil || t.executed {
+			return err
 		}
 
-		result := t.curRow
-		t.curChkInUse = true
-		t.curRow = t.curIter.Next()
+		t.childChunkIter.Begin()
+		t.filtersSelected, err = expression.VectorizedFilter(exec.ctx, t.filters, t.childChunkIter, t.filtersSelected)
+		if err != nil {
+			return err
+		}
 
-		if !t.hasNullInJoinKey(result) {
-			return result, nil
+		_, err = t.groupChecker.splitIntoGroups(t.childChunk)
+		if err != nil {
+			return err
 		}
 	}
+
+	t.groupRowsSelected = t.groupRowsSelected[:0]
+	t.selectNextGroup()
+	t.groupRowsIter.Begin()
+	return nil
 }
 
-func (t *mergeJoinInnerTable) hasNullInJoinKey(row chunk.Row) bool {
+func (t *mergeJoinTable) hasNullInJoinKey(row chunk.Row) bool {
 	for _, col := range t.joinKeys {
 		ordinal := col.Index
 		if row.IsNull(ordinal) {
@@ -216,56 +269,21 @@ func (t *mergeJoinInnerTable) hasNullInJoinKey(row chunk.Row) bool {
 	return false
 }
 
-// reallocCurChkForNext resets "t.curChk" to an empty Chunk to buffer the result of "t.reader".
-// It saves the curChk to RowContainer and then allocates a new one from RowContainer.
-func (t *mergeJoinInnerTable) reallocCurChkForReader() (err error) {
-	if !t.curChkInUse || t.curSel == nil {
-		// If "t.curResult" is not in use, we can just reuse it.
-		// Note: t.curSel should never be nil. There is a case the chunk is in use but curSel is nil,
-		// and it would cause panic, so we add the condition here to avoid it. The case is that when
-		// init is called, and the firstRow4Key is set up by nextRow(), however the first several rows
-		// contain null value and are skipped, and in the next time the reallocCurChkFOrReader is called
-		// the curChkInUse would be set however the curSel is still nil.
-		t.curChk.Reset()
-		return
-	}
-
-	newChk := t.rowContainer.AllocChunk()
-	t.memTracker.Consume(newChk.MemoryUsage() - t.curChk.MemoryUsage())
-
-	// hand over the management to the RowContainer, therefore needs to reserve the first row by CopyConstruct
-	t.firstRow4Key = t.firstRow4Key.CopyConstruct()
-	// curSel be never be nil, since the chunk is in use.
-	t.curChk.SetSel(t.curSel)
-	err = t.rowContainer.Add(t.curChk)
-	if err != nil {
-		return err
-	}
-	t.curChk = newChk
-	t.curChk.Reset()
-	t.curSel = nil
-	t.curChkInUse = false
-	t.curIter = chunk.NewIterator4Chunk(t.curChk)
-	return
-}
-
 // Close implements the Executor Close interface.
 func (e *MergeJoinExec) Close() error {
-	e.childrenResults = nil
-	if e.innerTable.curChk != nil {
-		e.innerTable.memTracker.Consume(-e.innerTable.curChk.MemoryUsage())
+	if err := e.innerTable.fini(); err != nil {
+		return err
 	}
-	e.memTracker = nil
-	if e.innerTable.rowContainer != nil {
-		if err := e.innerTable.rowContainer.Close(); err != nil {
-			return err
-		}
+	if err := e.outerTable.fini(); err != nil {
+		return err
 	}
 
+	e.hasMatch = false
+	e.hasNull = false
+	e.memTracker = nil
+	e.diskTracker = nil
 	return e.baseExecutor.Close()
 }
-
-var innerTableLabel fmt.Stringer = stringutil.StringerStr("innerTable")
 
 // Open implements the Executor Open interface.
 func (e *MergeJoinExec) Open(ctx context.Context) error {
@@ -273,80 +291,37 @@ func (e *MergeJoinExec) Open(ctx context.Context) error {
 		return err
 	}
 
-	e.prepared = false
 	e.memTracker = memory.NewTracker(e.id, e.ctx.GetSessionVars().MemQuotaMergeJoin)
 	e.memTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.MemTracker)
+	e.diskTracker = disk.NewTracker(e.id, -1)
+	e.diskTracker.AttachTo(e.ctx.GetSessionVars().StmtCtx.DiskTracker)
 
-	e.childrenResults = make([]*chunk.Chunk, 0, len(e.children))
-	for _, child := range e.children {
-		e.childrenResults = append(e.childrenResults, newFirstChunk(child))
-	}
-
-	e.innerTable.memTracker = memory.NewTracker(innerTableLabel, -1)
-	e.innerTable.memTracker.AttachTo(e.memTracker)
-
-	return nil
-}
-
-func compareChunkRow(cmpFuncs []chunk.CompareFunc, lhsRow, rhsRow chunk.Row, lhsKey, rhsKey []*expression.Column) int {
-	for i := range lhsKey {
-		cmp := cmpFuncs[i](lhsRow, lhsKey[i].Index, rhsRow, rhsKey[i].Index)
-		if cmp != 0 {
-			return cmp
-		}
-	}
-	return 0
-}
-
-func (e *MergeJoinExec) prepare(ctx context.Context, requiredRows int) error {
-	err := e.innerTable.init(ctx, e.ctx, e.childrenResults[e.outerIdx^1])
-	if err != nil {
-		return err
-	}
-
-	err = e.fetchNextInnerRows()
-	if err != nil {
-		return err
-	}
-
-	// init outer table.
-	e.outerTable.chk = e.childrenResults[e.outerIdx]
-	e.outerTable.iter = chunk.NewIterator4Chunk(e.outerTable.chk)
-	e.outerTable.selected = make([]bool, 0, e.maxChunkSize)
-
-	err = e.fetchNextOuterRows(ctx, requiredRows)
-	if err != nil {
-		return err
-	}
-
-	e.prepared = true
+	e.innerTable.init(e)
+	e.outerTable.init(e)
 	return nil
 }
 
 // Next implements the Executor Next interface.
-func (e *MergeJoinExec) Next(ctx context.Context, req *chunk.Chunk) error {
+func (e *MergeJoinExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	req.Reset()
-	if !e.prepared {
-		if err := e.prepare(ctx, req.RequiredRows()); err != nil {
-			return err
-		}
-	}
 
+	innerIter := e.innerTable.groupRowsIter
+	outerIter := e.outerTable.groupRowsIter
 	for !req.IsFull() {
-		hasMore, err := e.joinToChunk(ctx, req)
-		if err != nil || !hasMore {
-			return err
+		if innerIter.Current() == innerIter.End() {
+			if err := e.innerTable.fetchNextInnerGroup(ctx, e); err != nil {
+				return err
+			}
+			innerIter = e.innerTable.groupRowsIter
 		}
-	}
-	return nil
-}
-
-func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasMore bool, err error) {
-	for {
-		if e.outerTable.row == e.outerTable.iter.End() {
-			err = e.fetchNextOuterRows(ctx, chk.RequiredRows()-chk.NumRows())
-			if err != nil || e.outerTable.chk.NumRows() == 0 {
-				return false, err
+		if outerIter.Current() == outerIter.End() {
+			if err := e.outerTable.fetchNextOuterGroup(ctx, e, req.RequiredRows()-req.NumRows()); err != nil {
+				return err
+			}
+			outerIter = e.outerTable.groupRowsIter
+			// no more data to execute
+			if outerIter.Current() == outerIter.End() {
+				return nil
 			}
 		}
 
@@ -354,61 +329,57 @@ func (e *MergeJoinExec) joinToChunk(ctx context.Context, chk *chunk.Chunk) (hasM
 		if e.desc {
 			cmpResult = 1
 		}
-		if e.outerTable.selected[e.outerTable.row.Idx()] && e.innerIter4Row.Len() > 0 {
-			cmpResult, err = e.compare(e.outerTable.row, e.innerIter4Row.Current())
+		if innerIter.Current() != innerIter.End() {
+			cmpResult, err = e.compare(outerIter.Current(), innerIter.Current())
 			if err != nil {
-				return false, err
+				return err
 			}
 		}
 
 		if (cmpResult > 0 && !e.desc) || (cmpResult < 0 && e.desc) {
-			if err = e.fetchNextInnerRows(); err != nil {
-				return false, err
-			}
+			innerIter.ReachEnd()
 			continue
 		}
 
 		if (cmpResult < 0 && !e.desc) || (cmpResult > 0 && e.desc) {
-			e.joiner.onMissMatch(false, e.outerTable.row, chk)
-			if err != nil {
-				return false, err
-			}
-
-			e.outerTable.row = e.outerTable.iter.Next()
-			e.outerTable.hasMatch = false
-			e.outerTable.hasNull = false
-
-			if chk.IsFull() {
-				return true, nil
+			e.hasMatch = false
+			e.hasNull = false
+			for row := outerIter.Current(); row != outerIter.End() && !req.IsFull(); row = outerIter.Next() {
+				e.joiner.onMissMatch(false, row, req)
 			}
 			continue
 		}
 
-		matched, isNull, err := e.joiner.tryToMatchInners(e.outerTable.row, e.innerIter4Row, chk)
-		if err != nil {
-			return false, err
-		}
-		e.outerTable.hasMatch = e.outerTable.hasMatch || matched
-		e.outerTable.hasNull = e.outerTable.hasNull || isNull
-
-		if e.innerIter4Row.Current() == e.innerIter4Row.End() {
-			if !e.outerTable.hasMatch {
-				e.joiner.onMissMatch(e.outerTable.hasNull, e.outerTable.row, chk)
+		for row := outerIter.Current(); row != outerIter.End() && !req.IsFull(); row = outerIter.Next() {
+			if !e.outerTable.filtersSelected[row.Idx()] {
+				e.hasMatch = false
+				e.hasNull = false
+				e.joiner.onMissMatch(false, row, req)
+				continue
 			}
-			e.outerTable.row = e.outerTable.iter.Next()
-			e.outerTable.hasMatch = false
-			e.outerTable.hasNull = false
-			e.innerIter4Row.Begin()
-		}
 
-		if chk.IsFull() {
-			return true, err
+			matched, isNull, err := e.joiner.tryToMatchInners(row, innerIter, req)
+			if err != nil {
+				return err
+			}
+			e.hasMatch = e.hasMatch || matched
+			e.hasNull = e.hasNull || isNull
+
+			if innerIter.Current() == innerIter.End() {
+				if !e.hasMatch {
+					e.joiner.onMissMatch(e.hasNull, row, req)
+				}
+				e.hasMatch = false
+				e.hasNull = false
+				innerIter.Begin()
+			}
 		}
 	}
+	return nil
 }
 
 func (e *MergeJoinExec) compare(outerRow, innerRow chunk.Row) (int, error) {
-	outerJoinKeys := e.outerTable.keys
+	outerJoinKeys := e.outerTable.joinKeys
 	innerJoinKeys := e.innerTable.joinKeys
 	for i := range outerJoinKeys {
 		cmp, _, err := e.compareFuncs[i](e.ctx, outerJoinKeys[i], innerJoinKeys[i], outerRow, innerRow)
@@ -421,39 +392,4 @@ func (e *MergeJoinExec) compare(outerRow, innerRow chunk.Row) (int, error) {
 		}
 	}
 	return 0, nil
-}
-
-// fetchNextInnerRows fetches the next join group, within which all the rows
-// have the same join key, from the inner table.
-func (e *MergeJoinExec) fetchNextInnerRows() (err error) {
-	e.innerIter4Row, err = e.innerTable.rowsWithSameKeyIter()
-	if err != nil {
-		return err
-	}
-	e.innerIter4Row.Begin()
-	return nil
-}
-
-// fetchNextOuterRows fetches the next Chunk of outer table. Rows in a Chunk
-// may not all belong to the same join key, but are guaranteed to be sorted
-// according to the join key.
-func (e *MergeJoinExec) fetchNextOuterRows(ctx context.Context, requiredRows int) (err error) {
-	// It's hard to calculate selectivity if there is any filter or it's inner join,
-	// so we just push the requiredRows down when it's outer join and has no filter.
-	if e.isOuterJoin && len(e.outerTable.filter) == 0 {
-		e.outerTable.chk.SetRequiredRows(requiredRows, e.maxChunkSize)
-	}
-
-	err = Next(ctx, e.outerTable.reader, e.outerTable.chk)
-	if err != nil {
-		return err
-	}
-
-	e.outerTable.iter.Begin()
-	e.outerTable.selected, err = expression.VectorizedFilter(e.ctx, e.outerTable.filter, e.outerTable.iter, e.outerTable.selected)
-	if err != nil {
-		return err
-	}
-	e.outerTable.row = e.outerTable.iter.Begin()
-	return nil
 }

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -111,7 +111,7 @@ func (t *mergeJoinTable) init(exec *MergeJoinExec) {
 	t.memTracker.Consume(t.childChunk.MemoryUsage())
 }
 
-func (t *mergeJoinTable) fini() error {
+func (t *mergeJoinTable) finish() error {
 	t.memTracker.Consume(-t.childChunk.MemoryUsage())
 
 	if t.isInner {
@@ -271,10 +271,10 @@ func (t *mergeJoinTable) hasNullInJoinKey(row chunk.Row) bool {
 
 // Close implements the Executor Close interface.
 func (e *MergeJoinExec) Close() error {
-	if err := e.innerTable.fini(); err != nil {
+	if err := e.innerTable.finish(); err != nil {
 		return err
 	}
-	if err := e.outerTable.fini(); err != nil {
+	if err := e.outerTable.finish(); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
PCP #14216 

### What problem does this PR solve? <!--add issue link with summary if exists-->
Vectorize the merge join executor by `vecGroupChecker`, then we can process it group by group. 

### What is changed and how it works?
1. combine struct mergeJoinInnerTable and mergeJoinOuterTable to mergeJoinTable
2. group rows by  join keys by `vecGroupChecker`
3. process outer table by group instead of by row

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

### Benchmark
```bash
benchstat -delta-test none old.txt new.txt
name                                                                                                                                                old time/op    new time/op    delta
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8     1.27s ± 0%     0.34s ± 0%  -72.87%
MergeJoinExec/merge_join_(outerRows:3000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8       338ms ± 0%     172ms ± 0%  -48.96%
MergeJoinExec/merge_join_(outerRows:30,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8         330ms ± 0%      43ms ± 0%  -86.96%
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:330000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8     958ms ± 0%     309ms ± 0%  -67.73%

name                                                                                                                                                old alloc/op   new alloc/op   delta
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8    72.2MB ± 0%    58.5MB ± 0%  -18.98%
MergeJoinExec/merge_join_(outerRows:3000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8      65.9MB ± 0%    58.5MB ± 0%  -11.25%
MergeJoinExec/merge_join_(outerRows:30,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8        64.5MB ± 0%    62.6MB ± 0%   -2.94%
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:330000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8    72.1MB ± 0%    58.5MB ± 0%  -18.97%

name                                                                                                                                                old allocs/op  new allocs/op  delta
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8      908k ± 0%        4k ± 0%  -99.59%
MergeJoinExec/merge_join_(outerRows:3000,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8       37.8k ± 0%      3.8k ± 0%  -90.08%
MergeJoinExec/merge_join_(outerRows:30,_innerRows:300000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8         8.72k ± 0%     3.71k ± 0%  -57.45%
MergeJoinExec/merge_join_(outerRows:300000,_innerRows:330000,_concurency:4,_outerJoinKeyIdx:_[0_1],_innerJoinKeyIdx:_[0_1],_NeedOuterSort:false)-8      908k ± 0%        4k ± 0%  -99.58%
```
