### PR TITLE
session: make `CurrentBootstrapVersion` exported

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -432,7 +432,7 @@ func getTiDBVar(s Session, name string) (sVal string, isNull bool, e error) {
 func upgrade(s Session) {
 	ver, err := getBootstrapVersion(s)
 	terror.MustNil(err)
-	if ver >= currentBootstrapVersion {
+	if ver >= CurrentBootstrapVersion {
 		// It is already bootstrapped/upgraded by a higher version TiDB server.
 		return
 	}
@@ -610,13 +610,13 @@ func upgrade(s Session) {
 		if err1 != nil {
 			logutil.BgLogger().Fatal("upgrade failed", zap.Error(err1))
 		}
-		if v >= currentBootstrapVersion {
+		if v >= CurrentBootstrapVersion {
 			// It is already bootstrapped/upgraded by a higher version TiDB server.
 			return
 		}
 		logutil.BgLogger().Fatal("[Upgrade] upgrade failed",
 			zap.Int64("from", ver),
-			zap.Int("to", currentBootstrapVersion),
+			zap.Int("to", CurrentBootstrapVersion),
 			zap.Error(err))
 	}
 }
@@ -973,7 +973,7 @@ func upgradeToVer41(s Session) {
 func updateBootstrapVer(s Session) {
 	// Update bootstrap version.
 	sql := fmt.Sprintf(`INSERT HIGH_PRIORITY INTO %s.%s VALUES ("%s", "%d", "TiDB bootstrap version.") ON DUPLICATE KEY UPDATE VARIABLE_VALUE="%d"`,
-		mysql.SystemDB, mysql.TiDBTable, tidbServerVersionVar, currentBootstrapVersion, currentBootstrapVersion)
+		mysql.SystemDB, mysql.TiDBTable, tidbServerVersionVar, CurrentBootstrapVersion, CurrentBootstrapVersion)
 	mustExecute(s, sql)
 }
 
@@ -1069,7 +1069,7 @@ func doDMLWorks(s Session) {
 	mustExecute(s, sql)
 
 	sql = fmt.Sprintf(`INSERT HIGH_PRIORITY INTO %s.%s VALUES("%s", "%d", "Bootstrap version. Do not delete.")`,
-		mysql.SystemDB, mysql.TiDBTable, tidbServerVersionVar, currentBootstrapVersion)
+		mysql.SystemDB, mysql.TiDBTable, tidbServerVersionVar, CurrentBootstrapVersion)
 	mustExecute(s, sql)
 
 	writeSystemTZ(s)

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -200,7 +200,7 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	se := newSession(c, store, s.dbName)
 	mustExecSQL(c, se, "USE mysql;")
 
-	// bootstrap with currentBootstrapVersion
+	// bootstrap with CurrentBootstrapVersion
 	r := mustExecSQL(c, se, `SELECT VARIABLE_VALUE from mysql.TiDB where VARIABLE_NAME="tidb_server_version";`)
 	req := r.NewChunk()
 	err := r.Next(ctx, req)
@@ -208,13 +208,13 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(req.NumRows() == 0, IsFalse)
 	c.Assert(row.Len(), Equals, 1)
-	c.Assert(row.GetBytes(0), BytesEquals, []byte(fmt.Sprintf("%d", currentBootstrapVersion)))
+	c.Assert(row.GetBytes(0), BytesEquals, []byte(fmt.Sprintf("%d", CurrentBootstrapVersion)))
 	c.Assert(r.Close(), IsNil)
 
 	se1 := newSession(c, store, s.dbName)
 	ver, err := getBootstrapVersion(se1)
 	c.Assert(err, IsNil)
-	c.Assert(ver, Equals, int64(currentBootstrapVersion))
+	c.Assert(ver, Equals, int64(CurrentBootstrapVersion))
 
 	// Do something to downgrade the store.
 	// downgrade meta bootstrap version
@@ -254,12 +254,12 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	c.Assert(req.NumRows() == 0, IsFalse)
 	row = req.GetRow(0)
 	c.Assert(row.Len(), Equals, 1)
-	c.Assert(row.GetBytes(0), BytesEquals, []byte(fmt.Sprintf("%d", currentBootstrapVersion)))
+	c.Assert(row.GetBytes(0), BytesEquals, []byte(fmt.Sprintf("%d", CurrentBootstrapVersion)))
 	c.Assert(r.Close(), IsNil)
 
 	ver, err = getBootstrapVersion(se2)
 	c.Assert(err, IsNil)
-	c.Assert(ver, Equals, int64(currentBootstrapVersion))
+	c.Assert(ver, Equals, int64(CurrentBootstrapVersion))
 
 	// Verify that 'new_collation_enabled' is false.
 	r = mustExecSQL(c, se2, fmt.Sprintf(`SELECT VARIABLE_VALUE from mysql.TiDB where VARIABLE_NAME='%s';`, tidbNewCollationEnabled))

--- a/session/session.go
+++ b/session/session.go
@@ -1636,7 +1636,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	ver := getStoreBootstrapVersion(store)
 	if ver == notBootstrapped {
 		runInBootstrapSession(store, bootstrap)
-	} else if ver < currentBootstrapVersion {
+	} else if ver < CurrentBootstrapVersion {
 		runInBootstrapSession(store, upgrade)
 	}
 
@@ -1803,8 +1803,9 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 }
 
 const (
+	// CurrentBootstrapVersion is exported because it is needed by some external tools.
+	CurrentBootstrapVersion = version41
 	notBootstrapped         = 0
-	currentBootstrapVersion = version41
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {
@@ -1813,7 +1814,7 @@ func getStoreBootstrapVersion(store kv.Storage) int64 {
 	// check in memory
 	_, ok := storeBootstrapped[store.UUID()]
 	if ok {
-		return currentBootstrapVersion
+		return CurrentBootstrapVersion
 	}
 
 	var ver int64
@@ -1843,7 +1844,7 @@ func finishBootstrap(store kv.Storage) {
 
 	err := kv.RunInNewTxn(store, true, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn)
-		err := t.FinishBootstrap(currentBootstrapVersion)
+		err := t.FinishBootstrap(CurrentBootstrapVersion)
 		return err
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
By design, the tool BR(Backup/Restore) integrates tidb-server, and it needs
this variable to make sure the bootstrap version of the tidb-server it
integrated is the same with the cluster it serves.

### What is changed and how it works?
Make `CurrentBootstrapVersion` exported

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

Code changes

 - Has exported variable/fields change

Side effects

 - NA

Related changes

 - NA

Release note

 - Not needed.
