### PR TITLE
session: fix unexpected '0' written to `new_collation_enabled` value.

### DIFF
--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -267,7 +267,7 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	err = r.Next(ctx, req)
 	c.Assert(err, IsNil)
 	c.Assert(req.NumRows(), Equals, 1)
-	c.Assert(req.GetRow(0).GetString(0), Equals, "0")
+	c.Assert(req.GetRow(0).GetString(0), Equals, "False")
 	c.Assert(r.Close(), IsNil)
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -1569,13 +1569,13 @@ func loadCollationParameter(se *session) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if para == "true" {
+	if para == varTrue {
 		return true, nil
-	} else if para == "false" {
+	} else if para == varFalse {
 		return false, nil
 	}
-	logutil.BgLogger().Error(
-		"Unexpected value of 'new_collation_enabled' in 'mysql.tidb', use 'false' instead",
+	logutil.BgLogger().Warn(
+		"Unexpected value of 'new_collation_enabled' in 'mysql.tidb', use 'False' instead",
 		zap.String("value", para))
 	return false, nil
 }


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix the erorr log that appeared like:
```
[2020-02-19T04:08:08.589Z] [2020/02/19 12:08:02.958 +08:00] [ERROR] [session.go:1577] ["Unexpected value of 'new_collation_enabled' in 'mysql.tidb', use 'false' instead"] [value=0]
```

### What is changed and how it works?
Fix the wrong value written to `new_collation_enabled` in `mysql`.`tidb`: It should be 'True'/'False' rather than '1'/'0'.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

 - Has exported function/method change
 - Has persistent data change

Side effects

 - NA
