### PR TITLE
executor/inspect: add sync-log config check and fix invalid time panic when memory table predicate

### DIFF
--- a/executor/inspection_result.go
+++ b/executor/inspection_result.go
@@ -247,6 +247,12 @@ func (configInspection) inspectCheckConfig(_ context.Context, sctx sessionctx.Co
 			value:  "0",
 			detail: "slow-threshold = 0 will record every query to slow log, it may affect performance",
 		},
+		{
+			tp:     "tikv",
+			key:    "raftstore.sync-log",
+			value:  "false",
+			detail: "sync-log should be true to avoid recover region when the machine breaks down",
+		},
 	}
 
 	var results []inspectionResult
@@ -273,6 +279,7 @@ func (configInspection) inspectCheckConfig(_ context.Context, sctx sessionctx.Co
 			})
 		}
 	}
+
 	return results
 }
 

--- a/executor/inspection_result.go
+++ b/executor/inspection_result.go
@@ -279,7 +279,6 @@ func (configInspection) inspectCheckConfig(_ context.Context, sctx sessionctx.Co
 			})
 		}
 	}
-
 	return results
 }
 

--- a/executor/inspection_result_test.go
+++ b/executor/inspection_result_test.go
@@ -49,6 +49,7 @@ func (s *inspectionResultSuite) TestInspectionResult(c *C) {
 			types.MakeDatums("tikv", "192.168.3.33:26600", "coprocessor.high", "8"),
 			types.MakeDatums("tikv", "192.168.3.34:26600", "coprocessor.high", "7"),
 			types.MakeDatums("tikv", "192.168.3.35:26600", "coprocessor.high", "7"),
+			types.MakeDatums("tikv", "192.168.3.35:26600", "raftstore.sync-log", "false"),
 			types.MakeDatums("pd", "192.168.3.32:2379", "scheduler.limit", "3"),
 			types.MakeDatums("pd", "192.168.3.33:2379", "scheduler.limit", "3"),
 			types.MakeDatums("pd", "192.168.3.34:2379", "scheduler.limit", "3"),
@@ -111,6 +112,7 @@ func (s *inspectionResultSuite) TestInspectionResult(c *C) {
 				"config ddl.lease tidb inconsistent consistent warning the cluster has different config value of ddl.lease, execute the sql to see more detail: select * from information_schema.cluster_config where type='tidb' and `key`='ddl.lease'",
 				"config log.slow-threshold tidb 0 not 0 warning slow-threshold = 0 will record every query to slow log, it may affect performance",
 				"config log.slow-threshold tidb inconsistent consistent warning the cluster has different config value of log.slow-threshold, execute the sql to see more detail: select * from information_schema.cluster_config where type='tidb' and `key`='log.slow-threshold'",
+				"config raftstore.sync-log tikv false not false warning sync-log should be true to avoid recover region when the machine breaks down",
 				"version git_hash pd inconsistent consistent critical the cluster has 3 different pd versions, execute the sql to see more detail: select * from information_schema.cluster_info where type='pd'",
 				"version git_hash tidb inconsistent consistent critical the cluster has 3 different tidb versions, execute the sql to see more detail: select * from information_schema.cluster_info where type='tidb'",
 				"version git_hash tikv inconsistent consistent critical the cluster has 2 different tikv versions, execute the sql to see more detail: select * from information_schema.cluster_info where type='tikv'",
@@ -130,6 +132,7 @@ func (s *inspectionResultSuite) TestInspectionResult(c *C) {
 				"config ddl.lease tidb inconsistent consistent warning the cluster has different config value of ddl.lease, execute the sql to see more detail: select * from information_schema.cluster_config where type='tidb' and `key`='ddl.lease'",
 				"config log.slow-threshold tidb 0 not 0 warning slow-threshold = 0 will record every query to slow log, it may affect performance",
 				"config log.slow-threshold tidb inconsistent consistent warning the cluster has different config value of log.slow-threshold, execute the sql to see more detail: select * from information_schema.cluster_config where type='tidb' and `key`='log.slow-threshold'",
+				"config raftstore.sync-log tikv false not false warning sync-log should be true to avoid recover region when the machine breaks down",
 			},
 		},
 		{

--- a/planner/core/memtable_predicate_extractor.go
+++ b/planner/core/memtable_predicate_extractor.go
@@ -400,11 +400,10 @@ func (helper extractHelper) extractTimeRange(
 			timeType := types.NewFieldType(mysql.TypeDatetime)
 			timeType.Decimal = 3
 			timeDatum, err := datums[0].ConvertTo(ctx.GetSessionVars().StmtCtx, timeType)
-			if err != nil {
+			if err != nil || timeDatum.Kind() == types.KindNull {
 				remained = append(remained, expr)
 				continue
 			}
-
 			mysqlTime := timeDatum.GetMysqlTime()
 			timestamp := time.Date(mysqlTime.Year(),
 				time.Month(mysqlTime.Month()),

--- a/planner/core/memtable_predicate_extractor.go
+++ b/planner/core/memtable_predicate_extractor.go
@@ -404,6 +404,7 @@ func (helper extractHelper) extractTimeRange(
 				remained = append(remained, expr)
 				continue
 			}
+
 			mysqlTime := timeDatum.GetMysqlTime()
 			timestamp := time.Date(mysqlTime.Year(),
 				time.Month(mysqlTime.Month()),

--- a/planner/core/memtable_predicate_extractor_test.go
+++ b/planner/core/memtable_predicate_extractor_test.go
@@ -271,6 +271,12 @@ func (s *extractorSuite) TestClusterLogTableExtractor(c *C) {
 			instances: nil,
 		},
 		{
+			// Test for invalid time.
+			sql:       "select * from information_schema.cluster_log where time='2019-10-10 10::10'",
+			nodeTypes: set.NewStringSet(),
+			instances: set.NewStringSet(),
+		},
+		{
 			sql:       "select * from information_schema.cluster_log where type='tikv'",
 			nodeTypes: set.NewStringSet("tikv"),
 			instances: set.NewStringSet(),


### PR DESCRIPTION

### What problem does this PR solve?

* Fix panic when query predicate table with invalid time. 
eg: `select * from up where time="2020-03-09 20::00"`

```sql
[2020/03/20 22:02:01.208 +08:00] [ERROR] [conn.go:632] ["connection running loop panic"] [conn=398] [lastSQL="select * from up where time=\"2020-03-09 20::00\""] [err="interface conversion: interface {} is nil, not types.Time"] [stack="goroutine 6376 [running]:
github.com/pingcap/tidb/server.(*clientConn).Run.func1(0x5decd80, 0xc001a94e10, 0xc001aa9790)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:630 +0xee
panic(0x578c440, 0xc0016d9d10)
	/usr/local/go1.13/src/runtime/panic.go:679 +0x1b2
github.com/pingcap/tidb/types.(*Datum).GetMysqlTime(...)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/types/datum.go:323
github.com/pingcap/tidb/planner/core.extractHelper.extractTimeRange(0x5e25380, 0xc0013b4000, 0xc0016d9a40, 0xc0011e4c00, 0x4, 0x4, 0xc001de6cd0, 0x1, 0x1, 0x5a49cc9, ...)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/planner/core/memtable_predicate_extractor.go:408 +0xc30
github.com/pingcap/tidb/planner/core.(*MetricTableExtractor).Extract(0xc0008e61e0, 0x5e25380, 0xc0013b4000, 0xc0016d9a40, 0xc0011e4c00, 0x4, 0x4, 0xc001de6cd0, 0x1, 0x1, ...)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/planner/core/memtable_predicate_extractor.go:648 +0x1f5
github.com/pingcap/tidb/planner/core.(*LogicalMemTable).PredicatePushDown(0xc000211200, 0xc001de6cd0, 0x1, 0x1, 0x7394278, 0x0, 0x0, 0x0, 0x1)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/planner/core/rule_predicate_push_down.go:580 +0xf1
github.com/pingcap/tidb/planner/core.(*LogicalSelection).PredicatePushDown(0xc00020f290, 0x7394278, 0x0, 0x0, 0x4048ddc, 0x0, 0x5977de0, 0xc00057bc01, 0x7394278)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/planner/core/rule_predicate_push_down.go:77 +0x166
github.com/pingcap/tidb/planner/core.(*baseLogicalPlan).PredicatePushDown(0xc000fd04f0, 0x7394278, 0x0, 0x0, 0xc001de6cc0, 0x1, 0x1, 0x1, 0x5e24080)
	/Users/cs/code/goread/src/github.com/pingcap/tidb/planner/core/rule_predicate_push_down.go:56 +0xa6

```

* Add `raftstore.sync-log` config check rule. such as below:

```sql
mysql>select /*+ time_range('2020-03-20 15:00:00','2020-03-20 15:05:00') */ * from information_schema.INSPECTION_RESULT;
+-----------------+-----------------------------------------+------+-------------------+--------------+------------+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| RULE            | ITEM                                    | TYPE | INSTANCE          | VALUE        | REFERENCE  | SEVERITY | DETAILS                                                                                                                                                                                                                                      |
+-----------------+-----------------------------------------+------+-------------------+--------------+------------+----------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| config          | raftstore.sync-log                      | tikv | 172.16.5.40:20150 | false        | not false  | warning  | sync-log should be true to avoid recover region when the machine breaks down                                                                                                                                                                 |
| config          | raftstore.sync-log                      | tikv | 172.16.5.40:21150 | false        | not false  | warning  | sync-log should be true to avoid recover region when the machine breaks down                                                                                                                                                                 |

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->
