### PR TITLE
executor,infoschema: move `dataForTableConstraints` into executor

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1417,7 +1417,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			strings.ToLower(infoschema.TableCharacterSets),
 			strings.ToLower(infoschema.TableKeyColumn),
 			strings.ToLower(infoschema.TableUserPrivileges),
-			strings.ToLower(infoschema.TableCollationCharacterSetApplicability):
+			strings.ToLower(infoschema.TableCollationCharacterSetApplicability),
+			strings.ToLower(infoschema.TableConstraints):
 			return &MemTableReaderExec{
 				baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ExplainID()),
 				retriever: &memtableRetriever{

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -309,3 +309,8 @@ func (s *testInfoschemaTableSuite) TestPartitionsTable(c *C) {
 
 	tk.MustExec("DROP TABLE `test_partitions`;")
 }
+
+func (s *testInfoschemaTableSuite) TestTableConstraintsTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustQuery("select * from information_schema.TABLE_CONSTRAINTS where TABLE_NAME='gc_delete_range';").Check(testkit.Rows("def mysql delete_range_index mysql gc_delete_range UNIQUE"))
+}

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -67,11 +67,12 @@ const (
 	// TablePartitions is the string constant of infoschema table
 	TablePartitions = "PARTITIONS"
 	// TableKeyColumn is the string constant of KEY_COLUMN_USAGE
-	TableKeyColumn   = "KEY_COLUMN_USAGE"
-	tableReferConst  = "REFERENTIAL_CONSTRAINTS"
-	tableSessionVar  = "SESSION_VARIABLES"
-	tablePlugins     = "PLUGINS"
-	tableConstraints = "TABLE_CONSTRAINTS"
+	TableKeyColumn  = "KEY_COLUMN_USAGE"
+	tableReferConst = "REFERENTIAL_CONSTRAINTS"
+	tableSessionVar = "SESSION_VARIABLES"
+	tablePlugins    = "PLUGINS"
+	// TableConstraints is the string constant of TABLE_CONSTRAINTS.
+	TableConstraints = "TABLE_CONSTRAINTS"
 	tableTriggers    = "TRIGGERS"
 	// TableUserPrivileges is the string constant of infoschema user privilege table.
 	TableUserPrivileges   = "USER_PRIVILEGES"
@@ -146,7 +147,7 @@ var tableIDMap = map[string]int64{
 	tableReferConst:                         autoid.InformationSchemaDBID + 13,
 	tableSessionVar:                         autoid.InformationSchemaDBID + 14,
 	tablePlugins:                            autoid.InformationSchemaDBID + 15,
-	tableConstraints:                        autoid.InformationSchemaDBID + 16,
+	TableConstraints:                        autoid.InformationSchemaDBID + 16,
 	tableTriggers:                           autoid.InformationSchemaDBID + 17,
 	TableUserPrivileges:                     autoid.InformationSchemaDBID + 18,
 	tableSchemaPrivileges:                   autoid.InformationSchemaDBID + 19,
@@ -1407,62 +1408,6 @@ func dataForStatisticsInTable(schema *model.DBInfo, table *model.TableInfo) [][]
 	return rows
 }
 
-const (
-	primaryKeyType = "PRIMARY KEY"
-	// PrimaryConstraint is the string constant of PRIMARY
-	PrimaryConstraint = "PRIMARY"
-	uniqueKeyType     = "UNIQUE"
-)
-
-// dataForTableConstraints constructs data for table information_schema.constraints.See https://dev.mysql.com/doc/refman/5.7/en/table-constraints-table.html
-func dataForTableConstraints(ctx sessionctx.Context, schemas []*model.DBInfo) [][]types.Datum {
-	checker := privilege.GetPrivilegeManager(ctx)
-	var rows [][]types.Datum
-	for _, schema := range schemas {
-		for _, tbl := range schema.Tables {
-			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, tbl.Name.L, "", mysql.AllPrivMask) {
-				continue
-			}
-
-			if tbl.PKIsHandle {
-				record := types.MakeDatums(
-					CatalogVal,           // CONSTRAINT_CATALOG
-					schema.Name.O,        // CONSTRAINT_SCHEMA
-					mysql.PrimaryKeyName, // CONSTRAINT_NAME
-					schema.Name.O,        // TABLE_SCHEMA
-					tbl.Name.O,           // TABLE_NAME
-					primaryKeyType,       // CONSTRAINT_TYPE
-				)
-				rows = append(rows, record)
-			}
-
-			for _, idx := range tbl.Indices {
-				var cname, ctype string
-				if idx.Primary {
-					cname = mysql.PrimaryKeyName
-					ctype = primaryKeyType
-				} else if idx.Unique {
-					cname = idx.Name.O
-					ctype = uniqueKeyType
-				} else {
-					// The index has no constriant.
-					continue
-				}
-				record := types.MakeDatums(
-					CatalogVal,    // CONSTRAINT_CATALOG
-					schema.Name.O, // CONSTRAINT_SCHEMA
-					cname,         // CONSTRAINT_NAME
-					schema.Name.O, // TABLE_SCHEMA
-					tbl.Name.O,    // TABLE_NAME
-					ctype,         // CONSTRAINT_TYPE
-				)
-				rows = append(rows, record)
-			}
-		}
-	}
-	return rows
-}
-
 // dataForPseudoProfiling returns pseudo data for table profiling when system variable `profiling` is set to `ON`.
 func dataForPseudoProfiling() [][]types.Datum {
 	var rows [][]types.Datum
@@ -1851,7 +1796,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	tableReferConst:                         referConstCols,
 	tableSessionVar:                         sessionVarCols,
 	tablePlugins:                            pluginsCols,
-	tableConstraints:                        tableConstraintsCols,
+	TableConstraints:                        tableConstraintsCols,
 	tableTriggers:                           tableTriggersCols,
 	TableUserPrivileges:                     tableUserPrivilegesCols,
 	tableSchemaPrivileges:                   tableSchemaPrivilegesCols,
@@ -1936,8 +1881,6 @@ func (it *infoschemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows = dataForStatistics(ctx, dbs)
 	case tableSessionVar:
 		fullRows, err = dataForSessionVar(ctx)
-	case tableConstraints:
-		fullRows = dataForTableConstraints(ctx, dbs)
 	case tableFiles:
 	case tableProfiling:
 		if v, ok := ctx.GetSessionVars().GetSystemVar("profiling"); ok && variable.TiDBOptOn(v) {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -424,7 +424,6 @@ func (s *testTableSuite) TestSomeTables(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustQuery("select * from information_schema.SESSION_VARIABLES where VARIABLE_NAME='tidb_retry_limit';").Check(testkit.Rows("tidb_retry_limit 10"))
-	tk.MustQuery("select * from information_schema.TABLE_CONSTRAINTS where TABLE_NAME='gc_delete_range';").Check(testkit.Rows("def mysql delete_range_index mysql gc_delete_range UNIQUE"))
 
 	sm := &mockSessionManager{make(map[uint64]*util.ProcessInfo, 2)}
 	sm.processInfoMap[1] = &util.ProcessInfo{


### PR DESCRIPTION
UCP #15027 
Signed-off-by: Rustin-Liu <rustin.liu@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
move `dataForTableConstraints` into executor.

### What is changed and how it works?
move `dataForTableConstraints` into executor.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

None
Side effects

None

Related changes

 None
Release note
None
