### PR TITLE
rowcodec: make TypeYear's decodeDatum result consist with insert datum

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -196,6 +196,13 @@ func (s *testSuite8) TestInsertOnDuplicateKey(c *C) {
 	tk.MustExec(`insert into t1 set c1 = 0.1`)
 	tk.MustExec(`insert into t1 set c1 = 0.1 on duplicate key update c1 = 1`)
 	tk.MustQuery(`select * from t1 use index(primary)`).Check(testkit.Rows(`1.0000`))
+
+	tk.MustExec(`drop table if exists t1`)
+	tk.MustExec(`create table t1(c1 year null default '1970')`)
+	tk.MustExec(`insert into t1 set c1 = '2004'`)
+	tk.MustExec(`alter table t1 add index idx(c1)`)
+	tk.MustExec(`delete from t1`)
+	tk.MustExec(`admin check table t1`)
 }
 
 func (s *testSuite3) TestUpdateDuplicateKey(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -196,13 +196,58 @@ func (s *testSuite8) TestInsertOnDuplicateKey(c *C) {
 	tk.MustExec(`insert into t1 set c1 = 0.1`)
 	tk.MustExec(`insert into t1 set c1 = 0.1 on duplicate key update c1 = 1`)
 	tk.MustQuery(`select * from t1 use index(primary)`).Check(testkit.Rows(`1.0000`))
+}
 
-	tk.MustExec(`drop table if exists t1`)
-	tk.MustExec(`create table t1(c1 year null default '1970')`)
-	tk.MustExec(`insert into t1 set c1 = '2004'`)
-	tk.MustExec(`alter table t1 add index idx(c1)`)
-	tk.MustExec(`delete from t1`)
-	tk.MustExec(`admin check table t1`)
+func (s *testSuite3) TestInsertReorgDelete(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	inputs := []struct {
+		typ string
+		dat string
+	}{
+		{"year", "'2004'"},
+		{"year", "2004"},
+		{"bit", "1"},
+		{"smallint unsigned", "1"},
+		{"int unsigned", "1"},
+		{"smallint", "-1"},
+		{"int", "-1"},
+		{"decimal(6,4)", "'1.1'"},
+		{"decimal", "1.1"},
+		{"numeric", "-1"},
+		{"float", "1.2"},
+		{"double", "1.2"},
+		{"double", "1.3"},
+		{"real", "1.4"},
+		{"date", "'2020-01-01'"},
+		{"time", "'20:00:00'"},
+		{"datetime", "'2020-01-01 22:22:22'"},
+		{"timestamp", "'2020-01-01 22:22:22'"},
+		{"year", "'2020'"},
+		{"char(15)", "'test'"},
+		{"varchar(15)", "'test'"},
+		{"binary(3)", "'a'"},
+		{"varbinary(3)", "'b'"},
+		{"blob", "'test'"},
+		{"text", "'test'"},
+		{"enum('a', 'b')", "'a'"},
+		{"set('a', 'b')", "'a,b'"},
+	}
+
+	for _, i := range inputs {
+		tk.MustExec(`drop table if exists t1`)
+		tk.MustExec(fmt.Sprintf(`create table t1(c1 %s)`, i.typ))
+		tk.MustExec(fmt.Sprintf(`insert into t1 set c1 = %s`, i.dat))
+		switch i.typ {
+		case "blob", "text":
+			tk.MustExec(`alter table t1 add index idx(c1(3))`)
+		default:
+			tk.MustExec(`alter table t1 add index idx(c1)`)
+		}
+		tk.MustExec(`delete from t1`)
+		tk.MustExec(`admin check table t1`)
+	}
 }
 
 func (s *testSuite3) TestUpdateDuplicateKey(c *C) {

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -111,12 +111,14 @@ func (decoder *DatumMapDecoder) DecodeToDatumMap(rowData []byte, handle int64, r
 func (decoder *DatumMapDecoder) decodeColDatum(col *ColInfo, colData []byte) (types.Datum, error) {
 	var d types.Datum
 	switch byte(col.Tp) {
-	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny, mysql.TypeYear:
+	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny:
 		if mysql.HasUnsignedFlag(uint(col.Flag)) {
 			d.SetUint64(decodeUint(colData))
 		} else {
 			d.SetInt64(decodeInt(colData))
 		}
+	case mysql.TypeYear:
+		d.SetInt64(decodeInt(colData))
 	case mysql.TypeFloat:
 		_, fVal, err := codec.DecodeFloat(colData)
 		if err != nil {
@@ -248,12 +250,14 @@ func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, handle int64, chk *ch
 
 func (decoder *ChunkDecoder) decodeColToChunk(colIdx int, col *ColInfo, colData []byte, chk *chunk.Chunk) error {
 	switch byte(col.Tp) {
-	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny, mysql.TypeYear:
+	case mysql.TypeLonglong, mysql.TypeLong, mysql.TypeInt24, mysql.TypeShort, mysql.TypeTiny:
 		if mysql.HasUnsignedFlag(uint(col.Flag)) {
 			chk.AppendUint64(colIdx, decodeUint(colData))
 		} else {
 			chk.AppendInt64(colIdx, decodeInt(colData))
 		}
+	case mysql.TypeYear:
+		chk.AppendInt64(colIdx, decodeInt(colData))
 	case mysql.TypeFloat:
 		_, fVal, err := codec.DecodeFloat(colData)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

fix test case for 

```
	tk.MustExec(`drop table if exists t1`)
	tk.MustExec(`create table t1(c1 year null default '1970')`)
	tk.MustExec(`insert into t1 set c1 = '2004'`)
	tk.MustExec(`alter table t1 add index idx(c1)`)
	tk.MustExec(`delete from t1`)
	tk.MustExec(`admin check table t1`)
```
new row format doesn't encode data type into row data and always decode row data by table schema.

for mysql type `YEAR`, it must be unsigned, but for history reason, a year value in insert stmt will got a signed int datum and encode as signed int.

https://github.com/pingcap/tidb/blob/c46044f02651fa18b0d4654c22ae69e715a5fdd0/types/datum.go#L1232

new row-format lib try to fix it but when add index will fill the added index with wrong unsigned int value

### What is changed and how it works?

because insert type of TypeYear is definite int64, so we regardless of the unsigned flag always decode Year as signed int

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - impl

Side effects

 - n/a

Related changes

 - 4.0 only, no need cherry-pick 

Release note

 - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/14717)
<!-- Reviewable:end -->
