### PR TITLE
executor: support generated column on point get and batch point get

### DIFF
--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -214,3 +214,20 @@ HashAgg_5	8000.00	root	group by:Column#7, funcs:sum(Column#6)->Column#5
 └─Projection_12	10000.00	root	cast(test.t1.c, decimal(65,0) BINARY)->Column#6, test.t1.b
   └─TableReader_9	10000.00	root	data:TableFullScan_8
     └─TableFullScan_8	10000.00	cop[tikv]	table:t1, keep order:false, stats:pseudo
+DROP TABLE IF EXISTS tu;
+CREATE TABLE tu (a INT, b INT, c INT GENERATED ALWAYS AS (a + b) VIRTUAL, primary key (a), unique key uk(c));
+INSERT INTO tu(a, b) VALUES(1, 2);
+EXPLAIN SELECT * FROM tu WHERE c = 1;
+id	estRows	task	operator info
+Point_Get_5	1.00	root	table:tu, index:c
+EXPLAIN SELECT a, c FROM tu WHERE c = 1;
+id	estRows	task	operator info
+Projection_4	1.00	root	test.tu.a, test.tu.c
+└─Point_Get_5	1.00	root	table:tu, index:c
+EXPLAIN SELECT * FROM tu WHERE c in(1, 2, 3);
+id	estRows	task	operator info
+Batch_Point_Get_5	3.00	root	table:tu, index:c, keep order:false, desc:false
+EXPLAIN SELECT c, a FROM tu WHERE c in(1, 2, 3);
+id	estRows	task	operator info
+Projection_4	3.00	root	test.tu.c, test.tu.a
+└─Batch_Point_Get_5	3.00	root	table:tu, index:c, keep order:false, desc:false

--- a/cmd/explaintest/t/generated_columns.test
+++ b/cmd/explaintest/t/generated_columns.test
@@ -128,3 +128,12 @@ EXPLAIN SELECT sum(b) FROM t1 GROUP BY a;
 EXPLAIN SELECT sum(b) FROM t1 GROUP BY c;
 EXPLAIN SELECT sum(c) FROM t1 GROUP BY a;
 EXPLAIN SELECT sum(c) FROM t1 GROUP BY b;
+
+-- Virtual generated column for point get and batch point get
+DROP TABLE IF EXISTS tu;
+CREATE TABLE tu (a INT, b INT, c INT GENERATED ALWAYS AS (a + b) VIRTUAL, primary key (a), unique key uk(c));
+INSERT INTO tu(a, b) VALUES(1, 2);
+EXPLAIN SELECT * FROM tu WHERE c = 1;
+EXPLAIN SELECT a, c FROM tu WHERE c = 1;
+EXPLAIN SELECT * FROM tu WHERE c in(1, 2, 3);
+EXPLAIN SELECT c, a FROM tu WHERE c in(1, 2, 3);

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -21,7 +21,6 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -104,23 +103,9 @@ func (e *BatchPointGetExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		e.index++
 	}
 
-	virCols := chunk.NewChunkWithCapacity(e.virtualColumnRetFieldTypes, req.Capacity())
-	iter := chunk.NewIterator4Chunk(req)
-	for i, idx := range e.virtualColumnIndex {
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-			datum, err := e.schema.Columns[idx].EvalVirtualColumn(row)
-			if err != nil {
-				return err
-			}
-			// Because the expression might return different type from
-			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := table.CastValue(e.ctx, datum, e.columns[idx])
-			if err != nil {
-				return err
-			}
-			virCols.AppendDatum(i, &castDatum)
-		}
-		req.SetCol(idx, virCols.Column(i))
+	err := FillVirtualColumnValue(e.virtualColumnRetFieldTypes, e.virtualColumnIndex, e.schema, e.columns, e.ctx, req)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2915,14 +2915,14 @@ func newRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model
 			isGeneratedCol = true
 		}
 		reqCols[idx] = rowcodec.ColInfo{
-			ID:      col.ID,
-			Tp:      int32(col.RetType.Tp),
-			Flag:    int32(col.RetType.Flag),
-			Flen:    col.RetType.Flen,
-			Decimal: col.RetType.Decimal,
-			Elems:   col.RetType.Elems,
-			Collate: col.GetType().Collate,
-			GenCol:  isGeneratedCol,
+			ID:            col.ID,
+			Tp:            int32(col.RetType.Tp),
+			Flag:          int32(col.RetType.Flag),
+			Flen:          col.RetType.Flen,
+			Decimal:       col.RetType.Decimal,
+			Elems:         col.RetType.Elems,
+			Collate:       col.GetType().Collate,
+			VirtualGenCol: isGeneratedCol,
 		}
 	}
 	defVal := func(i int, chk *chunk.Chunk) error {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1634,3 +1634,28 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	vars.StmtCtx = sc
 	return
 }
