### PR TITLE
ddl: create partition table fail with strconv.ParseInt invalid syntax

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -273,6 +273,10 @@ func (s *testIntegrationSuite3) TestCreateTableWithPartition(c *C) {
 	tk.MustGetErrCode(`create table t34 (dt datetime) partition by range (unix_timestamp(dt)) (
 		partition p0 values less than (unix_timestamp('2020-04-04 00:00:00')),
 		partition p1 values less than (unix_timestamp('2020-04-05 00:00:00')));`, tmysql.ErrWrongExprInPartitionFunc)
+
+	// Fix https://github.com/pingcap/tidb/issues/16333
+	tk.MustExec(`create table t (dt timestamp) partition by range (unix_timestamp(dt))
+(partition p0 values less than (unix_timestamp('2020-04-15 00:00:00')));`)
 }
 
 func (s *testIntegrationSuite2) TestCreateTableWithHashPartition(c *C) {

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -275,7 +275,7 @@ func (s *testIntegrationSuite3) TestCreateTableWithPartition(c *C) {
 		partition p1 values less than (unix_timestamp('2020-04-05 00:00:00')));`, tmysql.ErrWrongExprInPartitionFunc)
 
 	// Fix https://github.com/pingcap/tidb/issues/16333
-	tk.MustExec(`create table t (dt timestamp) partition by range (unix_timestamp(dt))
+	tk.MustExec(`create table t35 (dt timestamp) partition by range (unix_timestamp(dt))
 (partition p0 values less than (unix_timestamp('2020-04-15 00:00:00')));`)
 }
 

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -470,7 +470,7 @@ func checkPartitionFuncType(ctx sessionctx.Context, s *ast.CreateTableStmt, tblI
 func checkCreatePartitionValue(ctx sessionctx.Context, tblInfo *model.TableInfo) error {
 	pi := tblInfo.Partition
 	defs := pi.Definitions
-	if len(defs) <= 1 {
+	if len(defs) == 0 {
 		return nil
 	}
 


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/16333

Problem Summary:

```
mysql> create table t (dt timestamp) partition by range (unix_timestamp(dt)) (partition p0 values less than (unix_timestamp('2020-04-15 00:00:00')));
ERROR 1105 (HY000): strconv.ParseInt: parsing "unix_timestamp(\"2020-04-15 00:00:00\")": invalid syntax
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Fix bug

How it Works:

During the create of the table, the partition information should be convert to integer.
The 'less than xxx' part of a partition in the model should be integers.

I don't know why it's broken and which PR cause this.
4.0 is  fine.



Tests <!-- At least one of them must be included. -->

- Unit test

