### PR TITLE
planner/cascades: optimize plan when group by a constant

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,7 @@ charset = utf-8
 indent_style = tab
 indent_size = 4
 trim_trailing_whitespace = true
+
+# disable *.result trim_trailing_whitespace
+[*.result]
+trim_trailing_whitespace = false

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -670,19 +670,19 @@ id	estRows	task	operator info
 Sort_13	2.00	root	Column#3:asc
 └─HashAgg_17	2.00	root	group by:Column#3, funcs:firstrow(Column#6)->Column#3
   └─Union_18	2.00	root	
-    ├─HashAgg_19	1.00	root	group by:1, funcs:firstrow(0)->Column#6, funcs:firstrow(0)->Column#3
-    │ └─TableDual_22	1.00	root	rows:1
-    └─HashAgg_25	1.00	root	group by:1, funcs:firstrow(1)->Column#6, funcs:firstrow(1)->Column#3
-      └─TableDual_28	1.00	root	rows:1
+    ├─StreamAgg_22	1.00	root	funcs:firstrow(0)->Column#6, funcs:firstrow(0)->Column#3
+    │ └─TableDual_27	1.00	root	rows:1
+    └─StreamAgg_32	1.00	root	funcs:firstrow(1)->Column#6, funcs:firstrow(1)->Column#3
+      └─TableDual_37	1.00	root	rows:1
 explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a);
 id	estRows	task	operator info
 HashAgg_15	2.00	root	group by:Column#3, funcs:firstrow(Column#6)->Column#3
 └─Union_16	2.00	root	
-  ├─HashAgg_17	1.00	root	group by:1, funcs:firstrow(0)->Column#6, funcs:firstrow(0)->Column#3
-  │ └─TableDual_20	1.00	root	rows:1
-  └─StreamAgg_27	1.00	root	group by:Column#1, funcs:firstrow(Column#1)->Column#6, funcs:firstrow(Column#1)->Column#3
-    └─Projection_32	1.00	root	1->Column#1
-      └─TableDual_33	1.00	root	rows:1
+  ├─StreamAgg_20	1.00	root	funcs:firstrow(0)->Column#6, funcs:firstrow(0)->Column#3
+  │ └─TableDual_25	1.00	root	rows:1
+  └─StreamAgg_31	1.00	root	group by:Column#1, funcs:firstrow(Column#1)->Column#6, funcs:firstrow(Column#1)->Column#3
+    └─Projection_36	1.00	root	1->Column#1
+      └─TableDual_37	1.00	root	rows:1
 create table t (i int key, j int, unique key (i, j));
 begin;
 insert into t values (1, 1);
@@ -772,4 +772,34 @@ label = "cop"
 "TableReader_7" -> "Selection_6"
 }
 
+drop table if exists t;
+create table t(a int, b int);
+explain select max(a) from t group by -1;
+id	estRows	task	operator info
+StreamAgg_13	1.00	root	funcs:max(test.t.a)->Column#4
+└─TopN_14	1.00	root	test.t.a:desc, offset:0, count:1
+  └─TableReader_23	1.00	root	data:TopN_22
+    └─TopN_22	1.00	cop[tikv]	test.t.a:desc, offset:0, count:1
+      └─Selection_21	9990.00	cop[tikv]	not(isnull(test.t.a))
+        └─TableFullScan_20	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+drop table if exists t;
+create table t(a int, b int);
+explain select max(a) from t group by (10-9+1);
+id	estRows	task	operator info
+StreamAgg_13	1.00	root	funcs:max(test.t.a)->Column#4
+└─TopN_14	1.00	root	test.t.a:desc, offset:0, count:1
+  └─TableReader_23	1.00	root	data:TopN_22
+    └─TopN_22	1.00	cop[tikv]	test.t.a:desc, offset:0, count:1
+      └─Selection_21	9990.00	cop[tikv]	not(isnull(test.t.a))
+        └─TableFullScan_20	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+drop table if exists t;
+create table t(a int, b int);
+explain select max(a) from t group by 'xyz';
+id	estRows	task	operator info
+StreamAgg_13	1.00	root	funcs:max(test.t.a)->Column#4
+└─TopN_14	1.00	root	test.t.a:desc, offset:0, count:1
+  └─TableReader_23	1.00	root	data:TopN_22
+    └─TopN_22	1.00	cop[tikv]	test.t.a:desc, offset:0, count:1
+      └─Selection_21	9990.00	cop[tikv]	not(isnull(test.t.a))
+        └─TableFullScan_20	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 drop table if exists t;

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -204,3 +204,16 @@ drop table if exists t;
 create table t(a int, b int);
 explain format="dot" select * from t where a < 2;
 drop table if exists t;
