### PR TITLE
ddl: ensure BLOB or TEXT index length is not zero

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -428,14 +428,16 @@ func (s *testIntegrationSuite5) TestMySQLErrorCode(c *C) {
 	tk.MustGetErrCode(sql, mysql.ErrWrongAutoKey)
 	sql = "create table t2 (id int auto_increment, a int key);"
 	tk.MustGetErrCode(sql, mysql.ErrWrongAutoKey)
-	sql = "create table t2 (a datetime(2) default current_timestamp(3))"
+	sql = "create table t2 (a datetime(2) default current_timestamp(3));"
 	tk.MustGetErrCode(sql, mysql.ErrInvalidDefault)
-	sql = "create table t2 (a datetime(2) default current_timestamp(2) on update current_timestamp)"
+	sql = "create table t2 (a datetime(2) default current_timestamp(2) on update current_timestamp);"
 	tk.MustGetErrCode(sql, mysql.ErrInvalidOnUpdate)
-	sql = "create table t2 (a datetime default current_timestamp on update current_timestamp(2))"
+	sql = "create table t2 (a datetime default current_timestamp on update current_timestamp(2));"
 	tk.MustGetErrCode(sql, mysql.ErrInvalidOnUpdate)
-	sql = "create table t2 (a datetime(2) default current_timestamp(2) on update current_timestamp(3))"
+	sql = "create table t2 (a datetime(2) default current_timestamp(2) on update current_timestamp(3));"
 	tk.MustGetErrCode(sql, mysql.ErrInvalidOnUpdate)
+	sql = "create table t(a blob(10), index(a(0)));"
+	tk.MustGetErrCode(sql, mysql.ErrKeyPart0)
 
 	sql = "create table t2 (id int primary key , age int);"
 	tk.MustExec(sql)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -438,6 +438,8 @@ func (s *testIntegrationSuite5) TestMySQLErrorCode(c *C) {
 	tk.MustGetErrCode(sql, mysql.ErrInvalidOnUpdate)
 	sql = "create table t(a blob(10), index(a(0)));"
 	tk.MustGetErrCode(sql, mysql.ErrKeyPart0)
+	sql = "create table t(a char(10), index(a(0)));"
+	tk.MustGetErrCode(sql, mysql.ErrKeyPart0)
 
 	sql = "create table t2 (id int primary key , age int);"
 	tk.MustExec(sql)

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -96,6 +96,7 @@ var (
 	errUnsupportedCharset        = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "charset %s and collate %s"))
 	errUnsupportedShardRowIDBits = terror.ClassDDL.New(mysql.ErrUnsupportedDDLOperation, fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation], "shard_row_id_bits for table with primary key as row id"))
 	errBlobKeyWithoutLength      = terror.ClassDDL.New(mysql.ErrBlobKeyWithoutLength, mysql.MySQLErrName[mysql.ErrBlobKeyWithoutLength])
+	errKeyPart0                  = terror.ClassDDL.New(mysql.ErrKeyPart0, mysql.MySQLErrName[mysql.ErrKeyPart0])
 	errIncorrectPrefixKey        = terror.ClassDDL.New(mysql.ErrWrongSubKey, mysql.MySQLErrName[mysql.ErrWrongSubKey])
 	errTooLongKey                = terror.ClassDDL.New(mysql.ErrTooLongKey,
 		fmt.Sprintf(mysql.MySQLErrName[mysql.ErrTooLongKey], maxPrefixLength))

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -140,9 +140,14 @@ func checkIndexColumn(col *model.ColumnInfo, ic *ast.IndexPartSpecification) err
 		return errors.Trace(errJSONUsedAsKey.GenWithStackByArgs(col.Name.O))
 	}
 
-	// Length must be specified for BLOB and TEXT column indexes.
-	if types.IsTypeBlob(col.FieldType.Tp) && ic.Length == types.UnspecifiedLength {
-		return errors.Trace(errBlobKeyWithoutLength.GenWithStackByArgs(col.Name.O))
+	// Length must be specified and non-zero for BLOB and TEXT column indexes.
+	if types.IsTypeBlob(col.FieldType.Tp) {
+		if ic.Length == types.UnspecifiedLength {
+			return errors.Trace(errBlobKeyWithoutLength.GenWithStackByArgs(col.Name.O))
+		}
+		if ic.Length == types.ErrorLength {
+			return errors.Trace(errKeyPart0.GenWithStackByArgs(col.Name.O))
+		}
 	}
 
 	// Length can only be specified for specifiable types.

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -157,8 +157,14 @@ func checkIndexColumn(col *model.ColumnInfo, ic *ast.IndexPartSpecification) err
 
 	// Key length must be shorter or equal to the column length.
 	if ic.Length != types.UnspecifiedLength &&
-		types.IsTypeChar(col.FieldType.Tp) && col.Flen < ic.Length {
-		return errors.Trace(errIncorrectPrefixKey)
+		types.IsTypeChar(col.FieldType.Tp) {
+		if col.Flen < ic.Length {
+			return errors.Trace(errIncorrectPrefixKey)
+		}
+		// Length must be non-zero for char.
+		if ic.Length == types.ErrorLength {
+			return errors.Trace(errKeyPart0.GenWithStackByArgs(col.Name.O))
+		}
 	}
 
 	// Specified length must be shorter than the max length for prefix.

--- a/types/field_type.go
+++ b/types/field_type.go
@@ -24,9 +24,10 @@ import (
 )
 
 // UnspecifiedLength is unspecified length.
-const (
-	UnspecifiedLength = -1
-)
+const UnspecifiedLength = -1
+
+// ErrorLength is error length for blob or text.
+const ErrorLength = 0
 
 // FieldType records field type information.
 type FieldType = ast.FieldType


### PR DESCRIPTION
Signed-off-by: Rustin-Liu <rustin.liu@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
solve #11049

### What is changed and how it works?

Add non-zero condition.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

None

Side effects

None

Related changes

None

Release note

None