### PR TITLE
*: make 2pc concurrency and txn ttl lifetime configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -346,20 +346,22 @@ type Status struct {
 
 // Performance is the performance section of the config.
 type Performance struct {
-	MaxProcs            uint    `toml:"max-procs" json:"max-procs"`
-	MaxMemory           uint64  `toml:"max-memory" json:"max-memory"`
-	StatsLease          string  `toml:"stats-lease" json:"stats-lease"`
-	StmtCountLimit      uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
-	FeedbackProbability float64 `toml:"feedback-probability" json:"feedback-probability"`
-	QueryFeedbackLimit  uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
-	PseudoEstimateRatio float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
-	ForcePriority       string  `toml:"force-priority" json:"force-priority"`
-	BindInfoLease       string  `toml:"bind-info-lease" json:"bind-info-lease"`
-	TxnTotalSizeLimit   uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
-	TCPKeepAlive        bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
-	CrossJoin           bool    `toml:"cross-join" json:"cross-join"`
-	RunAutoAnalyze      bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
-	DistinctAggPushDown bool    `toml:"distinct-agg-push-down" json:"agg-push-down-join"`
+	MaxProcs             uint    `toml:"max-procs" json:"max-procs"`
+	MaxMemory            uint64  `toml:"max-memory" json:"max-memory"`
+	StatsLease           string  `toml:"stats-lease" json:"stats-lease"`
+	StmtCountLimit       uint    `toml:"stmt-count-limit" json:"stmt-count-limit"`
+	FeedbackProbability  float64 `toml:"feedback-probability" json:"feedback-probability"`
+	QueryFeedbackLimit   uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
+	PseudoEstimateRatio  float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
+	ForcePriority        string  `toml:"force-priority" json:"force-priority"`
+	BindInfoLease        string  `toml:"bind-info-lease" json:"bind-info-lease"`
+	TxnTotalSizeLimit    uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
+	TCPKeepAlive         bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
+	CrossJoin            bool    `toml:"cross-join" json:"cross-join"`
+	RunAutoAnalyze       bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
+	DistinctAggPushDown  bool    `toml:"distinct-agg-push-down" json:"agg-push-down-join"`
+	CommitterConcurrency int     `toml:"committer-concurrency" json:"committer-concurrency"`
+	TLLMngLifetime       uint64  `toml:"ttl-mng-lifetime" json:"ttl-mng-lifetime"`
 }
 
 // PlanCache is the PlanCache section of the config.
@@ -581,19 +583,21 @@ var defaultConf = Config{
 		RecordQPSbyDB:   false,
 	},
 	Performance: Performance{
-		MaxMemory:           0,
-		TCPKeepAlive:        true,
-		CrossJoin:           true,
-		StatsLease:          "3s",
-		RunAutoAnalyze:      true,
-		StmtCountLimit:      5000,
-		FeedbackProbability: 0.05,
-		QueryFeedbackLimit:  1024,
-		PseudoEstimateRatio: 0.8,
-		ForcePriority:       "NO_PRIORITY",
-		BindInfoLease:       "3s",
-		TxnTotalSizeLimit:   DefTxnTotalSizeLimit,
-		DistinctAggPushDown: false,
+		MaxMemory:            0,
+		TCPKeepAlive:         true,
+		CrossJoin:            true,
+		StatsLease:           "3s",
+		RunAutoAnalyze:       true,
+		StmtCountLimit:       5000,
+		FeedbackProbability:  0.05,
+		QueryFeedbackLimit:   1024,
+		PseudoEstimateRatio:  0.8,
+		ForcePriority:        "NO_PRIORITY",
+		BindInfoLease:        "3s",
+		TxnTotalSizeLimit:    DefTxnTotalSizeLimit,
+		DistinctAggPushDown:  false,
+		CommitterConcurrency: 16,
+		TLLMngLifetime:       10 * 60 * 1000, // 10min
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/config/config.go
+++ b/config/config.go
@@ -361,7 +361,7 @@ type Performance struct {
 	RunAutoAnalyze       bool    `toml:"run-auto-analyze" json:"run-auto-analyze"`
 	DistinctAggPushDown  bool    `toml:"distinct-agg-push-down" json:"agg-push-down-join"`
 	CommitterConcurrency int     `toml:"committer-concurrency" json:"committer-concurrency"`
-	TLLMngLifetime       uint64  `toml:"ttl-mng-lifetime" json:"ttl-mng-lifetime"`
+	MaxTxnTTL            uint64  `toml:"max-txn-ttl" json:"max-txn-ttl"`
 }
 
 // PlanCache is the PlanCache section of the config.
@@ -597,7 +597,7 @@ var defaultConf = Config{
 		TxnTotalSizeLimit:    DefTxnTotalSizeLimit,
 		DistinctAggPushDown:  false,
 		CommitterConcurrency: 16,
-		TLLMngLifetime:       10 * 60 * 1000, // 10min
+		MaxTxnTTL:            10 * 60 * 1000, // 10min
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -241,6 +241,12 @@ distinct-agg-push-down = false
 # If binlog is not enabled, this value should be less than 10737418240(10G).
 txn-total-size-limit = 104857600
 
+# The max number of running concurrency two phase committer request for an SQL.
+committer-concurrency = 16
+
+# max lifetime of transaction ttl manager.
+ttl-mng-lifetime = 6000000
+
 [proxy-protocol]
 # PROXY protocol acceptable client networks.
 # Empty string means disable PROXY protocol, * means all networks.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -245,7 +245,7 @@ txn-total-size-limit = 104857600
 committer-concurrency = 16
 
 # max lifetime of transaction ttl manager.
-ttl-mng-lifetime = 6000000
+ttl-mng-lifetime = 600000
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -245,7 +245,7 @@ txn-total-size-limit = 104857600
 committer-concurrency = 16
 
 # max lifetime of transaction ttl manager.
-ttl-mng-lifetime = 600000
+max-txn-ttl = 600000
 
 [proxy-protocol]
 # PROXY protocol acceptable client networks.

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -730,13 +730,13 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 			}
 
 			uptime := uint64(oracle.ExtractPhysical(now) - oracle.ExtractPhysical(c.startTS))
-			if uptime > config.GetGlobalConfig().Performance.TLLMngLifetime {
+			if uptime > config.GetGlobalConfig().Performance.MaxTxnTTL {
 				// Checks maximum lifetime for the ttlManager, so when something goes wrong
 				// the key will not be locked forever.
 				logutil.Logger(bo.ctx).Info("ttlManager live up to its lifetime",
 					zap.Uint64("txnStartTS", c.startTS),
 					zap.Uint64("uptime", uptime),
-					zap.Uint64("maxLifetime", config.GetGlobalConfig().Performance.TLLMngLifetime))
+					zap.Uint64("maxTxnTTL", config.GetGlobalConfig().Performance.MaxTxnTTL))
 				metrics.TiKVTTLLifeTimeReachCounter.Inc()
 				// the pessimistic locks may expire if the ttl manager has timed out, set `LockExpired` flag
 				// so that this transaction could only commit or rollback with no more statement executions


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

the different machines should better use different committer concurrency value

and some biz logic needs to use longer or shorter TTL lifetime.

### What is changed and how it works?

What's Changed:

add two global + session variable:

- tidb_two_phase_committer_concurrency
- tidb_ttl_manager_life

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
use debug to watch value in condition
```

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

make tidb_two_phase_committer_concurrency and tidb_ttl_manager_life configurable

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16495)
<!-- Reviewable:end -->
