### PR TITLE
executor: migrate dataForServersInfo from infoschema pkg to executor

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1436,7 +1436,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			strings.ToLower(infoschema.TableTiKVRegionPeers),
 			strings.ToLower(infoschema.TableTiDBHotRegions),
 			strings.ToLower(infoschema.TableSessionVar),
-			strings.ToLower(infoschema.TableConstraints):
+			strings.ToLower(infoschema.TableConstraints),
+			strings.ToLower(infoschema.TableTiDBServersInfo):
 			return &MemTableReaderExec{
 				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 				table:        v.Table,

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -103,7 +103,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableSessionVar:
 			err = e.setDataFromSessionVar(sctx)
 		case infoschema.TableTiDBServersInfo:
-			e.rows, err = dataForServersInfo()
+			err = e.setDataForServersInfo()
 		}
 		if err != nil {
 			return nil, err
@@ -1122,10 +1122,10 @@ func (e *memtableRetriever) setDataForAnalyzeStatus(sctx sessionctx.Context) {
 	e.rows = dataForAnalyzeStatusHelper(sctx)
 }
 
-func dataForServersInfo() ([][]types.Datum, error) {
+func (e *memtableRetriever) setDataForServersInfo() error {
 	serversInfo, err := infosync.GetAllServerInfo(context.Background())
 	if err != nil {
-		return nil, err
+		return err
 	}
 	rows := make([][]types.Datum, 0, len(serversInfo))
 	for _, info := range serversInfo {
@@ -1141,5 +1141,6 @@ func dataForServersInfo() ([][]types.Datum, error) {
 		)
 		rows = append(rows, row)
 	}
-	return rows, nil
+	e.rows = rows
+	return nil
 }

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/privilege"
@@ -101,6 +102,8 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			e.setDataFromTableConstraints(sctx, dbs)
 		case infoschema.TableSessionVar:
 			err = e.setDataFromSessionVar(sctx)
+		case infoschema.TableTiDBServersInfo:
+			e.rows, err = dataForServersInfo()
 		}
 		if err != nil {
 			return nil, err
@@ -1117,4 +1120,26 @@ func dataForAnalyzeStatusHelper(sctx sessionctx.Context) (rows [][]types.Datum) 
 // setDataForAnalyzeStatus gets all the analyze jobs.
 func (e *memtableRetriever) setDataForAnalyzeStatus(sctx sessionctx.Context) {
 	e.rows = dataForAnalyzeStatusHelper(sctx)
+}
+
+func dataForServersInfo() ([][]types.Datum, error) {
+	serversInfo, err := infosync.GetAllServerInfo(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	rows := make([][]types.Datum, 0, len(serversInfo))
+	for _, info := range serversInfo {
+		row := types.MakeDatums(
+			info.ID,              // DDL_ID
+			info.IP,              // IP
+			int(info.Port),       // PORT
+			int(info.StatusPort), // STATUS_PORT
+			info.Lease,           // LEASE
+			info.Version,         // VERSION
+			info.GitHash,         // GIT_HASH
+			info.BinlogStatus,    // BINLOG_STATUS
+		)
+		rows = append(rows, row)
+	}
+	return rows, nil
 }

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -24,7 +24,6 @@ import (
 	"context"
 
 	"github.com/gorilla/mux"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/fn"

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -21,8 +21,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
-
 	"context"
+
 	"github.com/gorilla/mux"
 
 	. "github.com/pingcap/check"

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -22,9 +22,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gorilla/mux"
 	"context"
-	"strconv"
+	"github.com/gorilla/mux"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
@@ -722,3 +721,4 @@ func (s *testInfoschemaClusterTableSuite) TestTiDBClusterInfo(c *C) {
 		"tidb key3.key4.nest4 n-value5",
 		"tikv key3.key4.nest4 n-value5",
 	))
+}

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -21,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"time"
-	"context"
 
 	"github.com/gorilla/mux"
 	. "github.com/pingcap/check"

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -103,7 +103,8 @@ const (
 	tableTiKVRegionStatus = "TIKV_REGION_STATUS"
 	// TableTiKVRegionPeers is the string constant of infoschema table
 	TableTiKVRegionPeers = "TIKV_REGION_PEERS"
-	tableTiDBServersInfo = "TIDB_SERVERS_INFO"
+	// TableTiDBServersInfo is the string constant of TiDB server information table.
+	TableTiDBServersInfo = "TIDB_SERVERS_INFO"
 	// TableSlowQuery is the string constant of slow query memory table.
 	TableSlowQuery = "SLOW_QUERY"
 	// TableClusterInfo is the string constant of cluster info memory table.
@@ -174,7 +175,7 @@ var tableIDMap = map[string]int64{
 	TableAnalyzeStatus:                      autoid.InformationSchemaDBID + 38,
 	tableTiKVRegionStatus:                   autoid.InformationSchemaDBID + 39,
 	TableTiKVRegionPeers:                    autoid.InformationSchemaDBID + 40,
-	tableTiDBServersInfo:                    autoid.InformationSchemaDBID + 41,
+	TableTiDBServersInfo:                    autoid.InformationSchemaDBID + 41,
 	TableClusterInfo:                        autoid.InformationSchemaDBID + 42,
 	TableClusterConfig:                      autoid.InformationSchemaDBID + 43,
 	TableClusterLoad:                        autoid.InformationSchemaDBID + 44,
@@ -1274,28 +1275,6 @@ func dataForPseudoProfiling() [][]types.Datum {
 	return rows
 }
 
-func dataForServersInfo() ([][]types.Datum, error) {
-	serversInfo, err := infosync.GetAllServerInfo(context.Background())
-	if err != nil {
-		return nil, err
-	}
-	rows := make([][]types.Datum, 0, len(serversInfo))
-	for _, info := range serversInfo {
-		row := types.MakeDatums(
-			info.ID,              // DDL_ID
-			info.IP,              // IP
-			int(info.Port),       // PORT
-			int(info.StatusPort), // STATUS_PORT
-			info.Lease,           // LEASE
-			info.Version,         // VERSION
-			info.GitHash,         // GIT_HASH
-			info.BinlogStatus,    // BINLOG_STATUS
-		)
-		rows = append(rows, row)
-	}
-	return rows, nil
-}
-
 // ServerInfo represents the basic server information of single cluster component
 type ServerInfo struct {
 	ServerType     string
@@ -1537,7 +1516,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableAnalyzeStatus:                      tableAnalyzeStatusCols,
 	tableTiKVRegionStatus:                   tableTiKVRegionStatusCols,
 	TableTiKVRegionPeers:                    TableTiKVRegionPeersCols,
-	tableTiDBServersInfo:                    tableTiDBServersInfoCols,
+	TableTiDBServersInfo:                    tableTiDBServersInfoCols,
 	TableClusterInfo:                        tableClusterInfoCols,
 	TableClusterConfig:                      tableClusterConfigCols,
 	TableClusterLog:                         tableClusterLogCols,
@@ -1618,8 +1597,6 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows, err = dataForTiKVStoreStatus(ctx)
 	case tableTiKVRegionStatus:
 		fullRows, err = dataForTiKVRegionStatus(ctx)
-	case tableTiDBServersInfo:
-		fullRows, err = dataForServersInfo()
 	case tableTiFlashReplica:
 		fullRows = dataForTableTiFlashReplica(ctx, dbs)
 	// Data for cluster processlist memory table.

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -14,7 +14,6 @@
 package infoschema_test
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
 	"net"
@@ -35,7 +34,6 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
-	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -632,26 +630,6 @@ func (s *testTableSuite) TestSlowQuery(c *C) {
 	re = tk.MustQuery("select query from information_schema.slow_query order by time desc limit 1")
 	rows := re.Rows()
 	c.Assert(rows[0][0], Equals, sql)
-}
-
-func (s *testTableSuite) TestForServersInfo(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	result := tk.MustQuery("select * from information_schema.TIDB_SERVERS_INFO")
-	c.Assert(len(result.Rows()), Equals, 1)
-
-	serversInfo, err := infosync.GetAllServerInfo(context.Background())
-	c.Assert(err, IsNil)
-	c.Assert(len(serversInfo), Equals, 1)
-
-	for _, info := range serversInfo {
-		c.Assert(result.Rows()[0][0], Equals, info.ID)
-		c.Assert(result.Rows()[0][1], Equals, info.IP)
-		c.Assert(result.Rows()[0][2], Equals, strconv.FormatInt(int64(info.Port), 10))
-		c.Assert(result.Rows()[0][3], Equals, strconv.FormatInt(int64(info.StatusPort), 10))
-		c.Assert(result.Rows()[0][4], Equals, info.Lease)
-		c.Assert(result.Rows()[0][5], Equals, info.Version)
-		c.Assert(result.Rows()[0][6], Equals, info.GitHash)
-	}
 }
 
 func (s *testTableSuite) TestColumnStatistics(c *C) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
UCP #15033.

### What is changed and how it works?
Migrates the dataForServersInfo method from `infoschema` pkg to `executor`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 
Code changes

 - Has exported variable/fields change
 - Has persistent data change

Side effects

None

Related changes

None

Release note

None