### PR TITLE
*: add the tid to the schema-change related tables only when keys need to be locked (#15698)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -776,12 +776,6 @@ func (e *SelectLockExec) Open(ctx context.Context) error {
 		return err
 	}
 
-	txnCtx := e.ctx.GetSessionVars().TxnCtx
-	for id := range e.Schema().TblID2Handle {
-		// This operation is only for schema validator check.
-		txnCtx.UpdateDeltaForTable(id, 0, 0, map[int64]int64{})
-	}
-
 	if len(e.Schema().TblID2Handle) > 0 && len(e.partitionedTable) > 0 {
 		e.tblID2Table = make(map[int64]table.PartitionedTable, len(e.partitionedTable))
 		for id := range e.Schema().TblID2Handle {
@@ -835,6 +829,14 @@ func (e *SelectLockExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return nil
 	}
 	lockWaitTime := e.ctx.GetSessionVars().LockWaitTimeout
+
+	if len(e.keys) > 0 {
+		// This operation is only for schema validator check.
+		for id := range e.Schema().TblID2Handle {
+			e.ctx.GetSessionVars().TxnCtx.UpdateDeltaForTable(id, 0, 0, map[int64]int64{})
+		}
+	}
+
 	return doLockKeys(ctx, e.ctx, newLockCtx(e.ctx.GetSessionVars(), lockWaitTime), e.keys...)
 }
 


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Cherry pick #15698 to release 3.1

### Release note

Add the table ID to the schema-change related tables only when keys need to be locked in select for update statement.