### PR TITLE
rowcoder: fix DatumMapDecoder ignore the sign of handle value

### DIFF
--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -82,7 +82,7 @@ func (decoder *DatumMapDecoder) DecodeToDatumMap(rowData []byte, handle int64, r
 		if col.ID == decoder.handleColID {
 			if mysql.HasUnsignedFlag(uint(col.Flag)) {
 				row[col.ID] = types.NewUintDatum(uint64(handle))
-			}else{
+			} else {
 				row[col.ID] = types.NewIntDatum(handle)
 			}
 			continue

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -80,7 +80,11 @@ func (decoder *DatumMapDecoder) DecodeToDatumMap(rowData []byte, handle int64, r
 	}
 	for _, col := range decoder.columns {
 		if col.ID == decoder.handleColID {
-			row[col.ID] = types.NewIntDatum(handle)
+			if mysql.HasUnsignedFlag(uint(col.Flag)) {
+				row[col.ID] = types.NewUintDatum(uint64(handle))
+			}else{
+				row[col.ID] = types.NewIntDatum(handle)
+			}
 			continue
 		}
 		idx, isNil, notFound := decoder.row.findColID(col.ID)

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -200,7 +200,7 @@ func (s *testSuite) TestDecodeRowWithHandle(c *C) {
 		{
 			handleID,
 			withUnsigned(types.NewFieldType(mysql.TypeLonglong)),
-			types.NewIntDatum(handleValue),          // decode as chunk & map, always encode it as int
+			types.NewUintDatum(uint64(handleValue)),
 			types.NewUintDatum(uint64(handleValue)), // decode as bytes will uint if unsigned.
 			nil,
 			true,


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In function DecodeToDatumMap, we didn't check if the handle column is unsigned. And put the sign value into datums map.

### What is changed and how it works?
check the handle column flag, if the column is unsigned, put it into the map using uint type 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test