### PR TITLE
bindinfo, session: mute internal logs during capture bindings

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -615,7 +615,7 @@ func (h *BindHandle) CaptureBaselines() {
 		h.sctx.GetSessionVars().IsolationReadEngines = oriIsolationRead
 		h.sctx.Unlock()
 		if err != nil {
-			logutil.BgLogger().Info("generate hints failed", zap.String("SQL", sqls[i]), zap.Error(err))
+			logutil.BgLogger().Debug("generate hints failed", zap.String("SQL", sqls[i]), zap.Error(err))
 			continue
 		}
 		bindSQL := GenerateBindSQL(context.TODO(), stmt, hints)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Close #15801

Problem Summary: SPM read from the statement summary every 3 seconds, choose the select statement which appears at least 2 times to capture SQL baseline for it. As long as the SQL is existed in the statement summary and the table is kept dropped, tidb log would repeatedly prints the log presented in #15801 

### What is changed and how it works?

What's Changed: only print the parser error when it's not in restricted execution, which means it's an internal sql.

How it Works: SPM sql is executed in the restricted execution method.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

use the reproduce step described in #15801, the annoying log disappears.