### PR TITLE
session: add test case for retrying union statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20171020122428-b9ff6c35079e
 	github.com/pingcap/kvproto v0.0.0-20191106014506-c5d88d699a8d
 	github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd
-	github.com/pingcap/parser v0.0.0-20200108075733-73763c7a9133
+	github.com/pingcap/parser v0.0.0-20200301155133-79ec3dee69a5
 	github.com/pingcap/pd v1.1.0-beta.0.20191223090411-ea2b748f6ee2
 	github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible
 	github.com/pingcap/tipb v0.0.0-20191120045257-1b9900292ab6

--- a/go.sum
+++ b/go.sum
@@ -155,8 +155,8 @@ github.com/pingcap/kvproto v0.0.0-20191106014506-c5d88d699a8d h1:zTHgLr8+0LTEJmj
 github.com/pingcap/kvproto v0.0.0-20191106014506-c5d88d699a8d/go.mod h1:QMdbTAXCHzzygQzqcG9uVUgU2fKeSN1GmfMiykdSzzY=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd h1:hWDol43WY5PGhsh3+8794bFHY1bPrmu6bTalpssCrGg=
 github.com/pingcap/log v0.0.0-20190715063458-479153f07ebd/go.mod h1:WpHUKhNZ18v116SvGrmjkA9CBhYmuUTKL+p8JC9ANEw=
-github.com/pingcap/parser v0.0.0-20200108075733-73763c7a9133 h1:/8H/v/T1nwDGSuiI/DLwWEvGbamR6LZxwyYPD4DGPDk=
-github.com/pingcap/parser v0.0.0-20200108075733-73763c7a9133/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
+github.com/pingcap/parser v0.0.0-20200301155133-79ec3dee69a5 h1:r2c8RQynYNGCFDWFPgo3TNx7Roq94STRcYTrtTg3JQ4=
+github.com/pingcap/parser v0.0.0-20200301155133-79ec3dee69a5/go.mod h1:1FNvfp9+J0wvc4kl8eGNh7Rqrxveg15jJoWo/a0uHwA=
 github.com/pingcap/pd v1.1.0-beta.0.20191223090411-ea2b748f6ee2 h1:NL23b8tsg6M1QpSQedK14/Jx++QeyKL2rGiBvXAQVfA=
 github.com/pingcap/pd v1.1.0-beta.0.20191223090411-ea2b748f6ee2/go.mod h1:b4gaAPSxaVVtaB+EHamV4Nsv8JmTdjlw0cTKmp4+dRQ=
 github.com/pingcap/tidb-tools v3.0.6-0.20191119150227-ff0a3c6e5763+incompatible h1:I8HirWsu1MZp6t9G/g8yKCEjJJxtHooKakEgccvdJ4M=

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -589,6 +589,40 @@ func (s *testSessionSuite) TestReadOnlyNotInHistory(c *C) {
 	c.Assert(history.Count(), Equals, 0)
 }
 
+func (s *testSessionSuite) TestRetryUnion(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table history (a int)")
+	tk.MustExec("insert history values (1), (2), (3)")
+	tk.MustExec("set @@autocommit = 0")
+	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
+	// UNION should't be in retry history.
+	tk.MustQuery("(select * from history) union (select * from history)")
+	history := session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 0)
+	tk.MustQuery("(select * from history for update) union (select * from history)")
+	tk.MustExec("update history set a = a + 1")
+	history = session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 2)
+
+	// Make retryable error.
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("update history set a = a + 1")
+
+	_, err := tk.Exec("commit")
+	c.Assert(err, ErrorMatches, ".*can not retry select for update statement")
+}
+
+func (s *testSessionSuite) TestRetryShow(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("set @@autocommit = 0")
+	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
+	// UNION should't be in retry history.
+	tk.MustQuery("show variables")
+	tk.MustQuery("show databases")
+	history := session.GetHistory(tk.Se)
+	c.Assert(history.Count(), Equals, 0)
+}
+
 // TestTruncateAlloc tests that the auto_increment ID does not reuse the old table's allocator.
 func (s *testSessionSuite) TestTruncateAlloc(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Add test case for https://github.com/pingcap/tidb/issues/15050.

### What is changed and how it works?
Just add some test cases to test retrying `UNION` and `SHOW` statements.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test

I did the same as https://github.com/pingcap/tidb/issues/15050 and the log shows `UNION` statement is not retried.

```
[2020/03/01 18:12:15.574 +08:00] [WARN] [session.go:463] [sql] [conn=1] [label=general] [error="[kv:9007]Write conflict, txnStartTS=414989028796923904, conflictStartTS=414989031736606720, conflictCommitTS=414989031736606721, key={tableID=45, handle=120001} primary=[]byte(nil) [try again later]"] [txn="Txn{state=invalid}"]
[2020/03/01 18:12:15.574 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=0] [sql=begin]
[2020/03/01 18:12:15.575 +08:00] [INFO] [2pc.go:1074] ["2PC clean up done"] [conn=1] [txnStartTS=414989028796923904]
[2020/03/01 18:12:15.575 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=1] [sql="update test set id=id+1"]
[2020/03/01 18:12:15.575 +08:00] [WARN] [session.go:655] [retrying] [conn=1] [schemaVersion=36] [retryCnt=0] [queryNum=2] [sql=commit]
```

Code changes

N/A

Side effects

N/A

Related changes

N/A

Release note ( This release note applies to the parser PR https://github.com/pingcap/parser/pull/755)

 - Fix the bug that goroutine leaks when retrying a transaction which contains `UNION` statement.
