### PR TITLE
bindinfo: build ID of BindRecord from Hint instead of explain query

### DIFF
--- a/bindinfo/bind.go
+++ b/bindinfo/bind.go
@@ -14,8 +14,13 @@
 package bindinfo
 
 import (
+	"strings"
+
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/format"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 )
 
 // HintsSet contains all hints of a query.
@@ -42,6 +47,50 @@ func (hs *HintsSet) ContainTableHint(hint string) bool {
 		}
 	}
 	return false
+}
+
+// RestoreTableOptimizerHint returns string format of TableOptimizerHint.
+func RestoreTableOptimizerHint(hint *ast.TableOptimizerHint) string {
+	var sb strings.Builder
+	ctx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+	err := hint.Restore(ctx)
+	// There won't be any error for optimizer hint.
+	if err != nil {
+		logutil.BgLogger().Debug("restore TableOptimizerHint failed", zap.Error(err))
+	}
+	return sb.String()
+}
+
+// RestoreIndexHint returns string format of IndexHint.
+func RestoreIndexHint(hint *ast.IndexHint) (string, error) {
+	var sb strings.Builder
+	ctx := format.NewRestoreCtx(format.DefaultRestoreFlags, &sb)
+	err := hint.Restore(ctx)
+	if err != nil {
+		logutil.BgLogger().Debug("restore IndexHint failed", zap.Error(err))
+		return "", err
+	}
+	return sb.String(), nil
+}
+
+// Restore returns the string format of HintsSet.
+func (hs *HintsSet) Restore() (string, error) {
+	hintsStr := make([]string, 0, len(hs.tableHints)+len(hs.indexHints))
+	for _, tblHints := range hs.tableHints {
+		for _, tblHint := range tblHints {
+			hintsStr = append(hintsStr, RestoreTableOptimizerHint(tblHint))
+		}
+	}
+	for _, idxHints := range hs.indexHints {
+		for _, idxHint := range idxHints {
+			str, err := RestoreIndexHint(idxHint)
+			if err != nil {
+				return "", err
+			}
+			hintsStr = append(hintsStr, str)
+		}
+	}
+	return strings.Join(hintsStr, ", "), nil
 }
 
 type hintProcessor struct {

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -247,17 +247,11 @@ func handleEvolveTasks(ctx context.Context, sctx sessionctx.Context, br *bindinf
 		return
 	}
 	charset, collation := sctx.GetSessionVars().GetCharsetInfo()
-	hintsSet, err := bindinfo.ParseHintsSet(parser.New(), bindSQL, charset, collation)
-	if err != nil {
-		return
-	}
 	binding := bindinfo.Binding{
 		BindSQL:   bindSQL,
 		Status:    bindinfo.PendingVerify,
 		Charset:   charset,
 		Collation: collation,
-		Hint:      hintsSet,
-		ID:        planHint,
 	}
 	globalHandle := domain.GetDomain(sctx).BindHandle()
 	globalHandle.AddEvolvePlanTask(br.OriginalSQL, br.Db, binding)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

Same problem that https://github.com/pingcap/tidb/pull/15692 wants to solve, just use another approach.

### What is changed and how it works?

What's Changed:

Fill `ID` using string format of `Hint` in `BindRecord`, to avoid inconsistency between `ID` and `Hint`.

Note that, this PR does not drop the invalid bindings which reference dropped indexes.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects
N/A

### Release note <!-- bugfixes or new feature need a release note -->
