### PR TITLE
*: consolidate some settings related to the collation

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -83,7 +83,6 @@ func (d *ddl) CreateSchema(ctx sessionctx.Context, schema model.CIStr, charsetIn
 		if err != nil {
 			return errors.Trace(err)
 		}
-
 		dbInfo.Charset = charsetInfo.Chs
 		dbInfo.Collate = charsetInfo.Col
 	} else {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -949,8 +949,8 @@ func (s *testSerialSuite) TestForbidUnsupportedCollations(c *C) {
 	mustGetUnsupportedCollation("create database ucd charset utf8mb4 collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
 	mustGetUnsupportedCollation("create database ucd charset utf8 collate utf8_unicode_ci", "utf8_unicode_ci")
 	tk.MustExec("create database ucd")
-	tk.MustExec("alter database ucd charset utf8mb4 collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
-	tk.MustExec("alter database collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
+	mustGetUnsupportedCollation("alter database ucd charset utf8mb4 collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
+	mustGetUnsupportedCollation("alter database ucd collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
 
 	// Test default collation of table.
 	tk.MustExec("use ucd")
@@ -961,8 +961,9 @@ func (s *testSerialSuite) TestForbidUnsupportedCollations(c *C) {
 	mustGetUnsupportedCollation("alter table t convert to charset utf8mb4 collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
 
 	// Test collation of columns.
-	mustGetUnsupportedCollation("create table t1(a varchar(20) collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
-	mustGetUnsupportedCollation("create table t1(a varchar(20) charset utf8 collate utf8_unicode_ci", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("create table t1(a varchar(20)) collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
+	mustGetUnsupportedCollation("create table t1(a varchar(20)) charset utf8 collate utf8_unicode_ci", "utf8_unicode_ci")
+	tk.MustExec("create table t1(a varchar(20))")
 	mustGetUnsupportedCollation("alter table t1 modify a varchar(20) collate utf8mb4_unicode_ci", "utf8mb4_unicode_ci")
 	mustGetUnsupportedCollation("alter table t1 modify a varchar(20) charset utf8 collate utf8_unicode_ci", "utf8_unicode_ci")
 	mustGetUnsupportedCollation("alter table t1 modify a varchar(20) charset utf8 collate utf8_unicode_ci", "utf8_unicode_ci")

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/pdapi"
 	"github.com/pingcap/tidb/util/set"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -927,7 +928,7 @@ func (e *memtableRetriever) setDataFromCharacterSets() {
 
 func (e *memtableRetriever) setDataFromCollations() {
 	var rows [][]types.Datum
-	collations := charset.GetSupportedCollations()
+	collations := collate.GetSupportedCollations()
 	for _, collation := range collations {
 		isDefault := ""
 		if collation.IsDefault {
@@ -942,7 +943,7 @@ func (e *memtableRetriever) setDataFromCollations() {
 
 func (e *memtableRetriever) dataForCollationCharacterSetApplicability() {
 	var rows [][]types.Datum
-	collations := charset.GetSupportedCollations()
+	collations := collate.GetSupportedCollations()
 	for _, collation := range collations {
 		rows = append(rows,
 			types.MakeDatums(collation.Name, collation.CharsetName),

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -1208,7 +1208,7 @@ func (s *seqTestSuite) TestShowForNewCollations(c *C) {
 		"utf8_general_ci utf8 33  Yes 1",
 		"utf8mb4_bin utf8mb4 46 Yes Yes 1",
 		"utf8mb4_general_ci utf8mb4 45  Yes 1",
-		)
+	)
 	tk.MustQuery("show collation").Check(expectRows)
 	tk.MustQuery("select * from information_schema.COLLATIONS").Check(expectRows)
 }

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
@@ -1192,6 +1193,44 @@ func (s *seqTestSuite1) TestCoprocessorPriority(c *C) {
 	cli.mu.Lock()
 	cli.mu.checkPrio = false
 	cli.mu.Unlock()
+}
+
+func (s *seqTestSuite) TestShowForNewCollations(c *C) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+
+	tk := testkit.NewTestKit(c, s.store)
+	expectRows := testkit.Rows(
+		"ascii_bin ascii 65 Yes Yes 1",
+		"binary binary 63 Yes Yes 1",
+		"latin1_bin latin1 47 Yes Yes 1",
+		"utf8_bin utf8 83 Yes Yes 1",
+		"utf8_general_ci utf8 33  Yes 1",
+		"utf8mb4_bin utf8mb4 46 Yes Yes 1",
+		"utf8mb4_general_ci utf8mb4 45  Yes 1",
+		)
+	tk.MustQuery("show collation").Check(expectRows)
+	tk.MustQuery("select * from information_schema.COLLATIONS").Check(expectRows)
+}
+
+func (s *seqTestSuite) TestForbidUnsupportedCollations(c *C) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+
+	tk := testkit.NewTestKit(c, s.store)
+	mustGetUnsupportedCollation := func(sql string, coll string) {
+		tk.MustGetErrMsg(sql, fmt.Sprintf("[ddl:1273]Unsupported collation when new collation is enabled: '%s'", coll))
+	}
+
+	mustGetUnsupportedCollation("select 'a' collate utf8_unicode_ci", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("select cast('a' as char) collate utf8_unicode_ci", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set names utf8 collate utf8_unicode_ci", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set session collation_server = 'utf8_unicode_ci'", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set session collation_database = 'utf8_unicode_ci'", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set session collation_connection = 'utf8_unicode_ci'", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set global collation_server = 'utf8_unicode_ci'", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set global collation_database = 'utf8_unicode_ci'", "utf8_unicode_ci")
+	mustGetUnsupportedCollation("set global collation_connection = 'utf8_unicode_ci'", "utf8_unicode_ci")
 }
 
 func (s *seqTestSuite) TestAutoIncIDInRetry(c *C) {

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -137,6 +137,15 @@ func (s *testSuite5) TestSetVar(c *C) {
 	c.Assert(charset, Equals, "utf8")
 	c.Assert(collation, Equals, "utf8_bin")
 
+	expectErrMsg := "[ddl:1273]Unknown collation: 'non_exist_collation'"
+	tk.MustGetErrMsg("set names utf8 collate non_exist_collation", expectErrMsg)
+	tk.MustGetErrMsg("set @@session.collation_server='non_exist_collation'", expectErrMsg)
+	tk.MustGetErrMsg("set @@session.collation_database='non_exist_collation'", expectErrMsg)
+	tk.MustGetErrMsg("set @@session.collation_connection='non_exist_collation'", expectErrMsg)
+	tk.MustGetErrMsg("set @@global.collation_server='non_exist_collation'", expectErrMsg)
+	tk.MustGetErrMsg("set @@global.collation_database='non_exist_collation'", expectErrMsg)
+	tk.MustGetErrMsg("set @@global.collation_connection='non_exist_collation'", expectErrMsg)
+
 	tk.MustExec("set character_set_results = NULL")
 	tk.MustQuery("select @@character_set_results").Check(testkit.Rows(""))
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -54,6 +54,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/format"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/sqlexec"
@@ -1086,7 +1087,7 @@ func (e *ShowExec) fetchShowCreateDatabase() error {
 }
 
 func (e *ShowExec) fetchShowCollation() error {
-	collations := charset.GetSupportedCollations()
+	collations := collate.GetSupportedCollations()
 	for _, v := range collations {
 		isDefault := ""
 		if v.IsDefault {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -252,8 +252,7 @@ func (sr *simpleRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok boo
 		if collate.NewCollationEnabled() {
 			var collInfo *charset.Collation
 			// TODO(bb7133): use charset.ValidCharsetAndCollation when its bug is fixed.
-			if collInfo, sr.err = charset.GetCollationByName(v.Collate); sr.err != nil {
-				sr.err = charset.ErrUnknownCollation.GenWithStackByArgs(v.Collate)
+			if collInfo, sr.err = collate.GetCollationByName(v.Collate); sr.err != nil {
 				break
 			}
 			chs := arg.GetType().Charset

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -999,8 +999,7 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		if collate.NewCollationEnabled() {
 			var collInfo *charset.Collation
 			// TODO(bb7133): use charset.ValidCharsetAndCollation when its bug is fixed.
-			if collInfo, er.err = charset.GetCollationByName(v.Collate); er.err != nil {
-				er.err = charset.ErrUnknownCollation.GenWithStackByArgs(v.Collate)
+			if collInfo, er.err = collate.GetCollationByName(v.Collate); er.err != nil {
 				break
 			}
 			chs := arg.GetType().Charset

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -40,6 +40,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/rowcodec"
 	"github.com/pingcap/tidb/util/storeutil"
@@ -1210,6 +1211,10 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.MetricSchemaStep = tidbOptInt64(val, DefTiDBMetricSchemaStep)
 	case TiDBMetricSchemaRangeDuration:
 		s.MetricSchemaRangeDuration = tidbOptInt64(val, DefTiDBMetricSchemaRangeDuration)
+	case CollationConnection, CollationDatabase, CollationServer:
+		if _, err := collate.GetCollationByName(val); err != nil {
+			return errors.Trace(err)
+		}
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/timeutil"
 )
 
@@ -699,6 +700,10 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 			return value, errors.Errorf("%v(%d) cannot be smaller than %v or larger than %v", name, v, 10, 60*60*60)
 		}
 		return value, nil
+	case CollationConnection, CollationDatabase, CollationServer:
+		if _, err := collate.GetCollationByName(value); err != nil {
+			return value, errors.Trace(err)
+		}
 	}
 	return value, nil
 }

--- a/util/collate/bin.go
+++ b/util/collate/bin.go
@@ -1,0 +1,72 @@
+
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package collate
+
+import (
+	"strings"
+
+	"github.com/pingcap/tidb/util/stringutil"
+)
+
+type binCollator struct {
+}
+
+// Compare implement Collator interface.
+func (bc *binCollator) Compare(a, b string) int {
+	return strings.Compare(a, b)
+}
+
+// Key implement Collator interface.
+func (bc *binCollator) Key(str string) []byte {
+	return []byte(str)
+}
+
+// Pattern implements Collator interface.
+func (bc *binCollator) Pattern() WildcardPattern {
+	return &binPattern{}
+}
+
+type binPaddingCollator struct {
+}
+
+func (bpc *binPaddingCollator) Compare(a, b string) int {
+	return strings.Compare(truncateTailingSpace(a), truncateTailingSpace(b))
+}
+
+func (bpc *binPaddingCollator) Key(str string) []byte {
+	return []byte(truncateTailingSpace(str))
+}
+
+// Pattern implements Collator interface.
+// Notice that trailing spaces are significant.
+func (bpc *binPaddingCollator) Pattern() WildcardPattern {
+	return &binPattern{}
+}
+
+type binPattern struct {
+	patChars []byte
+	patTypes []byte
+}
+
+// Compile implements WildcardPattern interface.
+func (p *binPattern) Compile(patternStr string, escape byte) {
+	p.patChars, p.patTypes = stringutil.CompilePattern(patternStr, escape)
+}
+
+// Compile implements WildcardPattern interface.
+func (p *binPattern) DoMatch(str string) bool {
+	return stringutil.DoMatch(str, p.patChars, p.patTypes)
+}
+

--- a/util/collate/bin.go
+++ b/util/collate/bin.go
@@ -1,4 +1,3 @@
-
 // Copyright 2020 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -69,4 +68,3 @@ func (p *binPattern) Compile(patternStr string, escape byte) {
 func (p *binPattern) DoMatch(str string) bool {
 	return stringutil.DoMatch(str, p.patChars, p.patTypes)
 }
-

--- a/util/collate/collate.go
+++ b/util/collate/collate.go
@@ -14,38 +14,32 @@
 package collate
 
 import (
-	"strings"
+	"sort"
 	"sync/atomic"
 
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/stringutil"
 	"go.uber.org/zap"
 )
 
 var (
-	collatorMap         map[string]Collator
-	collatorIDMap       map[int]Collator
 	newCollatorMap      map[string]Collator
 	newCollatorIDMap    map[int]Collator
 	newCollationEnabled int32
+
+	// binCollatorInstance is a singleton used for all collations when newCollationEnabled is false.
+	binCollatorInstance = &binCollator{}
+
+	ErrUnsupportedCollation = terror.ClassDDL.New(mysql.ErrUnknownCollation, "Unsupported collation when new collation is enabled: '%-.64s'")
 )
 
 // DefaultLen is set for datum if the string datum don't know its length.
 const (
 	DefaultLen = 0
 )
-
-// CompatibleCollate checks whether the two collate are the same.
-func CompatibleCollate(collate1, collate2 string) bool {
-	if (collate1 == "utf8mb4_general_ci" || collate1 == "utf8_general_ci") && (collate2 == "utf8mb4_general_ci" || collate2 == "utf8_general_ci") {
-		return true
-	} else if (collate1 == "utf8mb4_bin" || collate1 == "utf8_bin") && (collate2 == "utf8mb4_bin" || collate2 == "utf8_bin") {
-		return true
-	} else {
-		return collate1 == collate2
-	}
-}
 
 // Collator provides functionality for comparing strings for a given
 // collation order.
@@ -56,6 +50,14 @@ type Collator interface {
 	Key(str string) []byte
 	// Pattern get a collation-aware WildcardPattern.
 	Pattern() WildcardPattern
+}
+
+// WildcardPattern is the interface used for wildcard pattern match.
+type WildcardPattern interface {
+	// Compile compiles the patternStr with specified escape character.
+	Compile(patternStr string, escape byte)
+	// DoMatch tries to match the str with compiled pattern, `Compile()` must be called before calling it.
+	DoMatch(str string) bool
 }
 
 // EnableNewCollations enables the new collation.
@@ -76,6 +78,17 @@ func SetNewCollationEnabledForTest(flag bool) {
 // NewCollationEnabled returns if the new collations are enabled.
 func NewCollationEnabled() bool {
 	return atomic.LoadInt32(&newCollationEnabled) == 1
+}
+
+// CompatibleCollate checks whether the two collate are the same.
+func CompatibleCollate(collate1, collate2 string) bool {
+	if (collate1 == "utf8mb4_general_ci" || collate1 == "utf8_general_ci") && (collate2 == "utf8mb4_general_ci" || collate2 == "utf8_general_ci") {
+		return true
+	} else if (collate1 == "utf8mb4_bin" || collate1 == "utf8_bin") && (collate2 == "utf8mb4_bin" || collate2 == "utf8_bin") {
+		return true
+	} else {
+		return collate1 == collate2
+	}
 }
 
 // RewriteNewCollationIDIfNeeded rewrites a collation id if the new collations are enabled.
@@ -111,15 +124,15 @@ func GetCollator(collate string) Collator {
 	if atomic.LoadInt32(&newCollationEnabled) == 1 {
 		ctor, ok := newCollatorMap[collate]
 		if !ok {
+			logutil.BgLogger().Warn(
+				"Unable to get collator by name, use binCollator instead.",
+				zap.String("name", collate),
+				zap.Stack("stack"))
 			return newCollatorMap["utf8mb4_bin"]
 		}
 		return ctor
 	}
-	ctor, ok := collatorMap[collate]
-	if !ok {
-		return collatorMap["utf8mb4_bin"]
-	}
-	return ctor
+	return binCollatorInstance
 }
 
 // GetCollatorByID get the collator according to id, it will return the binary collator if the corresponding collator doesn't exist.
@@ -127,33 +140,15 @@ func GetCollatorByID(id int) Collator {
 	if atomic.LoadInt32(&newCollationEnabled) == 1 {
 		ctor, ok := newCollatorIDMap[id]
 		if !ok {
+			logutil.BgLogger().Warn(
+				"Unable to get collator by ID, use binCollator instead.",
+				zap.Int("ID", id),
+				zap.Stack("stack"))
 			return newCollatorMap["utf8mb4_bin"]
 		}
 		return ctor
 	}
-	ctor, ok := collatorIDMap[id]
-	if !ok {
-		return collatorMap["utf8mb4_bin"]
-	}
-	return ctor
-}
-
-type binCollator struct {
-}
-
-// Compare implement Collator interface.
-func (bc *binCollator) Compare(a, b string) int {
-	return strings.Compare(a, b)
-}
-
-// Key implement Collator interface.
-func (bc *binCollator) Key(str string) []byte {
-	return []byte(str)
-}
-
-// Pattern implements Collator interface.
-func (bc *binCollator) Pattern() WildcardPattern {
-	return &binPattern{}
+	return binCollatorInstance
 }
 
 // CollationID2Name return the collation name by the given id.
@@ -161,12 +156,47 @@ func (bc *binCollator) Pattern() WildcardPattern {
 func CollationID2Name(id int32) string {
 	name, ok := mysql.Collations[uint8(id)]
 	if !ok {
+		// TODO(bb7133): fix repeating logs when the following code is uncommented.
+		//logutil.BgLogger().Warn(
+		//	"Unable to get collation name from ID, use default collation instead.",
+		//	zap.Int32("ID", id),
+		//	zap.Stack("stack"))
 		return mysql.DefaultCollationName
 	}
 	return name
 }
 
-type binPaddingCollator struct {
+// GetCollationByName wraps charset.GetCollationByName, it checks the collation.
+func GetCollationByName(name string) (coll *charset.Collation, err error) {
+	if coll, err = charset.GetCollationByName(name); err != nil {
+		return nil, errors.Trace(err)
+	}
+	if atomic.LoadInt32(&newCollationEnabled) == 1 {
+		if _, ok := newCollatorIDMap[coll.ID]; !ok {
+			return nil, ErrUnsupportedCollation.GenWithStackByArgs(name)
+		}
+	}
+	return
+}
+
+// GetSupportedCollations gets information for all collations supported so far.
+func GetSupportedCollations() []*charset.Collation {
+	if atomic.LoadInt32(&newCollationEnabled) == 1 {
+		newSupportedCollations := make([]*charset.Collation, 0, len(newCollatorMap))
+		for name, _ := range newCollatorMap {
+			if coll, err := charset.GetCollationByName(name); err != nil {
+				// Should never happens.
+				terror.Log(err)
+			} else {
+				newSupportedCollations = append(newSupportedCollations, coll)
+			}
+		}
+		sort.Slice(newSupportedCollations, func(i int, j int) bool {
+			return newSupportedCollations[i].Name < newSupportedCollations[j].Name
+		})
+		return newSupportedCollations
+	}
+	return charset.GetSupportedCollations()
 }
 
 func truncateTailingSpace(str string) string {
@@ -181,71 +211,22 @@ func truncateTailingSpace(str string) string {
 	return str
 }
 
-func (bpc *binPaddingCollator) Compare(a, b string) int {
-	return strings.Compare(truncateTailingSpace(a), truncateTailingSpace(b))
-}
-
-func (bpc *binPaddingCollator) Key(str string) []byte {
-	return []byte(truncateTailingSpace(str))
-}
-
-// Pattern implements Collator interface.
-// Notice that trailing spaces are significant.
-func (bpc *binPaddingCollator) Pattern() WildcardPattern {
-	return &binPattern{}
-}
-
-// WildcardPattern is the interface used for wildcard pattern match.
-type WildcardPattern interface {
-	// Compile compiles the patternStr with specified escape character.
-	Compile(patternStr string, escape byte)
-	// DoMatch tries to match the str with compiled pattern, `Compile()` must be called before calling it.
-	DoMatch(str string) bool
-}
-
-type binPattern struct {
-	patChars []byte
-	patTypes []byte
-}
-
-// Compile implements WildcardPattern interface.
-func (p *binPattern) Compile(patternStr string, escape byte) {
-	p.patChars, p.patTypes = stringutil.CompilePattern(patternStr, escape)
-}
-
-// Compile implements WildcardPattern interface.
-func (p *binPattern) DoMatch(str string) bool {
-	return stringutil.DoMatch(str, p.patChars, p.patTypes)
-}
-
 func init() {
-	collatorMap = make(map[string]Collator)
-	collatorIDMap = make(map[int]Collator)
 	newCollatorMap = make(map[string]Collator)
 	newCollatorIDMap = make(map[int]Collator)
 
-	collatorMap["binary"] = &binCollator{}
-	collatorMap["utf8mb4_bin"] = &binCollator{}
-	collatorMap["utf8_bin"] = &binCollator{}
-	collatorMap["utf8mb4_general_ci"] = &binCollator{}
-	collatorMap["utf8_general_ci"] = &binCollator{}
-
-	// See https://github.com/pingcap/parser/blob/master/charset/charset.go for more information about the IDs.
-	collatorIDMap[63] = &binCollator{}
-	collatorIDMap[46] = &binCollator{}
-	collatorIDMap[83] = &binCollator{}
-	collatorIDMap[45] = &binCollator{}
-	collatorIDMap[33] = &binCollator{}
-
 	newCollatorMap["binary"] = &binCollator{}
+	newCollatorIDMap[int(mysql.CollationNames["binary"])] = &binCollator{}
+	newCollatorMap["ascii_bin"] = &binPaddingCollator{}
+	newCollatorIDMap[int(mysql.CollationNames["ascii_bin"])] = &binPaddingCollator{}
+	newCollatorMap["latin1_bin"] = &binPaddingCollator{}
+	newCollatorIDMap[int(mysql.CollationNames["latin1_bin"])] = &binPaddingCollator{}
 	newCollatorMap["utf8mb4_bin"] = &binPaddingCollator{}
+	newCollatorIDMap[int(mysql.CollationNames["utf8mb4_bin"])] = &binPaddingCollator{}
 	newCollatorMap["utf8_bin"] = &binPaddingCollator{}
+	newCollatorIDMap[int(mysql.CollationNames["utf8_bin"])] = &binPaddingCollator{}
 	newCollatorMap["utf8mb4_general_ci"] = &generalCICollator{}
+	newCollatorIDMap[int(mysql.CollationNames["utf8mb4_general_ci"])] = &generalCICollator{}
 	newCollatorMap["utf8_general_ci"] = &generalCICollator{}
-
-	newCollatorIDMap[63] = &binCollator{}
-	newCollatorIDMap[46] = &binPaddingCollator{}
-	newCollatorIDMap[83] = &binPaddingCollator{}
-	newCollatorIDMap[45] = &generalCICollator{}
-	newCollatorIDMap[33] = &generalCICollator{}
+	newCollatorIDMap[int(mysql.CollationNames["utf8_general_ci"])] = &generalCICollator{}
 }

--- a/util/collate/collate.go
+++ b/util/collate/collate.go
@@ -33,6 +33,7 @@ var (
 	// binCollatorInstance is a singleton used for all collations when newCollationEnabled is false.
 	binCollatorInstance = &binCollator{}
 
+	// ErrUnsupportedCollation is returned when an unsupported collation is specified.
 	ErrUnsupportedCollation = terror.ClassDDL.New(mysql.ErrUnknownCollation, "Unsupported collation when new collation is enabled: '%-.64s'")
 )
 
@@ -183,7 +184,7 @@ func GetCollationByName(name string) (coll *charset.Collation, err error) {
 func GetSupportedCollations() []*charset.Collation {
 	if atomic.LoadInt32(&newCollationEnabled) == 1 {
 		newSupportedCollations := make([]*charset.Collation, 0, len(newCollatorMap))
-		for name, _ := range newCollatorMap {
+		for name := range newCollatorMap {
 			if coll, err := charset.GetCollationByName(name); err != nil {
 				// Should never happens.
 				terror.Log(err)

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -14,9 +14,17 @@
 package collate
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -26,9 +34,16 @@ func TestT(t *testing.T) {
 
 var (
 	_ = SerialSuites(&testCollateSuite{})
+    _ = SerialSuites(&testIntegrationCollateSuite{})
 )
 
 type testCollateSuite struct {
+}
+
+type testIntegrationCollateSuite struct {
+	store kv.Storage
+	dom   *domain.Domain
+	ctx   sessionctx.Context
 }
 
 type compareTable struct {
@@ -185,4 +200,29 @@ func (s *testCollateSuite) TestGetCollator(c *C) {
 	c.Assert(GetCollatorByID(45), FitsTypeOf, &binCollator{})
 	c.Assert(GetCollatorByID(33), FitsTypeOf, &binCollator{})
 	c.Assert(GetCollatorByID(9999), FitsTypeOf, &binCollator{})
+}
+
+func (s *testIntegrationCollateSuite) cleanEnv(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	r := tk.MustQuery("show tables")
+	for _, tb := range r.Rows() {
+		tableName := tb[0]
+		tk.MustExec(fmt.Sprintf("drop table %v", tableName))
+	}
+}
+
+func (s *testIntegrationCollateSuite) SetUpSuite(c *C) {
+	var err error
+	s.store, err = mockstore.NewMockTikvStore()
+	c.Assert(err, IsNil)
+	session.SetSchemaLease(0)
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+	s.ctx = mock.NewContext()
+}
+
+func (s *testIntegrationCollateSuite) TearDownSuite(c *C) {
+	s.dom.Close()
+	s.store.Close()
 }

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -14,17 +14,9 @@
 package collate
 
 import (
-	"fmt"
 	"testing"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/domain"
-	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/session"
-	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/store/mockstore"
-	"github.com/pingcap/tidb/util/mock"
-	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
 )
 
@@ -34,16 +26,9 @@ func TestT(t *testing.T) {
 
 var (
 	_ = SerialSuites(&testCollateSuite{})
-    _ = SerialSuites(&testIntegrationCollateSuite{})
 )
 
 type testCollateSuite struct {
-}
-
-type testIntegrationCollateSuite struct {
-	store kv.Storage
-	dom   *domain.Domain
-	ctx   sessionctx.Context
 }
 
 type compareTable struct {
@@ -200,29 +185,4 @@ func (s *testCollateSuite) TestGetCollator(c *C) {
 	c.Assert(GetCollatorByID(45), FitsTypeOf, &binCollator{})
 	c.Assert(GetCollatorByID(33), FitsTypeOf, &binCollator{})
 	c.Assert(GetCollatorByID(9999), FitsTypeOf, &binCollator{})
-}
-
-func (s *testIntegrationCollateSuite) cleanEnv(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	r := tk.MustQuery("show tables")
-	for _, tb := range r.Rows() {
-		tableName := tb[0]
-		tk.MustExec(fmt.Sprintf("drop table %v", tableName))
-	}
-}
-
-func (s *testIntegrationCollateSuite) SetUpSuite(c *C) {
-	var err error
-	s.store, err = mockstore.NewMockTikvStore()
-	c.Assert(err, IsNil)
-	session.SetSchemaLease(0)
-	s.dom, err = session.BootstrapSession(s.store)
-	c.Assert(err, IsNil)
-	s.ctx = mock.NewContext()
-}
-
-func (s *testIntegrationCollateSuite) TearDownSuite(c *C) {
-	s.dom.Close()
-	s.store.Close()
 }


### PR DESCRIPTION
### What is changed and how it works?

This PR aims to update the following collation-related features:

1. Restrict the settings of collation-related system variables `collation_connection`, `collation_server` and `collation_database`. Before this PR, they can be set to anything but now only valid collations are permitted, for example:

    Before this PR:
    ```
    tidb> set @@collation_connection='some_nonexist_collation';
    Query OK, 0 rows affected (0.00 sec)
    tidb> set names utf8mb4 collation some_nonexist_collation;
    Query OK, 0 rows affected (0.00 sec)
    ```

    After this PR(same with MySQL):
    ```
    tidb> set @@collation_connection='some_nonexist_collation';
    ERROR 1273 (HY000): Unknown collation: 'some_nonexist_collation'
    tidb> set names utf8mb4 collate some_nonexist_collation;
    ERROR 1273 (HY000): Unknown collation: 'some_nonexist_collation'
    ```

    **NOTICE**: This potentially breaks compatibility with old TiDB, but it should be fine since it means nothing if such system variables are set to an invalid value.

2. Forbid unsupported collations when new collation is enabled(see #14734 for more details about the switch):
    Before this PR when new collation is enabled:
    ```
    tidb> set names utf8mb4 collate utf8mb4_unicode_ci;
    Query OK, 0 rows affected (0.00 sec)
    ```
    After this PR when new collation is enabled:
    ```
    tidb> set names utf8mb4 collate utf8mb4_unicode_ci;
    ERROR 1273 (HY000): Unsupported collation when new collation is enabled: 'utf8mb4_unicode_ci'
    ```

3. Update the result of `information_schema`.`COLLATIONS` when new collation is enabled: `utf8mb4_general_ci` and `utf8_general_ci` are added since they're supported now:
    ```
    tidb> show collation;
    +--------------------+---------+------+---------+----------+---------+
    | Collation          | Charset | Id   | Default | Compiled | Sortlen |
    +--------------------+---------+------+---------+----------+---------+
    | binary             | binary  |   63 | Yes     | Yes      |       1 |
    | ascii_bin          | ascii   |   65 | Yes     | Yes      |       1 |
    | latin1_bin         | latin1  |   47 | Yes     | Yes      |       1 |
    | utf8mb4_bin        | utf8mb4 |   46 | Yes     | Yes      |       1 |
    | utf8_bin           | utf8    |   83 | Yes     | Yes      |       1 |
    | utf8mb4_general_ci | utf8mb4 |   45 |         | Yes      |       1 |
    | utf8_general_ci    | utf8    |   33 |         | Yes      |       1 |
    +--------------------+---------+------+---------+----------+---------+
    7 rows in set (0.00 sec)
    ```

### Related changes

- NA

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
    See above.

Side effects

- Breaking backward compatibility

### Release note

- When the new collation framework is enabled, collations not supported are now forbidden.
- Validate the value of system variables `collation_connection`, `collation_server` and `collation_database`,  `Unknown collation` will be returned if they're not valid.