### PR TITLE
server: fix tls setup and error log

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -282,7 +282,8 @@ func (s *Security) ToTLSConfig() (tlsConfig *tls.Config, err error) {
 			return
 		}
 		tlsConfig = &tls.Config{
-			RootCAs: certPool,
+			RootCAs:   certPool,
+			ClientCAs: certPool,
 		}
 
 		if len(s.ClusterSSLCert) != 0 && len(s.ClusterSSLKey) != 0 {

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -295,6 +295,9 @@ func (s *Server) setupStatusServerAndRPCServer(addr string, serverMux *http.Serv
 		logutil.BgLogger().Info("listen failed", zap.Error(err))
 		return
 	}
+	if tlsConfig != nil {
+		logutil.BgLogger().Info("status http/GRPC server secure connection is enabled", zap.Bool("CN verification enabled", tlsConfig.VerifyPeerCertificate != nil))
+	}
 	m := cmux.New(l)
 	// Match connections in order:
 	// First HTTP, and otherwise grpc.

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -296,7 +296,7 @@ func (s *Server) setupStatusServerAndRPCServer(addr string, serverMux *http.Serv
 		return
 	}
 	if tlsConfig != nil {
-		logutil.BgLogger().Info("status http/GRPC server secure connection is enabled", zap.Bool("CN verification enabled", tlsConfig.VerifyPeerCertificate != nil))
+		logutil.BgLogger().Info("HTTP/gRPC status server secure connection is enabled", zap.Bool("CN verification enabled", tlsConfig.VerifyPeerCertificate != nil))
 	}
 	m := cmux.New(l)
 	// Match connections in order:

--- a/server/server.go
+++ b/server/server.go
@@ -385,10 +385,10 @@ func (s *Server) Close() {
 func (s *Server) onConn(conn *clientConn) {
 	ctx := logutil.WithConnID(context.Background(), conn.connectionID)
 	if err := conn.handshake(ctx); err != nil {
+		terror.Log(err)
 		if plugin.IsEnable(plugin.Audit) {
 			conn.ctx.GetSessionVars().ConnectionInfo = conn.connectInfo()
 		}
-		terror.Log(err)
 		err = plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
 			authPlugin := plugin.DeclareAuditManifest(p.Manifest)
 			if authPlugin.OnConnectionEvent != nil {

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -218,34 +218,51 @@ func (ts *tidbTestSuite) TestStatusAPIWithTLS(c *C) {
 }
 
 func (ts *tidbTestSuite) TestStatusAPIWithTLSCNCheck(c *C) {
-	c.Skip("need add ca-tidb-test-1.crt to OS")
-	root := filepath.Join(os.Getenv("GOPATH"), "/src/github.com/pingcap/tidb")
-	ca := filepath.Join(root, "/tests/cncheckcert/ca-tidb-test-1.crt")
+	caPath := filepath.Join(os.TempDir(), "ca-cert-cn.pem")
+	serverKeyPath := filepath.Join(os.TempDir(), "server-key-cn.pem")
+	serverCertPath := filepath.Join(os.TempDir(), "server-cert-cn.pem")
+	client1KeyPath := filepath.Join(os.TempDir(), "client-key-cn-check-a.pem")
+	client1CertPath := filepath.Join(os.TempDir(), "client-cert-cn-check-a.pem")
+	client2KeyPath := filepath.Join(os.TempDir(), "client-key-cn-check-b.pem")
+	client2CertPath := filepath.Join(os.TempDir(), "client-cert-cn-check-b.pem")
+
+	caCert, caKey, err := generateCert(0, "TiDB CA CN CHECK", nil, nil, filepath.Join(os.TempDir(), "ca-key-cn.pem"), caPath)
+	c.Assert(err, IsNil)
+	_, _, err = generateCert(1, "tidb-server-cn-check", caCert, caKey, serverKeyPath, serverCertPath)
+	c.Assert(err, IsNil)
+	_, _, err = generateCert(2, "tidb-client-cn-check-a", caCert, caKey, client1KeyPath, client1CertPath, func(c *x509.Certificate) {
+		c.Subject.CommonName = "tidb-client-1"
+	})
+	c.Assert(err, IsNil)
+	_, _, err = generateCert(3, "tidb-client-cn-check-b", caCert, caKey, client2KeyPath, client2CertPath, func(c *x509.Certificate) {
+		c.Subject.CommonName = "tidb-client-2"
+	})
+	c.Assert(err, IsNil)
 
 	cli := newTestServerClient()
 	cli.statusScheme = "https"
 	cfg := config.NewConfig()
 	cfg.Port = cli.port
 	cfg.Status.StatusPort = cli.statusPort
-	cfg.Security.ClusterSSLCA = ca
-	cfg.Security.ClusterSSLCert = filepath.Join(root, "/tests/cncheckcert/server-cert.pem")
-	cfg.Security.ClusterSSLKey = filepath.Join(root, "/tests/cncheckcert/server-key.pem")
+	cfg.Security.ClusterSSLCA = caPath
+	cfg.Security.ClusterSSLCert = serverCertPath
+	cfg.Security.ClusterSSLKey = serverKeyPath
 	cfg.Security.ClusterVerifyCN = []string{"tidb-client-2"}
 	server, err := NewServer(cfg, ts.tidbdrv)
 	c.Assert(err, IsNil)
 	go server.Run()
 	time.Sleep(time.Millisecond * 100)
 
-	hc := newTLSHttpClient(c, ca,
-		filepath.Join(root, "/tests/cncheckcert/client-cert-1.pem"),
-		filepath.Join(root, "/tests/cncheckcert/client-key-1.pem"),
+	hc := newTLSHttpClient(c, caPath,
+		client1CertPath,
+		client1KeyPath,
 	)
 	_, err = hc.Get(cli.statusURL("/status"))
 	c.Assert(err, NotNil)
 
-	hc = newTLSHttpClient(c, ca,
-		filepath.Join(root, "/tests/cncheckcert/client-cert-2.pem"),
-		filepath.Join(root, "/tests/cncheckcert/client-key-2.pem"),
+	hc = newTLSHttpClient(c, caPath,
+		client2CertPath,
+		client2KeyPath,
 	)
 	_, err = hc.Get(cli.statusURL("/status"))
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

- fix wrong output for mysql-protocol tls enable log
- lack of tls enable log for status server
- handshake error maybe swallowed by audit plugin

### What is changed and how it works?

refine mysql-protocol and status server log.

```
[2020/03/11 16:34:44.080 +08:00] [INFO] [server.go:223] ["mysql protocol server secure connection is enabled"] ["client verification enabled"=true]
[2020/03/11 16:34:44.083 +08:00] [INFO] [http_status.go:299] ["HTTP/GRPC status server secure connection is enabled"] ["CN verification enabled"=true]
```

log handshake error before audit plugin


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test : use tls start and watch log


Code changes

 - log change

Side effects

 - n/a

Related changes

 - Need to cherry-pick to the release branch 3.1 and 3.0

Release note

 - n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/15287)
<!-- Reviewable:end -->
