### PR TITLE
statistics: fix repetitive selectivity accounting and stabilify the result

### DIFF
--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -15,6 +15,7 @@ package statistics
 
 import (
 	"math"
+	"math/bits"
 	"sort"
 
 	"github.com/pingcap/errors"
@@ -351,7 +352,7 @@ func GetUsableSetsByGreedy(nodes []*StatsNode) (newBlocks []*StatsNode) {
 				marked[i] = true
 				continue
 			}
-			bits := bitCount(curMask)
+			bits := bits.OnesCount64(uint64(curMask))
 			// This set cannot cover any thing, just skip it.
 			if bits == 0 {
 				marked[i] = true
@@ -376,15 +377,4 @@ func GetUsableSetsByGreedy(nodes []*StatsNode) (newBlocks []*StatsNode) {
 		marked[bestID] = true
 	}
 	return
-}
-
-// bitCount is the number of bit `1` in the binary representation of number x.
-func bitCount(x int64) int {
-	ret := 0
-	// x -= x & -x, remove the lowest bit of the x.
-	// e.g. result will be 2 if x is 3.
-	for ; x > 0; x -= x & -x {
-		ret++
-	}
-	return ret
 }

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -593,3 +593,21 @@ func (s *testStatsSuite) TestUniqCompEqualEst(c *C) {
 		testKit.MustQuery(input[i]).Check(testkit.Rows(output[i]...))
 	}
 }
+
+func (s *testStatsSuite) TestSelectivityGreedyAlgo(c *C) {
+	nodes := make([]*statistics.StatsNode, 3)
+	nodes[0] = statistics.MockStatsNode(1, 3, 2)
+	nodes[1] = statistics.MockStatsNode(2, 5, 2)
+	nodes[2] = statistics.MockStatsNode(3, 9, 2)
+
+	// Sets should not overlap on mask, so only nodes[0] is chosen.
+	usedSets := statistics.GetUsableSetsByGreedy(nodes)
+	c.Assert(len(usedSets), Equals, 1)
+	c.Assert(usedSets[0].ID, Equals, int64(1))
+
+	nodes[0], nodes[1] = nodes[1], nodes[0]
+	// Sets chosen should be stable, so the returned node is still the one with ID 1.
+	usedSets = statistics.GetUsableSetsByGreedy(nodes)
+	c.Assert(len(usedSets), Equals, 1)
+	c.Assert(usedSets[0].ID, Equals, int64(1))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
- in `Selectivity`, index order in `coll.Indices` is non-deterministic, so the greedy search algorithm may return different results in different runs, that would confuse users since the stats is not changed at all;
- in the greedy search algorithm, there are repetitive selectivity accounting sometimes. For example, if the filter is like `t.a = 1 and t.b > 1 and t.c > 1`, and there are 2 indexes `idx1(a,b)` and `idx2(a,c)`, the greedy algorithm would choose both indexes and multiply their selectivity computed respectively. Obviously, this is wrong, because selectivity of `t.a = 1` is accounted twice.

### What is changed and how it works?

What's Changed:
- do not choose indexes whose filters covered are overlapped;
- sort the `StatsNode` slice before greedy search;

How it Works:

Note that, how we sort the `StatsNode` slice impacts the greedy search result. I put the PK in the end of the slice, indexes in the middle and columns in the front, to enforce the heuristic rule that, PK is preferred over indexes in estimation, and indexes are preferred over columns.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression: the change of the selectivity result may change plan generated.
- Breaking backward compatibility: nope, in order to keep compatibility, I introduces the `compareType` function, instead of changing the values of `IndexType` / `PkType` / `ColType`, because feedback encoding uses these constants.

### Release note <!-- bugfixes or new feature need a release note -->
