### PR TITLE
planner: avoiding panic during cascades for partitioned tables (#14346)

### DIFF
--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -103,5 +103,11 @@
       "select a from (select a from t where b > 2 order by a, b limit 3 offset 1) as t1 order by a limit 2 offset 1",
       "select * from (select * from t order by a limit 3) as t1 order by a, b limit 5"
     ]
+  },
+  {
+    "name": "TestCascadePlannerHashedPartTable",
+    "cases": [
+      "select * from pt1"
+    ]
   }
 ]

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -874,5 +874,18 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestCascadePlannerHashedPartTable",
+    "Cases": [
+      {
+        "SQL": "select * from pt1",
+        "Plan": [
+          "TableReader_5 10000.00 root data:TableFullScan_6",
+          "└─TableFullScan_6 10000.00 cop[tikv] table:pt1, keep order:false, stats:pseudo"
+        ],
+        "Result": null
+      }
+    ]
   }
 ]

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -142,6 +142,9 @@ func (ds *DataSource) initStats() {
 	if ds.tableStats != nil {
 		return
 	}
+	if ds.statisticTable == nil {
+		ds.statisticTable = getStatsTable(ds.ctx, ds.tableInfo, ds.table.Meta().ID)
+	}
 	tableStats := &property.StatsInfo{
 		RowCount:     float64(ds.statisticTable.Count),
 		Cardinality:  make(map[int64]float64, ds.schema.Len()),


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
https://github.com/pingcap/tidb/issues/14346,
handled panic scenario, due to nil reference.

### What is changed and how it works?
When cascades is set, table stats were never assigned during query execution path for partitioned tables. This led to panic for that query.
To resolve, looked at other scenario how the value is assigned to it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - assigned value to an empty field

Side effects

 - Possible performance regression -- Don't have numbers
 - Increased code complexity - No
 - Breaking backward compatibility - No

Related changes

 - Need to cherry-pick to the release branch - Not sure
 - Need to update the documentation - Not required
 - Need to update the `tidb-ansible` repository - No

Release note

 - fixed[#14346]
