### PR TITLE
*: reduce the allocation caused by Datum.Copy

### DIFF
--- a/executor/admin.go
+++ b/executor/admin.go
@@ -535,15 +535,15 @@ func (e *CleanupIndexExec) deleteDanglingIdx(txn kv.Transaction, values map[stri
 
 func extractIdxVals(row chunk.Row, idxVals []types.Datum,
 	fieldTypes []*types.FieldType) []types.Datum {
-	if idxVals == nil {
-		idxVals = make([]types.Datum, 0, row.Len()-1)
+	if cap(idxVals) < row.Len()-1 {
+		idxVals = make([]types.Datum, row.Len()-1)
 	} else {
-		idxVals = idxVals[:0]
+		idxVals = idxVals[:row.Len()-1]
 	}
 
 	for i := 0; i < row.Len()-1; i++ {
 		colVal := row.GetDatum(i, fieldTypes[i])
-		idxVals = append(idxVals, *colVal.Copy())
+		colVal.Copy(&idxVals[i])
 	}
 	return idxVals
 }

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -326,7 +326,8 @@ func (e *InsertValues) evalRow(ctx context.Context, list []expression.Expression
 		}
 
 		offset := e.insertColumns[i].Offset
-		row[offset], hasValue[offset] = *val1.Copy(), true
+		val1.Copy(&row[offset])
+		hasValue[offset] = true
 		e.evalBuffer.SetDatum(offset, val1)
 	}
 	// Row may lack of generated column, autoIncrement column, empty column here.

--- a/executor/update.go
+++ b/executor/update.go
@@ -246,7 +246,7 @@ func (e *UpdateExec) fastComposeNewRow(rowIdx int, oldRow []types.Datum, cols []
 			}
 		}
 
-		newRowData[assign.Col.Index] = *val.Copy()
+		val.Copy(&newRowData[assign.Col.Index])
 	}
 	return newRowData, nil
 }
@@ -273,7 +273,7 @@ func (e *UpdateExec) composeNewRow(rowIdx int, oldRow []types.Datum, cols []*tab
 			}
 		}
 
-		newRowData[assign.Col.Index] = *val.Copy()
+		val.Copy(&newRowData[assign.Col.Index])
 		e.evalBuffer.SetDatum(assign.Col.Index, val)
 	}
 	return newRowData, nil

--- a/expression/aggregation/first_row.go
+++ b/expression/aggregation/first_row.go
@@ -36,7 +36,7 @@ func (ff *firstRowFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.Stat
 	if err != nil {
 		return err
 	}
-	evalCtx.Value = types.CloneDatum(value)
+	value.Copy(&evalCtx.Value)
 	evalCtx.GotFirstRow = true
 	return nil
 }

--- a/expression/aggregation/max_min.go
+++ b/expression/aggregation/max_min.go
@@ -42,7 +42,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 		return err
 	}
 	if evalCtx.Value.IsNull() {
-		evalCtx.Value = *(&value).Copy()
+		value.Copy(&evalCtx.Value)
 	}
 	if value.IsNull() {
 		return nil
@@ -53,7 +53,7 @@ func (mmf *maxMinFunction) Update(evalCtx *AggEvaluateContext, sc *stmtctx.State
 		return err
 	}
 	if (mmf.isMax && c == -1) || (!mmf.isMax && c == 1) {
-		evalCtx.Value = *(&value).Copy()
+		value.Copy(&evalCtx.Value)
 	}
 	return nil
 }

--- a/expression/aggregation/util.go
+++ b/expression/aggregation/util.go
@@ -68,7 +68,7 @@ func calculateSum(sc *stmtctx.StatementContext, sum, v types.Datum) (data types.
 			data = types.NewDecimalDatum(d)
 		}
 	case types.KindMysqlDecimal:
-		data = types.CloneDatum(v)
+		v.Copy(&data)
 	default:
 		var f float64
 		f, err = v.ToFloat64(sc)

