### PR TITLE
executor: add concurrency limit on the union executor

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -1340,6 +1340,18 @@ func (s *testSuiteP2) TestUnion(c *C) {
 	tk.MustQuery("select count(distinct a), sum(distinct a), avg(distinct a) from (select a from t union all select b from t) tmp;").Check(testkit.Rows("1 1.000 1.0000000"))
 }
 
+func (s *testSuiteP2) TestUnionLimit(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists union_limit")
+	tk.MustExec("create table union_limit (id int) partition by hash(id) partitions 30")
+	for i := 0; i < 60; i++ {
+		tk.MustExec(fmt.Sprintf("insert into union_limit values (%d)", i))
+	}
+	// Cover the code for worker count limit in the union executor.
+	tk.MustQuery("select * from union_limit limit 10")
+}
+
 func (s *testSuiteP1) TestNeighbouringProj(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

If we do not limit the concurrency of the union executor,
'select * from t limit 1000' could make TiDB OOM on a large partition table.

Problem Summary:

TiDB v3.0.3, on a large partition table

```
select * from t limit 0,1000
```

![image](https://user-images.githubusercontent.com/1420062/80240298-2eff8180-8694-11ea-9116-3555ef764087.png)

The union calls `Close` but the underlying childen node still running:

```
goroutine 5579939 [chan receive]:
github.com/pingcap/tidb/executor.(*UnionExec).Close(0xc0123ce620, 0xbc02d7, 0xc00004f900)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:1385 +0x9a
github.com/pingcap/tidb/executor.(*baseExecutor).Close(0xc00eee8140, 0x3, 0xc00004f970)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:110 +0x7e
github.com/pingcap/tidb/executor.(*LimitExec).Close(0xc00eee8140, 0xc3312a, 0xc01a655470)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:874 +0x41
github.com/pingcap/tidb/executor.(*recordSet).Close(0xc00c03b590, 0xc027012580, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/adapter.go:133 +0x38
github.com/pingcap/tidb/server.(*tidbResultSet).Close(0xc00c03b5e0, 0xc027012580, 0xc015ee4000)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/driver_tidb.go:383 +0x46
github.com/pingcap/parser/terror.Call(0xc01a655580)
/home/jenkins/workspace/release_tidb_3.0/go/pkg/mod/github.com/pingcap/parser@v0.0.0-20190806084718-1a31cabbaef2/terror/terror.go:348 +0x2b
github.com/pingcap/tidb/server.(*clientConn).writeResultset.func1(0x0, 0x228ece0, 0xc00c03b5e0, 0xc01a655738, 0x227cee0, 0xc011835b90, 0xc00a1db110)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/conn.go:1254 +0x582
github.com/pingcap/tidb/server.(*clientConn).writeResultset(0xc00a1db110, 0x227cee0, 0xc011835b90, 0x228ece0, 0xc00c03b5e0, 0xc00000fa00, 0x0, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/conn.go:1280 +0x14b
github.com/pingcap/tidb/server.(*clientConn).handleQuery(0xc00a1db110, 0x227cee0, 0xc011835b90, 0xc015eedec1, 0x3c, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/conn.go:1191 +0x212
github.com/pingcap/tidb/server.(*clientConn).dispatch(0xc00a1db110, 0x227cee0, 0xc011835b90, 0xc015eedec1, 0x3d, 0x3d, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/conn.go:897 +0x5c6
github.com/pingcap/tidb/server.(*clientConn).Run(0xc00a1db110, 0x227cee0, 0xc011835b90)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/conn.go:652 +0x258
github.com/pingcap/tidb/server.(*Server).onConn(0xc00b59c400, 0xc00a1db110)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/server.go:440 +0x481
created by github.com/pingcap/tidb/server.(*Server).Run     /home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/server/server.go:357 +0x83d
```


```
goroutine 5582348 [chan receive]:
github.com/pingcap/tidb/distsql.(*selectResult).getSelectResp(0xc026dbf740, 0x3564890, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/distsql/select_result.go:166 +0x22b
github.com/pingcap/tidb/distsql.(*selectResult).Next(0xc026dbf740, 0x227cee0, 0xc011835b90, 0xc00b529500, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/distsql/select_result.go:147 +0x82
github.com/pingcap/tidb/executor.(*tableResultHandler).nextChunk(0xc00b86d800, 0x227cee0, 0xc011835b90, 0xc00b529500, 0xc00ccd7d90, 0x1)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/table_reader.go:224 +0x5c
github.com/pingcap/tidb/executor.(*TableReaderExecutor).Next(0xc010ea4000, 0x227cee0, 0xc011835b90, 0xc00b529500, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/table_reader.go:148 +0xb5
github.com/pingcap/tidb/executor.Next(0x227cee0, 0xc011835b90, 0x2283da0, 0xc010ea4000, 0xc00b529500, 0xc002e2a9c0, 0x20)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:191 +0xbd
github.com/pingcap/tidb/executor.(*LimitExec).Next(0xc00b576960, 0x227cee0, 0xc011835b90, 0xc00b529500, 0x0, 0x0)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:843 +0x29d
github.com/pingcap/tidb/executor.Next(0x227cee0, 0xc011835b90, 0x2283620, 0xc00b576960, 0xc00b529500, 0xc0123ce620, 0xc0262a4058)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:191 +0xbd
github.com/pingcap/tidb/executor.(*UnionExec).resultPuller(0xc0123ce620, 0x227cee0, 0xc011835b90, 0x12)
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:1340 +0x272
created by github.com/pingcap/tidb/executor.(*UnionExec).initialize
/home/jenkins/workspace/release_tidb_3.0/go/src/github.com/pingcap/tidb/executor/executor.go:1308 +0x131
```

For each partition, the union executor use a new goroutine.
The table reader has load too much data before the limit could take effect.


### What is changed and how it works?

What's Changed:

How it Works:

Set a concurrency limiter for the union executor.
Do not spawn all goroutine immediately.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

The concurrency case is not easy to test, in this commit there is a simple test that just cover the new code.

Side effects

- Performance regression

Maybe, because of the introduce of the concurrency limit.

### Release note <!-- bugfixes or new feature need a release note -->
