### PR TITLE
test: fix data race in `TestNoneAccessPathsFoundByIsolationRead`

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = Suite(&testIntegrationSuite{})
+var _ = SerialSuites(&testIntegrationSuite{})
 
 type testIntegrationSuite struct {
 	testData testutil.TestData

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -26,7 +26,8 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = SerialSuites(&testIntegrationSuite{})
+var _ = Suite(&testIntegrationSuite{})
+var _ = SerialSuites(&testIntegrationSerialSuite{})
 
 type testIntegrationSuite struct {
 	testData testutil.TestData
@@ -51,6 +52,34 @@ func (s *testIntegrationSuite) SetUpTest(c *C) {
 }
 
 func (s *testIntegrationSuite) TearDownTest(c *C) {
+	s.dom.Close()
+	err := s.store.Close()
+	c.Assert(err, IsNil)
+}
+
+type testIntegrationSerialSuite struct {
+	testData testutil.TestData
+	store    kv.Storage
+	dom      *domain.Domain
+}
+
+func (s *testIntegrationSerialSuite) SetUpSuite(c *C) {
+	var err error
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "integration_suite")
+	c.Assert(err, IsNil)
+}
+
+func (s *testIntegrationSerialSuite) TearDownSuite(c *C) {
+	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
+}
+
+func (s *testIntegrationSerialSuite) SetUpTest(c *C) {
+	var err error
+	s.store, s.dom, err = newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+}
+
+func (s *testIntegrationSerialSuite) TearDownTest(c *C) {
 	s.dom.Close()
 	err := s.store.Close()
 	c.Assert(err, IsNil)
@@ -245,7 +274,7 @@ func (s *testIntegrationSuite) TestSimplifyOuterJoinWithCast(c *C) {
 	}
 }
 
-func (s *testIntegrationSuite) TestNoneAccessPathsFoundByIsolationRead(c *C) {
+func (s *testIntegrationSerialSuite) TestNoneAccessPathsFoundByIsolationRead(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("use test")
@@ -274,7 +303,7 @@ func (s *testIntegrationSuite) TestNoneAccessPathsFoundByIsolationRead(c *C) {
 	c.Assert(err.Error(), Equals, "[planner:1815]Internal : Can not find access path matching 'tidb_isolation_read_engines'(value: 'tikv,tiflash') and tidb-server config isolation-read(engines: '[tiflash]'). Available values are 'tikv'.")
 }
 
-func (s *testIntegrationSuite) TestSelPushDownTiFlash(c *C) {
+func (s *testIntegrationSerialSuite) TestSelPushDownTiFlash(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -311,7 +340,7 @@ func (s *testIntegrationSuite) TestSelPushDownTiFlash(c *C) {
 	))
 }
 
-func (s *testIntegrationSuite) TestIssue15110(c *C) {
+func (s *testIntegrationSerialSuite) TestIssue15110(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists crm_rd_150m")
@@ -346,7 +375,7 @@ func (s *testIntegrationSuite) TestIssue15110(c *C) {
 	tk.MustExec("explain SELECT count(*) FROM crm_rd_150m dataset_48 WHERE (CASE WHEN (month(dataset_48.customer_first_date)) <= 30 THEN '新客' ELSE NULL END) IS NOT NULL;")
 }
 
-func (s *testIntegrationSuite) TestReadFromStorageHint(c *C) {
+func (s *testIntegrationSerialSuite) TestReadFromStorageHint(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("use test")
@@ -386,7 +415,7 @@ func (s *testIntegrationSuite) TestReadFromStorageHint(c *C) {
 	}
 }
 
-func (s *testIntegrationSuite) TestReadFromStorageHintAndIsolationRead(c *C) {
+func (s *testIntegrationSerialSuite) TestReadFromStorageHintAndIsolationRead(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("use test")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #15431 

Problem Summary: data race in `TestNoneAccessPathsFoundByIsolationRead`

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: change the test `testIntegrationSuite` unparallel.

How it Works:

### Related changes

- Need to cherry-pick to the release branch (release-3.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
