### PR TITLE
planner: enhance rule partition pruning (#14544)

### DIFF
--- a/cmd/explaintest/r/partition_pruning.result
+++ b/cmd/explaintest/r/partition_pruning.result
@@ -4352,3 +4352,18 @@ Union_8	30000.00	root
 │ └─TableScan_11	10000.00	cop	table:t, partition:p1, range:[-inf,+inf], keep order:false, stats:pseudo
 └─TableReader_14	10000.00	root	data:TableScan_13
   └─TableScan_13	10000.00	cop	table:t, partition:p2, range:[-inf,+inf], keep order:false, stats:pseudo
+drop table if exists t;
+CREATE TABLE `t` (
+`a` int(11) DEFAULT NULL,
+`b` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(a) (
+PARTITION p0 VALUES LESS THAN (1),
+PARTITION p1 VALUES LESS THAN (10),
+PARTITION p2 VALUES LESS THAN (100)
+);
+desc select * from t where a = 11 and b = 1 or a = 12 and b = 1;
+id	count	task	operator info
+TableReader_8	8000.00	root	data:Selection_7
+└─Selection_7	8000.00	cop	or(and(eq(test.t.a, 11), eq(test.t.b, 1)), and(eq(test.t.a, 12), eq(test.t.b, 1)))
+  └─TableScan_6	10000.00	cop	table:t, partition:p2, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/t/partition_pruning.test
+++ b/cmd/explaintest/t/partition_pruning.test
@@ -963,3 +963,16 @@ insert into t values(201);
 explain select * from t;
 rollback;
 explain select * from t;
+
+drop table if exists t;
+CREATE TABLE `t` (
+  `a` int(11) DEFAULT NULL,
+  `b` int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY RANGE COLUMNS(a) (
+  PARTITION p0 VALUES LESS THAN (1),
+  PARTITION p1 VALUES LESS THAN (10),
+  PARTITION p2 VALUES LESS THAN (100)
+);
+
+desc select * from t where a = 11 and b = 1 or a = 12 and b = 1;

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -323,12 +323,11 @@ func (s *partitionProcessor) canBePruned(sctx sessionctx.Context, partCol *expre
 	// TODO: Remove prune by calculating range. Current constraint propagate doesn't
 	// handle the null condition, while calculate range can prune something like:
 	// "select * from t where t is null"
-	accessConds := ranger.ExtractAccessConditionsForColumn(conds, partCol.UniqueID)
-	r, err := ranger.BuildColumnRange(accessConds, sctx.GetSessionVars().StmtCtx, partCol.RetType, types.UnspecifiedLength)
+	res, err := ranger.DetachCondAndBuildRangeForIndex(sctx, conds, []*expression.Column{partCol}, []int{types.UnspecifiedLength})
 	if err != nil {
 		return false, err
 	}
-	return len(r) == 0, nil
+	return len(res.Ranges) == 0, nil
 }
 
 // findByName checks whether object name exists in list.


### PR DESCRIPTION
cherry-pick #14544 

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix https://github.com/pingcap/tidb/issues/14539

### What is changed and how it works?
Use `ranger.DetachCondAndBuildRangeForIndex` instead of `ranger.ExtractAccessConditionsForColumn` in `partitionProcessor.canBePruned`.
Because of that `ExtractAccessConditionsForColumn` only handles the scenario that the CNF/DNF only covers one column.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

release-3.0

Release note

Enhance the logical rule partition pruning to cover more scenarios.