### PR TITLE
executor: fix the potential goroutine leak in cluster log retriever

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -114,7 +114,7 @@ var _ = Suite(&testUpdateSuite{})
 var _ = Suite(&testPointGetSuite{})
 var _ = Suite(&testBatchPointGetSuite{})
 var _ = Suite(&testRecoverTable{})
-var _ = Suite(&testClusterReaderSuite{})
+var _ = Suite(&testMemTableReaderSuite{})
 var _ = SerialSuites(&testFlushSuite{})
 var _ = SerialSuites(&testAutoRandomSuite{&baseTestSuite{}})
 

--- a/executor/memtable_reader_test.go
+++ b/executor/memtable_reader_test.go
@@ -41,24 +41,24 @@ import (
 	"google.golang.org/grpc"
 )
 
-type testClusterReaderSuite struct {
+type testMemTableReaderSuite struct {
 	store kv.Storage
 	dom   *domain.Domain
 }
 
-func (s *testClusterReaderSuite) SetUpSuite(c *C) {
+func (s *testMemTableReaderSuite) SetUpSuite(c *C) {
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 	s.store = store
 	s.dom = dom
 }
 
-func (s *testClusterReaderSuite) TearDownSuite(c *C) {
+func (s *testMemTableReaderSuite) TearDownSuite(c *C) {
 	s.dom.Close()
 	s.store.Close()
 }
 
-func (s *testClusterReaderSuite) TestMetricTableData(c *C) {
+func (s *testMemTableReaderSuite) TestMetricTableData(c *C) {
 	fpName := "github.com/pingcap/tidb/executor/mockMetricsPromData"
 	c.Assert(failpoint.Enable(fpName, "return"), IsNil)
 	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
@@ -117,7 +117,7 @@ func (s *testClusterReaderSuite) TestMetricTableData(c *C) {
 	}
 }
 
-func (s *testClusterReaderSuite) TestTiDBClusterConfig(c *C) {
+func (s *testMemTableReaderSuite) TestTiDBClusterConfig(c *C) {
 	// mock PD http server
 	router := mux.NewRouter()
 
@@ -413,12 +413,12 @@ func (s *testClusterReaderSuite) TestTiDBClusterConfig(c *C) {
 	}
 }
 
-func (s *testClusterReaderSuite) writeTmpFile(c *C, dir, filename string, lines []string) {
+func (s *testMemTableReaderSuite) writeTmpFile(c *C, dir, filename string, lines []string) {
 	err := ioutil.WriteFile(filepath.Join(dir, filename), []byte(strings.Join(lines, "\n")), os.ModePerm)
 	c.Assert(err, IsNil, Commentf("write tmp file %s failed", filename))
 }
 
-func (s *testClusterReaderSuite) TestTiDBClusterLog(c *C) {
+func (s *testMemTableReaderSuite) TestTiDBClusterLog(c *C) {
 	type testServer struct {
 		typ     string
 		server  *grpc.Server
@@ -850,7 +850,7 @@ func (s *testClusterReaderSuite) TestTiDBClusterLog(c *C) {
 	}
 }
 
-func (s *testClusterReaderSuite) TestTiDBClusterLogError(c *C) {
+func (s *testMemTableReaderSuite) TestTiDBClusterLogError(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	fpName := "github.com/pingcap/tidb/executor/mockClusterLogServerInfo"
 	c.Assert(failpoint.Enable(fpName, `return("")`), IsNil)


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

This PR will fix #14747.

There will be goroutine  leak in the following situation in `clusterLogRetriever`:

1. Open a log search stream on a remote target and receive `SearchLogResponse` continuously.
2. Executor receives a `SearchLogResponse` from the channel in one retrieval iteration.
3. The retrieval iteration consumes part of lines in the `SearchLogResponse` (receive from channel again just if all lines in the `SearchLogResponse` be consumed).
4. The `MemTableReaderExec`(`clusterLogRetriever`) be closed by parent.
5. The stream receiver goroutine will be leaked.

### What is changed and how it works?

Add a new `exit` channel and check whether is `exit` channel has been closed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - Fix the issue that potential goroutine leak in cluster log retriever