### PR TITLE
privilege: fix show grants privilege check

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1164,6 +1164,17 @@ func (e *ShowExec) fetchShowGrants() error {
 	if checker == nil {
 		return errors.New("miss privilege checker")
 	}
+	sessVars := e.ctx.GetSessionVars()
+	if !e.User.CurrentUser {
+		userName := sessVars.User.AuthUsername
+		hostName := sessVars.User.AuthHostname
+		// Show grant user requires the SELECT privilege on mysql schema.
+		// Ref https://dev.mysql.com/doc/refman/8.0/en/show-grants.html
+		activeRoles := sessVars.ActiveRoles
+		if !checker.RequestVerification(activeRoles, mysql.SystemDB, "", "", mysql.SelectPriv) {
+			return ErrDBaccessDenied.GenWithStackByArgs(userName, hostName, mysql.SystemDB)
+		}
+	}
 	for _, r := range e.Roles {
 		if r.Hostname == "" {
 			r.Hostname = "%"

--- a/executor/show.go
+++ b/executor/show.go
@@ -1170,7 +1170,7 @@ func (e *ShowExec) fetchShowGrants() error {
 		hostName := sessVars.User.AuthHostname
 		// Show grant user requires the SELECT privilege on mysql schema.
 		// Ref https://dev.mysql.com/doc/refman/8.0/en/show-grants.html
-		if userName != e.User.AuthUsername || hostName != e.User.AuthHostname {
+		if userName != e.User.Username || hostName != e.User.Hostname {
 			activeRoles := sessVars.ActiveRoles
 			if !checker.RequestVerification(activeRoles, mysql.SystemDB, "", "", mysql.SelectPriv) {
 				return ErrDBaccessDenied.GenWithStackByArgs(userName, hostName, mysql.SystemDB)

--- a/executor/show.go
+++ b/executor/show.go
@@ -1170,9 +1170,11 @@ func (e *ShowExec) fetchShowGrants() error {
 		hostName := sessVars.User.AuthHostname
 		// Show grant user requires the SELECT privilege on mysql schema.
 		// Ref https://dev.mysql.com/doc/refman/8.0/en/show-grants.html
-		activeRoles := sessVars.ActiveRoles
-		if !checker.RequestVerification(activeRoles, mysql.SystemDB, "", "", mysql.SelectPriv) {
-			return ErrDBaccessDenied.GenWithStackByArgs(userName, hostName, mysql.SystemDB)
+		if userName != e.User.AuthUsername || hostName != e.User.AuthHostname {
+			activeRoles := sessVars.ActiveRoles
+			if !checker.RequestVerification(activeRoles, mysql.SystemDB, "", "", mysql.SelectPriv) {
+				return ErrDBaccessDenied.GenWithStackByArgs(userName, hostName, mysql.SystemDB)
+			}
 		}
 	}
 	for _, r := range e.Roles {

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -169,7 +169,7 @@ func (s *testSuite5) TestIssue10549(c *C) {
 	tk.MustExec("GRANT 'app_developer' TO 'dev';")
 	tk.MustExec("SET DEFAULT ROLE app_developer TO 'dev';")
 
-	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "dev", Hostname: "localhost", AuthUsername: "dev", AuthHostname: "localhost"}, nil, nil), IsTrue)
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "dev", Hostname: "%", AuthUsername: "dev", AuthHostname: "%"}, nil, nil), IsTrue)
 	tk.MustQuery("SHOW DATABASES;").Check(testkit.Rows("INFORMATION_SCHEMA", "newdb"))
 	tk.MustQuery("SHOW GRANTS;").Check(testkit.Rows("GRANT USAGE ON *.* TO 'dev'@'%'", "GRANT ALL PRIVILEGES ON newdb.* TO 'dev'@'%'", "GRANT 'app_developer'@'%' TO 'dev'@'%'"))
 	tk.MustQuery("SHOW GRANTS FOR CURRENT_USER").Check(testkit.Rows("GRANT USAGE ON *.* TO 'dev'@'%'", "GRANT 'app_developer'@'%' TO 'dev'@'%'"))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
`SHOW GRANTS` need `SELECT` privilege on `mysql` database, but tidb dosen't check. 

### What is changed and how it works?
add privilege check for `show grants`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

fix `SHOW GRANTS` privilege check
