### PR TITLE
tests: abstract `Cluster` interface for introducing new mock...

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -480,6 +480,7 @@ func (s *testFastAnalyze) TestFastAnalyzeRetryRowCount(c *C) {
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	mvccStore := mocktikv.MustNewMVCCStore()
+	cluster.SetMvccStore(mvccStore)
 	store, err := mockstore.NewMockTikvStore(
 		mockstore.WithHijackClient(hijackClient),
 		mockstore.WithCluster(cluster),
@@ -504,7 +505,7 @@ func (s *testFastAnalyze) TestFastAnalyzeRetryRowCount(c *C) {
 	for i := 0; i < 30; i++ {
 		tk.MustExec(fmt.Sprintf("insert into retry_row_count values (%d)", i))
 	}
-	cluster.SplitTable(mvccStore, tid, 6)
+	cluster.SplitTable(tid, 6)
 	// Flush the region cache first.
 	tk.MustQuery("select * from retry_row_count")
 	tk.MustExec("analyze table retry_row_count")

--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -66,7 +66,7 @@ func (s *testSuite3) TestCopClientSend(c *C) {
 	tblID := tbl.Meta().ID
 
 	// Split the table.
-	s.cluster.SplitTable(s.mvccStore, tblID, 100)
+	s.cluster.SplitTable(tblID, 100)
 
 	ctx := context.Background()
 	// Send coprocessor request when the table split.

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -23,16 +23,16 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
 type testUpdateSuite struct {
-	cluster   *mocktikv.Cluster
-	mvccStore mocktikv.MVCCStore
-	store     kv.Storage
-	domain    *domain.Domain
+	cluster cluster.Cluster
+	store   kv.Storage
+	domain  *domain.Domain
 	*parser.Parser
 	ctx *mock.Context
 }
@@ -42,12 +42,15 @@ func (s *testUpdateSuite) SetUpSuite(c *C) {
 	flag.Lookup("mockTikv")
 	useMockTikv := *mockTikv
 	if useMockTikv {
-		s.cluster = mocktikv.NewCluster()
-		mocktikv.BootstrapWithSingleStore(s.cluster)
-		s.mvccStore = mocktikv.MustNewMVCCStore()
+		cluster := mocktikv.NewCluster()
+		mocktikv.BootstrapWithSingleStore(cluster)
+		s.cluster = cluster
+
+		mvccStore := mocktikv.MustNewMVCCStore()
+		cluster.SetMvccStore(mvccStore)
 		store, err := mockstore.NewMockTikvStore(
-			mockstore.WithCluster(s.cluster),
-			mockstore.WithMVCCStore(s.mvccStore),
+			mockstore.WithCluster(cluster),
+			mockstore.WithMVCCStore(mvccStore),
 		)
 		c.Assert(err, IsNil)
 		s.store = store

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -196,7 +196,7 @@ func (s *testPessimisticSuite) TestSingleStatementRollback(c *C) {
 	tk.MustExec("create table single_statement (id int primary key, v int)")
 	tk.MustExec("insert into single_statement values (1, 1), (2, 1), (3, 1), (4, 1)")
 	tblID := tk.GetTableID("single_statement")
-	s.cluster.SplitTable(s.mvccStore, tblID, 2)
+	s.cluster.SplitTable(tblID, 2)
 	region1Key := codec.EncodeBytes(nil, tablecodec.EncodeRowKeyWithHandle(tblID, kv.IntHandle(1)))
 	region1, _ := s.cluster.GetRegionByKey(region1Key)
 	region1ID := region1.Id

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/table/tables"
@@ -71,11 +72,10 @@ var _ = SerialSuites(&testSchemaSerialSuite{})
 var _ = SerialSuites(&testSessionSerialSuite{})
 
 type testSessionSuiteBase struct {
-	cluster   *mocktikv.Cluster
-	mvccStore mocktikv.MVCCStore
-	store     kv.Storage
-	dom       *domain.Domain
-	pdAddr    string
+	cluster cluster.Cluster
+	store   kv.Storage
+	dom     *domain.Domain
+	pdAddr  string
 }
 
 type testSessionSuite struct {
@@ -158,7 +158,6 @@ func initPdAddrs() {
 
 func (s *testSessionSuiteBase) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	s.cluster = mocktikv.NewCluster()
 
 	if *withTiKV {
 		initPdAddrs()
@@ -174,11 +173,15 @@ func (s *testSessionSuiteBase) SetUpSuite(c *C) {
 		session.ResetStoreForWithTiKVTest(store)
 		s.store = store
 	} else {
-		mocktikv.BootstrapWithSingleStore(s.cluster)
-		s.mvccStore = mocktikv.MustNewMVCCStore()
+		cluster := mocktikv.NewCluster()
+		mocktikv.BootstrapWithSingleStore(cluster)
+		s.cluster = cluster
+
+		mvccStore := mocktikv.MustNewMVCCStore()
+		cluster.SetMvccStore(mvccStore)
 		store, err := mockstore.NewMockTikvStore(
-			mockstore.WithCluster(s.cluster),
-			mockstore.WithMVCCStore(s.mvccStore),
+			mockstore.WithCluster(cluster),
+			mockstore.WithMVCCStore(mvccStore),
 		)
 		c.Assert(err, IsNil)
 		s.store = store
@@ -1914,10 +1917,9 @@ func (s *testSessionSuite2) TestInformationSchemaCreateTime(c *C) {
 }
 
 type testSchemaSuiteBase struct {
-	cluster   *mocktikv.Cluster
-	mvccStore mocktikv.MVCCStore
-	store     kv.Storage
-	dom       *domain.Domain
+	cluster cluster.Cluster
+	store   kv.Storage
+	dom     *domain.Domain
 }
 
 type testSchemaSuite struct {
@@ -1939,12 +1941,15 @@ func (s *testSchemaSuiteBase) TearDownTest(c *C) {
 
 func (s *testSchemaSuiteBase) SetUpSuite(c *C) {
 	testleak.BeforeTest()
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithSingleStore(s.cluster)
-	s.mvccStore = mocktikv.MustNewMVCCStore()
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithSingleStore(cluster)
+	s.cluster = cluster
+
+	mvccStore := mocktikv.MustNewMVCCStore()
+	cluster.SetMvccStore(mvccStore)
 	store, err := mockstore.NewMockTikvStore(
-		mockstore.WithCluster(s.cluster),
-		mockstore.WithMVCCStore(s.mvccStore),
+		mockstore.WithCluster(cluster),
+		mockstore.WithMVCCStore(mvccStore),
 	)
 	c.Assert(err, IsNil)
 	s.store = store
@@ -2178,7 +2183,7 @@ func (s *testSchemaSuite) TestTableReaderChunk(c *C) {
 	}
 	tbl, err := domain.GetDomain(tk.Se).InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("chk"))
 	c.Assert(err, IsNil)
-	s.cluster.SplitTable(s.mvccStore, tbl.Meta().ID, 10)
+	s.cluster.SplitTable(tbl.Meta().ID, 10)
 
 	tk.Se.GetSessionVars().DistSQLScanConcurrency = 1
 	tk.MustExec("set tidb_init_chunk_size = 2")
@@ -2363,7 +2368,7 @@ func (s *testSchemaSuite) TestIndexLookUpReaderChunk(c *C) {
 	}
 	tbl, err := domain.GetDomain(tk.Se).InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("chk"))
 	c.Assert(err, IsNil)
-	s.cluster.SplitIndex(s.mvccStore, tbl.Meta().ID, tbl.Indices()[0].Meta().ID, 10)
+	s.cluster.SplitIndex(tbl.Meta().ID, tbl.Indices()[0].Meta().ID, 10)
 
 	tk.Se.GetSessionVars().IndexLookupSize = 10
 	rs, err := tk.Exec("select * from chk order by k")

--- a/store/mockstore/cluster/cluster.go
+++ b/store/mockstore/cluster/cluster.go
@@ -1,0 +1,45 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cluster
+
+import (
+	"time"
+
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/kv"
+)
+
+// Cluster simulates a TiKV cluster.
+// It can be used to change cluster states in tests.
+type Cluster interface {
+	// AllocID creates an unique ID in cluster. The ID could be used as either
+	// StoreID, RegionID, or PeerID.
+	AllocID() uint64
+	// GetRegionByKey returns the Region and its leader whose range contains the key.
+	GetRegionByKey(key []byte) (*metapb.Region, *metapb.Peer)
+	// GetAllStores returns all Stores' meta.
+	GetAllStores() []*metapb.Store
+	// ScheduleDelay schedules a delay event for a transaction on a region.
+	ScheduleDelay(startTS, regionID uint64, dur time.Duration)
+	// SetMvccStore sets the the mvccStore used by SplitTable, SplitIndex and SplitKeys.
+	Split(regionID, newRegionID uint64, key []byte, peerIDs []uint64, leaderPeerID uint64)
+	// SplitRaw splits a Region at the key (not encoded) and creates new Region.
+	SplitRaw(regionID, newRegionID uint64, rawKey []byte, peerIDs []uint64, leaderPeerID uint64) *metapb.Region
+	// SplitTable evenly splits the data in table into count regions.
+	SplitTable(tableID int64, count int)
+	// SplitIndex evenly splits the data in index into count regions.
+	SplitIndex(tableID, indexID int64, count int)
+	// SplitKeys evenly splits the start, end key into "count" regions.
+	SplitKeys(start, end kv.Key, count int)
+}

--- a/store/mockstore/mocktikv/cluster_test.go
+++ b/store/mockstore/mocktikv/cluster_test.go
@@ -42,6 +42,7 @@ func (s *testClusterSuite) TestClusterSplit(c *C) {
 	cluster := mocktikv.NewCluster()
 	mocktikv.BootstrapWithSingleStore(cluster)
 	mvccStore := mocktikv.MustNewMVCCStore()
+	cluster.SetMvccStore(mvccStore)
 	store, err := mockstore.NewMockTikvStore(
 		mockstore.WithCluster(cluster),
 		mockstore.WithMVCCStore(mvccStore),
@@ -76,7 +77,7 @@ func (s *testClusterSuite) TestClusterSplit(c *C) {
 	c.Assert(err, IsNil)
 
 	// Split Table into 10 regions.
-	cluster.SplitTable(mvccStore, tblID, 10)
+	cluster.SplitTable(tblID, 10)
 
 	// 10 table regions and first region and last region.
 	regions := cluster.GetAllRegions()
@@ -100,7 +101,7 @@ func (s *testClusterSuite) TestClusterSplit(c *C) {
 	}
 	c.Assert(allKeysMap, HasLen, 1000)
 
-	cluster.SplitIndex(mvccStore, tblID, idxID, 10)
+	cluster.SplitIndex(tblID, idxID, 10)
 
 	allIndexMap := make(map[string]bool)
 	indexPrefix := tablecodec.EncodeTableIndexPrefix(tblID, idxID)

--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/pd/v4/client"
+	pd "github.com/pingcap/pd/v4/client"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -36,9 +37,8 @@ import (
 
 type testCommitterSuite struct {
 	OneByOneSuite
-	cluster   *mocktikv.Cluster
-	store     *tikvStore
-	mvccStore mocktikv.MVCCStore
+	cluster cluster.Cluster
+	store   *tikvStore
 }
 
 var _ = SerialSuites(&testCommitterSuite{})
@@ -49,13 +49,14 @@ func (s *testCommitterSuite) SetUpSuite(c *C) {
 }
 
 func (s *testCommitterSuite) SetUpTest(c *C) {
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("a"), []byte("b"), []byte("c"))
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithMultiRegions(cluster, []byte("a"), []byte("b"), []byte("c"))
+	s.cluster = cluster
 	mvccStore, err := mocktikv.NewMVCCLevelDB("")
 	c.Assert(err, IsNil)
-	s.mvccStore = mvccStore
-	client := mocktikv.NewRPCClient(s.cluster, mvccStore)
-	pdCli := &codecPDClient{mocktikv.NewPDClient(s.cluster)}
+	cluster.SetMvccStore(mvccStore)
+	client := mocktikv.NewRPCClient(cluster, mvccStore)
+	pdCli := &codecPDClient{mocktikv.NewPDClient(cluster)}
 	spkv := NewMockSafePointKV()
 	store, err := newTikvStore("mocktikv-store", pdCli, spkv, client, false, nil)
 	c.Assert(err, IsNil)
@@ -845,7 +846,7 @@ func (c *twoPhaseCommitter) mutationsOfKeys(keys [][]byte) committerMutations {
 
 func (s *testCommitterSuite) TestCommitDeadLock(c *C) {
 	// Split into two region and let k1 k2 in different regions.
-	s.cluster.SplitKeys(s.mvccStore, kv.Key("z"), kv.Key("a"), 2)
+	s.cluster.SplitKeys(kv.Key("z"), kv.Key("a"), 2)
 	k1 := kv.Key("a_deadlock_k1")
 	k2 := kv.Key("y_deadlock_k2")
 

--- a/store/tikv/delete_range_test.go
+++ b/store/tikv/delete_range_test.go
@@ -20,21 +20,23 @@ import (
 	"sort"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testDeleteRangeSuite struct {
 	OneByOneSuite
-	cluster *mocktikv.Cluster
+	cluster cluster.Cluster
 	store   *tikvStore
 }
 
 var _ = Suite(&testDeleteRangeSuite{})
 
 func (s *testDeleteRangeSuite) SetUpTest(c *C) {
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithMultiRegions(s.cluster, []byte("b"), []byte("c"), []byte("d"))
-	client, pdClient, err := mocktikv.NewTiKVAndPDClient(s.cluster, nil, "")
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithMultiRegions(cluster, []byte("b"), []byte("c"), []byte("d"))
+	s.cluster = cluster
+	client, pdClient, err := mocktikv.NewTiKVAndPDClient(cluster, nil, "")
 	c.Assert(err, IsNil)
 
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockoracle"
 	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -50,7 +51,7 @@ func TestT(t *testing.T) {
 
 type testGCWorkerSuite struct {
 	store    tikv.Storage
-	cluster  *mocktikv.Cluster
+	cluster  cluster.Cluster
 	oracle   *mockoracle.MockOracle
 	gcWorker *GCWorker
 	dom      *domain.Domain
@@ -71,10 +72,11 @@ func (s *testGCWorkerSuite) SetUpTest(c *C) {
 		return client
 	}
 
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithMultiStores(s.cluster, 3)
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithMultiStores(cluster, 3)
+	s.cluster = cluster
 	store, err := mockstore.NewMockTikvStore(
-		mockstore.WithCluster(s.cluster),
+		mockstore.WithCluster(cluster),
 		mockstore.WithHijackClient(hijackClient))
 
 	s.store = store.(tikv.Storage)
@@ -84,7 +86,7 @@ func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	s.dom, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
 
-	s.pdClient = mocktikv.NewPDClient(s.cluster)
+	s.pdClient = mocktikv.NewPDClient(cluster)
 	gcWorker, err := NewGCWorker(s.store, s.pdClient)
 	c.Assert(err, IsNil)
 	gcWorker.Start()

--- a/store/tikv/range_task_test.go
+++ b/store/tikv/range_task_test.go
@@ -21,12 +21,13 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testRangeTaskSuite struct {
 	OneByOneSuite
-	cluster *mocktikv.Cluster
+	cluster cluster.Cluster
 	store   *tikvStore
 
 	testRanges     []kv.KeyRange
@@ -59,9 +60,10 @@ func (s *testRangeTaskSuite) SetUpTest(c *C) {
 	}
 	allRegionRanges = append(allRegionRanges, makeRange("z", ""))
 
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithMultiRegions(s.cluster, splitKeys...)
-	client, pdClient, err := mocktikv.NewTiKVAndPDClient(s.cluster, nil, "")
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithMultiRegions(cluster, splitKeys...)
+	s.cluster = cluster
+	client, pdClient, err := mocktikv.NewTiKVAndPDClient(cluster, nil, "")
 	c.Assert(err, IsNil)
 
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -19,12 +19,13 @@ import (
 	"fmt"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testRawKVSuite struct {
 	OneByOneSuite
-	cluster *mocktikv.Cluster
+	cluster cluster.Cluster
 	client  *RawKVClient
 	bo      *Backoffer
 }
@@ -32,15 +33,16 @@ type testRawKVSuite struct {
 var _ = Suite(&testRawKVSuite{})
 
 func (s *testRawKVSuite) SetUpTest(c *C) {
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithSingleStore(s.cluster)
-	pdClient := mocktikv.NewPDClient(s.cluster)
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithSingleStore(cluster)
+	s.cluster = cluster
+	pdClient := mocktikv.NewPDClient(cluster)
 	mvccStore := mocktikv.MustNewMVCCStore()
 	s.client = &RawKVClient{
 		clusterID:   0,
 		regionCache: NewRegionCache(pdClient),
 		pdClient:    pdClient,
-		rpcClient:   mocktikv.NewRPCClient(s.cluster, mvccStore),
+		rpcClient:   mocktikv.NewRPCClient(cluster, mvccStore),
 	}
 	s.bo = NewBackoffer(context.Background(), 5000)
 }

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -18,12 +18,13 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testSplitSuite struct {
 	OneByOneSuite
-	cluster *mocktikv.Cluster
+	cluster cluster.Cluster
 	store   *tikvStore
 	bo      *Backoffer
 }
@@ -31,9 +32,10 @@ type testSplitSuite struct {
 var _ = Suite(&testSplitSuite{})
 
 func (s *testSplitSuite) SetUpTest(c *C) {
-	s.cluster = mocktikv.NewCluster()
-	mocktikv.BootstrapWithSingleStore(s.cluster)
-	client, pdClient, err := mocktikv.NewTiKVAndPDClient(s.cluster, nil, "")
+	cluster := mocktikv.NewCluster()
+	mocktikv.BootstrapWithSingleStore(cluster)
+	s.cluster = cluster
+	client, pdClient, err := mocktikv.NewTiKVAndPDClient(cluster, nil, "")
 	c.Assert(err, IsNil)
 
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Some test cases need to manipulate region metadata through `mocktikv.Cluster`. For another type of mockstore, such as unistore, it has its own metadata management tool.
So we need to abstract a `Cluster` interface to allow using different tools for different mockstore.

### What is changed and how it works?
Just extract the used functions into a new interface, the reason for not include all existing methods is make it easier to implement this interface for the new mockstore at first time. We can add new methods to it as needed.

Note: This PR has ignored test suite in `region_request_test.go` and `region_cache_test.go`. These tests don't need a full mockstore, just need mock cluster metadata and request handler, but they need a bunch of `Cluster` methods. So I just ignored them to reduce the work need to do when implementing a new `Cluster`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code