+
+// FillVirtualColumnValue will calculate the virtual column value by evaluating generated
+// expression using rows from a chunk, and then fill this value into the chunk
+func FillVirtualColumnValue(virtualRetTypes []*types.FieldType, virtualColumnIndex []int,
+	schema *expression.Schema, columns []*model.ColumnInfo, sctx sessionctx.Context, req *chunk.Chunk) error {
+	virCols := chunk.NewChunkWithCapacity(virtualRetTypes, req.Capacity())
+	iter := chunk.NewIterator4Chunk(req)
+	for i, idx := range virtualColumnIndex {
+		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
+			datum, err := schema.Columns[idx].EvalVirtualColumn(row)
+			if err != nil {
+				return err
+			}
+			// Because the expression might return different type from
+			// the generated column, we should wrap a CAST on the result.
+			castDatum, err := table.CastValue(sctx, datum, columns[idx])
+			if err != nil {
+				return err
+			}
+			virCols.AppendDatum(i, &castDatum)
+		}
+		req.SetCol(idx, virCols.Column(i))
+	}
+	return nil
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1912,6 +1912,31 @@ func (s *testSuiteP1) TestGeneratedColumnRead(c *C) {
 	}
 }
 
+// TestGeneratedColumnRead tests generated columns using point get and batch point get
+func (s *testSuiteP1) TestGeneratedColumnPointGet(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists tu")
+	tk.MustExec("CREATE TABLE tu(a int, b int, c int GENERATED ALWAYS AS (a + b) VIRTUAL, d int as (a * b) stored, " +
+		"e int GENERATED ALWAYS as (b * 2) VIRTUAL, PRIMARY KEY (a), UNIQUE KEY ukc (c), unique key ukd(d), key ke(e))")
+	tk.MustExec("insert into tu(a, b) values(1, 2)")
+	tk.MustExec("insert into tu(a, b) values(5, 6)")
+	tk.MustQuery("select * from tu for update").Check(testkit.Rows("1 2 3 2 4", "5 6 11 30 12"))
+	tk.MustQuery("select * from tu where a = 1").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select * from tu where a in (1, 2)").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select * from tu where c in (1, 2, 3)").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select * from tu where c = 3").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select d, e from tu where c = 3").Check(testkit.Rows("2 4"))
+	tk.MustQuery("select * from tu where d in (1, 2, 3)").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select * from tu where d = 2").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustQuery("select c, d from tu where d = 2").Check(testkit.Rows("3 2"))
+	tk.MustQuery("select d, e from tu where e = 4").Check(testkit.Rows("2 4"))
+	tk.MustQuery("select * from tu where e = 4").Check(testkit.Rows("1 2 3 2 4"))
+	tk.MustExec("update tu set a = a + 1, b = b + 1 where c = 11")
+	tk.MustQuery("select * from tu for update").Check(testkit.Rows("1 2 3 2 4", "6 7 13 42 14"))
+	tk.MustExec("drop table if exists tu")
+}
+
 func (s *testSuiteP2) TestToPBExpr(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1934,6 +1934,10 @@ func (s *testSuiteP1) TestGeneratedColumnPointGet(c *C) {
 	tk.MustQuery("select * from tu where e = 4").Check(testkit.Rows("1 2 3 2 4"))
 	tk.MustExec("update tu set a = a + 1, b = b + 1 where c = 11")
 	tk.MustQuery("select * from tu for update").Check(testkit.Rows("1 2 3 2 4", "6 7 13 42 14"))
+	tk.MustQuery("select * from tu where a = 6").Check(testkit.Rows("6 7 13 42 14"))
+	tk.MustQuery("select * from tu where c in (5, 6, 13)").Check(testkit.Rows("6 7 13 42 14"))
+	tk.MustQuery("select b, c, e, d from tu where c = 13").Check(testkit.Rows("7 13 14 42"))
+	tk.MustQuery("select a, e, d from tu where c in (5, 6, 13)").Check(testkit.Rows("6 14 42"))
 	tk.MustExec("drop table if exists tu")
 }
 

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -209,23 +209,10 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		return err
 	}
 
