### PR TITLE
executor: fix wrong behavior when `ENUM` & `SET` column meet Aggregation (release 2.1)

### DIFF
--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -54,3 +54,192 @@ func (s *testSuite) TearDownTest(c *C) {
 	s.ctx.GetSessionVars().StmtCtx.SetWarnings(nil)
 	testleak.AfterTest(c)()
 }
+
+type aggTest struct {
+	dataType *types.FieldType
+	numRows  int
+	dataGen  func(i int) types.Datum
+	funcName string
+	results  []types.Datum
+}
+
+func (s *testSuite) testMergePartialResult(c *C, p aggTest) {
+	srcChk := chunk.NewChunkWithCapacity([]*types.FieldType{p.dataType}, p.numRows)
+	for i := 0; i < p.numRows; i++ {
+		dt := p.dataGen(i)
+		srcChk.AppendDatum(0, &dt)
+	}
+	iter := chunk.NewIterator4Chunk(srcChk)
+
+	args := []expression.Expression{&expression.Column{RetType: p.dataType, Index: 0}}
+	if p.funcName == ast.AggFuncGroupConcat {
+		args = append(args, &expression.Constant{Value: types.NewStringDatum(" "), RetType: types.NewFieldType(mysql.TypeString)})
+	}
+	desc, err := aggregation.NewAggFuncDesc(s.ctx, p.funcName, args, false)
+	c.Assert(err, IsNil)
+	partialDesc, finalDesc := desc.Split([]int{0, 1})
+
+	// build partial func for partial phase.
+	partialFunc := aggfuncs.Build(s.ctx, partialDesc, 0)
+	partialResult := partialFunc.AllocPartialResult()
+
+	// build final func for final phase.
+	finalFunc := aggfuncs.Build(s.ctx, finalDesc, 0)
+	finalPr := finalFunc.AllocPartialResult()
+	resultChk := chunk.NewChunkWithCapacity([]*types.FieldType{p.dataType}, 1)
+
+	// update partial result.
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		partialFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, partialResult)
+	}
+	partialFunc.AppendFinalResult2Chunk(s.ctx, partialResult, resultChk)
+	dt := resultChk.GetRow(0).GetDatum(0, p.dataType)
+	result, err := dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[0])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	err = finalFunc.MergePartialResult(s.ctx, partialResult, finalPr)
+	c.Assert(err, IsNil)
+	partialFunc.ResetPartialResult(partialResult)
+
+	iter.Begin()
+	iter.Next()
+	for row := iter.Next(); row != iter.End(); row = iter.Next() {
+		partialFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, partialResult)
+	}
+	resultChk.Reset()
+	partialFunc.AppendFinalResult2Chunk(s.ctx, partialResult, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, p.dataType)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[1])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+	err = finalFunc.MergePartialResult(s.ctx, partialResult, finalPr)
+	c.Assert(err, IsNil)
+
+	resultChk.Reset()
+	err = finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	c.Assert(err, IsNil)
+
+	dt = resultChk.GetRow(0).GetDatum(0, p.dataType)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[2])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+}
+
+func buildAggTester(funcName string, tp byte, numRows int, results ...interface{}) aggTest {
+	return buildAggTesterWithFieldType(funcName, types.NewFieldType(tp), numRows, results...)
+}
+
+func buildAggTesterWithFieldType(funcName string, ft *types.FieldType, numRows int, results ...interface{}) aggTest {
+	pt := aggTest{
+		dataType: ft,
+		numRows:  numRows,
+		funcName: funcName,
+		dataGen:  getDataGenFunc(ft),
+	}
+	for _, result := range results {
+		pt.results = append(pt.results, types.NewDatum(result))
+	}
+	return pt
+}
+
+func getDataGenFunc(ft *types.FieldType) func(i int) types.Datum {
+	switch ft.Tp {
+	case mysql.TypeLonglong:
+		return func(i int) types.Datum { return types.NewIntDatum(int64(i)) }
+	case mysql.TypeFloat:
+		return func(i int) types.Datum { return types.NewFloat32Datum(float32(i)) }
+	case mysql.TypeNewDecimal:
+		return func(i int) types.Datum { return types.NewDecimalDatum(types.NewDecFromInt(int64(i))) }
+	case mysql.TypeDouble:
+		return func(i int) types.Datum { return types.NewFloat64Datum(float64(i)) }
+	case mysql.TypeString:
+		return func(i int) types.Datum { return types.NewStringDatum(fmt.Sprintf("%d", i)) }
+	case mysql.TypeDate:
+		return func(i int) types.Datum { return types.NewTimeDatum(types.TimeFromDays(int64(i + 365))) }
+	case mysql.TypeDuration:
+		return func(i int) types.Datum { return types.NewDurationDatum(types.Duration{Duration: time.Duration(i)}) }
+	case mysql.TypeJSON:
+		return func(i int) types.Datum { return types.NewDatum(json.CreateBinary(int64(i))) }
+	case mysql.TypeEnum:
+		elems := []string{"a", "b", "c", "d", "e"}
+		return func(i int) types.Datum {
+			e, _ := types.ParseEnumValue(elems, uint64(i+1))
+			return types.NewMysqlEnumDatum(e)
+		}
+	case mysql.TypeSet:
+		elems := []string{"a", "b", "c", "d", "e"}
+		return func(i int) types.Datum {
+			e, _ := types.ParseSetValue(elems, uint64(i+1))
+			return types.NewMysqlSetDatum(e)
+		}
+	}
+	return nil
+}
+
+func (s *testSuite) testAggFunc(c *C, p aggTest) {
+	srcChk := chunk.NewChunkWithCapacity([]*types.FieldType{p.dataType}, p.numRows)
+	for i := 0; i < p.numRows; i++ {
+		dt := p.dataGen(i)
+		srcChk.AppendDatum(0, &dt)
+	}
+	srcChk.AppendDatum(0, &types.Datum{})
+
+	args := []expression.Expression{&expression.Column{RetType: p.dataType, Index: 0}}
+	if p.funcName == ast.AggFuncGroupConcat {
+		args = append(args, &expression.Constant{Value: types.NewStringDatum(" "), RetType: types.NewFieldType(mysql.TypeString)})
+	}
+	desc, err := aggregation.NewAggFuncDesc(s.ctx, p.funcName, args, false)
+	c.Assert(err, IsNil)
+	finalFunc := aggfuncs.Build(s.ctx, desc, 0)
+	finalPr := finalFunc.AllocPartialResult()
+	resultChk := chunk.NewChunkWithCapacity([]*types.FieldType{desc.RetTp}, 1)
+
+	iter := chunk.NewIterator4Chunk(srcChk)
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt := resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err := dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[1])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the empty input
+	resultChk.Reset()
+	finalFunc.ResetPartialResult(finalPr)
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[0])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the agg func with distinct
+	desc, err = aggregation.NewAggFuncDesc(s.ctx, p.funcName, args, true)
+	c.Assert(err, IsNil)
+	finalFunc = aggfuncs.Build(s.ctx, desc, 0)
+	finalPr = finalFunc.AllocPartialResult()
+
+	resultChk.Reset()
+	iter = chunk.NewIterator4Chunk(srcChk)
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+		finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+	}
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[1])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+
+	// test the empty input
+	resultChk.Reset()
+	finalFunc.ResetPartialResult(finalPr)
+	finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
+	dt = resultChk.GetRow(0).GetDatum(0, desc.RetTp)
+	result, err = dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[0])
+	c.Assert(err, IsNil)
+	c.Assert(result, Equals, 0)
+}

