### PR TITLE
executor: fix executor tests for TestFlushPrivilegesPanic and TestSortSpillDisk

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -34,8 +34,13 @@ import (
 )
 
 var _ = Suite(&testExecSuite{})
+var _ = Suite(&testExecSerialSuite{})
 
 type testExecSuite struct {
+}
+
+type testExecSerialSuite struct {
+
 }
 
 // mockSessionManager is a mocked session manager which is used for test.
@@ -240,7 +245,7 @@ func assertEqualStrings(c *C, got []field, expect []string) {
 	}
 }
 
-func (s *testExecSuite) TestSortSpillDisk(c *C) {
+func (s *testExecSerialSuite) TestSortSpillDisk(c *C) {
 	originCfg := config.GetGlobalConfig()
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 var _ = Suite(&testExecSuite{})
-var _ = Suite(&testExecSerialSuite{})
+var _ = SerialSuites(&testExecSerialSuite{})
 
 type testExecSuite struct {
 }

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -40,7 +40,6 @@ type testExecSuite struct {
 }
 
 type testExecSerialSuite struct {
-
 }
 
 // mockSessionManager is a mocked session manager which is used for test.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -114,7 +114,7 @@ var _ = Suite(&testPointGetSuite{})
 var _ = Suite(&testBatchPointGetSuite{})
 var _ = Suite(&testRecoverTable{})
 var _ = Suite(&testClusterReaderSuite{})
-var _ = Suite(&testFlushSuite{})
+var _ = SerialSuites(&testFlushSuite{})
 var _ = SerialSuites(&testAutoRandomSuite{&baseTestSuite{}})
 
 type testSuite struct{ *baseTestSuite }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix executor unit test

### What is changed and how it works?
some tests have side effect:
- test `testFlushSuite.TestFlushPrivilegesPanic` set `config.GetGlobalConfig().Security.SkipGrantTable` to true, thus cause a lot other test which depend on auth fail when run in parallel. 
- test `TestSortSpillDisk` change the global variable `MemQuotaQuery` to 1, thus will cause other test OOM.

By make theses tests suite as `serial`, we can make sure the side effect will not influent other tests.

close #14684 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
