### PR TITLE
tikv: reuse worker goroutine to reduce stack grow overhead.

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -550,7 +550,7 @@ func (it *copIterator) open(ctx context.Context) {
 
 			replicaReadSeed: it.replicaReadSeed,
 		}
-		go worker.run(ctx)
+		poolGo(func() { worker.run(ctx) })
 	}
 	taskSender := &copIteratorTaskSender{
 		taskCh:   taskCh,


### PR DESCRIPTION
This commit is just to check whether there will be performance improvements. 

For a more complete implementation, we can let each session have its own set of workers. This can solve the problems of reuse and concurrency control at the same time, and it looks more elegant than a global pool.