### PR TITLE
copr: fix inconsistant behavior caused by push down dayname

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -828,9 +828,9 @@ func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
 		// ast.Minute,
 		// ast.Second,
 		// ast.MicroSecond,
+		// ast.DayName,
 		ast.PeriodAdd,
 		ast.PeriodDiff,
-		ast.DayName,
 		ast.TimestampDiff,
 
 		// encryption functions.


### PR DESCRIPTION
Signed-off-by: zhongzc <zhongzc_arch@outlook.com>

### What problem does this PR solve? <!--add issue link with summary if exists-->
[Copr-test](https://github.com/tikv/copr-test/) failed due to the special cast of dayname (#9975) in tidb, the behavior between no push down and push down is inconsistent.

failure cases:
```sql
SELECT BIT_XOR( DAYNAME( `col_bigint` ) + `col_char_255` ) AS field1 FROM `table0_int_autoinc`  /* QNO 554 CON_ID 6 */ ;

-- NoPushDown Output: 
-- field1 
-- 0 

-- WithPushDown Output: 
-- Error 1105: other error: [components/tidb_query/src/rpn_expr/types/expr_builder.rs:300]: Invalid arithmetic (sig = PlusReal) signature: Evaluate error: [components/tidb_query/src/rpn_expr/types/function.rs:230]: Expect `Real`, received `Bytes`


SELECT AVG( `col_set` / -15648 ) AS field1, AVG( `col_smallint_unsigned` * FLOOR( RTRIM( '2033-07-14' ) ) ) AS field2 FROM `table1_int_autoinc` WHERE `col_binary_8_key` << DAYNAME( `col_double_unsigned` ) /* QNO 965 CON_ID 6 */ ;

-- NoPushDown Output: 
-- field1  field2
-- NULL    NULL

-- WithPushDown Output: 
-- Error 1105: other error: [components/tidb_query/src/rpn_expr/types/expr_builder.rs:300]: Invalid left_shift (sig = LeftShift) signature: Evaluate error: [components/tidb_query/src/rpn_expr/types/function.rs:230]: Expect `Int`, received `Bytes`
```


### What is changed and how it works?

CHANGED: not to push down function DAYNAME

IT WORKS: copr-test pass

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test