### PR TITLE
tikv: replace WithTimeout with time.NewTimer in sendBatchRequest

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -622,14 +622,17 @@ func sendBatchRequest(
 	failpoint.InjectContext(ctx, "sendIdleHeartbeatReq", func() {
 		entry.heartbeat = true
 	})
-	ctx1, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
 	select {
 	case batchConn.batchCommandsCh <- entry:
-	case <-ctx1.Done():
+	case <-ctx.Done():
 		logutil.BgLogger().Warn("send request is cancelled",
-			zap.String("to", addr), zap.String("cause", ctx1.Err().Error()))
-		return nil, errors.Trace(ctx1.Err())
+			zap.String("to", addr), zap.String("cause", ctx.Err().Error()))
+		return nil, errors.Trace(ctx.Err())
+	case <-timer.C:
+		return nil, context.DeadlineExceeded
 	}
 
 	select {
@@ -638,11 +641,13 @@ func sendBatchRequest(
 			return nil, errors.Trace(entry.err)
 		}
 		return tikvrpc.FromBatchCommandsResponse(res)
-	case <-ctx1.Done():
+	case <-ctx.Done():
 		atomic.StoreInt32(&entry.canceled, 1)
 		logutil.BgLogger().Warn("wait response is cancelled",
-			zap.String("to", addr), zap.String("cause", ctx1.Err().Error()))
-		return nil, errors.Trace(ctx1.Err())
+			zap.String("to", addr), zap.String("cause", ctx.Err().Error()))
+		return nil, errors.Trace(ctx.Err())
+	case <-timer.C:
+		return nil, context.DeadlineExceeded
 	}
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `context.WithTimeout` seems to have some extra overhead. But we just need a timer to terminate waiting in `snedBatchRequest` indeed.


![图片](https://user-images.githubusercontent.com/15031522/76493256-2e58b600-646d-11ea-8a49-bf3b9724d5ed.png)

```
BenchmarkWithTimeout-32          1000000              2953 ns/op             497 B/op          4 allocs/op
BenchmarkNewTimer-32             2866058               429 ns/op             248 B/op          3 allocs/op
```

<details>
<summary>Source Code</summary>

```go
func BenchmarkWithTimeout(b *testing.B) {
	ctx, _ := context.WithCancel(context.Background())
	var ctx1 context.Context
	for n := 0; n < b.N; n++ {
		ctx1, _ = context.WithTimeout(ctx, 1*time.Second)
	}
	_ = ctx1
}

func BenchmarkNewTimer(b *testing.B) {
	var t *time.Timer
	for n := 0; n < b.N; n++ {
		t = time.NewTimer(1 * time.Second)
	}
	_ = t
}
```

</details>

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - No code
