### PR TITLE
ddl: speed up ddl test

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1405,7 +1405,7 @@ func (s *testIntegrationSuite5) TestPartitionAddPrimaryKey(c *C) {
 	testPartitionAddIndexOrPK(c, tk, "primary key")
 }
 
-func (s *testIntegrationSuite1) TestPartitionAddIndex(c *C) {
+func (s *testIntegrationSuite6) TestPartitionAddIndex(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	testPartitionAddIndexOrPK(c, tk, "index")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -69,6 +69,7 @@ var _ = Suite(&testDBSuite5{&testDBSuite{}})
 var _ = Suite(&testDBSuite6{&testDBSuite{}})
 var _ = Suite(&testDBSuite7{&testDBSuite{}})
 var _ = Suite(&testDBSuite8{&testDBSuite{}})
+var _ = Suite(&testDBSuite9{&testDBSuite{}})
 
 const defaultBatchSize = 1024
 
@@ -138,6 +139,7 @@ type testDBSuite5 struct{ *testDBSuite }
 type testDBSuite6 struct{ *testDBSuite }
 type testDBSuite7 struct{ *testDBSuite }
 type testDBSuite8 struct{ *testDBSuite }
+type testDBSuite9 struct{ *testDBSuite }
 
 func (s *testDBSuite4) TestAddIndexWithPK(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
@@ -237,7 +239,7 @@ func (s *testDBSuite7) TestAddPrimaryKeyRollback1(c *C) {
 }
 
 // TestAddPrimaryKeyRollback2 is used to test scenarios that will roll back when a null primary key is encountered.
-func (s *testDBSuite1) TestAddPrimaryKeyRollback2(c *C) {
+func (s *testDBSuite9) TestAddPrimaryKeyRollback2(c *C) {
 	hasNullValsInKey := true
 	idxName := "PRIMARY"
 	addIdxSQL := "alter table t1 add primary key c3_index (c3);"
@@ -357,7 +359,7 @@ func (s *testDBSuite5) TestCancelAddPrimaryKey(c *C) {
 	tk.MustExec("drop table t1")
 }
 
-func (s *testDBSuite7) TestCancelAddIndex(c *C) {
+func (s *testDBSuite9) TestCancelAddIndex(c *C) {
 	idxName := "c3_index "
 	addIdxSQL := "create unique index c3_index on t1 (c3)"
 	testCancelAddIndex(c, s.store, s.dom.DDL(), s.lease, idxName, addIdxSQL, "")
@@ -909,7 +911,7 @@ func (s *testDBSuite6) TestAddPrimaryKey2(c *C) {
 			      partition p4 values less than maxvalue)`, "primary")
 }
 
-func (s *testDBSuite6) TestAddPrimaryKey3(c *C) {
+func (s *testDBSuite9) TestAddPrimaryKey3(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, key(c1))
 			      partition by hash (c3) partitions 4;`, "primary")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -889,12 +889,12 @@ func (s *testDBSuite5) TestAddMultiColumnsIndex(c *C) {
 	s.tk.MustExec("alter table tidb.test add index idx1 (a, b);")
 	s.tk.MustExec("admin check table test")
 }
-func (s *testDBSuite1) TestAddPrimaryKey1(c *C) {
+func (s *testDBSuite6) TestAddPrimaryKey1(c *C) {
 	testAddIndex(c, s.store, s.lease, false,
 		"create table test_add_index (c1 bigint, c2 bigint, c3 bigint, unique key(c1))", "primary")
 }
 
-func (s *testDBSuite2) TestAddPrimaryKey2(c *C) {
+func (s *testDBSuite6) TestAddPrimaryKey2(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, key(c1))
 			      partition by range (c3) (
@@ -905,13 +905,13 @@ func (s *testDBSuite2) TestAddPrimaryKey2(c *C) {
 			      partition p4 values less than maxvalue)`, "primary")
 }
 
-func (s *testDBSuite3) TestAddPrimaryKey3(c *C) {
+func (s *testDBSuite6) TestAddPrimaryKey3(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, key(c1))
 			      partition by hash (c3) partitions 4;`, "primary")
 }
 
-func (s *testDBSuite4) TestAddPrimaryKey4(c *C) {
+func (s *testDBSuite6) TestAddPrimaryKey4(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, key(c1))
 			      partition by range columns (c3) (

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -67,6 +67,8 @@ var _ = Suite(&testDBSuite3{&testDBSuite{}})
 var _ = Suite(&testDBSuite4{&testDBSuite{}})
 var _ = Suite(&testDBSuite5{&testDBSuite{}})
 var _ = Suite(&testDBSuite6{&testDBSuite{}})
+var _ = Suite(&testDBSuite7{&testDBSuite{}})
+var _ = Suite(&testDBSuite8{&testDBSuite{}})
 
 const defaultBatchSize = 1024
 
@@ -224,7 +226,7 @@ func backgroundExec(s kv.Storage, sql string, done chan error) {
 }
 
 // TestAddPrimaryKeyRollback1 is used to test scenarios that will roll back when a duplicate primary key is encountered.
-func (s *testDBSuite5) TestAddPrimaryKeyRollback1(c *C) {
+func (s *testDBSuite7) TestAddPrimaryKeyRollback1(c *C) {
 	hasNullValsInKey := false
 	idxName := "PRIMARY"
 	addIdxSQL := "alter table t1 add primary key c3_index (c3);"
@@ -353,7 +355,7 @@ func (s *testDBSuite5) TestCancelAddPrimaryKey(c *C) {
 	tk.MustExec("drop table t1")
 }
 
-func (s *testDBSuite3) TestCancelAddIndex(c *C) {
+func (s *testDBSuite7) TestCancelAddIndex(c *C) {
 	idxName := "c3_index "
 	addIdxSQL := "create unique index c3_index on t1 (c3)"
 	testCancelAddIndex(c, s.store, s.dom.DDL(), s.lease, idxName, addIdxSQL, "")
@@ -911,7 +913,7 @@ func (s *testDBSuite6) TestAddPrimaryKey3(c *C) {
 			      partition by hash (c3) partitions 4;`, "primary")
 }
 
-func (s *testDBSuite6) TestAddPrimaryKey4(c *C) {
+func (s *testDBSuite7) TestAddPrimaryKey4(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, key(c1))
 			      partition by range columns (c3) (
@@ -927,7 +929,7 @@ func (s *testDBSuite1) TestAddIndex1(c *C) {
 		"create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))", "")
 }
 
-func (s *testDBSuite2) TestAddIndex2(c *C) {
+func (s *testDBSuite8) TestAddIndex2(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))
 			      partition by range (c1) (
@@ -944,7 +946,7 @@ func (s *testDBSuite3) TestAddIndex3(c *C) {
 			      partition by hash (c1) partitions 4;`, "")
 }
 
-func (s *testDBSuite4) TestAddIndex4(c *C) {
+func (s *testDBSuite8) TestAddIndex4(c *C) {
 	testAddIndex(c, s.store, s.lease, true,
 		`create table test_add_index (c1 bigint, c2 bigint, c3 bigint, primary key(c1))
 			      partition by range columns (c1) (
@@ -1541,7 +1543,7 @@ func (s *testDBSuite5) TestCreateIndexType(c *C) {
 	s.tk.MustExec(sql)
 }
 
-func (s *testDBSuite1) TestColumn(c *C) {
+func (s *testDBSuite8) TestColumn(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
 	s.tk.MustExec("create table t2 (c1 int, c2 int, c3 int)")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1413,7 +1413,7 @@ func checkDelRangeDone(c *C, ctx sessionctx.Context, idx table.Index) {
 	c.Assert(handles, HasLen, 0, Commentf("take time %v", time.Since(startTime)))
 }
 
-func (s *testDBSuite4) TestAlterPrimaryKey(c *C) {
+func (s *testDBSuite8) TestAlterPrimaryKey(c *C) {
 	s.tk = testkit.NewTestKitWithInit(c, s.store)
 	s.tk.MustExec("create table test_add_pk(a int, b int unsigned , c varchar(255) default 'abc', d int as (a+b), e int as (a+1) stored, index idx(b))")
 	defer s.tk.MustExec("drop table test_add_pk")
@@ -1771,7 +1771,7 @@ LOOP:
 // TestDropColumn is for inserting value with a to-be-dropped column when do drop column.
 // Column info from schema in build-insert-plan should be public only,
 // otherwise they will not be consist with Table.Col(), then the server will panic.
-func (s *testDBSuite2) TestDropColumn(c *C) {
+func (s *testDBSuite7) TestDropColumn(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("create database drop_col_db")
 	s.tk.MustExec("use drop_col_db")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -136,6 +136,8 @@ type testDBSuite3 struct{ *testDBSuite }
 type testDBSuite4 struct{ *testDBSuite }
 type testDBSuite5 struct{ *testDBSuite }
 type testDBSuite6 struct{ *testDBSuite }
+type testDBSuite7 struct{ *testDBSuite }
+type testDBSuite8 struct{ *testDBSuite }
 
 func (s *testDBSuite4) TestAddIndexWithPK(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -1413,7 +1413,7 @@ func checkDelRangeDone(c *C, ctx sessionctx.Context, idx table.Index) {
 	c.Assert(handles, HasLen, 0, Commentf("take time %v", time.Since(startTime)))
 }
 
-func (s *testDBSuite5) TestAlterPrimaryKey(c *C) {
+func (s *testDBSuite4) TestAlterPrimaryKey(c *C) {
 	s.tk = testkit.NewTestKitWithInit(c, s.store)
 	s.tk.MustExec("create table test_add_pk(a int, b int unsigned , c varchar(255) default 'abc', d int as (a+b), e int as (a+1) stored, index idx(b))")
 	defer s.tk.MustExec("drop table test_add_pk")
@@ -1547,7 +1547,7 @@ func (s *testDBSuite5) TestCreateIndexType(c *C) {
 	s.tk.MustExec(sql)
 }
 
-func (s *testDBSuite8) TestColumn(c *C) {
+func (s *testDBSuite4) TestColumn(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)
 	s.tk.MustExec("create table t2 (c1 int, c2 int, c3 int)")

--- a/docs/design/TEMPLATE.md
+++ b/docs/design/TEMPLATE.md
@@ -48,12 +48,17 @@ A discussion of alternate approaches and the trade-offs, advantages, and disadva
 - What is the impact of not doing this?
 -->
 
-## Compatibility
+## Compatibility and Mirgration Plan
 
 <!--
 A discussion of the change with regard to the compatibility issues:
 - Does this proposal make TiDB not compatible with the old versions?
+- If the existing behavior will be changed, how will we phase out the older behavior?
 - Does this proposal make TiDB more compatible with MySQL?
+- What is the impact(if any) on the data migration:
+    + from MySQL to TiDB
+    + from TiDB to MySQL
+    + from old TiDB cluster to new TiDB cluster
 -->
 
 ## Implementation
@@ -64,6 +69,14 @@ A detailed description for each step in the implementation:
 - Who will do it?
 - When to do it?
 - How long it takes to accomplish it?
+-->
+
+## Testing Plan
+
+<!--
+A brief description on how the implementation will be tested. Both integration test and unit test should consider the following things:
+- How to ensure that the implementation works as expected?
+- How will we know nothing broke?
 -->
 
 ## Open issues (if applicable)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
These days tidb unit test CI became slower since `ddl test` is the bottleneck.


### What is changed and how it works?
Make spent time for testSuite well-distributed.
![image](https://user-images.githubusercontent.com/5809588/73809715-0c856700-480f-11ea-894f-836b75c3fad9.png)
* `testIntegrationSuite1`  took long time (84s)with many slow tests ,moving some ones to  `testIntegrationSuite2~6` can speed up at least 40s
* `testDBSuite1~5` is full but `testDBSuite6` is nearly "empty", every suite can "give" about 10s to `testDBSuite6`

（The graph is plotted handly, I'm also working on building online service to monitor the distrubution.）
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test



