### PR TITLE
util: build right range when where stmt only have string column.

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6218,3 +6218,15 @@ func (s *testIntegrationSuite) TestIssue16029(c *C) {
 	tk.MustExec("drop table t0;")
 	tk.MustExec("drop table t1;")
 }
+
+func (s *testIntegrationSuite) TestIssue16505(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("CREATE TABLE t(c varchar(100), index idx(c(100)));")
+	tk.MustExec("INSERT INTO t VALUES (NULL),('1'),('0'),(''),('aaabbb'),('0abc'),('123e456'),('0.0001deadsfeww');")
+	tk.MustQuery("select * from t where c;").Sort().Check(testkit.Rows("0.0001deadsfeww", "1", "123e456"))
+	tk.MustQuery("select /*+ USE_INDEX(t, idx) */ * from t where c;").Sort().Check(testkit.Rows("0.0001deadsfeww", "1", "123e456"))
+	tk.MustQuery("select /*+ IGNORE_INDEX(t, idx) */* from t where c;").Sort().Check(testkit.Rows("0.0001deadsfeww", "1", "123e456"))
+	tk.MustExec("drop table t;")
+}

--- a/util/ranger/checker.go
+++ b/util/ranger/checker.go
@@ -147,5 +147,8 @@ func (c *conditionChecker) checkColumn(expr expression.Expression) bool {
 	if !ok {
 		return false
 	}
+	if col.RetType.EvalType() == types.ETString {
+		return false
+	}
 	return c.colUniqueID == col.UniqueID
 }

--- a/util/ranger/checker.go
+++ b/util/ranger/checker.go
@@ -32,10 +32,9 @@ func (c *conditionChecker) check(condition expression.Expression) bool {
 	case *expression.ScalarFunction:
 		return c.checkScalarFunction(x)
 	case *expression.Column:
-		if s, ok := condition.(*expression.Column); ok {
-			if s.RetType.EvalType() == types.ETString {
-				return false
-			}
+		s, _ := condition.(*expression.Column)
+		if s.RetType.EvalType() == types.ETString {
+			return false
 		}
 		return c.checkColumn(x)
 	case *expression.Constant:

--- a/util/ranger/checker.go
+++ b/util/ranger/checker.go
@@ -32,6 +32,11 @@ func (c *conditionChecker) check(condition expression.Expression) bool {
 	case *expression.ScalarFunction:
 		return c.checkScalarFunction(x)
 	case *expression.Column:
+		if s, ok := condition.(*expression.Column); ok {
+			if s.RetType.EvalType() == types.ETString {
+				return false
+			}
+		}
 		return c.checkColumn(x)
 	case *expression.Constant:
 		return true

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -190,15 +190,6 @@ func (r *builder) buildFromConstant(expr *expression.Constant) []point {
 }
 
 func (r *builder) buildFromColumn(expr *expression.Column) []point {
-	if expr.GetType().EvalType() == types.ETString {
-		startPoint1 := point{value: types.MinNotNullDatum(), start: true}
-		endPoint1 := point{excl: true}
-		endPoint1.value.SetString("", mysql.DefaultCharset)
-		startPoint2 := point{excl: true, start: true}
-		startPoint2.value.SetString("", mysql.DefaultCharset)
-		endPoint2 := point{value: types.MaxValueDatum()}
-		return []point{startPoint1, endPoint1, startPoint2, endPoint2}
-	}
 	// column name expression is equivalent to column name is true.
 	startPoint1 := point{value: types.MinNotNullDatum(), start: true}
 	endPoint1 := point{excl: true}

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1161,3 +1161,34 @@ func (s *testRangerSuite) TestCompIndexInExprCorrCol(c *C) {
 		testKit.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
 	}
 }
+
+func (s *testRangerSuite) TestIndexStringIsTrueRange(c *C) {
+	defer testleak.AfterTest(c)()
+	dom, store, err := newDomainStoreWithBootstrap(c)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	c.Assert(err, IsNil)
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t0")
+	testKit.MustExec("CREATE TABLE t0(c0 TEXT(10));")
+	testKit.MustExec("INSERT INTO t0(c0) VALUES (1);")
+	testKit.MustExec("CREATE INDEX i0 ON t0(c0(10));")
+	testKit.MustExec("analyze table t0;")
+
+	var input []string
+	var output []struct {
+		SQL    string
+		Result []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Result = s.testData.ConvertRowsToStrings(testKit.MustQuery(tt).Rows())
+		})
+		testKit.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
+	}
+}

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1161,26 +1161,3 @@ func (s *testRangerSuite) TestCompIndexInExprCorrCol(c *C) {
 		testKit.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
 	}
 }
