### PR TITLE
*: print the statement causing write conflicts

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -3345,7 +3345,7 @@ func (s *testDBSuite4) TestAddColumn2(c *C) {
 	c.Assert(err, IsNil)
 	_, err = writeOnlyTable.AddRecord(s.tk.Se, types.MakeDatums(oldRow[0].GetInt64(), 2, oldRow[2].GetInt64()), table.IsUpdate)
 	c.Assert(err, IsNil)
-	err = s.tk.Se.StmtCommit(nil)
+	err = s.tk.Se.StmtCommit(nil, 0)
 	c.Assert(err, IsNil)
 	err = s.tk.Se.CommitTxn(ctx)
 	c.Assert(err, IsNil)
@@ -4016,7 +4016,7 @@ func (s *testDBSuite2) TestLockTables(c *C) {
 	tk2.MustExec("lock tables t1 write")
 	_, err = tk.Exec("commit")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "previous statement: insert into t1 set a=1: [domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later]")
+	c.Assert(err.Error(), Equals, "[domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later]")
 
 	// Test lock table by other session in transaction and commit with retry.
 	tk.MustExec("unlock tables")

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -95,7 +95,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 		e.memTracker.Consume(memUsageOfChk)
 		for chunkRow := iter.Begin(); chunkRow != iter.End(); chunkRow = iter.Next() {
 			if batchDelete && rowCount >= batchDMLSize {
-				if err = e.ctx.StmtCommit(e.memTracker); err != nil {
+				if err = e.ctx.StmtCommit(e.memTracker, 0); err != nil {
 					return err
 				}
 				if err = e.ctx.NewTxn(ctx); err != nil {

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -535,7 +535,7 @@ func checkCases(tests []testCase, ld *executor.LoadDataInfo,
 		}
 		ld.SetMessage()
 		tk.CheckLastMessage(tt.expectedMsg)
-		err := ctx.StmtCommit(nil)
+		err := ctx.StmtCommit(nil, 0)
 		c.Assert(err, IsNil)
 		txn, err := ctx.Txn(true)
 		c.Assert(err, IsNil)

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -456,7 +456,7 @@ func insertRowsFromSelect(ctx context.Context, base insertCommon) error {
 
 func (e *InsertValues) doBatchInsert(ctx context.Context) error {
 	sessVars := e.ctx.GetSessionVars()
-	if err := e.ctx.StmtCommit(e.memTracker); err != nil {
+	if err := e.ctx.StmtCommit(e.memTracker, 0); err != nil {
 		return err
 	}
 	if err := e.ctx.NewTxn(ctx); err != nil {

--- a/executor/load_data.go
+++ b/executor/load_data.go
@@ -205,7 +205,7 @@ func (e *LoadDataInfo) CommitOneTask(ctx context.Context, task CommitTask) error
 	failpoint.Inject("commitOneTaskErr", func() error {
 		return errors.New("mock commit one task error")
 	})
-	if err = e.Ctx.StmtCommit(nil); err != nil {
+	if err = e.Ctx.StmtCommit(nil, 0); err != nil {
 		logutil.Logger(ctx).Error("commit error commit", zap.Error(err))
 		return err
 	}

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -760,43 +760,6 @@ func (s *seqTestSuite) TestAdminShowNextID(c *C) {
 	r.Check(testkit.Rows("test1 tt id 41"))
 }
 
-func (s *seqTestSuite) TestNoHistoryWhenDisableRetry(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists history")
-	tk.MustExec("create table history (a int)")
-	tk.MustExec("set @@autocommit = 0")
-
-	// retry_limit = 0 will not add history.
-	tk.MustExec("set @@tidb_retry_limit = 0")
-	tk.MustExec("insert history values (1)")
-	c.Assert(session.GetHistory(tk.Se).Count(), Equals, 0)
-
-	// Disable auto_retry will add history for auto committed only
-	tk.MustExec("set @@autocommit = 1")
-	tk.MustExec("set @@tidb_retry_limit = 10")
-	tk.MustExec("set @@tidb_disable_txn_auto_retry = 1")
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/session/keepHistory", `return(true)`), IsNil)
-	tk.MustExec("insert history values (1)")
-	c.Assert(session.GetHistory(tk.Se).Count(), Equals, 1)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/keepHistory"), IsNil)
-	tk.MustExec("begin")
-	tk.MustExec("insert history values (1)")
-	c.Assert(session.GetHistory(tk.Se).Count(), Equals, 0)
-	tk.MustExec("commit")
-
-	// Enable auto_retry will add history for both.
-	tk.MustExec("set @@tidb_disable_txn_auto_retry = 0")
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/session/keepHistory", `return(true)`), IsNil)
-	tk.MustExec("insert history values (1)")
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/session/keepHistory"), IsNil)
-	c.Assert(session.GetHistory(tk.Se).Count(), Equals, 1)
-	tk.MustExec("begin")
-	tk.MustExec("insert history values (1)")
-	c.Assert(session.GetHistory(tk.Se).Count(), Equals, 2)
-	tk.MustExec("commit")
-}
-
 func (s *seqTestSuite) TestPrepareMaxParamCountCheck(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2252,7 +2252,7 @@ func (s *testSuite4) TestLoadDataIntoPartitionedTable(c *C) {
 	c.Assert(err, IsNil)
 	ld.SetMaxRowsInBatch(20000)
 	ld.SetMessage()
-	err = ctx.StmtCommit(nil)
+	err = ctx.StmtCommit(nil, 0)
 	c.Assert(err, IsNil)
 	txn, err := ctx.Txn(true)
 	c.Assert(err, IsNil)

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/sticnarf/parser v0.0.0-20200205025652-dcd44c927f04

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,6 @@ github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200120100653-1d87b3907217 h1:UtieYveNGV84dIdb01UIXMQzGIyGLRiAoGXgLe9rJws=
-github.com/pingcap/parser v0.0.0-20200120100653-1d87b3907217/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd v1.1.0-beta.0.20191219054547-4d65bbefbc6d h1:Ui80aiLTyd0EZD56o2tjFRYpHfhazBjtBdKeR8UoTFY=
 github.com/pingcap/pd v1.1.0-beta.0.20191219054547-4d65bbefbc6d/go.mod h1:CML+b1JVjN+VbDijaIcUSmuPgpDjXEY7UiOx5yDP8eE=
 github.com/pingcap/sysutil v0.0.0-20191216090214-5f9620d22b3b h1:EEyo/SCRswLGuSk+7SB86Ak1p8bS6HL1Mi4Dhyuv6zg=
@@ -263,6 +261,8 @@ github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasO
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
+github.com/sticnarf/parser v0.0.0-20200205025652-dcd44c927f04 h1:+d+hK/N8GmMCV1LwdY1yIBiGD6rJJVMSLjeClbgtKiI=
+github.com/sticnarf/parser v0.0.0-20200205025652-dcd44c927f04/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
@@ -384,8 +384,6 @@ golang.org/x/tools v0.0.0-20191029041327-9cc4af7d6b2c/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191107010934-f79515f33823/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
-golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589 h1:rjUrONFu4kLchcZTfp3/96bR8bW8dIa8uz3cR5n0cgM=
-golang.org/x/tools v0.0.0-20200114235610-7ae403b6b589/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200119215504-eb0d8dd85bcc h1:ZA7KFRdqWZkBr0/YbHm1h08vDJ5gQdjVG/8L153z5c4=
 golang.org/x/tools v0.0.0-20200119215504-eb0d8dd85bcc/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/kv/buffer_store.go
+++ b/kv/buffer_store.go
@@ -99,17 +99,17 @@ func (s *BufferStore) IterReverse(k Key) (Iterator, error) {
 }
 
 // WalkBuffer iterates all buffered kv pairs.
-func (s *BufferStore) WalkBuffer(f func(k Key, v []byte) error) error {
+func (s *BufferStore) WalkBuffer(f func(k Key, v, extras []byte) error) error {
 	return WalkMemBuffer(s.MemBuffer, f)
 }
 
-// SaveTo saves all buffered kv pairs into a Mutator.
-func (s *BufferStore) SaveTo(m Mutator) error {
-	err := s.WalkBuffer(func(k Key, v []byte) error {
+// SaveTo saves all buffered kv pairs into a MemBuffer.
+func (s *BufferStore) SaveTo(m MemBuffer) error {
+	err := s.WalkBuffer(func(k Key, v, extras []byte) error {
 		if len(v) == 0 {
 			return m.Delete(k)
 		}
-		return m.Set(k, v)
+		return m.SetWithExtras(k, v, extras)
 	})
 	return err
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -155,6 +155,14 @@ type MemBuffer interface {
 	// SetCap sets the MemBuffer capability, to reduce memory allocations.
 	// Please call it before you use the MemBuffer, otherwise it will not works.
 	SetCap(cap int)
+	// SetWithExtras sets the value for key k as v but also stores extra bytes associated with the key.
+	// Note that v cannot be nil or empty, otherwise it returns ErrCannotSetNilValue.
+	SetWithExtras(k Key, v, extras []byte) error
+	// DeleteWithExtras sets the value for k to empty but also stores extra bytes associated with the key.
+	DeleteWithExtras(k Key, extras []byte) error
+	// GetExtras gets the extra bytes associated with the key.
+	// If the corresponding entry does not exist, it returns (nil, ErrNotExist).
+	GetExtras(k Key) ([]byte, error)
 }
 
 // Transaction defines the interface for operations inside a Transaction.
@@ -190,6 +198,9 @@ type Transaction interface {
 	// If a key doesn't exist, there shouldn't be any corresponding entry in the result map.
 	BatchGet(ctx context.Context, keys []Key) (map[string][]byte, error)
 	IsPessimistic() bool
+	// ConflictStmtIdx returns the statement index which causes a write conflict error, counting from 1.
+	// If no write conflict occurs, ConflictStmtIdx returns 0.
+	ConflictStmtIdx() int
 }
 
 // LockCtx contains information for LockKeys method.

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -66,6 +66,10 @@ func (t *mockTxn) Get(ctx context.Context, k Key) ([]byte, error) {
 	return nil, nil
 }
 
+func (t *mockTxn) GetExtras(k Key) ([]byte, error) {
+	return nil, nil
+}
+
 func (t *mockTxn) BatchGet(ctx context.Context, keys []Key) (map[string][]byte, error) {
 	return nil, nil
 }
@@ -81,7 +85,16 @@ func (t *mockTxn) IterReverse(k Key) (Iterator, error) {
 func (t *mockTxn) Set(k Key, v []byte) error {
 	return nil
 }
+
+func (t *mockTxn) SetWithExtras(k Key, v, extras []byte) error {
+	return nil
+}
+
 func (t *mockTxn) Delete(k Key) error {
+	return nil
+}
+
+func (t *mockTxn) DeleteWithExtras(k Key, extras []byte) error {
 	return nil
 }
 
@@ -131,6 +144,10 @@ func (s *mockStorage) Begin() (Transaction, error) {
 
 func (*mockTxn) IsPessimistic() bool {
 	return false
+}
+
+func (*mockTxn) ConflictStmtIdx() int {
+	return 0
 }
 
 // BeginWithStartTS begins a transaction with startTS.
@@ -198,6 +215,10 @@ type mockSnapshot struct {
 
 func (s *mockSnapshot) Get(ctx context.Context, k Key) ([]byte, error) {
 	return s.store.Get(ctx, k)
+}
+
+func (s *mockSnapshot) GetExtras(k Key) ([]byte, error) {
+	return s.store.GetExtras(k)
 }
 
 func (s *mockSnapshot) SetPriority(priority int) {

--- a/kv/union_store.go
+++ b/kv/union_store.go
@@ -24,7 +24,7 @@ type UnionStore interface {
 	// DeleteKeyExistErrInfo deletes the key exist error info for the lazy check.
 	DeleteKeyExistErrInfo(k Key)
 	// WalkBuffer iterates all buffered kv pairs.
-	WalkBuffer(f func(k Key, v []byte) error) error
+	WalkBuffer(f func(k Key, v, extras []byte) error) error
 	// SetOption sets an option with a value, when val is nil, uses the default
 	// value of this option.
 	SetOption(opt Option, val interface{})
@@ -133,6 +133,14 @@ func (lmb *lazyMemBuffer) Get(ctx context.Context, k Key) ([]byte, error) {
 	return lmb.mb.Get(ctx, k)
 }
 
+func (lmb *lazyMemBuffer) GetExtras(k Key) ([]byte, error) {
+	if lmb.mb == nil {
+		return nil, ErrNotExist
+	}
+
+	return lmb.mb.GetExtras(k)
+}
+
 func (lmb *lazyMemBuffer) Set(key Key, value []byte) error {
 	if lmb.mb == nil {
 		lmb.mb = NewMemDbBuffer(lmb.cap)
@@ -141,12 +149,28 @@ func (lmb *lazyMemBuffer) Set(key Key, value []byte) error {
 	return lmb.mb.Set(key, value)
 }
 
+func (lmb *lazyMemBuffer) SetWithExtras(key Key, value, extras []byte) error {
+	if lmb.mb == nil {
+		lmb.mb = NewMemDbBuffer(lmb.cap)
+	}
+
+	return lmb.mb.SetWithExtras(key, value, extras)
+}
+
 func (lmb *lazyMemBuffer) Delete(k Key) error {
 	if lmb.mb == nil {
 		lmb.mb = NewMemDbBuffer(lmb.cap)
 	}
 
 	return lmb.mb.Delete(k)
+}
+
+func (lmb *lazyMemBuffer) DeleteWithExtras(k Key, extras []byte) error {
+	if lmb.mb == nil {
+		lmb.mb = NewMemDbBuffer(lmb.cap)
+	}
+
+	return lmb.mb.DeleteWithExtras(k, extras)
 }
 
 func (lmb *lazyMemBuffer) Iter(k Key, upperBound Key) (Iterator, error) {

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -313,7 +313,7 @@ func (s *testPlanSuite) TestDAGPlanBuilderUnionScan(c *C) {
 		txn, err := se.Txn(true)
 		c.Assert(err, IsNil)
 		txn.Set(kv.Key("AAA"), []byte("BBB"))
-		c.Assert(se.StmtCommit(nil), IsNil)
+		c.Assert(se.StmtCommit(nil, 0), IsNil)
 		p, _, err := planner.Optimize(context.TODO(), se, stmt, s.is)
 		c.Assert(err, IsNil)
 		s.testData.OnRecord(func() {

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -78,7 +78,9 @@ type Context interface {
 	HasDirtyContent(tid int64) bool
 
 	// StmtCommit flush all changes by the statement to the underlying transaction.
-	StmtCommit(tracker *memory.Tracker) error
+	// historyIdx is the index of this statement in the statement history. Due to historical reasons,
+	// historyIdx is counted from 1 so as to be error tolerant and 0 means history is unavailable.
+	StmtCommit(tracker *memory.Tracker, historyIdx int) error
 	// StmtRollback provides statement level rollback.
 	StmtRollback()
 	// StmtGetMutation gets the binlog mutation for current statement.

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -414,7 +414,7 @@ func (s *testLockSuite) mustGetLock(c *C, key []byte) *Lock {
 	c.Assert(resp.Resp, NotNil)
 	keyErr := resp.Resp.(*kvrpcpb.GetResponse).GetError()
 	c.Assert(keyErr, NotNil)
-	lock, err := extractLockFromKeyErr(keyErr)
+	lock, err := extractLockFromKeyErr(keyErr, nil)
 	c.Assert(err, IsNil)
 	return lock
 }

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -233,7 +233,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 		// Check if kvPair contains error, it should be a Lock.
 		for _, pair := range kvPairs {
 			if keyErr := pair.GetError(); keyErr != nil {
-				lock, err := extractLockFromKeyErr(keyErr)
+				lock, err := extractLockFromKeyErr(keyErr, nil)
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -320,7 +320,7 @@ func (ts *testSuite) TestUnsignedPK(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(len(row), Equals, 2)
 	c.Assert(row[0].Kind(), Equals, types.KindUint64)
-	c.Assert(ts.se.StmtCommit(nil), IsNil)
+	c.Assert(ts.se.StmtCommit(nil, 0), IsNil)
 	txn, err := ts.se.Txn(true)
 	c.Assert(err, IsNil)
 	c.Assert(txn.Commit(context.Background()), IsNil)

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -204,7 +204,7 @@ func (c *Context) GoCtx() context.Context {
 func (c *Context) StoreQueryFeedback(_ interface{}) {}
 
 // StmtCommit implements the sessionctx.Context interface.
-func (c *Context) StmtCommit(tracker *memory.Tracker) error {
+func (c *Context) StmtCommit(tracker *memory.Tracker, historyIdx int) error {
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

Fixes #14593 

### What is changed and how it works?

```
MySQL [test]> select * from t;
+----+------+
| pk | v    |
+----+------+
|  1 |    1 |
|  2 |    2 |
+----+------+
2 rows in set (0.002 sec)
```


Client 1|Client2
-----------|-------
begin optimistic;|
update t set v=2 where pk=1;|
update t set v=3 where pk=2;|
| |update t set v=0 where pk=1;
commit;|

The result will be:

```
MySQL [test]> commit;
ERROR 9007 (HY000): Write conflict, txnStartTS=414420145598627841, conflictStartTS=414420147931709441, conflictCommitTS=414420147931709442, key={tableID=5262, handle=1} primary={tableID=5262, handle=1}, conflict cause: update t set v=2 where pk=1 [try again later]
```

In order to know which statement causes the conflict, we need to store the statement index together with the kv pair. So `MemBuffer` is modified to support storing **extra bytes* associated with keys. Here, the extra bytes are used to store the statement index. We might also enlarge the space and store something else.

Because ticlient does not have access to the statement history, we need to return the conflicting statement index to session. However, errors returned from ticlient don't carry data (only messages), so the conflicting statement index is just stored in `tikvTxn` and is fetched by the caller.

To add the statement text to error message, I have no other idea but use a dirty way. `parser/terror` is changed to expose the inner arguments. So I can change the messages in `ErrWriteConflict`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change

Side effects

 - This PR depends on history no matter whether retry is enabled, so the changes in #11192 is basically reverted. I'm not sure if the memory usage really counts.