### PR TITLE
*: support to observe txn waiting relationship via processlists

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -655,7 +655,7 @@ var tableProcesslistCols = []columnInfo{
 	{name: "INFO", tp: mysql.TypeString, size: 512},
 	{name: "MEM", tp: mysql.TypeLonglong, size: 21},
 	{name: "TxnStart", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
-	{name: "WaitTxnTs", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
+	{name: "LastWaitTxn", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
 }
 
 var tableTiDBIndexesCols = []columnInfo{

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -655,6 +655,7 @@ var tableProcesslistCols = []columnInfo{
 	{name: "INFO", tp: mysql.TypeString, size: 512},
 	{name: "MEM", tp: mysql.TypeLonglong, size: 21},
 	{name: "TxnStart", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
+	{name: "WaitTxnTs", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag, deflt: ""},
 }
 
 var tableTiDBIndexesCols = []columnInfo{

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -565,8 +565,8 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 	tk.Se.SetSessionManager(sm)
 	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Sort().Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "do something"),
-			fmt.Sprintf("2 user-2 localhost test Init DB 9223372036 2 %s 0 ", strings.Repeat("x", 101)),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0  0", "do something"),
+			fmt.Sprintf("2 user-2 localhost test Init DB 9223372036 2 %s 0  0", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("SHOW PROCESSLIST;").Sort().Check(
 		testkit.Rows(
@@ -603,8 +603,8 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 	tk.Se.GetSessionVars().TimeZone = time.UTC
 	tk.MustQuery("select * from information_schema.PROCESSLIST order by ID;").Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "<nil>"),
-			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0  0", "<nil>"),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752) 0", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("SHOW PROCESSLIST;").Sort().Check(
 		testkit.Rows(
@@ -618,11 +618,11 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 		))
 	tk.MustQuery("select * from information_schema.PROCESSLIST where db is null;").Check(
 		testkit.Rows(
-			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752)", strings.Repeat("x", 101)),
+			fmt.Sprintf("2 user-2 localhost <nil> Init DB 9223372036 2 %s 0 07-29 03:26:05.158(410090409861578752) 0", strings.Repeat("x", 101)),
 		))
 	tk.MustQuery("select * from information_schema.PROCESSLIST where Info is null;").Check(
 		testkit.Rows(
-			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0 ", "<nil>"),
+			fmt.Sprintf("1 user-1 localhost information_schema Quit 9223372036 1 %s 0  0", "<nil>"),
 		))
 }
 
@@ -1062,7 +1062,7 @@ func (s *testClusterTableSuite) TestSelectClusterTable(c *C) {
 		tk.MustExec("set @@global.tidb_enable_stmt_summary=1")
 		tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("1"))
 		tk.MustQuery("select count(*) from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1"))
-		tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows(":10080 1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0 "))
+		tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows(":10080 1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0  0"))
 		tk.MustQuery("select query_time, conn_id from `CLUSTER_SLOW_QUERY` order by time limit 1").Check(testkit.Rows("4.895492 6"))
 		tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1"))
 		tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))
@@ -1113,7 +1113,7 @@ select * from t3;
 	tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("4"))
 	tk.MustQuery("select count(*) from `SLOW_QUERY`").Check(testkit.Rows("4"))
 	tk.MustQuery("select count(*) from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1"))
-	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows(":10080 1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0 "))
+	tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows(":10080 1 root 127.0.0.1 <nil> Query 9223372036 0 <nil> 0  0"))
 	tk.MustExec("create user user1")
 	tk.MustExec("create user user2")
 	user1 := testkit.NewTestKit(c, s.store)

