### PR TITLE
infoschema, planner: fix wrong `table_names` in statement summary

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -735,7 +735,7 @@ func newPointGetPlan(ctx sessionctx.Context, dbName string, schema *expression.S
 		outputNames:  names,
 		LockWaitTime: ctx.GetSessionVars().LockWaitTimeout,
 	}
-	ctx.GetSessionVars().StmtCtx.Tables = []stmtctx.TableEntry{{DB: ctx.GetSessionVars().CurrentDB, Table: tbl.Name.L}}
+	ctx.GetSessionVars().StmtCtx.Tables = []stmtctx.TableEntry{{DB: dbName, Table: tbl.Name.L}}
 	return p
 }
 

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -500,6 +500,10 @@ func (ssbd *stmtSummaryByDigest) init(sei *StmtExecInfo, beginTime int64, interv
 	// Use "," to separate table names to support FIND_IN_SET.
 	var buffer bytes.Buffer
 	for i, value := range sei.StmtCtx.Tables {
+		// In `create database` statement, DB name is not empty but table name is empty.
+		if len(value.Table) == 0 {
+			continue
+		}
 		buffer.WriteString(strings.ToLower(value.DB))
 		buffer.WriteString(".")
 		buffer.WriteString(strings.ToLower(value.Table))


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
1. In `create database test` statement, `table_names` in `events_statements_summary_by_digest` is "test.".
2. In point get statement, schema name in `table_names` is current db, not the schema where table exists.

### What is changed and how it works?
1. If table name is empty, do not output this table name.
2. Replace the schema name with the right one in point get statement.

`StmtCtx.Tables` is only used in statement summary and test cases, so it's safe.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

N/A

Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Fix the bug that `table_names` in statement summary tables may be wrong in some statements.
