### PR TITLE
plan, expression: add date function support for hash partition

### DIFF
--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -117,6 +117,19 @@ func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64
 			case ast.Div:
 				return rightVal / leftVal, true, false
 			}
+		} else if pi.FuncName.L == ast.Year || pi.FuncName.L == ast.Month || pi.FuncName.L == ast.ToDays {
+			col := pi.GetArgs()[0].(*Column)
+			idx := p.getColID(col)
+			val := p.constantMap[idx]
+			if val != nil {
+				pi.GetArgs()[0] = val
+				ret, _, err := pi.EvalInt(p.ctx, chunk.Row{})
+				if err != nil {
+					return 0, false, false
+				}
+				return ret, true, false
+			}
+			return 0, false, false
 		}
 	case *Constant:
 		val, err := pi.Eval(chunk.Row{})

--- a/expression/partition_pruner_test.go
+++ b/expression/partition_pruner_test.go
@@ -67,6 +67,8 @@ func (s *testSuite2) TestHashPartitionPruner(c *C) {
 	tk.MustExec("create table t2(id int, a int, b int, primary key(id, a)) partition by hash(id + a) partitions 10;")
 	tk.MustExec("create table t1(id int primary key, a int, b int) partition by hash(id) partitions 10;")
 	tk.MustExec("create table t3(id int, a int, b int, primary key(id, a)) partition by hash(id) partitions 10;")
+	tk.MustExec("create table t4(d datetime, a int, b int, primary key(d, a)) partition by hash(year(d)) partitions 10;")
+	tk.MustExec("create table t5(d date, a int, b int, primary key(d, a)) partition by hash(month(d)) partitions 10;")
 
 	var input []string
 	var output []struct {

--- a/expression/testdata/partition_pruner_in.json
+++ b/expression/testdata/partition_pruner_in.json
@@ -15,7 +15,10 @@
       // Negtive cases.
       "explain select * from t1 left join t2 on true where t1.a = 1 and false",
       "explain select * from t1 left join t2 on true where t1.a = 1 and null",
-      "explain select * from t1 left join t2 on true where t1.a = null"
+      "explain select * from t1 left join t2 on true where t1.a = null",
+      // Case with date.
+      "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
+      "explain select * from t5 where d = '2019-10-07'"
     ]
   }
 ]

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -80,9 +80,7 @@
       {
         "SQL": "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
         "Result": [
-          "IndexLookUp_8 1.00 root ",
-          "├─IndexRangeScan_6(Build) 1.00 cop[tikv] table:t4, partition:p9, index:d, a, range:[2019-10-07 10:40:00 1,2019-10-07 10:40:00 1], keep order:false, stats:pseudo",
-          "└─TableRowIDScan_7(Probe) 1.00 cop[tikv] table:t4, partition:p9, keep order:false, stats:pseudo"
+          "Point_Get_6 1.00 root table:t4, index:d a, partition:p9"
         ]
       },
       {

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -76,6 +76,22 @@
         "Result": [
           "TableDual_8 0.00 root rows:0"
         ]
+      },
+      {
+        "SQL": "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
+        "Result": [
+          "IndexLookUp_8 1.00 root ",
+          "├─IndexRangeScan_6(Build) 1.00 cop[tikv] table:t4, partition:p9, index:d, a, range:[2019-10-07 10:40:00 1,2019-10-07 10:40:00 1], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_7(Probe) 1.00 cop[tikv] table:t4, partition:p9, keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t5 where d = '2019-10-07'",
+        "Result": [
+          "IndexLookUp_11 10.00 root ",
+          "├─IndexRangeScan_9(Build) 10.00 cop[tikv] table:t5, partition:p0, index:d, a, range:[2019-10-07,2019-10-07], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_10(Probe) 10.00 cop[tikv] table:t5, partition:p0, keep order:false, stats:pseudo"
+        ]
       }
     ]
   }


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
After refactor hash partition pruning logic, hash partition doesn't support builtin function yet. This PR add logic to support builtin function relating to date and time.

### What is changed and how it works?
Support `YEAR`, `MONTH`, `TO_DAY` in hash partition.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - Increased code complexity

Related changes

 - Need to cherry-pick to the release branch

Release note


