### PR TITLE
executor: fix error when `set names default`

### DIFF
--- a/executor/set.go
+++ b/executor/set.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"
@@ -54,6 +55,13 @@ func (e *SetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		// Variable is case insensitive, we use lower case.
 		if v.Name == ast.SetNames {
 			// This is set charset stmt.
+			if v.IsDefault {
+				err := e.setCharset(mysql.DefaultCharset, "")
+				if err != nil {
+					return err
+				}
+				continue
+			}
 			dt, err := v.Expr.(*expression.Constant).Eval(chunk.Row{})
 			if err != nil {
 				return err

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -421,27 +421,104 @@ func (s *testSuite5) TestSetVar(c *C) {
 
 func (s *testSuite5) TestSetCharset(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec(`SET NAMES latin1`)
-
+	tk.MustExec("use test")
 	ctx := tk.Se.(sessionctx.Context)
 	sessionVars := ctx.GetSessionVars()
-	for _, v := range variable.SetNamesVariables {
-		sVar, err := variable.GetSessionSystemVar(sessionVars, v)
-		c.Assert(err, IsNil)
-		c.Assert(sVar != "utf8", IsTrue)
-	}
-	tk.MustExec(`SET NAMES utf8`)
-	for _, v := range variable.SetNamesVariables {
-		sVar, err := variable.GetSessionSystemVar(sessionVars, v)
-		c.Assert(err, IsNil)
-		c.Assert(sVar, Equals, "utf8")
-	}
-	sVar, err := variable.GetSessionSystemVar(sessionVars, variable.CollationConnection)
-	c.Assert(err, IsNil)
-	c.Assert(sVar, Equals, "utf8_bin")
 
-	// Issue 1523
+	var characterSetVariables = []string{
+		"character_set_client",
+		"character_set_connection",
+		"character_set_results",
+		"character_set_server",
+		"character_set_database",
+		"character_set_system",
+		"character_set_filesystem",
+	}
+
+	check := func(args ...string) {
+		for i, v := range characterSetVariables {
+			sVar, err := variable.GetSessionSystemVar(sessionVars, v)
+			c.Assert(err, IsNil)
+			c.Assert(sVar, Equals, args[i], Commentf("%d: %s", i, characterSetVariables[i]))
+		}
+	}
+
+	check(
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	tk.MustExec(`SET NAMES latin1`)
+	check(
+		"latin1",
+		"latin1",
+		"latin1",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	tk.MustExec(`SET NAMES default`)
+	check(
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	// Issue #1523
 	tk.MustExec(`SET NAMES binary`)
+	check(
+		"binary",
+		"binary",
+		"binary",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	tk.MustExec(`SET NAMES utf8`)
+	check(
+		"utf8",
+		"utf8",
+		"utf8",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	tk.MustExec(`SET CHARACTER SET latin1`)
+	check(
+		"latin1",
+		"latin1",
+		"latin1",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
+
+	tk.MustExec(`SET CHARACTER SET default`)
+	check(
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8mb4",
+		"utf8",
+		"binary",
+	)
 }
 
 func (s *testSuite5) TestValidateSetVar(c *C) {

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -420,8 +420,7 @@ func (s *testSuite5) TestSetVar(c *C) {
 }
 
 func (s *testSuite5) TestSetCharset(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
+	tk := testkit.NewTestKitWithInit(c, s.store)
 	ctx := tk.Se.(sessionctx.Context)
 	sessionVars := ctx.GetSessionVars()
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

In TiDB, 
```sql
mysql> set character set default;
ERROR 2013 (HY000): Lost connection to MySQL server during query
```

### What is changed and how it works?

In `set names xxx;` SQL statement, when call `executor.Next()`, TiDB only deal with case that has a specific character set name, but not deal with the case that has a `DEFAULT` keyword.

We should set character set to default character set `utfmb4` in `set names default;` statement.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None

Release note

 - None
