### PR TITLE
planner/expression: constant propagation and predicate pushdown should be aware of plan cache

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1208,7 +1208,7 @@ func RefineComparedConstant(ctx sessionctx.Context, targetFieldType types.FieldT
 // refineArgs will rewrite the arguments if the compare expression is `int column <cmp> non-int constant` or
 // `non-int constant <cmp> int column`. E.g., `a < 1.1` will be rewritten to `a < 2`.
 func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Expression) []Expression {
-	if ctx.GetSessionVars().StmtCtx.UseCache && ContainLazyConst(args) {
+	if ContainMutableConst(ctx, args) {
 		return args
 	}
 	arg0Type, arg1Type := args[0].GetType(), args[1].GetType()

--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -79,7 +79,7 @@ func (p *hashPartitionPruner) reduceColumnEQ() bool {
 
 func (p *hashPartitionPruner) reduceConstantEQ() bool {
 	for _, con := range p.conditions {
-		col, cond := validEqualCond(con)
+		col, cond := validEqualCond(p.ctx, con)
 		if col != nil {
 			id := p.getColID(col)
 			if p.constantMap[id] != nil {

--- a/expression/util.go
+++ b/expression/util.go
@@ -739,12 +739,17 @@ func IsMutableEffectsExpr(expr Expression) bool {
 }
 
 // RemoveDupExprs removes identical exprs. Not that if expr contains functions which
-// are mutable or have side effects, we cannot remove it even if it has duplicates.
+// are mutable or have side effects, we cannot remove it even if it has duplicates;
+// if the plan is going to be cached, we cannot remove expressions containing `?` neither.
 func RemoveDupExprs(ctx sessionctx.Context, exprs []Expression) []Expression {
 	res := make([]Expression, 0, len(exprs))
 	exists := make(map[string]struct{}, len(exprs))
 	sc := ctx.GetSessionVars().StmtCtx
 	for _, expr := range exprs {
+		if ContainMutableConst(ctx, []Expression{expr}) {
+			res = append(res, expr)
+			continue
+		}
 		key := string(expr.HashCode(sc))
 		if _, ok := exists[key]; !ok || IsMutableEffectsExpr(expr) {
 			res = append(res, expr)
@@ -804,8 +809,12 @@ func ContainVirtualColumn(exprs []Expression) bool {
 	return false
 }
 
-// ContainLazyConst checks if the expressions contain a lazy constant.
-func ContainLazyConst(exprs []Expression) bool {
+// ContainMutableConst checks if the expressions contain a lazy constant.
+func ContainMutableConst(ctx sessionctx.Context, exprs []Expression) bool {
+	// Treat all constants immutable if plan cache is not enabled for this query.
+	if !ctx.GetSessionVars().StmtCtx.UseCache {
+		return false
+	}
 	for _, expr := range exprs {
 		switch v := expr.(type) {
 		case *Constant:
@@ -813,7 +822,7 @@ func ContainLazyConst(exprs []Expression) bool {
 				return true
 			}
 		case *ScalarFunction:
-			if ContainLazyConst(v.GetArgs()) {
+			if ContainMutableConst(ctx, v.GetArgs()) {
 				return true
 			}
 		}

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -510,6 +510,9 @@ func Conds2TableDual(p LogicalPlan, conds []expression.Expression) LogicalPlan {
 		return nil
 	}
 	sc := p.SCtx().GetSessionVars().StmtCtx
+	if expression.ContainMutableConst(p.SCtx(), []expression.Expression{con}) {
+		return nil
+	}
 	if isTrue, err := con.Value.ToBool(sc); (err == nil && isTrue == 0) || con.Value.IsNull() {
 		dual := LogicalTableDual{}.Init(p.SCtx(), p.SelectBlockOffset())
 		dual.SetSchema(p.Schema())


### PR DESCRIPTION

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/14871 and https://github.com/pingcap/tidb/issues/14875

### What is changed and how it works?

Check whether `Constant` has `DeferredExpr` or `ParamMarker` in:
- constant propagation
- removing duplicate expressions
- converting constant false filter to TableDual

and disable some radical optimizations accordingly, otherwise, wrong results would be generated as illustrated in test cases of this PR.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

 - Increased code complexity


Related changes

N/A

Release note

 - Write release note for bug-fix or new feature.
`Fix bugs of constant propagation and predicate pushdown when plan cache is enabled`