### PR TITLE
expression, planner: fix group by and order by with explicit collate

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -5703,6 +5703,13 @@ func (s *testIntegrationSerialSuite) TestCollateSort(c *C) {
 	tk := s.prepare4Collation(c, false)
 	tk.MustQuery("select id from t order by v, id").Check(testkit.Rows("7", "1", "2", "3", "4", "5", "6"))
 	tk.MustQuery("select id from t_bin order by v, id").Check(testkit.Rows("7", "1", "5", "6", "2", "4", "3"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a char(10) collate utf8mb4_general_ci, key(a))")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustQuery("select * from t order by a collate utf8mb4_bin").Check(testkit.Rows("A", "A", "A", "a", "a", "a", "b", "b", "b"))
 }
 
 func (s *testIntegrationSerialSuite) TestCollateHashAgg(c *C) {
@@ -5717,6 +5724,13 @@ func (s *testIntegrationSerialSuite) TestCollateHashAgg(c *C) {
 	tk.MustQuery("select v, count(*) from t_bin group by v").Sort().Check(testkit.Rows("  1", "a 1", "b 1", "c 1", "À 1", "à 1", "á 1"))
 	tk.HasPlan("select v, count(*) from t group by v", "HashAgg")
 	tk.MustQuery("select v, count(*) from t group by v").Sort().Check(testkit.Rows("  1", "a 4", "b 1", "c 1"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a char(10) collate utf8mb4_general_ci, key(a))")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustExec("insert into t values ('a'), ('A'), ('b')")
+	tk.MustQuery("select count(1) from t group by a collate utf8mb4_bin").Check(testkit.Rows("3", "3", "3"))
 }
 
 func (s *testIntegrationSerialSuite) TestCollateStreamAgg(c *C) {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -265,8 +265,9 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 		// SetCollationExpr sets the collation explicitly, even when the evaluation type of the expression is non-string.
 		if _, ok := arg.(*Column); ok {
 			// Wrap a cast here to avoid changing the original FieldType of the column expression.
-			casted := BuildCastFunction(sr.ctx, arg, arg.GetType())
-			casted.GetType().Collate = v.Collate
+			exprType := arg.GetType().Clone()
+			exprType.Collate = v.Collate
+			casted := BuildCastFunction(sr.ctx, arg, exprType)
 			sr.pop()
 			sr.push(casted)
 		} else {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -17,6 +17,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/opcode"
@@ -24,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/collate"
 )
 
 type simpleRewriter struct {
@@ -245,6 +247,33 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 			Value:   types.NewStringDatum(v.Selector.String()),
 			RetType: types.NewFieldType(mysql.TypeVarchar),
 		})
+	case *ast.SetCollationExpr:
+		arg := sr.pop()
+		if collate.NewCollationEnabled() {
+			var collInfo *charset.Collation
+			// TODO(bb7133): use charset.ValidCharsetAndCollation when its bug is fixed.
+			if collInfo, sr.err = charset.GetCollationByName(v.Collate); sr.err != nil {
+				sr.err = charset.ErrUnknownCollation.GenWithStackByArgs(v.Collate)
+				break
+			}
+			chs := arg.GetType().Charset
+			if chs != "" && collInfo.CharsetName != chs {
+				sr.err = charset.ErrCollationCharsetMismatch.GenWithStackByArgs(collInfo.Name, chs)
+				break
+			}
+		}
+		// SetCollationExpr sets the collation explicitly, even when the evaluation type of the expression is non-string.
+		if _, ok := arg.(*Column); ok {
+			// Wrap a cast here to avoid changing the original FieldType of the column expression.
+			casted := BuildCastFunction(sr.ctx, arg, arg.GetType())
+			casted.GetType().Collate = v.Collate
+			sr.pop()
+			sr.push(casted)
+		} else {
+			// For constant and scalar function, we can set its collate directly.
+			arg.GetType().Collate = v.Collate
+		}
+		sr.stack[len(sr.stack)-1].SetCoercibility(CoercibilityExplicit)
 	default:
 		sr.err = errors.Errorf("UnknownType: %T", v)
 		return retNode, false

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1005,8 +1005,9 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		// SetCollationExpr sets the collation explicitly, even when the evaluation type of the expression is non-string.
 		if _, ok := arg.(*expression.Column); ok {
 			// Wrap a cast here to avoid changing the original FieldType of the column expression.
-			casted := expression.BuildCastFunction(er.sctx, arg, arg.GetType())
-			casted.GetType().Collate = v.Collate
+			exprType := arg.GetType().Clone()
+			exprType.Collate = v.Collate
+			casted := expression.BuildCastFunction(er.sctx, arg, exprType)
 			er.ctxStackPop(1)
 			er.ctxStackAppend(casted, types.EmptyName)
 		} else {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1005,7 +1005,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		// SetCollationExpr sets the collation explicitly, even when the evaluation type of the expression is non-string.
 		if _, ok := arg.(*expression.Column); ok {
 			// Wrap a cast here to avoid changing the original FieldType of the column expression.
-			casted := expression.WrapWithCastAsString(er.sctx, arg)
+			casted := expression.BuildCastFunction(er.sctx, arg, arg.GetType())
 			casted.GetType().Collate = v.Collate
 			er.ctxStackPop(1)
 			er.ctxStackAppend(casted, types.EmptyName)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
When rewrite the SetCollation, we use WrapWithCastAsString to build a cast function. But this is ineffective.

### What is changed and how it works?
Use buildCastfunction directly.
Besides, copy the logic from expression rewriter to simple rewriter.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


 - Integration test


Code changes



Side effects



Related changes



Release note