-	virCols := chunk.NewChunkWithCapacity(e.virtualColumnRetFieldTypes, req.Capacity())
-	iter := chunk.NewIterator4Chunk(req)
-	for i, idx := range e.virtualColumnIndex {
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-			datum, err := e.schema.Columns[idx].EvalVirtualColumn(row)
-			if err != nil {
-				return err
-			}
-			// Because the expression might return different type from
-			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := table.CastValue(e.ctx, datum, e.columns[idx])
-			if err != nil {
-				return err
-			}
-			virCols.AppendDatum(i, &castDatum)
-		}
-		req.SetCol(idx, virCols.Column(i))
+	err = FillVirtualColumnValue(e.virtualColumnRetFieldTypes, e.virtualColumnIndex,
+		e.schema, e.columns, e.ctx, req)
+	if err != nil {
+		return err
 	}
 	return nil
 }

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -311,6 +311,7 @@ func decodeOldRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle in
 	}
 	decoder := codec.NewDecoder(chk, e.ctx.GetSessionVars().Location())
 	for i, col := range e.schema.Columns {
+		// fill the virtual column value after row calculation
 		if col.VirtualExpr != nil {
 			chk.AppendNull(i)
 			continue

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -166,24 +166,9 @@ func (e *TableReaderExecutor) Next(ctx context.Context, req *chunk.Chunk) error 
 		return err
 	}
 
-	virCols := chunk.NewChunkWithCapacity(e.virtualColumnRetFieldTypes, req.Capacity())
-	iter := chunk.NewIterator4Chunk(req)
-
-	for i, idx := range e.virtualColumnIndex {
-		for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-			datum, err := e.schema.Columns[idx].EvalVirtualColumn(row)
-			if err != nil {
-				return err
-			}
-			// Because the expression might return different type from
-			// the generated column, we should wrap a CAST on the result.
-			castDatum, err := table.CastValue(e.ctx, datum, e.columns[idx])
-			if err != nil {
-				return err
-			}
-			virCols.AppendDatum(i, &castDatum)
-		}
-		req.SetCol(idx, virCols.Column(i))
+	err := FillVirtualColumnValue(e.virtualColumnRetFieldTypes, e.virtualColumnIndex, e.schema, e.columns, e.ctx, req)
+	if err != nil {
+		return nil
 	}
 
 	return nil

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -733,7 +733,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 			physicalTableID: ds.physicalTableID,
 		}.Init(ds.ctx, is.blockOffset)
 		ts.SetSchema(ds.schema.Clone())
-		ExpandVirtualColumn(&ts.Columns, ts.schema, ts.Table.Columns)
+		ts.Columns = ExpandVirtualColumn(ts.Columns, ts.schema, ts.Table.Columns)
 		cop.tablePlan = ts
 	}
 	cop.cst = cost

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -485,15 +485,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty) (t task, err
 					break
 				}
 			}
