### PR TITLE
executor: do not quote numbers in JSON data when using `set config` (#16835)

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -527,7 +527,6 @@ func (b *PlanBuilder) Build(ctx context.Context, node ast.Node) (Plan, error) {
 func (b *PlanBuilder) buildSetConfig(ctx context.Context, v *ast.SetConfigStmt) (Plan, error) {
 	mockTablePlan := LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
 	expr, _, err := b.rewrite(ctx, v.Value, mockTablePlan, nil, true)
-	expr = expression.WrapWithCastAsString(b.ctx, expr)
 	return &SetConfig{Name: v.Name, Type: v.Type, Instance: v.Instance, Value: expr}, err
 }
 


### PR DESCRIPTION
Cherry-pick for #16835.
**No conflicts**.