### PR TITLE
executor: fix admin show ddl jobs end time bug when job is not finished

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -485,7 +485,11 @@ func (e *ShowDDLJobsExec) appendJobToChunk(req *chunk.Chunk, job *model.Job) {
 	req.AppendInt64(6, job.TableID)
 	req.AppendInt64(7, job.RowCount)
 	req.AppendString(8, model.TSConvert2Time(job.StartTS).String())
-	req.AppendString(9, model.TSConvert2Time(finishTS).String())
+	if finishTS > 0 {
+		req.AppendString(9, model.TSConvert2Time(finishTS).String())
+	} else {
+		req.AppendString(9, "")
+	}
 	req.AppendString(10, job.State.String())
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -478,6 +478,7 @@ func (s *testSuiteP2) TestAdminShowDDLJobs(c *C) {
 	re = tk.MustQuery("admin show ddl jobs 1 where job_type='create table'")
 	row = re.Rows()[0]
 	c.Assert(row[1], Equals, "test_admin_show_ddl_jobs")
+	c.Assert(row[9], Equals, "")
 }
 
 func (s *testSuiteP2) TestAdminChecksumOfPartitionedTable(c *C) {


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

When DDL job doesn't finish, the `END_TIME` should be `''` instead of `1970-01-01 08:00:00 +0800 CST`.

Before this PR:

```sql
> admin show ddl jobs;
+--------+---------+------------+-----------+----------------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
| JOB_ID | DB_NAME | TABLE_NAME | JOB_TYPE  | SCHEMA_STATE         | SCHEMA_ID | TABLE_ID | ROW_COUNT | START_TIME                        | END_TIME                          | STATE   |
+--------+---------+------------+-----------+----------------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
| 57     | test    | t          | add index | write reorganization | 1         | 51       | 0         | 2020-02-12 11:07:01.817 +0800 CST | 1970-01-01 08:00:00 +0800 CST     | running |
| 58     | test    | t          | add index | none                 | 1         | 51       | 0         | 2020-02-12 11:07:02.972 +0800 CST | 1970-01-01 08:00:00 +0800 CST     | none    |
+--------+---------+------------+-----------+----------------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
```

This PR:

```sql
+--------+---------+------------+-----------+--------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
| JOB_ID | DB_NAME | TABLE_NAME | JOB_TYPE  | SCHEMA_STATE | SCHEMA_ID | TABLE_ID | ROW_COUNT | START_TIME                        | END_TIME                          | STATE   |
+--------+---------+------------+-----------+--------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
| 59     | test    | t          | add index | delete only  | 1         | 51       | 0         | 2020-02-12 11:08:48.919 +0800 CST |                                   | running |
| 60     | test    | t          | add index | none         | 1         | 51       | 0         | 2020-02-12 11:08:49.919 +0800 CST |                                   | none    |
+--------+---------+------------+-----------+--------------+-----------+----------+-----------+-----------------------------------+-----------------------------------+---------+
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test 

Code changes

 - Has exported function/method change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the `END_TIME` of  `admin show ddl jobs` bug, when the DDL job not finish, the `END_TIME` should be `""`.