-
-func (s *testRangerSuite) TestIndexStringIsTrueRange(c *C) {
-	// #15990
-	defer testleak.AfterTest(c)()
-	dom, store, err := newDomainStoreWithBootstrap(c)
-	defer func() {
-		dom.Close()
-		store.Close()
-	}()
-	c.Assert(err, IsNil)
-	testKit := testkit.NewTestKit(c, store)
-	testKit.MustExec("use test")
-	testKit.MustExec("drop table if exists t0")
-	testKit.MustExec("CREATE TABLE t0(c0 TEXT(10));")
-	testKit.MustExec("INSERT INTO t0(c0) VALUES (1);")
-	testKit.MustExec("CREATE INDEX i0 ON t0(c0(10));")
-	testKit.MustExec("analyze table t0;")
-	testKit.MustQuery("desc SELECT * FROM t0 WHERE ('a' != t0.c0) AND t0.c0;").Check(testkit.Rows(
-		"IndexReader_6 1.00 root  index:IndexRangeScan_5",
-		"└─IndexRangeScan_5 1.00 cop[tikv] table:t0, index:i0(c0) range:[-inf,\"\"), (\"\",\"a\"), (\"a\",+inf], keep order:false",
-	))
-	testKit.MustExec("drop table t0;")
-}

--- a/util/ranger/testdata/ranger_suite_in.json
+++ b/util/ranger/testdata/ranger_suite_in.json
@@ -5,5 +5,17 @@
       "explain select t.e in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c in (1, 2) and s.d = t.a and s.a = t1.a) from t",
       "select t.e in (select count(*) from t s use index(idx), t t1 where s.b = 1 and s.c in (1, 2) and s.d = t.a and s.a = t1.a) from t"
     ]
+  },
+  {
+    "name": "TestIndexStringIsTrueRange",
+    "cases": [
+      "explain select * from t0 where c0",
+      "explain select * from t0 where c0 and c0 > '123'",
+      "explain select * from t0 where c0 and c0 <> '123'",
+      "explain select * from t0 where c0 is true",
+      "explain select * from t0 where c0 is false",
+      "explain select * from t0 where c0 and c0 in ('123','456','789')",
+      "explain SELECT * FROM t0 WHERE ('a' != t0.c0) AND t0.c0;"
+    ]
   }
 ]

--- a/util/ranger/testdata/ranger_suite_out.json
+++ b/util/ranger/testdata/ranger_suite_out.json
@@ -25,5 +25,66 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestIndexStringIsTrueRange",
+    "Cases": [
+      {
+        "SQL": "explain select * from t0 where c0",
+        "Result": [
+          "TableReader_7 0.80 root  data:Selection_6",
+          "└─Selection_6 0.80 cop[tikv]  test.t0.c0",
+          "  └─TableFullScan_5 1.00 cop[tikv] table:t0 keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain select * from t0 where c0 and c0 > '123'",
+        "Result": [
+          "IndexReader_7 1.00 root  index:Selection_6",
+          "└─Selection_6 1.00 cop[tikv]  test.t0.c0",
+          "  └─IndexRangeScan_5 1.00 cop[tikv] table:t0, index:i0(c0) range:(\"123\",+inf], keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain select * from t0 where c0 and c0 <> '123'",
+        "Result": [
+          "IndexReader_7 1.00 root  index:Selection_6",
+          "└─Selection_6 1.00 cop[tikv]  test.t0.c0",
+          "  └─IndexRangeScan_5 1.00 cop[tikv] table:t0, index:i0(c0) range:[-inf,\"123\"), (\"123\",+inf], keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain select * from t0 where c0 is true",
+        "Result": [
+          "TableReader_7 0.80 root  data:Selection_6",
+          "└─Selection_6 0.80 cop[tikv]  istrue(cast(test.t0.c0))",
+          "  └─TableFullScan_5 1.00 cop[tikv] table:t0 keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain select * from t0 where c0 is false",
+        "Result": [
+          "TableReader_7 0.80 root  data:Selection_6",
+          "└─Selection_6 0.80 cop[tikv]  isfalse(cast(test.t0.c0))",
+          "  └─TableFullScan_5 1.00 cop[tikv] table:t0 keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain select * from t0 where c0 and c0 in ('123','456','789')",
+        "Result": [
+          "IndexReader_7 1.00 root  index:Selection_6",
+          "└─Selection_6 1.00 cop[tikv]  test.t0.c0",
+          "  └─IndexRangeScan_5 1.00 cop[tikv] table:t0, index:i0(c0) range:[\"123\",\"123\"], [\"456\",\"456\"], [\"789\",\"789\"], keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain SELECT * FROM t0 WHERE ('a' != t0.c0) AND t0.c0;",
+        "Result": [
+          "IndexReader_7 1.00 root  index:Selection_6",
+          "└─Selection_6 1.00 cop[tikv]  test.t0.c0",
+          "  └─IndexRangeScan_5 1.00 cop[tikv] table:t0, index:i0(c0) range:[-inf,\"a\"), (\"a\",+inf], keep order:false"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16505  , close #16190  <!-- REMOVE this line if no issue to close -->

Problem Summary: TableIndexScan's result is different from TableFullScan and Selection.

### What is changed and how it works?

What's Changed: If the where stmt only have String column, it shouldn't be one of accessCondition to build access range. Because we should convert the string to float to check it is ture/false.

How it Works: However, revert #16135  that only cover some cases. The pr can cover all situations.

### Related changes

- Need to cherry-pick to the release branch 2.1,3.0,3.1,4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
Fix the wrong result when where stmt only have string column.
