### PR TITLE
planner: fix datarace for plan cache config

### DIFF
--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -397,23 +397,17 @@ func (s *testPrepareSuite) TestPrepareCacheForPartition(c *C) {
 	c.Assert(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
-	orgCapacity := core.PreparedPlanCacheCapacity
-	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
-	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
-		core.PreparedPlanCacheCapacity = orgCapacity
-		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
-		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
-	core.PreparedPlanCacheCapacity = 100
-	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
-	// behavior would not be effected by the uncertain memory utilization.
-	core.PreparedPlanCacheMaxMemory.Store(math.MaxUint64)
+
+	tk.Se, err = session.CreateSession4TestWithOpt(store, &session.Opt{
+		PreparedPlanCache: kvcache.NewSimpleLRUCache(100, 0.1, math.MaxUint64),
+	})
+	c.Assert(err, IsNil)
 
 	tk.MustExec("use test")
 	// Test for PointGet and IndexRead.
@@ -471,23 +465,18 @@ func (s *testPrepareSerialSuite) TestConstPropAndPPDWithCache(c *C) {
 	c.Assert(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
 	orgEnable := core.PreparedPlanCacheEnabled()
-	orgCapacity := core.PreparedPlanCacheCapacity
-	orgMemGuardRatio := core.PreparedPlanCacheMemoryGuardRatio
-	orgMaxMemory := core.PreparedPlanCacheMaxMemory
 	defer func() {
 		dom.Close()
 		store.Close()
 		core.SetPreparedPlanCache(orgEnable)
-		core.PreparedPlanCacheCapacity = orgCapacity
-		core.PreparedPlanCacheMemoryGuardRatio = orgMemGuardRatio
-		core.PreparedPlanCacheMaxMemory = orgMaxMemory
 	}()
 	core.SetPreparedPlanCache(true)
-	core.PreparedPlanCacheCapacity = 100
-	core.PreparedPlanCacheMemoryGuardRatio = 0.1
-	// PreparedPlanCacheMaxMemory is set to MAX_UINT64 to make sure the cache
-	// behavior would not be effected by the uncertain memory utilization.
-	core.PreparedPlanCacheMaxMemory.Store(math.MaxUint64)
+
+	tk.Se, err = session.CreateSession4TestWithOpt(store, &session.Opt{
+		PreparedPlanCache: kvcache.NewSimpleLRUCache(100, 0.1, math.MaxUint64),
+	})
+	c.Assert(err, IsNil)
+
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a varchar(8) not null, b varchar(8) not null)")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

Fix https://github.com/pingcap/tidb/issues/15136 data race, like what https://github.com/pingcap/tidb/pull/14756 does.
```
[2020-03-07T13:24:35.773Z] ==================

[2020-03-07T13:24:35.773Z] WARNING: DATA RACE

[2020-03-07T13:24:35.773Z] Write at 0x0000051ad468 by goroutine 113:

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/planner/core_test.(*testPrepareSuite).TestPrepareCacheForPartition.func1()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/prepare_test.go:407 +0x6d

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/planner/core_test.(*testPrepareSuite).TestPrepareCacheForPartition()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/prepare_test.go:453 +0x10d6

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/planner/core_test.(*testPrepareSuite).TestPrepareCacheForPartition()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/prepare_test.go:438 +0xa6e

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/planner/core_test.(*testPrepareSuite).TestPrepareCacheForPartition()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/prepare_test.go:421 +0x399

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1024 +0x37f

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1022 +0x352

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1020 +0x325

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1018 +0x2f8

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1016 +0x2cb

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1014 +0x29e

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1012 +0x271

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1010 +0x244

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1008 +0x217

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1006 +0x1ea

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1004 +0x1bd

[2020-03-07T13:24:35.773Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.773Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1003 +0x190

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1002 +0x163

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:1001 +0x136

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:999 +0x109

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:997 +0xdc

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.doDDLWorks()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:995 +0x5b

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.bootstrap()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/bootstrap.go:306 +0x1a1

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.runInBootstrapSession()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1744 +0xe2

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.BootstrapSession()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1644 +0xb3f

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/planner/core_test.newStoreWithBootstrap()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/cbo_test.go:565 +0xb7

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/planner/core_test.(*testPrepareSuite).TestPrepareCacheForPartition()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/prepare_test.go:396 +0x83

[2020-03-07T13:24:35.774Z]   runtime.call32()

[2020-03-07T13:24:35.774Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a

[2020-03-07T13:24:35.774Z]   reflect.Value.Call()

[2020-03-07T13:24:35.774Z]       /usr/local/go/src/reflect/value.go:321 +0xd3

[2020-03-07T13:24:35.774Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:850 +0x9aa

[2020-03-07T13:24:35.774Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:739 +0x113

[2020-03-07T13:24:35.774Z] 

[2020-03-07T13:24:35.774Z] Previous read at 0x0000051ad468 by goroutine 225:

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.CreateSessionWithDomain()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1799 +0x62d

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/session.createSessionWithDomainFunc.func1()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:878 +0x75

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/domain.(*Domain).Init.func1()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:679 +0x49

[2020-03-07T13:24:35.774Z]   github.com/ngaut/pools.(*ResourcePool).get()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/ngaut/pools@v0.0.0-20180318154953-b7bc8c42aac7/resource_pool.go:119 +0x1df

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*sessionPool).get()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/ngaut/pools@v0.0.0-20180318154953-b7bc8c42aac7/resource_pool.go:84 +0xd5

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*delRange).addDelRangeJob()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/delete_range.go:85 +0x81

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).deleteRange()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:310 +0x92

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).finishDDLJob()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:336 +0x680

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue.func1()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:447 +0x3c2

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/kv.RunInNewTxn()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/kv/txn.go:47 +0x110

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.774Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.774Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*worker).start()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:150 +0x335

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*worker).start()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:150 +0x335

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*worker).handleDDLJobQueue()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:420 +0x19b

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*worker).start()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl_worker.go:150 +0x335

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/ddl.(*ddl).start.func2()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/ddl/ddl.go:487 +0x71

[2020-03-07T13:24:35.775Z]   github.com/pingcap/tidb/util.WithRecovery()

[2020-03-07T13:24:35.775Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/misc.go:90 +0x68

[2020-03-07T13:24:35.775Z] 
```

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 
 - No code

