### PR TITLE
memdb: compatible with Go 1.14's checkptr

### DIFF
--- a/kv/memdb/arena.go
+++ b/kv/memdb/arena.go
@@ -32,6 +32,8 @@ func newArenaAddr(idx int, offset uint32) arenaAddr {
 }
 
 const (
+	alignMask = 1<<32 - 8 // 29 bit 1 and 3 bit 0.
+
 	nullBlockOffset = math.MaxUint32
 	maxBlockSize    = 128 << 20
 )
@@ -117,7 +119,9 @@ func (a *arenaBlock) getFrom(offset uint32) []byte {
 }
 
 func (a *arenaBlock) alloc(size int) (uint32, []byte) {
-	offset := a.length
+	// We must align the allocated address for node
+	// to make runtime.checkptrAlignment happy.
+	offset := (a.length + 7) & alignMask
 	newLen := offset + size
 	if newLen > len(a.buf) {
 		return nullBlockOffset, nil

--- a/kv/memdb/iterator.go
+++ b/kv/memdb/iterator.go
@@ -45,7 +45,7 @@ func (it *Iterator) Value() []byte {
 
 // Next moves the iterator to the next entry.
 func (it *Iterator) Next() {
-	it.changeToAddr(it.curr.nexts[0])
+	it.changeToAddr(it.curr.nexts(0))
 }
 
 // Prev moves the iterator to the previous entry.

--- a/kv/memdb/memdb.go
+++ b/kv/memdb/memdb.go
@@ -39,21 +39,30 @@ type DB struct {
 // This DB is append-only, deleting an entry would remove entry node but not
 // reclaim KV buffer.
 func New(initBlockSize int) *DB {
-	return &DB{
+	db := &DB{
 		height: 1,
-		head:   nodeWithAddr{node: new(node)},
 		arena:  newArenaLocator(initBlockSize),
 	}
+	db.setHeadNode()
+	return db
 }
 
 // Reset resets the DB to initial empty state.
 // Release all blocks except the initial one.
 func (db *DB) Reset() {
 	db.height = 1
-	db.head.node = new(node)
 	db.length = 0
 	db.size = 0
 	db.arena.reset()
+	db.setHeadNode()
+}
+
+func (db *DB) setHeadNode() {
+	n, _ := db.newNode(db.arena, nil, nil, maxHeight)
+	for i := 0; i < maxHeight; i++ {
+		n.setNexts(i, arenaAddr{})
+	}
+	db.head.node = n
 }
 
 // Get gets the value for the given key. It returns nil if the
@@ -96,11 +105,11 @@ func (db *DB) Put(key []byte, v []byte) bool {
 	// We always insert from the base level and up. After you add a node in base level, we cannot
 	// create a node in the level above because it would have discovered the node in the base level.
 	for i := 0; i < height; i++ {
-		x.nexts[i] = next[i].addr
+		x.setNexts(i, next[i].addr)
 		if prev[i].node == nil {
 			prev[i] = db.head
 		}
-		prev[i].nexts[i] = addr
+		prev[i].setNexts(i, addr)
 	}
 
 	x.prev = prev[0].addr
@@ -125,7 +134,7 @@ func (db *DB) prepareOverwrite(next []nodeWithAddr) int {
 	height := int(old.height)
 	for i := 0; i < height; i++ {
 		if next[i].addr == old.addr {
-			next[i].addr = old.nexts[i]
+			next[i].addr = old.nexts(i)
 			if !next[i].addr.isNull() {
 				data := db.arena.getFrom(next[i].addr)
 				next[i].node = (*node)(unsafe.Pointer(&data[0]))
@@ -152,9 +161,9 @@ func (db *DB) Delete(key []byte) bool {
 	}
 
 	for i := int(keyNode.height) - 1; i >= 0; i-- {
-		prev[i].nexts[i] = keyNode.nexts[i]
+		prev[i].setNexts(i, keyNode.nexts(i))
 	}
-	nextAddr := keyNode.nexts[0]
+	nextAddr := keyNode.nexts(0)
 	if !nextAddr.isNull() {
 		nextData := db.arena.getFrom(nextAddr)
 		next := (*node)(unsafe.Pointer(&nextData[0]))
@@ -184,7 +193,7 @@ func (db *DB) Size() int {
 func (db *DB) findSpliceForLevel(arena *arena, key []byte, before nodeWithAddr, level int) (nodeWithAddr, nodeWithAddr, bool) {
 	for {
 		// Assume before.key < key.
-		nextAddr := before.nexts[level]
+		nextAddr := before.nexts(level)
 		if nextAddr.isNull() {
 			return before, nodeWithAddr{}, false
 		}
@@ -207,7 +216,7 @@ func (db *DB) findGreaterEqual(key []byte) (*node, []byte, bool) {
 	for {
 		var nextData []byte
 		var next *node
-		addr := prev.nexts[level]
+		addr := prev.nexts(level)
 		if !addr.isNull() {
 			arena := db.arena
 			nextData = arena.getFrom(addr)
@@ -329,8 +338,11 @@ type node struct {
 
 	// Addr of previous node at base level.
 	prev arenaAddr
-	// Height of the nexts.
-	nexts [maxHeight]arenaAddr
+
+	// node is a variable length struct.
+	// The nextsBase is the first element of nexts slice,
+	// it act as the base pointer we do pointer arithmetic in `next` and `setNext`.
+	nextsBase arenaAddr
 }
 
 type nodeWithAddr struct {
@@ -352,8 +364,21 @@ func (n *node) getValue(buf []byte) []byte {
 	return buf[nodeLenKeyLen : nodeLenKeyLen+int(n.valLen)]
 }
 
+func (n *node) nexts(level int) arenaAddr {
+	return *n.nextsAddr(level)
+}
+
+func (n *node) setNexts(level int, val arenaAddr) {
+	*n.nextsAddr(level) = val
+}
+
+func (n *node) nextsAddr(idx int) *arenaAddr {
+	offset := uintptr(idx) * unsafe.Sizeof(n.nextsBase)
+	return (*arenaAddr)(unsafe.Pointer(uintptr(unsafe.Pointer(&n.nextsBase)) + offset))
+}
+
 func (db *DB) getNext(n *node, level int) (*node, []byte) {
-	addr := n.nexts[level]
+	addr := n.nexts(level)
 	if addr.isNull() {
 		return nil, nil
 	}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The Go 1.14 introduces new instrumentation to check that Go code is following `unsafe.Pointer` safety rules dynamically. The new flag `-d=checkptr` is enabled by default with the `-race` or `-msan` flags.

Specifically, `-d=checkptr` checks the following:

1. When converting unsafe.Pointer to `*T`, the resulting pointer must be aligned appropriately for `T`.   
1. If the result of pointer arithmetic points into a Go heap object, one of the `unsafe.Pointer`-typed operands must point into the same object.   

So if you run unit test with `-race` in Go 1.14 you will get a panic like

```
fatal error: checkptr: unsafe pointer conversion
goroutine 1 [running]:
runtime.throw(0x6bbf63a, 0x23)
	/usr/local/go/src/runtime/panic.go:1112 +0x72 fp=0xc000e0bcf8 sp=0xc000e0bcc8 pc=0x40368e2
runtime.checkptrAlignment(0xc00065f1bf, 0x6981ba0, 0x1)
	/usr/local/go/src/runtime/checkptr.go:13 +0xd0 fp=0xc000e0bd28 sp=0xc000e0bcf8 pc=0x4008710
github.com/pingcap/tidb/kv/memdb.(*DB).newNode(0xc000de28a0, 0xc000de2870, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0x1, 0x0, ...)
	/Users/tangliu/program/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20200223044457-aedea3ec5e1e/kv/memdb/memdb.go:300 +0xbe fp=0xc000e0bda8 sp=0xc000e0bd28 pc=0x4b3b05e
github.com/pingcap/tidb/kv/memdb.(*DB).Put(0xc000de28a0, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0x6898b01)
	/Users/tangliu/program/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20200223044457-aedea3ec5e1e/kv/memdb/memdb.go:91 +0x2fb fp=0xc000e0c0a8 sp=0xc000e0bda8 pc=0x4b390bb
github.com/pingcap/tidb/kv.(*memDbBuffer).Set(0xc000da1fc0, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0x6614180, 0x0)
	/Users/tangliu/program/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20200223044457-aedea3ec5e1e/kv/memdb_buffer.go:104 +0x3fd fp=0xc000e0c1a0 sp=0xc000e0c0a8 pc=0x4b3dcdd
github.com/pingcap/tidb/kv.(*lazyMemBuffer).Set(0xc000bfef00, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0xaa592f0, 0x0)
	/Users/tangliu/program/go/pkg/mod/github.com/pingcap/tidb@v1.1.0-beta.0.20200223044457-aedea3ec5e1e/kv/union_store.go:141 +0xb5 fp=0xc000e0c208 sp=0xc000e0c1a0 pc=0x4b41535
github.com/pingcap/tidb/kv.(*unionStore).Set(0xc000bfef40, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0xc0001b030f, 0x10)
	<autogenerated>:1 +0xcd fp=0xc000e0c280 sp=0xc000e0c208 pc=0x4b4403d
github.com/pingcap/tidb/store/tikv.(*tikvTxn).Set(0xc000ad98c0, 0xc00005d530, 0x1b, 0x23, 0xc0001b0300, 0x10, 0x10, 0x0, 0x0)
```

### What is changed and how it works?
In fact, the current implementation does not really cause illegal memory access. The `node` struct is actually a variable-sized struct, the `nexts` array is dynamically allocated according to the node's height. But `checkptrAlignment` will use the size defined by the struct, which is usually larger than the actual size of the object. 

As a result, when Go's checker check the memory boundary according to **rule 2**, it will find some bytes in the `node.nexts` doesn't in the memory space returned by the allocator.

To address this problem, I modified the definition of `node` struct, change `nexts` array to `nextsBase`. Because each node always has at least one element in `nexts`, the checker will never fail.

The **rule 1** is easy to address, just align the allocation in `arenaBlock`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
    - Run test with `-race` using Go 1.14