### PR TITLE
ddl: add syntax for setting the cache step of auto id explicitly.

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2245,4 +2245,16 @@ func (s *testIntegrationSuite3) TestCreateTableWithAutoIdCache(c *C) {
 	nextInt, err := strconv.Atoi(next)
 	c.Assert(err, IsNil)
 	c.Assert(nextInt, Greater, 5)
+
+	// Test auto_id_cache overflows int64.
+	tk.MustExec("drop table if exists t;")
+	_, err = tk.Exec("create table t(a int) auto_id_cache = 9223372036854775808")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "table option auto_id_cache overflows int64")
+
+	tk.MustExec("create table t(a int) auto_id_cache = 9223372036854775807")
+	_, err = tk.Exec("alter table t auto_id_cache = 9223372036854775808")
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "table option auto_id_cache overflows int64")
+
 }

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2256,5 +2256,4 @@ func (s *testIntegrationSuite3) TestCreateTableWithAutoIdCache(c *C) {
 	_, err = tk.Exec("alter table t auto_id_cache = 9223372036854775808")
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "table option auto_id_cache overflows int64")
-
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1925,7 +1925,7 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) err
 			tbInfo.AutoIncID = int64(op.UintValue)
 		case ast.TableOptionAutoIdCache:
 			if op.UintValue > uint64(math.MaxInt64) {
-				// Todo: refine this error.
+				// TODO: Refine this error.
 				return errors.New("table option auto_id_cache overflows int64")
 			}
 			tbInfo.AutoIdCache = int64(op.UintValue)
