### PR TITLE
Fix module version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pingcap/tidb
+module github.com/pingcap/tidb/v4
 
 require (
 	github.com/BurntSushi/toml v0.3.1


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #16568 

Problem Summary: major version not compatible with `go mod`

### What is changed and how it works?

What's Changed: fix module version in `go.mod`

How it Works: `go mod` requires major version matches module version

### Related changes

- Need to apply similar change to release branch

### Check List

Tests 
- Manual test: `go get github.com/yujunz/tidb/v3@v3.1.0-fork`

Side effects: None

### Release note

None