### PR TITLE
test: fix data race in TestDisableTxnAutoRetry

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2679,7 +2679,6 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 	disableLatchCfg.TxnLocalLatches.Enabled = false
 	config.StoreGlobalConfig(&disableLatchCfg)
 	defer config.StoreGlobalConfig(orgCfg)
-	config.GetGlobalConfig().TxnLocalLatches.Enabled = false
 	tk1.MustExec("begin")
 	tk1.MustExec("update no_retry set id = 9")
 


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/14811
Data race found in `TestDisableTxnAutoRetry`.

### What is changed and how it works?
Fix it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Related changes

 - Need to cherry-pick to the release branch