### PR TITLE
makefile: let `make fmt` ensure std imports before non-std

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,7 @@ check-fail: goword check-slow
 fmt:
 	@echo "gofmt (simplify)"
 	@gofmt -s -l -w $(FILES) 2>&1 | $(FAIL_ON_STDOUT)
+	@cd cmd/importcheck && $(GO) run . ../..
 
 goword:tools/bin/goword
 	tools/bin/goword $(FILES) 2>&1 | $(FAIL_ON_STDOUT)

--- a/cmd/importcheck/importcheck.go
+++ b/cmd/importcheck/importcheck.go
@@ -1,4 +1,4 @@
-// Copyright 2018 PingCAP, Inc.
+// Copyright 2020 PingCAP, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cmd/importcheck/importcheck.go
+++ b/cmd/importcheck/importcheck.go
@@ -1,0 +1,119 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pingcap/tidb/util/hack"
+)
+
+func main() {
+	err := run()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "import check fail: %s\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	flag.Parse()
+
+	if flag.NArg() != 1 {
+		return errors.New("need given root folder param")
+	}
+
+	root, err := filepath.EvalSymlinks(flag.Arg(0))
+	if err != nil {
+		return fmt.Errorf("eval symlinks error: %s", err)
+	}
+
+	return filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if info.IsDir() {
+			return nil
+		}
+		if !strings.HasSuffix(path, ".go") {
+			return nil
+		}
+		return checkFile(path)
+	})
+}
+
+func checkFile(path string) error {
+	src, err := ioutil.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), path, src, parser.AllErrors|parser.ParseComments)
+	if err != nil {
+		return err
+	}
+
+	var importSpecs []*ast.ImportSpec
+	for _, d := range file.Decls {
+		if genDecl, ok := d.(*ast.GenDecl); ok {
+			if genDecl.Tok != token.IMPORT {
+				continue
+			}
+			for _, spec := range genDecl.Specs {
+				if importSpec, ok := spec.(*ast.ImportSpec); ok {
+					importSpecs = append(importSpecs, importSpec)
+				}
+			}
+		}
+	}
+
+	var preIsStd bool
+	for i, im := range importSpecs {
+		stdImport := !strings.Contains(im.Path.Value, ".")
+		if stdImport {
+			// std import
+			if i == 0 {
+				preIsStd = true
+				continue
+			}
+			if !preIsStd {
+				return errors.New(fmt.Sprintf("stdlib %s need be group together and before non-stdlib group in %s", im.Path.Value, path))
+			}
+			continue
+		}
+		// non-std import
+		if i != 0 {
+			if !preIsStd {
+				continue
+			}
+			if !checkSepWithNewline(src, importSpecs[i-1].Path.Pos(), im.Path.Pos()) {
+				return errors.New(fmt.Sprintf("non-stdlib %s need be group together and after stdlib group in %s", im.Path.Value, path))
+			}
+			preIsStd = false
+		}
+	}
+
+	return nil
+}
+
+func checkSepWithNewline(src []byte, pre token.Pos, cur token.Pos) bool {
+	preSrc := src[pre:cur]
+	newLine := strings.Count(string(hack.String(preSrc)), "\n")
+	return newLine == 2
+}

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -16,12 +16,12 @@ package executor_test
 import (
 	"bytes"
 	"fmt"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"math/rand"
 	"strings"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/testkit"
 )

--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/util/testkit"
 )

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -16,7 +16,6 @@ package core_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/util/testutil"
 	"math"
 	"strings"
 
@@ -31,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/util/kvcache"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/pingcap/tidb/util/testutil"
 	dto "github.com/prometheus/client_model/go"
 )
 

--- a/planner/core/rule_build_key_info.go
+++ b/planner/core/rule_build_key_info.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -15,6 +15,7 @@ package privilege
 
 import (
 	"crypto/tls"
+
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -15,6 +15,7 @@ package privileges_test
 
 import (
 	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/mysql"

--- a/store/tikv/backoff_test.go
+++ b/store/tikv/backoff_test.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"context"
 	"errors"
+
 	. "github.com/pingcap/check"
 )
 

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -15,12 +15,12 @@ package tables_test
 
 import (
 	"context"
-	"github.com/pingcap/parser/mysql"
 	"io"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"

--- a/util/sys/linux/sys_linux.go
+++ b/util/sys/linux/sys_linux.go
@@ -15,8 +15,9 @@
 package linux
 
 import (
-	"golang.org/x/sys/unix"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // OSVersion returns version info of operation system.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

we recieve many CR advises about "resort your import" every day 
(and we also give many CR advises about it to others every day :dog:  )

### What is changed and how it works?

add import check to `make fmt` to ensure std import/ non-std import group together and std one before non-std one.

What's Changed:

check import

How it Works:

check import...maybe we can rewrite it automic...but for this version we just check and report error

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test: and ohter files are found by this new check.

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

n/a

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16816)
<!-- Reviewable:end -->
