### PR TITLE
expression: fix json_key not compatible with MySQL (#14556)

### DIFF
--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -1179,7 +1179,7 @@ func (b *builtinJSONKeysSig) evalJSON(row chunk.Row) (res json.BinaryJSON, isNul
 		return res, isNull, err
 	}
 	if res.TypeCode != json.TypeCodeObject {
-		return res, true, json.ErrInvalidJSONData
+		return res, true, nil
 	}
 	return res.GetKeys(), false, nil
 }
@@ -1198,9 +1198,6 @@ func (b *builtinJSONKeys2ArgsSig) evalJSON(row chunk.Row) (res json.BinaryJSON, 
 	res, isNull, err = b.args[0].EvalJSON(b.ctx, row)
 	if isNull || err != nil {
 		return res, isNull, err
-	}
-	if res.TypeCode != json.TypeCodeObject {
-		return res, true, json.ErrInvalidJSONData
 	}
 
 	path, isNull, err := b.args[1].EvalString(b.ctx, row)

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -594,6 +594,7 @@ func (s *testEvaluatorSuite) TestJSONKeys(c *C) {
 		expected interface{}
 		success  bool
 	}{
+
 		// Tests nil arguments
 		{[]interface{}{nil}, nil, true},
 		{[]interface{}{nil, "$.c"}, nil, true},
@@ -601,12 +602,12 @@ func (s *testEvaluatorSuite) TestJSONKeys(c *C) {
 		{[]interface{}{nil, nil}, nil, true},
 
 		// Tests with other type
-		{[]interface{}{`1`}, nil, false},
-		{[]interface{}{`"str"`}, nil, false},
-		{[]interface{}{`true`}, nil, false},
-		{[]interface{}{`null`}, nil, false},
-		{[]interface{}{`[1, 2]`}, nil, false},
-		{[]interface{}{`["1", "2"]`}, nil, false},
+		{[]interface{}{`1`}, nil, true},
+		{[]interface{}{`"str"`}, nil, true},
+		{[]interface{}{`true`}, nil, true},
+		{[]interface{}{`null`}, nil, true},
+		{[]interface{}{`[1, 2]`}, nil, true},
+		{[]interface{}{`["1", "2"]`}, nil, true},
 
 		// Tests without path expression
 		{[]interface{}{`{}`}, `[]`, true},

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3817,13 +3817,13 @@ func (s *testIntegrationSuite) TestFuncJSON(c *C) {
 	r.Check(testkit.Rows("1 0 1 0"))
 
 	r = tk.MustQuery(`select
-
+		json_keys('[]'),
 		json_keys('{}'),
 		json_keys('{"a": 1, "b": 2}'),
 		json_keys('{"a": {"c": 3}, "b": 2}'),
 		json_keys('{"a": {"c": 3}, "b": 2}', "$.a")
 	`)
-	r.Check(testkit.Rows(`[] ["a", "b"] ["a", "b"] ["c"]`))
+	r.Check(testkit.Rows(`<nil> [] ["a", "b"] ["a", "b"] ["c"]`))
 
 	r = tk.MustQuery(`select
 		json_length('1'),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

port json_key patch from master to release3.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test


Release note

fix json_key not compatible with MySQL
