### PR TITLE
store/tikv: pre-split regions during 2PC to avoid hotspot

### DIFF
--- a/store/tikv/2pc_slow_test.go
+++ b/store/tikv/2pc_slow_test.go
@@ -41,9 +41,10 @@ func (s *testCommitterSuite) TestCommitMultipleRegions(c *C) {
 }
 
 func (s *testTiclientSuite) TestSplitRegionIn2PC(c *C) {
+	testSplitRegionFlag = true
 	bo := NewBackoffer(context.Background(), 1)
 	startKey := encodeKey(s.prefix, s08d("key", 0))
-	endKey := encodeKey(s.prefix, s08d("key", presplitKeyCount-1))
+	endKey := encodeKey(s.prefix, s08d("key", 1000))
 	checkKeyRegion := func(bo *Backoffer, start, end []byte, checker Checker) {
 		// Check regions after split.
 		loc1, err := s.store.regionCache.LocateKey(bo, start)
@@ -56,7 +57,7 @@ func (s *testTiclientSuite) TestSplitRegionIn2PC(c *C) {
 	// Check before test.
 	checkKeyRegion(bo, startKey, endKey, Equals)
 	txn := s.beginTxn(c)
-	for i := 0; i < presplitKeyCount+1; i++ {
+	for i := 0; i < 1000; i++ {
 		err := txn.Set(encodeKey(s.prefix, s08d("key", i)), valueBytes(i))
 		c.Assert(err, IsNil)
 	}

--- a/store/tikv/2pc_slow_test.go
+++ b/store/tikv/2pc_slow_test.go
@@ -43,9 +43,13 @@ func (s *testCommitterSuite) TestCommitMultipleRegions(c *C) {
 
 func (s *testTiclientSuite) TestSplitRegionIn2PC(c *C) {
 	const preSplitThresholdInTest = 500
-	old := atomic.LoadUint32(&preSplitThreshold)
-	defer atomic.StoreUint32(&preSplitThreshold, old)
-	atomic.StoreUint32(&preSplitThreshold, preSplitThresholdInTest)
+	old := atomic.LoadUint32(&preSplitDetectThreshold)
+	defer atomic.StoreUint32(&preSplitDetectThreshold, old)
+	atomic.StoreUint32(&preSplitDetectThreshold, preSplitThresholdInTest)
+
+	old = atomic.LoadUint32(&preSplitSizeThreshold)
+	defer atomic.StoreUint32(&preSplitSizeThreshold, old)
+	atomic.StoreUint32(&preSplitSizeThreshold, 5000)
 
 	bo := NewBackoffer(context.Background(), 1)
 	startKey := encodeKey(s.prefix, s08d("key", 0))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/16573

Problem Summary:

Pre-split region before it become a writing hotspot to avoid the TiKV 'server is busy' error.

### What is changed and how it works?

What's Changed:

Pre-split the region during 2PC if we detect there are many mutations into one region.

How it Works:

Call the `store.SplitRegions` and `store.WaitScatterRegionFinish` API.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

http://172.16.4.61:13000/d/000000011/test-cluster-tidb?orgId=1&from=1588073060157&to=1588082547757


### Release note <!-- bugfixes or new feature need a release note -->
