### PR TITLE
store: fix timing of prewrite binlog in slow log

### DIFF
--- a/executor/slow_query.go
+++ b/executor/slow_query.go
@@ -264,52 +264,52 @@ func getOneLine(reader *bufio.Reader) ([]byte, error) {
 }
 
 type slowQueryTuple struct {
-	time               time.Time
-	txnStartTs         uint64
-	user               string
-	host               string
-	connID             uint64
-	queryTime          float64
-	parseTime          float64
-	compileTime        float64
-	preWriteTime       float64
-	binlogPrewriteTime float64
-	commitTime         float64
-	getCommitTSTime    float64
-	commitBackoffTime  float64
-	backoffTypes       string
-	resolveLockTime    float64
-	localLatchWaitTime float64
-	writeKeys          uint64
-	writeSize          uint64
-	prewriteRegion     uint64
-	txnRetry           uint64
-	processTime        float64
-	waitTime           float64
-	backOffTime        float64
-	lockKeysTime       float64
-	requestCount       uint64
-	totalKeys          uint64
-	processKeys        uint64
-	db                 string
-	indexIDs           string
-	digest             string
-	statsInfo          string
-	avgProcessTime     float64
-	p90ProcessTime     float64
-	maxProcessTime     float64
-	maxProcessAddress  string
-	avgWaitTime        float64
-	p90WaitTime        float64
-	maxWaitTime        float64
-	maxWaitAddress     string
-	memMax             int64
-	prevStmt           string
-	sql                string
-	isInternal         bool
-	succ               bool
-	plan               string
-	planDigest         string
+	time                   time.Time
+	txnStartTs             uint64
+	user                   string
+	host                   string
+	connID                 uint64
+	queryTime              float64
+	parseTime              float64
+	compileTime            float64
+	preWriteTime           float64
+	waitPrewriteBinlogTime float64
+	commitTime             float64
+	getCommitTSTime        float64
+	commitBackoffTime      float64
+	backoffTypes           string
+	resolveLockTime        float64
+	localLatchWaitTime     float64
+	writeKeys              uint64
+	writeSize              uint64
+	prewriteRegion         uint64
+	txnRetry               uint64
+	processTime            float64
+	waitTime               float64
+	backOffTime            float64
+	lockKeysTime           float64
+	requestCount           uint64
+	totalKeys              uint64
+	processKeys            uint64
+	db                     string
+	indexIDs               string
+	digest                 string
+	statsInfo              string
+	avgProcessTime         float64
+	p90ProcessTime         float64
+	maxProcessTime         float64
+	maxProcessAddress      string
+	avgWaitTime            float64
+	p90WaitTime            float64
+	maxWaitTime            float64
+	maxWaitAddress         string
+	memMax                 int64
+	prevStmt               string
+	sql                    string
+	isInternal             bool
+	succ                   bool
+	plan                   string
+	planDigest             string
 }
 
 func (st *slowQueryTuple) setFieldValue(tz *time.Location, field, value string, lineNum int, checker *slowLogChecker) (valid bool, err error) {
@@ -349,8 +349,8 @@ func (st *slowQueryTuple) setFieldValue(tz *time.Location, field, value string, 
 		st.compileTime, err = strconv.ParseFloat(value, 64)
 	case execdetails.PreWriteTimeStr:
 		st.preWriteTime, err = strconv.ParseFloat(value, 64)
-	case execdetails.BinlogPrewriteTimeStr:
-		st.binlogPrewriteTime, err = strconv.ParseFloat(value, 64)
+	case execdetails.WaitPrewriteBinlogTimeStr:
+		st.waitPrewriteBinlogTime, err = strconv.ParseFloat(value, 64)
 	case execdetails.CommitTimeStr:
 		st.commitTime, err = strconv.ParseFloat(value, 64)
 	case execdetails.GetCommitTSTimeStr:
@@ -439,7 +439,7 @@ func (st *slowQueryTuple) convertToDatumRow() []types.Datum {
 	record = append(record, types.NewFloat64Datum(st.parseTime))
 	record = append(record, types.NewFloat64Datum(st.compileTime))
 	record = append(record, types.NewFloat64Datum(st.preWriteTime))
-	record = append(record, types.NewFloat64Datum(st.binlogPrewriteTime))
+	record = append(record, types.NewFloat64Datum(st.waitPrewriteBinlogTime))
 	record = append(record, types.NewFloat64Datum(st.commitTime))
 	record = append(record, types.NewFloat64Datum(st.getCommitTSTime))
 	record = append(record, types.NewFloat64Datum(st.commitBackoffTime))

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -688,7 +688,7 @@ var slowQueryCols = []columnInfo{
 	{name: variable.SlowLogParseTimeStr, tp: mysql.TypeDouble, size: 22},
 	{name: variable.SlowLogCompileTimeStr, tp: mysql.TypeDouble, size: 22},
 	{name: execdetails.PreWriteTimeStr, tp: mysql.TypeDouble, size: 22},
-	{name: execdetails.BinlogPrewriteTimeStr, tp: mysql.TypeDouble, size: 22},
+	{name: execdetails.WaitPrewriteBinlogTimeStr, tp: mysql.TypeDouble, size: 22},
 	{name: execdetails.CommitTimeStr, tp: mysql.TypeDouble, size: 22},
 	{name: execdetails.GetCommitTSTimeStr, tp: mysql.TypeDouble, size: 22},
 	{name: execdetails.CommitBackoffTimeStr, tp: mysql.TypeDouble, size: 22},

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -528,7 +528,7 @@ func prepareSlowLogfile(c *C, slowLogFileName string) {
 # Query_time: 4.895492
 # Parse_time: 0.4
 # Compile_time: 0.2
-# LockKeys_time: 1.71 Request_count: 1 Prewrite_time: 0.19 Binlog_prewrite_time: 0.21 Commit_time: 0.01 Commit_backoff_time: 0.18 Backoff_types: [txnLock] Resolve_lock_time: 0.03 Write_keys: 15 Write_size: 480 Prewrite_region: 1 Txn_retry: 8
+# LockKeys_time: 1.71 Request_count: 1 Prewrite_time: 0.19 Wait_prewrite_binlog_time: 0.21 Commit_time: 0.01 Commit_backoff_time: 0.18 Backoff_types: [txnLock] Resolve_lock_time: 0.03 Write_keys: 15 Write_size: 480 Prewrite_region: 1 Txn_retry: 8
 # Process_time: 0.161 Request_count: 1 Total_keys: 100001 Process_keys: 100000
 # Wait_time: 0.101
 # Backoff_time: 0.092

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -1147,9 +1147,9 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		commitDetail.Mu.Unlock()
 	}
 	if binlogChan != nil {
-		binlogPrewriteStart := time.Now()
+		startWaitBinlog := time.Now()
 		binlogWriteResult := <-binlogChan
-		commitDetail.BinlogPrewriteTime = time.Since(binlogPrewriteStart)
+		commitDetail.WaitPrewriteBinlogTime = time.Since(startWaitBinlog)
 		if binlogWriteResult != nil {
 			binlogSkipped = binlogWriteResult.Skipped()
 			binlogErr := binlogWriteResult.GetError()

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -48,13 +48,13 @@ type ExecDetails struct {
 
 // CommitDetails contains commit detail information.
 type CommitDetails struct {
-	GetCommitTsTime    time.Duration
-	PrewriteTime       time.Duration
-	BinlogPrewriteTime time.Duration
-	CommitTime         time.Duration
-	LocalLatchTime     time.Duration
-	CommitBackoffTime  int64
-	Mu                 struct {
+	GetCommitTsTime        time.Duration
+	PrewriteTime           time.Duration
+	WaitPrewriteBinlogTime time.Duration
+	CommitTime             time.Duration
+	LocalLatchTime         time.Duration
+	CommitBackoffTime      int64
+	Mu                     struct {
 		sync.Mutex
 		BackoffTypes []fmt.Stringer
 	}
@@ -82,8 +82,8 @@ const (
 	ProcessKeysStr = "Process_keys"
 	// PreWriteTimeStr means the time of pre-write.
 	PreWriteTimeStr = "Prewrite_time"
-	// BinlogPrewriteTimeStr means the time of binlog prewrite
-	BinlogPrewriteTimeStr = "Binlog_prewrite_time"
+	// WaitPrewriteBinlogTime means the time of waiting prewrite binlog finished when transaction committing.
+	WaitPrewriteBinlogTimeStr = "Wait_prewrite_binlog_time"
 	// CommitTimeStr means the time of commit.
 	CommitTimeStr = "Commit_time"
 	// GetCommitTSTimeStr means the time of getting commit ts.
@@ -135,8 +135,8 @@ func (d ExecDetails) String() string {
 		if commitDetails.PrewriteTime > 0 {
 			parts = append(parts, PreWriteTimeStr+": "+strconv.FormatFloat(commitDetails.PrewriteTime.Seconds(), 'f', -1, 64))
 		}
-		if commitDetails.BinlogPrewriteTime > 0 {
-			parts = append(parts, BinlogPrewriteTimeStr+": "+strconv.FormatFloat(commitDetails.BinlogPrewriteTime.Seconds(), 'f', -1, 64))
+		if commitDetails.WaitPrewriteBinlogTime > 0 {
+			parts = append(parts, WaitPrewriteBinlogTimeStr+": "+strconv.FormatFloat(commitDetails.WaitPrewriteBinlogTime.Seconds(), 'f', -1, 64))
 		}
 		if commitDetails.CommitTime > 0 {
 			parts = append(parts, CommitTimeStr+": "+strconv.FormatFloat(commitDetails.CommitTime.Seconds(), 'f', -1, 64))

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -82,7 +82,7 @@ const (
 	ProcessKeysStr = "Process_keys"
 	// PreWriteTimeStr means the time of pre-write.
 	PreWriteTimeStr = "Prewrite_time"
-	// WaitPrewriteBinlogTime means the time of waiting prewrite binlog finished when transaction committing.
+	// WaitPrewriteBinlogTimeStr means the time of waiting prewrite binlog finished when transaction committing.
 	WaitPrewriteBinlogTimeStr = "Wait_prewrite_binlog_time"
 	// CommitTimeStr means the time of commit.
 	CommitTimeStr = "Commit_time"


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The time of prewrite binlog in slow log covers the time of prewrite keys, which makes it not accurate.

### What is changed and how it works?
Fix it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. start a cluster of master without binlog
1. start a cluster of this PR without binlog
1. compare the commit slow log with `Binlog_prewrite_time`

Code changes

 - Has exported function/method change

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
Fix timing of prewrite binlog `Binlog_prewrite_time` in slow log to make it accurate.
