### PR TITLE
tikv: refine region cache error handle

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,8 @@ const (
 	DefPort = 4000
 	// DefStatusPort is the default status port of TiBD
 	DefStatusPort = 10080
+	// DefStoreLivenessTimeout is the default value for store liveness timeout(unit: ms).
+	DefStoreLivenessTimeout = 120
 )
 
 // Valid config maps
@@ -449,6 +451,8 @@ type TiKVClient struct {
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
+	// StoreLivenessTimeout in nanosecond is the timeout for store liveness check request.
+	StoreLivenessTimeout int `toml:"store-liveness-timeout" json:"store-liveness-timeout"`
 
 	CoprCache CoprocessorCache `toml:"copr-cache" json:"copr-cache"`
 }
@@ -625,8 +629,9 @@ var defaultConf = Config{
 
 		EnableChunkRPC: true,
 
-		RegionCacheTTL: 600,
-		StoreLimit:     0,
+		RegionCacheTTL:       600,
+		StoreLimit:           0,
+		StoreLivenessTimeout: DefStoreLivenessTimeout,
 
 		CoprCache: CoprocessorCache{
 			Enabled:               true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -341,6 +341,9 @@ region-cache-ttl = 600
 # default 0 means shutting off store limit.
 store-limit = 0
 
+# store-liveness-timeout is used to control timeout for store liveness after sending request failed(unit: ms).
+store-liveness-timeout = 120
+
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
 # reuses the result when corresponding data in TiKV is unchanged, on a region basis.

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -115,8 +115,8 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 		return nil, errors.Trace(err)
 	}
 
-	tikvCliConfig := &config.GetGlobalConfig().TiKVClient
-	s, err := newTikvStore(uuid, &codecPDClient{pdCli}, spkv, newRPCClient(security), !disableGC, tikvCliConfig)
+	coprCacheConfig := &config.GetGlobalConfig().TiKVClient.CoprCache
+	s, err := newTikvStore(uuid, &codecPDClient{pdCli}, spkv, newRPCClient(security), !disableGC, coprCacheConfig)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -192,16 +192,10 @@ func (s *tikvStore) CheckVisibility(startTime uint64) error {
 	return nil
 }
 
-func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Client, enableGC bool, tikvClientCfg *config.TiKVClient) (*tikvStore, error) {
+func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Client, enableGC bool, coprCacheConfig *config.CoprocessorCache) (*tikvStore, error) {
 	o, err := oracles.NewPdOracle(pdClient, time.Duration(oracleUpdateInterval)*time.Millisecond)
 	if err != nil {
 		return nil, errors.Trace(err)
-	}
-	var (
-		coprCacheConfig *config.CoprocessorCache
-	)
-	if tikvClientCfg != nil {
-		coprCacheConfig = &tikvClientCfg.CoprCache
 	}
 	store := &tikvStore{
 		clusterID:       pdClient.GetClusterID(context.TODO()),

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1429,6 +1429,9 @@ func (s *Store) livenessLoop() {
 	t := time.NewTimer(time.Duration(atomic.LoadUint64(&s.liveness.checkInterval)))
 	for {
 		select {
+		case <-s.rc.closeCh:
+			t.Stop()
+			return
 		case <-s.closed:
 			t.Stop()
 			return

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1499,6 +1499,9 @@ func (s *Store) currentEpoch() uint32 {
 }
 
 func (s *Store) currentLivenessState() livenessState {
+	if s == nil {
+		return unknown
+	}
 	return livenessState(atomic.LoadUint32(&s.livenessState))
 }
 

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -294,19 +294,18 @@ func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRe
 	if err != nil {
 		return nil, err
 	}
-	addr := store.addr
 	// enable by `curl -XPUT -d '1*return("[some-addr]")->return("")' http://host:port/github.com/pingcap/tidb/store/tikv/injectWrongStoreAddr`
 	failpoint.Inject("injectWrongStoreAddr", func(val failpoint.Value) {
 		if a, ok := val.(string); ok && len(a) > 0 {
-			addr = a
+			store = nil
 		}
 	})
-	if store == nil || len(addr) == 0 {
+	if store == nil || len(store.addr) == 0 {
 		// Store not found, region must be out of date.
 		cachedRegion.invalidate()
 		return nil, nil
 	}
-
+	addr := store.addr
 	if store.currentEpoch() != regionStore.storeEpochs[storeIdx] {
 		cachedRegion.invalidate()
 		logutil.BgLogger().Info("invalidate current region, because others request detect store was down",

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1379,7 +1379,10 @@ func (s *Store) doResolve(bo *Backoffer) (ns *Store, err error) {
 
 func (s *Store) requestResolveAddr(retryBo *Backoffer, f func(store *metapb.Store)) (err error) {
 	rsCh := resolveSf.DoChan(strconv.FormatUint(s.storeID, 10), func() (interface{}, error) {
-		var st *metapb.Store
+		var (
+			st  *metapb.Store
+			err error
+		)
 		st, err = s.rc.pdClient.GetStore(context.Background(), s.storeID) // TODO: how long we should set timeout?
 		if err != nil {
 			tikvRegionCacheCounterWithGetStoreError.Inc()

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -1100,9 +1100,7 @@ func BenchmarkOnRequestFail(b *testing.B) {
 				Store:   store,
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
-			if r == nil {
-				cache.switchNextPeer(r, rpcCtx.PeerIdx, nil)
-			}
+			r.getStore().switchNextPeer(r, rpcCtx.PeerIdx)
 		}
 	})
 	if len(cache.mu.regions) != regionCnt*2/3 {

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -304,7 +304,7 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnSendFail(s.bo, ctx, false, nil)
+	s.cache.OnStoreDown(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -384,7 +384,7 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnSendFail(s.bo, ctx, false, nil)
+	s.cache.OnStoreDown(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -473,7 +473,7 @@ func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
 	// Send fail on region1
 	ctx, _ := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	s.checkCache(c, 2)
-	s.cache.OnSendFail(s.bo, ctx, false, errors.New("test error"))
+	s.cache.OnStoreDown(s.bo, ctx, false, errors.New("test error"))
 
 	// Get region2 cache will get nil then reload.
 	ctx2, err := s.cache.GetTiKVRPCContext(s.bo, loc2.Region, kv.ReplicaReadLeader, 0)
@@ -515,7 +515,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnSendFail(s.bo, ctx, false, nil)
+	s.cache.OnStoreDown(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -538,7 +538,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// send 2 fail leader switch to 3
-	s.cache.OnSendFail(s.bo, ctx, false, nil)
+	s.cache.OnStoreDown(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
@@ -938,7 +938,7 @@ func (s *testRegionCacheSuite) TestFollowerReadFallback(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// send fail on store2, next follower read is going to fallback to store3
-	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
+	s.cache.OnStoreDown(s.bo, ctxFollower1, false, errors.New("test error"))
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
@@ -973,7 +973,7 @@ func (s *testRegionCacheSuite) TestMixedReadFallback(c *C) {
 	c.Assert(ctxFollower3.Peer.Id, Equals, peer3)
 
 	// send fail on store2, next follower read is going to fallback to store3
-	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
+	s.cache.OnStoreDown(s.bo, ctxFollower1, false, errors.New("test error"))
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadMixed, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -304,7 +304,7 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnStoreDown(s.bo, ctx, false, nil)
+	s.cache.OnSendFail(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -384,7 +384,7 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnStoreDown(s.bo, ctx, false, nil)
+	s.cache.OnSendFail(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -473,7 +473,7 @@ func (s *testRegionCacheSuite) TestSendFailInvalidateRegionsInSameStore(c *C) {
 	// Send fail on region1
 	ctx, _ := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	s.checkCache(c, 2)
-	s.cache.OnStoreDown(s.bo, ctx, false, errors.New("test error"))
+	s.cache.OnSendFail(s.bo, ctx, false, errors.New("test error"))
 
 	// Get region2 cache will get nil then reload.
 	ctx2, err := s.cache.GetTiKVRPCContext(s.bo, loc2.Region, kv.ReplicaReadLeader, 0)
@@ -515,7 +515,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// send fail leader switch to 2
-	s.cache.OnStoreDown(s.bo, ctx, false, nil)
+	s.cache.OnSendFail(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -538,7 +538,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// send 2 fail leader switch to 3
-	s.cache.OnStoreDown(s.bo, ctx, false, nil)
+	s.cache.OnSendFail(s.bo, ctx, false, nil)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
@@ -938,7 +938,7 @@ func (s *testRegionCacheSuite) TestFollowerReadFallback(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// send fail on store2, next follower read is going to fallback to store3
-	s.cache.OnStoreDown(s.bo, ctxFollower1, false, errors.New("test error"))
+	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadFollower, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
@@ -973,7 +973,7 @@ func (s *testRegionCacheSuite) TestMixedReadFallback(c *C) {
 	c.Assert(ctxFollower3.Peer.Id, Equals, peer3)
 
 	// send fail on store2, next follower read is going to fallback to store3
-	s.cache.OnStoreDown(s.bo, ctxFollower1, false, errors.New("test error"))
+	s.cache.OnSendFail(s.bo, ctxFollower1, false, errors.New("test error"))
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadMixed, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -295,7 +295,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 	}
 
 	if ctx.Meta != nil {
-		s.regionCache.OnStoreDown(bo, ctx, s.needReloadRegion(ctx), err)
+		s.regionCache.OnSendFail(bo, ctx, s.needReloadRegion(ctx), err)
 	}
 
 	// Retry on send request failure when it's not canceled.

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -281,7 +281,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 	}
 
 	if ctx.Meta != nil {
-		s.regionCache.OnSendFail(bo, ctx, s.needReloadRegion(ctx), err)
+		s.regionCache.OnStoreDown(bo, ctx, s.needReloadRegion(ctx), err)
 	}
 
 	// Retry on send request failure when it's not canceled.
@@ -352,7 +352,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, seed
 		logutil.BgLogger().Warn("tikv reports `StoreNotMatch` retry later",
 			zap.Stringer("storeNotMatch", storeNotMatch),
 			zap.Stringer("ctx", ctx))
-		ctx.Store.markNeedCheck(s.regionCache.notifyCheckCh)
+		ctx.Store.scheduleResolve()
 		return true, nil
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

after #11344 we will invalid all region-cache entries for the same store when sending a request failed(this is the old logic in 2.1 too) and switch to the next peer to find a new region leader.

but we often see two problems:

1. tikv timeout invalid region cache but tikv just partially slow.

> a slow cop/2pc request timeout in tikv will lead tidb to invalid all region-cache item in the same store, this will lead to a RegionMiss backoff(although it fast), switch next peer (often lead a notleader backoff if store isn't real down) and send more requests to PD to fetch same region info and write many logs like "invalidate current region, because others failed on same store"
> but the store is alive and the region leader didn't change and maybe other regions in the same store also works well, there are just some slow processes in some regions.....

2. super batch client slow make region invalid

> when super batch became overload, it will return many DeadlineExceed error at [here](https://github.com/pingcap/tidb/blob/15f50f17f6c58a12ec4aa1cc0d9ecdcab1fa6728/store/tikv/client_batch.go#L635) will lead invalid region cache, this maybe caused by tikv slow or batch client busy, invalid region cache and switch leader will make more request and let batch client became busier...

The Question is we didn't distinguish *store down error* from *sending error*, leader change operation only happened when store is real down if store live it will response NotLeader to told us a new leader.

### What is changed and how it works?

What's Changed:

add a liveness check to learn the truth of store liveness before invalid region-cache or change leader.

How it Works:

inspired by #15988, when we meet sending fail, we recheck tikv http status api to failure store with a short timeout (50ms?) to ensure the liveness of store.

status addr info is avaliable in pd 4.0, we also need handle pd failure or cache outdated situation(we choose degrade liveness function when those happen)

it will pay the cost to send more one request when sending fail happened, but we set very sort timeout and it's better than sending many requests to not-leader-peer and pd, and we also use setup a singleflight to deduplicate check requests.
 
### Related changes

- Need to cherry-pick to the release branch, maybe better cherry-pick to 3.0/3.1/4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

need more test

Side effects

- Performance regression
    - send an additional one request when the store is down but avoid sending more requests when store is fake down
- Change the vital code path and needs many tests.

### Release note <!-- bugfixes or new feature need a release note -->

avoid useless switch leader and invalid store region cache caused by timeout error

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/15989)
<!-- Reviewable:end -->
