### PR TITLE
executor: do not log slow query for pessimistic write conflict retry …

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -375,25 +375,20 @@ func (a *ExecStmt) handlePessimisticSelectForUpdate(ctx context.Context, e Execu
 }
 
 func (a *ExecStmt) runPessimisticSelectForUpdate(ctx context.Context, e Executor) (sqlexec.RecordSet, error) {
-	rs := &recordSet{
-		executor: e,
-		stmt:     a,
-	}
 	defer func() {
-		terror.Log(rs.Close())
+		terror.Log(e.Close())
 	}()
-
 	var rows []chunk.Row
 	var err error
-	fields := rs.Fields()
-	req := rs.NewChunk()
+	req := newFirstChunk(e)
 	for {
-		err = rs.Next(ctx, req)
+		err = Next(ctx, e, req)
 		if err != nil {
 			// Handle 'write conflict' error.
 			break
 		}
 		if req.NumRows() == 0 {
+			fields := schema2ResultFields(e.Schema(), a.Ctx.GetSessionVars().CurrentDB)
 			return &chunkRowRecordSet{rows: rows, fields: fields, e: e}, nil
 		}
 		iter := chunk.NewIterator4Chunk(req)


### PR DESCRIPTION
cherry-pick #15890 to release-3.0

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Slow Query is logged for each pessimistic select for update retry statement, which is confusing.

### What is changed and how it works?

What's Changed:
Do not use `recordSet`, execute directly.

How it Works:
`recordSet` log slow query on `Close`, remove it to avoid logging slow query.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
Run a conflicting workload for a while and check that the slow-log file size is smaller compares to the master.