--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -14,12 +14,21 @@
 package aggfuncs_test
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/executor/aggfuncs"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 )

--- a/executor/aggfuncs/aggfuncs.go
+++ b/executor/aggfuncs/aggfuncs.go
@@ -43,6 +43,8 @@ var (
 	_ AggFunc = (*firstRow4Float32)(nil)
 	_ AggFunc = (*firstRow4Float64)(nil)
 	_ AggFunc = (*firstRow4JSON)(nil)
+	_ AggFunc = (*firstRow4Enum)(nil)
+	_ AggFunc = (*firstRow4Set)(nil)
 
 	// All the AggFunc implementations for "MAX"/"MIN" are listed here.
 	_ AggFunc = (*maxMin4Int)(nil)

--- a/executor/aggfuncs/builder.go
+++ b/executor/aggfuncs/builder.go
@@ -182,6 +182,13 @@ func buildFirstRow(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	switch aggFuncDesc.Mode {
 	case aggregation.DedupMode:
 	default:
+		switch fieldType.Tp {
+		case mysql.TypeEnum:
+			return &firstRow4Enum{base}
+		case mysql.TypeSet:
+			return &firstRow4Set{base}
+		}
+
 		switch evalType {
 		case types.ETInt:
 			return &firstRow4Int{base}

--- a/executor/aggfuncs/func_first_row.go
+++ b/executor/aggfuncs/func_first_row.go
@@ -78,6 +78,18 @@ type partialResult4FirstRowJSON struct {
 	val json.BinaryJSON
 }
 
+type partialResult4FirstRowEnum struct {
+	basePartialResult4FirstRow
+
+	val types.Enum
+}
+
+type partialResult4FirstRowSet struct {
+	basePartialResult4FirstRow
+
+	val types.Set
+}
+
 type firstRow4Int struct {
 	baseAggFunc
 }
@@ -450,5 +462,97 @@ func (*firstRow4Decimal) MergePartialResult(sctx sessionctx.Context, src Partial
 	if !p2.gotFirstRow {
 		*p2 = *p1
 	}
+	return nil
+}
+
+type firstRow4Enum struct {
+	baseAggFunc
+}
+
+func (e *firstRow4Enum) AllocPartialResult() PartialResult {
+	return PartialResult(new(partialResult4FirstRowEnum))
+}
+
+func (e *firstRow4Enum) ResetPartialResult(pr PartialResult) {
+	p := (*partialResult4FirstRowEnum)(pr)
+	p.isNull, p.gotFirstRow = false, false
+}
+
+func (e *firstRow4Enum) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
+	p := (*partialResult4FirstRowEnum)(pr)
+	if p.gotFirstRow {
+		return nil
+	}
+	for _, row := range rowsInGroup {
+		d, err := e.args[0].Eval(row)
+		if err != nil {
+			return err
+		}
+		p.gotFirstRow, p.isNull, p.val = true, d.IsNull(), d.GetMysqlEnum()
+		break
+	}
+	return nil
+}
+
+func (*firstRow4Enum) MergePartialResult(sctx sessionctx.Context, src PartialResult, dst PartialResult) error {
+	p1, p2 := (*partialResult4FirstRowEnum)(src), (*partialResult4FirstRowEnum)(dst)
+	if !p2.gotFirstRow {
+		*p2 = *p1
+	}
+	return nil
+}
+func (e *firstRow4Enum) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
+	p := (*partialResult4FirstRowEnum)(pr)
+	if p.isNull || !p.gotFirstRow {
+		chk.AppendNull(e.ordinal)
+		return nil
+	}
+	chk.AppendEnum(e.ordinal, p.val)
+	return nil
+}
+
+type firstRow4Set struct {
+	baseAggFunc
+}
+
+func (e *firstRow4Set) AllocPartialResult() PartialResult {
+	return PartialResult(new(partialResult4FirstRowSet))
+}
+
+func (e *firstRow4Set) ResetPartialResult(pr PartialResult) {
+	p := (*partialResult4FirstRowSet)(pr)
+	p.isNull, p.gotFirstRow = false, false
+}
+
+func (e *firstRow4Set) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) error {
+	p := (*partialResult4FirstRowSet)(pr)
+	if p.gotFirstRow {
+		return nil
+	}
+	for _, row := range rowsInGroup {
+		d, err := e.args[0].Eval(row)
+		if err != nil {
+			return err
+		}
+		p.gotFirstRow, p.isNull, p.val = true, d.IsNull(), d.GetMysqlSet()
+		break
+	}
+	return nil
+}
+
+func (*firstRow4Set) MergePartialResult(sctx sessionctx.Context, src PartialResult, dst PartialResult) error {
+	p1, p2 := (*partialResult4FirstRowSet)(src), (*partialResult4FirstRowSet)(dst)
+	if !p2.gotFirstRow {
+		*p2 = *p1
+	}
+	return nil
+}
+func (e *firstRow4Set) AppendFinalResult2Chunk(sctx sessionctx.Context, pr PartialResult, chk *chunk.Chunk) error {
+	p := (*partialResult4FirstRowSet)(pr)
+	if p.isNull || !p.gotFirstRow {
+		chk.AppendNull(e.ordinal)
+		return nil
+	}
+	chk.AppendSet(e.ordinal, p.val)
 	return nil
 }

--- a/executor/aggfuncs/func_first_row_test.go
+++ b/executor/aggfuncs/func_first_row_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggfuncs_test
+
+import (
+	"time"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
+)
+
+func (s *testSuite) TestMergePartialResult4FirstRow(c *C) {
+	elems := []string{"a", "b", "c", "d", "e"}
+	enumA, _ := types.ParseEnumName(elems, "a")
+	enumC, _ := types.ParseEnumName(elems, "c")
+
+	setA, _ := types.ParseSetName(elems, "a")
+	setAB, _ := types.ParseSetName(elems, "a,b")
+
+	tests := []aggTest{
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeLonglong, 5, 0, 2, 0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeFloat, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDouble, 5, 0.0, 2.0, 0.0),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeNewDecimal, 5, types.NewDecFromInt(0), types.NewDecFromInt(2), types.NewDecFromInt(0)),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeString, 5, "0", "2", "0"),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDate, 5, types.TimeFromDays(365), types.TimeFromDays(367), types.TimeFromDays(365)),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeDuration, 5, types.Duration{Duration: time.Duration(0)}, types.Duration{Duration: time.Duration(2)}, types.Duration{Duration: time.Duration(0)}),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeJSON, 5, json.CreateBinary(int64(0)), json.CreateBinary(int64(2)), json.CreateBinary(int64(0))),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeEnum, 5, enumA, enumC, enumA),
+		buildAggTester(ast.AggFuncFirstRow, mysql.TypeSet, 5, setA, setAB, setA),
+	}
+	for _, test := range tests {
+		s.testMergePartialResult(c, test)
+	}
+}

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -355,7 +355,7 @@ func (a *AggFuncDesc) typeInfer4MaxMin(ctx sessionctx.Context) {
 		a.Args[0] = expression.BuildCastFunction(ctx, a.Args[0], tp)
 	}
 	a.RetTp = a.Args[0].GetType()
