### PR TITLE
executor: do not quote numbers in JSON data when using `set config` #16829

### DIFF
--- a/executor/set_config.go
+++ b/executor/set_config.go
@@ -24,10 +24,12 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/pdapi"
@@ -38,8 +40,8 @@ import (
 // SetConfigExec executes 'SET CONFIG' statement.
 type SetConfigExec struct {
 	baseExecutor
-	p *core.SetConfig
-	v string
+	p        *core.SetConfig
+	jsonBody string
 }
 
 // Open implements the Executor Open interface.
@@ -67,15 +69,9 @@ func (s *SetConfigExec) Open(ctx context.Context) error {
 	}
 	s.p.Name = strings.ToLower(s.p.Name)
 
-	val, isNull, err := s.p.Value.EvalString(s.ctx, chunk.Row{})
-	if err != nil {
-		return err
-	}
-	if isNull {
-		return errors.Errorf("can't set config to null")
-	}
-	s.v = val
-	return nil
+	body, err := ConvertConfigItem2JSON(s.ctx, s.p.Name, s.p.Value)
+	s.jsonBody = body
+	return err
 }
 
 // TestSetConfigServerInfoKey is used as the key to store 'TestSetConfigServerInfoFunc' in the context.
@@ -124,7 +120,7 @@ func (s *SetConfigExec) Next(ctx context.Context, req *chunk.Chunk) error {
 }
 
 func (s *SetConfigExec) doRequest(url string) (retErr error) {
-	body := bytes.NewBufferString(fmt.Sprintf(`{"%s":"%s"}`, s.p.Name, s.v))
+	body := bytes.NewBufferString(s.jsonBody)
 	req, err := http.NewRequest(http.MethodPost, url, body)
 	if err != nil {
 		return err
@@ -168,4 +164,52 @@ func isValidInstance(instance string) bool {
 	}
 	v := net.ParseIP(ip)
 	return v != nil
+}
+
+// ConvertConfigItem2JSON converts the config item specified by key and val to json.
+// For example:
+// 	set config x key="val" ==> {"key":"val"}
+// 	set config x key=233 ==> {"key":233}
+func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.Expression) (body string, err error) {
+	if val == nil {
+		return "", errors.Errorf("cannot set config to null")
+	}
+	isNull := false
+	str := ""
+	switch val.GetType().EvalType() {
+	case types.ETString:
+		var s string
+		s, isNull, err = val.EvalString(ctx, chunk.Row{})
+		if err == nil && !isNull {
+			str = fmt.Sprintf(`"%s"`, s)
+		}
+	case types.ETInt:
+		var i int64
+		i, isNull, err = val.EvalInt(ctx, chunk.Row{})
+		if err == nil && !isNull {
+			str = fmt.Sprintf("%v", i)
+		}
+	case types.ETReal:
+		var f float64
+		f, isNull, err = val.EvalReal(ctx, chunk.Row{})
+		if err == nil && !isNull {
+			str = fmt.Sprintf("%v", f)
+		}
+	case types.ETDecimal:
+		d := new(types.MyDecimal)
+		d, isNull, err = val.EvalDecimal(ctx, chunk.Row{})
+		if err == nil && !isNull {
+			str = string(d.ToString())
+		}
+	default:
+		return "", errors.Errorf("unsupported config value type")
+	}
+	if err != nil {
+		return
+	}
+	if isNull {
+		return "", errors.Errorf("cannot set config to null")
+	}
+	body = fmt.Sprintf(`{"%s":%s}`, key, str)
+	return body, nil
 }

--- a/executor/set_config.go
+++ b/executor/set_config.go
@@ -208,7 +208,7 @@ func ConvertConfigItem2JSON(ctx sessionctx.Context, key string, val expression.E
 		return
 	}
 	if isNull {
-		return "", errors.Errorf("cannot set config to null")
+		return "", errors.Errorf("can't set config to null")
 	}
 	body = fmt.Sprintf(`{"%s":%s}`, key, str)
 	return body, nil

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -17,14 +17,13 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/pingcap/parser/mysql"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/executor"
@@ -32,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
 )
@@ -1000,6 +1000,7 @@ func (s *testSuite5) TestSetClusterConfigJSONData(c *C) {
 		{&expression.Constant{Value: types.NewStringDatum("abcd"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"abcd"}`, true},
 		{&expression.Constant{Value: types.NewDecimalDatum(&d), RetType: types.NewFieldType(mysql.TypeNewDecimal)}, `{"k":123.456}`, true},
 		{&expression.Constant{Value: types.NewDatum(nil), RetType: types.NewFieldType(mysql.TypeLonglong)}, "", false},
+		{&expression.Constant{RetType: types.NewFieldType(mysql.TypeJSON)}, "", false}, // unsupported type
 		{nil, "", false},
 	}
 

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -17,6 +17,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -982,4 +985,31 @@ func (s *testSuite5) TestSetClusterConfig(c *C) {
 	tk.MustExec("set config tikv log.level='info'")
 	tk.MustQuery("show warnings").Check(testkit.Rows(
 		"Warning 1105 bad request to http://127.0.0.1:5555/config: WRONG", "Warning 1105 bad request to http://127.0.0.1:6666/config: WRONG"))
+}
+
+func (s *testSuite5) TestSetClusterConfigJSONData(c *C) {
+	var d types.MyDecimal
+	c.Assert(d.FromFloat64(123.456), IsNil)
+	cases := []struct {
+		val    expression.Expression
+		result string
+		succ   bool
+	}{
+		{&expression.Constant{Value: types.NewIntDatum(2333), RetType: types.NewFieldType(mysql.TypeLong)}, `{"k":2333}`, true},
+		{&expression.Constant{Value: types.NewFloat64Datum(23.33), RetType: types.NewFieldType(mysql.TypeDouble)}, `{"k":23.33}`, true},
+		{&expression.Constant{Value: types.NewStringDatum("abcd"), RetType: types.NewFieldType(mysql.TypeString)}, `{"k":"abcd"}`, true},
+		{&expression.Constant{Value: types.NewDecimalDatum(&d), RetType: types.NewFieldType(mysql.TypeNewDecimal)}, `{"k":123.456}`, true},
+		{&expression.Constant{Value: types.NewDatum(nil), RetType: types.NewFieldType(mysql.TypeLonglong)}, "", false},
+		{nil, "", false},
+	}
+
+	ctx := mock.NewContext()
+	for _, t := range cases {
+		result, err := executor.ConvertConfigItem2JSON(ctx, "k", t.val)
+		if t.succ {
+			c.Assert(t.result, Equals, result)
+		} else {
+			c.Assert(err, NotNil)
+		}
+	}
 }

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"errors"
-	"github.com/pingcap/tidb/util/mock"
 	"io/ioutil"
 	"net/http"
 	"strconv"
@@ -32,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
 )

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -527,7 +527,6 @@ func (b *PlanBuilder) Build(ctx context.Context, node ast.Node) (Plan, error) {
 func (b *PlanBuilder) buildSetConfig(ctx context.Context, v *ast.SetConfigStmt) (Plan, error) {
 	mockTablePlan := LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
 	expr, _, err := b.rewrite(ctx, v.Value, mockTablePlan, nil, true)
-	expr = expression.WrapWithCastAsString(b.ctx, expr)
 	return &SetConfig{Name: v.Name, Type: v.Type, Instance: v.Instance, Value: expr}, err
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16829 <!-- REMOVE this line if no issue to close -->

Problem Summary: When using `set config`, if the config value is a number, its value in JSON data cannot be quoted. For example, `set config A B=1` should be `{"B":1}` instead of `{"B":"1"}`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test