### PR TITLE
executor: fix last_insert_id in auto_random mode

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1160,7 +1160,7 @@ func setTableAutoRandomBits(tbInfo *model.TableInfo, colDefs []*ast.ColumnDef) e
 			if autoRandBits == 0 {
 				return ErrInvalidAutoRandom.GenWithStackByArgs(autoid.AutoRandomNonPositive)
 			} else if autoRandBits >= maxFieldTypeBitsLength {
-				return ErrInvalidAutoRandom.GenWithStackByArgs(fmt.Sprintf(autoid.AutoRandomOverflowErrMsg, autoRandBits, maxFieldTypeBitsLength))
+				return ErrInvalidAutoRandom.GenWithStackByArgs(fmt.Sprintf(autoid.AutoRandomOverflowErrMsg, col.Name.Name.L, maxFieldTypeBitsLength, autoRandBits, col.Name.Name.L, maxFieldTypeBitsLength-1))
 			}
 			tbInfo.AutoRandomBits = autoRandBits
 		}

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
+// Make it serial because config is modified in test cases.
 var _ = SerialSuites(&testSerialSuite{})
 
 type testSerialSuite struct {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -749,8 +749,8 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertWithAutoInc := func(sql string) {
 		assertInvalidAutoRandomErr(sql, autoid.AutoRandomIncompatibleWithAutoIncErrMsg)
 	}
-	assertOverflow := func(sql string, autoRandBits, maxFieldLength uint64) {
-		assertInvalidAutoRandomErr(sql, autoid.AutoRandomOverflowErrMsg, autoRandBits, maxFieldLength)
+	assertOverflow := func(sql, colType string, autoRandBits, maxFieldLength uint64) {
+		assertInvalidAutoRandomErr(sql, autoid.AutoRandomOverflowErrMsg, colType, maxFieldLength, autoRandBits, colType, maxFieldLength-1)
 	}
 	assertModifyColType := func(sql string) {
 		assertInvalidAutoRandomErr(sql, autoid.AutoRandomModifyColTypeErrMsg)
@@ -794,11 +794,11 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertWithAutoInc("create table t (a bigint auto_random(3) auto_increment, primary key (a))")
 
 	// Overflow data type max length.
-	assertOverflow("create table t (a bigint auto_random(65) primary key)", 65, 64)
-	assertOverflow("create table t (a int auto_random(33) primary key)", 33, 32)
-	assertOverflow("create table t (a mediumint auto_random(25) primary key)", 25, 24)
-	assertOverflow("create table t (a smallint auto_random(17) primary key)", 17, 16)
-	assertOverflow("create table t (a tinyint auto_random(9) primary key)", 9, 8)
+	assertOverflow("create table t (a bigint auto_random(65) primary key)", "bigint", 65, 64)
+	assertOverflow("create table t (a int auto_random(33) primary key)", "int", 33, 32)
+	assertOverflow("create table t (a mediumint auto_random(25) primary key)", "mediumint", 25, 24)
+	assertOverflow("create table t (a smallint auto_random(17) primary key)", "smallint", 17, 16)
+	assertOverflow("create table t (a tinyint auto_random(9) primary key)", "tinyint", 9, 8)
 
 	assertNonPositive("create table t (a bigint auto_random(0) primary key)")
 

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -794,11 +794,11 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertWithAutoInc("create table t (a bigint auto_random(3) auto_increment, primary key (a))")
 
 	// Overflow data type max length.
-	assertOverflow("create table t (a bigint auto_random(65) primary key)", "bigint", 65, 64)
-	assertOverflow("create table t (a int auto_random(33) primary key)", "int", 33, 32)
-	assertOverflow("create table t (a mediumint auto_random(25) primary key)", "mediumint", 25, 24)
-	assertOverflow("create table t (a smallint auto_random(17) primary key)", "smallint", 17, 16)
-	assertOverflow("create table t (a tinyint auto_random(9) primary key)", "tinyint", 9, 8)
+	assertOverflow("create table t (a bigint auto_random(65) primary key)", "a", 65, 64)
+	assertOverflow("create table t (a int auto_random(33) primary key)", "a", 33, 32)
+	assertOverflow("create table t (a mediumint auto_random(25) primary key)", "a", 25, 24)
+	assertOverflow("create table t (a smallint auto_random(17) primary key)", "a", 17, 16)
+	assertOverflow("create table t (a tinyint auto_random(9) primary key)", "a", 9, 8)
 
 	assertNonPositive("create table t (a bigint auto_random(0) primary key)")
 

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -784,7 +784,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 
 	// Test explicit insert.
 	tk.MustExec("create table t (a tinyint primary key auto_random(2), b int)")
-	for i := 0; i < 100; i++ {
+	for i := 1; i <= 100; i++ {
 		tk.MustExec("insert into t values (?, ?)", i, i)
 	}
 	_, err = tk.Exec("insert into t (b) values (0)")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -813,8 +813,8 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	tk.MustExec("drop table t")
 
 	tk.MustExec("create table t (a tinyint primary key auto_random(2), b int)")
-	tk.MustExec("insert into t values (0, 2)")
-	tk.MustExec("update t set a = 31 where a = 0")
+	tk.MustExec("insert into t values (1, 2)")
+	tk.MustExec("update t set a = 31 where a = 1")
 	_, err = tk.Exec("insert into t (b) values (0)")
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, autoid.ErrAutoRandReadFailed.GenWithStackByArgs().Error())

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -15,7 +15,6 @@ package executor_test
 
 import (
 	"fmt"
-	"go.etcd.io/etcd/proxy/grpcproxy/adapter"
 	"strconv"
 	"strings"
 	"sync"
@@ -981,8 +980,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	firstValue, err := strconv.Atoi(rs.Rows()[0][0].(string))
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Greater, 0)
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(id) values (0)`)
@@ -991,8 +989,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	firstValue, err = strconv.Atoi(rs.Rows()[0][0].(string))
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Greater, 0)
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(name) values ('a')`)
@@ -1001,8 +998,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	firstValue, err = strconv.Atoi(rs.Rows()[0][0].(string))
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Greater, 0)
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 
 	tk.MustExec(`drop table ar`)
 }
