### PR TITLE
distsql: reduce memory allocation in TableHandlesToKVRanges

### DIFF
--- a/kv/key.go
+++ b/kv/key.go
@@ -57,6 +57,24 @@ func (k Key) PrefixNext() Key {
 	return buf
 }
 
+// PrefixNextWithBuffer like PrefixNext but use a buffer.
+func (k Key) PrefixNextWithBuffer(buf []byte) Key {
+	buf = buf[:len(k)]
+	copy(buf, []byte(k))
+	var i int
+	for i = len(k) - 1; i >= 0; i-- {
+		buf[i]++
+		if buf[i] != 0 {
+			break
+		}
+	}
+	if i == -1 {
+		copy(buf, k)
+		buf = append(buf, 0)
+	}
+	return buf
+}
+
 // Cmp returns the comparison result of two key.
 // The result will be 0 if a==b, -1 if a < b, and +1 if a > b.
 func (k Key) Cmp(another Key) int {

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -67,9 +67,23 @@ func EncodeRowKey(tableID int64, encodedHandle []byte) kv.Key {
 	return buf
 }
 
+// AppendRowKey encodes the table id and record handle into a kv.Key
+func AppendRowKey(buf []byte, tableID int64, encodedHandle []byte) kv.Key {
+	buf = appendTableRecordPrefix(buf, tableID)
+	buf = append(buf, encodedHandle...)
+	return buf
+}
+
 // EncodeRowKeyWithHandle encodes the table id, row handle into a kv.Key
 func EncodeRowKeyWithHandle(tableID int64, handle int64) kv.Key {
 	buf := make([]byte, 0, RecordRowKeyLen)
+	buf = appendTableRecordPrefix(buf, tableID)
+	buf = codec.EncodeInt(buf, handle)
+	return buf
+}
+
+// AppendRowKeyWithHandle encodes the table id, row handle into a kv.Key
+func AppendRowKeyWithHandle(buf []byte, tableID int64, handle int64) kv.Key {
 	buf = appendTableRecordPrefix(buf, tableID)
 	buf = codec.EncodeInt(buf, handle)
 	return buf


### PR DESCRIPTION
## master
```
BenchmarkTableHandlesToKVRanges-16          9711            118450 ns/op          139266 B/op       5121 allocs/op
```
## new
```
BenchmarkTableHandlesToKVRanges-16         23294             51724 ns/op           90112 B/op          2 allocs/op
```

## benchmark code
```go
func BenchmarkTableHandlesToKVRanges(b *testing.B) {
	rnd := rand.New(rand.NewSource(0xdeadbeef))
	intHandles := rnd.Perm(1024)
	handles := make([]int64, 0, len(intHandles))
	for _, h := range intHandles {
		handles = append(handles, int64(h))
	}
	b.ResetTimer()

	for n := 0; n < b.N; n++ {
		TableHandlesToKVRanges(114514, handles)
	}
}
```
