### PR TITLE
*: remove some debug print in test files

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -842,7 +842,6 @@ func (s *testSuiteP1) TestAllocateContinuousRowID(c *C) {
 				}
 				tk.MustExec(sql)
 				q := "select _tidb_rowid from t1 where a=" + k
-				fmt.Printf("query: %v\n", q)
 				rows := tk.MustQuery(q).Rows()
 				c.Assert(len(rows), Equals, 21)
 				last := 0

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -840,7 +840,6 @@ func (s *testEvaluatorSuite) TestJSONSearch(c *C) {
 				c.Assert(err, IsNil)
 				j2 = d.GetMysqlJSON()
 				cmp := json.CompareBinary(j1, j2)
-				//fmt.Println(j1, j2)
 				c.Assert(cmp, Equals, 0)
 			case nil:
 				c.Assert(d.IsNull(), IsTrue)

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -1272,10 +1271,7 @@ func (s *testEvaluatorSuite) TestChar(c *C) {
 			c.Assert(err, IsNil)
 			c.Assert(f, NotNil)
 			r, err := evalBuiltinFunc(f, chunk.Row{})
-			if err != nil {
-				fmt.Printf("%s\n", err.Error())
-			}
-			c.Assert(err, IsNil)
+			c.Assert(err, IsNil, Commentf("err: %v", err))
 			c.Assert(r, testutil.DatumEquals, types.NewDatum(v.result))
 		}
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -434,7 +434,6 @@ func (s *testKVSuite) TestSeekMin(c *C) {
 	it, err := txn.Iter(nil, nil)
 	c.Assert(err, IsNil)
 	for it.Valid() {
-		fmt.Printf("%s, %s\n", it.Key(), it.Value())
 		it.Next()
 	}
 

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -936,6 +936,7 @@ func BenchmarkAccess(b *testing.B) {
 			sum += rowChk.GetRow(j).GetInt64(0)
 		}
 	}
+	fmt.Println(sum)
 }
 
 func BenchmarkChunkMemoryUsage(b *testing.B) {

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -936,7 +936,6 @@ func BenchmarkAccess(b *testing.B) {
 			sum += rowChk.GetRow(j).GetInt64(0)
 		}
 	}
-	fmt.Println(sum)
 }
 
 func BenchmarkChunkMemoryUsage(b *testing.B) {

--- a/util/localpool/localpool_test.go
+++ b/util/localpool/localpool_test.go
@@ -57,7 +57,6 @@ func (s *testPoolSuite) TestPool(c *C) {
 	wg.Wait()
 	var getHit, getMiss, putHit, putMiss int
 	for _, slot := range pool.slots {
-		fmt.Println(slot.getHit, slot.getMiss, slot.putHit, slot.putMiss)
 		getHit += slot.getHit
 		getMiss += slot.getMiss
 		putHit += slot.putHit

--- a/util/localpool/localpool_test.go
+++ b/util/localpool/localpool_test.go
@@ -16,7 +16,6 @@
 package localpool
 
 import (
-	"fmt"
 	"math/rand"
 	"runtime"
 	"sync"

--- a/util/logutil/log_test.go
+++ b/util/logutil/log_test.go
@@ -91,7 +91,6 @@ func (s *testLogSuite) TestLogging(c *C) {
 	entry, err = s.buf.ReadString('\n')
 	c.Assert(err, IsNil)
 	c.Assert(entry, Matches, logPattern)
-	fmt.Println(entry, logPattern)
 	c.Assert(strings.Contains(entry, "log_test.go"), IsTrue)
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Some `fmt.Println` and `fmt.Printf` are still in test files.

### What is changed and how it works?
Remove them.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code