### PR TITLE
server: change failpoint http path same with tikv

### DIFF
--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -1134,7 +1134,7 @@ func (ts *HTTPHandlerTestSuite) TestFailpointHandler(c *C) {
 
 	// start server without enabling failpoint integration
 	ts.startServer(c)
-	resp, err := ts.fetchStatus("/failpoints/")
+	resp, err := ts.fetchStatus("/fail/")
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusNotFound)
 	ts.stopServer(c)
@@ -1142,7 +1142,7 @@ func (ts *HTTPHandlerTestSuite) TestFailpointHandler(c *C) {
 	// enable failpoint integration and start server
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/server/integrateFailpoint", "return"), IsNil)
 	ts.startServer(c)
-	resp, err = ts.fetchStatus("/failpoints/")
+	resp, err = ts.fetchStatus("/fail/")
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	b, err := ioutil.ReadAll(resp.Body)

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -257,8 +257,8 @@ func (s *Server) startHTTPServer() {
 	serverMux.HandleFunc("/debug/sub-optimal-plan", fetcher.zipInfoForSQL)
 
 	failpoint.Inject("integrateFailpoint", func() {
-		serverMux.HandleFunc("/failpoints/", func(w http.ResponseWriter, r *http.Request) {
-			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/failpoints")
+		serverMux.HandleFunc("/fail/", func(w http.ResponseWriter, r *http.Request) {
+			r.URL.Path = strings.TrimPrefix(r.URL.Path, "/fail")
 			new(failpoint.HttpHandler).ServeHTTP(w, r)
 		})
 	})


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Change the fail point HTTP path same as `tikv` for `automated-tests` project

### What is changed and how it works?



What's Changed:

How it Works:

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects



### Release note <!-- bugfixes or new feature need a release note -->
