### PR TITLE
planner: BatchPointGet support partition table

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/hack"
+	"github.com/pingcap/tidb/util/math"
 	"github.com/pingcap/tidb/util/rowcodec"
 )
 
@@ -35,6 +36,8 @@ type BatchPointGetExec struct {
 	tblInfo    *model.TableInfo
 	idxInfo    *model.IndexInfo
 	handles    []int64
+	physIDs    []int64
+	partPos    int
 	idxVals    [][]types.Datum
 	startTS    uint64
 	snapshotTS uint64
@@ -111,7 +114,8 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		dedup := make(map[hack.MutableString]struct{})
 		keys := make([]kv.Key, 0, len(e.idxVals))
 		for _, idxVals := range e.idxVals {
-			idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, e.tblInfo.ID)
+			physID := getPhysID(e.tblInfo, idxVals[e.partPos].GetInt64())
+			idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
 			if err1 != nil && !kv.ErrNotExist.Equal(err1) {
 				return err1
 			}
@@ -139,6 +143,9 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		}
 
 		e.handles = make([]int64, 0, len(keys))
+		if e.tblInfo.Partition != nil {
+			e.physIDs = make([]int64, 0, len(keys))
+		}
 		for _, key := range keys {
 			handleVal := handleVals[string(key)]
 			if len(handleVal) == 0 {
@@ -149,6 +156,9 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 				return err1
 			}
 			e.handles = append(e.handles, handle)
+			if e.tblInfo.Partition != nil {
+				e.physIDs = append(e.physIDs, tablecodec.DecodeTableID(key))
+			}
 		}
 
 		// The injection is used to simulate following scenario:
@@ -175,7 +185,13 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 
 	keys := make([]kv.Key, len(e.handles))
 	for i, handle := range e.handles {
-		key := tablecodec.EncodeRowKeyWithHandle(e.tblInfo.ID, handle)
+		var tID int64
+		if len(e.physIDs) > 0 {
+			tID = e.physIDs[i]
+		} else {
+			tID = getPhysID(e.tblInfo, handle)
+		}
+		key := tablecodec.EncodeRowKeyWithHandle(tID, handle)
 		keys[i] = key
 	}
 
@@ -254,4 +270,13 @@ func (e *BatchPointGetExec) lockKeys(ctx context.Context, keys []kv.Key) (map[st
 		return lctx.Values, nil
 	}
 	return nil, nil
+}
+
+func getPhysID(tblInfo *model.TableInfo, val int64) int64 {
+	pi := tblInfo.Partition
+	if pi == nil {
+		return tblInfo.ID
+	}
+	partIdx := math.Abs(val) % int64(pi.Num)
+	return pi.Definitions[partIdx].ID
 }

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2945,6 +2945,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 		desc:         plan.Desc,
 		lock:         plan.Lock,
 		waitTime:     plan.LockWaitTime,
+		partPos:      plan.PartitionColPos,
 	}
 	if e.lock {
 		b.hasLock = true

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -371,3 +371,36 @@ func (s *testPointGetSuite) TestBatchPointGetPlanCache(c *C) {
 		"4 4",
 	))
 }
+
+func (s *testPointGetSuite) TestBatchPointGetPartition(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	orgEnable := core.PreparedPlanCacheEnabled()
+	defer func() {
+		core.SetPreparedPlanCache(orgEnable)
+	}()
+	core.SetPreparedPlanCache(true)
+
+	var err error
+	tk.Se, err = session.CreateSession4TestWithOpt(s.store, &session.Opt{
+		PreparedPlanCache: kvcache.NewSimpleLRUCache(100, 0.1, math.MaxUint64),
+	})
+	c.Assert(err, IsNil)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key, b int) PARTITION BY HASH(a) PARTITIONS 4")
+	tk.MustExec("insert into t values (1, 1), (2, 2), (3, 3), (4, 4)")
+	tk.MustQuery("explain select * from t where a in (1, 2, 3, 4)").Check(testkit.Rows(
+		"Batch_Point_Get_1 4.00 root table:t, handle:[1 2 3 4], keep order:false, desc:false",
+	))
+	tk.MustQuery("select * from t where a in (1, 2, 3, 4)").Check(testkit.Rows("1 1", "2 2", "3 3", "4 4"))
+
+	tk.MustExec("drop table t")
+	tk.MustExec("create table t(a int, b int, c int, primary key (a, b)) PARTITION BY HASH(a) PARTITIONS 4")
+	tk.MustExec("insert into t values (1, 1, 1), (2, 2, 2), (3, 3, 3), (4, 4, 4)")
+	tk.MustQuery("explain select * from t where (a, b) in ((1, 1), (2, 2), (3, 3), (4, 4))").Check(testkit.Rows(
+		"Batch_Point_Get_1 4.00 root table:t, index:a b, keep order:false, desc:false",
+	))
+	tk.MustQuery("select * from t where (a, b) in ((1, 1), (2, 2), (3, 3), (4, 4))").
+		Check(testkit.Rows("1 1 1", "2 2 2", "3 3 3", "4 4 4"))
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
make BatchPointGet support partition table for better performance.

### What is changed and how it works?
- calculate the partition column position in the BatchPointGet plan.
- calculate the physical ID for each key in the BatchPointGet executor.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test

Release note

 - BatchPointGet support partition table.
