### PR TITLE
config: make alter-primary-key and allow-auto-random non-exclusive

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -847,9 +847,6 @@ func (c *Config) Valid() error {
 		return fmt.Errorf("refresh-interval in [stmt-summary] should be greater than 0")
 	}
 
-	if c.AlterPrimaryKey && c.Experimental.AllowAutoRandom {
-		return fmt.Errorf("allow-auto-random is unavailable when alter-primary-key is enabled")
-	}
 	if c.PreparedPlanCache.Capacity < 1 {
 		return fmt.Errorf("capacity in [prepared-plan-cache] should be at least 1")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -391,19 +391,6 @@ func (s *testConfigSuite) TestTxnTotalSizeLimitValid(c *C) {
 	c.Assert(conf.Valid(), NotNil)
 }
 
-func (s *testConfigSuite) TestAllowAutoRandomValid(c *C) {
-	conf := NewConfig()
-	checkValid := func(allowAlterPK, allowAutoRand, shouldBeValid bool) {
-		conf.AlterPrimaryKey = allowAlterPK
-		conf.Experimental.AllowAutoRandom = allowAutoRand
-		c.Assert(conf.Valid() == nil, Equals, shouldBeValid)
-	}
-	checkValid(true, true, false)
-	checkValid(true, false, true)
-	checkValid(false, true, true)
-	checkValid(false, false, true)
-}
-
 func (s *testConfigSuite) TestMaxIndexLength(c *C) {
 	conf := NewConfig()
 	checkValid := func(indexLen int, shouldBeValid bool) {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -838,6 +838,12 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertPKIsNotHandle("create table t (a bigint auto_random(3), b int, primary key (a, b))", "a")
 	assertPKIsNotHandle("create table t (a int auto_random(3), b int, c char, primary key (a, c))", "a")
 
+	testutil.ConfigTestUtils.EnableAlterPrimaryKeyConfig()
+	assertPKIsNotHandle("create table t (a bigint auto_random(3) primary key, b int)", "a")
+	assertPKIsNotHandle("create table t (a int auto_random(3) primary key, b int)", "a")
+	assertPKIsNotHandle("create table t (a int, b int auto_random(3) primary key)", "b")
+	testutil.ConfigTestUtils.DisableAlterPrimaryKeyConfig()
+
 	// Can not set auto_random along with auto_increment.
 	assertWithAutoInc("create table t (a bigint auto_random(3) primary key auto_increment)")
 	assertWithAutoInc("create table t (a bigint primary key auto_increment auto_random(3))")

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -30,7 +30,7 @@ var (
 
 const (
 	// AutoRandomPKisNotHandleErrMsg indicates the auto_random column attribute is defined on a non-primary key column, or the table's primary key is not a single integer column.
-	AutoRandomPKisNotHandleErrMsg = "column %s is not the single integer primary key, or alter-primary-key is enabled"
+	AutoRandomPKisNotHandleErrMsg = "column %s is not the integer primary key"
 	// AutoRandomExperimentalDisabledErrMsg is reported when the experimental option allow-auto-random is not enabled.
 	AutoRandomExperimentalDisabledErrMsg = "auto_random is an experimental feature, which can only be used when allow-auto-random is enabled. This can be changed in the configuration."
 	// AutoRandomIncompatibleWithAutoIncErrMsg is reported when auto_random and auto_increment are specified on the same column.

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -334,6 +334,14 @@ func (a *autoRandom) SetupAutoRandomTestConfig() {
 	globalCfg.Experimental.AllowAutoRandom = true
 }
 
+func (a *autoRandom) EnableAlterPrimaryKeyConfig() {
+	config.GetGlobalConfig().AlterPrimaryKey = true
+}
+
+func (a *autoRandom) DisableAlterPrimaryKeyConfig() {
+	config.GetGlobalConfig().AlterPrimaryKey = false
+}
+
 // RestoreAutoRandomTestConfig restore the values had been saved in SetupTestConfig.
 // This method should only be used for the tests in SerialSuite.
 func (a *autoRandom) RestoreAutoRandomTestConfig() {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: disallowing `alter-primary-key` and `allow-auto-random` to be enabled at the same time is too restricted. Alternatively, we can check `PKIsHandle` at the table level.

### What is changed and how it works?

What's Changed: remove the config validation check and add a few tests.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
The configuration option 'alter-primary-key' and 'allow-auto-random' are not exclusive anymore.  
