### PR TITLE
*: do not add extra locks for optimistic transactions

### DIFF
--- a/cmd/explaintest/r/explain-non-select-stmt.result
+++ b/cmd/explaintest/r/explain-non-select-stmt.result
@@ -11,18 +11,16 @@ Insert_1	N/A	root	N/A
   └─TableFullScan_6	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 explain delete from t where a > 100;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	3333.33	root	for update
-  └─TableReader_10	3333.33	root	data:Selection_9
-    └─Selection_9	3333.33	cop[tikv]	gt(test.t.a, 100)
-      └─TableFullScan_8	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─TableReader_8	3333.33	root	data:Selection_7
+  └─Selection_7	3333.33	cop[tikv]	gt(test.t.a, 100)
+    └─TableFullScan_6	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 explain update t set b = 100 where a = 200;
 id	estRows	task	operator info
-Update_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─TableReader_10	10.00	root	data:Selection_9
-    └─Selection_9	10.00	cop[tikv]	eq(test.t.a, 200)
-      └─TableFullScan_8	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Update_4	N/A	root	N/A
+└─TableReader_8	10.00	root	data:Selection_7
+  └─Selection_7	10.00	cop[tikv]	eq(test.t.a, 200)
+    └─TableFullScan_6	10000.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 explain replace into t select a, 100 from t;
 id	estRows	task	operator info
 Insert_1	N/A	root	N/A

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -57,11 +57,10 @@ Update_2	N/A	root	N/A
 └─Point_Get_1	1.00	root	table:t1, handle:1
 explain delete from t1 where t1.c2 = 1;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t1, index:c2, range:[1,1], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t1, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t1, index:c2, range:[1,1], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t1, keep order:false, stats:pseudo
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	estRows	task	operator info
 Projection_11	9990.00	root	cast(Column#8, bigint(21) BINARY)->Column#7

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -58,11 +58,10 @@ Update_2	N/A	root	N/A
 └─Point_Get_1	1.00	root	table:t1, handle:1
 explain delete from t1 where t1.c2 = 1;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	0.00	root	for update
-  └─IndexLookUp_13	0.00	root	
-    ├─IndexRangeScan_11(Build)	0.00	cop[tikv]	table:t1, index:c2, range:[1,1], keep order:false
-    └─TableRowIDScan_12(Probe)	0.00	cop[tikv]	table:t1, keep order:false
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	0.00	root	
+  ├─IndexRangeScan_9(Build)	0.00	cop[tikv]	table:t1, index:c2, range:[1,1], keep order:false
+  └─TableRowIDScan_10(Probe)	0.00	cop[tikv]	table:t1, keep order:false
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	estRows	task	operator info
 Projection_11	1985.00	root	cast(Column#8, bigint(21) BINARY)->Column#7

--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -135,32 +135,28 @@ b+a
 8
 desc update t set a=1 where a+1 = 3;
 id	estRows	task	operator info
-Update_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:c, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Update_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:c, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc update t set a=2, b = 3 where b+a = 3;
 id	estRows	task	operator info
-Update_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:e, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Update_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:e, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc delete from t where a+1 = 3;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:c, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:c, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc delete from t where b+a = 0;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:e, range:[0,0], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:e, range:[0,0], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 alter table t drop index idx_c;
 alter table t drop index idx_e;
 alter table t add index expr_idx_c((a+1));
@@ -306,29 +302,25 @@ b+a
 8
 desc update t set a=1 where a+1 = 3;
 id	estRows	task	operator info
-Update_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_c_0, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Update_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_c_0, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc update t set a=2, b = 3 where b+a = 3;
 id	estRows	task	operator info
-Update_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_e_0, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Update_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_e_0, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc delete from t where a+1 = 3;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_c_0, range:[3,3], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_c_0, range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
 desc delete from t where b+a = 0;
 id	estRows	task	operator info
-Delete_5	N/A	root	N/A
-└─SelectLock_7	10.00	root	for update
-  └─IndexLookUp_13	10.00	root	
-    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_e_0, range:[0,0], keep order:false, stats:pseudo
-    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo
+Delete_4	N/A	root	N/A
+└─IndexLookUp_11	10.00	root	
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:_V$_expr_idx_e_0, range:[0,0], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t, keep order:false, stats:pseudo

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3166,7 +3166,7 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 			return nil, err
 		}
 	}
-	if !b.ctx.GetSessionVars().IsAutocommit() || b.ctx.GetSessionVars().InTxn() {
+	if b.ctx.GetSessionVars().TxnCtx.IsPessimistic {
 		if !update.MultipleTable {
 			p = b.buildSelectLock(p, ast.SelectLockForUpdate)
 		}
@@ -3406,7 +3406,7 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, delete *ast.DeleteStmt) (
 			return nil, err
 		}
 	}
-	if !b.ctx.GetSessionVars().IsAutocommit() || b.ctx.GetSessionVars().InTxn() {
+	if b.ctx.GetSessionVars().TxnCtx.IsPessimistic {
 		if !delete.IsMultiTable {
 			p = b.buildSelectLock(p, ast.SelectLockForUpdate)
 		}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2092,6 +2092,18 @@ func (s *testSchemaSuite) TestCommitWhenSchemaChanged(c *C) {
 	c.Assert(terror.ErrorEqual(err, plannercore.ErrWrongValueCountOnRow), IsTrue, Commentf("err %v", err))
 }
 
+func (s *testSchemaSuite) TestRetrySchemaChangeDebug(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create table t (i int)")
+	tk.MustExec("create table t1 (i int)")
+	tk.MustExec("begin")
+	tk1.MustExec("alter table t add j int")
+	tk.MustExec("delete from t")
+	tk.MustExec("insert into t1 values (1)")
+	tk.MustExec("commit")
+}
+
 func (s *testSchemaSuite) TestRetrySchemaChange(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2092,7 +2092,7 @@ func (s *testSchemaSuite) TestCommitWhenSchemaChanged(c *C) {
 	c.Assert(terror.ErrorEqual(err, plannercore.ErrWrongValueCountOnRow), IsTrue, Commentf("err %v", err))
 }
 
-func (s *testSchemaSuite) TestRetrySchemaChangeDebug(c *C) {
+func (s *testSchemaSuite) TestRetrySchemaChangeForEmptyChange(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table t (i int)")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2099,6 +2099,7 @@ func (s *testSchemaSuite) TestRetrySchemaChangeForEmptyChange(c *C) {
 	tk.MustExec("create table t1 (i int)")
 	tk.MustExec("begin")
 	tk1.MustExec("alter table t add j int")
+	tk.MustExec("update t set i = -i")
 	tk.MustExec("delete from t")
 	tk.MustExec("insert into t1 values (1)")
 	tk.MustExec("commit")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
https://github.com/pingcap/tidb/pull/15257 adds locks for all types of transactions. It seems more reasonable if no data changed in the transaction, we should not check its schema changed or not in an optimistic transaction.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Add pessimistic transaction condition.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Maybe need to cherry-pick to release-4.0 manually.

### Release note <!-- bugfixes or new feature need a release note -->
Do not add extra locks for optimistic transactions.