### PR TITLE
bindinfo: fix panic when load invalid sqls

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -305,11 +305,12 @@ func (h *BindHandle) GetAllBindRecord() (bindRecords []*BindMeta) {
 
 func (h *BindHandle) newBindMeta(record *BindRecord) (hash string, meta *BindMeta, err error) {
 	hash = parser.DigestNormalized(record.OriginalSQL)
+	meta = &BindMeta{BindRecord: record}
 	stmtNodes, _, err := h.bindInfo.parser.Parse(record.BindSQL, record.Charset, record.Collation)
 	if err != nil {
-		return "", nil, err
+		return hash, meta, err
 	}
-	meta = &BindMeta{BindRecord: record, Hint: CollectHint(stmtNodes[0])}
+	meta.Hint = CollectHint(stmtNodes[0])
 	return hash, meta, nil
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When sqls in the bind_info table is not valid, it will panic in `Update`.

### What is changed and how it works?

It panics in 
```
		hash, meta, err := h.newBindMeta(newBindRecord(row))
		// Update lastUpdateTime to the newest one.
		if meta.UpdateTime.Compare(h.lastUpdateTime) > 0 {
			h.lastUpdateTime = meta.UpdateTime
		}
```
The invalid sql would cause error in `newBindMeta`, and the `meta` is nil, so it cause panic in following lines. This PR does not fixes it by check err first because we need to update the `lastUpdateTime` to avoid fail in next `Update`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

Release note

 - fix panic when load invalid bind records into cache