### PR TITLE
planner: fix different err msg from MySQL when group by window function (#16134)

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1589,6 +1589,10 @@ func (g *gbyResolver) Leave(inNode ast.Node) (ast.Node, bool) {
 			g.err = ErrWrongGroupField.GenWithStackByArgs(g.fields[pos-1].Text())
 			return inNode, false
 		}
+		if _, ok := ret.(*ast.WindowFuncExpr); ok {
+			g.err = ErrWrongGroupField.GenWithStackByArgs(g.fields[pos-1].Text())
+			return inNode, false
+		}
 		return ret, true
 	case *ast.ValuesExpr:
 		if v.Column == nil {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2120,7 +2120,8 @@ func (s *testPlanSuite) TestNameResolver(c *C) {
 		{"delete a from (select * from t ) as a, t", "[planner:1288]The target table a of the DELETE is not updatable"},
 		{"delete b from (select * from t ) as a, t", "[planner:1109]Unknown table 'b' in MULTI DELETE"},
 		{"select '' as fakeCol from t group by values(fakeCol)", "[planner:1054]Unknown column '' in 'VALUES() function'"},
-		{"update t, (select * from t) as b set b.a = t.a", "[planner:1288]The target table b of the UPDATE is not updatable"},
+		{"update t, (select * from ht) as b set b.a = t.a", "[planner:1288]The target table b of the UPDATE is not updatable"},
+		{"select row_number() over () from t group by 1", "[planner:1056]Can't group on 'row_number() over ()'"},
 	}
 
 	ctx := context.Background()

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -51,7 +51,9 @@ type testPlanSuite struct {
 func (s *testPlanSuite) SetUpSuite(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{MockSignedTable(), MockView()})
 	s.ctx = MockContext()
+	s.ctx.GetSessionVars().EnableWindowFunction = true
 	s.Parser = parser.New()
+	s.Parser.EnableWindowFunc(true)
 }
 
 func (s *testPlanSuite) TestPredicatePushDown(c *C) {


### PR DESCRIPTION
cherry-pick #16134 to release-3.1


---
### What problem does this PR solve?

Issue Number: close #11518

Problem Summary: When GROUP BY is followed by a number in a select stmt and this number correspond to a window function in select fields, TiDB prints a different error message from MySQL.

### What is changed and how it works?

What's Changed: When dealing with ast.PositionExpr in gbyResolver's Leave() method, we check if it's a ast.WindowFuncExpr. If so, ErrWrongGroupField will occur, which is expected.

### Check List

Tests 
- Unit test