--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -410,7 +410,7 @@ func (b *BucketFeedback) splitBucket(newNumBkts int, totalCount float64, originB
 	bkts := make([]bucket, 0, len(bounds)-1)
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	for i := 1; i < len(bounds); i++ {
-		newBkt := bucket{&bounds[i-1], bounds[i].Copy(), 0, 0}
+		newBkt := bucket{&bounds[i-1], bounds[i].Clone(), 0, 0}
 		// get bucket count
 		_, ratio := getOverlapFraction(Feedback{b.lower, b.upper, int64(originBucketCount), 0}, newBkt)
 		countInNewBkt := originBucketCount * ratio

--- a/statistics/handle/bootstrap.go
+++ b/statistics/handle/bootstrap.go
@@ -109,7 +109,15 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache *stat
 				terror.Log(errors.Trace(err))
 			}
 			hist := statistics.NewHistogram(id, ndv, nullCount, version, types.NewFieldType(mysql.TypeBlob), chunk.InitialCapacity, 0)
-			table.Indices[hist.ID] = &statistics.Index{Histogram: *hist, CMSketch: cms, Info: idxInfo, StatsVer: row.GetInt64(8), Flag: row.GetInt64(10), LastAnalyzePos: *lastAnalyzePos.Copy()}
+			index := &statistics.Index{
+				Histogram: *hist,
+				CMSketch:  cms,
+				Info:      idxInfo,
+				StatsVer:  row.GetInt64(8),
+				Flag:      row.GetInt64(10),
+			}
+			lastAnalyzePos.Copy(&index.LastAnalyzePos)
+			table.Indices[hist.ID] = index
 		} else {
 			var colInfo *model.ColumnInfo
 			for _, col := range tbl.Meta().Columns {
@@ -123,15 +131,16 @@ func (h *Handle) initStatsHistograms4Chunk(is infoschema.InfoSchema, cache *stat
 			}
 			hist := statistics.NewHistogram(id, ndv, nullCount, version, &colInfo.FieldType, 0, totColSize)
 			hist.Correlation = row.GetFloat64(9)
-			table.Columns[hist.ID] = &statistics.Column{
-				Histogram:      *hist,
-				PhysicalID:     table.PhysicalID,
-				Info:           colInfo,
-				Count:          nullCount,
-				IsHandle:       tbl.Meta().PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
-				Flag:           row.GetInt64(10),
-				LastAnalyzePos: *lastAnalyzePos.Copy(),
+			col := &statistics.Column{
+				Histogram:  *hist,
+				PhysicalID: table.PhysicalID,
+				Info:       colInfo,
+				Count:      nullCount,
+				IsHandle:   tbl.Meta().PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				Flag:       row.GetInt64(10),
 			}
+			lastAnalyzePos.Copy(&col.LastAnalyzePos)
+			table.Columns[hist.ID] = col
 		}
 	}
 }

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -396,7 +396,8 @@ func (h *Handle) indexStatsFromStorage(reader *statsReader, row chunk.Row, table
 			if err != nil {
 				return errors.Trace(err)
 			}
-			idx = &statistics.Index{Histogram: *hg, CMSketch: cms, Info: idxInfo, ErrorRate: errorRate, StatsVer: row.GetInt64(7), Flag: flag, LastAnalyzePos: *lastAnalyzePos.Copy()}
+			idx = &statistics.Index{Histogram: *hg, CMSketch: cms, Info: idxInfo, ErrorRate: errorRate, StatsVer: row.GetInt64(7), Flag: flag}
+			lastAnalyzePos.Copy(&idx.LastAnalyzePos)
 		}
 		break
 	}
@@ -444,15 +445,15 @@ func (h *Handle) columnStatsFromStorage(reader *statsReader, row chunk.Row, tabl
 				return errors.Trace(err)
 			}
 			col = &statistics.Column{
-				PhysicalID:     table.PhysicalID,
-				Histogram:      *statistics.NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
-				Info:           colInfo,
-				Count:          count + nullCount,
-				ErrorRate:      errorRate,
-				IsHandle:       tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
-				Flag:           flag,
-				LastAnalyzePos: *lastAnalyzePos.Copy(),
+				PhysicalID: table.PhysicalID,
+				Histogram:  *statistics.NewHistogram(histID, distinct, nullCount, histVer, &colInfo.FieldType, 0, totColSize),
+				Info:       colInfo,
+				Count:      count + nullCount,
+				ErrorRate:  errorRate,
+				IsHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				Flag:       flag,
 			}
+			lastAnalyzePos.Copy(&col.LastAnalyzePos)
 			col.Histogram.Correlation = correlation
 			break
 		}
@@ -466,16 +467,16 @@ func (h *Handle) columnStatsFromStorage(reader *statsReader, row chunk.Row, tabl
 				return errors.Trace(err)
 			}
 			col = &statistics.Column{
-				PhysicalID:     table.PhysicalID,
-				Histogram:      *hg,
-				Info:           colInfo,
-				CMSketch:       cms,
-				Count:          int64(hg.TotalRowCount()),
-				ErrorRate:      errorRate,
-				IsHandle:       tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
-				Flag:           flag,
-				LastAnalyzePos: *lastAnalyzePos.Copy(),
+				PhysicalID: table.PhysicalID,
+				Histogram:  *hg,
+				Info:       colInfo,
+				CMSketch:   cms,
+				Count:      int64(hg.TotalRowCount()),
+				ErrorRate:  errorRate,
+				IsHandle:   tableInfo.PKIsHandle && mysql.HasPriKeyFlag(colInfo.Flag),
+				Flag:       flag,
 			}
