### PR TITLE
executor: do not store rows in UpdateExec

### DIFF
--- a/executor/update.go
+++ b/executor/update.go
@@ -124,12 +124,12 @@ func (e *UpdateExec) canNotUpdate(handle types.Datum) bool {
 func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if !e.drained {
-		rows, err := e.updateRows(ctx)
+		numRows, err := e.updateRows(ctx)
 		if err != nil {
 			return err
 		}
 		e.drained = true
-		e.ctx.GetSessionVars().StmtCtx.AddRecordRows(uint64(rows))
+		e.ctx.GetSessionVars().StmtCtx.AddRecordRows(uint64(numRows))
 	}
 	return nil
 }

--- a/executor/update.go
+++ b/executor/update.go
@@ -41,32 +41,24 @@ type UpdateExec struct {
 	updatedRowKeys map[int64]map[int64]bool
 	tblID2table    map[int64]table.Table
 
-	rows        [][]types.Datum // The rows fetched from TableExec.
-	newRowsData [][]types.Datum // The new values to be set.
-	cursor      int
-	matched     uint64 // a counter of matched rows during update
+	matched uint64 // a counter of matched rows during update
 	// tblColPosInfos stores relationship between column ordinal to its table handle.
 	// the columns ordinals is present in ordinal range format, @see plannercore.TblColPosInfos
 	tblColPosInfos            plannercore.TblColPosInfoSlice
 	evalBuffer                chunk.MutRow
 	allAssignmentsAreConstant bool
-	fetched                   bool
+	drained                   bool
 	memTracker                *memory.Tracker
 }
 
-func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema) ([]types.Datum, error) {
+func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema, row, newData []types.Datum) error {
 	assignFlag, err := e.getUpdateColumns(e.ctx, schema.Len())
 	if err != nil {
-		return nil, err
-	}
-	if e.cursor >= len(e.rows) {
-		return nil, nil
+		return err
 	}
 	if e.updatedRowKeys == nil {
 		e.updatedRowKeys = make(map[int64]map[int64]bool)
 	}
-	row := e.rows[e.cursor]
-	newData := e.newRowsData[e.cursor]
 	for _, content := range e.tblColPosInfos {
 		tbl := e.tblID2table[content.TblID]
 		if e.updatedRowKeys[content.TblID] == nil {
@@ -113,10 +105,9 @@ func (e *UpdateExec) exec(ctx context.Context, schema *expression.Schema) ([]typ
 			sc.AppendWarning(err1)
 			continue
 		}
-		return nil, err1
+		return err1
 	}
-	e.cursor++
-	return []types.Datum{}, nil
+	return nil
 }
 
 // canNotUpdate checks the handle of a record to decide whether that record
@@ -132,32 +123,18 @@ func (e *UpdateExec) canNotUpdate(handle types.Datum) bool {
 // Next implements the Executor Next interface.
 func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
-	if !e.fetched {
-		err := e.fetchChunkRows(ctx)
+	if !e.drained {
+		rows, err := e.updateRows(ctx)
 		if err != nil {
 			return err
 		}
-		e.fetched = true
-		e.ctx.GetSessionVars().StmtCtx.AddRecordRows(uint64(len(e.rows)))
-
-		for {
-			row, err := e.exec(ctx, e.children[0].Schema())
-			if err != nil {
-				return err
-			}
-
-			// once "row == nil" there is no more data waiting to be updated,
-			// the execution of UpdateExec is finished.
-			if row == nil {
-				break
-			}
-		}
+		e.drained = true
+		e.ctx.GetSessionVars().StmtCtx.AddRecordRows(uint64(rows))
 	}
-
 	return nil
 }
 
-func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
+func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	fields := retTypes(e.children[0])
 	colsInfo := make([]*table.Column, len(fields))
 	for _, content := range e.tblColPosInfos {
@@ -176,11 +153,12 @@ func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
 		composeFunc = e.composeNewRow
 	}
 	memUsageOfChk := int64(0)
+	totalNumRows := 0
 	for {
 		e.memTracker.Consume(-memUsageOfChk)
 		err := Next(ctx, e.children[0], chk)
 		if err != nil {
-			return err
+			return 0, err
 		}
 
 		if chk.NumRows() == 0 {
@@ -188,23 +166,21 @@ func (e *UpdateExec) fetchChunkRows(ctx context.Context) error {
 		}
 		memUsageOfChk = chk.MemoryUsage()
 		e.memTracker.Consume(memUsageOfChk)
-		firstRowIdx := globalRowIdx
 		for rowIdx := 0; rowIdx < chk.NumRows(); rowIdx++ {
 			chunkRow := chk.GetRow(rowIdx)
 			datumRow := chunkRow.GetDatumRow(fields)
 			newRow, err1 := composeFunc(globalRowIdx, datumRow, colsInfo)
 			if err1 != nil {
-				return err1
+				return 0, err1
 			}
-			e.rows = append(e.rows, datumRow)
-			e.newRowsData = append(e.newRowsData, newRow)
-			globalRowIdx++
+			if err := e.exec(ctx, e.children[0].Schema(), datumRow, newRow); err != nil {
+				return 0, err
+			}
 		}
-		e.memTracker.Consume(types.EstimatedMemUsage(e.rows[firstRowIdx], globalRowIdx-firstRowIdx))
-		e.memTracker.Consume(types.EstimatedMemUsage(e.newRowsData[firstRowIdx], globalRowIdx-firstRowIdx))
+		totalNumRows += chk.NumRows()
 		chk = chunk.Renew(chk, e.maxChunkSize)
 	}
-	return nil
+	return totalNumRows, nil
 }
 
 func (e *UpdateExec) handleErr(colName model.CIStr, rowIdx int, err error) error {


### PR DESCRIPTION
### What problem does this PR solve? <!--add issue link with summary if exists-->

If the child executor of `UpdateExec` outputs a lot of rows, the current `UpdateExec` implementation will store all the rows and use a lot of memory.

### What is changed and how it works?

This PR changes the `UpdateExec` not to collect rows from the underlying executor.

### Check List <!--REMOVE the items that are not applicable-->

Tests

 - Unit test
 - Integration test
-  Manual test

I run `update sbtest1 set k = k + 1` on a 10,000,000 rows table (with 2.9GB data) generated by sysbench.

Master (d7a8eab8): 
![image](https://user-images.githubusercontent.com/17217495/76498936-ca3bef00-6478-11ea-9e71-ba4bae17a947.png)

This PR:
![image](https://user-images.githubusercontent.com/17217495/76499074-0a9b6d00-6479-11ea-88ce-33c43d8381e5.png)

Peek memory use is reduced by 10GB.

Side effects

 - Possible performance regression

This may lead to worse cache hit rate. I would like to see some benchmark result.