### PR TITLE
add notes about plan cache hit

### DIFF
--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -348,7 +348,7 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 		note := errors.New("Hit plan cache: True")
 		sctx.GetSessionVars().StmtCtx.AppendNote(note)
 	} else {
-		note := errors.New("Hit plan cache: False c2")
+		note := errors.New("Hit plan cache: False")
 		sctx.GetSessionVars().StmtCtx.AppendNote(note)
 	}
 	return err

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -44,8 +44,8 @@ import (
 
 var planCacheCounter = metrics.PlanCacheCounter.WithLabelValues("prepare")
 
-var planCacheHintMiss = errors.New("Hit plan cache: False")
-var planCacheHintGot = errors.New("Hit plan cache: True")
+var planCacheHintMiss error
+var planCacheHintGot error
 
 // ShowDDL is for showing DDL information.
 type ShowDDL struct {
@@ -267,6 +267,12 @@ func (e *Execute) checkPreparedPriv(ctx context.Context, sctx sessionctx.Context
 }
 
 func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, preparedStmt *CachedPrepareStmt) error {
+	if planCacheHintMiss == nil {
+		planCacheHintMiss = errors.New("Hit plan cache: True")
+	}
+	if planCacheHintGot == nil {
+		planCacheHintGot = errors.New("Hit plan cache: False")
+	}
 	stmtCtx := sctx.GetSessionVars().StmtCtx
 	prepared := preparedStmt.PreparedAst
 	if prepared.CachedPlan != nil {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -271,6 +271,9 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 		// type from "paramMarker" to "Constant".When Point Select queries are executed,
 		// the expression in the where condition will not be evaluated,
 		// so you don't need to consider whether prepared.useCache is enabled.
+		note := errors.New("Hit plan cache: True")
+		sctx.GetSessionVars().StmtCtx.AppendNote(note)
+
 		plan := prepared.CachedPlan.(Plan)
 		names := prepared.CachedNames.(types.NameSlice)
 		err := e.rebuildRange(plan)
@@ -292,6 +295,8 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 	if prepared.UseCache {
 		cacheKey = NewPSTMTPlanCacheKey(sctx.GetSessionVars(), e.ExecID, prepared.SchemaVersion)
 		if cacheValue, exists := sctx.PreparedPlanCache().Get(cacheKey); exists {
+			note := errors.New("Hit plan cache: True")
+			sctx.GetSessionVars().StmtCtx.AppendNote(note)
 			if err := e.checkPreparedPriv(ctx, sctx, preparedStmt, is); err != nil {
 				return err
 			}
@@ -340,6 +345,11 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 		preparedStmt.NormalizedPlan, preparedStmt.PlanDigest = NormalizePlan(p)
 		stmtCtx.SetPlanDigest(preparedStmt.NormalizedPlan, preparedStmt.PlanDigest)
 		sctx.PreparedPlanCache().Put(cacheKey, cached)
+		note := errors.New("Hit plan cache: True")
+		sctx.GetSessionVars().StmtCtx.AppendNote(note)
+	} else {
+		note := errors.New("Hit plan cache: False c2")
+		sctx.GetSessionVars().StmtCtx.AppendNote(note)
 	}
 	return err
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #16127  <!-- REMOVE this line if no issue to close -->

### What is changed and how it works?

What's Changed: add some warnings about the plan cache in order to help test work.

How it Works: described in the issue discussion.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
After executing a prepared statement, we will store the plan cache hit information in the warning log.
`Hit plan cache: True` for a successful hit.
`Hit plan cache: False` for a miss.
