### PR TITLE
executor: start workers in Next instead of Open for IndexMergeReader

### DIFF
--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -684,9 +684,10 @@ func (s *seqTestSuite) TestIndexMergeReaderClose(c *C) {
 	tk.MustExec("create index idx1 on t(a)")
 	tk.MustExec("create index idx2 on t(b)")
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/startPartialIndexWorkerErr", "return"), IsNil)
-	_, err := tk.Exec("select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where a > 10 or b < 100")
+	err := tk.QueryToErr("select /*+ USE_INDEX_MERGE(t, idx1, idx2) */ * from t where a > 10 or b < 100")
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/startPartialIndexWorkerErr"), IsNil)
 	c.Assert(err, NotNil)
+	c.Check(checkGoroutineExists("fetchLoop"), IsFalse)
 	c.Check(checkGoroutineExists("fetchHandles"), IsFalse)
 	c.Check(checkGoroutineExists("waitPartialWorkersAndCloseFetchChan"), IsFalse)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #14336 

### What is changed and how it works?


Start workers in Next instead of Open

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

Side effects

Related changes

Release note
