### PR TITLE
codec, json: fix type json hash group key

### DIFF
--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -1186,9 +1186,7 @@ func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf []
 				buf[i] = append(buf[i], NilFlag)
 			} else {
 				buf[i] = append(buf[i], jsonFlag)
-				j := col.GetJSON(i)
-				buf[i] = append(buf[i], j.TypeCode)
-				buf[i] = append(buf[i], j.Value...)
+				buf[i] = col.GetJSON(i).HashValue(buf[i])
 			}
 		}
 	case types.ETString:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #10467

### What is changed and how it works?

What's Changed:
change hashgroupkey when col type is json

How it Works:
change int64 in json to float64

I write a samle code to test benchmark [gist](https://gist.github.com/zxh326/1e9605eb1d0124d650e8fea1a3af256d)，will lose some performance in aggregate executor when col type is json 

```
goos: darwin
goarch: amd64
pkg: leet-go/jsont
BenchmarkHashJsonValue-8        12260102                96.3 ns/op            80 B/op          2 allocs/op
BenchmarkBasic-8                32172847                36.5 ns/op            48 B/op          1 allocs/op
PASS
ok      leet-go/jsont   3.095s

```
### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test
- Integration test

Side effects
N/A

### Release note <!-- bugfixes or new feature need a release note -->
