### PR TITLE
txn: stop more statement executions if pessimistic transaction ttl manager timed out

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1069,6 +1069,7 @@ const (
 	ErrCannotCancelDDLJob             = 8226
 	ErrSequenceUnsupportedTableOption = 8227
 	ErrColumnTypeUnsupportedNextValue = 8228
+	ErrLockExpire                     = 8229
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout        = 9001

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1066,6 +1066,7 @@ var MySQLErrName = map[uint16]string{
 	ErrInvalidWildCard:                     "Wildcard fields without any table name appears in wrong place",
 	ErrMixOfGroupFuncAndFieldsIncompatible: "In aggregated query without GROUP BY, expression #%d of SELECT list contains nonaggregated column '%s'; this is incompatible with sql_mode=only_full_group_by",
 	ErrUnsupportedSecondArgumentType:       "JSON_OBJECTAGG: unsupported second argument type %v",
+	ErrLockExpire:                          "TTL manager has timed out, pessimistic locks may expire, please commit or rollback this transaction",
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:        "PD server timeout",

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -928,6 +928,7 @@ func newLockCtx(seVars *variable.SessionVars, lockWaitTime int64) *kv.LockCtx {
 		PessimisticLockWaited: &seVars.StmtCtx.PessimisticLockWaited,
 		LockKeysDuration:      &seVars.StmtCtx.LockKeysDuration,
 		LockKeysCount:         &seVars.StmtCtx.LockKeysCount,
+		LockExpired:           &seVars.TxnCtx.LockExpire,
 	}
 }
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -213,6 +213,7 @@ type LockCtx struct {
 	ReturnValues          bool
 	Values                map[string]ReturnedValue
 	ValuesLock            sync.Mutex
+	LockExpired           *uint32
 }
 
 // ReturnedValue pairs the Value and AlreadyLocked flag for PessimisticLock return values result.

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -155,6 +155,7 @@ type TransactionContext struct {
 	CouldRetry     bool
 	IsPessimistic  bool
 	Isolation      string
+	LockExpire     uint32
 }
 
 // AddUnchangedRowKey adds an unchanged row key in update statement for pessimistic lock.

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -223,6 +223,7 @@ func newTwoPhaseCommitter(txn *tikvTxn, connID uint64) (*twoPhaseCommitter, erro
 		ttlManager: ttlManager{
 			ch: make(chan struct{}),
 		},
+		isPessimistic: txn.IsPessimistic(),
 	}, nil
 }
 
@@ -681,17 +682,17 @@ const (
 )
 
 type ttlManager struct {
-	state  ttlManagerState
-	ch     chan struct{}
-	killed *uint32
+	state   ttlManagerState
+	ch      chan struct{}
+	lockCtx *kv.LockCtx
 }
 
-func (tm *ttlManager) run(c *twoPhaseCommitter, killed *uint32) {
+func (tm *ttlManager) run(c *twoPhaseCommitter, lockCtx *kv.LockCtx) {
 	// Run only once.
 	if !atomic.CompareAndSwapUint32((*uint32)(&tm.state), uint32(stateUninitialized), uint32(stateRunning)) {
 		return
 	}
-	tm.killed = killed
+	tm.lockCtx = lockCtx
 	go tm.keepAlive(c)
 }
 
@@ -712,7 +713,7 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 			return
 		case <-ticker.C:
 			// If kill signal is received, the ttlManager should exit.
-			if tm.killed != nil && atomic.LoadUint32(tm.killed) != 0 {
+			if tm.lockCtx != nil && tm.lockCtx.Killed != nil && atomic.LoadUint32(tm.lockCtx.Killed) != 0 {
 				return
 			}
 			bo := NewBackoffer(context.Background(), pessimisticLockMaxBackoff).WithVars(c.txn.vars)
@@ -735,6 +736,11 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 				logutil.Logger(bo.ctx).Info("ttlManager live up to its lifetime",
 					zap.Uint64("txnStartTS", c.startTS))
 				metrics.TiKVTTLLifeTimeReachCounter.Inc()
+				// the pessimistic locks may expire if the ttl manager has timed out, set `LockExpired` flag
+				// so that this transaction could only commit or rollback with no more statement executions
+				if c.isPessimistic && tm.lockCtx != nil && tm.lockCtx.LockExpired != nil {
+					atomic.StoreUint32(tm.lockCtx.LockExpired, 1)
+				}
 				return
 			}
 

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -42,6 +42,7 @@ var (
 	ErrLockAcquireFailAndNoWaitSet = terror.ClassTiKV.New(mysql.ErrLockAcquireFailAndNoWaitSet, mysql.MySQLErrName[mysql.ErrLockAcquireFailAndNoWaitSet])
 	ErrLockWaitTimeout             = terror.ClassTiKV.New(mysql.ErrLockWaitTimeout, mysql.MySQLErrName[mysql.ErrLockWaitTimeout])
 	ErrTokenLimit                  = terror.ClassTiKV.New(mysql.ErrTiKVStoreLimit, mysql.MySQLErrName[mysql.ErrTiKVStoreLimit])
+	ErrLockExpire                  = terror.ClassTiKV.New(mysql.ErrLockExpire, mysql.MySQLErrName[mysql.ErrLockExpire])
 	ErrUnknown                     = terror.ClassTiKV.New(mysql.ErrUnknown, mysql.MySQLErrName[mysql.ErrUnknown])
 )
 

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -395,7 +395,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 			return err
 		}
 		if assignedPrimaryKey {
-			txn.committer.ttlManager.run(txn.committer, lockCtx.Killed)
+			txn.committer.ttlManager.run(txn.committer, lockCtx)
 		}
 	}
 	txn.mu.Lock()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

Allow only `commit` or `rollback` if pessimistic transaction TTL manager has timed out

### What is changed and how it works?

What's Changed:

1. fix the problem that `twoPhaseCommitter`.`isPessimistic` field has incorrect value as it's not intialized before `LockKeys`
2. Set timed out flag in `TxnCtx` and check this flag before executing another statement, for example in 
`RC` mode, users could not do more read since the lock cache has expired

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
1. start transaction 
2. add pessimistic locks
3. let ttl manager time out
4. try to do more executions 

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
