### PR TITLE
privilege, executor: add db exist check for db level `GRANT`

### DIFF
--- a/executor/grant.go
+++ b/executor/grant.go
@@ -91,6 +91,15 @@ func (e *GrantExec) Next(ctx context.Context, req *chunk.Chunk) error {
 			}
 		}
 	}
+	// Make sure the db exist.
+	if e.Level.Level == ast.GrantLevelDB {
+		dbNameStr := model.NewCIStr(dbName)
+		schema := infoschema.GetInfoSchema(e.ctx)
+		db, succ := schema.SchemaByName(dbNameStr)
+		if !succ || db.Name.String() != dbName {
+			return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName)
+		}
+	}
 
 	// Commit the old transaction, like DDL.
 	if err := e.ctx.NewTxn(ctx); err != nil {

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -286,6 +286,7 @@ func (s *testSuite3) TestGrantUnderANSIQuotes(c *C) {
 	// Fix a bug that the GrantExec fails in ANSI_QUOTES sql mode
 	// The bug is caused by the improper usage of double quotes like:
 	// INSERT INTO mysql.user ... VALUES ("..", "..", "..")
+	tk.MustExec(`CREATE DATABASE video_ulimit`)
 	tk.MustExec(`SET SQL_MODE='ANSI_QUOTES'`)
 	tk.MustExec(`GRANT ALL PRIVILEGES ON video_ulimit.* TO web@'%' IDENTIFIED BY 'eDrkrhZ>l2sV'`)
 	tk.MustExec(`REVOKE ALL PRIVILEGES ON video_ulimit.* FROM web@'%';`)

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -384,3 +384,14 @@ func (s *testSuite3) TestGrantOnNonExistTable(c *C) {
 	_, err = tk.Exec("grant Select,Update on test.xx to 'genius'")
 	c.Assert(err, IsNil)
 }
+
+func (s *testSuite3) TestGrantOnNonExistDB(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create user imtbkcat")
+	_, err := tk.Exec("use nonexist")
+	c.Assert(terror.ErrorEqual(err, infoschema.ErrDatabaseNotExists), IsTrue)
+	_, err = tk.Exec("grant Select,Insert on nonexist.* to 'imtbkcat'")
+	c.Assert(terror.ErrorEqual(err, infoschema.ErrDatabaseNotExists), IsTrue)
+	_, err = tk.Exec("grant Select,Insert on test.* to 'imtbkcat'")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#14611 has fixed table check problems on `GRANT`.
But there is still another problem that `GRANT` can execute on non-existed db.

```
mysql> grant select on a.* to u1;
Query OK, 0 rows affected (0.01 sec)
mysql> use a
ERROR 1049 (42000): Unknown database 'a'
```

### What is changed and how it works?
add db check for db level `GRANT`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Code changes

 - None

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

Release note

 - fix `GRANT` can be executed on non-existed database and table.
