### PR TITLE
workflow: remove PR auto assignment

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -3,8 +3,6 @@ name: Auto Assign Project Local
 on:
   issues:
     types: [labeled]
-  pull_request:
-    types: [labeled]
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -16,40 +14,16 @@ jobs:
     - name: Run issues assignment to project SIG Runtime Kanban
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: |
-        github.event_name == 'issues' && (
         contains(github.event.issue.labels.*.name, 'component/executor') ||
         contains(github.event.issue.labels.*.name, 'component/expression')
-        )
       with:
         project: 'https://github.com/pingcap/tidb/projects/38'
         column_name: 'Issue Backlog: Need Triage'
-    - name: Run PRs assignment to project SIG Runtime Kanban
-      uses: srggrs/assign-one-project-github-action@1.2.0
-      if: |
-        github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'component/executor') ||
-        contains(github.event.pull_request.labels.*.name, 'component/expression')
-        )
-      with:
-        project: 'https://github.com/pingcap/tidb/projects/38'
-        column_name: 'PR: In Progress'
     - name: Run issues assignment to project SIG Planner Kanban
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: |
-        github.event_name == 'issues' && (
         contains(github.event.issue.labels.*.name, 'component/planner') ||
         contains(github.event.issue.labels.*.name, 'component/statistics')
-        )
       with:
         project: 'https://github.com/pingcap/tidb/projects/39'
         column_name: 'Issue Backlog: Need Triage'
-    - name: Run PRs assignment to project SIG Planner Kanban
-      uses: srggrs/assign-one-project-github-action@1.2.0
-      if: |
-        github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.labels.*.name, 'component/planner') ||
-        contains(github.event.pull_request.labels.*.name, 'component/statistics')
-        )
-      with:
-        project: 'https://github.com/pingcap/tidb/projects/39'
-        column_name: 'PR: In Progress'


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

See https://github.com/pingcap/tidb/runs/499979335?check_suite_focus=true
GitHub API returns `Resource not accessible by integration`, it seems that forked PR does not have the permission to create cards in Project.


### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - No code

