### PR TITLE
privilege: fix select current_role() error

### DIFF
--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -59,6 +59,22 @@ func (s *testSuite3) TestDo(c *C) {
 	tk.MustQuery("select @a").Check(testkit.Rows("1"))
 }
 
+func (s *testSuite3) TestSetRoleAllCorner(c *C) {
+	// For user with no role, `SET ROLE ALL` should active
+	// a empty slice, rather than nil.
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create user set_role_all")
+	se, err := session.CreateSession4Test(s.store)
+	c.Check(err, IsNil)
+	defer se.Close()
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "set_role_all", Hostname: "localhost"}, nil, nil), IsTrue)
+	ctx := context.Background()
+	_, err = se.Execute(ctx, `set role all`)
+	c.Assert(err, IsNil)
+	_, err = se.Execute(ctx, `select current_role`)
+	c.Assert(err, IsNil)
+}
+
 func (s *testSuite3) TestCreateRole(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create user testCreateRole;")

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -1253,11 +1253,10 @@ func (p *MySQLPrivilege) getAllRoles(user, host string) []*auth.RoleIdentity {
 	key := user + "@" + host
 	edgeTable, ok := p.RoleGraph[key]
 	ret := make([]*auth.RoleIdentity, 0, len(edgeTable.roleList))
-	if !ok {
-		return nil
-	}
-	for _, r := range edgeTable.roleList {
-		ret = append(ret, r)
+	if ok {
+		for _, r := range edgeTable.roleList {
+			ret = append(ret, r)
+		}
 	}
 	return ret
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

For user with no role, execute `SET ROLE ALL`, then `SELECT CURRENT_ROLE()`

```
mysql> set role all;
Query OK, 0 rows affected (0.00 sec)

mysql> select current_role();
ERROR 1105 (HY000): Missing session variable when eval builtin
```

Problem Summary:
This was caused by `GetAllRole`, which will return `nil` if user has no role.

### What is changed and how it works?

let `GetAllRole` return a empty slice, rather than `nil`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->
