### PR TITLE
server: Mute HTTP handler logs

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -102,7 +102,6 @@ func writeData(w http.ResponseWriter, data interface{}) {
 		writeError(w, err)
 		return
 	}
-	logutil.BgLogger().Info(string(js))
 	// write response
 	w.Header().Set(headerContentType, contentTypeJSON)
 	w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
Signed-off-by: Breezewish <me@breeswish.org>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Resolve the issue that TiDB prints too much logs when use with Dashboard.

### What is changed and how it works?

Remove logs in HTTP handlers, since Dashboard requests TiDB HTTP API frequently.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
