### PR TITLE
*: add a configuration entry to control if new collations are enabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -110,7 +110,9 @@ type Config struct {
 	IsolationRead IsolationRead `toml:"isolation-read" json:"isolation-read"`
 	// MaxServerConnections is the maximum permitted number of simultaneous client connections.
 	MaxServerConnections uint32 `toml:"max-server-connections" json:"max-server-connections"`
-
+	// NewCollationsEnabledOnFirstBootstrap indicates if the new collations are enabled, it effects only when a TiDB cluster bootstrapped on the first time.
+	NewCollationsEnabledOnFirstBootstrap bool `toml:"new_collations_enabled_on_first_bootstrap" json:"new_collations_enabled_on_first_bootstrap"`
+	// Experimental contains parameters for experimental features.
 	Experimental Experimental `toml:"experimental" json:"experimental"`
 }
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -90,6 +90,9 @@ repair-table-list = []
 # The maximum permitted number of simultaneous client connections.
 max-server-connections = 4096
 
+# Whether new collations are enabled, as indicated by its name, this configuration entry take effect ONLY when a TiDB cluster bootstraps for the first time.
+new_collations_enabled_on_first_bootstrap = false
+
 [log]
 # Log level: debug, info, warn, error, fatal.
 level = "info"

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -325,6 +325,8 @@ const (
 	// The variable name in mysql.tidb table and it will be used when we want to know
 	// system timezone.
 	tidbSystemTZ = "system_tz"
+
+	tidbNewCollationEnabled = "new_collation_enabled"
 	// Const for TiDB server version 2.
 	version2  = 2
 	version3  = 3
@@ -353,7 +355,7 @@ const (
 	version26 = 26
 	version27 = 27
 	version28 = 28
-	version29 = 29
+	// version29 is not needed.
 	version30 = 30
 	version31 = 31
 	version32 = 32
@@ -364,6 +366,9 @@ const (
 	version37 = 37
 	version38 = 38
 	version39 = 39
+	// version40 is the version that introduce new collation in TiDB,
+	// see https://github.com/pingcap/tidb/pull/14574 for more details.
+	version40 = 40
 )
 
 func checkBootstrapped(s Session) (bool, error) {
@@ -578,6 +583,10 @@ func upgrade(s Session) {
 
 	if ver < version39 {
 		upgradeToVer39(s)
+	}
+
+	if ver < version40 {
+		upgradeToVer40(s)
 	}
 
 	updateBootstrapVer(s)
@@ -928,6 +937,18 @@ func upgradeToVer39(s Session) {
 	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET File_priv='Y' where Super_priv='Y'")
 }
 
+func writeNewCollationParameter(s Session, flag bool) {
+	comment := "If the new collations are enabled. Do not edit it."
+	sql := fmt.Sprintf(`INSERT HIGH_PRIORITY INTO %s.%s VALUES ("%s", %v, '%s') ON DUPLICATE KEY UPDATE VARIABLE_VALUE=%v`,
+		mysql.SystemDB, mysql.TiDBTable, tidbNewCollationEnabled, flag, comment, flag)
+	mustExecute(s, sql)
+}
+
+func upgradeToVer40(s Session) {
+	// There is no way to enable new collation for an existing TiDB cluster.
+	writeNewCollationParameter(s, false)
+}
+
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.
 func updateBootstrapVer(s Session) {
 	// Update bootstrap version.
@@ -1032,6 +1053,9 @@ func doDMLWorks(s Session) {
 	mustExecute(s, sql)
 
 	writeSystemTZ(s)
+
+	writeNewCollationParameter(s, config.GetGlobalConfig().NewCollationsEnabledOnFirstBootstrap)
+
 	_, err := s.Execute(context.Background(), "COMMIT")
 	if err != nil {
 		sleepTime := 1 * time.Second

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -325,7 +325,7 @@ const (
 	// The variable name in mysql.tidb table and it will be used when we want to know
 	// system timezone.
 	tidbSystemTZ = "system_tz"
-
+	// The variable name in mysql.tidb table and it will indicate if the new collations are enabled in the TiDB cluster.
 	tidbNewCollationEnabled = "new_collation_enabled"
 	// Const for TiDB server version 2.
 	version2  = 2

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -260,6 +260,15 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	ver, err = getBootstrapVersion(se2)
 	c.Assert(err, IsNil)
 	c.Assert(ver, Equals, int64(currentBootstrapVersion))
+
+	// Verify that 'new_collation_enabled' is false.
+	r = mustExecSQL(c, se2, fmt.Sprintf(`SELECT VARIABLE_VALUE from mysql.TiDB where VARIABLE_NAME='%s';`, tidbNewCollationEnabled))
+	req = r.NewChunk()
+	err = r.Next(ctx, req)
+	c.Assert(err, IsNil)
+	c.Assert(req.NumRows(), Equals, 1)
+	c.Assert(req.GetRow(0).GetString(0), Equals, "0")
+	c.Assert(r.Close(), IsNil)
 }
 
 func (s *testBootstrapSuite) TestANSISQLMode(c *C) {

--- a/session/session.go
+++ b/session/session.go
@@ -63,6 +63,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tidb/util/logutil"
@@ -1559,12 +1560,34 @@ func CreateSession(store kv.Storage) (Session, error) {
 
 // loadSystemTZ loads systemTZ from mysql.tidb
 func loadSystemTZ(se *session) (string, error) {
-	sql := `select variable_value from mysql.tidb where variable_name = 'system_tz'`
+	return loadParameter(se, "system_tz")
+}
+
+// loadCollationParameter loads collation parameter from mysql.tidb
+func loadCollationParameter(se *session) (bool, error) {
+	para, err := loadParameter(se, tidbNewCollationEnabled)
+	if err != nil {
+		return false, err
+	}
+	if para == "true" {
+		return true, nil
+	} else if para == "false" {
+		return false, nil
+	}
+	logutil.BgLogger().Error(
+		"Unexpected value of 'new_collation_enabled' in 'mysql.tidb', use 'false' instead",
+		zap.String("value", para))
+	return false, nil
+}
+
+// loadParameter loads read-only parameter from mysql.tidb
+func loadParameter(se *session, name string) (string, error) {
+	sql := "select variable_value from mysql.tidb where variable_name = '" + name + "'"
 	rss, errLoad := se.Execute(context.Background(), sql)
 	if errLoad != nil {
 		return "", errLoad
 	}
-	// the record of mysql.tidb under where condition: variable_name = "system_tz" should shall only be one.
+	// the record of mysql.tidb under where condition: variable_name = $name should shall only be one.
 	defer func() {
 		if err := rss[0].Close(); err != nil {
 			logutil.BgLogger().Error("close result set error", zap.Error(err))
@@ -1610,8 +1633,15 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	timeutil.SetSystemTZ(tz)
+
+	// get the flag from `mysql`.`tidb` which indicating if new collations are enabled.
+	newCollationEnabled, err := loadCollationParameter(se)
+	if err != nil {
+		return nil, err
+	}
+	collate.SetNewCollationEnabled(newCollationEnabled)
+
 	dom := domain.GetDomain(se)
 	dom.InitExpensiveQueryHandle()
 
@@ -1747,7 +1777,7 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = version39
+	currentBootstrapVersion = version40
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {

--- a/util/collate/collate.go
+++ b/util/collate/collate.go
@@ -15,11 +15,14 @@ package collate
 
 import (
 	"strings"
+	"sync"
 )
 
 var (
-	collatorMap   map[string]Collator
-	collatorIDMap map[int]Collator
+	collatorMap         map[string]Collator
+	collatorIDMap       map[int]Collator
+	newCollationEnabled bool
+	setCollationOnce    sync.Once
 )
 
 // CollatorOption is the option of collator.
@@ -34,6 +37,18 @@ type Collator interface {
 	Compare(a, b string, opt CollatorOption) int
 	// Key returns the collate key for str.
 	Key(str string, opt CollatorOption) []byte
+}
+
+// SetNewCollationEnabled sets if the new collation are enabled.
+func SetNewCollationEnabled(flag bool) {
+	setCollationOnce.Do(func() {
+		newCollationEnabled = flag
+	})
+}
+
+// NewCollationEnabled returns if the new collations are enabled.
+func NewCollationEnabled() bool {
+	return newCollationEnabled
 }
 
 // GetCollator get the collator according to collate, it will return the binary collator if the corresponding collator doesn't exist.

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -24,11 +24,17 @@ func TestT(t *testing.T) {
 	TestingT(t)
 }
 
-var _ = Suite(&testBinCollatorSuite{})
-var _ = Suite(&testGeneralCICollatorSuite{})
-var _ = Suite(&testGetCollatorSuite{})
+var (
+	_ = Suite(&testBinCollatorSuite{})
+	_ = Suite(&testCollateSuite{})
+	_ = Suite(&testGeneralCICollatorSuite{})
+	_ = Suite(&testGetCollatorSuite{})
+)
 
 type testBinCollatorSuite struct {
+}
+
+type testCollateSuite struct {
 }
 
 type testGeneralCICollatorSuite struct {
@@ -101,6 +107,14 @@ func (s *testBinCollatorSuite) TestGeneralCICollator(c *C) {
 	}
 	testCompareTable(compareTable, "utf8mb4_general_ci", c)
 	testKeyTable(keyTable, "utf8mb4_general_ci", c)
+}
+
+func (s *testCollateSuite) TestSetNewCollateEnabled(c *C) {
+	SetNewCollationEnabled(false)
+	c.Assert(NewCollationEnabled(), Equals, false)
+	// It can be set only once.
+	SetNewCollationEnabled(true)
+	c.Assert(NewCollationEnabled(), Equals, false)
 }
 
 func (s *testGetCollatorSuite) TestGetCollator(c *C) {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR tries to close #14686 

According to the design in #14574:

> Only TiDB clusters that initially bootstrapped with the new TiDB version are allowed to enable the new collations. For old TiDB clusters, everything remains unchanged after the upgrade.
> 
> We can also provide a configuration entry for the users to choose between old/new collations when deploying the new clusters.

This PR is the implementation of it.

### What is changed and how it works?
Configuration entry `new_collations_enabled_on_first_bootstrap` is
added, which determines if the new collations can be enabled when a
TiDB cluster is initialized for the first time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has exported function/method change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Increased code complexity

Related changes

 - Need to update the documentation
 - Need to update the `tidb-ansible` repository

Release note

 - Add new configuration entry `new_collations_enabled_on_first_bootstrap`, which determines if the new collations can be enabled when a TiDB cluster is initialized for the first time.
