### PR TITLE
ddl: add column name to errBlobKeyWithoutLength error (#13453)

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -116,6 +116,17 @@ func (s *testIntegrationSuite) TestInvalidDefault(c *C) {
 	c.Assert(terror.ErrorEqual(err, types.ErrInvalidDefault), IsTrue, Commentf("err %v", err))
 }
 
+// TestKeyWithoutLength for issue #13452
+func (s testIntegrationSuite) TestKeyWithoutLengthCreateTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("USE test")
+
+	_, err := tk.Exec("create table t_without_length (a text primary key)")
+	c.Assert(err, NotNil)
+	c.Assert(err, ErrorMatches, ".*BLOB/TEXT column 'a' used in key specification without a key length")
+}
+
 // TestInvalidNameWhenCreateTable for issue #3848
 func (s *testIntegrationSuite) TestInvalidNameWhenCreateTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -100,7 +100,7 @@ var (
 
 	errUnsupportedShardRowIDBits = terror.ClassDDL.New(codeUnsupportedShardRowIDBits, "unsupported shard_row_id_bits for table with primary key as row id.")
 
-	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "index for BLOB/TEXT column must specify a key length")
+	errBlobKeyWithoutLength = terror.ClassDDL.New(codeBlobKeyWithoutLength, "BLOB/TEXT column '%-.192s' used in key specification without a key length")
 	errIncorrectPrefixKey   = terror.ClassDDL.New(codeIncorrectPrefixKey, "Incorrect prefix key; the used key part isn't a string, the used length is longer than the key part, or the storage engine doesn't support unique prefix keys")
 	errTooLongKey           = terror.ClassDDL.New(codeTooLongKey,
 		fmt.Sprintf("Specified key was too long; max key length is %d bytes", maxPrefixLength))

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -73,7 +73,7 @@ func buildIndexColumns(columns []*model.ColumnInfo, idxColNames []*ast.IndexColN
 
 		// Length must be specified for BLOB and TEXT column indexes.
 		if types.IsTypeBlob(col.FieldType.Tp) && ic.Length == types.UnspecifiedLength {
-			return nil, errors.Trace(errBlobKeyWithoutLength)
+			return nil, errors.Trace(errBlobKeyWithoutLength.GenWithStackByArgs(col.Name.O))
 		}
 
 		// Length can only be specified for specifiable types.


### PR DESCRIPTION
cherry-pick #13453 to release-2.1

---

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/13452

### What is changed and how it works?
Return error with column name

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)

```
mysql> create table td (a text primary key);
ERROR 1170 (42000): BLOB/TEXT column 'a' used in key specification without a key length
```

Code changes

Side effects

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the error that `ERROR 1170` didn't show correct column name