### PR TITLE
tikv: collapse duplicate resolve locks in region requests

### DIFF
--- a/store/tikv/client_collapse.go
+++ b/store/tikv/client_collapse.go
@@ -54,11 +54,11 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 	case tikvrpc.CmdResolveLock:
 		resolveLock := req.ResolveLock()
 		if len(resolveLock.Keys) > 0 {
-			// can not collapse resolveLite
+			// can not collapse resolve lock lite
 			return
 		}
 		canCollapse = true
-		key := addr + "-" + strconv.FormatUint(resolveLock.StartVersion, 10) + "-" + strconv.FormatUint(resolveLock.CommitVersion, 10)
+		key := strconv.FormatUint(resolveLock.Context.RegionId, 10) + "-" + strconv.FormatUint(resolveLock.StartVersion, 10)
 		resp, err = r.collapse(ctx, key, &resolveRegionSf, addr, req, timeout)
 		return
 	default:

--- a/store/tikv/client_collapse.go
+++ b/store/tikv/client_collapse.go
@@ -1,0 +1,92 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tikv provides tcp connection to kvserver.
+package tikv
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"golang.org/x/sync/singleflight"
+)
+
+var _ Client = reqCollapse{}
+
+var resolveRegionSf singleflight.Group
+
+type reqCollapse struct {
+	Client
+}
+
+func (r reqCollapse) Close() error {
+	if r.Client == nil {
+		panic("client should not be nil")
+	}
+	return r.Client.Close()
+}
+
+func (r reqCollapse) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	if r.Client == nil {
+		panic("client should not be nil")
+	}
+	if canCollapse, resp, err := r.tryCollapseRequest(ctx, addr, req, timeout); canCollapse {
+		return resp, err
+	}
+	return r.Client.SendRequest(ctx, addr, req, timeout)
+}
+
+func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (canCollapse bool, resp *tikvrpc.Response, err error) {
+	switch req.Type {
+	case tikvrpc.CmdResolveLock:
+		resolveLock := req.ResolveLock()
+		if len(resolveLock.Keys) > 0 {
+			// can not collapse resolveLite
+			return
+		}
+		canCollapse = true
+		key := addr + "-" + strconv.FormatUint(resolveLock.StartVersion, 10) + "-" + strconv.FormatUint(resolveLock.CommitVersion, 10)
+		resp, err = r.collapse(ctx, key, &resolveRegionSf, addr, req, timeout)
+		return
+	default:
+		// now we only support collapse resolve lock.
+		return
+	}
+}
+
+func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,
+	addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
+	rsC := sf.DoChan(key, func() (interface{}, error) {
+		return r.Client.SendRequest(context.Background(), addr, req, ReadTimeoutMedium) // set longer timeout than outer's.
+	})
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		err = errors.Trace(ctx.Err())
+		return
+	case <-timer.C:
+		err = errors.Trace(context.DeadlineExceeded)
+		return
+	case rs := <-rsC:
+		if rs.Err != nil {
+			err = errors.Trace(rs.Err)
+			return
+		}
+		resp = rs.Val.(*tikvrpc.Response)
+		return
+	}
+}

--- a/store/tikv/client_collapse.go
+++ b/store/tikv/client_collapse.go
@@ -70,7 +70,7 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 func (r reqCollapse) collapse(ctx context.Context, key string, sf *singleflight.Group,
 	addr string, req *tikvrpc.Request, timeout time.Duration) (resp *tikvrpc.Response, err error) {
 	rsC := sf.DoChan(key, func() (interface{}, error) {
-		return r.Client.SendRequest(context.Background(), addr, req, ReadTimeoutMedium) // set longer timeout than outer's.
+		return r.Client.SendRequest(context.Background(), addr, req, readTimeoutShort) // use resolveLock timeout.
 	})
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -201,7 +201,7 @@ func newTikvStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Clie
 		clusterID:       pdClient.GetClusterID(context.TODO()),
 		uuid:            uuid,
 		oracle:          o,
-		client:          client,
+		client:          reqCollapse{client},
 		pdClient:        pdClient,
 		regionCache:     NewRegionCache(pdClient),
 		coprCache:       nil,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

When txn1, txn2 meet txn1's lock, and txn1 is large txn that modify many keys

both txn1, txn2 will try to resolve(after check txn status) the whole region even if txn1 meet lock at k1 and txn2 meet lock at k2.

we can deduplicate resolve requests that try to resolve the whole region.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

At first glance, we should do it in LockResolver, but the question is it's hard to maintain backoff behavior at LockResolver level:

if we collapse multiple lock requests into one request at LockResolver level, working request maybe meet many error and backoff(e.g. regionMiss, notLeader, kvRpc...), we are hard to let those backoff info feedback to collapsed requests that waiting for working request.

so this PR chooses to do it in lower level ---- at TiClient that this level, we only need to take care context.Cancel and timeout.

How it Works:

collapse multi resolve request into one request using singleflight.

and chose `DoChan` to impl request level timeout and context.Cancel

### Related changes

- Need to cherry-pick to the release branch(after test..)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test(old test)

Side effects

- reduce kv resolve request count

### Release note <!-- bugfixes or new feature need a release note -->

collapse duplicate resolve locks in region requests

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16838)
<!-- Reviewable:end -->
