### PR TITLE
test: revert PR#16387

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 			|| { $(FAILPOINT_DISABLE); exit 1; }
 else
 	@echo "Running in native mode."
-	@export log_level=info; export TZ='Asia/Shanghai'; \
+	@export log_level=fatal; export TZ='Asia/Shanghai'; \
 	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) -check.p true -check.timeout 4s || { $(FAILPOINT_DISABLE); exit 1; }
 endif
 	@$(FAILPOINT_DISABLE)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

#16387 try to modify log level to `info` in CI environment, but actually it do nothing with CI environment. So we revert this change.


### What is changed and how it works?

What's Changed:

Modify log level in `Makefile` back to `fatal`


### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- None

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->
