### PR TITLE
ddl: fix a test may fail in TestAutoRandomTableOption

### DIFF
--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -930,12 +930,6 @@ func (s *testAutoRandomSuite) TestAutoRandomTableOption(c *C) {
 	allHandles, err := ddltestutil.ExtractAllTableHandles(tk.Se, "test", "auto_random_table_option")
 	c.Assert(err, IsNil)
 	c.Assert(len(allHandles), Equals, 5)
-	// Test the high bits of handles are not all zero.
-	allZero := true
-	for _, h := range allHandles {
-		allZero = allZero && (h>>(64-6)) == 0
-	}
-	c.Assert(allZero, IsFalse)
 	// Test non-shard-bits part of auto random id is monotonic increasing and continuous.
 	orderedHandles := testutil.ConfigTestUtils.MaskSortHandles(allHandles, 5, mysql.TypeLonglong)
 	size := int64(len(allHandles))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Fix a [assertion may fail](https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/34516/pipeline) randomly in `TestAutoRandomTableOption`
The fail is because: 
```
1: The inserted 5 rows are in one DML statement, so their shadow bits (5 bits) is all the same
2: The start stamp of this TXN will be used to calc hash & 000...011111(get the first 5 bits), then use left shit(<<) to make it as the high 5 bits of this inserted 5 rows. 

So there is a ratio that the first 5 bits of hash calculated from start stamp is all ZERO.
If we insert it in different TXN, this ratio will be decreased.
For here, this code is not necessary for the test, so we can just remove it.
```

Problem Summary: fix a test fail in TestAutoRandomTableOption

### What is changed and how it works?

What's Changed:

fix a test fail in TestAutoRandomTableOption

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note: ddl: fix a test may fail in TestAutoRandomTableOption <!-- bugfixes or new feature need a release note -->
