### PR TITLE
plan: make query on partition table not cacheable

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -178,7 +178,7 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		SchemaVersion: e.is.SchemaMetaVersion(),
 	}
 
-	prepared.UseCache = plannercore.PreparedPlanCacheEnabled() && plannercore.Cacheable(stmt)
+	prepared.UseCache = plannercore.PreparedPlanCacheEnabled() && plannercore.Cacheable(stmt, e.is)
 
 	// We try to build the real statement of preparedStmt.
 	for i := range prepared.Params {

--- a/planner/core/cacheable_checker.go
+++ b/planner/core/cacheable_checker.go
@@ -122,8 +122,8 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 func (checker *cacheableChecker) isPartitionTable(tn *ast.TableName) bool {
 	tb, err := checker.schema.TableByName(tn.Schema, tn.Name)
 	if err != nil {
-		return false
 		logutil.BgLogger().Error("Error occur in checking cacheable", zap.Error(err))
+		return false
 	}
 	if tb.Meta().Partition != nil {
 		return true

--- a/planner/core/cacheable_checker.go
+++ b/planner/core/cacheable_checker.go
@@ -18,6 +18,8 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/types/parser_driver"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
 )
 
 // Cacheable checks whether the input ast is cacheable.
@@ -118,7 +120,11 @@ func (checker *cacheableChecker) Enter(in ast.Node) (out ast.Node, skipChildren 
 }
 
 func (checker *cacheableChecker) isPartitionTable(tn *ast.TableName) bool {
-	tb, _ := checker.schema.TableByName(tn.Schema, tn.Name)
+	tb, err := checker.schema.TableByName(tn.Schema, tn.Name)
+	if err != nil {
+		return false
+		logutil.BgLogger().Error("Error occur in checking cacheable", zap.Error(err))
+	}
 	if tb.Meta().Partition != nil {
 		return true
 	}

--- a/planner/core/cacheable_checker_test.go
+++ b/planner/core/cacheable_checker_test.go
@@ -11,14 +11,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package core
+package core_test
 
 import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/types/parser_driver"
+	"github.com/pingcap/tidb/util/testkit"
 )
 
 var _ = Suite(&testCacheableSuite{})
@@ -27,20 +30,33 @@ type testCacheableSuite struct {
 }
 
 func (s *testCacheableSuite) TestCacheable(c *C) {
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk.MustExec("use test")
+	tk.MustExec("create table t1(a int, b int) partition by range(a) ( partition p0 values less than (6), partition p1 values less than (11) )")
+	tk.MustExec("create table t2(a int, b int) partition by hash(a) partitions 11")
+	tk.MustExec("create table t3(a int, b int)")
+	tbl := &ast.TableName{Schema: model.NewCIStr("test"), Name: model.NewCIStr("t3")}
+	is := infoschema.GetInfoSchema(tk.Se)
 	// test non-SelectStmt/-InsertStmt/-DeleteStmt/-UpdateStmt/-SelectStmt
 	var stmt ast.Node = &ast.UnionStmt{}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	stmt = &ast.ShowStmt{}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	stmt = &ast.LoadDataStmt{}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
-	tableRefsClause := &ast.TableRefsClause{TableRefs: &ast.Join{Left: &ast.TableSource{Source: &ast.TableName{}}}}
+	tableRefsClause := &ast.TableRefsClause{TableRefs: &ast.Join{Left: &ast.TableSource{Source: tbl}}}
 	// test InsertStmt
 	stmt = &ast.InsertStmt{Table: tableRefsClause}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	// test DeleteStmt
 	whereExpr := &ast.FuncCallExpr{}
@@ -48,21 +64,21 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Where:     whereExpr,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	for funcName := range expression.UnCacheableFunctions {
 		whereExpr.FnName = model.NewCIStr(funcName)
-		c.Assert(Cacheable(stmt), IsFalse)
+		c.Assert(core.Cacheable(stmt, is), IsFalse)
 	}
 
 	whereExpr.FnName = model.NewCIStr(ast.Rand)
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt = &ast.DeleteStmt{
 		TableRefs: tableRefsClause,
 		Where:     &ast.ExistsSubqueryExpr{},
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt := &ast.Limit{
 		Count: &driver.ParamMarkerExpr{},
@@ -71,7 +87,7 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{
 		Offset: &driver.ParamMarkerExpr{},
@@ -80,19 +96,19 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{}
 	stmt = &ast.DeleteStmt{
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt.(*ast.DeleteStmt).TableHints = append(stmt.(*ast.DeleteStmt).TableHints, &ast.TableOptimizerHint{
-		HintName: model.NewCIStr(HintIgnorePlanCache),
+		HintName: model.NewCIStr(core.HintIgnorePlanCache),
 	})
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	// test UpdateStmt
 	whereExpr = &ast.FuncCallExpr{}
@@ -100,21 +116,21 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Where:     whereExpr,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	for funcName := range expression.UnCacheableFunctions {
 		whereExpr.FnName = model.NewCIStr(funcName)
-		c.Assert(Cacheable(stmt), IsFalse)
+		c.Assert(core.Cacheable(stmt, is), IsFalse)
 	}
 
 	whereExpr.FnName = model.NewCIStr(ast.Rand)
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt = &ast.UpdateStmt{
 		TableRefs: tableRefsClause,
 		Where:     &ast.ExistsSubqueryExpr{},
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{
 		Count: &driver.ParamMarkerExpr{},
@@ -123,7 +139,7 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{
 		Offset: &driver.ParamMarkerExpr{},
@@ -132,39 +148,39 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{}
 	stmt = &ast.UpdateStmt{
 		TableRefs: tableRefsClause,
 		Limit:     limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt.(*ast.UpdateStmt).TableHints = append(stmt.(*ast.UpdateStmt).TableHints, &ast.TableOptimizerHint{
-		HintName: model.NewCIStr(HintIgnorePlanCache),
+		HintName: model.NewCIStr(core.HintIgnorePlanCache),
 	})
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	// test SelectStmt
 	whereExpr = &ast.FuncCallExpr{}
 	stmt = &ast.SelectStmt{
 		Where: whereExpr,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	for funcName := range expression.UnCacheableFunctions {
 		whereExpr.FnName = model.NewCIStr(funcName)
-		c.Assert(Cacheable(stmt), IsFalse)
+		c.Assert(core.Cacheable(stmt, is), IsFalse)
 	}
 
 	whereExpr.FnName = model.NewCIStr(ast.Rand)
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt = &ast.SelectStmt{
 		Where: &ast.ExistsSubqueryExpr{},
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{
 		Count: &driver.ParamMarkerExpr{},
@@ -172,7 +188,7 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 	stmt = &ast.SelectStmt{
 		Limit: limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{
 		Offset: &driver.ParamMarkerExpr{},
@@ -180,33 +196,55 @@ func (s *testCacheableSuite) TestCacheable(c *C) {
 	stmt = &ast.SelectStmt{
 		Limit: limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	limitStmt = &ast.Limit{}
 	stmt = &ast.SelectStmt{
 		Limit: limitStmt,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	paramExpr := &driver.ParamMarkerExpr{}
 	orderByClause := &ast.OrderByClause{Items: []*ast.ByItem{{Expr: paramExpr}}}
 	stmt = &ast.SelectStmt{
 		OrderBy: orderByClause,
 	}
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	valExpr := &driver.ValueExpr{}
 	orderByClause = &ast.OrderByClause{Items: []*ast.ByItem{{Expr: valExpr}}}
 	stmt = &ast.SelectStmt{
 		OrderBy: orderByClause,
 	}
-	c.Assert(Cacheable(stmt), IsTrue)
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 
 	stmt.(*ast.SelectStmt).TableHints = append(stmt.(*ast.SelectStmt).TableHints, &ast.TableOptimizerHint{
-		HintName: model.NewCIStr(HintIgnorePlanCache),
+		HintName: model.NewCIStr(core.HintIgnorePlanCache),
 	})
-	c.Assert(Cacheable(stmt), IsFalse)
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
 
 	boundExpr := &ast.FrameBound{Expr: &driver.ParamMarkerExpr{}}
-	c.Assert(Cacheable(boundExpr), IsFalse)
+	c.Assert(core.Cacheable(boundExpr, is), IsFalse)
+
+	// Partition table can not be cached.
+	join := &ast.Join{
+		Left:  &ast.TableName{Schema: model.NewCIStr("test"), Name: model.NewCIStr("t1")},
+		Right: &ast.TableName{Schema: model.NewCIStr("test"), Name: model.NewCIStr("t2")},
+	}
+	stmt = &ast.SelectStmt{
+		From: &ast.TableRefsClause{
+			TableRefs: join,
+		},
+	}
+	c.Assert(core.Cacheable(stmt, is), IsFalse)
+
+	join = &ast.Join{
+		Left: &ast.TableName{Schema: model.NewCIStr("test"), Name: model.NewCIStr("t3")},
+	}
+	stmt = &ast.SelectStmt{
+		From: &ast.TableRefsClause{
+			TableRefs: join,
+		},
+	}
+	c.Assert(core.Cacheable(stmt, is), IsTrue)
 }

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -348,9 +348,12 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 	}
 	e.names = names
 	e.Plan = p
-	isRange := e.isRangePartition(p)
 	_, isTableDual := p.(*PhysicalTableDual)
-	if !isTableDual && prepared.UseCache && !isRange {
+	if !isTableDual && prepared.UseCache {
+		err = e.setFoundInPlanCache(sctx, true)
+		if err != nil {
+			return err
+		}
 		cached := NewPSTMTPlanCacheValue(p, names, stmtCtx.TblInfo2UnionScan)
 		preparedStmt.NormalizedPlan, preparedStmt.PlanDigest = NormalizePlan(p)
 		stmtCtx.SetPlanDigest(preparedStmt.NormalizedPlan, preparedStmt.PlanDigest)
@@ -524,36 +527,6 @@ func (e *Execute) rebuildRange(p Plan) error {
 		}
 	}
 	return nil
-}
-
-func checkRangePartitionInfo(pi *model.PartitionInfo) bool {
-	if pi != nil && pi.Type == model.PartitionTypeRange {
-		return true
-	}
-	return false
-}
-
-// Prepare plan cache is not support query plan on range partition table.
-func (e *Execute) isRangePartition(p Plan) bool {
-	isRange := false
-	switch x := p.(type) {
-	case *PhysicalTableReader:
-		ts := x.TablePlans[0].(*PhysicalTableScan)
-		return checkRangePartitionInfo(ts.Table.Partition)
-	case *PhysicalIndexLookUpReader:
-		is := x.IndexPlans[0].(*PhysicalIndexScan)
-		return checkRangePartitionInfo(is.Table.Partition)
-	case *PhysicalIndexReader:
-		is := x.IndexPlans[0].(*PhysicalIndexScan)
-		return checkRangePartitionInfo(is.Table.Partition)
-	case PhysicalPlan:
-		for _, child := range x.Children() {
-			if e.isRangePartition(child) {
-				isRange = true
-			}
-		}
-	}
-	return isRange
 }
 
 func (e *Execute) buildRangeForIndexScan(sctx sessionctx.Context, is *PhysicalIndexScan) ([]*ranger.Range, error) {

--- a/server.toml
+++ b/server.toml
@@ -1,0 +1,4 @@
+[prepared-plan-cache]
+enabled = true
+capacity = 100
+memory-guard-ratio = 0.1

--- a/server.toml
+++ b/server.toml
@@ -1,4 +1,0 @@
-[prepared-plan-cache]
-enabled = true
-capacity = 100
-memory-guard-ratio = 0.1


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16364  <!-- REMOVE this line if no issue to close -->

Problem Summary:
#15697 will check whether plan is a query on partition table and will pass by if is true. But there is still some problems bring by `stmtCtx.UseCache`. If a plan is `Cacheable`, `stmtCtx.UseCache` is set to `true`. So the `simpleRewriter` has different output compare with not cached plan. 

For example, in #16364. If prepare-plan-cache is on, although query on partition table is not cached, it has different plan.

not use cache:
`lt(test.employees.id, 3) `
use cache:
`lt(cast(test.employees.id), 3)`

this small change in `rewriter` cause partition pruning fail.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
add partition check in `Cacheable` function rather than `getPhysicalPlan`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->
