### PR TITLE
tikv: recheck kv status before invalidate region on sending fail

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -50,8 +50,8 @@ const (
 	DefPort = 4000
 	// DefStatusPort is the default status port of TiBD
 	DefStatusPort = 10080
-	// DefStoreLivenessTimeout is the default value for store liveness timeout(unit: ms).
-	DefStoreLivenessTimeout = 120
+	// DefStoreLivenessTimeout is the default value for store liveness timeout.
+	DefStoreLivenessTimeout = "120s"
 )
 
 // Valid config maps
@@ -453,8 +453,8 @@ type TiKVClient struct {
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
-	// StoreLivenessTimeout in nanosecond is the timeout for store liveness check request.
-	StoreLivenessTimeout int `toml:"store-liveness-timeout" json:"store-liveness-timeout"`
+	// StoreLivenessTimeout is the timeout for store liveness check request.
+	StoreLivenessTimeout string `toml:"store-liveness-timeout" json:"store-liveness-timeout"`
 
 	CoprCache CoprocessorCache `toml:"copr-cache" json:"copr-cache"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -50,6 +50,8 @@ const (
 	DefPort = 4000
 	// DefStatusPort is the default status port of TiBD
 	DefStatusPort = 10080
+	// DefStoreLivenessTimeout is the default value for store liveness timeout(unit: ms).
+	DefStoreLivenessTimeout = 120
 )
 
 // Valid config maps
@@ -451,6 +453,8 @@ type TiKVClient struct {
 	// If a store has been up to the limit, it will return error for successive request to
 	// prevent the store occupying too much token in dispatching level.
 	StoreLimit int64 `toml:"store-limit" json:"store-limit"`
+	// StoreLivenessTimeout in nanosecond is the timeout for store liveness check request.
+	StoreLivenessTimeout int `toml:"store-liveness-timeout" json:"store-liveness-timeout"`
 
 	CoprCache CoprocessorCache `toml:"copr-cache" json:"copr-cache"`
 }
@@ -629,8 +633,9 @@ var defaultConf = Config{
 
 		EnableChunkRPC: true,
 
-		RegionCacheTTL: 600,
-		StoreLimit:     0,
+		RegionCacheTTL:       600,
+		StoreLimit:           0,
+		StoreLivenessTimeout: DefStoreLivenessTimeout,
 
 		CoprCache: CoprocessorCache{
 			Enabled:               true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -348,7 +348,7 @@ region-cache-ttl = 600
 store-limit = 0
 
 # store-liveness-timeout is used to control timeout for store liveness after sending request failed(unit: ms).
-store-liveness-timeout = 120
+store-liveness-timeout = "120s"
 
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -347,6 +347,9 @@ region-cache-ttl = 600
 # default 0 means shutting off store limit.
 store-limit = 0
 
+# store-liveness-timeout is used to control timeout for store liveness after sending request failed(unit: ms).
+store-liveness-timeout = 120
+
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
 # reuses the result when corresponding data in TiKV is unchanged, on a region basis.

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -347,7 +347,7 @@ region-cache-ttl = 600
 # default 0 means shutting off store limit.
 store-limit = 0
 
-# store-liveness-timeout is used to control timeout for store liveness after sending request failed(unit: ms).
+# store-liveness-timeout is used to control timeout for store liveness after sending request failed.
 store-liveness-timeout = "120s"
 
 [tikv-client.copr-cache]

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -149,6 +149,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TotalCopProcHistogram)
 	prometheus.MustRegister(TotalCopWaitHistogram)
 	prometheus.MustRegister(TiKVPendingBatchRequests)
+	prometheus.MustRegister(TiKVStatusDuration)
+	prometheus.MustRegister(TiKVStatusCounter)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
 	prometheus.MustRegister(TiKVBatchClientUnavailable)
 	prometheus.MustRegister(TiKVBatchClientWaitEstablish)

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -156,6 +156,23 @@ var (
 			Help:      "Pending batch requests",
 		}, []string{"store"})
 
+	TiKVStatusDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "kv_status_api_duration",
+			Help:      "duration for kv status api.",
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 20), // 0.5ms ~ 262s
+		}, []string{"store"})
+
+	TiKVStatusCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "kv_status_api_count",
+			Help:      "Counter of access kv status api.",
+		}, []string{LblResult})
+
 	TiKVBatchWaitDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -28,11 +29,15 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	pd "github.com/pingcap/pd/v4/client"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/prometheus/client_golang/prometheus"
 	atomic2 "go.uber.org/atomic"
 	"go.uber.org/zap"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -56,6 +61,9 @@ var (
 	tikvRegionCacheCounterWithGetStoreOK                  = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "ok")
 	tikvRegionCacheCounterWithGetStoreError               = metrics.TiKVRegionCacheCounter.WithLabelValues("get_store", "err")
 	tikvRegionCacheCounterWithInvalidateStoreRegionsOK    = metrics.TiKVRegionCacheCounter.WithLabelValues("invalidate_store_regions", "ok")
+
+	tikvStatusCountWithOK    = metrics.TiKVStatusCounter.WithLabelValues("ok")
+	tikvStatusCountWithError = metrics.TiKVStatusCounter.WithLabelValues("err")
 )
 
 const (
@@ -492,11 +500,34 @@ func (c *RegionCache) OnSendFail(bo *Backoffer, ctx *RPCContext, scheduleReload 
 	tikvRegionCacheCounterWithSendFail.Inc()
 	r := c.getCachedRegionWithRLock(ctx.Region)
 	if r != nil {
-		if ctx.Store.storeType == kv.TiKV {
-			c.switchNextPeer(r, ctx.PeerIdx, err)
-		} else {
-			c.switchNextFlashPeer(r, ctx.PeerIdx, err)
+		rs := r.getStore()
+		if err != nil {
+			s := rs.stores[ctx.PeerIdx]
+
+			// send fail but store is reachable, keep retry current peer.
+			if s.requestLiveness(bo) == reachable {
+				return
+			}
+
+			// invalidate regions in store.
+			epoch := rs.storeFails[ctx.PeerIdx]
+			if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
+				logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
+				tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
+			}
+
+			// schedule a store addr resolve.
+			s.markNeedCheck(c.notifyCheckCh)
 		}
+
+		// try next peer to found new leader.
+		if ctx.Store.storeType == kv.TiKV {
+			rs.switchNextPeer(r, ctx.PeerIdx)
+		} else {
+			rs.switchNextFlashPeer(r, ctx.PeerIdx)
+		}
+
+		// force reload region when retry all known peers in region.
 		if scheduleReload {
 			r.scheduleReload()
 		}
@@ -705,7 +736,8 @@ func (c *RegionCache) UpdateLeader(regionID RegionVerID, leaderStoreID uint64, c
 	}
 
 	if leaderStoreID == 0 {
-		c.switchNextPeer(r, currentPeerIdx, nil)
+		rs := r.getStore()
+		rs.switchNextPeer(r, currentPeerIdx)
 		logutil.BgLogger().Info("switch region peer to next due to NotLeader with NULL leader",
 			zap.Int("currIdx", currentPeerIdx),
 			zap.Uint64("regionID", regionID.GetID()))
@@ -1169,49 +1201,25 @@ func (c *RegionCache) switchToPeer(r *Region, targetStoreID uint64) (found bool)
 	return
 }
 
-func (c *RegionCache) switchNextFlashPeer(r *Region, currentPeerIdx int, err error) {
-	rs := r.getStore()
-
-	if err != nil { // TODO: refine err, only do this for some errors.
-		s := rs.stores[currentPeerIdx]
-		epoch := rs.storeFails[currentPeerIdx]
-		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
-			logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
-			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
-		}
-		s.markNeedCheck(c.notifyCheckCh)
-	}
-
-	nextIdx := (currentPeerIdx + 1) % len(rs.stores)
-	newRegionStore := rs.clone()
+func (r *RegionStore) switchNextFlashPeer(rr *Region, currentPeerIdx int) {
+	nextIdx := (currentPeerIdx + 1) % len(r.stores)
+	newRegionStore := r.clone()
 	newRegionStore.workTiFlashIdx = int32(nextIdx)
-	r.compareAndSwapStore(rs, newRegionStore)
+	rr.compareAndSwapStore(r, newRegionStore)
 }
 
-func (c *RegionCache) switchNextPeer(r *Region, currentPeerIdx int, err error) {
-	rs := r.getStore()
-
-	if err != nil { // TODO: refine err, only do this for some errors.
-		s := rs.stores[currentPeerIdx]
-		epoch := rs.storeFails[currentPeerIdx]
-		if atomic.CompareAndSwapUint32(&s.fail, epoch, epoch+1) {
-			logutil.BgLogger().Info("mark store's regions need be refill", zap.String("store", s.addr))
-			tikvRegionCacheCounterWithInvalidateStoreRegionsOK.Inc()
-		}
-		s.markNeedCheck(c.notifyCheckCh)
-	}
-
-	if int(rs.workTiKVIdx) != currentPeerIdx {
+func (r *RegionStore) switchNextPeer(rr *Region, currentPeerIdx int) {
+	if int(r.workTiKVIdx) != currentPeerIdx {
 		return
 	}
 
-	nextIdx := (currentPeerIdx + 1) % len(rs.stores)
-	for rs.stores[nextIdx].storeType == kv.TiFlash {
-		nextIdx = (nextIdx + 1) % len(rs.stores)
+	nextIdx := (currentPeerIdx + 1) % len(r.stores)
+	for r.stores[nextIdx].storeType == kv.TiFlash {
+		nextIdx = (nextIdx + 1) % len(r.stores)
 	}
-	newRegionStore := rs.clone()
+	newRegionStore := r.clone()
 	newRegionStore.workTiKVIdx = int32(nextIdx)
-	r.compareAndSwapStore(rs, newRegionStore)
+	rr.compareAndSwapStore(r, newRegionStore)
 }
 
 func (c *RegionCache) getPeerStoreIndex(r *Region, id uint64) (idx int, found bool) {
@@ -1260,6 +1268,7 @@ func (r *Region) ContainsByEnd(key []byte) bool {
 // Store contains a kv process's address.
 type Store struct {
 	addr         string        // loaded store address
+	saddr        string        // loaded store status address
 	storeID      uint64        // store's id
 	state        uint64        // unsafe store storeState
 	resolveMutex sync.Mutex    // protect pd from concurrent init requests
@@ -1310,6 +1319,7 @@ func (s *Store) initResolve(bo *Backoffer, c *RegionCache) (addr string, err err
 		}
 		addr = store.GetAddress()
 		s.addr = addr
+		s.saddr = store.GetStatusAddress()
 		s.storeType = GetStoreTypeByMeta(store)
 	retry:
 		state = s.getResolveState()
@@ -1365,7 +1375,7 @@ func (s *Store) reResolve(c *RegionCache) {
 	addr = store.GetAddress()
 	if s.addr != addr {
 		state := resolved
-		newStore := &Store{storeID: s.storeID, addr: addr, storeType: storeType}
+		newStore := &Store{storeID: s.storeID, addr: addr, saddr: store.GetStatusAddress(), storeType: storeType}
 		newStore.state = *(*uint64)(&state)
 		c.storeMu.Lock()
 		c.storeMu.stores[newStore.storeID] = newStore
@@ -1420,4 +1430,88 @@ retry:
 	default:
 	}
 
+}
+
+type livenessState uint32
+
+var livenessSf singleflight.Group
+
+const (
+	unknown livenessState = iota
+	reachable
+	unreachable
+	offline
+)
+
+func (s *Store) requestLiveness(bo *Backoffer) (l livenessState) {
+	saddr := s.saddr
+	if len(saddr) == 0 {
+		l = unknown
+		return
+	}
+	rsCh := livenessSf.DoChan(saddr, func() (interface{}, error) {
+		return invokeKVStatusAPI(saddr, time.Duration(config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout)*time.Second), nil
+	})
+	var ctx context.Context
+	if bo != nil {
+		ctx = bo.ctx
+	} else {
+		ctx = context.Background()
+	}
+	select {
+	case rs := <-rsCh:
+		l = rs.Val.(livenessState)
+	case <-ctx.Done():
+		l = unknown
+		return
+	}
+	return
+}
+
+var kvStatusDurationCache sync.Map
+
+func invokeKVStatusAPI(saddr string, timeout time.Duration) (l livenessState) {
+	start := time.Now()
+	defer func() {
+		if l == reachable {
+			tikvStatusCountWithOK.Inc()
+		} else {
+			tikvStatusCountWithError.Inc()
+		}
+
+		v, ok := kvStatusDurationCache.Load(saddr)
+		if !ok {
+			v = metrics.TiKVStatusDuration.WithLabelValues(saddr)
+			kvStatusDurationCache.Store(saddr, v)
+		}
+		v.(prometheus.Observer).Observe(time.Since(start).Seconds())
+	}()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	url := fmt.Sprintf("%s://%s/status", util.InternalHTTPSchema(), saddr)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		logutil.BgLogger().Info("[liveness] build kv status request fail", zap.String("store", saddr), zap.Error(err))
+		l = unreachable
+		return
+	}
+	resp, err := util.InternalHTTPClient().Do(req)
+	if err != nil {
+		logutil.BgLogger().Info("[liveness] request kv status fail", zap.String("store", saddr), zap.Error(err))
+		l = unreachable
+		return
+	}
+	defer func() {
+		err1 := resp.Body.Close()
+		if err1 != nil {
+			logutil.BgLogger().Debug("[liveness] close kv status api body failed", zap.String("store", saddr), zap.Error(err))
+		}
+	}()
+	if resp.StatusCode != http.StatusOK {
+		logutil.BgLogger().Info("[liveness] request kv status fail", zap.String("store", saddr), zap.String("status", resp.Status))
+		l = unreachable
+		return
+	}
+	l = reachable
+	return
 }

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -1139,8 +1139,8 @@ func BenchmarkOnRequestFail(b *testing.B) {
 				Store:   store,
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
-			if r == nil {
-				cache.switchNextPeer(r, rpcCtx.PeerIdx, nil)
+			if r != nil {
+				r.getStore().switchNextPeer(r, rpcCtx.PeerIdx)
 			}
 		}
 	})


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

the simple and cherry-pickable part of https://github.com/pingcap/tidb/pull/15989

do addition kv status check before invalidate region to avoid false-invalidate region cache when tikv isn't down but sending request failure(like meet network timeout).

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

do addition kv status check before invalidate region

How it Works:

do addition kv status check before invalidate region

and add metric to new check operation.

if status API unavaliable tidb will works as code before this pr

### Related changes

- Need to cherry-pick to the release branch 4.0 to help large-txn test

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

recheck kv status before invalidating region on sending fail

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/16933)
<!-- Reviewable:end -->
