### PR TITLE
expression: remove memorization to guarantee thread safe

### DIFF
--- a/expression/builtin_like.go
+++ b/expression/builtin_like.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"regexp"
+	"sync"
 
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -121,6 +122,7 @@ type builtinRegexpSharedSig struct {
 	compile         func(string) (*regexp.Regexp, error)
 	memorizedRegexp *regexp.Regexp
 	memorizedErr    error
+	once            sync.Once
 }
 
 func (b *builtinRegexpSharedSig) clone(from *builtinRegexpSharedSig) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: realted to https://github.com/pingcap/tidb/issues/15810, https://github.com/pingcap/tidb/pull/16600

Problem Summary: shared parameters in a sturct is not thread-safe.

### What is changed and how it works?

remove the shared parameters for `builtinRegexpSharedSig`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->
fix thread-unsafe problem for `builtinRegexpSharedSig`