-			// TODO: we ignore generate column now, because there are some errors happened when point get on generate columns
-			hasGenerateCol := false
-			for _, colInfo := range ds.Columns {
-				if colInfo.IsGenerated() {
-					hasGenerateCol = true
-					break
-				}
-			}
-			if allRangeIsPoint && !hasGenerateCol {
+			if allRangeIsPoint {
 				var pointGetTask task
 				if len(path.Ranges) == 1 {
 					pointGetTask = ds.convertToPointGet(prop, candidate)
@@ -741,7 +733,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 			physicalTableID: ds.physicalTableID,
 		}.Init(ds.ctx, is.blockOffset)
 		ts.SetSchema(ds.schema.Clone())
-		ts.ExpandVirtualColumn()
+		ExpandVirtualColumn(&ts.Columns, ts.schema, ts.Table.Columns)
 		cop.tablePlan = ts
 	}
 	cop.cst = cost
@@ -1128,6 +1120,7 @@ func (ds *DataSource) convertToPointGet(prop *property.PhysicalProperty, candida
 		TblInfo:      ds.TableInfo(),
 		outputNames:  ds.OutputNames(),
 		LockWaitTime: ds.ctx.GetSessionVars().LockWaitTimeout,
+		Columns:      ds.Columns,
 	}.Init(ds.ctx, ds.stats.ScaleByExpectCnt(1.0), ds.blockOffset)
 	var partitionInfo *model.PartitionDefinition
 	if ds.isPartition {
@@ -1198,6 +1191,7 @@ func (ds *DataSource) convertToBatchPointGet(prop *property.PhysicalProperty, ca
 		ctx:       ds.ctx,
 		TblInfo:   ds.TableInfo(),
 		KeepOrder: !prop.IsEmpty(),
+		Columns:   ds.Columns,
 	}.Init(ds.ctx, ds.stats.ScaleByExpectCnt(float64(len(candidate.path.Ranges))), ds.schema.Clone(), ds.names, ds.blockOffset)
 	if batchPointGetPlan.KeepOrder {
 		batchPointGetPlan.Desc = prop.Items[0].Desc

--- a/planner/core/initialize.go
+++ b/planner/core/initialize.go
@@ -451,7 +451,7 @@ func (p BatchPointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInf
 	p.schema = schema
 	p.names = names
 	p.stats = stats
-	ExpandVirtualColumn(&p.Columns, p.schema, p.TblInfo.Columns)
+	p.Columns = ExpandVirtualColumn(p.Columns, p.schema, p.TblInfo.Columns)
 	return &p
 }
 

--- a/planner/core/initialize.go
+++ b/planner/core/initialize.go
@@ -451,6 +451,7 @@ func (p BatchPointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInf
 	p.schema = schema
 	p.names = names
 	p.stats = stats
+	ExpandVirtualColumn(&p.Columns, p.schema, p.TblInfo.Columns)
 	return &p
 }
 

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -260,7 +260,8 @@ func (ts *PhysicalTableScan) IsPartition() (bool, int64) {
 }
 
 // ExpandVirtualColumn expands the virtual column's dependent columns to ts's schema and column.
-func ExpandVirtualColumn(columns *[]*model.ColumnInfo, schema *expression.Schema, colsInfo []*model.ColumnInfo) {
+func ExpandVirtualColumn(columns []*model.ColumnInfo, schema *expression.Schema,
+	colsInfo []*model.ColumnInfo) []*model.ColumnInfo {
 	schemaColumns := schema.Columns
 	for _, col := range schemaColumns {
 		if col.VirtualExpr == nil {
@@ -271,10 +272,11 @@ func ExpandVirtualColumn(columns *[]*model.ColumnInfo, schema *expression.Schema
 		for _, baseCol := range baseCols {
 			if !schema.Contains(baseCol) {
 				schema.Columns = append(schema.Columns, baseCol)
-				*columns = append(*columns, FindColumnInfoByID(colsInfo, baseCol.ID))
+				columns = append(columns, FindColumnInfoByID(colsInfo, baseCol.ID))
 			}
 		}
 	}
+	return columns
 }
 
 //SetIsChildOfIndexLookUp is to set the bool if is a child of IndexLookUpReader

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -260,17 +260,18 @@ func (ts *PhysicalTableScan) IsPartition() (bool, int64) {
 }
 
 // ExpandVirtualColumn expands the virtual column's dependent columns to ts's schema and column.
-func (ts *PhysicalTableScan) ExpandVirtualColumn() {
-	for _, col := range ts.schema.Columns {
+func ExpandVirtualColumn(columns *[]*model.ColumnInfo, schema *expression.Schema, colsInfo []*model.ColumnInfo) {
+	schemaColumns := schema.Columns
+	for _, col := range schemaColumns {
 		if col.VirtualExpr == nil {
 			continue
 		}
 
 		baseCols := expression.ExtractDependentColumns(col.VirtualExpr)
 		for _, baseCol := range baseCols {
-			if !ts.schema.Contains(baseCol) {
-				ts.schema.Columns = append(ts.schema.Columns, baseCol)
-				ts.Columns = append(ts.Columns, FindColumnInfoByID(ts.Table.Columns, baseCol.ID))
+			if !schema.Contains(baseCol) {
+				schema.Columns = append(schema.Columns, baseCol)
+				*columns = append(*columns, FindColumnInfoByID(colsInfo, baseCol.ID))
 			}
 		}
 	}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -167,11 +167,7 @@ func (p *PointGetPlan) SetChild(i int, child PhysicalPlan) {}
 
 // ResolveIndices resolves the indices for columns. After doing this, the columns can evaluate the rows by their indices.
 func (p *PointGetPlan) ResolveIndices() error {
-	err := resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
-	if err != nil {
-		return err
-	}
-	return nil
+	return resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
 }
 
 // OutputNames returns the outputting names of each column.
@@ -297,11 +293,7 @@ func (p *BatchPointGetPlan) SetChild(i int, child PhysicalPlan) {}
 
 // ResolveIndices resolves the indices for columns. After doing this, the columns can evaluate the rows by their indices.
 func (p *BatchPointGetPlan) ResolveIndices() error {
-	err := resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
-	if err != nil {
-		return err
-	}
-	return nil
+	return resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
 }
 
 // OutputNames returns the outputting names of each column.

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -72,7 +72,7 @@ type nameValuePair struct {
 func (p PointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInfo, offset int, props ...*property.PhysicalProperty) *PointGetPlan {
 	p.basePlan = newBasePlan(ctx, plancodec.TypePointGet, offset)
 	p.stats = stats
-	ExpandVirtualColumn(&p.Columns, p.schema, p.TblInfo.Columns)
+	p.Columns = ExpandVirtualColumn(p.Columns, p.schema, p.TblInfo.Columns)
 	return &p
 }
 

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -59,6 +59,7 @@ type PointGetPlan struct {
 	outputNames        []*types.FieldName
 	LockWaitTime       int64
 	partitionColumnPos int
+	Columns            []*model.ColumnInfo
 }
 
 type nameValuePair struct {
@@ -71,6 +72,7 @@ type nameValuePair struct {
 func (p PointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInfo, offset int, props ...*property.PhysicalProperty) *PointGetPlan {
 	p.basePlan = newBasePlan(ctx, plancodec.TypePointGet, offset)
 	p.stats = stats
+	ExpandVirtualColumn(&p.Columns, p.schema, p.TblInfo.Columns)
 	return &p
 }
 
@@ -165,6 +167,10 @@ func (p *PointGetPlan) SetChild(i int, child PhysicalPlan) {}
 
 // ResolveIndices resolves the indices for columns. After doing this, the columns can evaluate the rows by their indices.
 func (p *PointGetPlan) ResolveIndices() error {
+	err := resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -212,6 +218,7 @@ type BatchPointGetPlan struct {
 	Desc             bool
 	Lock             bool
 	LockWaitTime     int64
+	Columns          []*model.ColumnInfo
 }
 
 // attach2Task makes the current physical plan as the father of task's physicalPlan and updates the cost of
@@ -290,6 +297,10 @@ func (p *BatchPointGetPlan) SetChild(i int, child PhysicalPlan) {}
 
 // ResolveIndices resolves the indices for columns. After doing this, the columns can evaluate the rows by their indices.
 func (p *BatchPointGetPlan) ResolveIndices() error {
+	err := resolveIndicesForVirtualColumn(p.schema.Columns, p.schema)
+	if err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -708,7 +708,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 			StoreType: ts.StoreType,
 		}.Init(ctx, t.tablePlan.SelectBlockOffset())
 		p.stats = t.tablePlan.statsInfo()
-		ExpandVirtualColumn(&ts.Columns, ts.schema, ts.Table.Columns)
+		ts.Columns = ExpandVirtualColumn(ts.Columns, ts.schema, ts.Table.Columns)
 		newTask.p = p
 	}
 

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -708,7 +708,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 			StoreType: ts.StoreType,
 		}.Init(ctx, t.tablePlan.SelectBlockOffset())
 		p.stats = t.tablePlan.statsInfo()
-		ts.ExpandVirtualColumn()
+		ExpandVirtualColumn(&ts.Columns, ts.schema, ts.Table.Columns)
 		newTask.p = p
 	}
 

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1182,11 +1182,11 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk2 := testkit.NewTestKitWithInit(c, s.store)
 		tk2.MustExec("begin pessimistic")
 		err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
-		c.Assert(err, NotNil)
+		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(2, 2);")
 		err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
-		c.Assert(err, NotNil)
+		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		// test batch point get lock
 		tk.MustExec("begin pessimistic")
@@ -1194,11 +1194,11 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk.MustQuery("select * from tu where z in (1, 3, 5) for update").Check(testkit.Rows("1 2 3"))
 		tk2.MustExec("begin pessimistic")
 		err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
-		c.Assert(err, NotNil)
+		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(5, 6);")
 		err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
-		c.Assert(err, NotNil)
+		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		tk.MustExec("commit")
 		tk2.MustExec("commit")

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/codec"
@@ -1165,34 +1166,41 @@ func (s *testPessimisticSuite) TestRCSubQuery(c *C) {
 
 func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("drop table if exists tu")
-	tk.MustExec("CREATE TABLE `tu`(`x` int, `y` int, `z` int GENERATED ALWAYS AS (x + y) VIRTUAL, PRIMARY KEY (`x`), UNIQUE KEY `idz` (`z`))")
-	tk.MustExec("insert into tu(x, y) values(1, 2);")
+	defer func() {
+		tk.MustExec(fmt.Sprintf("set global tidb_row_format_version = %d", variable.DefTiDBRowFormatV2))
+	}()
+	tests2 := []int{variable.DefTiDBRowFormatV1, variable.DefTiDBRowFormatV2}
+	for _, rowFormat := range tests2 {
+		tk.MustExec(fmt.Sprintf("set global tidb_row_format_version = %d", rowFormat))
+		tk.MustExec("drop table if exists tu")
+		tk.MustExec("CREATE TABLE `tu`(`x` int, `y` int, `z` int GENERATED ALWAYS AS (x + y) VIRTUAL, PRIMARY KEY (`x`), UNIQUE KEY `idz` (`z`))")
+		tk.MustExec("insert into tu(x, y) values(1, 2);")
 
-	// test point get lock
-	tk.MustExec("begin pessimistic")
-	tk.MustQuery("select * from tu where z = 3 for update").Check(testkit.Rows("1 2 3"))
-	tk2 := testkit.NewTestKitWithInit(c, s.store)
-	tk2.MustExec("begin pessimistic")
-	err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
-	c.Assert(err, NotNil)
-	tk.MustExec("begin pessimistic")
-	tk.MustExec("insert into tu(x, y) values(2, 2);")
-	err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
-	c.Assert(err, NotNil)
+		// test point get lock
+		tk.MustExec("begin pessimistic")
+		tk.MustQuery("select * from tu where z = 3 for update").Check(testkit.Rows("1 2 3"))
+		tk2 := testkit.NewTestKitWithInit(c, s.store)
+		tk2.MustExec("begin pessimistic")
+		err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
+		c.Assert(err, NotNil)
+		tk.MustExec("begin pessimistic")
+		tk.MustExec("insert into tu(x, y) values(2, 2);")
+		err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
+		c.Assert(err, NotNil)
 
-	// test batch point get lock
-	tk.MustExec("begin pessimistic")
-	tk2.MustExec("begin pessimistic")
-	tk.MustQuery("select * from tu where z in (1, 3, 5) for update").Check(testkit.Rows("1 2 3"))
-	tk2.MustExec("begin pessimistic")
-	err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
-	c.Assert(err, NotNil)
-	tk.MustExec("begin pessimistic")
-	tk.MustExec("insert into tu(x, y) values(5, 6);")
-	err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
-	c.Assert(err, NotNil)
+		// test batch point get lock
+		tk.MustExec("begin pessimistic")
+		tk2.MustExec("begin pessimistic")
+		tk.MustQuery("select * from tu where z in (1, 3, 5) for update").Check(testkit.Rows("1 2 3"))
+		tk2.MustExec("begin pessimistic")
+		err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
+		c.Assert(err, NotNil)
+		tk.MustExec("begin pessimistic")
+		tk.MustExec("insert into tu(x, y) values(5, 6);")
+		err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
+		c.Assert(err, NotNil)
 
-	tk.MustExec("commit")
-	tk2.MustExec("commit")
+		tk.MustExec("commit")
+		tk2.MustExec("commit")
+	}
 }

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1162,3 +1162,37 @@ func (s *testPessimisticSuite) TestRCSubQuery(c *C) {
 	tk.MustQuery("select * from t1 where c1 = (select c1 from t where c1 = 1) and 1=1;").Check(testkit.Rows("1 4"))
 	tk.MustExec("rollback")
 }
+
+func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists tu")
+	tk.MustExec("CREATE TABLE `tu`(`x` int, `y` int, `z` int GENERATED ALWAYS AS (x + y) VIRTUAL, PRIMARY KEY (`x`), UNIQUE KEY `idz` (`z`))")
+	tk.MustExec("insert into tu(x, y) values(1, 2);")
+
+	// test point get lock
+	tk.MustExec("begin pessimistic")
+	tk.MustQuery("select * from tu where z = 3 for update").Check(testkit.Rows("1 2 3"))
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk2.MustExec("begin pessimistic")
+	err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
+	c.Assert(err, NotNil)
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert into tu(x, y) values(2, 2);")
+	err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
+	c.Assert(err, NotNil)
+
+	// test batch point get lock
+	tk.MustExec("begin pessimistic")
+	tk2.MustExec("begin pessimistic")
+	tk.MustQuery("select * from tu where z in (1, 3, 5) for update").Check(testkit.Rows("1 2 3"))
+	tk2.MustExec("begin pessimistic")
+	err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
+	c.Assert(err, NotNil)
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert into tu(x, y) values(5, 6);")
+	err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("commit")
+	tk2.MustExec("commit")
+}

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -54,6 +54,7 @@ type ColInfo struct {
 	Decimal int
 	Elems   []string
 	Collate string
+	GenCol  bool
 }
 
 // DatumMapDecoder decodes the row to datum map.
@@ -219,6 +220,10 @@ func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, handle int64, chk *ch
 	for colIdx, col := range decoder.columns {
 		if col.ID == decoder.handleColID {
 			chk.AppendInt64(colIdx, handle)
+			continue
+		}
+		if col.GenCol {
+			chk.AppendNull(colIdx)
 			continue
 		}
 

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -50,11 +50,11 @@ type ColInfo struct {
 	Flag       int32
 	IsPKHandle bool
 
-	Flen    int
-	Decimal int
-	Elems   []string
-	Collate string
-	GenCol  bool
+	Flen          int
+	Decimal       int
+	Elems         []string
+	Collate       string
+	VirtualGenCol bool
 }
 
 // DatumMapDecoder decodes the row to datum map.
@@ -222,7 +222,8 @@ func (decoder *ChunkDecoder) DecodeToChunk(rowData []byte, handle int64, chk *ch
 			chk.AppendInt64(colIdx, handle)
 			continue
 		}
-		if col.GenCol {
+		// fill the virtual column value after row calculation
+		if col.VirtualGenCol {
 			chk.AppendNull(colIdx)
 			continue
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:


To make the lock behaviors the same for accessing unique index with general columns and common columns.

### What is changed and how it works?

Let the point get and batch point get could be used for accessing data using an index on virtual generated column

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects



### Release note <!-- bugfixes or new feature need a release note -->