+
+# https://github.com/pingcap/tidb/issues/15488
+create table t(a int, b int);
+explain select max(a) from t group by -1;
+drop table if exists t;
+
+create table t(a int, b int);
+explain select max(a) from t group by (10-9+1);
+drop table if exists t;
+
+create table t(a int, b int);
+explain select max(a) from t group by 'xyz';
+drop table if exists t;

--- a/planner/cascades/testdata/transformation_rules_suite_out.json
+++ b/planner/cascades/testdata/transformation_rules_suite_out.json
@@ -2001,8 +2001,10 @@
           "Group#0 Schema:[Column#13]",
           "    Projection_3 input:[Group#1], Column#13",
           "Group#1 Schema:[Column#13]",
-          "    Aggregation_2 input:[Group#2], group by:1, funcs:count(case(gt(test.t.a, 10), test.t.b))",
+          "    Aggregation_5 input:[Group#2], funcs:count(test.t.b)",
           "Group#2 Schema:[test.t.a,test.t.b]",
+          "    Selection_4 input:[Group#3], gt(test.t.a, 10)",
+          "Group#3 Schema:[test.t.a,test.t.b]",
           "    DataSource_1 table:t"
         ]
       },
@@ -2034,8 +2036,10 @@
           "Group#0 Schema:[Column#13]",
           "    Projection_3 input:[Group#1], Column#13",
           "Group#1 Schema:[Column#13]",
-          "    Aggregation_2 input:[Group#2], group by:1, funcs:count(case(gt(test.t.a, 10), test.t.b))",
+          "    Aggregation_5 input:[Group#2], funcs:count(test.t.b)",
           "Group#2 Schema:[test.t.a,test.t.b]",
+          "    Selection_4 input:[Group#3], gt(test.t.a, 10)",
+          "Group#3 Schema:[test.t.a,test.t.b]",
           "    DataSource_1 table:t"
         ]
       },

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -71,7 +71,7 @@ func testGroupToString(input []string, output []struct {
 			output[i].SQL = sql
 			output[i].Result = ToString(group)
 		})
-		c.Assert(ToString(group), DeepEquals, output[i].Result)
+		c.Assert(ToString(group), DeepEquals, output[i].Result, Commentf(sql))
 	}
 }
 

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -121,11 +121,6 @@ func (la *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) 
 				selfUsedCols = append(selfUsedCols, cols...)
 			}
 		}
-		// If all the group by items are pruned, we should add a constant 1 to keep the correctness.
-		// Because `select count(*) from t` is different from `select count(*) from t group by 1`.
-		if len(la.GroupByItems) == 0 {
-			la.GroupByItems = []expression.Expression{expression.One}
-		}
 	}
 	return child.PruneColumns(selfUsedCols)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #15488 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`LogicalAggregation.PruneColumns()` appends the constant `1` to the group-by items if all of them are eliminated as constant expressions. 
https://github.com/pingcap/tidb/blob/b05e01f45a39539e95d5b43eaf3f89dfa728af49/planner/core/rule_column_pruning.go#L115-L129

It tries to distinguish statements like `select count(*) from t` between `select count(*) from t group by 1`.

__However, this is unnecessary and incorrect__.

There are two cases in group-by constants:
- positive integer `n`: it refers to the nth element in the selection fields. For example,
  ```sql
  select a, count(a) from t group by 1 
  select a, count(a) from t group by 2
  ```
  are equivalent to
  ```sql
  select a, count(a) from t group by a
  select a, count(a) from t group by count(a)   // this is invalid
  ```
  The integers here are parsed into `ast.PositionExpr`, which are converted to selection field expression by `gbyResolver` during plan building. In other words, statements like `group by 1` are impossible to reach `LogicalAggregation.PruneColumns()`.

- other constant expressions like `'a'`, `(10-9)`, `-1`: these expressions should be ignored in this case, otherwise the appended constant `1` will be pushed down to the coprocessor without any conversion(since `gbyResolver` only participate in plan building), causing coprocessor error shown as #15488.

### What is changed and how it works?

What's Changed:
Not to append constant `1` in `LogicalAggregation.PruneColumns()`.

How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->
