### PR TITLE
planner: make DML locks consistent in all transaction modes

### DIFF
--- a/cmd/explaintest/r/explain-non-select-stmt.result
+++ b/cmd/explaintest/r/explain-non-select-stmt.result
@@ -11,16 +11,18 @@ Insert_1	N/A	root		N/A
   └─TableFullScan_6	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain delete from t where a > 100;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─TableReader_8	3333.33	root		data:Selection_7
-  └─Selection_7	3333.33	cop[tikv]		gt(test.t.a, 100)
-    └─TableFullScan_6	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	3333.33	root		for update
+  └─TableReader_10	3333.33	root		data:Selection_9
+    └─Selection_9	3333.33	cop[tikv]		gt(test.t.a, 100)
+      └─TableFullScan_8	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain update t set b = 100 where a = 200;
 id	estRows	task	access object	operator info
-Update_4	N/A	root		N/A
-└─TableReader_8	10.00	root		data:Selection_7
-  └─Selection_7	10.00	cop[tikv]		eq(test.t.a, 200)
-    └─TableFullScan_6	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Update_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─TableReader_10	10.00	root		data:Selection_9
+    └─Selection_9	10.00	cop[tikv]		eq(test.t.a, 200)
+      └─TableFullScan_8	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain replace into t select a, 100 from t;
 id	estRows	task	access object	operator info
 Insert_1	N/A	root		N/A

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -57,10 +57,11 @@ Update_2	N/A	root		N/A
 └─Point_Get_1	1.00	root	table:t1	handle:1
 explain delete from t1 where t1.c2 = 1;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t1, index:c2(c2)	range:[1,1], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t1, index:c2(c2)	range:[1,1], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	estRows	task	access object	operator info
 Projection_11	9990.00	root		cast(Column#8, bigint(21) BINARY)->Column#7

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -58,10 +58,11 @@ Update_2	N/A	root		N/A
 └─Point_Get_1	1.00	root	table:t1	handle:1
 explain delete from t1 where t1.c2 = 1;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	0.00	root		
-  ├─IndexRangeScan_9(Build)	0.00	cop[tikv]	table:t1, index:c2(c2)	range:[1,1], keep order:false
-  └─TableRowIDScan_10(Probe)	0.00	cop[tikv]	table:t1	keep order:false
+Delete_5	N/A	root		N/A
+└─SelectLock_7	0.00	root		for update
+  └─IndexLookUp_13	0.00	root		
+    ├─IndexRangeScan_11(Build)	0.00	cop[tikv]	table:t1, index:c2(c2)	range:[1,1], keep order:false
+    └─TableRowIDScan_12(Probe)	0.00	cop[tikv]	table:t1	keep order:false
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	estRows	task	access object	operator info
 Projection_11	1985.00	root		cast(Column#8, bigint(21) BINARY)->Column#7

--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -135,28 +135,32 @@ b+a
 8
 desc update t set a=1 where a+1 = 3;
 id	estRows	task	access object	operator info
-Update_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:idx_c(c)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Update_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:idx_c(c)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc update t set a=2, b = 3 where b+a = 3;
 id	estRows	task	access object	operator info
-Update_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:idx_e(e)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Update_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:idx_e(e)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc delete from t where a+1 = 3;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:idx_c(c)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:idx_c(c)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc delete from t where b+a = 0;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:idx_e(e)	range:[0,0], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:idx_e(e)	range:[0,0], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 alter table t drop index idx_c;
 alter table t drop index idx_e;
 alter table t add index expr_idx_c((a+1));
@@ -302,25 +306,29 @@ b+a
 8
 desc update t set a=1 where a+1 = 3;
 id	estRows	task	access object	operator info
-Update_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(_V$_expr_idx_c_0)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Update_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(_V$_expr_idx_c_0)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc update t set a=2, b = 3 where b+a = 3;
 id	estRows	task	access object	operator info
-Update_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(_V$_expr_idx_e_0)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Update_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(_V$_expr_idx_e_0)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc delete from t where a+1 = 3;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(_V$_expr_idx_c_0)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(_V$_expr_idx_c_0)	range:[3,3], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc delete from t where b+a = 0;
 id	estRows	task	access object	operator info
-Delete_4	N/A	root		N/A
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(_V$_expr_idx_e_0)	range:[0,0], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+Delete_5	N/A	root		N/A
+└─SelectLock_7	10.00	root		for update
+  └─IndexLookUp_13	10.00	root		
+    ├─IndexRangeScan_11(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(_V$_expr_idx_e_0)	range:[0,0], keep order:false, stats:pseudo
+    └─TableRowIDScan_12(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1088,7 +1088,6 @@ func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bo
 }
 
 // IsAutoCommitTxn checks if session is in autocommit mode and not InTxn
-// used for fast plan like point get
 func IsAutoCommitTxn(ctx sessionctx.Context) bool {
 	return ctx.GetSessionVars().IsAutocommit() && !ctx.GetSessionVars().InTxn()
 }

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3193,7 +3193,7 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 			return nil, err
 		}
 	}
-	if b.ctx.GetSessionVars().TxnCtx.IsPessimistic {
+	if !IsAutoCommitTxn(b.ctx) {
 		if !update.MultipleTable {
 			p = b.buildSelectLock(p, ast.SelectLockForUpdate)
 		}
@@ -3466,7 +3466,7 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, delete *ast.DeleteStmt) (
 			return nil, err
 		}
 	}
-	if b.ctx.GetSessionVars().TxnCtx.IsPessimistic {
+	if !IsAutoCommitTxn(b.ctx) {
 		if !delete.IsMultiTable {
 			p = b.buildSelectLock(p, ast.SelectLockForUpdate)
 		}


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
DML locks are not consistent in all transaction modes
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Make DML locks consistent in all transaction modes.
How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
The blind update will write locks to the storage node. If it is a big blind update, the performance will be worse.

### Release note <!-- bugfixes or new feature need a release note -->
Make DML locks consistent in all transaction