### PR TITLE
binlog_test: fix unit test error in ci

### DIFF
--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -571,7 +571,7 @@ func mustGetDDLBinlog(s *testBinlogSuite, ddlQuery string, c *C) (matched bool) 
 				break
 			}
 		}
-		time.Sleep(time.Millisecond * 10)
+		time.Sleep(time.Millisecond * 30)
 	}
 	return
 }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
This PR try to fix `binlog_test` radom failure.
The ci link is [error](https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/25778/pipeline)

### What is changed and how it works?
add the wait time to check the last ddl binlog.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Release note

 - add the wait time to check the last ddl binlog.
