### PR TITLE
bindinfo: set correct default_db for captured bindings

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -498,6 +498,33 @@ func (s *testSuite) TestCapturePlanBaseline(c *C) {
 	c.Assert(rows[0][1], Equals, "SELECT /*+ USE_INDEX(@`sel_1` `test`.`t` )*/ * FROM `t` WHERE `a`>10")
 }
 
+func (s *testSuite) TestCaptureBaselinesDefaultDB(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	s.cleanBindingEnv(tk)
+	stmtsummary.StmtSummaryByDigestMap.Clear()
+	tk.MustExec(" set @@tidb_capture_plan_baselines = on")
+	defer func() {
+		tk.MustExec(" set @@tidb_capture_plan_baselines = off")
+	}()
+	tk.MustExec("use test")
+	tk.MustExec("drop database if exists spm")
+	tk.MustExec("create database spm")
+	tk.MustExec("create table spm.t(a int, index idx_a(a))")
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk.MustExec("select * from spm.t ignore index(idx_a) where a > 10")
+	tk.MustExec("select * from spm.t ignore index(idx_a) where a > 10")
+	tk.MustExec("admin capture bindings")
+	rows := tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	// Default DB should be "" when all columns have explicit database name.
+	c.Assert(rows[0][2], Equals, "")
+	c.Assert(rows[0][3], Equals, "using")
+	tk.MustExec("use spm")
+	tk.MustExec("select * from spm.t where a > 10")
+	// Should use TableScan because of the "ignore index" binding.
+	c.Assert(len(tk.Se.GetSessionVars().StmtCtx.IndexNames), Equals, 0)
+}
+
 func (s *testSuite) TestUseMultiplyBindings(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	s.cleanBindingEnv(tk)

--- a/util/parser/ast.go
+++ b/util/parser/ast.go
@@ -1,0 +1,47 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package parser
+
+import (
+	"github.com/pingcap/parser/ast"
+)
+
+// GetDefaultDB checks if all columns in the AST have explicit DBName. If not, return specified DBName.
+func GetDefaultDB(sel ast.StmtNode, dbName string) string {
+	implicitDB := &implicitDatabase{}
+	sel.Accept(implicitDB)
+	if implicitDB.hasImplicit {
+		return dbName
+	}
+	return ""
+}
+
+type implicitDatabase struct {
+	hasImplicit bool
+}
+
+func (i *implicitDatabase) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
+	switch x := in.(type) {
+	case *ast.TableName:
+		if x.Schema.L == "" {
+			i.hasImplicit = true
+		}
+		return in, true
+	}
+	return in, i.hasImplicit
+}
+
+func (i *implicitDatabase) Leave(in ast.Node) (out ast.Node, ok bool) {
+	return in, true
+}


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

For this case:
```
set tidb_capture_plan_baselines=ON;
set tidb_enable_stmt_summary=ON;
set tidb_use_plan_baselines=ON;
use test;
drop database if exists spm;
create database spm;
create table spm.t(a int, index idx_a(a));
select * from spm.t ignore index(idx_a) where a > 10;
select * from spm.t ignore index(idx_a) where a > 10;
do sleep(4);
show global bindings;
use spm;
select * from spm.t where a > 1;
```

The last query is supposed to use `TableScan` instead of `IndexScan` because of the captured binding.

### What is changed and how it works?

The root cause is that, for captured binding, the `default_db` is filled with the database where the query is executed, even if all columns in the query have explicit database name. Check this case and set `default_db` for them correctly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change

Side effects

N/A

Related changes

N/A

Release note

 - Write release note for bug-fix or new feature.
`Fix problem that some captured bindings are unable to be used`
