### PR TITLE
executor: fix show session binding error after drop bindings

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -388,6 +388,9 @@ func (s *testSuite) TestGlobalAndSessionBindingBothExist(c *C) {
 	// Session bindings should be able to cover the global bindings.
 	tk.MustExec("drop session binding for select * from t where a > 10")
 	tk.MustIndexLookup("select * from t where a > -1")
+	res := tk.MustQuery("show session bindings")
+	c.Assert(len(res.Rows()), Equals, 1)
+	c.Assert(res.Rows()[0][3], Equals, "deleted")
 }
 
 func (s *testSuite) TestExplain(c *C) {

--- a/executor/show.go
+++ b/executor/show.go
@@ -234,6 +234,20 @@ func (e *ShowExec) fetchShowBind() error {
 	}
 	parser := parser.New()
 	for _, bindData := range bindRecords {
+		// Deleted bind record won't have bind sql.
+		if bindData.BindSQL == "" {
+			e.appendRow([]interface{}{
+				bindData.OriginalSQL,
+				bindData.BindSQL,
+				bindData.Db,
+				bindData.Status,
+				bindData.CreateTime,
+				bindData.UpdateTime,
+				bindData.Charset,
+				bindData.Collation,
+			})
+			continue
+		}
 		stmt, err := parser.ParseOneStmt(bindData.BindSQL, bindData.Charset, bindData.Collation)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

After drop binding, the `bind sql` would be empty string, so if `show bindings` tries to parse it, error would be thrown.

### What is changed and how it works?

Do not parse the deleted bindings.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change

Side effects

 - None

Related changes

 - None

Release note

 -  fix show session bindings error after drop session bindings
