### PR TITLE
config: remove the special limit of txn-total-size-limit when binlog enabled

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -828,9 +828,6 @@ func (c *Config) Valid() error {
 		return fmt.Errorf("grpc-connection-count should be greater than 0")
 	}
 
-	if c.Performance.TxnTotalSizeLimit > 100<<20 && c.Binlog.Enable {
-		return fmt.Errorf("txn-total-size-limit should be less than %d with binlog enabled", 100<<20)
-	}
 	if c.Performance.TxnTotalSizeLimit > 10<<30 {
 		return fmt.Errorf("txn-total-size-limit should be less than %d", 10<<30)
 	}

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -237,8 +237,9 @@ distinct-agg-push-down = false
 
 # The limitation of the size in byte for the entries in one transaction.
 # If using TiKV as the storage, the entry represents a key/value pair.
-# NOTE: If binlog is enabled, this value should be less than 104857600(10M) because this is the maximum size that can be handled by Pumper.
-# If binlog is not enabled, this value should be less than 10737418240(10G).
+# NOTE: If binlog is enabled with Kafka (e.g. arbiter cluster),
+# this value should be less than 1073741824(1G) because this is the maximum size that can be handled by Kafka.
+# If binlog is disabled or binlog is enabled without Kafka, this value should be less than 10737418240(10G).
 txn-total-size-limit = 104857600
 
 # The max number of running concurrency two phase committer request for an SQL.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -385,10 +385,6 @@ func (s *testConfigSuite) TestTxnTotalSizeLimitValid(c *C) {
 		conf.Performance.TxnTotalSizeLimit = tt.limit
 		c.Assert(conf.Valid() == nil, Equals, tt.valid)
 	}
-
-	conf.Binlog.Enable = true
-	conf.Performance.TxnTotalSizeLimit = 100<<20 + 1
-	c.Assert(conf.Valid(), NotNil)
 }
 
 func (s *testConfigSuite) TestAllowAutoRandomValid(c *C) {


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
We've tested the big transaction when binlog enabled, pump, and drainer can handle 10GB transactions. But with Kafka as an arbiter or some other usage of binlog, it could only handle 1GB transactions, because Kafka has its own max message limit.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
We could not know if there is a Kafka cluster using in the binlog replication. So we remove the limitation and keep the warnings of txn-total-size-limit usage.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
There is an internal doc for it.

### Release note <!-- bugfixes or new feature need a release note -->
Remove the special limit of txn-total-size-limit when binlog enabled.