### PR TITLE
executor: concurrently fetch chunks, but inseting a hash table using a lock

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -917,16 +917,15 @@ func BenchmarkHashJoinExec(b *testing.B) {
 
 	b.ReportAllocs()
 	cas := defaultHashJoinTestCase(cols, 0, false)
-	buildConcurrency := []int{1}
+	buildConcurrency := []int{1, 2, 4}
 	for _, con := range buildConcurrency {
 		cas.concurrency = con
 		cas.disk = false
+		cas.keyIdx = []int{0, 1}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
 		})
-	}
-	return
-	{
+
 		cas.keyIdx = []int{0}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
@@ -957,6 +956,7 @@ func BenchmarkHashJoinExec(b *testing.B) {
 	cas = defaultHashJoinTestCase(cols, 0, false)
 	for _, con := range buildConcurrency {
 		cas.concurrency = con
+		cas.keyIdx = []int{0, 1}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
 		})

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -179,8 +179,6 @@ func (c *hashRowContainer) PutChunk(chk *chunk.Chunk, workID uint, useOuterToBui
 // key of hash table: hash value of key columns
 // value of hash table: RowPtr of the corresponded row
 func (c *hashRowContainer) PutChunkSelected(chk *chunk.Chunk, selected []bool, workID uint, useOuterToBuild bool) error {
-	start := time.Now()
-	defer func() { c.stat.buildTableElapse += time.Since(start) }()
 	// safely add chunks
 	c.lock.Lock()
 	chkIdx := uint32(c.rowContainer.NumChunks())

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -15,7 +15,6 @@ package executor
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/bitmap"
 	"hash"
 	"hash/fnv"
 	"sync"
@@ -25,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/bitmap"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/disk"

--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -150,16 +150,18 @@ func (s *pkgTestSuite) testHashRowContainer(c *C, hashFunc func() hash.Hash64, s
 	for i := 0; i < numRows; i++ {
 		hCtx.hashVals = append(hCtx.hashVals, hashFunc())
 	}
-	rowContainer := newHashRowContainer(sctx, 0, hCtx)
+	var hCtxArray []*hashContext
+	hCtxArray = append(hCtxArray, hCtx)
+	rowContainer := newHashRowContainer(sctx, 0, hCtxArray)
 	tracker := rowContainer.GetMemTracker()
 	tracker.SetLabel(buildSideResultLabel)
 	if spill {
 		rowContainer.ActionSpill().Action(tracker)
 		tracker.SetBytesLimit(1)
 	}
-	err = rowContainer.PutChunk(chk0)
+	err = rowContainer.PutChunk(chk0, 0, false)
 	c.Assert(err, IsNil)
-	err = rowContainer.PutChunk(chk1)
+	err = rowContainer.PutChunk(chk1, 0, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(rowContainer.alreadySpilled(), Equals, spill)

--- a/executor/join.go
+++ b/executor/join.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/config"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/types"

--- a/executor/join.go
+++ b/executor/join.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -678,6 +679,8 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 
 	// e.concurrency goroutines concurrently fetch chunks from e.buildSideResultCh
 	// and put chunks into a hashtable
+	start := time.Now()
+	defer func() { e.rowContainer.stat.buildTableElapse += time.Since(start) }()
 	for i := uint(0); i < e.concurrency; i++ {
 		e.buildWorkerWaitGroup.Add(1)
 		workID := i


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16618, following https://github.com/pingcap/tidb/pull/16678
this PR concurrently fetch chunks, but inseting a hash table using a lock; then merge the concurrent hash table, to achieve concurrent build.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- update original test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- supporting concurrently building hash tables in hash joins.

```
mac:executor fzh$  GO111MODULE=on go test -bench=BenchmarkHashJoinExec  -run=benchmark_test.go
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/executor
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12         	       1	2061576955 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12           	       6	 195755346 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:true)-12            	       1	1404806421 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12         	       2	 883162828 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12           	       7	 152035427 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:true)-12            	       2	 951167150 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12         	       2	 574322972 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12           	       7	 160684326 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-12            	       2	 852675996 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                       	   32583	     37450 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                       	   27750	     43769 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                       	   22494	     54612 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12                	      20	  50950582 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                  	      26	  44504567 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12                	      32	  34171317 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                  	      37	  31200499 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12                	      42	  28914399 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                  	      42	  27063405 ns/op
PASS
ok  	github.com/pingcap/tidb/executor	48.264s
```