### PR TITLE
*: make 'password' in mysql.user as a generated column of `authentication_string`

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -718,10 +718,6 @@ func upgradeToVer12(s Session) {
 	terror.MustNil(err)
 	sql := "SELECT HIGH_PRIORITY user, host, password FROM mysql.user WHERE password != ''"
 	rs, err := s.Execute(ctx, sql)
-	if terror.ErrorEqual(err, core.ErrUnknownColumn) {
-		sql := "SELECT HIGH_PRIORITY user, host, authentication_string FROM mysql.user WHERE authentication_string != ''"
-		rs, err = s.Execute(ctx, sql)
-	}
 	terror.MustNil(err)
 	r := rs[0]
 	sqls := make([]string, 0, 1)
@@ -966,7 +962,8 @@ func upgradeToVer40(s Session) {
 }
 
 func upgradeToVer41(s Session) {
-	doReentrantDDL(s, "ALTER TABLE mysql.user CHANGE COLUMN `Password` `authentication_string` TEXT", infoschema.ErrColumnNotExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.user CHANGE `password` `authentication_string` TEXT", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.user ADD COLUMN `password` TEXT as (`authentication_string`)", infoschema.ErrColumnExists)
 }
 
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
#14598 renames column `password` to `authentication_string` in mysql.user. However, since there is no 'password' field in mysql.user, it is not possible to create a new session on an older version of TiDB during a rolling update.

This PR tries to solve the problem of `authentication_string` in another way.

### What is changed and how it works?
Make `authentication_string` in mysql.user as a generated column of 'password'.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test

Code changes

 - Has persistent data change

Side effects


Related changes
 - Need to update the documentation

Release note

 - Add column field 'authentication_string' to mysql.user as a generated column of 'password'  
