### PR TITLE
executor: rename startTS to snapshotTS in executor builder

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -73,12 +73,11 @@ var (
 // executorBuilder builds an Executor from a Plan.
 // The InfoSchema must not change during execution.
 type executorBuilder struct {
-	ctx     sessionctx.Context
-	is      infoschema.InfoSchema
-	startTS uint64 // cached when the first time getStartTS() is called
-	// err is set when there is error happened during Executor building process.
-	err     error
-	hasLock bool
+	ctx        sessionctx.Context
+	is         infoschema.InfoSchema
+	snapshotTS uint64 // The consistent snapshot timestamp for the executor to read data.
+	err        error  // err is set when there is error happened during Executor building process.
+	hasLock    bool
 }
 
 func newExecutorBuilder(ctx sessionctx.Context, is infoschema.InfoSchema) *executorBuilder {
@@ -526,7 +525,7 @@ func (b *executorBuilder) buildChecksumTable(v *plannercore.ChecksumTable) Execu
 		tables:       make(map[int64]*checksumContext),
 		done:         false,
 	}
-	startTs, err := b.getStartTS()
+	startTs, err := b.getSnapshotTS()
 	if err != nil {
 		b.err = err
 		return nil
@@ -565,7 +564,7 @@ func (b *executorBuilder) buildSelectLock(v *plannercore.PhysicalLock) Executor 
 		return nil
 	}
 	// Build 'select for update' using the 'for update' ts.
-	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+	b.snapshotTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 
 	src := b.build(v.Children()[0])
 	if b.err != nil {
@@ -697,7 +696,7 @@ func (b *executorBuilder) buildInsert(v *plannercore.Insert) Executor {
 			return nil
 		}
 	}
-	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+	b.snapshotTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 	selectExec := b.build(v.SelectPlan)
 	if b.err != nil {
 		return nil
@@ -1294,25 +1293,25 @@ func (b *executorBuilder) buildTableDual(v *plannercore.PhysicalTableDual) Execu
 	return e
 }
 
-func (b *executorBuilder) getStartTS() (uint64, error) {
-	if b.startTS != 0 {
+func (b *executorBuilder) getSnapshotTS() (uint64, error) {
+	if b.snapshotTS != 0 {
 		// Return the cached value.
-		return b.startTS, nil
+		return b.snapshotTS, nil
 	}
 
-	startTS := b.ctx.GetSessionVars().SnapshotTS
+	snapshotTS := b.ctx.GetSessionVars().SnapshotTS
 	txn, err := b.ctx.Txn(true)
 	if err != nil {
 		return 0, err
 	}
-	if startTS == 0 {
-		startTS = txn.StartTS()
+	if snapshotTS == 0 {
+		snapshotTS = txn.StartTS()
 	}
-	b.startTS = startTS
-	if b.startTS == 0 {
+	b.snapshotTS = snapshotTS
+	if b.snapshotTS == 0 {
 		return 0, errors.Trace(ErrGetStartTS)
 	}
-	return startTS, nil
+	return snapshotTS, nil
 }
 
 func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executor {
@@ -1603,7 +1602,7 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {
 	if b.err = b.updateForUpdateTSIfNeeded(v.SelectPlan); b.err != nil {
 		return nil
 	}
-	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+	b.snapshotTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 	selExec := b.build(v.SelectPlan)
 	if b.err != nil {
 		return nil
@@ -1628,7 +1627,7 @@ func (b *executorBuilder) buildDelete(v *plannercore.Delete) Executor {
 	if b.err = b.updateForUpdateTSIfNeeded(v.SelectPlan); b.err != nil {
 		return nil
 	}
-	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+	b.snapshotTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 	selExec := b.build(v.SelectPlan)
 	if b.err != nil {
 		return nil
@@ -1693,7 +1692,7 @@ func (b *executorBuilder) refreshForUpdateTSForRC() error {
 	if err := UpdateForUpdateTS(b.ctx, newForUpdateTS); err != nil {
 		return err
 	}
-	b.startTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+	b.snapshotTS = b.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
 	return nil
 }
 
@@ -2196,7 +2195,7 @@ func buildNoRangeTableReader(b *executorBuilder, v *plannercore.PhysicalTableRea
 		pt := tbl.(table.PartitionedTable)
 		tbl = pt.GetPartition(physicalTableID)
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		return nil, err
 	}
@@ -2276,7 +2275,7 @@ func buildNoRangeIndexReader(b *executorBuilder, v *plannercore.PhysicalIndexRea
 	} else {
 		physicalTableID = is.Table.ID
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		return nil, err
 	}
@@ -2373,7 +2372,7 @@ func buildNoRangeIndexLookUpReader(b *executorBuilder, v *plannercore.PhysicalIn
 		pt := tbl.(table.PartitionedTable)
 		tbl = pt.GetPartition(physicalTableID)
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		return nil, err
 	}
@@ -2486,7 +2485,7 @@ func buildNoRangeIndexMergeReader(b *executorBuilder, v *plannercore.PhysicalInd
 	if err != nil {
 		return nil, err
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		return nil, err
 	}
@@ -2605,7 +2604,7 @@ func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Contex
 		colExec := true
 		e.dagPB.CollectExecutionSummaries = &colExec
 	}
-	startTS, err := builder.getStartTS()
+	startTS, err := builder.getSnapshotTS()
 	if err != nil {
 		return nil, err
 	}
@@ -2931,7 +2930,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 			return nil
 		}
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		b.err = err
 		return nil

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -126,9 +126,9 @@ func (e *IndexNestedLoopHashJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
-	// cached start ts to construct DAG.
+	// cached snapshot ts to construct DAG.
 	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -126,10 +126,10 @@ func (e *IndexNestedLoopHashJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getStartTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached start ts to construct DAG.
-	_, err := e.innerCtx.readerBuilder.getStartTS()
+	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err
 	}

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -156,9 +156,9 @@ func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
-	// cached start ts to construct DAG.
+	// cached snapshot ts to construct DAG.
 	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -156,10 +156,10 @@ func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getStartTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached start ts to construct DAG.
-	_, err := e.innerCtx.readerBuilder.getStartTS()
+	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err
 	}

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -159,9 +159,9 @@ func (e *IndexLookUpMergeJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
-	// cached start ts to construct DAG.
+	// cached snapshot ts to construct DAG.
 	_, err := e.innerMergeCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -159,10 +159,10 @@ func (e *IndexLookUpMergeJoin) Open(ctx context.Context) error {
 	// recordSet.Next()
 	// e.dataReaderBuilder.Build() // txn is used again, which is already closed
 	//
-	// The trick here is `getStartTS` will cache start ts in the dataReaderBuilder,
+	// The trick here is `getSnapshotTS` will cache start ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached start ts to construct DAG.
-	_, err := e.innerMergeCtx.readerBuilder.getStartTS()
+	_, err := e.innerMergeCtx.readerBuilder.getSnapshotTS()
 	if err != nil {
 		return err
 	}

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -37,7 +37,7 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
 			return nil
 		}
 	}
-	startTS, err := b.getStartTS()
+	startTS, err := b.getSnapshotTS()
 	if err != nil {
 		b.err = err
 		return nil


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
The `startTS` in `executorBuilder` is actually the snapshot for reading data to the storage.

### What is changed and how it works?
Rename it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test (existed)
