### PR TITLE
Util: Fix global tracker mutex contention

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1564,7 +1564,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		DiskTracker: disk.NewTracker(stringutil.MemoizeStr(s.Text), -1),
 	}
 	c := config.GetGlobalConfig()
-	if c.OOMUseTmpStorage && c.TempStorageQuota >= 0 && GlobalDiskUsageTracker != nil {
+	if c.OOMUseTmpStorage && GlobalDiskUsageTracker != nil {
 		sc.DiskTracker.AttachTo(GlobalDiskUsageTracker)
 	}
 	switch c.OOMAction {

--- a/util/disk/tracker.go
+++ b/util/disk/tracker.go
@@ -24,3 +24,6 @@ type Tracker = memory.Tracker
 //	1. "label" is the label used in the usage string.
 //	2. "bytesLimit <= 0" means no limit.
 var NewTracker = memory.NewTracker
+
+// NewGlobalTracker creates a global tracker
+var NewGlobalTracker = memory.NewGlobalTracker

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -134,9 +134,11 @@ func (t *Tracker) AttachTo(parent *Tracker) {
 	if t.parent != nil {
 		t.parent.remove(t)
 	}
-	parent.mu.Lock()
-	parent.mu.children = append(parent.mu.children, t)
-	parent.mu.Unlock()
+	if !parent.globalTracker {
+		parent.mu.Lock()
+		parent.mu.children = append(parent.mu.children, t)
+		parent.mu.Unlock()
+	}
 
 	t.parent = parent
 	t.parent.Consume(t.BytesConsumed())

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -134,11 +134,9 @@ func (t *Tracker) AttachTo(parent *Tracker) {
 	if t.parent != nil {
 		t.parent.remove(t)
 	}
-	if !parent.globalTracker {
-		parent.mu.Lock()
-		parent.mu.children = append(parent.mu.children, t)
-		parent.mu.Unlock()
-	}
+	parent.mu.Lock()
+	parent.mu.children = append(parent.mu.children, t)
+	parent.mu.Unlock()
 
 	t.parent = parent
 	t.parent.Consume(t.BytesConsumed())

--- a/util/memory/tracker_test.go
+++ b/util/memory/tracker_test.go
@@ -249,11 +249,12 @@ func (s *testSuite) TestReplaceChild(c *C) {
 	c.Assert(c1.parent, Equals, g)
 	c.Assert(len(g.mu.children), Equals, 0)
 
+	// ReplaceChild didn't work as GlobalTracker didn't support ReplaceChild
 	c2.Consume(200)
 	g.ReplaceChild(c1, c2)
-	c.Assert(g.BytesConsumed(), Equals, int64(200))
-	c.Assert(c1.parent, IsNil)
-	c.Assert(c2.parent, DeepEquals, g)
+	c.Assert(g.BytesConsumed(), Equals, int64(100))
+	c.Assert(c1.parent, DeepEquals, g)
+	c.Assert(c2.parent, IsNil)
 	c.Assert(len(g.mu.children), Equals, 0)
 }
 
@@ -306,10 +307,15 @@ func (s *testSuite) TestToString(c *C) {
 	c3.AttachTo(g)
 	c4.AttachTo(g)
 
-	child1.Consume(100)
-	child2.Consume(2 * 1024)
-	child3.Consume(3 * 1024 * 1024)
-	child4.Consume(4 * 1024 * 1024 * 1024)
+	c1.Consume(100)
+	c2.Consume(2 * 1024)
+	c3.Consume(3 * 1024 * 1024)
+	c4.Consume(4 * 1024 * 1024 * 1024)
+	c.Assert(g.String(), Equals, `
+"parent"{
+  "consumed": 4.00293168798089 GB
+}
+`)
 }
 
 func (s *testSuite) TestMaxConsumed(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

For the Global Tracker, the Attaching and Detaching would cause the mutex contention which would decrease the qps.

Issue Number: close https://github.com/pingcap/tidb/issues/16258

Problem Summary:

### What is changed and how it works?

How it Works:
Import the Global flag in the Tracker, if the flag is true, it would skip the logic for solving the children relationship as it is unnecessary.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
