### PR TITLE
test: add some goroutines to leak check white list

### DIFF
--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -59,8 +59,8 @@ func interestingGoroutines() (gs []string) {
 			// these go routines are async terminated, so they may still alive after test end, thus cause
 			// false positive leak failures
 			strings.Contains(stack, "google.golang.org/grpc.(*addrConn).resetTransport") ||
-			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb/util.(*BufferPool).drain") ||
 			strings.Contains(stack, "google.golang.org/grpc.(*ccBalancerWrapper).watcher") ||
+			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb/util.(*BufferPool).drain") ||
 			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb.(*DB).compactionError") ||
 			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb.(*DB).mpoolDrain") {
 			continue

--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -55,7 +55,14 @@ func interestingGoroutines() (gs []string) {
 			strings.Contains(stack, "runtime.goexit") ||
 			strings.Contains(stack, "created by runtime.gc") ||
 			strings.Contains(stack, "interestingGoroutines") ||
-			strings.Contains(stack, "runtime.MHeap_Scavenger") {
+			strings.Contains(stack, "runtime.MHeap_Scavenger") ||
+			// these go routines are async terminated, so they may still alive after test end, thus cause
+			// false positive leak failures
+			strings.Contains(stack, "google.golang.org/grpc.(*addrConn).resetTransport") ||
+			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb/util.(*BufferPool).drain") ||
+			strings.Contains(stack, "google.golang.org/grpc.(*ccBalancerWrapper).watcher") ||
+			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb.(*DB).compactionError") ||
+			strings.Contains(stack, "github.com/pingcap/goleveldb/leveldb.(*DB).mpoolDrain") {
 			continue
 		}
 		gs = append(gs, stack)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
add some go routines to the leak check white list to reduce the leak check failures caused by these routines

### What is changed and how it works?
Some go routines e.g. grpc/goleveldb have some backgroud go routines that are async terminated. So It is possible for them to live longer that the main routine, thus they will cause leak check failure even if there are acutally no go routine leak.

I make a statistics about the latest 500 build (21935~22435) for `tidb_ghpr_unit_test` pipeline in our CI. There is totally 151 failed builds that contains go routine leaks. And if we exclude failed tests that contains routine created by tidb/tikv, there are 31 remains. So there are up to **20%** false positive failed leak check.

routines that cause the false positive failure are list below:

| name | count |
| ---- | ---- |
| [google.golang.org/grpc.(*addrConn).resetTransport](https://github.com/grpc/grpc-go/blob/v1.25.1/clientconn.go#L800) |  29 |
| [google.golang.org/grpc.(*ccBalancerWrapper).watcher](https://github.com/grpc/grpc-go/blob/v1.25.1/balancer_conn_wrappers.go#L59) | 14 |
| [github.com/pingcap/goleveldb/leveldb.(*DB).compactionError](https://github.com/pingcap/goleveldb/blob/master/leveldb/db.go#L139) | 14 |
| [github.com/pingcap/goleveldb/leveldb.(*DB).mpoolDrain](https://github.com/pingcap/goleveldb/blob/master/leveldb/db.go#L140) | 14 |
| [google.golang.org/grpc.(*ccBalancerWrapper).watcher](https://github.com/pingcap/goleveldb/blob/master/leveldb/util/buffer_pool.go#L237) | 14 |
| [github.com/pingcap/goleveldb/leveldb.(*DB).mCompaction](https://github.com/pingcap/goleveldb/blob/master/leveldb/db.go#L147) | 14 |
| [github.com/pingcap/goleveldb/leveldb.(*DB).tCompaction](https://github.com/pingcap/goleveldb/blob/master/leveldb/db.go#L146) | 14 |

NOTE: the `mCompaction` and `tCompaction` should be closed before leveldb is closed according to the implement , so there maybe be logic error in our test code that should be further invested.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

