### PR TITLE
server: remove error stack in log file when parsing failed (#15017)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -695,14 +695,25 @@ func (cc *clientConn) Run(ctx context.Context) {
 			if cc.ctx != nil {
 				txnMode = cc.ctx.GetSessionVars().GetReadableTxnMode()
 			}
-			logutil.Logger(ctx).Warn("command dispatched failed",
-				zap.String("connInfo", cc.String()),
-				zap.String("command", mysql.Command2Str[data[0]]),
-				zap.String("status", cc.SessionStatusToString()),
-				zap.Stringer("sql", getLastStmtInConn{cc}),
-				zap.String("txn_mode", txnMode),
-				zap.String("err", errStrForLog(err)),
-			)
+			if parser.ErrParse.Equal(err) {
+				logutil.Logger(ctx).Warn("command dispatched failed",
+					zap.String("connInfo", cc.String()),
+					zap.String("command", mysql.Command2Str[data[0]]),
+					zap.String("status", cc.SessionStatusToString()),
+					zap.Stringer("sql", getLastStmtInConn{cc}),
+					zap.String("txn_mode", txnMode),
+					zap.Error(err),
+				)
+			} else {
+				logutil.Logger(ctx).Warn("command dispatched failed",
+					zap.String("connInfo", cc.String()),
+					zap.String("command", mysql.Command2Str[data[0]]),
+					zap.String("status", cc.SessionStatusToString()),
+					zap.Stringer("sql", getLastStmtInConn{cc}),
+					zap.String("txn_mode", txnMode),
+					zap.String("err", errStrForLog(err)),
+				)
+			}
 			err1 := cc.writeError(err)
 			terror.Log(err1)
 		}


### PR DESCRIPTION
UCP #15017 

Signed-off-by: zhang555 <4598181@qq.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
remove error stack in log file when parsing failed (#15017)

### What is changed and how it works?
add a judgement condition.
it won't print error stack when parsing failed .

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has persistent data change

Side effects

 - Increased code complexity

Related changes


Release note