-	if a.RetTp.Tp == mysql.TypeEnum || a.RetTp.Tp == mysql.TypeSet {
+	if (a.RetTp.Tp == mysql.TypeEnum || a.RetTp.Tp == mysql.TypeSet) && a.Name != ast.AggFuncFirstRow {
 		a.RetTp = &types.FieldType{Tp: mysql.TypeString, Flen: mysql.MaxFieldCharLength}
 	}
 }

--- a/types/datum.go
+++ b/types/datum.go
@@ -1776,6 +1776,12 @@ func NewMysqlEnumDatum(e Enum) (d Datum) {
 	return d
 }
 
+// NewMysqlSetDatum creates a new MysqlSet Datum for a Enum value.
+func NewMysqlSetDatum(e Set) (d Datum) {
+	d.SetMysqlSet(e)
+	return d
+}
+
 // MakeDatums creates datum slice from interfaces.
 func MakeDatums(args ...interface{}) []Datum {
 	datums := make([]Datum, len(args))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix wrong behavior when `ENUM` and `SET` column meet Aggregation as #13027 .
(Cherry-pick 9bf17e6 from #14035 to release-2.1)

### What is changed and how it works?
Add `firstRow4Enum`, the `first_row` executor for `ENUM`.
Add `firstRow4Set`, the `first_row` executor for `SET`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```sql
mysql> create table t(a enum('a', 'b'));
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t values('a'), ('b');
Query OK, 2 rows affected (0.00 sec)
Records: 2  Duplicates: 0  Warnings: 0

mysql> select cast(a as signed) from (select a from t group by a) t;
+-------------------+
| cast(a as signed) |
+-------------------+
|                 1 |
|                 2 |
+-------------------+
2 rows in set (0.00 sec)

mysql> create table t1(f set('a', 'b', 'c'));
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t1 values('a'), ('b'), ('a,b,c');
Query OK, 3 rows affected (0.00 sec)

mysql> select cast(f as signed) from (select f from t1 group by f) t1;
+-------------------+
| cast(f as signed) |
+-------------------+
|                 1 |
|                 2 |
|                 7 |
+-------------------+
3 rows in set (0.00 sec)
```
