### PR TITLE
GenAutoRandomID should be paired with GenAutoTableID in onRenameTable

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -634,10 +634,12 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
-		_, err = t.GenAutoRandomID(newSchemaID, tblInfo.ID, autoRandomID)
-		if err != nil {
-			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+		if autoRandomID > 0 {
+			_, err = t.GenAutoRandomID(newSchemaID, tblInfo.ID, autoRandomID)
+			if err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Trace(err)
+			}
 		}
 	}
 

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -629,6 +629,11 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
+		_, err = t.GenAutoRandomID(newSchemaID, tblInfo.ID, baseID)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
 	}
 
 	ver, err = updateSchemaVersion(t, job)


### PR DESCRIPTION
`AutoRandomID` and `AutoTableID` are cleared together, so they should be generated together too.