### PR TITLE
server: fix load leak

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1124,10 +1124,8 @@ func (cc *clientConn) handleLoadData(ctx context.Context, loadDataInfo *executor
 	loadDataInfo.InitQueues()
 	loadDataInfo.SetMaxRowsInBatch(uint64(loadDataInfo.Ctx.GetSessionVars().DMLBatchSize))
 	loadDataInfo.StartStopWatcher()
-	defer func() {
-		// let stop watcher goroutine quit
-		loadDataInfo.ForceQuit()
-	}()
+	// let stop watcher goroutine quit
+	defer loadDataInfo.ForceQuit()
 	err = loadDataInfo.Ctx.NewTxn(ctx)
 	if err != nil {
 		return err

--- a/server/conn.go
+++ b/server/conn.go
@@ -1124,6 +1124,10 @@ func (cc *clientConn) handleLoadData(ctx context.Context, loadDataInfo *executor
 	loadDataInfo.InitQueues()
 	loadDataInfo.SetMaxRowsInBatch(uint64(loadDataInfo.Ctx.GetSessionVars().DMLBatchSize))
 	loadDataInfo.StartStopWatcher()
+	defer func() {
+		// let stop watcher goroutine quit
+		loadDataInfo.ForceQuit()
+	}()
 	err = loadDataInfo.Ctx.NewTxn(ctx)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

The `StartStopWatcher` goroutine should quit after load data processing

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
Execute load statements, and check goroutine stack

Code changes



Side effects



Related changes

 - Need to cherry-pick to the release branch


Release note