@@ -1029,8 +1025,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	c.Assert(firstValue, Greater, 0)
 	c.Assert(rs.Rows()[1][0].(string), Equals, fmt.Sprintf("%d", firstValue+1))
 	c.Assert(rs.Rows()[2][0].(string), Equals, fmt.Sprintf("%d", firstValue+2))
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(id) values (0),(0),(0)`)
@@ -1041,8 +1036,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	c.Assert(firstValue, Greater, 0)
 	c.Assert(rs.Rows()[1][0].(string), Equals, fmt.Sprintf("%d", firstValue+1))
 	c.Assert(rs.Rows()[2][0].(string), Equals, fmt.Sprintf("%d", firstValue+2))
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(name) values ('a'),('a'),('a')`)
@@ -1053,8 +1047,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	c.Assert(firstValue, Greater, 0)
 	c.Assert(rs.Rows()[1][0].(string), Equals, fmt.Sprintf("%d", firstValue+1))
 	c.Assert(rs.Rows()[2][0].(string), Equals, fmt.Sprintf("%d", firstValue+2))
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 
 	tk.MustExec(`drop table ar`)
 }
@@ -1083,8 +1076,7 @@ func (s *testSuite3) TestAutoRandomIDAllowZero(c *C) {
 	firstValue, err := strconv.Atoi(rs.Rows()[0][0].(string))
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Equals, 0)
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 
 	tk.MustExec(`insert into ar(id) values (null)`)
 	rs = tk.MustQuery(`select id from ar`)
@@ -1092,8 +1084,7 @@ func (s *testSuite3) TestAutoRandomIDAllowZero(c *C) {
 	firstValue, err = strconv.Atoi(rs.Rows()[0][0].(string))
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Greater, 0)
-	rs = tk.MustQuery(`select last_insert_id()`)
-	c.Assert(rs.Rows()[0][0].(string), Equals, fmt.Sprintf("%d", firstValue))
+	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 
 	tk.MustExec(`drop table ar`)
 }

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -960,7 +960,7 @@ func (s *testSuite3) TestAutoIDIncrementAndOffset(c *C) {
 	c.Assert(err.Error(), Equals, "[autoid:8060]Invalid auto_increment settings: auto_increment_increment: 65536, auto_increment_offset: 65536, both of them must be in range [1..65535]")
 }
 
