### PR TITLE
config: reload tikv/tidb cluster tls for every new established conn

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -258,38 +258,47 @@ func (e *ErrConfigValidationFailed) Error() string {
 }
 
 // ToTLSConfig generates tls's config based on security section of the config.
-func (s *Security) ToTLSConfig() (*tls.Config, error) {
-	var tlsConfig *tls.Config
+func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 	if len(s.ClusterSSLCA) != 0 {
-		var certificates = make([]tls.Certificate, 0)
-		if len(s.ClusterSSLCert) != 0 && len(s.ClusterSSLKey) != 0 {
-			// Load the client certificates from disk
-			certificate, err := tls.LoadX509KeyPair(s.ClusterSSLCert, s.ClusterSSLKey)
-			if err != nil {
-				return nil, errors.Errorf("could not load client key pair: %s", err)
-			}
-			certificates = append(certificates, certificate)
-		}
-
-		// Create a certificate pool from the certificate authority
 		certPool := x509.NewCertPool()
-		ca, err := ioutil.ReadFile(s.ClusterSSLCA)
+		// Create a certificate pool from the certificate authority
+		var ca []byte
+		ca, err = ioutil.ReadFile(s.ClusterSSLCA)
 		if err != nil {
-			return nil, errors.Errorf("could not read ca certificate: %s", err)
+			err = errors.Errorf("could not read ca certificate: %s", err)
+			return
 		}
-
 		// Append the certificates from the CA
 		if !certPool.AppendCertsFromPEM(ca) {
-			return nil, errors.New("failed to append ca certs")
+			err = errors.New("failed to append ca certs")
+			return
+		}
+		tlsConfig = &tls.Config{
+			RootCAs: certPool,
 		}
 
-		tlsConfig = &tls.Config{
-			Certificates: certificates,
-			RootCAs:      certPool,
+		if len(s.ClusterSSLCert) != 0 && len(s.ClusterSSLKey) != 0 {
+			getCert := func() (*tls.Certificate, error) {
+				// Load the client certificates from disk
+				cert, err := tls.LoadX509KeyPair(s.ClusterSSLCert, s.ClusterSSLKey)
+				if err != nil {
+					return nil, errors.Errorf("could not load client key pair: %s", err)
+				}
+				return &cert, nil
+			}
+			// pre-test cert's loading.
+			if _, err = getCert(); err != nil {
+				return
+			}
+			tlsConfig.GetClientCertificate = func(info *tls.CertificateRequestInfo) (certificate *tls.Certificate, err error) {
+				return getCert()
+			}
+			tlsConfig.GetCertificate = func(info *tls.ClientHelloInfo) (certificate *tls.Certificate, err error) {
+				return getCert()
+			}
 		}
 	}
-
-	return tlsConfig, nil
+	return
 }
 
 // Status is the status section of the config.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

support reload cluster TLS cert/key file used by TiKV or TiDB-self(CA still can not be hot-reload now)

pd's cert/key will be handled by new pdclient

### What is changed and how it works?

reload TLS for every new connection(include grpc auto retry in resetTransport) like [etcd](https://github.com/etcd-io/etcd/pull/7829/files#diff-49da67db64ea3c7dc7da8e0d779b54fbR180)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test 

Code changes

 -  change conf way

Side effects

 - n/a

Related changes

 - n/a

Release note

 - reload tikv/tidb cluster tls for every new established conn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/14833)
<!-- Reviewable:end -->
