### PR TITLE
expression, executor: correct the funcName for wrapWithIsTrue

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -1845,3 +1845,11 @@ func (s *testSuiteJoin1) TestIssue13177(c *C) {
 		"abcd 1 1",
 	))
 }
+
+func (s *testSuiteJoin1) TestIssue14514(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (pk varchar(14) primary key, a varchar(12));")
+	tk.MustQuery("select * from (select t1.pk or '/' as c from t as t1 left join t as t2 on t1.a = t2.pk) as t where t.c = 1;").Check(testkit.Rows())
+}

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -728,7 +728,7 @@ func wrapWithIsTrue(ctx sessionctx.Context, keepNull bool, arg Expression) (Expr
 		return nil, err
 	}
 	sf := &ScalarFunction{
-		FuncName: model.NewCIStr(fmt.Sprintf("sig_%T", f)),
+		FuncName: model.NewCIStr(ast.IsTruth),
 		Function: f,
 		RetType:  f.getRetTp(),
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #14514 

### What is changed and how it works?
Correct the name of function IsTrue in wrapWithIsTrue.
In SimplifyOuterJoin, all the columns will be replaced by `null`, and the function will be reconstructed. The invalid function name before this commit will cause a panic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test


Code changes

 - Has exported function/method change


Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

Release note

