### PR TITLE
planner: fix error when select view_name.col_name from view_name(#14314)

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2562,7 +2562,7 @@ func (b *PlanBuilder) buildProjUponView(ctx context.Context, dbName model.CIStr,
 		}
 		projSchema.Append(&expression.Column{
 			UniqueID:    b.ctx.GetSessionVars().AllocPlanColumnID(),
-			TblName:     col.TblName,
+			TblName:     tableInfo.Name,
 			OrigTblName: col.OrigTblName,
 			ColName:     columnInfo[i].Name,
 			OrigColName: origColName,

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2231,6 +2231,10 @@ func (s *testPlanSuite) TestSelectView(c *C) {
 			sql:  "select * from v",
 			best: "DataScan(t)->Projection",
 		},
+		{
+			sql:  "select v.b, v.c, v.d from v",
+			best: "DataScan(t)->Projection",
+		},
 	}
 	ctx := context.TODO()
 	for i, tt := range tests {


### PR DESCRIPTION
cherry-pick #14314
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before this commit:
``` sql
tidb> create table t(a int);
Query OK, 0 rows affected (0.01 sec)
tidb> create view v as select * from t;
Query OK, 0 rows affected (0.01 sec)
tidb> desc select v.a from v;
ERROR 1054 (42S22): Unknown column 'v.a' in 'field list'
```

### What is changed and how it works?
We build a projection upon the underlying select when execute `select from a view`.
The output name of the built projection should be `view_name.col_name` instead of `underlying_table_name.col_name`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test


Code changes

 - Has exported function/method change


Side effects

N/A

Related changes

 - Need to cherry-pick to the release branch
release-3.0, release-3.1

Release note

Fix an error when executing SQL like `select view_name.col_name from view_name`.