### PR TITLE
planner: reset plan id before optimizing point get (#14471)

### DIFF
--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -14,6 +14,7 @@
 package perfschema_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/pingcap/check"

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -101,6 +101,18 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 		where digest_text like 'insert into t%'`,
 	).Check(testkit.Rows("insert test test.t <nil> 4 0 0 0 0 0 2 2 1 1 1 insert into t values(1, 'a') "))
 
+	// Test point get.
+	tk.MustExec("drop table if exists p")
+	tk.MustExec("create table p(a int primary key, b int)")
+	for i := 1; i < 3; i++ {
+		tk.MustQuery("select b from p where a=1")
+		expectedResult := fmt.Sprintf("%d \tPoint_Get_1\troot\t1\ttable:p, handle:1", i)
+		tk.MustQuery(`select exec_count, plan
+			from performance_schema.events_statements_summary_by_digest
+			where digest_text like 'select b from p%'`,
+		).Check(testkit.Rows(expectedResult))
+	}
+
 	// Test SELECT.
 	const failpointName = "github.com/pingcap/tidb/planner/core/mockPlanRowCount"
 	c.Assert(failpoint.Enable(failpointName, "return(100)"), IsNil)

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -155,6 +155,8 @@ func (p *PointGetPlan) ResolveIndices() error {
 
 // TryFastPlan tries to use the PointGetPlan for the query.
 func TryFastPlan(ctx sessionctx.Context, node ast.Node) Plan {
+	ctx.GetSessionVars().PlanID = 0
+	ctx.GetSessionVars().PlanColumnID = 0
 	switch x := node.(type) {
 	case *ast.SelectStmt:
 		fp := tryPointGetPlan(ctx, x)


### PR DESCRIPTION
Conflicting files: 
`planner/core/point_get_plan_test.go`

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Plan id is reset before optimization every time, so that ids of operators are the same when physical plans are the same.
But when the plan is a point get, the plan id is not reset, leading to different ids of `PointGet`, so plan digests are different.
If the plan digest are different, statement summary can't work properly. Refer to issue https://github.com/pingcap/tidb/issues/14432

### What is changed and how it works?
Reset plan id before `tryFastPlan` and add test cases.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Breaking backward compatibility

Related changes

N/A

Release note

 - Fix operator ids of point get.
