### PR TITLE
ddl: make TestTransactionOnAddDropColumn and  TestTransactionWithWriteOnlyColumn  stable

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -88,7 +88,7 @@ type testDBSuite struct {
 func setUpSuite(s *testDBSuite, c *C) {
 	var err error
 
-	s.lease = 100 * time.Millisecond
+	s.lease = 600 * time.Millisecond
 	session.SetSchemaLease(s.lease)
 	session.DisableStats4Test()
 	s.schemaName = "test_db"


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Issue Number: close #16485 and #16488, and it may handle #13641 <!-- REMOVE this line if no issue to close -->

```
[2020-04-16T10:24:51.537Z] ----------------------------------------------------------------------
[2020-04-16T10:24:51.537Z] FAIL: db_test.go:3379: testDBSuite2.TestTransactionOnAddDropColumn
[2020-04-16T10:24:51.537Z]
[2020-04-16T10:24:51.537Z] db_test.go:3431:
[2020-04-16T10:24:51.537Z]     c.Assert(checkErr, IsNil)
[2020-04-16T10:24:51.537Z] ... value *errors.fundamental = err: previous statement: update t1 set b=1 where a=1: [domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later], sql: commit, job schema state: write only ("err: previous statement: update t1 set b=1 where a=1: [domain:8028]Information schema is changed during the execution of the statement(for example, table definition may be updated by other DDL ran in parallel). If you see this error often, try increasing `tidb_max_delta_schema_count`. [try again later], sql: commit, job schema state: write only")
[2020-04-16T10:24:51.537Z]
```

Issue Number: close #16485 <!-- REMOVE this line if no issue to close -->

Problem Summary:
For adding column operation, when the job with the schema state of `write only` put to `OnJobRunBeforeExported`, but the current TiDB doesn't load the schema(the new column is write-only state). Then we begin a transaction and do some operations. After that, we may load the schema. When we commit this transaction, we will find the schema is changed.

![WeChatWorkScreenshot_ce18f7ae-8909-458f-a3b7-24b02e5aa510](https://user-images.githubusercontent.com/4242506/79530237-5b6a3b00-80a1-11ea-8b61-8fc3e0973031.png)


### What is changed and how it works?

What's Changed:
Increase the value of DDL lease. 

The test execution speed has remained basically unchanged. Using `go test -v -vet=off -p 20 -timeout 3m -race  -check.f testDBSuite` to check. The following are the results of two executions：
Before this PR
`--- PASS: TestT (52.01s)`
`--- PASS: TestT (44.07)`
After this PR
`--- PASS: TestT (47.06s)`
`--- PASS: TestT (44.86s)`

How it Works:
Make TiDB has more time to load schema.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

### Release note <!-- bugfixes or new feature need a release note -->
Make TestTransactionOnAddDropColumn stable