### PR TITLE
infoschema: Migrate the infoschema's retrieving data logic for 'CharacterSets/Collations' to executor 

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1402,7 +1402,7 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			}
 		case strings.ToLower(infoschema.TableSchemata),
 			strings.ToLower(infoschema.TableViews),
-      strings.ToLower(infoschema.TableEngines),
+			strings.ToLower(infoschema.TableEngines),
 			strings.ToLower(infoschema.TableCollations),
 			strings.ToLower(infoschema.TableCharacterSets):
 			return &MemTableReaderExec{

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1400,7 +1400,10 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 					timeRange: v.QueryTimeRange,
 				},
 			}
-		case strings.ToLower(infoschema.TableSchemata), strings.ToLower(infoschema.TableViews):
+		case strings.ToLower(infoschema.TableSchemata),
+			strings.ToLower(infoschema.TableViews),
+			strings.ToLower(infoschema.TableCollations),
+			strings.ToLower(infoschema.TableCharacterSets):
 			return &MemTableReaderExec{
 				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 				retriever: &memtableRetriever{

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -15,9 +15,9 @@ package executor
 
 import (
 	"context"
-	"github.com/pingcap/parser/charset"
 	"sort"
 
+	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/infoschema"
@@ -53,7 +53,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			e.rows = dataForSchemata(sctx, dbs)
 		case infoschema.TableViews:
 			e.rows, err = dataForViews(sctx, dbs)
-    case infoschema.TableEngines:
+		case infoschema.TableEngines:
 			e.rows = dataForEngines()
 		case infoschema.TableCharacterSets:
 			e.rows = dataForCharacterSets()
@@ -198,4 +198,3 @@ func dataForCollations() (records [][]types.Datum) {
 	}
 	return records
 }
-

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -83,3 +83,16 @@ func (s *testInfoschemaTableSuite) TestViews(c *C) {
 	tk.MustQuery("SELECT * FROM information_schema.views WHERE table_schema='test' AND table_name='v1'").Check(testkit.Rows("def test v1 SELECT 1 CASCADED NO root@localhost DEFINER utf8mb4 utf8mb4_bin"))
 	tk.MustQuery("SELECT table_catalog, table_schema, table_name, table_type, engine, version, row_format, table_rows, avg_row_length, data_length, max_data_length, index_length, data_free, auto_increment, update_time, check_time, table_collation, checksum, create_options, table_comment FROM information_schema.tables WHERE table_schema='test' AND table_name='v1'").Check(testkit.Rows("def test v1 VIEW <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> <nil> VIEW"))
 }
+
+func (s *testInfoschemaTableSuite) TestCharacterSetCollations(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	// The description column is not important
+	tk.MustQuery("SELECT default_collate_name, maxlen FROM information_schema.character_sets ORDER BY character_set_name").Check(
+		testkit.Rows("ascii_bin 1", "binary 1", "latin1_bin 1", "utf8_bin 3", "utf8mb4_bin 4"))
+
+	// The is_default column is not important
+	// but the id's are used by client libraries and must be stable
+	tk.MustQuery("SELECT character_set_name, id, sortlen FROM information_schema.collations ORDER BY collation_name").Check(
+		testkit.Rows("ascii 65 1", "binary 63 1", "latin1 47 1", "utf8 83 1", "utf8mb4 46 1"))
+}

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -101,4 +101,3 @@ func (s *testInfoschemaTableSuite) TestCharacterSetCollations(c *C) {
 	tk.MustQuery("SELECT character_set_name, id, sortlen FROM information_schema.collations ORDER BY collation_name").Check(
 		testkit.Rows("ascii 65 1", "binary 63 1", "latin1 47 1", "utf8 83 1", "utf8mb4 46 1"))
 }
-

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -57,9 +57,11 @@ const (
 	tableColumns          = "COLUMNS"
 	tableColumnStatistics = "COLUMN_STATISTICS"
 	tableStatistics       = "STATISTICS"
-	tableCharacterSets    = "CHARACTER_SETS"
-	tableCollations       = "COLLATIONS"
-	tableFiles            = "FILES"
+	// TableCharacterSets is the string constant of infoschema charactersets memory table
+	TableCharacterSets = "CHARACTER_SETS"
+	// TableCollations is the string constant of infoschema collations memory table
+	TableCollations = "COLLATIONS"
+	tableFiles      = "FILES"
 	// CatalogVal is the string constant of TABLE_CATALOG
 	CatalogVal            = "def"
 	tableProfiling        = "PROFILING"
@@ -127,8 +129,8 @@ var tableIDMap = map[string]int64{
 	tableColumns:                            autoid.InformationSchemaDBID + 3,
 	tableColumnStatistics:                   autoid.InformationSchemaDBID + 4,
 	tableStatistics:                         autoid.InformationSchemaDBID + 5,
-	tableCharacterSets:                      autoid.InformationSchemaDBID + 6,
-	tableCollations:                         autoid.InformationSchemaDBID + 7,
+	TableCharacterSets:                      autoid.InformationSchemaDBID + 6,
+	TableCollations:                         autoid.InformationSchemaDBID + 7,
 	tableFiles:                              autoid.InformationSchemaDBID + 8,
 	CatalogVal:                              autoid.InformationSchemaDBID + 9,
 	tableProfiling:                          autoid.InformationSchemaDBID + 10,
@@ -1120,43 +1122,6 @@ func dataForTiKVStoreStatus(ctx sessionctx.Context) (records [][]types.Datum, er
 		records = append(records, row)
 	}
 	return records, nil
-}
-
-func dataForCharacterSets() (records [][]types.Datum) {
-
-	charsets := charset.GetSupportedCharsets()
-
-	for _, charset := range charsets {
-
-		records = append(records,
-			types.MakeDatums(charset.Name, charset.DefaultCollation, charset.Desc, charset.Maxlen),
-		)
-
-	}
-
-	return records
-
-}
-
-func dataForCollations() (records [][]types.Datum) {
-
-	collations := charset.GetSupportedCollations()
-
-	for _, collation := range collations {
-
-		isDefault := ""
-		if collation.IsDefault {
-			isDefault = "Yes"
-		}
-
-		records = append(records,
-			types.MakeDatums(collation.Name, collation.CharsetName, collation.ID, isDefault, "Yes", 1),
-		)
-
-	}
-
-	return records
-
 }
 
 func dataForCollationCharacterSetApplicability() (records [][]types.Datum) {
@@ -2404,8 +2369,8 @@ var tableNameToColumns = map[string][]columnInfo{
 	tableColumns:                            columnsCols,
 	tableColumnStatistics:                   columnStatisticsCols,
 	tableStatistics:                         statisticsCols,
-	tableCharacterSets:                      charsetCols,
-	tableCollations:                         collationsCols,
+	TableCharacterSets:                      charsetCols,
+	TableCollations:                         collationsCols,
 	tableFiles:                              filesCols,
 	tableProfiling:                          profilingCols,
 	tablePartitions:                         partitionsCols,
@@ -2499,10 +2464,6 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows = dataForColumns(ctx, dbs)
 	case tableStatistics:
 		fullRows = dataForStatistics(ctx, dbs)
-	case tableCharacterSets:
-		fullRows = dataForCharacterSets()
-	case tableCollations:
-		fullRows = dataForCollations()
 	case tableSessionVar:
 		fullRows, err = dataForSessionVar(ctx)
 	case tableConstraints:

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -325,15 +325,6 @@ func (s *testTableSuite) TestDataForTableStatsField(c *C) {
 func (s *testTableSuite) TestCharacterSetCollations(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
-	// The description column is not important
-	tk.MustQuery("SELECT default_collate_name, maxlen FROM information_schema.character_sets ORDER BY character_set_name").Check(
-		testkit.Rows("ascii_bin 1", "binary 1", "latin1_bin 1", "utf8_bin 3", "utf8mb4_bin 4"))
-
-	// The is_default column is not important
-	// but the id's are used by client libraries and must be stable
-	tk.MustQuery("SELECT character_set_name, id, sortlen FROM information_schema.collations ORDER BY collation_name").Check(
-		testkit.Rows("ascii 65 1", "binary 63 1", "latin1 47 1", "utf8 83 1", "utf8mb4 46 1"))
-
 	// Test charset/collation in information_schema.COLUMNS table.
 	tk.MustExec("DROP DATABASE IF EXISTS charset_collate_test")
 	tk.MustExec("CREATE DATABASE charset_collate_test; USE charset_collate_test")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Infoschema contains too much logic for retrieving data, which is confusing, we need to migrate this part to the executor so that infoshema only contains schema information. Detail ref #15040 #15035 

### What is changed and how it works?
migrate function dataForCharacterSets/dataForCollations from infoschema pkg to executor/infoschema_reader.go

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - Has exported function/method change