-var _ = SerialSuites(&testSuite9{})
+var _ = SerialSuites(&testSuite9{&baseTestSuite{}})
 
 type testSuite9 struct {
 	*baseTestSuite

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1077,6 +1077,7 @@ func (s *testSuite3) TestAutoRandomIDAllowZero(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(firstValue, Equals, 0)
 	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
+	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(id) values (null)`)
 	rs = tk.MustQuery(`select id from ar`)

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -972,7 +972,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	tk.MustExec(`create table ar (id int key auto_random, name char(10))`)
 
 	tk.MustExec(`insert into ar(id) values (null)`)
-	rs := tk.MustQuery(`select id from io`)
+	rs := tk.MustQuery(`select id from ar`)
 	c.Assert(len(rs.Rows()), Equals, 1)
 	firstValue := rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -981,7 +981,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(id) values (0)`)
-	rs = tk.MustQuery(`select id from io`)
+	rs = tk.MustQuery(`select id from ar`)
 	c.Assert(len(rs.Rows()), Equals, 1)
 	firstValue = rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -990,7 +990,7 @@ func (s *testSuite3) TestAutoRandomID(c *C) {
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(name) values ('a')`)
-	rs = tk.MustQuery(`select id from io`)
+	rs = tk.MustQuery(`select id from ar`)
 	c.Assert(len(rs.Rows()), Equals, 1)
 	firstValue = rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -1012,7 +1012,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	tk.MustExec(`create table ar (id int key auto_random, name char(10))`)
 
 	tk.MustExec(`insert into ar(id) values (null),(null),(null)`)
-	rs := tk.MustQuery(`select id from io order by id`)
+	rs := tk.MustQuery(`select id from ar order by id`)
 	c.Assert(len(rs.Rows()), Equals, 3)
 	firstValue := rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -1023,7 +1023,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(id) values (0),(0),(0)`)
-	rs = tk.MustQuery(`select id from io order by id`)
+	rs = tk.MustQuery(`select id from ar order by id`)
 	c.Assert(len(rs.Rows()), Equals, 3)
 	firstValue = rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -1034,7 +1034,7 @@ func (s *testSuite3) TestMultiAutoRandomID(c *C) {
 	tk.MustExec(`delete from ar`)
 
 	tk.MustExec(`insert into ar(name) values ('a'),('a'),('a')`)
-	rs = tk.MustQuery(`select id from io order by id`)
+	rs = tk.MustQuery(`select id from ar order by id`)
 	c.Assert(len(rs.Rows()), Equals, 3)
 	firstValue = rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))
@@ -1062,7 +1062,7 @@ func (s *testSuite3) TestAutoRandomIDAllowZero(c *C) {
 	tk.MustExec(fmt.Sprintf(`set session sql_mode="%s,%s"`, sqlMode, "NO_AUTO_VALUE_ON_ZERO"))
 
 	tk.MustExec(`insert into ar(id) values (0)`)
-	rs = tk.MustQuery(`select id from io`)
+	rs = tk.MustQuery(`select id from ar`)
 	c.Assert(len(rs.Rows()), Equals, 1)
 	firstValue := rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Equals, int64(0))
@@ -1070,7 +1070,7 @@ func (s *testSuite3) TestAutoRandomIDAllowZero(c *C) {
 	c.Assert(rs.Rows()[0][0].(int64), Equals, firstValue)
 
 	tk.MustExec(`insert into ar(id) values (null)`)
-	rs = tk.MustQuery(`select id from io`)
+	rs = tk.MustQuery(`select id from ar`)
 	c.Assert(len(rs.Rows()), Equals, 1)
 	firstValue = rs.Rows()[0][0].(int64)
 	c.Assert(firstValue, Greater, int64(0))

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -38,7 +38,7 @@ const (
 	// AutoRandomIncompatibleWithDefaultValueErrMsg is reported when auto_random and default are specified on the same column.
 	AutoRandomIncompatibleWithDefaultValueErrMsg = "auto_random is incompatible with default"
 	// AutoRandomOverflowErrMsg is reported when auto_random is greater than max length of a MySQL data type.
-	AutoRandomOverflowErrMsg = "Bits of column `%s` is %d, but auto_random bits is %d. Max allowed bits for column `%s` is %d"
+	AutoRandomOverflowErrMsg = "Bits of column `%s` is %d, but auto_random bits is %d. Max allowed auto_random bits for column `%s` is %d"
 	// AutoRandomModifyColTypeErrMsg is reported when a user is trying to modify the type of a column specified with auto_random.
 	AutoRandomModifyColTypeErrMsg = "modifying the auto_random column type is not supported"
 	// AutoRandomAlterErrMsg is reported when a user is trying to add/drop/modify the value of auto_random attribute.

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -38,7 +38,7 @@ const (
 	// AutoRandomIncompatibleWithDefaultValueErrMsg is reported when auto_random and default are specified on the same column.
 	AutoRandomIncompatibleWithDefaultValueErrMsg = "auto_random is incompatible with default"
 	// AutoRandomOverflowErrMsg is reported when auto_random is greater than max length of a MySQL data type.
-	AutoRandomOverflowErrMsg = "Bits of `%s` is %d, but auto_random bits is %d. Max allowed bits for `%s` is %d"
+	AutoRandomOverflowErrMsg = "Bits of column `%s` is %d, but auto_random bits is %d. Max allowed bits for column `%s` is %d"
 	// AutoRandomModifyColTypeErrMsg is reported when a user is trying to modify the type of a column specified with auto_random.
 	AutoRandomModifyColTypeErrMsg = "modifying the auto_random column type is not supported"
 	// AutoRandomAlterErrMsg is reported when a user is trying to add/drop/modify the value of auto_random attribute.

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -38,7 +38,7 @@ const (
 	// AutoRandomIncompatibleWithDefaultValueErrMsg is reported when auto_random and default are specified on the same column.
 	AutoRandomIncompatibleWithDefaultValueErrMsg = "auto_random is incompatible with default"
 	// AutoRandomOverflowErrMsg is reported when auto_random is greater than max length of a MySQL data type.
-	AutoRandomOverflowErrMsg = "auto_random = %d will overflow. The max length of bits is %d"
+	AutoRandomOverflowErrMsg = "Bits of `%s` is %d, but auto_random bits is %d. Max allowed bits for `%s` is %d"
 	// AutoRandomModifyColTypeErrMsg is reported when a user is trying to modify the type of a column specified with auto_random.
 	AutoRandomModifyColTypeErrMsg = "modifying the auto_random column type is not supported"
 	// AutoRandomAlterErrMsg is reported when a user is trying to add/drop/modify the value of auto_random attribute.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix https://github.com/pingcap/tidb/issues/15140.
- Last insert id shouldn't be 0 when inserting with auto_random.
- 0 is not replaced with an auto allocated value.
- Error message of auto_random is confusing.

### What is changed and how it works?
- Set last insert id after inserting 0.
- Consider `NO_AUTO_VALUE_ON_ZERO` and fill auto value with inserting 0.
- Refine error message of auto_random.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Manual test (add detailed scripts or steps below)
```
mysql> insert ar value(0, 'a'), (0, 'b');
Query OK, 2 rows affected (0.00 sec)
Records: 2  Duplicates: 0  Warnings: 0

mysql> select * from ar;
+-----------+------+
| id        | name |
+-----------+------+
| 671178642 | a    |
| 671178643 | b    |
+-----------+------+
2 rows in set (0.00 sec)

mysql> select last_insert_id();
+------------------+
| last_insert_id() |
+------------------+
|        671178642 |
+------------------+
1 row in set (0.01 sec)
```

```
mysql> create table ar(id int key auto_random(32));
ERROR 8216 (HY000): Invalid auto random: Bits of column `id` is 32, but auto_random bits is 32. Max allowed auto_random bits for column `id` is 31
mysql> create table ar(id int key auto_random(31));
Query OK, 0 rows affected (0.00 sec)
```

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the bug that `last_insert_id` is wrong when inserting with `auto_random`; Inserting 0 with `auto_random` column is not replaced with an allocated value.
