### PR TITLE
util: introduce thread local pool

### DIFF
--- a/util/localpool/localpool.go
+++ b/util/localpool/localpool.go
@@ -1,0 +1,64 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package localpool
+
+import (
+	"runtime"
+	_ "unsafe" // required by go:linkname
+)
+
+// LocalPool is an thread local object pool.
+// It's similar to sync.Pool but has some difference
+// - It can define the size of the pool.
+// - It never get GCed.
+type LocalPool struct {
+	sizePerProc int
+	slots       []*slot
+	newFn       func() interface{}
+	resetFn     func(obj interface{})
+}
+
+type slot struct {
+	objs    []interface{}
+	getHit  int
+	getMiss int
+	putHit  int
+	putMiss int
+}
+
+// NewLocalPool creates a pool.
+// The sizePerProc is pool size for each PROC, so total pool size is (GOMAXPROCS * sizePerProc)
+// It can only be used when the GOMAXPROCS never change after the pool created.
+// newFn is the function to create a new object.
+// resetFn is the function called before put back to the pool, it can be nil.
+func NewLocalPool(sizePerProc int, newFn func() interface{}, resetFn func(obj interface{})) *LocalPool {
+	slots := make([]*slot, runtime.GOMAXPROCS(0))
+	for i := 0; i < len(slots); i++ {
+		slots[i] = &slot{
+			objs: make([]interface{}, 0, sizePerProc),
+		}
+	}
+	return &LocalPool{
+		sizePerProc: sizePerProc,
+		slots:       slots,
+		newFn:       newFn,
+		resetFn:     resetFn,
+	}
+}
+
+//go:linkname procPin runtime.procPin
+func procPin() int
+
+//go:linkname procUnpin runtime.procUnpin
+func procUnpin() int

--- a/util/localpool/localpool_norace.go
+++ b/util/localpool/localpool_norace.go
@@ -1,0 +1,58 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !race
+
+package localpool
+
+// Get gets an object from the pool.
+func (p *LocalPool) Get() interface{} {
+	pid := procPin()
+	slot := p.slots[pid]
+	objLen := len(slot.objs)
+	var result interface{}
+	if objLen > 0 {
+		lastIdx := objLen - 1
+		result = slot.objs[lastIdx]
+		slot.objs[lastIdx] = nil
+		slot.objs = slot.objs[:lastIdx]
+		slot.getHit++
+	} else {
+		slot.getMiss++
+	}
+	procUnpin()
+	if result == nil {
+		result = p.newFn()
+	}
+	return result
+}
+
+// Put puts an object back to the pool.
+// It returns true if the pool is not full and the obj is successfully put into the pool.
+func (p *LocalPool) Put(obj interface{}) bool {
+	if p.resetFn != nil {
+		p.resetFn(obj)
+	}
+	var ok bool
+	pid := procPin()
+	slot := p.slots[pid]
+	if len(slot.objs) < p.sizePerProc {
+		slot.objs = append(slot.objs, obj)
+		slot.putHit++
+		ok = true
+	} else {
+		slot.putMiss++
+	}
+	procUnpin()
+	return ok
+}

--- a/util/localpool/localpool_race.go
+++ b/util/localpool/localpool_race.go
@@ -1,0 +1,26 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build race
+
+package localpool
+
+// Get gets an object from the pool.
+func (p *LocalPool) Get() interface{} {
+	return p.newFn()
+}
+
+// Put puts an object back to the pool.
+func (p *LocalPool) Put(obj interface{}) bool {
+	return false
+}

--- a/util/localpool/localpool_test.go
+++ b/util/localpool/localpool_test.go
@@ -1,0 +1,79 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build !race
+
+package localpool
+
+import (
+	"fmt"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+type Obj struct {
+	val int64
+}
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testPoolSuite{})
+
+type testPoolSuite struct {
+}
+
+func (s *testPoolSuite) TestPool(c *C) {
+	numWorkers := runtime.GOMAXPROCS(0)
+	wg := new(sync.WaitGroup)
+	wg.Add(numWorkers)
+	pool := NewLocalPool(16, func() interface{} {
+		return new(Obj)
+	}, nil)
+	n := 1000
+	for i := 0; i < numWorkers; i++ {
+		go func() {
+			for j := 0; j < n; j++ {
+				GetAndPut(pool)
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	var getHit, getMiss, putHit, putMiss int
+	for _, slot := range pool.slots {
+		fmt.Println(slot.getHit, slot.getMiss, slot.putHit, slot.putMiss)
+		getHit += slot.getHit
+		getMiss += slot.getMiss
+		putHit += slot.putHit
+		putMiss += slot.putMiss
+	}
+	c.Assert(getHit, Greater, getMiss)
+	c.Assert(putHit, Greater, putMiss)
+}
+
+func GetAndPut(pool *LocalPool) {
+	objs := make([]interface{}, rand.Intn(4)+1)
+	for i := 0; i < len(objs); i++ {
+		objs[i] = pool.Get()
+	}
+	runtime.Gosched()
+	for _, obj := range objs {
+		pool.Put(obj)
+	}
+}


### PR DESCRIPTION
Cherry-pick https://github.com/pingcap/tidb/pull/14647

Implement a thread local pool that is similar to sync.Pool but has some difference:
- It contains multiple local objects instead of one.
- It doesn't have any lock.
- It never get GCed.