### PR TITLE
test: speed up `TestVectorizedMergeJoin` by removing some test cases

### DIFF
--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -16,12 +16,13 @@ package executor_test
 import (
 	"bytes"
 	"fmt"
+	"math/rand"
+	"strings"
+	
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testkit"
-	"math/rand"
-	"strings"
 )
 
 const plan1 = `[[TableScan_12 {

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -522,7 +522,7 @@ func (s *testSuite2) TestVectorizedMergeJoin(c *C) {
 		}
 	}
 
-	tk.Se.GetSessionVars().MaxChunkSize = 16
+	tk.Se.GetSessionVars().MaxChunkSize = 8
 	chunkSize := tk.Se.GetSessionVars().MaxChunkSize
 	cases := []struct {
 		t1 []int
@@ -543,27 +543,12 @@ func (s *testSuite2) TestVectorizedMergeJoin(c *C) {
 		{[]int{chunkSize + 1}, []int{chunkSize}},
 		{[]int{chunkSize + 1}, []int{chunkSize - 1}},
 		{[]int{chunkSize + 1}, []int{chunkSize + 1}},
-		{[]int{1, 1, 1}, []int{chunkSize + 1, chunkSize*5 + 10, chunkSize - 10}},
-		{[]int{0, 0, chunkSize}, []int{chunkSize + 1, chunkSize*5 + 10, chunkSize - 10}},
-		{[]int{chunkSize + 1, 0, chunkSize}, []int{chunkSize + 1, chunkSize*5 + 10, chunkSize - 10}},
+		{[]int{1, 1, 1}, []int{chunkSize + 1, chunkSize*5 + 5, chunkSize - 5}},
+		{[]int{0, 0, chunkSize}, []int{chunkSize + 1, chunkSize*5 + 5, chunkSize - 5}},
+		{[]int{chunkSize + 1, 0, chunkSize}, []int{chunkSize + 1, chunkSize*5 + 5, chunkSize - 5}},
 	}
 	for _, ca := range cases {
 		runTest(ca.t1, ca.t2)
 		runTest(ca.t2, ca.t1)
-	}
-
-	// random complex cases
-	genCase := func() []int {
-		n := rand.Intn(32) + 32
-		ts := make([]int, n)
-		for i := 0; i < n; i++ {
-			ts[i] = rand.Intn(chunkSize * 2)
-		}
-		return ts
-	}
-	for i := 0; i < 16; i++ {
-		t1 := genCase()
-		t2 := genCase()
-		runTest(t1, t2)
 	}
 }

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -16,13 +16,12 @@ package executor_test
 import (
 	"bytes"
 	"fmt"
-	"math/rand"
-	"strings"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testkit"
+	"math/rand"
+	"strings"
 )
 
 const plan1 = `[[TableScan_12 {
@@ -461,12 +460,13 @@ func (s *testSuite2) TestMergeJoinDifferentTypes(c *C) {
 func (s *testSuite2) TestVectorizedMergeJoin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (a int, b int)")
+	tk.MustExec("create table t2 (a int, b int)")
 	runTest := func(t1, t2 []int) {
-		tk.MustExec("create table t1 (a int, b int)")
-		defer tk.MustExec("drop table t1")
-		tk.MustExec("create table t2 (a int, b int)")
-		defer tk.MustExec("drop table t2")
-
+		tk.MustExec("truncate table t1")
+		tk.MustExec("truncate table t2")
 		insert := func(tName string, ts []int) {
 			for i, n := range ts {
 				if n == 0 {

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strings"
-	
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util"

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"bytes"
 	"fmt"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"math/rand"
 	"strings"
 
@@ -523,7 +524,7 @@ func (s *testSuite2) TestVectorizedMergeJoin(c *C) {
 		}
 	}
 
-	tk.Se.GetSessionVars().MaxChunkSize = 8
+	tk.Se.GetSessionVars().MaxChunkSize = variable.DefInitChunkSize
 	chunkSize := tk.Se.GetSessionVars().MaxChunkSize
 	cases := []struct {
 		t1 []int


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Speed up `TestVectorizedMergeJoin` by removing some test cases and reducing test data.
After this PR it costs 18s now whereas 90s before.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test.
