### PR TITLE
session: fix unseccessfully isolation read engines init session

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -568,6 +568,7 @@ func setGlobalVars() {
 	variable.SysVars[variable.Socket].Value = cfg.Socket
 	variable.SysVars[variable.DataDir].Value = cfg.Path
 	variable.SysVars[variable.TiDBSlowQueryFile].Value = cfg.Log.SlowQueryFile
+	variable.SysVars[variable.TiDBIsolationReadEngines].Value = strings.Join(cfg.IsolationRead.Engines, ", ")
 
 	// For CI environment we default enable prepare-plan-cache.
 	plannercore.SetPreparedPlanCache(config.CheckTableBeforeDrop || cfg.PreparedPlanCache.Enabled)

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -40,13 +40,13 @@ var _ = Suite(&testMainSuite{})
 type testMainSuite struct{}
 
 func (t *testMainSuite) TestSetGlobalVars(c *C) {
-	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines], Equals, "tikv, tiflash, tidb")
-	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 1<<30)
+	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines].Value, Equals, "tikv, tiflash, tidb")
+	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery].Value, Equals, "1073741824")
 
 	config.GetGlobalConfig().IsolationRead.Engines = []string{"tikv", "tidb"}
 	config.GetGlobalConfig().MemQuotaQuery = 9999999
 	setGlobalVars()
 
-	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines], Equals, "tikv, tidb")
-	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 9999999)
+	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines].Value, Equals, "tikv, tidb")
+	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery].Value, Equals, "9999999")
 }

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -41,7 +41,7 @@ type testMainSuite struct{}
 
 func (t *testMainSuite) TestSetGlobalVars(c *C) {
 	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines], Equals, "tikv, tiflash, tidb")
-	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 1 << 30)
+	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 1<<30)
 
 	config.GetGlobalConfig().IsolationRead.Engines = []string{"tikv", "tidb"}
 	config.GetGlobalConfig().MemQuotaQuery = 9999999

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/sessionctx/variable"
 )
 
 var isCoverageServer = "0"
@@ -31,4 +33,20 @@ func TestRunMain(t *testing.T) {
 
 func TestT(t *testing.T) {
 	TestingT(t)
+}
+
+var _ = Suite(&testMainSuite{})
+
+type testMainSuite struct{}
+
+func (t *testMainSuite) TestSetGlobalVars(c *C) {
+	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines], Equals, "tikv, tiflash, tidb")
+	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 1 << 30)
+
+	config.GetGlobalConfig().IsolationRead.Engines = []string{"tikv", "tidb"}
+	config.GetGlobalConfig().MemQuotaQuery = 9999999
+	setGlobalVars()
+
+	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines], Equals, "tikv, tidb")
+	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery], Equals, 9999999)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: as the title says.

### What is changed and how it works?

What's Changed: isolation read engines should be re-init after config load.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

