### PR TITLE
infoschema: add metrics_tables that contain all metrics tables definition

### DIFF
--- a/executor/cluster_reader_test.go
+++ b/executor/cluster_reader_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/util/pdapi"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
 	pmodel "github.com/prometheus/common/model"
 	"google.golang.org/grpc"
 )
@@ -85,15 +86,15 @@ func (s *testClusterReaderSuite) TestMetricTableData(c *C) {
 	rs, err := tk.Se.Execute(ctx, "select * from tidb_query_duration;")
 	c.Assert(err, IsNil)
 	result := tk.ResultSetToResultWithCtx(ctx, rs[0], Commentf("execute sql fail"))
-	result.Check(testkit.Rows(
-		"2019-12-23 20:11:35.000000 127.0.0.1:10080  0.9 0.1"))
+	result.Check(testutil.RowsWithSep("|",
+		"2019-12-23 20:11:35.000000|127.0.0.1:10080| 0.9|0.1|The quantile of TiDB query durations(second)"))
 
-	rs, err = tk.Se.Execute(ctx, "select * from tidb_query_duration where quantile in (0.85, 0.95);")
+	rs, err = tk.Se.Execute(ctx, "select time,instance,quantile,value from tidb_query_duration where quantile in (0.85, 0.95);")
 	c.Assert(err, IsNil)
 	result = tk.ResultSetToResultWithCtx(ctx, rs[0], Commentf("execute sql fail"))
 	result.Check(testkit.Rows(
-		"2019-12-23 20:11:35.000000 127.0.0.1:10080  0.85 0.1",
-		"2019-12-23 20:11:35.000000 127.0.0.1:10080  0.95 0.1"))
+		"2019-12-23 20:11:35.000000 127.0.0.1:10080 0.85 0.1",
+		"2019-12-23 20:11:35.000000 127.0.0.1:10080 0.95 0.1"))
 }
 
 func (s *testClusterReaderSuite) TestTiDBClusterConfig(c *C) {

--- a/executor/metric_reader.go
+++ b/executor/metric_reader.go
@@ -77,7 +77,7 @@ func (e *MetricRetriever) retrieve(ctx context.Context, sctx sessionctx.Context)
 		if err != nil {
 			return nil, err
 		}
-		partRows := e.genRows(queryValue, queryRange, quantile)
+		partRows := e.genRows(queryValue, quantile)
 		totalRows = append(totalRows, partRows...)
 	}
 	return totalRows, nil
@@ -128,7 +128,7 @@ func (e *MetricRetriever) getQueryRange(sctx sessionctx.Context) promQLQueryRang
 	return promQLQueryRange{Start: startTime, End: endTime, Step: step}
 }
 
