### PR TITLE
*: support pessimistic lock return values

### DIFF
--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -60,6 +60,8 @@ type PointGetExecutor struct {
 	handle       int64
 	idxInfo      *model.IndexInfo
 	partInfo     *model.PartitionDefinition
+	idxKey       kv.Key
+	handleVal    []byte
 	idxVals      []types.Datum
 	startTS      uint64
 	snapshot     kv.Snapshot
@@ -120,21 +122,21 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		tblID = e.tblInfo.ID
 	}
 	if e.idxInfo != nil {
-		idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, e.idxVals, tblID)
-		if err1 != nil && !kv.ErrNotExist.Equal(err1) {
-			return err1
+		e.idxKey, err = encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, e.idxVals, tblID)
+		if err != nil && !kv.ErrNotExist.Equal(err) {
+			return err
 		}
 
-		handleVal, err1 := e.get(ctx, idxKey)
-		if err1 != nil && !kv.ErrNotExist.Equal(err1) {
-			return err1
+		e.handleVal, err = e.get(ctx, e.idxKey)
+		if err != nil && !kv.ErrNotExist.Equal(err) {
+			return err
 		}
-		if len(handleVal) == 0 {
-			return e.lockKeyIfNeeded(ctx, idxKey)
+		if len(e.handleVal) == 0 {
+			return e.lockKeyIfNeeded(ctx, e.idxKey)
 		}
-		e.handle, err1 = tables.DecodeHandle(handleVal)
-		if err1 != nil {
-			return err1
+		e.handle, err = tables.DecodeHandle(e.handleVal)
+		if err != nil {
+			return err
 		}
 
 		// The injection is used to simulate following scenario:
@@ -153,12 +155,13 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 
 	key := tablecodec.EncodeRowKeyWithHandle(tblID, e.handle)
-	val, err := e.get(ctx, key)
-	if err != nil && !kv.ErrNotExist.Equal(err) {
-		return err
-	}
+	// Lock the key before get, then get will get the value from the cache.
 	err = e.lockKeyIfNeeded(ctx, key)
 	if err != nil {
+		return err
+	}
+	val, err := e.get(ctx, key)
+	if err != nil && !kv.ErrNotExist.Equal(err) {
 		return err
 	}
 	if len(val) == 0 {
@@ -173,7 +176,22 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 
 func (e *PointGetExecutor) lockKeyIfNeeded(ctx context.Context, key []byte) error {
 	if e.lock {
-		return doLockKeys(ctx, e.ctx, newLockCtx(e.ctx.GetSessionVars(), e.lockWaitTime), key)
+		seVars := e.ctx.GetSessionVars()
+		lockCtx := newLockCtx(seVars, e.lockWaitTime)
+		lockCtx.ReturnValues = true
+		lockCtx.Values = map[string][]byte{}
+		err := doLockKeys(ctx, e.ctx, lockCtx, key)
+		if err != nil {
+			return err
+		}
+		lockCtx.ValuesLock.Lock()
+		defer lockCtx.ValuesLock.Unlock()
+		for key, val := range lockCtx.Values {
+			seVars.TxnCtx.SetPessimisticLockCache(kv.Key(key), val)
+		}
+		if len(e.handleVal) > 0 {
+			seVars.TxnCtx.SetPessimisticLockCache(e.idxKey, e.handleVal)
+		}
 	}
 	return nil
 }
@@ -192,6 +210,11 @@ func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) (val []byte, err
 		}
 		if !kv.IsErrNotFound(err) {
 			return nil, err
+		}
+		var ok bool
+		val, ok = e.ctx.GetSessionVars().TxnCtx.GetKeyInPessimisticLockCache(key)
+		if ok {
+			return
 		}
 		// fallthrough to snapshot get.
 	}

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -16,6 +16,10 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -479,4 +483,27 @@ func (s *testPointGetSuite) TestSelectCheckVisibility(c *C) {
 	checkSelectResultError("select b from t where b > 0 ", tikv.ErrGCTooEarly)
 	// Test table read.
 	checkSelectResultError("select * from t", tikv.ErrGCTooEarly)
+}
+
+func (s *testPointGetSuite) TestReturnValues(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a varchar(64) primary key, b int)")
+	tk.MustExec("insert t values ('a', 1), ('b', 2), ('c', 3)")
+	tk.MustExec("begin pessimistic")
+	tk.MustQuery("select * from t where a = 'b' for update").Check(testkit.Rows("b 2"))
+	tid := tk.GetTableID("t")
+	idxVal, err := codec.EncodeKey(tk.Se.GetSessionVars().StmtCtx, nil, types.NewStringDatum("b"))
+	c.Assert(err, IsNil)
+	pk := tablecodec.EncodeIndexSeekKey(tid, 1, idxVal)
+	txnCtx := tk.Se.GetSessionVars().TxnCtx
+	val, ok := txnCtx.GetKeyInPessimisticLockCache(pk)
+	c.Assert(ok, IsTrue)
+	handle, err := tables.DecodeHandle(val)
+	c.Assert(err, IsNil)
+	rowKey := tablecodec.EncodeRowKeyWithHandle(tid, handle)
+	_, ok = txnCtx.GetKeyInPessimisticLockCache(rowKey)
+	c.Assert(ok, IsTrue)
+	tk.MustExec("rollback")
 }

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -16,10 +16,6 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/table/tables"
-	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/codec"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -29,6 +25,10 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/testkit"
 )
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -15,6 +15,7 @@ package kv
 
 import (
 	"context"
+	"sync"
 	"time"
 
 	"github.com/pingcap/tidb/config"
@@ -202,6 +203,9 @@ type LockCtx struct {
 	PessimisticLockWaited *int32
 	LockKeysDuration      *time.Duration
 	LockKeysCount         *int32
+	ReturnValues          bool
+	Values                map[string][]byte
+	ValuesLock            sync.Mutex
 }
 
 // Client is used to send request to KV layer.

--- a/store/mockstore/mocktikv/mvcc.go
+++ b/store/mockstore/mocktikv/mvcc.go
@@ -256,8 +256,7 @@ type MVCCStore interface {
 	Scan(startKey, endKey []byte, limit int, startTS uint64, isoLevel kvrpcpb.IsolationLevel, resolvedLocks []uint64) []Pair
 	ReverseScan(startKey, endKey []byte, limit int, startTS uint64, isoLevel kvrpcpb.IsolationLevel, resolvedLocks []uint64) []Pair
 	BatchGet(ks [][]byte, startTS uint64, isoLevel kvrpcpb.IsolationLevel, resolvedLocks []uint64) []Pair
-	PessimisticLock(mutations []*kvrpcpb.Mutation, primary []byte, startTS,
-		forUpdateTS uint64, ttl uint64, lockWaitTime int64) []error
+	PessimisticLock(req *kvrpcpb.PessimisticLockRequest) *kvrpcpb.PessimisticLockResponse
 	PessimisticRollback(keys [][]byte, startTS, forUpdateTS uint64) []error
 	Prewrite(req *kvrpcpb.PrewriteRequest) []error
 	Commit(keys [][]byte, startTS, commitTS uint64) error

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -324,18 +324,10 @@ func (h *rpcHandler) handleKvPessimisticLock(req *kvrpcpb.PessimisticLockRequest
 	startTS := req.StartVersion
 	regionID := req.Context.RegionId
 	h.cluster.handleDelay(startTS, regionID)
-	errs := h.mvccStore.PessimisticLock(req.Mutations, req.PrimaryLock, req.GetStartVersion(), req.GetForUpdateTs(),
-		req.GetLockTtl(), req.WaitTimeout)
-	if req.WaitTimeout == kv.LockAlwaysWait {
-		// TODO: remove this when implement sever side wait.
-		h.simulateServerSideWaitLock(errs)
-	}
-	return &kvrpcpb.PessimisticLockResponse{
-		Errors: convertToKeyErrors(errs),
-	}
+	return h.mvccStore.PessimisticLock(req)
 }
 
-func (h *rpcHandler) simulateServerSideWaitLock(errs []error) {
+func simulateServerSideWaitLock(errs []error) {
 	for _, err := range errs {
 		if _, ok := err.(*ErrLocked); ok {
 			time.Sleep(time.Millisecond * 5)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Reduce RPC cost.

### What is changed and how it works?
pass `ReturnValues` option to TiKV and put the return values into pessimistic lock cache.
The following get request would get the value directly from the cache.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - support pessimistic lock return values.
