### PR TITLE
store: fix another race in mergeLockScanner

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1810,7 +1810,7 @@ func (s *mergeLockScanner) Start(ctx context.Context) error {
 			if err != nil {
 				logutil.Logger(ctx).Error("physical scan lock for store encountered error",
 					zap.Uint64("safePoint", s.safePoint),
-					zap.Any("store", store),
+					zap.Any("store", store1),
 					zap.Error(err))
 				ch <- scanLockResult{Err: err}
 			}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
there is a race in `mergeLockScanner` can cause ci fail.

```
ICATE KEY           UPDATE variable_value = '20200120-11:36:22 +0800', comment = 'The time when last GC starts. (DO NOT EDIT)';"

[2020-01-20T02:56:43.425Z] ==================

[2020-01-20T02:56:43.425Z] WARNING: DATA RACE

[2020-01-20T02:56:43.425Z] Read at 0x00c000cb6698 by goroutine 111:

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*mergeLockScanner).Start.func1()

[2020-01-20T02:56:43.425Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1813 +0x208

[2020-01-20T02:56:43.425Z] 

[2020-01-20T02:56:43.425Z] Previous write at 0x00c000cb6698 by goroutine 54:

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*mergeLockScanner).Start()

[2020-01-20T02:56:43.425Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1803 +0x202

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).makeMergedMockClient.func2()

[2020-01-20T02:56:43.425Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:925 +0x78

[2020-01-20T02:56:43.425Z] 

[2020-01-20T02:56:43.425Z] Goroutine 111 (running) created at:

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*mergeLockScanner).Start()

[2020-01-20T02:56:43.425Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1806 +0x2c6

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).makeMergedMockClient.func2()

[2020-01-20T02:56:43.425Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:925 +0x78

[2020-01-20T02:56:43.425Z] 

[2020-01-20T02:56:43.425Z] Goroutine 54 (running) created at:

[2020-01-20T02:56:43.425Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).makeMergedMockClient()

[2020-01-20T02:56:43.426Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:924 +0x779

[2020-01-20T02:56:43.426Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).makeMergedMockClient-fm()

[2020-01-20T02:56:43.426Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:890 +0x76

[2020-01-20T02:56:43.426Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).TestMergeLockScanner()

[2020-01-20T02:56:43.426Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:1015 +0x1c4b

[2020-01-20T02:56:43.426Z]   runtime.call32()

[2020-01-20T02:56:43.426Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2020-01-20T02:56:43.426Z]   reflect.Value.Call()

[2020-01-20T02:56:43.426Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2020-01-20T02:56:43.426Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2020-01-20T02:56:43.426Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20191216031241-8a5a85928f12/check.go:850 +0x9aa

[2020-01-20T02:56:43.426Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2020-01-20T02:56:43.426Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20191216031241-8a5a85928f12/check.go:739 +0x113

[2020-01-20T02:56:43.426Z] ==================

```

### What is changed and how it works?
fix race by using temp variable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - None

Related changes

 - None


