### PR TITLE
executor, planner: make update work when updateList does not contains view columns

### DIFF
--- a/executor/update.go
+++ b/executor/update.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
-	"github.com/sirupsen/logrus"
 )
 
 // UpdateExec represents a new update executor.
@@ -135,7 +134,6 @@ func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 
 func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	fields := retTypes(e.children[0])
-	logrus.Warning("len(fields)", len(fields))
 	colsInfo := make([]*table.Column, len(fields))
 	for _, content := range e.tblColPosInfos {
 		tbl := e.tblID2table[content.TblID]
@@ -154,14 +152,12 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	}
 	memUsageOfChk := int64(0)
 	totalNumRows := 0
-	logrus.Warning(e.children[0].Schema().Columns)
 	for {
 		e.memTracker.Consume(-memUsageOfChk)
 		err := Next(ctx, e.children[0], chk)
 		if err != nil {
 			return 0, err
 		}
-		logrus.Warning("chk.NumCols()", chk.NumCols(), " chk.numrows ", chk.NumRows())
 
 		if chk.NumRows() == 0 {
 			break
@@ -169,7 +165,6 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 		memUsageOfChk = chk.MemoryUsage()
 		e.memTracker.Consume(memUsageOfChk)
 		for rowIdx := 0; rowIdx < chk.NumRows(); rowIdx++ {
-			logrus.Warning("rowIdx", rowIdx)
 			chunkRow := chk.GetRow(rowIdx)
 			datumRow := chunkRow.GetDatumRow(fields)
 			newRow, err1 := composeFunc(globalRowIdx, datumRow, colsInfo)

--- a/executor/update.go
+++ b/executor/update.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
+	"github.com/sirupsen/logrus"
 )
 
 // UpdateExec represents a new update executor.
@@ -134,6 +135,7 @@ func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 
 func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	fields := retTypes(e.children[0])
+	logrus.Warning("len(fields)", len(fields))
 	colsInfo := make([]*table.Column, len(fields))
 	for _, content := range e.tblColPosInfos {
 		tbl := e.tblID2table[content.TblID]
@@ -152,12 +154,14 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 	}
 	memUsageOfChk := int64(0)
 	totalNumRows := 0
+	logrus.Warning(e.children[0].Schema().Columns)
 	for {
 		e.memTracker.Consume(-memUsageOfChk)
 		err := Next(ctx, e.children[0], chk)
 		if err != nil {
 			return 0, err
 		}
+		logrus.Warning("chk.NumCols()", chk.NumCols(), " chk.numrows ", chk.NumRows())
 
 		if chk.NumRows() == 0 {
 			break
@@ -165,6 +169,7 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 		memUsageOfChk = chk.MemoryUsage()
 		e.memTracker.Consume(memUsageOfChk)
 		for rowIdx := 0; rowIdx < chk.NumRows(); rowIdx++ {
+			logrus.Warning("rowIdx", rowIdx)
 			chunkRow := chk.GetRow(rowIdx)
 			datumRow := chunkRow.GetDatumRow(fields)
 			newRow, err1 := composeFunc(globalRowIdx, datumRow, colsInfo)

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -302,6 +302,21 @@ func (s *testSuite) TestInsert(c *C) {
 	tk.MustExec("drop view v")
 }
 
+func (s *testSuite) TestIssue16253(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t1")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values(1)")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("insert into t1 values(1)")
+	tk.MustExec("CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`127.0.0.1` SQL SECURITY DEFINER VIEW v_16253 as select * from t1")
+	tk.MustExec("update t,v_16253 set t.a = 2 where t.a = v_16253.a")
+	_, err := tk.Exec("update t,v_16253 set v_16253.a = 2 where t.a=v_16253.a")
+	c.Assert(err.Error(), Equals, "")
+	tk.MustExec("drop view v_16253")
+}
+
 func (s *testSuiteP2) TestMultiBatch(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3012,7 +3012,6 @@ func (b *PlanBuilder) buildProjUponView(ctx context.Context, dbName model.CIStr,
 		projSchema.Append(&expression.Column{
 			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
 			RetType:  cols[i].GetType(),
-			OrigName: origColName.L,
 		})
 		projExprs = append(projExprs, cols[i])
 	}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -45,7 +45,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	util2 "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	utilhint "github.com/pingcap/tidb/util/hint"


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16253  <!-- REMOVE this line if no issue to close -->

Problem Summary:
If an update statement queries data from a view, but the update list does not contains a view. We should not forbidden this sql.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
1. Prune useless column for update.SelectPlan
2. Check whether the update lists contain columns from view.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->
