### PR TITLE
sessionctx/binloginfo: fix auto_random regex pattern

### DIFF
--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -47,7 +47,7 @@ var pumpsClient *pumpcli.PumpsClient
 var pumpsClientLock sync.RWMutex
 var shardPat = regexp.MustCompile(`SHARD_ROW_ID_BITS\s*=\s*\d+\s*`)
 var preSplitPat = regexp.MustCompile(`PRE_SPLIT_REGIONS\s*=\s*\d+\s*`)
-var autoRandomPat = regexp.MustCompile(`AUTO_RANDOM\s*\(\s*\d+\s*\)\s*`)
+var autoRandomPat = regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\))?\s*`)
 
 // BinlogInfo contains binlog data and binlog client.
 type BinlogInfo struct {

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -552,12 +552,24 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int primary key /*T!30100 auto_random(2) */ );",
 		},
 		{
-			"create table t1 (id int auto_random ( 4 ) primary key);",
-			"create table t1 (id int /*T!30100 auto_random ( 4 ) */ primary key);",
+			"create table t1 (id int auto_random(4) primary key);",
+			"create table t1 (id int /*T!30100 auto_random(4) */ primary key);",
 		},
 		{
 			"create table t1 (id int  auto_random  (   4    ) primary key);",
 			"create table t1 (id int  /*T!30100 auto_random  (   4    ) */ primary key);",
+		},
+		{
+			"create table t1 (id int auto_random primary key);",
+			"create table t1 (id int /*T!30100 auto_random */ primary key);",
+		},
+		{
+			"create table t1 (id int AUTO_RANDOM primary key);",
+			"create table t1 (id int /*T!30100 AUTO_RANDOM */ primary key);",
+		},
+		{
+			"create table t1 (id int AUTO_RANDOM(5) primary key);",
+			"create table t1 (id int /*T!30100 AUTO_RANDOM(5) */ primary key);",
 		},
 	}
 	for _, ca := range testCase {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
The keyword `auto_random` in DDL statements should be commented out in binlog. For example,
```sql
create table t (a int auto_random primary key)
``` 
should be converted to
```sql
create table t (a int /*T!30100 auto_random */ primary key)
```
in binlog. However, the current implementation is problematic:
```go
regexp.MustCompile(`AUTO_RANDOM\s*\(\s*\d+\s*\)\s*`)
```
fails to match the `auto_random` in above statement.

### What is changed and how it works?

What's Changed:
We should use case-insensitive regex and make `(digit)` part optional.
```go
regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\))?\s*`)
```

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->
