### PR TITLE
bindinfo, executor: show warning msg when deleting bind with auto capture enabled

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -496,6 +496,8 @@ func (s *testSuite) TestCapturePlanBaseline(c *C) {
 	c.Assert(len(rows), Equals, 1)
 	c.Assert(rows[0][0], Equals, "select * from t where a > ?")
 	c.Assert(rows[0][1], Equals, "SELECT /*+ USE_INDEX(@`sel_1` `test`.`t` )*/ * FROM `t` WHERE `a`>10")
+	tk.MustExec("drop global binding for select count(*) from t where a > 10;")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 SQL bindings are captured automatically, please set tidb_capture_plan_baselines to false before deleting"))
 }
 
 func (s *testSuite) TestCaptureBaselinesDefaultDB(c *C) {

--- a/executor/bind.go
+++ b/executor/bind.go
@@ -73,7 +73,7 @@ func (e *SQLBindExec) dropSQLBind() error {
 		return handle.DropBindRecord(e.normdOrigSQL, e.db, bindInfo)
 	}
 	if variable.TiDBOptOn(variable.CapturePlanBaseline.GetVal()) {
-		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("SQL bindings are captured automatically, please set tidb_capture_plan_baselines to false before deleting"))
+		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("This global binding might be captured back, to forbid that, please set global tidb_capture_plan_baselines=false"))
 	}
 	return domain.GetDomain(e.ctx).BindHandle().DropBindRecord(e.normdOrigSQL, e.db, bindInfo)
 }

--- a/executor/bind.go
+++ b/executor/bind.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/domain"
 	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/chunk"
 )
 
@@ -70,6 +71,9 @@ func (e *SQLBindExec) dropSQLBind() error {
 	if !e.isGlobal {
 		handle := e.ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
 		return handle.DropBindRecord(e.normdOrigSQL, e.db, bindInfo)
+	}
+	if variable.TiDBOptOn(variable.CapturePlanBaseline.GetVal()) {
+		e.ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("SQL bindings are captured automatically, please set tidb_capture_plan_baselines to false before deleting"))
 	}
 	return domain.GetDomain(e.ctx).BindHandle().DropBindRecord(e.normdOrigSQL, e.db, bindInfo)
 }


### PR DESCRIPTION
…ture enabled

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

When `tidb_capture_plan_baselines` is true, we will capture sql bindings background.
If we deleting the bindings, it may be added later by the background thread.

Only capture the SQLs only existing after last deleting operation is not a easy task. So i add warnings message finally.

### What is changed and how it works?

Add warnings msg if we delete a binding with capture enabled.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
