### PR TITLE
session: add compile and execute time metric for prepare statement

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1210,8 +1210,15 @@ func (s *session) CommonExec(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	sessionExecuteCompileDurationGeneral.Observe(time.Since(s.sessionVars.StartTime).Seconds())
+	startTime := time.Now()
 	logQuery(st.OriginText(), s.sessionVars)
-	return runStmt(ctx, s, st)
+	recordSet, err := runStmt(ctx, s, st)
+	if err != nil {
+		return nil, err
+	}
+	sessionExecuteRunDurationGeneral.Observe(time.Since(startTime).Seconds())
+	return recordSet, nil
 }
 
 // CachedPlanExec short path currently ONLY for cached "point select plan" execution
@@ -1239,7 +1246,11 @@ func (s *session) CachedPlanExec(ctx context.Context,
 		OutputNames: execPlan.OutputNames(),
 		PsStmt:      prepareStmt,
 	}
-	s.GetSessionVars().DurationCompile = time.Since(s.sessionVars.StartTime)
+	compileDuration := time.Since(s.sessionVars.StartTime)
+	sessionExecuteCompileDurationGeneral.Observe(compileDuration.Seconds())
+	s.GetSessionVars().DurationCompile = compileDuration
+
+	startTime := time.Now()
 	stmt.Text = prepared.Stmt.Text()
 	stmtCtx.OriginalSQL = stmt.Text
 	stmtCtx.InitSQLDigest(prepareStmt.NormalizedSQL, prepareStmt.SQLDigest)
@@ -1260,6 +1271,7 @@ func (s *session) CachedPlanExec(ctx context.Context,
 		prepared.CachedPlan = nil
 		return nil, errors.Errorf("invalid cached plan type")
 	}
+	sessionExecuteRunDurationGeneral.Observe(time.Since(startTime).Seconds())
 	return resultSet, err
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -1214,11 +1214,8 @@ func (s *session) CommonExec(ctx context.Context,
 	startTime := time.Now()
 	logQuery(st.OriginText(), s.sessionVars)
 	recordSet, err := runStmt(ctx, s, st)
-	if err != nil {
-		return nil, err
-	}
 	sessionExecuteRunDurationGeneral.Observe(time.Since(startTime).Seconds())
-	return recordSet, nil
+	return recordSet, err
 }
 
 // CachedPlanExec short path currently ONLY for cached "point select plan" execution


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

As the title said. Before this PR, TiDB doesn't record the compile and execute metrics when executing the prepared statement.

### What is changed and how it works?


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->
- Add compile and execute time metrics for prepare statements.