### PR TITLE
bindinfo: delete invalid bindings that reference dropped indexes

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -699,7 +699,7 @@ func (b *PlanBuilder) getPossibleAccessPaths(indexHints []*ast.IndexHint, tbl ta
 			if path == nil {
 				err := ErrKeyDoesNotExist.GenWithStackByArgs(idxName, tblInfo.Name)
 				// if hint is from comment-style sql hints, we should throw a warning instead of error.
-				if i < indexHintsLen {
+				if i < indexHintsLen || b.ctx.GetSessionVars().HintWarningAsError {
 					return nil, err
 				}
 				b.ctx.GetSessionVars().StmtCtx.AppendWarning(err)

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -588,6 +588,9 @@ type SessionVars struct {
 	// WindowingUseHighPrecision determines whether to compute window operations without loss of precision.
 	// see https://dev.mysql.com/doc/refman/8.0/en/window-function-optimization.html for more details.
 	WindowingUseHighPrecision bool
+
+	// HintWarningAsError determines whether warning or error is reported when hint references invalid objects, e.g dropped indexes.
+	HintWarningAsError bool
 }
 
 // PreparedParams contains the parameters of the current prepared statement when executing it.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

- if we create a binding `USE_INDEX(t, a)`, and then drop index `a`, the binding would not be dropped automatically now; for each incoming query of this pattern, there would be a meaningless call of `optimize`; if the `tidb_evolve_plan_baselines` is `on`, there would be meaningless evolution attempts for this query as well.

- if a binding like above is added by evolution, and it is marked as `rejected`, the if the index `a` is dropped, this `rejected` binding cannot be dropped automatically either, and there would be one meaningless verify attempt for this rejected binding each week.

- following the meaningless evolution attempt in the second case, other bindings in the same `BindRecord` may be polluted by the rejected binding during `Update()`, because the `ID` and `Hint` of the rejected binding would be inconsistent, e.g, the `Hint` is from `USE_INDEX(t,a)`, while the `ID` is `USE_INDEX(t)`, then this binding would override other bindings with same `ID`, i.e, `USE_INDEX(t)`.

### What is changed and how it works?

What's Changed:

- specially mark a query if it is executed in background jobs of SPM, and raise error instead of warning if the hint references dropped indexes;
- drop these invalid bindings by checking above raised errors;
- make `ID` and `Hint` consistent by checking above raised errors;

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->
