### PR TITLE
tables: disable UpdateDeltaForTable if TxnCtx is nil

### DIFF
--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -590,15 +590,19 @@ func (t *TableCommon) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ..
 		}
 	}
 	sc.AddAffectedRows(1)
-	colSize := make(map[int64]int64, len(r))
-	for id, col := range t.Cols() {
-		size, err := codec.EstimateValueSize(sc, r[id])
-		if err != nil {
-			continue
+	if sessVars.TxnCtx != nil {
+		// we allow caller to set `sessVars.TxnCtx = nil` to skip updating table delta
+		// this is disabled in TiDB Lightning (which doesn't need stats) to improve performance.
+		colSize := make(map[int64]int64, len(r))
+		for id, col := range t.Cols() {
+			size, err := codec.EstimateValueSize(sc, r[id])
+			if err != nil {
+				continue
+			}
+			colSize[col.ID] = int64(size) - 1
 		}
-		colSize[col.ID] = int64(size) - 1
+		sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 1, 1, colSize)
 	}
-	sessVars.TxnCtx.UpdateDeltaForTable(t.physicalTableID, 1, 1, colSize)
 	return recordID, nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

This is a follow-up to pingcap/tidb-lightning#274. 

In the flamegraph of `AddRecord()` (with a special session used by Lightning), it was found that calculation used for `(*TransactionContext).UpdateDeltaForTable()` occupy 27% run time (!) of the entire `AddRecord()` call. The delta info is useless for Lightning, so we need a way to disable it.

<details><summary>Flamegraph for Lightning before this PR</summary>

![Annotation 2020-03-01 033907-fs8](https://user-images.githubusercontent.com/103023/75614081-f0f05080-5b6f-11ea-907e-563d6598847b.png)

</details>

### What is changed and how it works?

Lightning will set `sessVar.TxnCtx = nil` as a signal that `UpdateDeltaForTable` is not needed. This PR adds the `nil` check in `AddRecord()` for skipping the computation. (`UpdateRecord()` and `RemoveRecord()` are not used by Lightning and thus their use of `UpdateDeltaForTable` are untouched.)

<details><summary>Flamegraph for Lightning after this PR</summary>

![Annotation 2020-03-01 034115-fs8](https://user-images.githubusercontent.com/103023/75614086-fc437c00-5b6f-11ea-9578-f763caaace80.png)

</details>

The time needed to encode one row of TPC-C "CUSTOMER" table (21 columns, 1 index) went down from 10.5&nbsp;ms/op to 8.2&nbsp;ms/op.

Note that this PR does *not* affect TiDB itself, since `sessVar.TxnCtx` should always be non-nil in normal use. Thus no test cases were added in TiDB itself. (Test for correctness will be in Lightning.)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

Side effects

Related changes

Release note
