### PR TITLE
executor: disallow subquery in insert values clause reference upper scope

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5458,3 +5458,29 @@ func (s *testSuite1) TestIssue16854(c *C) {
 	tk.MustQuery("select distinct a from t order by a").Check(testkit.Rows("WAITING", "PRINTED", "WAITING,PRINTED", "STOCKUP", "WAITING,STOCKUP", "PRINTED,STOCKUP", "WAITING,PRINTED,STOCKUP"))
 	tk.MustExec("drop table t")
 }
+
+// this is from jira issue #5856
+func (s *testSuite1) TestInsertValuesWithSubQuery(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t2(a int, b int, c int)")
+	defer tk.MustExec("drop table if exists t2")
+
+	// should not reference upper scope
+	c.Assert(tk.ExecToErr("insert into t2 values (11, 8, (select not b))"), NotNil)
+	c.Assert(tk.ExecToErr("insert into t2 set a = 11, b = 8, c = (select b))"), NotNil)
+
+	// subquery reference target table is allowed
+	tk.MustExec("insert into t2 values(1, 1, (select b from t2))")
+	tk.MustQuery("select * from t2").Check(testkit.Rows("1 1 <nil>"))
+	tk.MustExec("insert into t2 set a = 1, b = 1, c = (select b+1 from t2)")
+	tk.MustQuery("select * from t2").Check(testkit.Rows("1 1 <nil>", "1 1 2"))
+
+	// insert using column should work normally
+	tk.MustExec("delete from t2")
+	tk.MustExec("insert into t2 values(2, 4, a)")
+	tk.MustQuery("select * from t2").Check(testkit.Rows("2 4 2"))
+	tk.MustExec("insert into t2 set a = 3, b = 5, c = b")
+	tk.MustQuery("select * from t2").Check(testkit.Rows("2 4 2", "3 5 5"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Insert statements with subquery in value clause write incorrect values
```
mysql root@127.0.0.1:test> select * from t2;
+---+---+---+
| a | b | c |
+---+---+---+
0 rows in set
Time: 0.013s
mysql root@127.0.0.1:test> show create table t2;
+-------+-------------------------------------------------------------+
| Table | Create Table                                                |
+-------+-------------------------------------------------------------+
| t2    | CREATE TABLE `t2` (                                         |
|       |   `a` int(11) NOT NULL,                                     |
|       |   `b` int(11) DEFAULT NULL,                                 |
|       |   `c` int(11) DEFAULT NULL,                                 |
|       |   PRIMARY KEY (`a`)                                         |
|       | ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+-------------------------------------------------------------+
1 row in set
Time: 0.014s
mysql root@127.0.0.1:test> insert into t2 values (11, 8, (select not b));
Query OK, 1 row affected
Time: 0.001s
mysql root@127.0.0.1:test> select * from t2;
+----+---+----+
| a  | b | c  |
+----+---+----+
| 11 | 8 | 11 |
+----+---+----+
1 row in set
Time: 0.018s
```

### What is changed and how it works?

What's Changed:
Prevent subquery in insert values clause referencing upper scope columns, these column expressions will not be treated as correlated columns.

This change is compatible with `pg` but not `mysql` , the inserted table is not allowed to be used in insert value clause, eg:
```
mysql> insert into t2 values (11, 8, (select c from t2 limit 1));
ERROR 1093 (HY000): You can't specify target table 't2' for update in FROM clause
```


How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->
