### PR TITLE
util: use a simple pool to reduce column allocation overhead

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -469,6 +469,7 @@ func (a *ExecStmt) runPessimisticSelectForUpdate(ctx context.Context, e Executor
 	var err error
 	fields := rs.Fields()
 	req := rs.NewChunk()
+	a.Ctx.GetSessionVars().StmtCtx.RegisterChunk(req)
 	for {
 		err = rs.Next(ctx, req)
 		if err != nil {
@@ -482,7 +483,9 @@ func (a *ExecStmt) runPessimisticSelectForUpdate(ctx context.Context, e Executor
 		for r := iter.Begin(); r != iter.End(); r = iter.Next() {
 			rows = append(rows, r)
 		}
+
 		req = chunk.Renew(req, a.Ctx.GetSessionVars().MaxChunkSize)
+		a.Ctx.GetSessionVars().StmtCtx.RegisterChunk(req)
 	}
 	return nil, err
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -982,6 +982,7 @@ func init() {
 				row := r.GetDatumRow(retTypes(exec))
 				rows = append(rows, row)
 			}
+			sctx.GetSessionVars().StmtCtx.RegisterChunk(chk)
 			chk = chunk.Renew(chk, sctx.GetSessionVars().MaxChunkSize)
 		}
 	}
@@ -1419,6 +1420,9 @@ func (e *UnionExec) Close() error {
 // Before every execution, we must clear statement context.
 func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	vars := ctx.GetSessionVars()
+	if vars.StmtCtx != nil {
+		vars.StmtCtx.FreeChunks()
+	}
 	sc := &stmtctx.StatementContext{
 		TimeZone:    vars.Location(),
 		MemTracker:  memory.NewTracker(stringutil.MemoizeStr(s.Text), vars.MemQuotaQuery),

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -406,6 +406,7 @@ func (e *IndexNestedLoopHashJoin) newInnerWorker(taskCh chan *indexHashJoinTask,
 		joinKeyBuf:        make([]byte, 1),
 		outerRowStatus:    make([]outerRowStatusFlag, 0, e.maxChunkSize),
 	}
+	e.ctx.GetSessionVars().StmtCtx.RegisterChunk(iw.innerWorker.executorChk)
 	if e.lastColHelper != nil {
 		// nextCwf.TmpConstant needs to be reset for every individual
 		// inner worker to avoid data race when the inner workers is running

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -187,7 +187,9 @@ func (e *IndexLookUpMergeJoin) startWorkers(ctx context.Context) {
 	for i := 0; i < concurrency; i++ {
 		e.joinChkResourceCh[i] = make(chan *chunk.Chunk, numResChkHold)
 		for j := 0; j < numResChkHold; j++ {
-			e.joinChkResourceCh[i] <- chunk.NewChunkWithCapacity(e.retFieldTypes, e.maxChunkSize)
+			chk := chunk.NewChunkWithCapacity(e.retFieldTypes, e.maxChunkSize)
+			e.ctx.GetSessionVars().StmtCtx.RegisterChunk(chk)
+			e.joinChkResourceCh[i] <- chk
 		}
 	}
 	workerCtx, cancelFunc := context.WithCancel(ctx)

--- a/executor/join.go
+++ b/executor/join.go
@@ -244,6 +244,7 @@ func (e *HashJoinExec) fetchBuildSideRows(ctx context.Context, chkCh chan<- *chu
 			return
 		}
 		chk := chunk.NewChunkWithCapacity(e.buildSideExec.base().retFieldTypes, e.ctx.GetSessionVars().MaxChunkSize)
+		e.ctx.GetSessionVars().StmtCtx.RegisterChunk(chk)
 		err = Next(ctx, e.buildSideExec, chk)
 		if err != nil {
 			e.buildFinished <- errors.Trace(err)

--- a/executor/joiner.go
+++ b/executor/joiner.go
@@ -118,6 +118,7 @@ func newJoiner(ctx sessionctx.Context, joinType plannercore.JoinType,
 		}
 		base.initDefaultInner(innerColTypes, defaultInner)
 	}
+	sctx := ctx.GetSessionVars().StmtCtx
 	switch joinType {
 	case plannercore.SemiJoin:
 		base.shallowRow = chunk.MutRowFromTypes(colTypes)
@@ -133,12 +134,15 @@ func newJoiner(ctx sessionctx.Context, joinType plannercore.JoinType,
 		return &antiLeftOuterSemiJoiner{base}
 	case plannercore.LeftOuterJoin:
 		base.chk = chunk.NewChunkWithCapacity(colTypes, ctx.GetSessionVars().MaxChunkSize)
+		sctx.RegisterChunk(base.chk)
 		return &leftOuterJoiner{base}
 	case plannercore.RightOuterJoin:
 		base.chk = chunk.NewChunkWithCapacity(colTypes, ctx.GetSessionVars().MaxChunkSize)
+		sctx.RegisterChunk(base.chk)
 		return &rightOuterJoiner{base}
 	case plannercore.InnerJoin:
 		base.chk = chunk.NewChunkWithCapacity(colTypes, ctx.GetSessionVars().MaxChunkSize)
+		sctx.RegisterChunk(base.chk)
 		return &innerJoiner{base}
 	}
 	panic("unsupported join type in func newJoiner()")

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -166,6 +166,7 @@ func (e *TableReaderExecutor) Next(ctx context.Context, req *chunk.Chunk) error 
 	}
 
 	virCols := chunk.NewChunkWithCapacity(e.virtualColumnRetFieldTypes, req.Capacity())
+	e.ctx.GetSessionVars().StmtCtx.RegisterChunk(virCols)
 	iter := chunk.NewIterator4Chunk(req)
 
 	for i, idx := range e.virtualColumnIndex {

--- a/executor/update.go
+++ b/executor/update.go
@@ -202,6 +202,7 @@ func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
 		}
 		e.memTracker.Consume(types.EstimatedMemUsage(e.rows[firstRowIdx], globalRowIdx-firstRowIdx))
 		e.memTracker.Consume(types.EstimatedMemUsage(e.newRowsData[firstRowIdx], globalRowIdx-firstRowIdx))
+		e.ctx.GetSessionVars().StmtCtx.RegisterChunk(chk)
 		chk = chunk.Renew(chk, e.maxChunkSize)
 	}
 	return nil

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -539,6 +539,7 @@ func (p *MySQLPrivilege) loadTable(sctx sessionctx.Context, sql string,
 		// NOTE: decodeTableRow decodes data from a chunk Row, that is a shallow copy.
 		// The result will reference memory in the chunk, so the chunk must not be reused
 		// here, otherwise some werid bug will happen!
+		sctx.GetSessionVars().StmtCtx.RegisterChunk(req)
 		req = chunk.Renew(req, sctx.GetSessionVars().MaxChunkSize)
 	}
 }

--- a/session/session.go
+++ b/session/session.go
@@ -891,6 +891,7 @@ func drainRecordSet(ctx context.Context, se *session, rs sqlexec.RecordSet) ([]c
 		for r := iter.Begin(); r != iter.End(); r = iter.Next() {
 			rows = append(rows, r)
 		}
+		// se.GetSessionVars().StmtCtx.RegisterChunk(req)
 		req = chunk.Renew(req, se.sessionVars.MaxChunkSize)
 	}
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Use a simple pool to reduce the allocation overhead of `Chunk`.

| <tpcc performance>                          | terminals:2000 | terminals:1500 | terminals:1000 |    terminals:800 |
| --- | --- | --- | --- | --- |
|tag:baseline0              warehouses:1000 | 6) -+553 40453 | 6) -+593 40627 | 6) -+356 40616 | 6) -+395   40537 |
| tag:cache_point_get        warehouses:1000 | 4) -+620 40988 | 3) -+573 41790 | 3) -+662 42164 | 3) -+403   42158 |
tag:chunk-pool             warehouses:1000 | 7) -+542 43262 | 5) -+707 43434 | 3) -+323 43265 | 2) -+949   42657 |