@@ -2158,7 +2158,7 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 					err = d.RebaseAutoID(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionAutoIdCache:
 					if opt.UintValue > uint64(math.MaxInt64) {
-						// Todo: refine this error.
+						// TODO: Refine this error.
 						return errors.New("table option auto_id_cache overflows int64")
 					}
 					err = d.AlterTableAutoIDCache(ctx, ident, int64(opt.UintValue))

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2153,7 +2153,7 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 				case ast.TableOptionAutoIncrement:
 					err = d.RebaseAutoID(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionAutoIdCache:
-					err = d.AlterTableAutoIncCache(ctx, ident, int64(opt.UintValue))
+					err = d.AlterTableAutoIDCache(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionComment:
 					spec.Comment = opt.StrValue
 					err = d.AlterTableComment(ctx, ident, spec)
@@ -3398,8 +3398,8 @@ func (d *ddl) AlterTableComment(ctx sessionctx.Context, ident ast.Ident, spec *a
 	return errors.Trace(err)
 }
 
-// AlterTableComment updates the table comment information.
-func (d *ddl) AlterTableAutoIncCache(ctx sessionctx.Context, ident ast.Ident, newCache int64) error {
+// AlterTableAutoIDCache updates the table comment information.
+func (d *ddl) AlterTableAutoIDCache(ctx sessionctx.Context, ident ast.Ident, newCache int64) error {
 	is := d.infoHandle.Get()
 	schema, ok := is.SchemaByName(ident.Schema)
 	if !ok {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3408,15 +3408,9 @@ func (d *ddl) AlterTableComment(ctx sessionctx.Context, ident ast.Ident, spec *a
 
 // AlterTableAutoIDCache updates the table comment information.
 func (d *ddl) AlterTableAutoIDCache(ctx sessionctx.Context, ident ast.Ident, newCache int64) error {
-	is := d.infoHandle.Get()
-	schema, ok := is.SchemaByName(ident.Schema)
-	if !ok {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(ident.Schema)
-	}
-
-	tb, err := is.TableByName(ident.Schema, ident.Name)
+	schema, tb, err := d.getSchemaAndTableByIdent(ctx, ident)
 	if err != nil {
-		return errors.Trace(infoschema.ErrTableNotExists.GenWithStackByArgs(ident.Schema, ident.Name))
+		return errors.Trace(err)
 	}
 
 	job := &model.Job{

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1924,6 +1924,10 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) err
 		case ast.TableOptionAutoIncrement:
 			tbInfo.AutoIncID = int64(op.UintValue)
 		case ast.TableOptionAutoIdCache:
+			if op.UintValue > uint64(math.MaxInt64) {
+				// Todo: refine this error.
+				return errors.New("table option auto_id_cache overflows int64")
+			}
 			tbInfo.AutoIdCache = int64(op.UintValue)
 		case ast.TableOptionComment:
 			tbInfo.Comment = op.StrValue
@@ -2153,6 +2157,10 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 				case ast.TableOptionAutoIncrement:
 					err = d.RebaseAutoID(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionAutoIdCache:
+					if opt.UintValue > uint64(math.MaxInt64) {
+						// Todo: refine this error.
+						return errors.New("table option auto_id_cache overflows int64")
+					}
 					err = d.AlterTableAutoIDCache(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionComment:
 					spec.Comment = opt.StrValue

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1923,8 +1923,8 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) err
 		switch op.Tp {
 		case ast.TableOptionAutoIncrement:
 			tbInfo.AutoIncID = int64(op.UintValue)
-		case ast.TableOptionAutoIncrementCache:
-			tbInfo.AutoIncCache = int64(op.UintValue)
+		case ast.TableOptionAutoIdCache:
+			tbInfo.AutoIdCache = int64(op.UintValue)
 		case ast.TableOptionComment:
 			tbInfo.Comment = op.StrValue
 		case ast.TableOptionCompression:
@@ -2152,7 +2152,7 @@ func (d *ddl) AlterTable(ctx sessionctx.Context, ident ast.Ident, specs []*ast.A
 					err = d.ShardRowID(ctx, ident, opt.UintValue)
 				case ast.TableOptionAutoIncrement:
 					err = d.RebaseAutoID(ctx, ident, int64(opt.UintValue))
-				case ast.TableOptionAutoIncrementCache:
+				case ast.TableOptionAutoIdCache:
 					err = d.AlterTableAutoIncCache(ctx, ident, int64(opt.UintValue))
 				case ast.TableOptionComment:
 					spec.Comment = opt.StrValue
@@ -3415,7 +3415,7 @@ func (d *ddl) AlterTableAutoIncCache(ctx sessionctx.Context, ident ast.Ident, ne
 		SchemaID:   schema.ID,
 		TableID:    tb.Meta().ID,
 		SchemaName: schema.Name.L,
-		Type:       model.ActionModifyTableAutoIncCache,
+		Type:       model.ActionModifyTableAutoIdCache,
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       []interface{}{newCache},
 	}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -635,7 +635,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = w.onShardRowID(d, t, job)
 	case model.ActionModifyTableComment:
 		ver, err = onModifyTableComment(t, job)
-	case model.ActionModifyTableAutoIncCache:
+	case model.ActionModifyTableAutoIdCache:
 		ver, err = onModifyTableAutoIncCache(t, job)
 	case model.ActionAddTablePartition:
 		ver, err = onAddTablePartition(d, t, job)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -636,7 +636,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionModifyTableComment:
 		ver, err = onModifyTableComment(t, job)
 	case model.ActionModifyTableAutoIdCache:
-		ver, err = onModifyTableAutoIncCache(t, job)
+		ver, err = onModifyTableAutoIDCache(t, job)
 	case model.ActionAddTablePartition:
 		ver, err = onAddTablePartition(d, t, job)
 	case model.ActionModifyTableCharsetAndCollate:

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -635,6 +635,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = w.onShardRowID(d, t, job)
 	case model.ActionModifyTableComment:
 		ver, err = onModifyTableComment(t, job)
+	case model.ActionModifyTableAutoIncCache:
+		ver, err = onModifyTableAutoIncCache(t, job)
 	case model.ActionAddTablePartition:
 		ver, err = onAddTablePartition(d, t, job)
 	case model.ActionModifyTableCharsetAndCollate:

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -349,7 +349,7 @@ func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) 
 		model.ActionModifyColumn, model.ActionAddForeignKey,
 		model.ActionDropForeignKey, model.ActionRenameTable,
 		model.ActionModifyTableCharsetAndCollate, model.ActionTruncateTablePartition,
-		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable:
+		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIncCache:
 		ver, err = cancelOnlyNotHandledJob(job)
 	default:
 		job.State = model.JobStateCancelled

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -349,7 +349,7 @@ func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) 
 		model.ActionModifyColumn, model.ActionAddForeignKey,
 		model.ActionDropForeignKey, model.ActionRenameTable,
 		model.ActionModifyTableCharsetAndCollate, model.ActionTruncateTablePartition,
-		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIncCache:
+		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIdCache:
 		ver, err = cancelOnlyNotHandledJob(job)
 	default:
 		job.State = model.JobStateCancelled

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -512,7 +512,7 @@ func onRebaseAutoID(store kv.Storage, t *meta.Meta, job *model.Job) (ver int64, 
 	return ver, nil
 }
 
-func onModifyTableAutoIncCache(t *meta.Meta, job *model.Job) (ver int64, _ error) {
+func onModifyTableAutoIDCache(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	var cache int64
 	if err := job.DecodeArgs(&cache); err != nil {
 		job.State = model.JobStateCancelled

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -524,7 +524,7 @@ func onModifyTableAutoIncCache(t *meta.Meta, job *model.Job) (ver int64, _ error
 		return ver, errors.Trace(err)
 	}
 
-	tblInfo.AutoIncCache = cache
+	tblInfo.AutoIdCache = cache
 	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -512,20 +512,20 @@ func onRebaseAutoID(store kv.Storage, t *meta.Meta, job *model.Job) (ver int64, 
 	return ver, nil
 }
 
-func onModifyTableAutoIDCache(t *meta.Meta, job *model.Job) (ver int64, _ error) {
+func onModifyTableAutoIDCache(t *meta.Meta, job *model.Job) (int64, error) {
 	var cache int64
 	if err := job.DecodeArgs(&cache); err != nil {
 		job.State = model.JobStateCancelled
-		return ver, errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 
 	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, job.SchemaID)
 	if err != nil {
-		return ver, errors.Trace(err)
+		return 0, errors.Trace(err)
 	}
 
 	tblInfo.AutoIdCache = cache
-	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
+	ver, err := updateVersionAndTableInfo(t, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}

--- a/executor/show.go
+++ b/executor/show.go
@@ -904,7 +904,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoIdCache != 0 {
-		fmt.Fprintf(buf, " AUTO_ID_CACHE=%d", tableInfo.AutoIdCache)
+		fmt.Fprintf(buf, " /*!90000 AUTO_ID_CACHE=%d */", tableInfo.AutoIdCache)
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -904,7 +904,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoIdCache != 0 {
-		fmt.Fprintf(buf, " /*!90000 AUTO_ID_CACHE=%d */", tableInfo.AutoIdCache)
+		fmt.Fprintf(buf, " /*T![auto_id_cache] AUTO_ID_CACHE=%d */", tableInfo.AutoIdCache)
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,8 +903,8 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		}
 	}
 
-	if tableInfo.AutoIncCache != 0 {
-		fmt.Fprintf(buf, " AUTO_INCREMENT_CACHE=%d", tableInfo.AutoIncCache)
+	if tableInfo.AutoIdCache != 0 {
+		fmt.Fprintf(buf, " AUTO_ID_CACHE=%d", tableInfo.AutoIdCache)
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,6 +903,10 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		}
 	}
 
+	if tableInfo.AutoIncCache != 0 {
+		fmt.Fprintf(buf, " AUTO_INCREMENT_CACHE=%d", tableInfo.AutoIncCache)
+	}
+
 	if tableInfo.ShardRowIDBits > 0 {
 		fmt.Fprintf(buf, "/*!90000 SHARD_ROW_ID_BITS=%d ", tableInfo.ShardRowIDBits)
 		if tableInfo.PreSplitRegions > 0 {

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -717,6 +717,42 @@ func (s *testAutoRandomSuite) TestShowCreateTableAutoRandom(c *C) {
 	))
 }
 
+// Override testAutoRandomSuite to test auto id cache.
+func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int auto_increment key) auto_id_cache = 10")
+	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `a` int(11) NOT NULL AUTO_INCREMENT,\n"+
+			"  PRIMARY KEY (`a`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=10 */",
+	))
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int auto_increment unique, b int key) auto_id_cache 100")
+	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `a` int(11) NOT NULL AUTO_INCREMENT,\n"+
+			"  `b` int(11) NOT NULL,\n"+
+			"  PRIMARY KEY (`b`),\n"+
+			"  UNIQUE KEY `a` (`a`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=100 */",
+	))
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int key) auto_id_cache 5")
+	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `a` int(11) NOT NULL,\n"+
+			"  PRIMARY KEY (`a`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T![auto_id_cache] AUTO_ID_CACHE=5 */",
+	))
+}
+
 func (s *testSuite5) TestShowEscape(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20200409034505-a5af800ca2ef
 	github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd
-	github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff
+	github.com/pingcap/parser v0.0.0-20200410065024-81f3db8e6095
 	github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3
 	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
 	github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible
@@ -76,5 +76,3 @@ require (
 )
 
 go 1.13
-
-replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757
+replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48
+replace github.com/pingcap/parser => github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc

--- a/go.mod
+++ b/go.mod
@@ -77,4 +77,4 @@ require (
 
 go 1.13
 
-replace github.com/pingcap/parser => github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc
+replace github.com/pingcap/parser => github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757

--- a/go.sum
+++ b/go.sum
@@ -1,10 +1,4 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AilinKid/parser v0.0.0-20200311094700-32b00c20e49f h1:I8Harvh03p9uzSDM8LrMbHTQwEQ8PR2tqTrjOpKF0RE=
-github.com/AilinKid/parser v0.0.0-20200311094700-32b00c20e49f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
-github.com/AilinKid/parser v0.0.0-20200313072339-42bee261ee7f h1:u8F8lTaR509OBPq7XuyINXfh7Kbs/5xAKoyhGyr0ulg=
-github.com/AilinKid/parser v0.0.0-20200313072339-42bee261ee7f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
-github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48 h1:4BpU8z0GnWwLBlAjM5z7hq9TvxzSK7reTcMG5b6HwOw=
-github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -15,6 +9,8 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
+github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc h1:qBBY6d7Q6l88c9rMPZnAyTATC7T7jX/drqyTSwZQ5e8=
+github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757 h1:AUZSKFo5yAVRBHNO6zyWAFSR76eiMUIQDuM/KiefxZg=
+github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -9,8 +11,6 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc h1:qBBY6d7Q6l88c9rMPZnAyTATC7T7jX/drqyTSwZQ5e8=
-github.com/ailinkid/parser v0.0.0-20200317122321-00fe11648edc/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -271,8 +271,6 @@ github.com/pingcap/kvproto v0.0.0-20200409034505-a5af800ca2ef/go.mod h1:IOdRDPLy
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff h1:FolYHDHFe4y0WXj6A8nxnlFO4f7gRo0XYBew6JNu8Uk=
-github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3 h1:Yrp99FnjHAEuDrSBql2l0IqCtJX7KwJbTsD5hIArkvk=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/go.mod h1:25GfNw6+Jcr9kca5rtmTb4gKCJ4jOpow2zV2S9Dgafs=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757 h1:AUZSKFo5yAVRBHNO6zyWAFSR76eiMUIQDuM/KiefxZg=
 github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c h1:lEvNMYabWIrDwn5HZN5aIOoLgAXm9EM6hFb7cXUyKbQ=
+github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -271,6 +273,8 @@ github.com/pingcap/kvproto v0.0.0-20200409034505-a5af800ca2ef/go.mod h1:IOdRDPLy
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
+github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff h1:FolYHDHFe4y0WXj6A8nxnlFO4f7gRo0XYBew6JNu8Uk=
+github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3 h1:Yrp99FnjHAEuDrSBql2l0IqCtJX7KwJbTsD5hIArkvk=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/go.mod h1:25GfNw6+Jcr9kca5rtmTb4gKCJ4jOpow2zV2S9Dgafs=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,10 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
+github.com/AilinKid/parser v0.0.0-20200311094700-32b00c20e49f h1:I8Harvh03p9uzSDM8LrMbHTQwEQ8PR2tqTrjOpKF0RE=
+github.com/AilinKid/parser v0.0.0-20200311094700-32b00c20e49f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/AilinKid/parser v0.0.0-20200313072339-42bee261ee7f h1:u8F8lTaR509OBPq7XuyINXfh7Kbs/5xAKoyhGyr0ulg=
+github.com/AilinKid/parser v0.0.0-20200313072339-42bee261ee7f/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48 h1:4BpU8z0GnWwLBlAjM5z7hq9TvxzSK7reTcMG5b6HwOw=
+github.com/AilinKid/parser v0.0.0-20200313094519-fdd8d3c78f48/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,4 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
-github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757 h1:AUZSKFo5yAVRBHNO6zyWAFSR76eiMUIQDuM/KiefxZg=
-github.com/AilinKid/parser v0.0.0-20200409064215-02df21090757/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
-github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c h1:lEvNMYabWIrDwn5HZN5aIOoLgAXm9EM6hFb7cXUyKbQ=
-github.com/AilinKid/parser v0.0.0-20200410024344-d0ef9c49b74c/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
@@ -273,8 +269,8 @@ github.com/pingcap/kvproto v0.0.0-20200409034505-a5af800ca2ef/go.mod h1:IOdRDPLy
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd h1:CV3VsP3Z02MVtdpTMfEgRJ4T9NGgGTxdHpJerent7rM=
 github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff h1:FolYHDHFe4y0WXj6A8nxnlFO4f7gRo0XYBew6JNu8Uk=
-github.com/pingcap/parser v0.0.0-20200407074807-436f1c8c4cff/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
+github.com/pingcap/parser v0.0.0-20200410065024-81f3db8e6095 h1:DyL/YbS4r89FmiZd3XbUrpMSsVFtpOZzh1busGKytiI=
+github.com/pingcap/parser v0.0.0-20200410065024-81f3db8e6095/go.mod h1:9v0Edh8IbgjGYW2ArJr19E+bvL8zKahsFp+ixWeId+4=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3 h1:Yrp99FnjHAEuDrSBql2l0IqCtJX7KwJbTsD5hIArkvk=
 github.com/pingcap/pd/v4 v4.0.0-beta.1.0.20200305072537-61d9f9cc35d3/go.mod h1:25GfNw6+Jcr9kca5rtmTb4gKCJ4jOpow2zV2S9Dgafs=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -74,7 +74,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var allocs autoid.Allocators
 	if tableIDIsValid(oldTableID) {
-		if oldTableID == newTableID && diff.Type != model.ActionRenameTable && diff.Type != model.ActionRebaseAutoID {
+		if oldTableID == newTableID && diff.Type != model.ActionRenameTable && diff.Type != model.ActionRebaseAutoID && diff.Type != model.ActionModifyTableAutoIncCache {
 			allocs, _ = b.is.AllocByID(oldTableID)
 		}
 

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -74,7 +74,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var allocs autoid.Allocators
 	if tableIDIsValid(oldTableID) {
-		if oldTableID == newTableID && diff.Type != model.ActionRenameTable && diff.Type != model.ActionRebaseAutoID && diff.Type != model.ActionModifyTableAutoIncCache {
+		if oldTableID == newTableID && diff.Type != model.ActionRenameTable && diff.Type != model.ActionRebaseAutoID && diff.Type != model.ActionModifyTableAutoIdCache {
 			allocs, _ = b.is.AllocByID(oldTableID)
 		}
 

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -76,6 +76,20 @@ const (
 	SequenceType
 )
 
+// CustomAutoIncCacheOption is one kind of AllocOption to customize the allocator step length.
+type CustomAutoIncCacheOption int64
+
+// ApplyOn is implement the AllocOption interface.
+func (step CustomAutoIncCacheOption) ApplyOn(alloc *allocator) {
+	alloc.step = int64(step)
+	alloc.customStep = true
+}
+
+// AllocOption is a interface to define allocator custom options coming in future.
+type AllocOption interface {
+	ApplyOn(*allocator)
+}
+
 // Allocator is an auto increment id generator.
 // Just keep id unique actually.
 type Allocator interface {
@@ -138,6 +152,7 @@ type allocator struct {
 	isUnsigned    bool
 	lastAllocTime time.Time
 	step          int64
+	customStep    bool
 	allocType     AllocatorType
 	sequence      *model.SequenceInfo
 }
@@ -370,8 +385,8 @@ func NextStep(curStep int64, consumeDur time.Duration) int64 {
 }
 
 // NewAllocator returns a new auto increment id generator on the store.
-func NewAllocator(store kv.Storage, dbID int64, isUnsigned bool, allocType AllocatorType) Allocator {
-	return &allocator{
+func NewAllocator(store kv.Storage, dbID int64, isUnsigned bool, allocType AllocatorType, opts ...AllocOption) Allocator {
+	alloc := &allocator{
 		store:         store,
 		dbID:          dbID,
 		isUnsigned:    isUnsigned,
@@ -379,6 +394,10 @@ func NewAllocator(store kv.Storage, dbID int64, isUnsigned bool, allocType Alloc
 		lastAllocTime: time.Now(),
 		allocType:     allocType,
 	}
+	for _, fn := range opts {
+		fn.ApplyOn(alloc)
+	}
+	return alloc
 }
 
 // NewSequenceAllocator returns a new sequence value generator on the store.
@@ -398,7 +417,11 @@ func NewSequenceAllocator(store kv.Storage, dbID int64, info *model.SequenceInfo
 func NewAllocatorsFromTblInfo(store kv.Storage, schemaID int64, tblInfo *model.TableInfo) Allocators {
 	var allocs []Allocator
 	dbID := tblInfo.GetDBID(schemaID)
-	allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType))
+	if tblInfo.AutoIncCache > 0 {
+		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType, CustomAutoIncCacheOption(tblInfo.AutoIncCache)))
+	} else {
+		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType))
+	}
 	if tblInfo.ContainsAutoRandomBits() {
 		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoRandomBitColUnsigned(), AutoRandomType))
 	}
@@ -606,13 +629,18 @@ func (alloc *allocator) alloc4Signed(tableID int64, n uint64, increment, offset 
 	if alloc.base+n1 > alloc.end {
 		var newBase, newEnd int64
 		startTime := time.Now()
-		// Although it may skip a segment here, we still think it is consumed.
-		consumeDur := startTime.Sub(alloc.lastAllocTime)
-		nextStep := NextStep(alloc.step, consumeDur)
-		// Make sure nextStep is big enough.
+		nextStep := alloc.step
+		if !alloc.customStep {
+			// Although it may skip a segment here, we still think it is consumed.
+			consumeDur := startTime.Sub(alloc.lastAllocTime)
+			nextStep = NextStep(alloc.step, consumeDur)
+		}
+		// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
 		if nextStep <= n1 {
-			alloc.step = mathutil.MinInt64(n1*2, maxStep)
-		} else {
+			nextStep = mathutil.MinInt64(n1*2, maxStep)
+		}
+		// Store the step for non-customized-step allocator to calculate next dynamic step.
+		if !alloc.customStep {
 			alloc.step = nextStep
 		}
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
@@ -622,7 +650,7 @@ func (alloc *allocator) alloc4Signed(tableID int64, n uint64, increment, offset 
 			if err1 != nil {
 				return err1
 			}
-			tmpStep := mathutil.MinInt64(math.MaxInt64-newBase, alloc.step)
+			tmpStep := mathutil.MinInt64(math.MaxInt64-newBase, nextStep)
 			// The global rest is not enough for alloc.
 			if tmpStep < n1 {
 				return ErrAutoincReadFailed
@@ -668,13 +696,18 @@ func (alloc *allocator) alloc4Unsigned(tableID int64, n uint64, increment, offse
 	if uint64(alloc.base)+uint64(n1) > uint64(alloc.end) {
 		var newBase, newEnd int64
 		startTime := time.Now()
-		// Although it may skip a segment here, we still treat it as consumed.
-		consumeDur := startTime.Sub(alloc.lastAllocTime)
-		nextStep := NextStep(alloc.step, consumeDur)
-		// Make sure nextStep is big enough.
+		nextStep := alloc.step
+		if !alloc.customStep {
+			// Although it may skip a segment here, we still treat it as consumed.
+			consumeDur := startTime.Sub(alloc.lastAllocTime)
+			nextStep = NextStep(alloc.step, consumeDur)
+		}
+		// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
 		if nextStep <= n1 {
-			alloc.step = mathutil.MinInt64(n1*2, maxStep)
-		} else {
+			nextStep = mathutil.MinInt64(n1*2, maxStep)
+		}
+		// Store the step for non-customized-step allocator to calculate next dynamic step.
+		if !alloc.customStep {
 			alloc.step = nextStep
 		}
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
@@ -684,7 +717,7 @@ func (alloc *allocator) alloc4Unsigned(tableID int64, n uint64, increment, offse
 			if err1 != nil {
 				return err1
 			}
-			tmpStep := int64(mathutil.MinUint64(math.MaxUint64-uint64(newBase), uint64(alloc.step)))
+			tmpStep := int64(mathutil.MinUint64(math.MaxUint64-uint64(newBase), uint64(nextStep)))
 			// The global rest is not enough for alloc.
 			if tmpStep < n1 {
 				return ErrAutoincReadFailed

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -417,8 +417,8 @@ func NewSequenceAllocator(store kv.Storage, dbID int64, info *model.SequenceInfo
 func NewAllocatorsFromTblInfo(store kv.Storage, schemaID int64, tblInfo *model.TableInfo) Allocators {
 	var allocs []Allocator
 	dbID := tblInfo.GetDBID(schemaID)
-	if tblInfo.AutoIncCache > 0 {
-		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType, CustomAutoIncCacheOption(tblInfo.AutoIncCache)))
+	if tblInfo.AutoIdCache > 0 {
+		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType, CustomAutoIncCacheOption(tblInfo.AutoIdCache)))
 	} else {
 		allocs = append(allocs, NewAllocator(store, dbID, tblInfo.IsAutoIncColUnsigned(), RowIDAllocType))
 	}

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -575,6 +575,10 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int) auto_id_cache=5;",
 			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache=5 */ ;",
 		},
+		{
+			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache=5 */ ;",
+			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache=5 */ ;",
+		},
 	}
 	for _, ca := range testCase {
 		re := binloginfo.AddSpecialComment(ca.input)

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -559,6 +559,18 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int  auto_random  (   4    ) primary key);",
 			"create table t1 (id int  /*T![auto_rand] auto_random  (   4    ) */ primary key);",
 		},
+		{
+			"create table t1 (id int auto_increment key) auto_id_cache 100;",
+			"create table t1 (id int auto_increment key) /*T![auto_id_cache] auto_id_cache 100 */ ;",
+		},
+		{
+			"create table t1 (id int auto_increment unique) auto_id_cache 10;",
+			"create table t1 (id int auto_increment unique) /*T![auto_id_cache] auto_id_cache 10 */ ;",
+		},
+		{
+			"create table t1 (id int) auto_id_cache 5;",
+			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache 5 */ ;",
+		},
 	}
 	for _, ca := range testCase {
 		re := binloginfo.AddSpecialComment(ca.input)

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -568,8 +568,12 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int auto_increment unique) /*T![auto_id_cache] auto_id_cache 10 */ ;",
 		},
 		{
-			"create table t1 (id int) auto_id_cache 5;",
-			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache 5 */ ;",
+			"create table t1 (id int) auto_id_cache = 5;",
+			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache = 5 */ ;",
+		},
+		{
+			"create table t1 (id int) auto_id_cache=5;",
+			"create table t1 (id int) /*T![auto_id_cache] auto_id_cache=5 */ ;",
 		},
 	}
 	for _, ca := range testCase {

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -60,5 +60,5 @@ const (
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
 	FeatureIDAutoRandom:  regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\))?\s*`),
-	FeatureIDAutoIDCache: regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*\d+\s*`),
+	FeatureIDAutoIDCache: regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 }

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -110,7 +110,7 @@ func IsJobRollbackable(job *model.Job) bool {
 		model.ActionTruncateTable, model.ActionAddForeignKey,
 		model.ActionDropForeignKey, model.ActionRenameTable,
 		model.ActionModifyTableCharsetAndCollate, model.ActionTruncateTablePartition,
-		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable:
+		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIncCache:
 		return job.SchemaState == model.StateNone
 	}
 	return true

--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -110,7 +110,7 @@ func IsJobRollbackable(job *model.Job) bool {
 		model.ActionTruncateTable, model.ActionAddForeignKey,
 		model.ActionDropForeignKey, model.ActionRenameTable,
 		model.ActionModifyTableCharsetAndCollate, model.ActionTruncateTablePartition,
-		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIncCache:
+		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable, model.ActionModifyTableAutoIdCache:
 		return job.SchemaState == model.StateNone
 	}
 	return true


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
That autoid allocator's cache step is quite big now, it will consume a lot of autoid when tidb restarts or crashes. For those scenes which treasure autoid heavily, it's not acceptable.

Parser link: [#765](https://github.com/pingcap/parser/pull/765)

Problem Summary:

### What is changed and how it works?
Add `auto_increment_cache` in create table / alter table statement and it will determine the allocator's cache step.

**But there is an exception when a statement like an insert batch(`insert into values()()...`) which requires allocating consecutive N autoid in one statement, we will make sure that the custom cache step is adequate for it with `if step < N, then step = min(2N, maxstep)`**

>Attention please: 
tidb handle share the same allocator with auto_increment, so here:
`auto_increment_cache` will take effect on `handle` if `PKIshandle` is `false`, or even there is no auto_increment column at all. 

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note: 
ddl: add syntax for setting the cache step of auto id explicitly. <!-- bugfixes or new feature need a release note -->
