### PR TITLE
gc_worker: Skip TiFlash nodes when doing UnsafeDestroyRange and Green GC

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -742,7 +742,7 @@ const (
 	engineLabelTiKV    = "tikv"
 )
 
-// needsGCOperationForStore checks if the store-level quests related to GC needs to be sent to the store. The store-level
+// needsGCOperationForStore checks if the store-level requests related to GC needs to be sent to the store. The store-level
 // requests includes UnsafeDestroyRange, PhysicalScanLock, etc.
 func needsGCOperationForStore(store *metapb.Store) (bool, error) {
 	engineLabel := ""

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -401,7 +401,7 @@ func (w *GCWorker) getGCConcurrency(ctx context.Context) (int, error) {
 		return w.loadGCConcurrencyWithDefault()
 	}
 
-	stores, err := w.getUpStores(ctx)
+	stores, err := w.getUpStoresForGC(ctx)
 	concurrency := len(stores)
 	if err != nil {
 		logutil.Logger(ctx).Error("[gc worker] failed to get up stores to calculate concurrency. use config.",
@@ -669,7 +669,7 @@ func (w *GCWorker) redoDeleteRanges(ctx context.Context, safePoint uint64, concu
 
 func (w *GCWorker) doUnsafeDestroyRangeRequest(ctx context.Context, startKey []byte, endKey []byte, concurrency int) error {
 	// Get all stores every time deleting a region. So the store list is less probably to be stale.
-	stores, err := w.getUpStores(ctx)
+	stores, err := w.getUpStoresForGC(ctx)
 	if err != nil {
 		logutil.Logger(ctx).Error("[gc worker] delete ranges: got an error while trying to get store list from PD",
 			zap.String("uuid", w.uuid),
@@ -736,7 +736,47 @@ func (w *GCWorker) doUnsafeDestroyRangeRequest(ctx context.Context, startKey []b
 	return nil
 }
 
-func (w *GCWorker) getUpStores(ctx context.Context) ([]*metapb.Store, error) {
+const (
+	engineLabelKey     = "engine"
+	engineLabelTiFlash = "tiflash"
+	engineLabelTiKV    = "tikv"
+)
+
+// needsGCOperationForStore checks if the store-level quests related to GC needs to be sent to the store. The store-level
+// requests includes UnsafeDestroyRange, PhysicalScanLock, etc.
+func needsGCOperationForStore(store *metapb.Store) (bool, error) {
+	engineLabel := ""
+
+	for _, label := range store.GetLabels() {
+		if label.GetKey() == engineLabelKey {
+			engineLabel = label.GetValue()
+			break
+		}
+	}
+
+	switch engineLabel {
+	case engineLabelTiFlash:
+		// For a TiFlash node, it uses other approach to delete dropped tables, so it's safe to skip sending
+		// UnsafeDestroyRange requests; it has only learner peers and their data must exist in TiKV, so it's safe to
+		// skip physical resolve locks for it.
+		return false, nil
+
+	case "":
+		// If no engine label is set, it should be a TiKV node.
+		fallthrough
+	case engineLabelTiKV:
+		return true, nil
+
+	default:
+		return true, errors.Errorf("unsupported store engine \"%v\" with storeID %v, addr %v",
+			engineLabel,
+			store.GetId(),
+			store.GetAddress())
+	}
+}
+
+// getUpStoresForGC gets the list of stores that needs to be processed during GC.
+func (w *GCWorker) getUpStoresForGC(ctx context.Context) ([]*metapb.Store, error) {
 	stores, err := w.pdClient.GetAllStores(ctx)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -744,15 +784,22 @@ func (w *GCWorker) getUpStores(ctx context.Context) ([]*metapb.Store, error) {
 
 	upStores := make([]*metapb.Store, 0, len(stores))
 	for _, store := range stores {
-		if store.State == metapb.StoreState_Up {
+		if store.State != metapb.StoreState_Up {
+			continue
+		}
+		needsGCOp, err := needsGCOperationForStore(store)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		if needsGCOp {
 			upStores = append(upStores, store)
 		}
 	}
 	return upStores, nil
 }
 
-func (w *GCWorker) getUpStoresMap(ctx context.Context) (map[uint64]*metapb.Store, error) {
-	stores, err := w.getUpStores(ctx)
+func (w *GCWorker) getUpStoresMapForGC(ctx context.Context) (map[uint64]*metapb.Store, error) {
+	stores, err := w.getUpStoresForGC(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -990,7 +1037,7 @@ func (w *GCWorker) resolveLocksPhysical(ctx context.Context, safePoint uint64) e
 		zap.Uint64("safePoint", safePoint))
 	startTime := time.Now()
 
-	stores, err := w.getUpStoresMap(ctx)
+	stores, err := w.getUpStoresMapForGC(ctx)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1008,7 +1055,7 @@ func (w *GCWorker) resolveLocksPhysical(ctx context.Context, safePoint uint64) e
 			return errors.Trace(err)
 		}
 
-		stores, err = w.getUpStoresMap(ctx)
+		stores, err = w.getUpStoresMapForGC(ctx)
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/15496

Problem Summary: GC delete range phase and (if green gc is enabled) resolve lock phase cannot successfully run when there are TiFlash nodes in the cluster.

### What is changed and how it works?

What's Changed: Filters out TiFlash nodes when sending UnsafeDestroyRange and Green GC related stuff, according to the store's "engine" label. But note that it's possible to be broken when the label is incorrectly configured (see https://github.com/tikv/tikv/issues/7153). 

How it Works: For a TiFlash node, it uses other approach to delete dropped tables, so it's safe to skip sending UnsafeDestroyRange requests; it has only learner peers and their data must exist in TiKV, so it's safe to skip physical resolve locks for it. So in theory GC is still correct.

### Related changes

- Need to cherry-pick to the release branch
  - release-3.1 (which supports TiFlash)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
  - Need to be test if it actually works in a TiFlash-equipped cluster. (Help wanted)

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

(I'm not sure if this is needed since it's related to TiFlash)
- Fixes the issue that GC may not work in a cluster that has TiFlash