### PR TITLE
types: fix parse DATETIME/TIME from string incompatible with MySQL (#14547) 

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3618,12 +3618,12 @@ func (s *testIntegrationSuite) TestSetVariables(c *C) {
 	c.Assert(err, IsNil)
 	_, err = tk.Exec("INSERT INTO tab0 select cast('999:44:33' as time);")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[types:1292]Truncated incorrect time value: '999h44m33s'")
+	c.Assert(err.Error(), Equals, "[types:1292]Truncated incorrect time value: '999:44:33'")
 	_, err = tk.Exec("set sql_mode=' ,';")
 	c.Assert(err, NotNil)
 	_, err = tk.Exec("INSERT INTO tab0 select cast('999:44:33' as time);")
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[types:1292]Truncated incorrect time value: '999h44m33s'")
+	c.Assert(err.Error(), Equals, "[types:1292]Truncated incorrect time value: '999:44:33'")
 
 	// issue #5478
 	_, err = tk.Exec("set session transaction read write;")

--- a/types/time.go
+++ b/types/time.go
@@ -720,6 +720,9 @@ func parseDatetime(sc *stmtctx.StatementContext, str string, fsp int, isFloat bo
 			year = adjustYear(year)
 		case 8: // YYYYMMDD
 			_, err = fmt.Sscanf(seps[0], "%4d%2d%2d", &year, &month, &day)
+		case 7: // YYMMDDH
+			_, err = fmt.Sscanf(seps[0], "%2d%2d%2d%1d", &year, &month, &day, &hour)
+			year = adjustYear(year)
 		case 6, 5:
 			// YYMMDD && YYMMD
 			_, err = fmt.Sscanf(seps[0], "%2d%2d%2d", &year, &month, &day)
@@ -1181,6 +1184,17 @@ func ParseDuration(sc *stmtctx.StatementContext, str string, fsp int) (Duration,
 	if minute >= 60 || second > 60 || (!overflow && second == 60) {
 		return ZeroDuration, ErrTruncatedWrongVal.GenWithStackByArgs("time", origStr)
 	}
+
+	if day*24+hour > TimeMaxHour {
+		var t gotime.Duration
+		if sign == -1 {
+			t = MinTime
+		} else {
+			t = MaxTime
+		}
+		return Duration{Duration: t, Fsp: fsp}, ErrTruncatedWrongVal.GenWithStackByArgs("time", origStr)
+	}
+
 	d := gotime.Duration(day*24*3600+hour*3600+minute*60+second)*gotime.Second + gotime.Duration(fracPart)*gotime.Microsecond
 	if sign == -1 {
 		d = -d

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -67,6 +67,7 @@ func (s *testTimeSuite) TestDateTime(c *C) {
 		{"2018.01.01", "2018-01-01 00:00:00.00"},
 		{"2018/01/01-00:00:00", "2018-01-01 00:00:00"},
 		{"2018.01.01 00:00:00", "2018-01-01 00:00:00"},
+		{"4710072", "2047-10-07 02:00:00"},
 	}
 
 	for _, test := range table {
@@ -246,6 +247,10 @@ func (s *testTimeSuite) TestTime(c *C) {
 		_, err := types.ParseDuration(sc, test, types.DefaultFsp)
 		c.Assert(err, NotNil)
 	}
+
+	t, err := types.ParseDuration(sc, "4294967295 0:59:59", types.DefaultFsp)
+	c.Assert(err, NotNil)
+	c.Assert(t.String(), Equals, "838:59:59")
 
 	// test time compare
 	cmpTable := []struct {


### PR DESCRIPTION
cherry-pick #14547 to release-2.1

---

Conflicts: types/time_test.go

---

Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR fixes the issue that the result of parse string to DATETIME/TIME incompatible with MySQL.

MySQL result:

```
mysql> select convert('4710072', DATEtime);
+------------------------------+
| convert('4710072', DATEtime) |
+------------------------------+
| 2047-10-07 02:00:00          |
+------------------------------+
1 row in set (0.00 sec)

mysql> select convert('4294967295 0:59:59', time);
+-------------------------------------+
| convert('4294967295 0:59:59', time) |
+-------------------------------------+
| 838:59:59                           |
+-------------------------------------+
1 row in set, 1 warning (0.00 sec)
```

### What is changed and how it works?

1. Support parse `YYMMDDH` format string.
2. Check the overflow of duration hours.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - Fixes the issue that the result of parse string to DATETIME/TIME incompatible with MySQL.
