### PR TITLE
session: invalid pending txn if it's a empty stmt

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1047,7 +1047,12 @@ func (s *session) execute(ctx context.Context, sql string) (recordSets []sqlexec
 	} else {
 		sessionExecuteParseDurationGeneral.Observe(durParse.Seconds())
 	}
-
+	if len(stmtNodes) == 0 {
+		if s.txn.pending() {
+			s.txn.changeToInvalid()
+		}
+		return recordSets, nil
+	}
 	var tempStmtNodes []ast.StmtNode
 	compiler := executor.Compiler{Ctx: s}
 	multiQuery := len(stmtNodes) > 1


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/15716 in 3.0

https://github.com/pingcap/tidb/pull/11981 has fixed it in 4.0

Problem Summary:

execute ‘-- T1’ will be parsed as empty stmt and start a txn but without closing it after empty stmt finished

### What is changed and how it works?

What's Changed:

close txn after empty stmt returned

How it Works:

close txn after empty stmt returned

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test(WIP)
- Manual test (add detailed scripts or steps below)

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

invalid pending txn if it's a empty stmt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16325)
<!-- Reviewable:end -->
