### PR TITLE
planner: Add explain info for InspectionRuleTableExtractor

### DIFF
--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -119,3 +119,13 @@ func (s *testSuite) TestExplainMetricTable(c *C) {
 	tk.MustQuery("desc select * from information_schema.cluster_log where type in ('high_cpu_1','high_memory_1') and time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13'").Check(testkit.Rows(
 		`MemTableScan_5 10000.00 root table:CLUSTER_LOG start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13, node_types:["high_cpu_1","high_memory_1"]`))
 }
+
+func (s *testSuite) TestInspectionRuleTable(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustQuery(fmt.Sprintf("desc select * from information_schema.inspection_rules where type='inspection'")).Check(testkit.Rows(
+		`MemTableScan_5 10000.00 root table:INSPECTION_RULES node_types:["inspection"]`))
+	tk.MustQuery(fmt.Sprintf("desc select * from information_schema.inspection_rules where type='inspection' or type='summary'")).Check(testkit.Rows(
+		`MemTableScan_5 10000.00 root table:INSPECTION_RULES node_types:["inspection","summary"]`))
+	tk.MustQuery(fmt.Sprintf("desc select * from information_schema.inspection_rules where type='inspection' and type='summary'")).Check(testkit.Rows(
+		`MemTableScan_5 10000.00 root table:INSPECTION_RULES skip_request: true`))
+}

--- a/planner/core/memtable_predicate_extractor.go
+++ b/planner/core/memtable_predicate_extractor.go
@@ -890,7 +890,15 @@ func (e *InspectionRuleTableExtractor) Extract(
 }
 
 func (e *InspectionRuleTableExtractor) explainInfo(p *PhysicalMemTable) string {
-	return ""
+	if e.SkipRequest {
+		return "skip_request: true"
+	}
+
+	r := new(bytes.Buffer)
+	if len(e.Types) > 0 {
+		r.WriteString(fmt.Sprintf("node_types:[%s]", extractStringFromStringSet(e.Types)))
+	}
+	return r.String()
 }
 
 // SlowQueryExtractor is used to extract some predicates of `slow_query`


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close [#15382](https://github.com/pingcap/tidb/issues/15382)

Problem Summary:

### What is changed and how it works?

What's Changed:

UCP: Add explain info for InspectionRuleTableExtractor
1. planner/core: memtable_predicate_extractor.go
2. *: Add explain info for InspectionRuleTableExtractor

Here is an example I query it locally：

```
mysql> desc select * from information_schema.inspection_rules where type='inspection';
+----------------+----------+------+------------------------+---------------------------+
| id             | estRows  | task | access object          | operator info             |
+----------------+----------+------+------------------------+---------------------------+
| MemTableScan_5 | 10000.00 | root | table:INSPECTION_RULES | node_types:["inspection"] |
+----------------+----------+------+------------------------+---------------------------+
1 row in set (0.00 sec)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
