### PR TITLE
ddl: fix create table with like bug when refer table has tiflash replica

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2067,7 +2067,7 @@ func (s *testDBSuite4) TestCreateTableWithLike2(c *C) {
 	c.Assert(t2.Meta().TiFlashReplica.LocationLabels, DeepEquals, t1.Meta().TiFlashReplica.LocationLabels)
 	c.Assert(t2.Meta().TiFlashReplica.Available, IsFalse)
 	c.Assert(t2.Meta().TiFlashReplica.AvailablePartitionIDs, HasLen, 0)
-	// Test for not affect the original table.
+	// Test for not affecting the original table.
 	t1 = testGetTableByName(c, s.s, "test_db", "t1")
 	c.Assert(t1.Meta().TiFlashReplica, NotNil)
 	c.Assert(t1.Meta().TiFlashReplica.Available, IsTrue)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2067,6 +2067,11 @@ func (s *testDBSuite4) TestCreateTableWithLike2(c *C) {
 	c.Assert(t2.Meta().TiFlashReplica.LocationLabels, DeepEquals, t1.Meta().TiFlashReplica.LocationLabels)
 	c.Assert(t2.Meta().TiFlashReplica.Available, IsFalse)
 	c.Assert(t2.Meta().TiFlashReplica.AvailablePartitionIDs, HasLen, 0)
+	// Test for not affect the original table.
+	t1 = testGetTableByName(c, s.s, "test_db", "t1")
+	c.Assert(t1.Meta().TiFlashReplica, NotNil)
+	c.Assert(t1.Meta().TiFlashReplica.Available, IsTrue)
+	c.Assert(t1.Meta().TiFlashReplica.AvailablePartitionIDs, DeepEquals, []int64{partition.Definitions[0].ID, partition.Definitions[1].ID})
 }
 
 func (s *testDBSuite1) TestCreateTable(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1349,9 +1349,11 @@ func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) mode
 	tblInfo.AutoIncID = 0
 	tblInfo.ForeignKeys = nil
 	if tblInfo.TiFlashReplica != nil {
+		replica := *tblInfo.TiFlashReplica
 		// Keep the tiflash replica setting, remove the replica available status.
-		tblInfo.TiFlashReplica.AvailablePartitionIDs = nil
-		tblInfo.TiFlashReplica.Available = false
+		replica.AvailablePartitionIDs = nil
+		replica.Available = false
+		tblInfo.TiFlashReplica = &replica
 	}
 	if referTblInfo.Partition != nil {
 		pi := *referTblInfo.Partition


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix a bug of a shallow copy when do `create table like`

Bugfix of https://github.com/pingcap/tidb/pull/14772

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test