### PR TITLE
domain/infosync: edit `getTopologyInfo` and Try to fix dashboard version.

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -309,7 +309,10 @@ func (is *InfoSyncer) getTopologyInfo() topologyInfo {
 		s = ""
 	}
 	return topologyInfo{
-		ServerVersionInfo: is.info.ServerVersionInfo,
+		ServerVersionInfo: ServerVersionInfo{
+			Version: mysql.TiDBReleaseVersion,
+			GitHash: is.info.ServerVersionInfo.GitHash,
+		},
 		StatusPort:        is.info.StatusPort,
 		BinaryPath:        s,
 	}

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -313,8 +313,8 @@ func (is *InfoSyncer) getTopologyInfo() topologyInfo {
 			Version: mysql.TiDBReleaseVersion,
 			GitHash: is.info.ServerVersionInfo.GitHash,
 		},
-		StatusPort:        is.info.StatusPort,
-		BinaryPath:        s,
+		StatusPort: is.info.StatusPort,
+		BinaryPath: s,
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: mapleFU <1506118561@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: https://github.com/pingcap-incubator/tidb-dashboard/issues/221

Problem Summary:

TiDB-Dashboard Should not use `ServerVersion`, instead, it should use `TiDBReleaseVersion`. This pr fix that problem.

### What is changed and how it works?

What's Changed:

changed `ServerVersion` to using `TiDBReleaseVersion`.

How it Works:

### Related changes

This Pr: https://github.com/pingcap/tidb/pull/14809

- PR to update `pingcap/docs`/`pingcap/docs-cn`: None
- PR to update `pingcap/tidb-ansible`: None
- Need to cherry-pick to the release branch: 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->
