### PR TITLE
server: introduce a safe mode for the server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ var (
 	CheckTableBeforeDrop = false
 	// checkBeforeDropLDFlag is a go build flag.
 	checkBeforeDropLDFlag = "None"
+	SafeMode              = atomic.NewBool(false)
 )
 
 // Config contains configuration options.
@@ -653,6 +654,9 @@ func StoreGlobalConfig(config *Config) {
 
 // ReloadGlobalConfig reloads global configuration for this server.
 func ReloadGlobalConfig() error {
+	if SafeMode.Load() {
+		return errors.New("cannot reload config in safe mode")
+	}
 	confReloadLock.Lock()
 	defer confReloadLock.Unlock()
 

--- a/server/conn.go
+++ b/server/conn.go
@@ -297,27 +297,7 @@ func (cc *clientConn) getSessionVarsWaitTimeout(ctx context.Context) uint64 {
 }
 
 func (cc *clientConn) setSafeModeSessionVars() error {
-	vars := cc.ctx.GetSessionVars()
-	names := []string{
-		variable.TiDBChecksumTableConcurrency,
-		variable.TiDBBuildStatsConcurrency,
-		variable.TiDBDistSQLScanConcurrency,
-		variable.TiDBIndexLookupConcurrency,
-		variable.TiDBIndexLookupJoinConcurrency,
-		variable.TiDBIndexSerialScanConcurrency,
-		variable.TiDBHashJoinConcurrency,
-		variable.TiDBProjectionConcurrency,
-		variable.TiDBHashAggPartialConcurrency,
-		variable.TiDBHashAggFinalConcurrency,
-		variable.TiDBWindowConcurrency,
-	}
-	for _, v := range names {
-		err := variable.SetSessionSystemVar(vars, v, types.NewUintDatum(1))
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+	return variable.SetSessionSystemVar(cc.ctx.GetSessionVars(), variable.TiDBDistSQLScanConcurrency, types.NewIntDatum(1))
 }
 
 type handshakeResponse41 struct {

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -363,7 +363,7 @@ func (ts *ConnTestSuite) testGetSessionVarsWaitTimeout(c *C) {
 	c.Assert(cc.getSessionVarsWaitTimeout(context.Background()), Equals, 28800)
 }
 
-func (ts *ConnTestSuite) TestSafeMode(c *C) {
+func (ts *ConnTestSuite) TestSafeModeSysVars(c *C) {
 	c.Parallel()
 	se, err := session.CreateSession4Test(ts.store)
 	c.Assert(err, IsNil)
@@ -379,16 +379,7 @@ func (ts *ConnTestSuite) TestSafeMode(c *C) {
 		ctx: tc,
 	}
 	c.Assert(cc.setSafeModeSessionVars(), IsNil)
-	conVars := se.GetSessionVars().Concurrency
-	c.Assert(conVars.DistSQLScanConcurrency == 1, IsTrue)
-	c.Assert(conVars.HashAggFinalConcurrency == 1, IsTrue)
-	c.Assert(conVars.HashAggPartialConcurrency == 1, IsTrue)
-	c.Assert(conVars.DistSQLScanConcurrency == 1, IsTrue)
-	c.Assert(conVars.IndexLookupConcurrency == 1, IsTrue)
-	c.Assert(conVars.IndexLookupJoinConcurrency == 1, IsTrue)
-	c.Assert(conVars.IndexSerialScanConcurrency == 1, IsTrue)
-	c.Assert(conVars.ProjectionConcurrency == 1, IsTrue)
-	c.Assert(conVars.WindowConcurrency == 1, IsTrue)
+	c.Assert(se.GetSessionVars().Concurrency.DistSQLScanConcurrency == 1, IsTrue)
 }
 
 func mapIdentical(m1, m2 map[string]string) bool {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -535,20 +535,9 @@ func setSafeModeConfig() {
 	if cfg.Store != "mocktikv" {
 		cfg.RunDDL = false
 	}
-	cfg.TokenLimit = 1
-	cfg.EnableStreaming = false
-	cfg.EnableBatchDML = false
-	cfg.AlterPrimaryKey = false
-	cfg.EnableTableLock = false
-	cfg.TxnLocalLatches.Enabled = false
-	cfg.Performance.RunAutoAnalyze = false
-	cfg.Performance.CrossJoin = false
-	cfg.Performance.FeedbackProbability = 0
 	cfg.Performance.ForcePriority = "HIGH_PRIORITY"
 	cfg.Performance.TxnTotalSizeLimit = config.DefTxnTotalSizeLimit
-	cfg.PreparedPlanCache.Enabled = false
 	cfg.TiKVClient.GrpcConnectionCount = 1
-	cfg.TiKVClient.StoreLimit = 1
 }
 
 func setGlobalVars() {

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/config"
 )
 
 var isCoverageServer = "0"
@@ -29,6 +30,29 @@ func TestRunMain(t *testing.T) {
 	}
 }
 
+var _ = Suite(&testMainSuite{})
+
+type testMainSuite struct{}
+
 func TestT(t *testing.T) {
 	TestingT(t)
+}
+
+func (t *testMainSuite) TestSafeMode(c *C) {
+	cfg = config.GetGlobalConfig()
+	setSafeModeConfig()
+	c.Assert(cfg.TokenLimit == 1, IsTrue)
+	c.Assert(cfg.EnableStreaming, IsFalse)
+	c.Assert(cfg.EnableBatchDML, IsFalse)
+	c.Assert(cfg.AlterPrimaryKey, IsFalse)
+	c.Assert(cfg.EnableTableLock, IsFalse)
+	c.Assert(cfg.TxnLocalLatches.Enabled, IsFalse)
+	c.Assert(cfg.Performance.RunAutoAnalyze, IsFalse)
+	c.Assert(cfg.Performance.CrossJoin, IsFalse)
+	c.Assert(cfg.Performance.FeedbackProbability == 0, IsTrue)
+	c.Assert(cfg.Performance.ForcePriority == "HIGH_PRIORITY", IsTrue)
+	c.Assert(cfg.Performance.TxnTotalSizeLimit == config.DefTxnTotalSizeLimit, IsTrue)
+	c.Assert(cfg.PreparedPlanCache.Enabled, IsFalse)
+	c.Assert(cfg.TiKVClient.GrpcConnectionCount == 1, IsTrue)
+	c.Assert(cfg.TiKVClient.StoreLimit == 1, IsTrue)
 }

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -38,21 +38,10 @@ func TestT(t *testing.T) {
 	TestingT(t)
 }
 
-func (t *testMainSuite) TestSafeMode(c *C) {
+func (t *testMainSuite) TestSafeModeCfg(c *C) {
 	cfg = config.GetGlobalConfig()
 	setSafeModeConfig()
-	c.Assert(cfg.TokenLimit == 1, IsTrue)
-	c.Assert(cfg.EnableStreaming, IsFalse)
-	c.Assert(cfg.EnableBatchDML, IsFalse)
-	c.Assert(cfg.AlterPrimaryKey, IsFalse)
-	c.Assert(cfg.EnableTableLock, IsFalse)
-	c.Assert(cfg.TxnLocalLatches.Enabled, IsFalse)
-	c.Assert(cfg.Performance.RunAutoAnalyze, IsFalse)
-	c.Assert(cfg.Performance.CrossJoin, IsFalse)
-	c.Assert(cfg.Performance.FeedbackProbability == 0, IsTrue)
 	c.Assert(cfg.Performance.ForcePriority == "HIGH_PRIORITY", IsTrue)
 	c.Assert(cfg.Performance.TxnTotalSizeLimit == config.DefTxnTotalSizeLimit, IsTrue)
-	c.Assert(cfg.PreparedPlanCache.Enabled, IsFalse)
 	c.Assert(cfg.TiKVClient.GrpcConnectionCount == 1, IsTrue)
-	c.Assert(cfg.TiKVClient.StoreLimit == 1, IsTrue)
 }


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
DBAs often use a separate TiDB to perform some routine maintenance tasks. But due to some mistakes, often write SQL that has a great impact on the cluster.

### What is changed and how it works?
Introduce a safe mode for the server. `./tidb-server -safe-mode` will limit resource usage automatically.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
1. `./tidb-server -safe-mode`
1. Connect to TiDB
1. Check the variable e.g. `tidb-config`, and some concurrent variables.

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch