### PR TITLE
build: Auto assign issue to project SIG Runtime Kanban/SIG Planner Kanban   

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -17,7 +17,7 @@ jobs:
         column_name: 'Need Triage'
     - name: Run assignment to project SIG Planner Kanban
       uses: SunRunAway/assign-one-project-github-action@1.1.6
-      if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'component/planner')
+      if: github.event.action == 'labeled' && (contains(github.event.issue.labels.*.name, 'component/planner') || contains(github.event.issue.labels.*.name, 'component/statistics'))
       with:
         project: 'https://github.com/pingcap/tidb/projects/39'
         column_name: 'Need Triage'

--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -1,0 +1,23 @@
+name: Auto Assign Project Local
+
+on: [issues]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Run assignment to project SIG Runtime Kanban
+      uses: SunRunAway/assign-one-project-github-action@1.1.6
+      if: github.event.action == 'labeled' && (contains(github.event.issue.labels.*.name, 'component/executor') || contains(github.event.issue.labels.*.name, 'component/expression'))
+      with:
+        project: 'https://github.com/pingcap/tidb/projects/38'
+        column_name: 'Need Triage'
+    - name: Run assignment to project SIG Planner Kanban
+      uses: SunRunAway/assign-one-project-github-action@1.1.6
+      if: github.event.action == 'labeled' && contains(github.event.issue.labels.*.name, 'component/planner')
+      with:
+        project: 'https://github.com/pingcap/tidb/projects/39'
+        column_name: 'Need Triage'


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Auto assign issue to project SIG Runtime Kanban/SIG Planner Kanban using github action.

### What is changed and how it works?

Use https://github.com/SunRunAway/assign-one-project-github-action

### Check List <!--REMOVE the items that are not applicable-->

