### PR TITLE
config: modify default mem_quota_query

### DIFF
--- a/cmd/explaintest/config.toml
+++ b/cmd/explaintest/config.toml
@@ -1,5 +1,6 @@
 port = 4001
 lease = "0"
+mem-quota-query = 34359738368
 
 [log]
 level = "error"

--- a/config/config.go
+++ b/config/config.go
@@ -499,7 +499,7 @@ var defaultConf = Config{
 	TokenLimit:                   1000,
 	OOMUseTmpStorage:             true,
 	OOMAction:                    "log",
-	MemQuotaQuery:                32 << 30,
+	MemQuotaQuery:                1 << 30,
 	EnableStreaming:              false,
 	EnableBatchDML:               false,
 	CheckMb4ValueInUTF8:          true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -31,8 +31,8 @@ split-table = true
 # The limit of concurrent executed sessions.
 token-limit = 1000
 
-# Set the memory quota for a query in bytes. Default: 32GB
-mem-quota-query = 34359738368
+# Set the memory quota for a query in bytes. Default: 1GB
+mem-quota-query = 1073741824
 
 # Set to true to enable use of temporary disk for some executors when mem-quota-query is exceeded.
 oom-use-tmp-storage = true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -184,6 +184,7 @@ enable-batch-dml = true
 server-version = "test_version"
 repair-mode = true
 max-server-connections = 200
+mem-quota-query = 10000
 [performance]
 txn-total-size-limit=2000
 [tikv-client]
@@ -234,6 +235,7 @@ engines = ["tiflash"]
 	c.Assert(conf.EnableBatchDML, Equals, true)
 	c.Assert(conf.RepairMode, Equals, true)
 	c.Assert(conf.MaxServerConnections, Equals, uint32(200))
+	c.Assert(conf.MemQuotaQuery, Equals, int64(10000))
 	c.Assert(conf.Experimental.AllowAutoRandom, IsTrue)
 	c.Assert(conf.IsolationRead.Engines, DeepEquals, []string{"tiflash"})
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
fix issue https://github.com/pingcap/tidb/issues/12937
Now the default `mem-quota-query` is too large, so it causes OOM before logging expensive queries.

### What is changed and how it works?
Change the default config.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```
mysql> select @@tidb_mem_quota_query;
+------------------------+
| @@tidb_mem_quota_query |
+------------------------+
| 1073741824             |
+------------------------+
1 row in set (0.00 sec)
```

Code changes

N/A

Side effects

N/A

Related changes

 - Need to update the documentation

Release note

 - Change the default value of `mem-quota-query` from 32G to 1G.
