### PR TITLE
[DNM] executor: limit attachto the GlobalDiskTracker

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1563,7 +1563,8 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		MemTracker:  memory.NewTracker(stringutil.MemoizeStr(s.Text), vars.MemQuotaQuery),
 		DiskTracker: disk.NewTracker(stringutil.MemoizeStr(s.Text), -1),
 	}
-	if config.GetGlobalConfig().OOMUseTmpStorage && GlobalDiskUsageTracker != nil {
+	// we only attach the GlobalDiskUsageTracker only when OOMUseTmpStorage is enabled and TempStorageQuota >= 0
+	if config.GetGlobalConfig().OOMUseTmpStorage && GlobalDiskUsageTracker != nil && config.GetGlobalConfig().TempStorageQuota >= 0 {
 		sc.DiskTracker.AttachTo(GlobalDiskUsageTracker)
 	}
 	switch config.GetGlobalConfig().OOMAction {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1564,10 +1564,11 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		DiskTracker: disk.NewTracker(stringutil.MemoizeStr(s.Text), -1),
 	}
 	// we only attach the GlobalDiskUsageTracker only when OOMUseTmpStorage is enabled and TempStorageQuota >= 0
-	if config.GetGlobalConfig().OOMUseTmpStorage && GlobalDiskUsageTracker != nil && config.GetGlobalConfig().TempStorageQuota >= 0 {
+	c := config.GetGlobalConfig()
+	if c.OOMUseTmpStorage && c.TempStorageQuota >= 0 && GlobalDiskUsageTracker != nil {
 		sc.DiskTracker.AttachTo(GlobalDiskUsageTracker)
 	}
-	switch config.GetGlobalConfig().OOMAction {
+	switch c.OOMAction {
 	case config.OOMActionCancel:
 		action := &memory.PanicOnExceed{ConnID: ctx.GetSessionVars().ConnectionID}
 		action.SetLogHook(domain.GetDomain(ctx).ExpensiveQueryHandle().LogOnQueryExceedMemQuota)

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -131,8 +131,6 @@ func (t *Tracker) Detach() {
 		return
 	}
 	t.parent.remove(t)
-	t.mu.Lock()
-	defer t.mu.Unlock()
 	t.parent = nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
The quota of GlobalDiskTracker is unlimited in default while the executors' disktracker would still attach to the GlobalDiskTracker which would cause the pointless mutex contention.


What's Changed:
Only when `OOMUseTmpStorage` is enabled and `TempStorageQuota` is bigger than 0, we would attach the executors' disktracker to the GlobalDiskTracker.

### Release note <!-- bugfixes or new feature need a release note -->
None