### PR TITLE
backoff: add single backoff for tikv error server is busy

### DIFF
--- a/kv/variables.go
+++ b/kv/variables.go
@@ -21,6 +21,9 @@ type Variables struct {
 	// BackOffWeight specifies the weight of the max back off time duration.
 	BackOffWeight int
 
+	// BackOffKVBusy specifies the weight of the max back off time duration for kv is busy.
+	BackOffKVBusy int
+
 	// Hook is used for test to verify the variable take effect.
 	Hook func(name string, vars *Variables)
 
@@ -34,6 +37,7 @@ func NewVariables(killed *uint32) *Variables {
 	return &Variables{
 		BackoffLockFast: DefBackoffLockFast,
 		BackOffWeight:   DefBackOffWeight,
+		BackOffKVBusy:   DefBackOffKVBusy,
 		Killed:          killed,
 	}
 }
@@ -47,4 +51,5 @@ var DefaultVars = NewVariables(&ignoreKill)
 const (
 	DefBackoffLockFast = 100
 	DefBackOffWeight   = 2
+	DefBackOffKVBusy   = 10
 )

--- a/session/session.go
+++ b/session/session.go
@@ -1918,6 +1918,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBWindowConcurrency,
 	variable.TiDBBackoffLockFast,
 	variable.TiDBBackOffWeight,
+	variable.TiDBBackOffKVBusy,
 	variable.TiDBConstraintCheckInPlace,
 	variable.TiDBDDLReorgWorkerCount,
 	variable.TiDBDDLReorgBatchSize,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1096,6 +1096,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.KVVars.BackoffLockFast = tidbOptPositiveInt32(val, kv.DefBackoffLockFast)
 	case TiDBBackOffWeight:
 		s.KVVars.BackOffWeight = tidbOptPositiveInt32(val, kv.DefBackOffWeight)
+	case TiDBBackOffKVBusy:
+		s.KVVars.BackOffKVBusy = tidbOptPositiveInt32(val, kv.DefBackOffKVBusy)
 	case TiDBConstraintCheckInPlace:
 		s.ConstraintCheckInPlace = TiDBOptOn(val)
 	case TiDBBatchInsert:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -664,6 +664,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBWindowConcurrency, strconv.Itoa(DefTiDBWindowConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBBackoffLockFast, strconv.Itoa(kv.DefBackoffLockFast)},
 	{ScopeGlobal | ScopeSession, TiDBBackOffWeight, strconv.Itoa(kv.DefBackOffWeight)},
+	{ScopeGlobal | ScopeSession, TiDBBackOffKVBusy, strconv.Itoa(kv.DefBackOffKVBusy)},
 	{ScopeGlobal | ScopeSession, TiDBRetryLimit, strconv.Itoa(DefTiDBRetryLimit)},
 	{ScopeGlobal | ScopeSession, TiDBDisableTxnAutoRetry, BoolToIntStr(DefTiDBDisableTxnAutoRetry)},
 	{ScopeGlobal | ScopeSession, TiDBConstraintCheckInPlace, BoolToIntStr(DefTiDBConstraintCheckInPlace)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -281,6 +281,10 @@ const (
 	// Only positive integers can be accepted, which means that the maximum back off time can only grow.
 	TiDBBackOffWeight = "tidb_backoff_weight"
 
+	// tidb_backoff_weight is used to control the max back off time for tikv is busy in TiDB.
+	// Only positive integers can be accepted, which means that the maximum back off time can only grow.
+	TiDBBackOffKVBusy = "tidb_backoff_kv_busy"
+
 	// tidb_ddl_reorg_worker_cnt defines the count of ddl reorg workers.
 	TiDBDDLReorgWorkerCount = "tidb_ddl_reorg_worker_cnt"
 

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -488,7 +488,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string) (string,
 		TiDBWindowConcurrency,
 		TiDBDistSQLScanConcurrency,
 		TiDBIndexSerialScanConcurrency, TiDBDDLReorgWorkerCount,
-		TiDBBackoffLockFast, TiDBBackOffWeight,
+		TiDBBackoffLockFast, TiDBBackOffWeight, TiDBBackOffKVBusy,
 		TiDBDMLBatchSize, TiDBOptimizerSelectivityLevel:
 		v, err := strconv.Atoi(value)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
If TiKV reports "Server is busy", it indicates that the cluster write pressure is high. Give TiKV more time to wait for TiKV to handle these write requests.

### What is changed and how it works?

Add a session variable **tidb_backoff_kv_busy** as the backoff weight for TiKV "Server is busy" error. The default value is 10.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
