### PR TITLE
bindinfo: add a loop GC worker to delete invalid binding

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -16,7 +16,6 @@ package bindinfo
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/set"
 	"runtime"
 	"strconv"
 	"strings"
@@ -38,6 +37,7 @@ import (
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/set"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/stmtsummary"
 	"github.com/pingcap/tidb/util/timeutil"
@@ -189,7 +189,7 @@ func (h *BindHandle) GCBindRecord() error {
 			tmpDB := row.GetString(0)
 			dbSet.Insert(tmpDB)
 			sql += "\"" + tmpDB + "\""
-			if row.Idx() != len(rows) - 1 {
+			if row.Idx() != len(rows)-1 {
 				sql += ","
 			}
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: For SQL bind, if we delete the database or evolve some SQL plans. There are many rejected or deleted or invalid SQL bindings. It's not friendly for users, so we need a GC worker to delete the invalid bindings periodly.

### What is changed and how it works?

What's Changed: add a loop GC worker to delete the invalid bindings

How it Works: the invalid binding is like which status in (invalid, deleted, rejected) and whose default_db does not exist.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

