### PR TITLE
*: replace global mutex random with lock-free FastRand function.

### DIFF
--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -15,7 +15,6 @@ package statistics
 
 import (
 	"context"
-	"math/rand"
 	"sort"
 
 	"github.com/pingcap/errors"
@@ -24,6 +23,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tipb/go-tipb"
@@ -165,9 +165,9 @@ func (c *SampleCollector) collect(sc *stmtctx.StatementContext, d types.Datum) e
 		newItem := &SampleItem{Value: types.CloneDatum(d)}
 		c.Samples = append(c.Samples, newItem)
 	} else {
-		shouldAdd := rand.Int63n(c.seenValues) < c.MaxSampleSize
+		shouldAdd := int64(util.FastRand64N(uint64(c.seenValues))) < c.MaxSampleSize
 		if shouldAdd {
-			idx := rand.Intn(int(c.MaxSampleSize))
+			idx := int(util.FastRand32N(uint32(c.MaxSampleSize)))
 			newItem := &SampleItem{Value: types.CloneDatum(d)}
 			// To keep the order of the elements, we use delete and append, not direct replacement.
 			c.Samples = append(c.Samples[:idx], c.Samples[idx+1:]...)

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"math/rand"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -91,12 +91,12 @@ func NewBackoffFn(base, cap, jitter int) func(ctx context.Context, maxSleepMs in
 			sleep = expo(base, cap, attempts)
 		case FullJitter:
 			v := expo(base, cap, attempts)
-			sleep = rand.Intn(v)
+			sleep = int(util.FastRand32N(uint32(v)))
 		case EqualJitter:
 			v := expo(base, cap, attempts)
-			sleep = v/2 + rand.Intn(v/2)
+			sleep = v/2 + int(util.FastRand32N(uint32(v/2)))
 		case DecorrJitter:
-			sleep = int(math.Min(float64(cap), float64(base+rand.Intn(lastSleep*3-base))))
+			sleep = int(math.Min(float64(cap), float64(base+int(util.FastRand32N(uint32(lastSleep*3-base))))))
 		}
 		logutil.BgLogger().Debug("backoff",
 			zap.Int("base", base),

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -33,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/oracle/oracles"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.etcd.io/etcd/clientv3"
 	"go.uber.org/zap"
@@ -208,7 +209,7 @@ func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Clie
 		safePoint:       0,
 		spTime:          time.Now(),
 		closed:          make(chan struct{}),
-		replicaReadSeed: rand.Uint32(),
+		replicaReadSeed: util.FastRand(),
 	}
 	store.lockResolver = newLockResolver(store)
 	store.enableGC = enableGC

--- a/util/random.go
+++ b/util/random.go
@@ -14,7 +14,7 @@
 package util
 
 import (
-	"math/rand"
+	_ "unsafe" // required by go:linkname
 )
 
 // RandomBuf generates a random string using ASCII characters but avoid separator character.
@@ -22,10 +22,33 @@ import (
 func RandomBuf(size int) []byte {
 	buf := make([]byte, size)
 	for i := 0; i < size; i++ {
-		buf[i] = byte(rand.Intn(127))
+		buf[i] = byte(FastRand32N(127))
 		if buf[i] == 0 || buf[i] == byte('$') {
 			buf[i]++
 		}
 	}
 	return buf
+}
+
+// FastRand returns a lock free uint32 value.
+//go:linkname FastRand runtime.fastrand
+func FastRand() uint32
+
+// FastRand32N returns, as an uint32, a pseudo-random number in [0,n).
+func FastRand32N(n uint32) uint32 {
+	if n&(n-1) == 0 { // n is power of two, can mask
+		return FastRand() & (n - 1)
+	}
+	return FastRand() % n
+}
+
+// FastRand64N returns, as an uint64, a pseudo-random number in [0,n).
+func FastRand64N(n uint64) uint64 {
+	a := FastRand()
+	b := FastRand()
+	v := uint64(a)<<32 + uint64(b)
+	if n&(n-1) == 0 { // n is power of two, can mask
+		return v & (n - 1)
+	}
+	return v % n
 }

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -15,6 +15,8 @@ package util
 
 import (
 	. "github.com/pingcap/check"
+	"math/rand"
+	"testing"
 )
 
 var _ = Suite(&testRandSuite{})
@@ -29,4 +31,22 @@ func (s *testMiscSuite) TestRand(c *C) {
 	c.Assert(y < 1<<63, IsTrue)
 
 	_ = RandomBuf(20)
+}
+
+func BenchmarkFastRand(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			FastRand()
+		}
+	})
+	b.Log(FastRand())
+}
+
+func BenchmarkGlobalRand(b *testing.B) {
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			rand.Int()
+		}
+	})
+	b.Log(rand.Int())
 }

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -32,6 +33,19 @@ func (s *testMiscSuite) TestRand(c *C) {
 	c.Assert(y < 1<<63, IsTrue)
 
 	_ = RandomBuf(20)
+	var arr [256]bool
+	for i := 0; i < 1024; i++ {
+		idx := FastRand32N(256)
+		arr[idx] = true
+	}
+	sum := 0
+	for i := 0; i < 256; i++ {
+		if arr[i] == false {
+			sum++
+		}
+	}
+	fmt.Println(sum)
+	c.Assert(sum < 6, IsTrue)
 }
 
 func BenchmarkFastRand(b *testing.B) {

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -14,9 +14,10 @@
 package util
 
 import (
-	. "github.com/pingcap/check"
 	"math/rand"
 	"testing"
+
+	. "github.com/pingcap/check"
 )
 
 var _ = Suite(&testRandSuite{})

--- a/util/random_test.go
+++ b/util/random_test.go
@@ -1,0 +1,32 @@
+// Copyright 2020-present PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package util
+
+import (
+	. "github.com/pingcap/check"
+)
+
+var _ = Suite(&testRandSuite{})
+
+type testRandSuite struct {
+}
+
+func (s *testMiscSuite) TestRand(c *C) {
+	x := FastRand32N(1024)
+	c.Assert(x < 1024, IsTrue)
+	y := FastRand64N(1 << 63)
+	c.Assert(y < 1<<63, IsTrue)
+
+	_ = RandomBuf(20)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Improve the perfromance.

### What is changed and how it works?
replace global mutex random with lock-free FastRand function.

```
   BenchmarkFastRand-12    	1000000000	         0.435 ns/op
   BenchmarkGlobalRand-12    	18839404	     61.8 ns/op
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
