### PR TITLE
executor: fix naming of a confusing variable

### DIFF
--- a/executor/join.go
+++ b/executor/join.go
@@ -207,13 +207,13 @@ func (e *HashJoinExec) fetchProbeSideChunks(ctx context.Context) {
 				e.finished.Store(true)
 				return
 			}
-			noNeedFurtherProcess, buildErr := e.wait4BuildSide()
+			emptyBuild, buildErr := e.wait4BuildSide()
 			if buildErr != nil {
 				e.joinResultCh <- &hashjoinWorkerResult{
 					err: buildErr,
 				}
 				return
-			} else if noNeedFurtherProcess {
+			} else if emptyBuild {
 				return
 			}
 			hasWaitedForBuild = true
@@ -227,7 +227,7 @@ func (e *HashJoinExec) fetchProbeSideChunks(ctx context.Context) {
 	}
 }
 
-func (e *HashJoinExec) wait4BuildSide() (noNeedFurtherProcess bool, err error) {
+func (e *HashJoinExec) wait4BuildSide() (emptyBuild bool, err error) {
 	select {
 	case <-e.closeCh:
 		return true, nil

--- a/executor/join.go
+++ b/executor/join.go
@@ -207,13 +207,13 @@ func (e *HashJoinExec) fetchProbeSideChunks(ctx context.Context) {
 				e.finished.Store(true)
 				return
 			}
-			jobFinished, buildErr := e.wait4BuildSide()
+			noNeedFurtherProcess, buildErr := e.wait4BuildSide()
 			if buildErr != nil {
 				e.joinResultCh <- &hashjoinWorkerResult{
 					err: buildErr,
 				}
 				return
-			} else if jobFinished {
+			} else if noNeedFurtherProcess {
 				return
 			}
 			hasWaitedForBuild = true
@@ -227,7 +227,7 @@ func (e *HashJoinExec) fetchProbeSideChunks(ctx context.Context) {
 	}
 }
 
-func (e *HashJoinExec) wait4BuildSide() (finished bool, err error) {
+func (e *HashJoinExec) wait4BuildSide() (noNeedFurtherProcess bool, err error) {
 	select {
 	case <-e.closeCh:
 		return true, nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

The name of `finished` is confusing, it means the finishing of the whole processing however reads like finishing waiting.

### What is changed and how it works?

What's Changed:

Rename it to `emptyBuild`.

### Related changes

No related changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

no side effects.
