### PR TITLE
executor: merge overlapped ranges when build key ranges for indexJoin

### DIFF
--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -189,13 +189,10 @@ func (s *testSuite5) TestIndexJoinPartitionTable(c *C) {
 
 func (s *testSuite5) TestIndexJoinMultiCondition(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
-
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(a int not null, b int not null, key idx_a_b(a,b))")
 	tk.MustExec("create table t2(a int not null, b int not null)")
 	tk.MustExec("insert into t1 values (0,1), (0,2), (0,3)")
 	tk.MustExec("insert into t2 values (0,1), (0,2), (0,3)")
-	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ count(*) from t1, t2 where t1.a = t2.a and t1.b < t2.b").Check(testkit.Rows(
-		"3"))
+	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ count(*) from t1, t2 where t1.a = t2.a and t1.b < t2.b").Check(testkit.Rows("3"))
 }

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -186,3 +186,16 @@ func (s *testSuite5) TestIndexJoinPartitionTable(c *C) {
 	tk.MustQuery("SELECT /*+ INL_HASH_JOIN(t1) */ count(1) FROM t t1 INNER JOIN (SELECT a, max(c) AS c FROM t WHERE b = 27 AND a = 1 GROUP BY a) t2 ON t1.a = t2.a AND t1.c = t2.c WHERE t1.b = 27").Check(testkit.Rows("1"))
 	tk.MustQuery("SELECT /*+ INL_MERGE_JOIN(t1) */ count(1) FROM t t1 INNER JOIN (SELECT a, max(c) AS c FROM t WHERE b = 27 AND a = 1 GROUP BY a) t2 ON t1.a = t2.a AND t1.c = t2.c WHERE t1.b = 27").Check(testkit.Rows("1"))
 }
+
+func (s *testSuite5) TestIndexJoinMultiCondition(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t1(a int not null, b int not null, key idx_a_b(a,b))")
+	tk.MustExec("create table t2(a int not null, b int not null)")
+	tk.MustExec("insert into t1 values (0,1), (0,2), (0,3)")
+	tk.MustExec("insert into t2 values (0,1), (0,2), (0,3)")
+	tk.MustQuery("select /*+ TIDB_INLJ(t1) */ count(*) from t1, t2 where t1.a = t2.a and t1.b < t2.b").Check(testkit.Rows(
+		"3"))
+}

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -189,6 +189,7 @@ func (s *testSuite5) TestIndexJoinPartitionTable(c *C) {
 
 func (s *testSuite5) TestIndexJoinMultiCondition(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(a int not null, b int not null, key idx_a_b(a,b))")
 	tk.MustExec("create table t2(a int not null, b int not null)")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix https://github.com/pingcap/tidb/issues/14534
### What is changed and how it works?

When indexJoin's inner range is decided by more than one condition, it may generate overlapped ranges for inner side which might lead to incorrect result. 

This PR merges the overlapped ranges.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Side effects

 - Possible performance regression

Related changes

 - Need to cherry-pick to the release-3.0

Release note

 - Fix the bug that IndexJoin may get wrong results when inner range is decided by more than one condition.
