### PR TITLE
planner : change the define of 'last_plan_from_cache'

### DIFF
--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -351,17 +351,12 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 	isRange := e.isRangePartition(p)
 	_, isTableDual := p.(*PhysicalTableDual)
 	if !isTableDual && prepared.UseCache && !isRange {
-		err = e.setFoundInPlanCache(sctx, true)
-		if err != nil {
-			return err
-		}
 		cached := NewPSTMTPlanCacheValue(p, names, stmtCtx.TblInfo2UnionScan)
 		preparedStmt.NormalizedPlan, preparedStmt.PlanDigest = NormalizePlan(p)
 		stmtCtx.SetPlanDigest(preparedStmt.NormalizedPlan, preparedStmt.PlanDigest)
 		sctx.PreparedPlanCache().Put(cacheKey, cached)
-	} else {
-		err = e.setFoundInPlanCache(sctx, false)
 	}
+	err = e.setFoundInPlanCache(sctx, false)
 	return err
 }
 

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -705,6 +705,8 @@ func (s *testPlanSerialSuite) TestPlanCacheHitInfo(c *C) {
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
 	tk.MustQuery("execute stmt using @doma").Check(testkit.Rows("1"))
 	// Test if last_plan_from_cache is updated after a plan cache hit.
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustQuery("execute stmt using @doma").Check(testkit.Rows("1"))
 	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
 	tk.MustQuery("execute stmt2 using @doma").Check(testkit.Rows("1"))
 	// Test if last_plan_from_cache is updated after a plan cache miss caused by a prepared statement.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Problem Summary: correct the definition of `last_plan_from_cache`
relevant PR : https://github.com/pingcap/tidb/pull/16321

### What is changed and how it works?

What's Changed:
* small change to common_plans.go
* relevant change to prepare_test.go

How it Works:
* Newly added plans will no longer trigger `last_plan_from_cache = 1`

### Related changes
- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects
