### PR TITLE
server: change log frequency, add flag to quit drain loop

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1165,9 +1165,16 @@ func (cc *clientConn) handleLoadData(ctx context.Context, loadDataInfo *executor
 	err = loadDataInfo.CommitWork(ctx)
 	wg.Wait()
 	if err != nil {
+		if !loadDataInfo.Drained {
+			logutil.Logger(ctx).Info("not drained yet, try reading left data from client connection")
+		}
 		// drain the data from client conn util empty packet received, otherwise the connection will be reset
 		for !loadDataInfo.Drained {
-			logutil.Logger(ctx).Info("not drained yet, try reading left data from client connection")
+			// check kill flag again, let the draining loop could quit if empty packet could not be received
+			if atomic.CompareAndSwapUint32(&loadDataInfo.Ctx.GetSessionVars().Killed, 1, 0) {
+				logutil.Logger(ctx).Warn("receiving kill, stop draining data, connection may be reset")
+				return executor.ErrQueryInterrupted
+			}
 			curData, err1 := cc.readPacket()
 			if err1 != nil {
 				logutil.Logger(ctx).Error("drain reading left data encounter errors", zap.Error(err1))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
When the `load data` statement meets error, the drain loop may print a lot of logs, like
` [INFO] [conn.go:1170] ["not drained yet, try reading left data from client connection"] `

### What is changed and how it works?

What's Changed:
Do not log logs during draining data, add kill flag check to let the drain loop could be break if there are some other errors

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
1. start load data
2. kill tidb query
3. kill tidb query again, client get connection reset error

Side effects



### Release note <!-- bugfixes or new feature need a release note -->
