### PR TITLE
config: bug fix for the config-check mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -708,6 +708,22 @@ func InitializeConfig(confPath string, configCheck, configStrict bool, reloadFun
 		}
 	}
 	enforceCmdArgs(cfg)
+
+	if err := cfg.Valid(); err != nil {
+		if !filepath.IsAbs(confPath) {
+			if tmp, err := filepath.Abs(confPath); err == nil {
+				confPath = tmp
+			}
+		}
+		fmt.Fprintln(os.Stderr, "load config file:", confPath)
+		fmt.Fprintln(os.Stderr, "invalid config", err)
+		os.Exit(1)
+	}
+	if configCheck {
+		fmt.Println("config check successful")
+		os.Exit(0)
+	}
+
 	globalConfHandler, err = NewConfHandler(confPath, cfg, reloadFunc, nil)
 	terror.MustNil(err)
 	globalConfHandler.Start()

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -161,21 +161,6 @@ func main() {
 	registerStores()
 	registerMetrics()
 	config.InitializeConfig(*configPath, *configCheck, *configStrict, reloadConfig, overrideConfig)
-	if err := config.GetGlobalConfig().Valid(); err != nil {
-		absConfigPath := *configPath
-		if !filepath.IsAbs(absConfigPath) {
-			if tmp, err := filepath.Abs(absConfigPath); err == nil {
-				absConfigPath = tmp
-			}
-		}
-		fmt.Fprintln(os.Stderr, "load config file:", absConfigPath)
-		fmt.Fprintln(os.Stderr, "invalid config", err)
-		os.Exit(1)
-	}
-	if *configCheck {
-		fmt.Println("config check successful")
-		os.Exit(0)
-	}
 	setGlobalVars()
 	setCPUAffinity()
 	setupLog()


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
In this PR(https://github.com/pingcap/tidb/pull/14750), we support updating configs online according to PD, and the first step to implement this feature(https://github.com/pingcap/tidb/pull/13660) is to register the current config to PD when TiDB starts.

But in the config-check mode(when the `config-check` flag is true), we don't need to do this register operation.

### What is changed and how it works?
If the `config-check` flag is true, exit immediately after checking the config.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
