### PR TITLE
tikv: fix RowKVClient scan method can't rightly break loop (#14365)

### DIFF
--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -302,7 +302,7 @@ func (c *RawKVClient) Scan(startKey, endKey []byte, limit int) (keys [][]byte, v
 		return nil, nil, errors.Trace(ErrMaxScanLimitExceeded)
 	}
 
-	for len(keys) < limit {
+	for len(keys) < limit && (len(endKey) == 0 || bytes.Compare(startKey, endKey) < 0) {
 		req := &tikvrpc.Request{
 			Type: tikvrpc.CmdRawScan,
 			RawScan: &kvrpcpb.RawScanRequest{
@@ -348,7 +348,7 @@ func (c *RawKVClient) ReverseScan(startKey, endKey []byte, limit int) (keys [][]
 		return nil, nil, errors.Trace(ErrMaxScanLimitExceeded)
 	}
 
-	for len(keys) < limit {
+	for len(keys) < limit && bytes.Compare(startKey, endKey) > 0 {
 		req := &tikvrpc.Request{
 			Type: tikvrpc.CmdRawScan,
 			RawScan: &kvrpcpb.RawScanRequest{


### PR DESCRIPTION
cherry-pick for https://github.com/pingcap/tidb/pull/14365