### PR TITLE
plugin: support logging rejected connection attempts in audit log

### DIFF
--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -45,6 +45,8 @@ const (
 	ChangeUser
 	// PreAuth presents event before start auth.
 	PreAuth
+	// Reject presents event reject connection event.
+	Reject
 )
 
 func (c ConnectionEvent) String() string {
@@ -57,6 +59,8 @@ func (c ConnectionEvent) String() string {
 		return "ChangeUser"
 	case PreAuth:
 		return "PreAuth"
+	case Reject:
+		return "Reject"
 	}
 	return ""
 }
@@ -84,6 +88,11 @@ type AuditManifest struct {
 	// OnParseEvent will be called around parse logic.
 	OnParseEvent func(ctx context.Context, sctx *variable.SessionVars, event ParseEvent) error
 }
+
+type (
+	// RejectReasonCtxValue will be used in OnConnectionEvent to pass RejectReason to plugin.
+	RejectReasonCtxValue struct{}
+)
 
 type execStartTimeCtxKeyType struct{}
 

--- a/plugin/conn_ip_example/conn_ip_example.go
+++ b/plugin/conn_ip_example/conn_ip_example.go
@@ -46,3 +46,14 @@ func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugi
 	fmt.Println("variable test: ", variable.GetSysVar("conn_ip_example_test_variable").Value)
 	fmt.Printf("new connection by %s\n", ctx.Value("ip"))
 }
+
+// OnConnectionEvent implements TiDB Audit plugin's OnConnectionEvent SPI.
+func OnConnectionEvent(ctx context.Context, event plugin.ConnectionEvent, info *variable.ConnectionInfo) error {
+	var reason string
+	if r := ctx.Value(plugin.RejectReasonCtxValue{}); r != nil {
+		reason = r.(string)
+	}
+	fmt.Println("conn_ip_example onConnect called")
+	fmt.Printf("conenct event: %s, reason: %s\n", event, reason)
+	return nil
+}

--- a/plugin/conn_ip_example/manifest.toml
+++ b/plugin/conn_ip_example/manifest.toml
@@ -11,5 +11,6 @@ validate = "Validate"
 onInit = "OnInit"
 onShutdown = "OnShutdown"
 export = [
-    {extPoint="OnGeneralEvent", impl="OnGeneralEvent"}
+    {extPoint="OnGeneralEvent", impl="OnGeneralEvent"},
+    {extPoint="OnConnectionEvent", impl="OnConnectionEvent"}
 ]

--- a/server/server.go
+++ b/server/server.go
@@ -413,6 +413,18 @@ func (s *Server) Close() {
 func (s *Server) onConn(conn *clientConn) {
 	ctx := logutil.WithConnID(context.Background(), conn.connectionID)
 	if err := conn.handshake(ctx); err != nil {
+		if plugin.IsEnable(plugin.Audit) {
+			conn.ctx.GetSessionVars().ConnectionInfo = conn.connectInfo()
+		}
+		err = plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
+			authPlugin := plugin.DeclareAuditManifest(p.Manifest)
+			if authPlugin.OnConnectionEvent != nil {
+				pluginCtx := context.WithValue(context.Background(), plugin.RejectReasonCtxValue{}, err.Error())
+				return authPlugin.OnConnectionEvent(pluginCtx, plugin.Reject, conn.ctx.GetSessionVars().ConnectionInfo)
+			}
+			return nil
+		})
+		terror.Log(err)
 		// Some keep alive services will send request to TiDB and disconnect immediately.
 		// So we only record metrics.
 		metrics.HandShakeErrorCounter.Inc()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fixes #14563 

releated PR in plugin https://github.com/pingcap/enterprise-plugin/pull/25

### What is changed and how it works?

- add new reject audit type
- pass reject reason via ctx

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
```
build plugin and load it with new audit plugin 
login fail
see 

[2020/02/03 12:33:54.921 +08:00] [INFO] [logger.go:70] [ID=15807044340] [TIMESTAMP=2020/02/03 12:33:54.921 +08:00] [EVENT_CLASS=CONNECTION] [EVENT_SUBCLASS=Reject] [STATUS_CODE=0] [COST_TIME=0] [HOST=127.0.0.1] [CLIENT_IP=127.0.0.1] [USER=root] [DATABASES="[test]"] [TABLES="[]"] [SQL_TEXT=] [ROWS=0] [CLIENT_PORT=34160] [CONNECTION_ID=2] [CONNECTION_TYPE=Socket] [SERVER_ID=1] [SERVER_PORT=4000] [DURATION=0] [SERVER_OS_LOGIN_USER=robi] [OS_VERSION="Linux 5.3.18-1-MANJARO.x86_64"] [CLIENT_VERSION=] [SERVER_VERSION=v4.0.0-beta-51-gc46044f02-dirty] [AUDIT_VERSION=] [SSL_VERSION=v1.2.0] [PID=30808] [Reason="[server:1045]Access denied for user 'root'@'127.0.0.1' (using password: YES)"]

in audit log
```

Code changes

 - Has exported function/method change

Side effects

 - need cherry-pick to keep 3.0, 2.1 CI works

Related changes

 - Need to cherry-pick to the release branch

Release note

 - support logging rejected connection attempts in audit log.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/14594)
<!-- Reviewable:end -->
