### PR TITLE
tikv, server: turn on grpc channelz to help diagnosis and add wait conn establish metric

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -11929,6 +11929,7 @@
             {
               "expr": "histogram_quantile(0.95, sum(rate(tidb_tikvclient_batch_client_unavailable_seconds_bucket[1m])) by (le, instance))",
               "format": "time_series",
+              "hide": false,
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
               "refId": "A",
@@ -11983,7 +11984,7 @@
     }
   ],
   "refresh": "30s",
-  "schemaVersion": 18,
+  "schemaVersion": 20,
   "style": "dark",
   "tags": [],
   "templating": {

--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -11711,7 +11711,7 @@
           "dashLength": 10,
           "dashes": false,
           "datasource": "${DS_TEST-CLUSTER}",
-          "description": "kv storage batch processing unvailable durations",
+          "description": "kv storage batch client wait new connection establish duration",
           "editable": true,
           "error": false,
           "fill": 1,
@@ -11722,7 +11722,7 @@
             "x": 16,
             "y": 16
           },
-          "id": 180,
+          "id": 204,
           "legend": {
             "alignAsTable": true,
             "avg": false,
@@ -11748,7 +11748,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(0.95, sum(rate(tidb_tikvclient_batch_client_unavailable_seconds_bucket[1m])) by (le, instance))",
+              "expr": "histogram_quantile(0.9999, sum(rate(tidb_tikvclient_batch_client_wait_connection_establish_bucket[1m])) by (le, instance))",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{instance}}",
@@ -11760,7 +11760,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Batch Client Unavailable Duration 95",
+          "title": "Wait Connection Establish Duration",
           "tooltip": {
             "msResolution": false,
             "shared": true,
@@ -11868,6 +11868,99 @@
               "logBase": 1,
               "max": null,
               "min": null,
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_TEST-CLUSTER}",
+          "description": "kv storage batch processing unvailable durations",
+          "editable": true,
+          "error": false,
+          "fill": 1,
+          "grid": {},
+          "gridPos": {
+            "h": 7,
+            "w": 8,
+            "x": 16,
+            "y": 23
+          },
+          "id": 180,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 2,
+          "links": [],
+          "nullPointMode": "null as zero",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.95, sum(rate(tidb_tikvclient_batch_client_unavailable_seconds_bucket[1m])) by (le, instance))",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "{{instance}}",
+              "refId": "A",
+              "step": 10
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "Batch Client Unavailable Duration 95",
+          "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": "0",
               "show": true
             },
             {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -151,6 +151,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVPendingBatchRequests)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
 	prometheus.MustRegister(TiKVBatchClientUnavailable)
+	prometheus.MustRegister(TiKVBatchClientWaitEstablish)
 	prometheus.MustRegister(TiKVRangeTaskStats)
 	prometheus.MustRegister(TiKVRangeTaskPushDuration)
 	prometheus.MustRegister(HandleSchemaValidate)

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -173,6 +173,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms ~ 1000s
 			Help:      "batch client unavailable",
 		})
+	TiKVBatchClientWaitEstablish = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "batch_client_wait_connection_establish",
+			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms ~ 1000s
+			Help:      "batch client wait new connection establish",
+		})
 
 	TiKVRangeTaskStats = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -46,6 +46,7 @@ import (
 	"github.com/soheilhy/cmux"
 	"github.com/tiancaiamao/appdash/traceapp"
 	"go.uber.org/zap"
+	"google.golang.org/grpc/channelz/service"
 	static "sourcegraph.com/sourcegraph/appdash-data"
 )
 
@@ -305,6 +306,7 @@ func (s *Server) startStatusServerAndRPCServer(serverMux *http.ServeMux) {
 
 	s.statusServer = &http.Server{Addr: s.statusAddr, Handler: CorsHandler{handler: serverMux, cfg: s.cfg}}
 	s.grpcServer = NewRPCServer(s.cfg, s.dom, s)
+	service.RegisterChannelzServiceToServer(s.grpcServer)
 
 	go util.WithRecovery(func() {
 		err := s.grpcServer.Serve(grpcL)

--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -288,6 +288,13 @@ func (c *batchCommandsClient) failPendingRequests(err error) {
 }
 
 func (c *batchCommandsClient) waitConnReady() (err error) {
+	if c.conn.GetState() == connectivity.Ready {
+		return
+	}
+	start := time.Now()
+	defer func() {
+		metrics.TiKVBatchClientWaitEstablish.Observe(time.Since(start).Seconds())
+	}()
 	dialCtx, cancel := context.WithTimeout(context.Background(), dialTimeout)
 	for {
 		s := c.conn.GetState()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

[channelz](https://grpc.io/blog/a-short-introduction-to-channelz/) is one of two officially recommended tool to debug grpc question(another is log, tidb enable it by https://github.com/pingcap/tidb/pull/14140). 

and officially test said that turn it on by default is very low overhead, so maybe we can try it.

official [view tool ](https://github.com/grpc/grpc-experiments/tree/master/gdebug) need install npm and start other server.....very hard to use

but there are a unofficial tool https://github.com/kazegusuri/channelzcli seems be useful.

after this Patch,  TiDB status-port(default 10080) will export channelz service, then we can use https://github.com/kazegusuri/channelzcli:

1. which channels  TiDB used to connect other

```
./channelzcli -k --addr 0.0.0.0:10080 list channel                   
ID	Name                                                                            	State	Channel	SubChannel	Calls	Success	Fail	LastCall
1	127.0.0.1:2379                                                                  	READY	0      	1         	47    	46    	0     	8s      
4	endpoint://client-7dd43e13-d160-405d-aa72-d2fea023ba8e/127.0.0.1:2379           	READY	0      	1         	173   	173   	0     	8s      
7	127.0.0.1:40500                                                                 	READY	0      	1         	10    	9     	0     	21m     
9	127.0.0.1:40500                                                                 	READY	0      	1         	11    	10    	0     	21m     
11	127.0.0.1:40500                                                                 	READY	0      	1         	11    	10    	0     	21m     
13	127.0.0.1:40500                                                                 	READY	0      	1         	11    	10    	0     	20m     
22	endpoint://client-2618b91a-09c6-40ee-8dcd-ab67d4f783ba/127.0.0.1:2379           	READY	0      	2         	194   	192   	0     	5s    
```

`127.0.0.1:40500` is tikv and `127.0.0.1:2379` is pd

2. channel detail

```
./channelzcli -k --addr 0.0.0.0:10080 describe channel 7
Name:     	127.0.0.1:40500
ChannelID:	7
State:    	READY
Target:   	127.0.0.1:40500
Calls:
  Started:        	2
  Succeeded:      	0
  Failed:         	1
  LastCallStarted:	2020-04-09 16:17:41.317816978 +0000 UTC
Socket:   	<none>
Channels:   	<none>
Subchannels:
  ID	Name	State	Start	Succeeded	Failed
  8		READY	2	0	1
Trace:
  NumEvents:	46
  CreationTimestamp:	2020-04-09 16:16:46.19125706 +0000 UTC
  Events
    Severity	Description                                                                     	Timestamp
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:03.889785185 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:03.890119389 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:05.039407607 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:05.039660693 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:06.693333846 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:06.694109686 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:09.042878093 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:09.04324 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:12.42886261 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:12.429131451 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:14.859276276 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:14.85938234 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:18.209358109 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:18.20993323 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:21.187080916 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:21.18741749 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:24.321505023 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:24.321754044 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:27.014237302 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:27.014638801 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:29.947948483 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:29.948568087 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:32.519156992 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:32.519477234 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:35.416572618 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:35.41690579 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:38.220759965 +0000 UTC
    INFO	Channel Connectivity change to TRANSIENT_FAILURE                                	2020-04-09 16:17:38.221381207 +0000 UTC
    INFO	Channel Connectivity change to CONNECTING                                       	2020-04-09 16:17:41.316467407 +0000 UTC
    INFO	Channel Connectivity change to READY                                            	2020-04-09 16:17:41.317780751 +0000 UTC
```
we can see fail/success count and connection event log without change tidb code

and read more about tools in channelzcli's Readme.

and maybe we can integrate channelzcli https://github.com/kazegusuri/channelzcli/blob/master/channelz/client.go into TiDB-Dashboard in future

### What is changed and how it works?

What's Changed:

- turn on channelz by default
- add metric for wait conn establish

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - wait bench result

### Release note <!-- bugfixes or new feature need a release note -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16263)
<!-- Reviewable:end -->
