### PR TITLE
types: fix decimal tests failed

### DIFF
--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -21,8 +21,13 @@ import (
 )
 
 var _ = Suite(&testMyDecimalSuite{})
+var _ = SerialSuites(&testMyDecimalSerialSuite{})
 
 type testMyDecimalSuite struct {
+}
+
+// testMyDecimalSerialSuite hold test cases that must run in serial
+type testMyDecimalSerialSuite struct {
 }
 
 func (s *testMyDecimalSuite) TestFromInt(c *C) {
@@ -254,7 +259,8 @@ func (s *testMyDecimalSuite) TestRemoveTrailingZeros(c *C) {
 	}
 }
 
-func (s *testMyDecimalSuite) TestShift(c *C) {
+// this test will change global variable `wordBufLen`, so it must run in serial
+func (s *testMyDecimalSerialSuite) TestShift(c *C) {
 	type tcase struct {
 		input  string
 		shift  int
@@ -472,7 +478,8 @@ func (s *testMyDecimalSuite) TestRoundWithCeil(c *C) {
 	}
 }
 
-func (s *testMyDecimalSuite) TestFromString(c *C) {
+// this test will change global variable `wordBufLen`, so it must run in serial
+func (s *testMyDecimalSerialSuite) TestFromString(c *C) {
 	type tcase struct {
 		input  string
 		output string


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix occasional tests failed for package type

### What is changed and how it works?
move test `TestShift ` and `TestFromString` to serial suite because the will change global variable `wordBufLen` thus cause parse decimal failed when run in parallel.

close #14612, close #14706 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code
