### PR TITLE
domain: rename `binary_path` to `deploy_path`

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -301,7 +301,7 @@ func (is *InfoSyncer) RemoveServerInfo() {
 type topologyInfo struct {
 	ServerVersionInfo
 	StatusPort     uint   `json:"status_port"`
-	BinaryPath     string `json:"binary_path"`
+	DeployPath     string `json:"deploy_path"`
 	StartTimestamp int64  `json:"start_timestamp"`
 }
 
@@ -316,7 +316,7 @@ func (is *InfoSyncer) getTopologyInfo() topologyInfo {
 			GitHash: is.info.ServerVersionInfo.GitHash,
 		},
 		StatusPort:     is.info.StatusPort,
-		BinaryPath:     s,
+		DeployPath:     s,
 		StartTimestamp: is.info.StartTimestamp,
 	}
 }

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -310,13 +311,14 @@ func (is *InfoSyncer) getTopologyInfo() topologyInfo {
 	if err != nil {
 		s = ""
 	}
+	dir := path.Dir(s)
 	return topologyInfo{
 		ServerVersionInfo: ServerVersionInfo{
 			Version: mysql.TiDBReleaseVersion,
 			GitHash: is.info.ServerVersionInfo.GitHash,
 		},
 		StatusPort:     is.info.StatusPort,
-		DeployPath:     s,
+		DeployPath:     dir,
 		StartTimestamp: is.info.StartTimestamp,
 	}
 }

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -129,6 +129,17 @@ func TestTopology(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	s, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := path.Dir(s)
+
+	if topo.DeployPath != dir {
+		t.Fatal("DeployPath not match expected path")
+	}
+
 	if topo.StartTimestamp != 1282967700000 {
 		t.Fatal("start_timestamp of topology info does not match")
 	}
@@ -161,16 +172,5 @@ func TestTopology(t *testing.T) {
 	}
 	if !ttlExists {
 		t.Fatal("ttl non-exists")
-	}
-
-	s, err := os.Executable()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	dir := path.Dir(s)
-
-	if info.getTopologyInfo().DeployPath != dir {
-		t.Fatal("DeployPath not match expected path")
 	}
 }

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
+	"path"
 	"reflect"
 	"testing"
 	"time"
@@ -159,5 +161,16 @@ func TestTopology(t *testing.T) {
 	}
 	if !ttlExists {
 		t.Fatal("ttl non-exists")
+	}
+
+	s, err := os.Executable()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dir := path.Dir(s)
+
+	if info.getTopologyInfo().DeployPath != dir {
+		t.Fatal("DeployPath not match expected path")
 	}
 }


### PR DESCRIPTION
Signed-off-by: mapleFU <1506118561@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

In tidb cluster, all components has a content like `binary_path` or `deploy_path`. And we want to unify them to `deploy_path`.

### What is changed and how it works?

What's Changed:

field name for `binary_path`.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

No

### Release note <!-- bugfixes or new feature need a release note -->

* Unify the component interface and change `binary_path` to `deploy_path`.