### PR TITLE
exec: remove duplicate auto-generated test cases

### DIFF
--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -603,7 +603,7 @@ func (s *testSuite5) TestAdminCheckTableFailed(c *C) {
 	tk.MustExec("admin check table admin_test")
 }
 
-func (s *testSuite4) TestAdminCheckTable(c *C) {
+func (s *testSuite8) TestAdminCheckTable(c *C) {
 	// test NULL value.
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -399,7 +399,7 @@ func (s *testSuite5) TestAdminCleanupIndexMore(c *C) {
 	tk.MustExec("admin check table admin_test")
 }
 
-func (s *testSuite2) TestAdminCheckPartitionTableFailed(c *C) {
+func (s *testSuite3) TestAdminCheckPartitionTableFailed(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists admin_test_p")
@@ -603,7 +603,7 @@ func (s *testSuite5) TestAdminCheckTableFailed(c *C) {
 	tk.MustExec("admin check table admin_test")
 }
 
-func (s *testSuite2) TestAdminCheckTable(c *C) {
+func (s *testSuite4) TestAdminCheckTable(c *C) {
 	// test NULL value.
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -198,7 +198,7 @@ func (s *testSuite8) TestInsertOnDuplicateKey(c *C) {
 	tk.MustQuery(`select * from t1 use index(primary)`).Check(testkit.Rows(`1.0000`))
 }
 
-func (s *testSuite3) TestInsertReorgDelete(c *C) {
+func (s *testSuite2) TestInsertReorgDelete(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Speedup executor unit test

### What is changed and how it works?
- remove duplicate auto-generated test case for `testClusterTableSuite` inherit from `testSuite1`, these test cases will cause nearly 20s as `testClusterTableSuite` is serial
- reorganize some test suites so tests can run more evenly.

Result:
before:
```
$ go test -v -vet=off -p 20 -timeout 15m -race github.com/pingcap/tidb/executor
ok  	github.com/pingcap/tidb/executor	101.722s
```
after:
```
$ go test -v -vet=off -p 20 -timeout 15m -race github.com/pingcap/tidb/executor
ok  	github.com/pingcap/tidb/executor	76.135s
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
