### PR TITLE
planner: reset plan id before optimizing point get

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -260,6 +260,8 @@ func (p *BatchPointGetPlan) SetOutputNames(names types.NameSlice) {
 
 // TryFastPlan tries to use the PointGetPlan for the query.
 func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
+	ctx.GetSessionVars().PlanID = 0
+	ctx.GetSessionVars().PlanColumnID = 0
 	switch x := node.(type) {
 	case *ast.SelectStmt:
 		// Try to convert the `SELECT a, b, c FROM t WHERE (a, b, c) in ((1, 2, 4), (1, 3, 5))` to

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -14,6 +14,7 @@
 package core_test
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -22,7 +23,10 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/planner"
 	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 	dto "github.com/prometheus/client_model/go"
@@ -268,4 +272,28 @@ func (s *testPointGetSuite) TestWhereIn2BatchPointGet(c *C) {
 		"2 3 4",
 		"4 5 6",
 	))
+}
+
+// Test that the plan id will be reset before optimization every time.
+func (s *testPointGetSuite) TestPointGetId(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (c1 int primary key, c2 int)")
+	defer tk.MustExec("drop table if exists t")
+	pointGetQuery := "select c2 from t where c1 = 1"
+	for i := 0; i < 2; i++ {
+		ctx := tk.Se.(sessionctx.Context)
+		stmts, err := session.Parse(ctx, pointGetQuery)
+		c.Assert(err, IsNil)
+		c.Assert(stmts, HasLen, 1)
+		stmt := stmts[0]
+		is := domain.GetDomain(ctx).InfoSchema()
+		err = core.Preprocess(ctx, stmt, is)
+		c.Assert(err, IsNil)
+		p, _, err := planner.Optimize(context.TODO(), ctx, stmt, is)
+		c.Assert(err, IsNil)
+		// Test explain result is useless, plan id will be reset when running `explain`.
+		c.Assert(p.ID(), Equals, 1)
+	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Plan id is reset before optimization every time, so that ids of operators are the same when physical plans are the same.
But when the plan is a point get, the plan id is not reset, leading to different ids of `PointGet`, so plan digests are different.
If the plan digest are different, statement summary can't work properly. Refer to issue https://github.com/pingcap/tidb/issues/14432

### What is changed and how it works?
Reset plan id before `tryFastPlan` and add test cases.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Breaking backward compatibility

Related changes

N/A

Release note

 - Fix operator ids of point get.
