### PR TITLE
executor: reduce task queue size to reduce memory consume for load statement

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -492,20 +492,6 @@ func (e *InsertValues) getRow(ctx context.Context, vals []types.Datum) ([]types.
 	return e.fillRow(ctx, row, hasValue)
 }
 
-func (e *InsertValues) getRowInPlace(ctx context.Context, vals []types.Datum, rowBuf []types.Datum) ([]types.Datum, error) {
-	hasValue := make([]bool, len(e.Table.Cols()))
-	for i, v := range vals {
-		casted, err := table.CastValue(e.ctx, v, e.insertColumns[i].ToInfo())
-		if e.handleErr(nil, &v, 0, err) != nil {
-			return nil, err
-		}
-		offset := e.insertColumns[i].Offset
-		rowBuf[offset] = casted
-		hasValue[offset] = true
-	}
-	return e.fillRow(ctx, rowBuf, hasValue)
-}
-
 // getColDefaultValue gets the column default value.
 func (e *InsertValues) getColDefaultValue(idx int, col *table.Column) (d types.Datum, err error) {
 	if !col.DefaultIsExpr && e.colDefaultVals != nil && e.colDefaultVals[idx].valid {


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->

1. Reduce the task queue size for  `load data` statements, the default batch commit is slower than batch prepare most of the time,  it's not necessary to cache many prepared data in memory.

2. Simplify some logic

Testing with loading a wide table with 512 `col412 blob,col413 varchar(200)` like columns table with 2 2 million rows, the loading time the same, and the memory consume is 
![image](https://user-images.githubusercontent.com/3692139/76676411-267c4b80-65fe-11ea-8ab9-838fc98f785b.png)
  

### What is changed and how it works?


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes



Side effects



Related changes



Release note


