### PR TITLE
server: stop the server when writing binlog failed

### DIFF
--- a/metrics/server.go
+++ b/metrics/server.go
@@ -79,9 +79,7 @@ var (
 	EventStart        = "start"
 	EventGracefulDown = "graceful_shutdown"
 	// Eventkill occurs when the server.Kill() function is called.
-	EventKill = "kill"
-	// EventHang occurs when server meet some critical error. It will close the listening port and hang for ever.
-	EventHang          = "hang"
+	EventKill          = "kill"
 	EventClose         = "close"
 	ServerEventCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/server/conn.go
+++ b/server/conn.go
@@ -686,13 +686,8 @@ func (cc *clientConn) Run(ctx context.Context) {
 				logutil.Logger(ctx).Error("result undetermined, close this connection", zap.Error(err))
 				return
 			} else if terror.ErrCritical.Equal(err) {
-				logutil.Logger(ctx).Error("critical error, stop the server listener", zap.Error(err))
 				metrics.CriticalErrorCounter.Add(1)
-				select {
-				case cc.server.stopListenerCh <- struct{}{}:
-				default:
-				}
-				return
+				logutil.Logger(ctx).Fatal("critical error, stop the server", zap.Error(err))
 			}
 			var txnMode string
 			if cc.ctx != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -115,13 +115,8 @@ type Server struct {
 	clients           map[uint32]*clientConn
 	capability        uint32
 	dom               *domain.Domain
-
-	// stopListenerCh is used when a critical error occurred, we don't want to exit the process, because there may be
-	// a supervisor automatically restart it, then new client connection will be created, but we can't server it.
-	// So we just stop the listener and store to force clients to chose other TiDB servers.
-	stopListenerCh chan struct{}
-	statusServer   *http.Server
-	grpcServer     *grpc.Server
+	statusServer      *http.Server
+	grpcServer        *grpc.Server
 }
 
 // ConnectionCount gets current connection count.
@@ -209,7 +204,6 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		driver:            driver,
 		concurrentLimiter: NewTokenLimiter(cfg.TokenLimit),
 		clients:           make(map[uint32]*clientConn),
-		stopListenerCh:    make(chan struct{}, 1),
 	}
 
 	tlsConfig, err := util.LoadTLSCertificates(s.cfg.Security.SSLCA, s.cfg.Security.SSLKey, s.cfg.Security.SSLCert)
@@ -303,11 +297,6 @@ func (s *Server) Run() error {
 			logutil.BgLogger().Error("accept failed", zap.Error(err))
 			return errors.Trace(err)
 		}
-		if s.shouldStopListener() {
-			err = conn.Close()
-			terror.Log(errors.Trace(err))
-			break
-		}
 
 		clientConn := s.newConn(conn)
 
@@ -334,23 +323,6 @@ func (s *Server) Run() error {
 		}
 
 		go s.onConn(clientConn)
-	}
-	err := s.listener.Close()
-	terror.Log(errors.Trace(err))
-	s.listener = nil
-	for {
-		metrics.ServerEventCounter.WithLabelValues(metrics.EventHang).Inc()
-		logutil.BgLogger().Error("listener stopped, waiting for manual kill.")
-		time.Sleep(time.Minute)
-	}
-}
-
-func (s *Server) shouldStopListener() bool {
-	select {
-	case <-s.stopListenerCh:
-		return true
-	default:
-		return false
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Previously TiDB stops the service when it failed to write the binlog, but did not exit the process. Now that the binlog architecture has changed, TiDB can exit the process and let the watchdog pull up so that when the binlog writing resumes, the service can be automatically recovered.
Fix https://github.com/pingcap/tidb/issues/15314

### What is changed and how it works?
Stop the server when writing binlog failed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Manual test (add detailed scripts or steps below)
1. start a cluster with this pr's binary and pump.
1. stop pump.
1. start a transaction and then commit
1. the connection will lost and got the FATAL error in tidb.log
1. tidb-server will restart by systemd.

Code changes

 - Has exported function/method change

Side effects

 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch

Release note

 - Write release note for bug-fix or new feature.
Stop the server when writing binlog failed.