### PR TITLE
store/tikv/gcworker: fix a place of data race code

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1802,19 +1802,18 @@ func (s *mergeLockScanner) Start(ctx context.Context) error {
 
 	for storeID, store := range s.stores {
 		ch := make(chan scanLockResult, scanLockResultBufferSize)
-		store1 := store
-		go func() {
+		go func(store1 *metapb.Store) {
 			defer close(ch)
 
 			err := s.physicalScanLocksForStore(ctx, s.safePoint, store1, ch)
 			if err != nil {
 				logutil.Logger(ctx).Error("physical scan lock for store encountered error",
 					zap.Uint64("safePoint", s.safePoint),
-					zap.Any("store", store),
+					zap.Any("store", store1),
 					zap.Error(err))
 				ch <- scanLockResult{Err: err}
 			}
-		}()
+		}(store)
 		receivers = append(receivers, &receiver{Ch: ch, StoreID: storeID})
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

```
[2020-01-20T07:25:32.212Z] ==================
[2020-01-20T07:25:32.212Z] WARNING: DATA RACE
[2020-01-20T07:25:32.212Z] Read at 0x00c0021be740 by goroutine 130:
[2020-01-20T07:25:32.212Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*mergeLockScanner).Start.func1()
[2020-01-20T07:25:32.212Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1813 +0x208
[2020-01-20T07:25:32.212Z] 
[2020-01-20T07:25:32.212Z] Previous write at 0x00c0021be740 by goroutine 107:
[2020-01-20T07:25:32.212Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*mergeLockScanner).Start()
[2020-01-20T07:25:32.212Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker.go:1803 +0x202
[2020-01-20T07:25:32.212Z]   github.com/pingcap/tidb/store/tikv/gcworker.(*testGCWorkerSuite).makeMergedMockClient.func2()
[2020-01-20T07:25:32.212Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/gcworker/gc_worker_test.go:925 +0x78
[2020-01-20T07:25:32.212Z] 
```


### What is changed and how it works?

This is a stupid mistake: the variable `store` is used in the closure and modified each in `for range` loop.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Related changes

 - Need to cherry-pick to the release branch
