### PR TITLE
executor: fill warning message with column name and row index

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -105,9 +105,9 @@ func (s *testSuite5) TestShowWarnings(c *C) {
 	tk.MustExec("set @@sql_mode=''")
 	tk.MustExec("insert show_warnings values ('a')")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(1))
-	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect FLOAT value: 'a'"))
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1366|Incorrect int value: 'a' for column 'a' at row 1"))
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(0))
-	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect FLOAT value: 'a'"))
+	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|1366|Incorrect int value: 'a' for column 'a' at row 1"))
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(0))
 
 	// Test Warning level 'Error'

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -374,6 +374,17 @@ func (sc *StatementContext) AppendError(warn error) {
 	sc.mu.Unlock()
 }
 
+// ConvertWarningFrom converts the warning from a start point.
+func (sc *StatementContext) ConvertWarningFrom(idx int, convertFunc func(error) error) int {
+	sc.mu.Lock()
+	lastWarn := len(sc.mu.warnings)
+	for i := idx; i < lastWarn; i++ {
+		sc.mu.warnings[i].Err = convertFunc(sc.mu.warnings[i].Err)
+	}
+	sc.mu.Unlock()
+	return lastWarn
+}
+
 // SetHistogramsNotLoad sets histogramsNotLoad.
 func (sc *StatementContext) SetHistogramsNotLoad() {
 	sc.mu.Lock()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When there is data truncate in DML, the column name and row index is not showed in warning messages.

### What is changed and how it works?

Fill in the column name and row count in warnings by tranverse the warnings.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - Need to cherry-pick to the release branch
Release note

 - fill in warning message with column name and row index when there are data truncates