### PR TITLE
planner: fix push down distinct when need to inject projection

### DIFF
--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -50,6 +50,7 @@
   {
     "name": "TestPushdownDistinctEnable",
     "cases": [
+      "select /*+ HASH_AGG() */ avg(distinct a) from t;", // InjectProjBelowAgg
       "select /*+ HASH_AGG() */ a, count(distinct a) from t;", // firstrow(a) cannot be removed.
       "select /*+ HASH_AGG() */ avg(b), c, avg(b), count(distinct A, B),  count(distinct A), count(distinct c), sum(b) from t group by c;",
       "select /*+ STREAM_AGG() */ count(distinct c) from t group by c;", // should push down after stream agg implemented
@@ -63,6 +64,7 @@
     "name": "TestPushdownDistinctDisable",
     "cases": [
       // do not pushdown even AGG_TO_COP is specified.
+      "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(distinct a) from t;",
       "select /*+ HASH_AGG(), AGG_TO_COP() */ a, count(distinct a) from t;",
       "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(b), c, avg(b), count(distinct A, B),  count(distinct A), count(distinct c), sum(b) from t group by c;",
       "select /*+ STREAM_AGG(), AGG_TO_COP() */ count(distinct c) from t group by c;",

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -458,6 +458,19 @@
     "Name": "TestPushdownDistinctEnable",
     "Cases": [
       {
+        "SQL": "select /*+ HASH_AGG() */ avg(distinct a) from t;",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:avg(distinct Column#8)->Column#5",
+          "└─Projection_15 8000.00 root  cast(test.t.a, decimal(65,4) BINARY)->Column#8",
+          "  └─TableReader_13 8000.00 root  data:HashAgg_14",
+          "    └─HashAgg_14 8000.00 cop[tikv]  group by:test.t.a, ",
+          "      └─TableFullScan_10 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1.5000"
+        ]
+      },
+      {
         "SQL": "select /*+ HASH_AGG() */ a, count(distinct a) from t;",
         "Plan": [
           "Projection_8 1.00 root  test.t.a, Column#5",
@@ -554,6 +567,18 @@
   {
     "Name": "TestPushdownDistinctDisable",
     "Cases": [
+      {
+        "SQL": "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(distinct a) from t;",
+        "Plan": [
+          "HashAgg_6 1.00 root  funcs:avg(distinct Column#7)->Column#5",
+          "└─Projection_9 10000.00 root  cast(test.t.a, decimal(65,4) BINARY)->Column#7",
+          "  └─TableReader_7 10000.00 root  data:TableFullScan_8",
+          "    └─TableFullScan_8 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1.5000"
+        ]
+      },
       {
         "SQL": "select /*+ HASH_AGG(), AGG_TO_COP() */ a, count(distinct a) from t;",
         "Plan": [

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1169,11 +1169,12 @@ func (p *basePhysicalAgg) newPartialAggregate(copTaskType kv.StoreType) (partial
 	p.schema = partialPref.Schema
 	partialAgg := p.self
 	// Create physical "final" aggregation.
+	prop := &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64}
 	if p.tp == plancodec.TypeStreamAgg {
 		finalAgg := basePhysicalAgg{
 			AggFuncs:     finalPref.AggFuncs,
 			GroupByItems: finalPref.GroupByItems,
-		}.initForStream(p.ctx, p.stats, p.blockOffset)
+		}.initForStream(p.ctx, p.stats, p.blockOffset, prop)
 		finalAgg.schema = finalPref.Schema
 		return partialAgg, finalAgg
 	}
@@ -1181,7 +1182,7 @@ func (p *basePhysicalAgg) newPartialAggregate(copTaskType kv.StoreType) (partial
 	finalAgg := basePhysicalAgg{
 		AggFuncs:     finalPref.AggFuncs,
 		GroupByItems: finalPref.GroupByItems,
-	}.initForHash(p.ctx, p.stats, p.blockOffset)
+	}.initForHash(p.ctx, p.stats, p.blockOffset, prop)
 	finalAgg.schema = finalPref.Schema
 	return partialAgg, finalAgg
 }

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -537,6 +537,7 @@
   {
     "name": "TestPushdownDistinctEnable",
     "cases": [
+      "select /*+ HASH_AGG() */ avg(distinct a) from t;", // InjectProjBelowAgg
       "select /*+ HASH_AGG() */ a, count(distinct a) from t;", // firstrow(a) cannot be removed.
       "select /*+ HASH_AGG() */ avg(b), c, avg(b), count(distinct A, B),  count(distinct A), count(distinct c), sum(b) from t group by c;",
       "select /*+ STREAM_AGG() */ count(distinct c) from t group by c;", // can push down
@@ -550,6 +551,7 @@
     "name": "TestPushdownDistinctDisable",
     "cases": [
       // do not pushdown even AGG_TO_COP is specified.
+      "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(distinct a) from t;",
       "select /*+ HASH_AGG(), AGG_TO_COP() */ a, count(distinct a) from t;",
       "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(b), c, avg(b), count(distinct A, B),  count(distinct A), count(distinct c), sum(b) from t group by c;",
       "select /*+ STREAM_AGG(), AGG_TO_COP() */ count(distinct c) from t group by c;",

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -1436,6 +1436,19 @@
     "Name": "TestPushdownDistinctEnable",
     "Cases": [
       {
+        "SQL": "select /*+ HASH_AGG() */ avg(distinct a) from t;",
+        "Plan": [
+          "HashAgg_8 1.00 root  funcs:avg(distinct Column#6)->Column#5",
+          "└─Projection_10 1.00 root  cast(test.t.a, decimal(65,4) BINARY)->Column#6",
+          "  └─TableReader_9 1.00 root  data:HashAgg_5",
+          "    └─HashAgg_5 1.00 cop[tikv]  group by:test.t.a, ",
+          "      └─TableFullScan_7 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1.5000"
+        ]
+      },
+      {
         "SQL": "select /*+ HASH_AGG() */ a, count(distinct a) from t;",
         "Plan": [
           "Projection_4 1.00 root  test.t.a, Column#5",
@@ -1531,6 +1544,18 @@
   {
     "Name": "TestPushdownDistinctDisable",
     "Cases": [
+      {
+        "SQL": "select /*+ HASH_AGG(), AGG_TO_COP() */ avg(distinct a) from t;",
+        "Plan": [
+          "HashAgg_5 1.00 root  funcs:avg(distinct Column#6)->Column#5",
+          "└─Projection_8 10000.00 root  cast(test.t.a, decimal(65,4) BINARY)->Column#6",
+          "  └─TableReader_7 10000.00 root  data:TableFullScan_6",
+          "    └─TableFullScan_6 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1.5000"
+        ]
+      },
       {
         "SQL": "select /*+ HASH_AGG(), AGG_TO_COP() */ a, count(distinct a) from t;",
         "Plan": [


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #15999

Problem Summary:
If aggregation function is _avg(distinct)_ or _sum(distinct)_ when `tidb_opt_distinct_agg_push_down` is set to `1`, Planner needs to inject a projection to cast `cop`  data from type int to type decimal. So a property of `finalAgg` is necessary or it will panic. 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- A fix for https://github.com/pingcap/tidb/pull/15500

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- None
