### PR TITLE
store/mockstore/mocktikv: Add mvccGetByKeyNoLock() to avoid double RLock

### DIFF
--- a/store/mockstore/mocktikv/mvcc_leveldb.go
+++ b/store/mockstore/mocktikv/mvcc_leveldb.go
@@ -1657,7 +1657,7 @@ func (mvcc *MVCCLevelDB) MvccGetByStartTS(starTS uint64) (*kvrpcpb.MvccInfo, []b
 		iter.Next()
 	}
 
-	return mvcc.MvccGetByKey(key), key
+	return mvcc.mvccGetByKeyNoLock(key), key
 }
 
 var valueTypeOpMap = [...]kvrpcpb.Op{
@@ -1672,6 +1672,11 @@ func (mvcc *MVCCLevelDB) MvccGetByKey(key []byte) *kvrpcpb.MvccInfo {
 	mvcc.mu.RLock()
 	defer mvcc.mu.RUnlock()
 
+	return mvcc.mvccGetByKeyNoLock(key)
+}
+
+// mvccGetByKeyNoLock implements the MVCCDebugger interface without Lock.
+func (mvcc *MVCCLevelDB) mvccGetByKeyNoLock(key []byte) *kvrpcpb.MvccInfo {
 	info := &kvrpcpb.MvccInfo{}
 
 	startKey := mvccEncode(key, lockVer)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?
What's Changed:
Add `mvccGetByKeyNoLock()`, which contains all the content in `MvccGetByKey()` except the lock.
Then make `MvccGetByKey()` call it with lock protection. Replace the call to `MvccGetByKey()` in `MvccGetByStartTS()` with the No-lock version.

How it Works:
As the [https://golang.org/pkg/sync/](https://golang.org/pkg/sync/) says about RLock:
`It should not be used for recursive read locking; a blocked Lock call excludes new readers from acquiring the lock.`
So double read lock should also be avoided.

The first lock is in `MvccGetByStartTS()`, then it calls `MvccGetByKey()`, where the second lock resides.

The patch removes the second lock to avoid double Rlock.


### Related changes
- Need to cherry-pick to the release branch

- Unit test
- Integration test

Side effects
No

### Release note <!-- bugfixes or new feature need a release note -->
Avoid double RLock in MvccGetByStartTS()