--- a/server/driver.go
+++ b/server/driver.go
@@ -54,6 +54,8 @@ type QueryCtx interface {
 
 	SetProcessInfo(sql string, t time.Time, command byte, maxExecutionTime uint64)
 
+	TryUpdateProcessor(f func(info *util.ProcessInfo)) bool
+
 	// CommitTxn commits the transaction operations.
 	CommitTxn(ctx context.Context) error
 

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -218,6 +218,7 @@ func (tc *TiDBContext) SetProcessInfo(sql string, t time.Time, command byte, max
 	tc.session.SetProcessInfo(sql, t, command, maxExecutionTime)
 }
 
+// TryUpdateProcessor implements QueryCtx TryUpdateProcessor method.
 func (tc *TiDBContext) TryUpdateProcessor(f func(info *util.ProcessInfo)) bool {
 	return tc.session.TryUpdateProcessor(f)
 }

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -218,6 +218,10 @@ func (tc *TiDBContext) SetProcessInfo(sql string, t time.Time, command byte, max
 	tc.session.SetProcessInfo(sql, t, command, maxExecutionTime)
 }
 
+func (tc *TiDBContext) TryUpdateProcessor(f func(info *util.ProcessInfo)) bool {
+	return tc.session.TryUpdateProcessor(f)
+}
+
 // RollbackTxn implements QueryCtx RollbackTxn method.
 func (tc *TiDBContext) RollbackTxn() {
 	tc.session.RollbackTxn(context.TODO())

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -330,7 +330,7 @@ func (s *testPessimisticSuite) TestProcesslistLastWait(c *C) {
 		defer wg.Done()
 		session2.Exec("select * from x where id = 1 for update")
 	}()
-	time.Sleep(1 * time.Second)
+	time.Sleep(3 * time.Second)
 	ps := session3.Se.GetSessionManager().ShowProcessList()
 	var waitTs uint64
 	for _, p := range ps {

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -330,7 +330,7 @@ func (s *testPessimisticSuite) TestProcesslistLastWait(c *C) {
 		defer wg.Done()
 		session2.Exec("select * from x where id = 1 for update")
 	}()
-	time.Sleep(50 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	ps := session3.Se.GetSessionManager().ShowProcessList()
 	var waitTs uint64
 	for _, p := range ps {

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -327,10 +327,10 @@ func (s *testPessimisticSuite) TestProcesslistLastWait(c *C) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 	go func() {
-		session2.MustQuery("select * from x where id = 1 for update").Check(testkit.Rows("1 1"))
-		wg.Done()
+		defer wg.Done()
+		session2.Exec("select * from x where id = 1 for update")
 	}()
-	time.Sleep(2 * time.Second)
+	time.Sleep(50 * time.Millisecond)
 	ps := session3.Se.GetSessionManager().ShowProcessList()
 	var waitTs uint64
 	for _, p := range ps {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -813,7 +813,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			updater := bo.ctx.Value(util.ProcessInfoUpdaterCtxKey{})
 			if updater != nil {
 				updater.(util.ProcessInfoUpdater)(func(p *util.ProcessInfo) {
-					p.BlockTxnTs = waitTxn
+					p.LastWaitTxn = waitTxn
 				})
 			}
 		}

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -785,7 +785,7 @@ type clientHelper struct {
 
 // ResolveLocks wraps the ResolveLocks function and store the resolved result.
 func (ch *clientHelper) ResolveLocks(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, error) {
-	msBeforeTxnExpired, resolvedLocks, err := ch.LockResolver.ResolveLocks(bo, callerStartTS, locks)
+	msBeforeTxnExpired, resolvedLocks, _, err := ch.LockResolver.ResolveLocks(bo, callerStartTS, locks)
 	if err != nil {
 		return msBeforeTxnExpired, err
 	}

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -296,13 +296,13 @@ func (s *testLockSuite) TestCheckTxnStatus(c *C) {
 
 	// Test the ResolveLocks API
 	lock := s.mustGetLock(c, []byte("second"))
-	timeBeforeExpire, _, err := resolver.ResolveLocks(bo, currentTS, []*Lock{lock})
+	timeBeforeExpire, _, _, err := resolver.ResolveLocks(bo, currentTS, []*Lock{lock})
 	c.Assert(err, IsNil)
 	c.Assert(timeBeforeExpire > int64(0), IsTrue)
 
 	// Force rollback the lock using lock.TTL = 0.
 	lock.TTL = uint64(0)
-	timeBeforeExpire, _, err = resolver.ResolveLocks(bo, currentTS, []*Lock{lock})
+	timeBeforeExpire, _, _, err = resolver.ResolveLocks(bo, currentTS, []*Lock{lock})
 	c.Assert(err, IsNil)
 	c.Assert(timeBeforeExpire, Equals, int64(0))
 
@@ -510,19 +510,19 @@ func (s *testLockSuite) TestZeroMinCommitTS(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/mockZeroCommitTS"), IsNil)
 
 	lock := s.mustGetLock(c, []byte("key"))
-	expire, pushed, err := newLockResolver(s.store).ResolveLocks(bo, 0, []*Lock{lock})
+	expire, pushed, _, err := newLockResolver(s.store).ResolveLocks(bo, 0, []*Lock{lock})
 	c.Assert(err, IsNil)
 	c.Assert(pushed, HasLen, 0)
 	c.Assert(expire, Greater, int64(0))
 
-	expire, pushed, err = newLockResolver(s.store).ResolveLocks(bo, math.MaxUint64, []*Lock{lock})
+	expire, pushed, _, err = newLockResolver(s.store).ResolveLocks(bo, math.MaxUint64, []*Lock{lock})
 	c.Assert(err, IsNil)
 	c.Assert(pushed, HasLen, 0)
 	c.Assert(expire, Greater, int64(0))
 
 	// Clean up this test.
 	lock.TTL = uint64(0)
-	expire, _, err = newLockResolver(s.store).ResolveLocks(bo, 0, []*Lock{lock})
+	expire, _, _, err = newLockResolver(s.store).ResolveLocks(bo, 0, []*Lock{lock})
 	c.Assert(err, IsNil)
 	c.Assert(expire, Equals, int64(0))
 }

--- a/util/expensivequery/expensivequerey_test.go
+++ b/util/expensivequery/expensivequerey_test.go
@@ -47,6 +47,7 @@ func (s *testSuite) TestLogFormat(c *C) {
 		DB:            "Database",
 		Info:          "select * from table where a > 1",
 		CurTxnStartTS: 23333,
+		LastWaitTxn:   24444,
 		StatsInfo: func(interface{}) map[string]uint64 {
 			return nil
 		},
@@ -56,7 +57,7 @@ func (s *testSuite) TestLogFormat(c *C) {
 	}
 	costTime := time.Second * 233
 	logFields := genLogFields(costTime, info)
-	c.Assert(len(logFields), Equals, 7)
+	c.Assert(len(logFields), Equals, 8)
 	c.Assert(logFields[0].Key, Equals, "cost_time")
 	c.Assert(logFields[0].String, Equals, "233s")
 	c.Assert(logFields[1].Key, Equals, "conn_id")
@@ -67,8 +68,10 @@ func (s *testSuite) TestLogFormat(c *C) {
 	c.Assert(logFields[3].String, Equals, "Database")
 	c.Assert(logFields[4].Key, Equals, "txn_start_ts")
 	c.Assert(logFields[4].Integer, Equals, int64(23333))
-	c.Assert(logFields[5].Key, Equals, "mem_max")
-	c.Assert(logFields[5].String, Equals, "2013265920 Bytes (1.875 GB)")
-	c.Assert(logFields[6].Key, Equals, "sql")
-	c.Assert(logFields[6].String, Equals, "select * from table where a > 1")
+	c.Assert(logFields[5].Key, Equals, "last_wait_txn")
+	c.Assert(logFields[5].Integer, Equals, int64(24444))
+	c.Assert(logFields[6].Key, Equals, "mem_max")
+	c.Assert(logFields[6].String, Equals, "2013265920 Bytes (1.875 GB)")
+	c.Assert(logFields[7].Key, Equals, "sql")
+	c.Assert(logFields[7].String, Equals, "select * from table where a > 1")
 }

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -146,6 +146,7 @@ func genLogFields(costTime time.Duration, info *util.ProcessInfo) []zap.Field {
 		logFields = append(logFields, zap.String("index_names", indexNames))
 	}
 	logFields = append(logFields, zap.Uint64("txn_start_ts", info.CurTxnStartTS))
+	logFields = append(logFields, zap.Uint64("wait_txn_ts", info.BlockTxnTs))
 	if memTracker := info.StmtCtx.MemTracker; memTracker != nil {
 		logFields = append(logFields, zap.String("mem_max", fmt.Sprintf("%d Bytes (%v)", memTracker.MaxConsumed(), memTracker.BytesToString(memTracker.MaxConsumed()))))
 	}

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -146,7 +146,7 @@ func genLogFields(costTime time.Duration, info *util.ProcessInfo) []zap.Field {
 		logFields = append(logFields, zap.String("index_names", indexNames))
 	}
 	logFields = append(logFields, zap.Uint64("txn_start_ts", info.CurTxnStartTS))
-	logFields = append(logFields, zap.Uint64("wait_txn_ts", info.BlockTxnTs))
+	logFields = append(logFields, zap.Uint64("last_wait_txn", info.LastWaitTxn))
 	if memTracker := info.StmtCtx.MemTracker; memTracker != nil {
 		logFields = append(logFields, zap.String("mem_max", fmt.Sprintf("%d Bytes (%v)", memTracker.MaxConsumed(), memTracker.BytesToString(memTracker.MaxConsumed()))))
 	}

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -34,7 +34,7 @@ type ProcessInfo struct {
 	Time          time.Time
 	Info          string
 	CurTxnStartTS uint64
-	BlockTxnTs    uint64
+	LastWaitTxn   uint64
 	StmtCtx       *stmtctx.StatementContext
 	StatsInfo     func(interface{}) map[string]uint64
 	// MaxExecutionTime is the timeout for select statement, in milliseconds.
@@ -95,7 +95,7 @@ func (pi *ProcessInfo) ToRow(tz *time.Location) []interface{} {
 	if pi.StmtCtx != nil && pi.StmtCtx.MemTracker != nil {
 		bytesConsumed = pi.StmtCtx.MemTracker.BytesConsumed()
 	}
-	return append(pi.ToRowForShow(true), bytesConsumed, pi.txnStartTs(tz), strconv.FormatUint(pi.BlockTxnTs, 10))
+	return append(pi.ToRowForShow(true), bytesConsumed, pi.txnStartTs(tz), strconv.FormatUint(pi.LastWaitTxn, 10))
 }
 
 // SessionManager is an interface for session manage. Show processlist and


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

when a pessimistic txn blocked by others, we are hard to observe "who is other?"

### What is changed and how it works?

record last long wait lock's txn start ts in processlist just like this:

![image](https://user-images.githubusercontent.com/528332/75804958-d9a5a300-5dbb-11ea-84da-452992c4ded7.png)

row 2 block by wait-txn-ts(which point to row 1)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (just like blow pic)

Code changes

- pass a processinfo change hook
- update processinfo when tikv wait back but lock not expired that need next wait

Side effects

 - n/a

Related changes

 - n/a

Release note

 - add pessimistic txn's wait-txn-ts to infoschema.processlists

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/15108)
<!-- Reviewable:end -->