+			lastAnalyzePos.Copy(&col.LastAnalyzePos)
 			break
 		}
 		if col.TotColSize != totColSize {

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -162,13 +162,15 @@ func (c *SampleCollector) collect(sc *stmtctx.StatementContext, d types.Datum) e
 	// to the underlying slice, GC can't free them which lead to memory leak eventually.
 	// TODO: Refactor the proto to avoid copying here.
 	if len(c.Samples) < int(c.MaxSampleSize) {
-		newItem := &SampleItem{Value: types.CloneDatum(d)}
+		newItem := &SampleItem{}
+		d.Copy(&newItem.Value)
 		c.Samples = append(c.Samples, newItem)
 	} else {
 		shouldAdd := int64(util.FastRand64N(uint64(c.seenValues))) < c.MaxSampleSize
 		if shouldAdd {
 			idx := int(util.FastRand32N(uint32(c.MaxSampleSize)))
-			newItem := &SampleItem{Value: types.CloneDatum(d)}
+			newItem := &SampleItem{}
+			d.Copy(&newItem.Value)
 			// To keep the order of the elements, we use delete and append, not direct replacement.
 			c.Samples = append(c.Samples[:idx], c.Samples[idx+1:]...)
 			c.Samples = append(c.Samples, newItem)

--- a/types/datum.go
+++ b/types/datum.go
@@ -70,21 +70,27 @@ type Datum struct {
 	x         interface{} // x hold all other types.
 }
 
-// Copy deep copies a Datum.
-func (d *Datum) Copy() *Datum {
-	ret := *d
+// Clone create a deep copy of the Datum.
+func (d *Datum) Clone() *Datum {
+	ret := new(Datum)
+	d.Copy(ret)
+	return ret
+}
+
+// Copy deep copies a Datum into destination.
+func (d *Datum) Copy(dst *Datum) {
+	*dst = *d
 	if d.b != nil {
-		ret.b = make([]byte, len(d.b))
-		copy(ret.b, d.b)
+		dst.b = make([]byte, len(d.b))
+		copy(dst.b, d.b)
 	}
-	switch ret.Kind() {
+	switch dst.Kind() {
 	case KindMysqlDecimal:
 		d := *d.GetMysqlDecimal()
-		ret.SetMysqlDecimal(&d)
+		dst.SetMysqlDecimal(&d)
 	case KindMysqlTime:
-		ret.SetMysqlTime(d.GetMysqlTime())
+		dst.SetMysqlTime(d.GetMysqlTime())
 	}
-	return &ret
 }
 
 // Kind gets the kind of the datum.
@@ -1949,14 +1955,16 @@ func DatumsToStrNoErr(datums []Datum) string {
 // CloneDatum returns a new copy of the datum.
 // TODO: Abandon this function.
 func CloneDatum(datum Datum) Datum {
-	return *datum.Copy()
+	var ret Datum
+	datum.Copy(&ret)
+	return ret
 }
 
 // CloneRow deep copies a Datum slice.
 func CloneRow(dr []Datum) []Datum {
 	c := make([]Datum, len(dr))
 	for i, d := range dr {
-		c[i] = *d.Copy()
+		d.Copy(&c[i])
 	}
 	return c
 }

--- a/types/datum.go
+++ b/types/datum.go
@@ -1952,14 +1952,6 @@ func DatumsToStrNoErr(datums []Datum) string {
 	return str
 }
 
-// CloneDatum returns a new copy of the datum.
-// TODO: Abandon this function.
-func CloneDatum(datum Datum) Datum {
-	var ret Datum
-	datum.Copy(&ret)
-	return ret
-}
-
 // CloneRow deep copies a Datum slice.
 func CloneRow(dr []Datum) []Datum {
 	c := make([]Datum, len(dr))

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -360,7 +360,7 @@ func (ts *testDatumSuite) TestCloneDatum(c *C) {
 	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	for _, tt := range tests {
-		tt1 := CloneDatum(tt)
+		tt1 := *tt.Clone()
 		res, err := tt.CompareDatum(sc, &tt1)
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, 0)

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -162,15 +162,15 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 		},
 		{
 			ran: ranger.Range{
-				LowVal:  []types.Datum{*nullDatum.Copy()},
+				LowVal:  []types.Datum{*nullDatum.Clone()},
 				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 			},
 			isFullRange: true,
 		},
 		{
 			ran: ranger.Range{
-				LowVal:  []types.Datum{*nullDatum.Copy()},
-				HighVal: []types.Datum{*nullDatum.Copy()},
+				LowVal:  []types.Datum{*nullDatum.Clone()},
+				HighVal: []types.Datum{*nullDatum.Clone()},
 			},
 			isFullRange: true,
 		},


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If we inspect the escape analyzer's log, we can find `Datum.Copy` caused an unnecessary heap allocation
```
./datum.go:74:7: leaking param content: d
./datum.go:76:8: moved to heap: d
./datum.go:75:12: new(Datum) escapes to heap
./datum.go:76:8: make([]byte, len(d.b)) escapes to heap
./datum.go:76:8: b escapes to heap
```
![image](https://user-images.githubusercontent.com/15031522/76187383-2c45eb80-6210-11ea-92ba-f1746ba08989.png)

### What is changed and how it works?
This PR changed the `Datum.Copy` to take a parameter as the destination, and write data to it directly to avoid leaking object to the heap.

```
./datum.go:81:7: leaking param content: d
./datum.go:81:22: dst does not escape
./datum.go:89:3: moved to heap: d
./datum.go:84:15: make([]byte, len(d.b)) escapes to heap
./datum.go:92:19: b escapes to heap
```

The old-style `Datum.Copy` have renamed to `Datum.Clone`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code

Code changes

 - Has exported function/method change