### PR TITLE
executor: reuse transaction snapshot if applicable

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -97,9 +97,16 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		return err
 	}
 	e.txn = txn
-	snapshot, err := e.ctx.GetStore().GetSnapshot(kv.Version{Ver: e.snapshotTS})
-	if err != nil {
-		return err
+	var snapshot kv.Snapshot
+	if txn.Valid() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
+		// We can safely reuse the transaction snapshot if startTS is equal to forUpdateTS.
+		// The snapshot may contains cache that can reduce RPC call.
+		snapshot = txn.GetSnapshot()
+	} else {
+		snapshot, err = e.ctx.GetStore().GetSnapshot(kv.Version{Ver: e.snapshotTS})
+		if err != nil {
+			return err
+		}
 	}
 	if e.ctx.GetSessionVars().GetReplicaRead().IsFollowerRead() {
 		snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -66,6 +66,7 @@ type PointGetExecutor struct {
 	handleVal    []byte
 	idxVals      []types.Datum
 	startTS      uint64
+	txn          kv.Transaction
 	snapshot     kv.Snapshot
 	done         bool
 	lock         bool
@@ -105,14 +106,23 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		return nil
 	}
 	e.done = true
+	txnCtx := e.ctx.GetSessionVars().TxnCtx
 	snapshotTS := e.startTS
 	if e.lock {
-		snapshotTS = e.ctx.GetSessionVars().TxnCtx.GetForUpdateTS()
+		snapshotTS = txnCtx.GetForUpdateTS()
 	}
 	var err error
-	e.snapshot, err = e.ctx.GetStore().GetSnapshot(kv.Version{Ver: snapshotTS})
+	e.txn, err = e.ctx.Txn(false)
 	if err != nil {
 		return err
+	}
+	if e.txn.Valid() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
+		e.snapshot = e.txn.GetSnapshot()
+	} else {
+		e.snapshot, err = e.ctx.GetStore().GetSnapshot(kv.Version{Ver: snapshotTS})
+		if err != nil {
+			return err
+		}
 	}
 	if e.ctx.GetSessionVars().GetReplicaRead().IsFollowerRead() {
 		e.snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
@@ -201,14 +211,10 @@ func (e *PointGetExecutor) lockKeyIfNeeded(ctx context.Context, key []byte) erro
 }
 
 func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) (val []byte, err error) {
-	txn, err := e.ctx.Txn(false)
-	if err != nil {
-		return nil, err
-	}
-	if txn != nil && txn.Valid() && !txn.IsReadOnly() {
+	if e.txn.Valid() && !e.txn.IsReadOnly() {
 		// We cannot use txn.Get directly here because the snapshot in txn and the snapshot of e.snapshot may be
 		// different for pessimistic transaction.
-		val, err = txn.GetMemBuffer().Get(ctx, key)
+		val, err = e.txn.GetMemBuffer().Get(ctx, key)
 		if err == nil {
 			return val, err
 		}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -190,6 +190,8 @@ type Transaction interface {
 	Valid() bool
 	// GetMemBuffer return the MemBuffer binding to this transaction.
 	GetMemBuffer() MemBuffer
+	// GetSnapshot returns the Snapshot binding to this transaction.
+	GetSnapshot() Snapshot
 	// SetVars sets variables to the transaction.
 	SetVars(vars *Variables)
 	// BatchGet gets kv from the memory buffer of statement and transaction, and the kv storage.

--- a/kv/mock.go
+++ b/kv/mock.go
@@ -101,6 +101,10 @@ func (t *mockTxn) GetMemBuffer() MemBuffer {
 	return nil
 }
 
+func (t *mockTxn) GetSnapshot() Snapshot {
+	return nil
+}
+
 func (t *mockTxn) SetCap(cap int) {
 
 }

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -464,3 +464,7 @@ func (txn *tikvTxn) Size() int {
 func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {
 	return txn.us.GetMemBuffer()
 }
+
+func (txn *tikvTxn) GetSnapshot() kv.Snapshot {
+	return txn.snapshot
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

PointGetExecutor and BatchPointGetExecutor create a snapshot every time, the snapshot cache is not used.

### What is changed and how it works?

What's Changed:
Use the transaction snapshot if transaction StartTS is the same as ForUpdateTS.

How it Works:
The snapshot in the transaction has cache, get from it would hit the cache.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Logs the cache hit count during the TPCC benchmark, compare the hit count with the master branch.
The master branch cache hit count for a transaction is under 5, this PR cache hit count is up to 15.
