### PR TITLE
session: add test case for retrying union statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20200221125103-35b65c96516e
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
-	github.com/pingcap/parser v0.0.0-20200225075606-4cf2c2d4f51b
+	github.com/pingcap/parser v0.0.0-20200301092054-bfc519c0a57f
 	github.com/pingcap/pd v1.1.0-beta.0.20200106144140-f5a7aa985497
 	github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd
 	github.com/pingcap/tidb-tools v3.0.6-0.20191106033616-90632dda3863+incompatible

--- a/go.sum
+++ b/go.sum
@@ -211,8 +211,8 @@ github.com/pingcap/kvproto v0.0.0-20200221125103-35b65c96516e/go.mod h1:IOdRDPLy
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200225075606-4cf2c2d4f51b h1:zCtRk1lFGXfXKAaYTG+JLkM/5zaSGk1RcVseUWAFd8E=
-github.com/pingcap/parser v0.0.0-20200225075606-4cf2c2d4f51b/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/pingcap/parser v0.0.0-20200301092054-bfc519c0a57f h1:SfzX0ZDTyXgzLExMsJ385DTMIaX7CeBQMCGQKdQYO7o=
+github.com/pingcap/parser v0.0.0-20200301092054-bfc519c0a57f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd v1.1.0-beta.0.20200106144140-f5a7aa985497 h1:FzLErYtcXnSxtC469OuVDlgBbh0trJZzNxw0mNKzyls=
 github.com/pingcap/pd v1.1.0-beta.0.20200106144140-f5a7aa985497/go.mod h1:cfT/xu4Zz+Tkq95QrLgEBZ9ikRcgzy4alHqqoaTftqI=
 github.com/pingcap/sysutil v0.0.0-20191216090214-5f9620d22b3b/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -702,6 +702,41 @@ func (s *testSessionSuite) TestReadOnlyNotInHistory(c *C) {
 	c.Assert(history.Count(), Equals, 0)
 }
 
+func (s *testSessionSuite) TestRetryUnion(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table history (a int)")
+	tk.MustExec("insert history values (1), (2), (3)")
+	tk.MustExec("set @@autocommit = 0")
+	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
+	// UNION should't be in retry history.
+	tk.MustQuery("(select * from history) union (select * from history)")
+	history := session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 0)
+	tk.MustQuery("(select * from history for update) union (select * from history)")
+	tk.MustExec("update history set a = a + 1")
+	history = session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 2)
+
+	// Make retryable error.
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("update history set a = a + 1")
+
+	_, err := tk.Exec("commit")
+	c.Assert(err, ErrorMatches, "can not retry select for update statement")
+}
+
+func (s *testSessionSuite) TestRetryShow(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("set @@autocommit = 0")
+	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
+	// UNION should't be in retry history.
+	tk.MustQuery("show variables")
+	tk.MustQuery("show grants")
+	tk.MustQuery("admin show ddl jobs")
+	history := session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 0)
+}
+
 func (s *testSessionSuite) TestNoRetryForCurrentTxn(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -722,7 +722,7 @@ func (s *testSessionSuite) TestRetryUnion(c *C) {
 	tk1.MustExec("update history set a = a + 1")
 
 	_, err := tk.Exec("commit")
-	c.Assert(err, ErrorMatches, "can not retry select for update statement")
+	c.Assert(err, ErrorMatches, ".*can not retry select for update statement")
 }
 
 func (s *testSessionSuite) TestRetryShow(c *C) {
@@ -731,8 +731,7 @@ func (s *testSessionSuite) TestRetryShow(c *C) {
 	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
 	// UNION should't be in retry history.
 	tk.MustQuery("show variables")
-	tk.MustQuery("show grants")
-	tk.MustQuery("admin show ddl jobs")
+	tk.MustQuery("show databases")
 	history := session.GetHistory(tk.Se)
 	c.Assert(history.Count(), Equals, 0)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add test case for https://github.com/pingcap/tidb/issues/15050.

### What is changed and how it works?
Just add some test cases to test retrying `UNION` and `SHOW` statements.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

I did the same as https://github.com/pingcap/tidb/issues/15050 and the log shows `UNION` statement is not retried.

```
[2020/03/01 18:12:15.574 +08:00] [WARN] [session.go:463] [sql] [conn=1] [label=general] [error="[kv:9007]Write conflict, txnStartTS=414989028796923904, conflictStartTS=414989031736606720, conflictCommitTS=414989031736606721, key={tableID=45, handle=120001} primary=[]byte(nil) [try again later]"] [txn="Txn{state=invalid}"]
[2020/03/01 18:12:15.574 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=0] [sql=begin]
[2020/03/01 18:12:15.575 +08:00] [INFO] [2pc.go:1074] ["2PC clean up done"] [conn=1] [txnStartTS=414989028796923904]
[2020/03/01 18:12:15.575 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=1] [sql="update test set id=id+1"]
[2020/03/01 18:12:15.575 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=2] [sql=commit]
```

Code changes

N/A

Side effects

N/A

Related changes

N/A

Release note ( This release note applies to the parser PR https://github.com/pingcap/parser/pull/755)

 - Fix the bug that goroutine leaks when retrying a transaction which contains `UNION` statement.