-func (e *MetricRetriever) genRows(value pmodel.Value, r promQLQueryRange, quantile float64) [][]types.Datum {
+func (e *MetricRetriever) genRows(value pmodel.Value, quantile float64) [][]types.Datum {
 	var rows [][]types.Datum
 	switch value.Type() {
 	case pmodel.ValMatrix:

--- a/executor/metric_reader.go
+++ b/executor/metric_reader.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -134,7 +135,7 @@ func (e *MetricRetriever) genRows(value pmodel.Value, r promQLQueryRange, quanti
 		matrix := value.(pmodel.Matrix)
 		for _, m := range matrix {
 			for _, v := range m.Values {
-				record := e.genRecord(m.Metric, v, r, quantile)
+				record := e.genRecord(m.Metric, v, quantile)
 				rows = append(rows, record)
 			}
 		}
@@ -142,7 +143,7 @@ func (e *MetricRetriever) genRows(value pmodel.Value, r promQLQueryRange, quanti
 	return rows
 }
 
-func (e *MetricRetriever) genRecord(metric pmodel.Metric, pair pmodel.SamplePair, r promQLQueryRange, quantile float64) []types.Datum {
+func (e *MetricRetriever) genRecord(metric pmodel.Metric, pair pmodel.SamplePair, quantile float64) []types.Datum {
 	record := make([]types.Datum, 0, 2+len(e.tblDef.Labels)+1)
 	// Record order should keep same with genColumnInfos.
 	record = append(record, types.NewTimeDatum(types.NewTime(
@@ -168,6 +169,7 @@ func (e *MetricRetriever) genRecord(metric pmodel.Metric, pair pmodel.SamplePair
 	} else {
 		record = append(record, types.NewFloat64Datum(float64(pair.Value)))
 	}
+	record = append(record, types.NewStringDatum(e.tblDef.Comment))
 	return record
 }
 
@@ -216,7 +218,13 @@ func (e *MetricSummaryRetriever) retrieve(ctx context.Context, sctx sessionctx.C
 	}
 	startTime := e.extractor.StartTime.Format(plannercore.MetricTableTimeFormat)
 	endTime := e.extractor.EndTime.Format(plannercore.MetricTableTimeFormat)
-	for name, def := range infoschema.MetricTableMap {
+	tables := make([]string, 0, len(infoschema.MetricTableMap))
+	for name := range infoschema.MetricTableMap {
+		tables = append(tables, name)
+	}
+	sort.Strings(tables)
+	for _, name := range tables {
+		def := infoschema.MetricTableMap[name]
 		sqls := e.genMetricQuerySQLS(name, startTime, endTime, def.Quantile, quantiles)
 		for _, sql := range sqls {
 			rows, _, err := sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(sql)
@@ -233,12 +241,12 @@ func (e *MetricSummaryRetriever) retrieve(ctx context.Context, sctx sessionctx.C
 
 func (e *MetricSummaryRetriever) genMetricQuerySQLS(name, startTime, endTime string, quantile float64, quantiles []float64) []string {
 	if quantile == 0 {
-		sql := fmt.Sprintf(`select "%s",min(time),sum(value),avg(value),min(value),max(value) from metric_schema.%s where time > '%s' and time < '%s'`, name, name, startTime, endTime)
+		sql := fmt.Sprintf(`select "%s",min(time),sum(value),avg(value),min(value),max(value),comment from metric_schema.%s where time > '%s' and time < '%s'`, name, name, startTime, endTime)
 		return []string{sql}
 	}
 	sqls := []string{}
 	for _, quantile := range quantiles {
-		sql := fmt.Sprintf(`select "%s_%v",min(time),sum(value),avg(value),min(value),max(value) from metric_schema.%s where time > '%s' and time < '%s' and quantile=%v`, name, quantile, name, startTime, endTime, quantile)
+		sql := fmt.Sprintf(`select "%s_%v",min(time),sum(value),avg(value),min(value),max(value),comment from metric_schema.%s where time > '%s' and time < '%s' and quantile=%v`, name, quantile, name, startTime, endTime, quantile)
 		sqls = append(sqls, sql)
 	}
 	return sqls
@@ -265,7 +273,13 @@ func (e *MetricSummaryByLabelRetriever) retrieve(ctx context.Context, sctx sessi
 	}
 	startTime := e.extractor.StartTime.Format(plannercore.MetricTableTimeFormat)
 	endTime := e.extractor.EndTime.Format(plannercore.MetricTableTimeFormat)
-	for name, def := range infoschema.MetricTableMap {
+	tables := make([]string, 0, len(infoschema.MetricTableMap))
+	for name := range infoschema.MetricTableMap {
+		tables = append(tables, name)
+	}
+	sort.Strings(tables)
+	for _, name := range tables {
+		def := infoschema.MetricTableMap[name]
 		sqls := e.genMetricQuerySQLS(name, startTime, endTime, quantiles, def)
 		for _, sql := range sqls {
 			rows, _, err := sctx.(sqlexec.RestrictedSQLExecutor).ExecRestrictedSQL(sql)
@@ -294,10 +308,10 @@ func (e *MetricSummaryByLabelRetriever) genMetricQuerySQLS(name, startTime, endT
 	for _, quantile := range quantiles {
 		var sql string
 		if quantile == 0 {
-			sql = fmt.Sprintf(`select "%[1]s", %[2]s as label,min(time),sum(value),avg(value),min(value),max(value) from metric_schema.%[1]s where time > '%[3]s' and time < '%[4]s'`,
+			sql = fmt.Sprintf(`select "%[1]s", %[2]s as label,min(time),sum(value),avg(value),min(value),max(value),comment from metric_schema.%[1]s where time > '%[3]s' and time < '%[4]s'`,
 				name, labelsColumn, startTime, endTime)
 		} else {
-			sql = fmt.Sprintf(`select "%[1]s_%[5]v", %[2]s as label,min(time),sum(value),avg(value),min(value),max(value) from metric_schema.%[1]s where time > '%[3]s' and time < '%[4]s' and quantile=%[5]v`,
+			sql = fmt.Sprintf(`select "%[1]s_%[5]v", %[2]s as label,min(time),sum(value),avg(value),min(value),max(value),comment from metric_schema.%[1]s where time > '%[3]s' and time < '%[4]s' and quantile=%[5]v`,
 				name, labelsColumn, startTime, endTime, quantile)
 		}
 		if len(def.Labels) > 0 {

--- a/infoschema/metric_schema.go
+++ b/infoschema/metric_schema.go
@@ -94,6 +94,7 @@ func (def *MetricTableDef) genColumnInfos() []columnInfo {
 		cols = append(cols, columnInfo{"quantile", mysql.TypeDouble, 22, 0, defaultValue, nil})
 	}
 	cols = append(cols, columnInfo{"value", mysql.TypeDouble, 22, 0, nil, nil})
+	cols = append(cols, columnInfo{"comment", mysql.TypeVarchar, 256, 0, nil, nil})
 	return cols
 }
 

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1150,7 +1150,9 @@ var tableMetricSummaryCols = []columnInfo{
 	{"AVG_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"MIN_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"MAX_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
+	{"COMMENT", mysql.TypeVarchar, 256, 0, nil, nil},
 }
+
 var tableMetricSummaryByLabelCols = []columnInfo{
 	{"METRIC_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"LABEL", mysql.TypeVarchar, 64, 0, nil, nil},
@@ -1159,6 +1161,7 @@ var tableMetricSummaryByLabelCols = []columnInfo{
 	{"AVG_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"MIN_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"MAX_VALUE", mysql.TypeDouble, 22, 0, nil, nil},
+	{"COMMENT", mysql.TypeVarchar, 256, 0, nil, nil},
 }
 
 func dataForSchemata(ctx sessionctx.Context, schemas []*model.DBInfo) [][]types.Datum {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -108,6 +108,8 @@ const (
 	TableInspectionResult = "INSPECTION_RESULT"
 	// TableMetricSummary is a summary table that contains all metrics.
 	TableMetricSummary = "METRIC_SUMMARY"
+	// TableMetricTables is a table that contains all metrics table definition.
+	TableMetricTables = "METRICS_TABLES"
 )
 
 var tableIDMap = map[string]int64{
@@ -163,6 +165,7 @@ var tableIDMap = map[string]int64{
 	TableClusterSystemInfo:                  autoid.InformationSchemaDBID + 50,
 	TableInspectionResult:                   autoid.InformationSchemaDBID + 51,
 	TableMetricSummary:                      autoid.InformationSchemaDBID + 52,
+	TableMetricTables:                       autoid.InformationSchemaDBID + 54,
 }
 
 type columnInfo struct {
@@ -1126,6 +1129,15 @@ var tableInspectionResultCols = []columnInfo{
 	{"REFERENCE", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"SEVERITY", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"DETAILS", mysql.TypeVarchar, 256, 0, nil, nil},
+}
+
+var tableMetricTablesCols = []columnInfo{
+	{"METRIC_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"PROMQL", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"GENERATE_PROMQL", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"LABEL", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"QUANTILE", mysql.TypeDouble, 22, 0, nil, nil},
+	{"COMMENT", mysql.TypeVarchar, 256, 0, nil, nil},
 }
 
 var tableMetricSummaryCols = []columnInfo{
@@ -2297,6 +2309,30 @@ func dataForTableTiFlashReplica(schemas []*model.DBInfo) [][]types.Datum {
 	return rows
 }
 
+// dataForTableTiFlashReplica constructs data for table tiflash replica info.
+func dataForMetricTables(ctx sessionctx.Context) [][]types.Datum {
+	var rows [][]types.Datum
+	tables := make([]string, 0, len(MetricTableMap))
+	for name := range MetricTableMap {
+		tables = append(tables, name)
+	}
+	sort.Strings(tables)
+	for _, name := range tables {
+		schema := MetricTableMap[name]
+		genPromQL := schema.GenPromQL(ctx, nil, schema.Quantile)
+		record := types.MakeDatums(
+			name,                             // METRIC_NAME
+			schema.PromQL,                    // PROMQL
+			genPromQL,                        // GENERATE_PROMQL
+			strings.Join(schema.Labels, ","), //LABEL
+			schema.Quantile,                  // QUANTILE
+			schema.Comment,                   // COMMENT
+		)
+		rows = append(rows, record)
+	}
+	return rows
+}
+
 var tableNameToColumns = map[string][]columnInfo{
 	tableSchemata:                           schemataCols,
 	tableTables:                             tablesCols,
@@ -2347,6 +2383,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableClusterSystemInfo:                  tableClusterSystemInfoCols,
 	TableInspectionResult:                   tableInspectionResultCols,
 	TableMetricSummary:                      tableMetricSummaryCols,
+	TableMetricTables:                       tableMetricTablesCols,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, meta *model.TableInfo) (table.Table, error) {
@@ -2456,6 +2493,8 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows, err = dataForTiDBClusterInfo(ctx)
 	case tableTiFlashReplica:
 		fullRows = dataForTableTiFlashReplica(dbs)
+	case TableMetricTables:
+		fullRows = dataForMetricTables(ctx)
 	// Data for cluster memory table.
 	case clusterTableSlowLog, clusterTableProcesslist:
 		fullRows, err = getClusterMemTableRows(ctx, it.meta.Name.O)

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -2323,7 +2323,7 @@ func dataForTableTiFlashReplica(schemas []*model.DBInfo) [][]types.Datum {
 	return rows
 }
 
-// dataForTableTiFlashReplica constructs data for table tiflash replica info.
+// dataForTableTiFlashReplica constructs data for all metric table definition.
 func dataForMetricTables(ctx sessionctx.Context) [][]types.Datum {
 	var rows [][]types.Datum
 	tables := make([]string, 0, len(MetricTableMap))

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -2336,7 +2336,7 @@ func dataForMetricTables(ctx sessionctx.Context) [][]types.Datum {
 		record := types.MakeDatums(
 			name,                             // METRIC_NAME
 			schema.PromQL,                    // PROMQL
-			strings.Join(schema.Labels, ","), // LABEL
+			strings.Join(schema.Labels, ","), // LABELS
 			schema.Quantile,                  // QUANTILE
 			schema.Comment,                   // COMMENT
 		)

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1135,10 +1135,9 @@ var tableInspectionResultCols = []columnInfo{
 }
 
 var tableMetricTablesCols = []columnInfo{
-	{"METRIC_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"TABLE_NAME", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"PROMQL", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"GENERATE_PROMQL", mysql.TypeVarchar, 64, 0, nil, nil},
-	{"LABEL", mysql.TypeVarchar, 64, 0, nil, nil},
+	{"LABELS", mysql.TypeVarchar, 64, 0, nil, nil},
 	{"QUANTILE", mysql.TypeDouble, 22, 0, nil, nil},
 	{"COMMENT", mysql.TypeVarchar, 256, 0, nil, nil},
 }
@@ -2334,12 +2333,10 @@ func dataForMetricTables(ctx sessionctx.Context) [][]types.Datum {
 	sort.Strings(tables)
 	for _, name := range tables {
 		schema := MetricTableMap[name]
-		genPromQL := schema.GenPromQL(ctx, nil, schema.Quantile)
 		record := types.MakeDatums(
 			name,                             // METRIC_NAME
 			schema.PromQL,                    // PROMQL
-			genPromQL,                        // GENERATE_PROMQL
-			strings.Join(schema.Labels, ","), //LABEL
+			strings.Join(schema.Labels, ","), // LABEL
 			schema.Quantile,                  // QUANTILE
 			schema.Comment,                   // COMMENT
 		)

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -979,8 +979,8 @@ func (s *testClusterTableSuite) TestForMetricTables(c *C) {
 	statistics.ClearHistoryJobs()
 	tk.MustExec("use information_schema")
 	tk.MustQuery("select count(*) > 0 from `METRICS_TABLES`").Check(testkit.Rows("1"))
-	tk.MustQuery("select * from `METRICS_TABLES` where metric_name='tidb_qps'").
-		Check(testutil.RowsWithSep("|", "tidb_qps|sum(rate(tidb_server_query_total{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (result,type,instance)|sum(rate(tidb_server_query_total{}[60s])) by (result,type,instance)|instance,type,result|0|TiDB query processing numbers per second"))
+	tk.MustQuery("select * from `METRICS_TABLES` where table_name='tidb_qps'").
+		Check(testutil.RowsWithSep("|", "tidb_qps|sum(rate(tidb_server_query_total{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (result,type,instance)|instance,type,result|0|TiDB query processing numbers per second"))
 }
 
 func (s *testClusterTableSuite) TestForClusterServerInfo(c *C) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -974,6 +974,15 @@ func (s *testTableSuite) TestForTableTiFlashReplica(c *C) {
 	tk.MustQuery("select TABLE_SCHEMA,TABLE_NAME,REPLICA_COUNT,LOCATION_LABELS,AVAILABLE from information_schema.tiflash_replica").Check(testkit.Rows("test t 2 a,b 1"))
 }
 
+func (s *testClusterTableSuite) TestForMetricTables(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	statistics.ClearHistoryJobs()
+	tk.MustExec("use information_schema")
+	tk.MustQuery("select count(*) > 0 from `METRICS_TABLES`").Check(testkit.Rows("1"))
+	tk.MustQuery("select * from `METRICS_TABLES` where metric_name='tidb_qps'").
+		Check(testutil.RowsWithSep("|", "tidb_qps|sum(rate(tidb_server_query_total{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (result,type,instance)|sum(rate(tidb_server_query_total{}[60s])) by (result,type,instance)|instance,type,result|0|TiDB query processing numbers per second"))
+}
+
 func (s *testClusterTableSuite) TestForClusterServerInfo(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	instances := []string{


### PR DESCRIPTION

Signed-off-by: crazycs <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
* Add `information_schema.metrics_tables` that contain all metrics tables definition.
* Add `comment` column in all metrics tables to explain the metric meaning.
```sql
> select * from `METRICS_TABLES` limit 2\G
***************************[ 1. row ]***************************
METRIC_NAME     | abnormal_stores
PROMQL          | sum(pd_cluster_status{ type=~"store_disconnected_count|store_unhealth_count|store_low_space_count|store_down_count|store_offline_count|store_tombstone_count"})
GENERATE_PROMQL | sum(pd_cluster_status{ type=~"store_disconnected_count|store_unhealth_count|store_low_space_count|store_down_count|store_offline_count|store_tombstone_count"})
LABEL           | instance,type
QUANTILE        | 0.0
COMMENT         |
***************************[ 2. row ]***************************
METRIC_NAME     | connection_count
PROMQL          | tidb_server_connections{$LABEL_CONDITIONS}
GENERATE_PROMQL | tidb_server_connections{}
LABEL           | instance
QUANTILE        | 0.0
COMMENT         | TiDB current connection counts

> select `METRIC_NAME`, `AVG_VALUE`,`COMMENT` from `METRICS_SUMMARY_BY_LABEL` limit 3;
+-------------------------------+-------------------+-----------------------------------------------------------------------+
| METRIC_NAME                   | AVG_VALUE         | COMMENT                                                               |
+-------------------------------+-------------------+-----------------------------------------------------------------------+
| etcd_disk_wal_fsync_rate      | 120.598140046     | The rate of writing WAL into the persistent storage                   |
| etcd_wal_fsync_duration_0.999 |   0.0202235687646 | The quantile time consumed of writing WAL into the persistent storage |
| go_gc_count                   |   0.0799993200264 | The Go garbage collection counts per second                           |
+-------------------------------+-------------------+-----------------------------------------------------------------------+
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change
