### PR TITLE
executor: Refactor Shuffle and implement parallel sort (executor part)

### DIFF
--- a/cmd/explaintest/r/window_function.result
+++ b/cmd/explaintest/r/window_function.result
@@ -66,43 +66,48 @@ Projection_7	10000.00	root		Column#6
 explain select sum(a) over(partition by a order by b) from t;
 id	estRows	task	access object	operator info
 Projection_7	10000.00	root		Column#6
-└─Shuffle_12	10000.00	root		execution info: concurrency:4, data source:TableReader_10
+└─Shuffle_13	10000.00	root		execution info: concurrency:4, fan out:1, splitter:none, merger:random
   └─Window_8	10000.00	root		sum(cast(test.t.a, decimal(65,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b asc range between unbounded preceding and current row)
     └─Sort_11	10000.00	root		test.t.a:asc, test.t.b:asc
-      └─TableReader_10	10000.00	root		data:TableFullScan_9
-        └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+      └─Shuffle_12	10000.00	root		execution info: concurrency:1, fan out:4, splitter:hash(test.t.a), merger:none
+        └─TableReader_10	10000.00	root		data:TableFullScan_9
+          └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select sum(a) over(partition by a order by b rows unbounded preceding) from t;
 id	estRows	task	access object	operator info
 Projection_7	10000.00	root		Column#6
-└─Shuffle_12	10000.00	root		execution info: concurrency:4, data source:TableReader_10
+└─Shuffle_13	10000.00	root		execution info: concurrency:4, fan out:1, splitter:none, merger:random
   └─Window_8	10000.00	root		sum(cast(test.t.a, decimal(65,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b asc rows between unbounded preceding and current row)
     └─Sort_11	10000.00	root		test.t.a:asc, test.t.b:asc
-      └─TableReader_10	10000.00	root		data:TableFullScan_9
-        └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+      └─Shuffle_12	10000.00	root		execution info: concurrency:1, fan out:4, splitter:hash(test.t.a), merger:none
+        └─TableReader_10	10000.00	root		data:TableFullScan_9
+          └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select sum(a) over(partition by a order by b rows between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection_7	10000.00	root		Column#6
-└─Shuffle_12	10000.00	root		execution info: concurrency:4, data source:TableReader_10
+└─Shuffle_13	10000.00	root		execution info: concurrency:4, fan out:1, splitter:none, merger:random
   └─Window_8	10000.00	root		sum(cast(test.t.a, decimal(65,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b asc rows between 1 preceding and 1 following)
     └─Sort_11	10000.00	root		test.t.a:asc, test.t.b:asc
-      └─TableReader_10	10000.00	root		data:TableFullScan_9
-        └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+      └─Shuffle_12	10000.00	root		execution info: concurrency:1, fan out:4, splitter:hash(test.t.a), merger:none
+        └─TableReader_10	10000.00	root		data:TableFullScan_9
+          └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select sum(a) over(partition by a order by b range between 1 preceding and 1 following) from t;
 id	estRows	task	access object	operator info
 Projection_7	10000.00	root		Column#6
-└─Shuffle_12	10000.00	root		execution info: concurrency:4, data source:TableReader_10
+└─Shuffle_13	10000.00	root		execution info: concurrency:4, fan out:1, splitter:none, merger:random
   └─Window_8	10000.00	root		sum(cast(test.t.a, decimal(65,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.b asc range between 1 preceding and 1 following)
     └─Sort_11	10000.00	root		test.t.a:asc, test.t.b:asc
-      └─TableReader_10	10000.00	root		data:TableFullScan_9
-        └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+      └─Shuffle_12	10000.00	root		execution info: concurrency:1, fan out:4, splitter:hash(test.t.a), merger:none
+        └─TableReader_10	10000.00	root		data:TableFullScan_9
+          └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 explain select sum(a) over(partition by a order by c range between interval '2:30' minute_second preceding and interval '2:30' minute_second following) from t;
 id	estRows	task	access object	operator info
 Projection_7	10000.00	root		Column#6
-└─Shuffle_12	10000.00	root		execution info: concurrency:4, data source:TableReader_10
+└─Shuffle_13	10000.00	root		execution info: concurrency:4, fan out:1, splitter:none, merger:random
   └─Window_8	10000.00	root		sum(cast(test.t.a, decimal(65,0) BINARY))->Column#6 over(partition by test.t.a order by test.t.c asc range between interval "2:30" "MINUTE_SECOND" preceding and interval "2:30" "MINUTE_SECOND" following)
     └─Sort_11	10000.00	root		test.t.a:asc, test.t.c:asc
-      └─TableReader_10	10000.00	root		data:TableFullScan_9
-        └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+      └─Shuffle_12	10000.00	root		execution info: concurrency:1, fan out:4, splitter:hash(test.t.a), merger:none
+        └─TableReader_10	10000.00	root		data:TableFullScan_9
+          └─TableFullScan_9	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t1;
 create table t1(a int primary key, b int);
 insert into t1 values(1, 1), (2, 1);
@@ -119,8 +124,9 @@ analyze table t1;
 explain select sum(a) over(partition by b) from t1;
 id	estRows	task	access object	operator info
 Projection_7	3.00	root		Column#4
-└─Shuffle_12	3.00	root		execution info: concurrency:2, data source:TableReader_10
+└─Shuffle_13	3.00	root		execution info: concurrency:2, fan out:1, splitter:none, merger:random
   └─Window_8	3.00	root		sum(cast(test.t1.a, decimal(65,0) BINARY))->Column#4 over(partition by test.t1.b)
     └─Sort_11	3.00	root		test.t1.b:asc
-      └─TableReader_10	3.00	root		data:TableFullScan_9
-        └─TableFullScan_9	3.00	cop[tikv]	table:t1	keep order:false
+      └─Shuffle_12	3.00	root		execution info: concurrency:1, fan out:2, splitter:hash(test.t1.b), merger:none
+        └─TableReader_10	3.00	root		data:TableFullScan_9
+          └─TableFullScan_9	3.00	cop[tikv]	table:t1	keep order:false

--- a/executor/shuffle_merger.go
+++ b/executor/shuffle_merger.go
@@ -1,0 +1,260 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"container/heap"
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/planner/property"
+	"github.com/pingcap/tidb/util/chunk"
+)
+
+var (
+	_ shuffleMerger = (*shuffleRandomMerger)(nil)
+	_ shuffleMerger = (*shuffleMergeSortMerger)(nil)
+)
+
+// shuffleMerger is the results merger of Shuffle executor.
+type shuffleMerger interface {
+	// Open initializes merger.
+	Open(ctx context.Context) error
+	// Prepare for executing. Should prepare merger before worker/splitter.
+	Prepare(ctx context.Context, finishCh <-chan struct{})
+	// Close de-initializes merger. Should close merger after worker/splitter.
+	Close() error
+	// Next retrievals next result. Each merger should implement `Next` for different merge algorithm.
+	Next(ctx context.Context, chk *chunk.Chunk) error
+	// PushToMerger is called by workers to push results or error to merger.
+	PushToMerger(workerIdx int, data *shuffleData)
+	// WorkerFinished signals that a worker is finished. Notice that it would not be called if not prepared.
+	WorkerFinished(workerIdx int)
+	// WorkersAllFinished signals that all workers are finished. Notice that it would not be called if not prepared.
+	WorkersAllFinished()
+}
+
+type baseShuffleMerger struct {
+	shuffle *ShuffleExec
+
+	// fanIn is number of input channels. Should be equal to number of workers.
+	fanIn int
+	// isSingleDataCh indicates the merger need single(e.g shuffleRandomMerger) or multiple(e.g ShuffleMergeSortMerger) output channels.
+	isSingleDataCh bool
+
+	prepared bool
+	finishCh <-chan struct{}
+	dataCh   []chan *shuffleData
+}
+
+func (m *baseShuffleMerger) Open(ctx context.Context) error {
+	m.prepared = false
+	return nil
+}
+
+func (m *baseShuffleMerger) Prepare(ctx context.Context, finishCh <-chan struct{}) {
+	m.finishCh = finishCh
+	if m.isSingleDataCh {
+		m.dataCh = make([]chan *shuffleData, 1)
+		m.dataCh[0] = make(chan *shuffleData, m.fanIn)
+	} else {
+		m.dataCh = make([]chan *shuffleData, m.fanIn)
+		for i := range m.dataCh {
+			m.dataCh[i] = make(chan *shuffleData, 1)
+		}
+	}
+	m.prepared = true
+}
+
+func (m *baseShuffleMerger) Close() error {
+	if m.prepared {
+		// waiting workers exit and close `dataCh` here.
+		for _, ch := range m.dataCh {
+			for range ch {
+			}
+		}
+	}
+	return nil
+}
+
+func (m *baseShuffleMerger) PushToMerger(workerIdx int, data *shuffleData) {
+	if m.isSingleDataCh {
+		m.dataCh[0] <- data
+	} else {
+		m.dataCh[workerIdx] <- data
+	}
+}
+
+func (m *baseShuffleMerger) WorkerFinished(workerIdx int) {
+	if !m.isSingleDataCh {
+		close(m.dataCh[workerIdx])
+	}
+}
+
+func (m *baseShuffleMerger) WorkersAllFinished() {
+	if m.isSingleDataCh {
+		close(m.dataCh[0])
+	}
+}
+
+func (m *baseShuffleMerger) fetchData(ctx context.Context, partitionIdx int, chk *chunk.Chunk) error {
+	chk.Reset()
+
+	select {
+	case <-m.finishCh:
+		return nil
+	case result, ok := <-m.dataCh[partitionIdx]:
+		if !ok {
+			return nil
+		}
+		if result.err != nil {
+			return result.err
+		}
+
+		chk.SwapColumns(result.chk) // worker will not send an empty chunk
+		result.giveBackCh <- result.chk
+		return nil
+	}
+}
+
+// shuffleRandomMerger merges results by the whole chunk, resulting random order.
+type shuffleRandomMerger struct {
+	baseShuffleMerger
+}
+
+// newShuffleRandomMerger creates shuffleRandomMerger.
+func newShuffleRandomMerger(shuffle *ShuffleExec, fanIn int) *shuffleRandomMerger {
+	return &shuffleRandomMerger{baseShuffleMerger{
+		shuffle:        shuffle,
+		fanIn:          fanIn,
+		isSingleDataCh: true,
+	},
+	}
+}
+
+// Next implements shuffleMerger interface.
+func (m *shuffleRandomMerger) Next(ctx context.Context, chk *chunk.Chunk) error {
+	return m.fetchData(ctx, 0, chk)
+}
+
+// shuffleMergeSortMerger merges results by merge-sort.
+// See also executor/sort.go, `multiWayMerge`.
+// See also https://en.wikipedia.org/wiki/K-way_merge_algorithm.
+type shuffleMergeSortMerger struct {
+	baseShuffleMerger
+
+	byItems     []property.ItemExpression
+	keyCmpFuncs []chunk.CompareFunc
+	keyColumns  []int
+
+	multiWayMerge *multiWayMerge
+	partitionList []*chunk.Chunk
+}
+
+// newShuffleMergeSortMerger creates shuffleMergeSortMerger
+func newShuffleMergeSortMerger(shuffle *ShuffleExec, fanIn int, byItems []property.ItemExpression) *shuffleMergeSortMerger {
+	return &shuffleMergeSortMerger{
+		baseShuffleMerger: baseShuffleMerger{
+			shuffle:        shuffle,
+			fanIn:          fanIn,
+			isSingleDataCh: false,
+		},
+		byItems: byItems,
+	}
+}
+
+func (m *shuffleMergeSortMerger) initCompareFuncs() {
+	m.keyCmpFuncs = make([]chunk.CompareFunc, len(m.byItems))
+	for i := range m.byItems {
+		keyType := m.byItems[i].Expr.GetType()
+		m.keyCmpFuncs[i] = chunk.GetCompareFunc(keyType)
+	}
+}
+
+func (m *shuffleMergeSortMerger) buildKeyColumns() {
+	m.keyColumns = make([]int, 0, len(m.byItems))
+	for _, by := range m.byItems {
+		col := by.Expr.(*expression.Column)
+		m.keyColumns = append(m.keyColumns, col.Index)
+	}
+}
+
+func (m *shuffleMergeSortMerger) lessRow(rowI, rowJ chunk.Row) bool {
+	for i, colIdx := range m.keyColumns {
+		cmpFunc := m.keyCmpFuncs[i]
+		cmp := cmpFunc(rowI, colIdx, rowJ, colIdx)
+		if m.byItems[i].Desc {
+			cmp = -cmp
+		}
+		if cmp < 0 {
+			return true
+		} else if cmp > 0 {
+			return false
+		}
+	}
+	return false
+}
+
+func (m *shuffleMergeSortMerger) Prepare(ctx context.Context, finishCh <-chan struct{}) {
+	m.baseShuffleMerger.Prepare(ctx, finishCh)
+
+	m.initCompareFuncs()
+	m.buildKeyColumns()
+}
+
+// Next implements shuffleMerger interface.
+func (m *shuffleMergeSortMerger) Next(ctx context.Context, req *chunk.Chunk) (err error) {
+	if m.multiWayMerge == nil {
+		m.multiWayMerge = &multiWayMerge{m.lessRow, make([]partitionPointer, 0, m.fanIn)}
+		m.partitionList = make([]*chunk.Chunk, m.fanIn)
+		for i := 0; i < m.fanIn; i++ {
+			chk := newFirstChunk(m.shuffle)
+			if err := m.fetchData(ctx, i, chk); err != nil {
+				return err
+			}
+			if chk.NumRows() > 0 {
+				m.partitionList[i] = chk
+				row := m.partitionList[i].GetRow(0)
+				m.multiWayMerge.elements = append(m.multiWayMerge.elements, partitionPointer{row: row, partitionID: i, consumed: 0})
+			}
+		}
+		heap.Init(m.multiWayMerge)
+	}
+
+	req.Reset()
+
+	for !req.IsFull() && m.multiWayMerge.Len() > 0 {
+		ptr := m.multiWayMerge.elements[0]
+		req.AppendRow(ptr.row)
+		ptr.consumed++
+
+		if ptr.consumed >= m.partitionList[ptr.partitionID].NumRows() {
+			if err = m.fetchData(ctx, ptr.partitionID, m.partitionList[ptr.partitionID]); err != nil {
+				return err
+			}
+			if m.partitionList[ptr.partitionID].NumRows() == 0 {
+				m.partitionList[ptr.partitionID] = nil
+				heap.Remove(m.multiWayMerge, 0)
+				continue
+			}
+			ptr.consumed = 0
+		}
+
+		ptr.row = m.partitionList[ptr.partitionID].GetRow(ptr.consumed)
+		m.multiWayMerge.elements[0] = ptr
+		heap.Fix(m.multiWayMerge, 0)
+	}
+
+	return nil
+}

--- a/executor/shuffle_splitter.go
+++ b/executor/shuffle_splitter.go
@@ -1,0 +1,195 @@
+// Copyright 2019 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package executor
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/spaolacci/murmur3"
+)
+
+var (
+	_ shuffleSplitter = (*shuffleRandomSplitter)(nil)
+	_ shuffleSplitter = (*shuffleHashSplitter)(nil)
+)
+
+// shuffleSplitter is the input splitter of Shuffle executor.
+type shuffleSplitter interface {
+	// Open initializes splitter.
+	Open(ctx context.Context) error
+	// Prepare for executing.
+	Prepare(ctx context.Context, finishCh <-chan struct{})
+	// Close de-initializes splitter.
+	Close() error
+	// PushResult pushs result to splitter.
+	PushResult(ctx context.Context, chk *chunk.Chunk) (finished bool, err error)
+	// SplitByRow splits input into partitions row by row. Override this method to implement different splitter scheme.
+	SplitByRow(ctx context.Context, input *chunk.Chunk, partitionIndices []int) ([]int, error)
+}
+
+type baseShuffleSplitter struct {
+	workerIdx int
+	shuffle   *ShuffleExec
+
+	// fanOut is number of merger. Can be NOT equal to number of workers.
+	fanOut int
+	// self is the concrete shuffleSplitter itself.
+	self shuffleSplitter
+
+	finishCh <-chan struct{}
+	holderCh []chan *chunk.Chunk
+
+	// temporary variables
+	results          []*chunk.Chunk
+	partitionIndices []int
+}
+
+func (s *baseShuffleSplitter) Open(ctx context.Context) error {
+	return nil
+}
+
+func (s *baseShuffleSplitter) Close() error {
+	return nil
+}
+
+func (s *baseShuffleSplitter) Prepare(ctx context.Context, finishCh <-chan struct{}) {
+	s.finishCh = finishCh
+	s.holderCh = make([]chan *chunk.Chunk, s.fanOut)
+	for i := range s.holderCh {
+		s.holderCh[i] = make(chan *chunk.Chunk, 1)
+		s.holderCh[i] <- newFirstChunk(s.shuffle)
+	}
+}
+
+func (s *baseShuffleSplitter) PushResult(ctx context.Context, chk *chunk.Chunk) (finished bool, err error) {
+	if s.results == nil {
+		s.results = make([]*chunk.Chunk, s.fanOut)
+	}
+
+	numRows := chk.NumRows()
+	if numRows > 0 {
+		s.partitionIndices, err = s.self.SplitByRow(ctx, chk, s.partitionIndices)
+		if err != nil {
+			return false, err
+		}
+		for i := 0; i < numRows; i++ {
+			partitionIdx := s.partitionIndices[i]
+
+			if s.results[partitionIdx] == nil {
+				select {
+				case <-s.finishCh:
+					return true, nil
+				case s.results[partitionIdx] = <-s.holderCh[partitionIdx]:
+					break
+				}
+			}
+			s.results[partitionIdx].AppendRow(chk.GetRow(i))
+			if s.results[partitionIdx].IsFull() {
+				data := &shuffleData{chk: s.results[partitionIdx], giveBackCh: s.holderCh[partitionIdx]}
+				s.shuffle.PushToMerger(partitionIdx, s.workerIdx, data)
+				s.results[partitionIdx] = nil
+			}
+		}
+		return false, nil
+	}
+
+	for partitionIdx := 0; partitionIdx < s.fanOut; partitionIdx++ {
+		if s.results[partitionIdx] != nil {
+			data := &shuffleData{chk: s.results[partitionIdx], giveBackCh: s.holderCh[partitionIdx]}
+			s.shuffle.PushToMerger(partitionIdx, s.workerIdx, data)
+			s.results[partitionIdx] = nil
+		}
+	}
+	return true, nil
+}
+
+// shuffleRandomSplitter splits data source by the whole chunk, resulting random order.
+type shuffleRandomSplitter struct {
+	baseShuffleSplitter
+	partitionIdx int
+}
+
+// newShuffleRandomSplitter creates shuffleRandomSplitter
+func newShuffleRandomSplitter(workerIdx int, shuffle *ShuffleExec, fanOut int) *shuffleRandomSplitter {
+	splitter := &shuffleRandomSplitter{}
+	splitter.baseShuffleSplitter = baseShuffleSplitter{
+		workerIdx: workerIdx,
+		shuffle:   shuffle,
+		fanOut:    fanOut,
+		self:      splitter,
+	}
+	return splitter
+}
+
+// PushResult implements shuffleSplitter interface.
+func (s *shuffleRandomSplitter) PushResult(ctx context.Context, result *chunk.Chunk) (finished bool, err error) {
+	if result.NumRows() > 0 {
+		select {
+		case <-s.finishCh:
+			return true, nil
+		case chk := <-s.holderCh[s.partitionIdx]:
+			chk.SwapColumns(result)
+			data := &shuffleData{chk: chk, giveBackCh: s.holderCh[s.partitionIdx]}
+			s.shuffle.PushToMerger(s.partitionIdx, s.workerIdx, data)
+			s.partitionIdx = (s.partitionIdx + 1) % s.fanOut
+			return false, nil
+		}
+	}
+	return true, nil
+}
+
+// SplitByRow is just a placeholder.
+func (s *shuffleRandomSplitter) SplitByRow(ctx context.Context, input *chunk.Chunk, workerIndices []int) ([]int, error) {
+	panic("Should not reach here")
+}
+
+// shuffleHashSplitter splits data by hash
+type shuffleHashSplitter struct {
+	baseShuffleSplitter
+	byItems  []expression.Expression
+	hashKeys [][]byte
+}
+
+// newShuffleHashSplitter creates shuffleHashSplitter
+func newShuffleHashSplitter(workerIdx int, shuffle *ShuffleExec, fanOut int, byItems []*expression.Column) *shuffleHashSplitter {
+	items := make([]expression.Expression, len(byItems))
+	for i, col := range byItems {
+		items[i] = col
+	}
+	splitter := &shuffleHashSplitter{byItems: items}
+	splitter.baseShuffleSplitter = baseShuffleSplitter{
+		workerIdx: workerIdx,
+		shuffle:   shuffle,
+		fanOut:    fanOut,
+		self:      splitter,
+	}
+	return splitter
+}
+
+// SplitByRow implements shuffleSplitter SplitByRow interface.
+func (s *shuffleHashSplitter) SplitByRow(ctx context.Context, input *chunk.Chunk, partitionIndices []int) ([]int, error) {
+	var err error
+	s.hashKeys, err = getGroupKey(s.shuffle.ctx, input, s.hashKeys, s.byItems)
+	if err != nil {
+		return partitionIndices, err
+	}
+	partitionIndices = partitionIndices[:0]
+	numRows := input.NumRows()
+	for i := 0; i < numRows; i++ {
+		partitionIndices = append(partitionIndices, int(murmur3.Sum32(s.hashKeys[i]))%s.fanOut)
+	}
+	return partitionIndices, nil
+}

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -427,12 +427,18 @@ func (p *PhysicalShuffle) ResolveIndices() (err error) {
 	if err != nil {
 		return err
 	}
-	for i := range p.HashByItems {
-		// "Shuffle" get value of items from `DataSource`, other than children[0].
-		p.HashByItems[i], err = p.HashByItems[i].ResolveIndices(p.DataSource.Schema())
+	for i := range p.MergeByItems {
+		p.MergeByItems[i].Expr, err = p.MergeByItems[i].Expr.ResolveIndices(p.children[0].Schema())
 		if err != nil {
 			return err
 		}
+	}
+	for i := range p.SplitByItems {
+		newCol, err := p.SplitByItems[i].ResolveIndices(p.children[0].Schema())
+		if err != nil {
+			return err
+		}
+		p.SplitByItems[i] = newCol.(*expression.Column)
 	}
 	return err
 }

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -259,9 +259,9 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 	case *PhysicalWindow:
 		str = fmt.Sprintf("Window(%s)", x.ExplainInfo())
 	case *PhysicalShuffle:
-		str = fmt.Sprintf("Partition(%s)", x.ExplainInfo())
+		str = fmt.Sprintf("Shuffle(%s)", x.ExplainInfo())
 	case *PhysicalShuffleDataSourceStub:
-		str = fmt.Sprintf("PartitionDataSourceStub(%s)", x.ExplainInfo())
+		str = fmt.Sprintf("ShuffleDataSourceStub(%s)", x.ExplainInfo())
 	case *PointGetPlan:
 		str = fmt.Sprintf("PointGet(")
 		if x.IndexInfo != nil {

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -1771,7 +1771,7 @@
       },
       {
         "SQL": "select lead(a, 1) over (partition by b) as c from t",
-        "Best": "TableReader(Table(t))->Sort->Window(lead(test.t.a, 1)->Column#14 over(partition by test.t.b))->Partition(execution info: concurrency:4, data source:TableReader_10)->Projection"
+        "Best": "TableReader(Table(t))->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(test.t.b), merger:none)->Sort->Window(lead(test.t.a, 1)->Column#14 over(partition by test.t.b))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection"
       }
     ]
   },

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -254,8 +254,8 @@
     "Name": "TestWindowParallelFunction",
     "Cases": [
       "TableReader(Table(t))->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.a))->Projection",
-      "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.b))->Partition(execution info: concurrency:4, data source:TableReader_10)->Projection",
-      "IndexReader(Index(t.f)[[NULL,+inf]])->Projection->Sort->Window(avg(cast(Column#16, decimal(65,4) BINARY))->Column#17 over(partition by Column#15))->Partition(execution info: concurrency:4, data source:Projection_8)->Projection",
+      "TableReader(Table(t))->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(test.t.b), merger:none)->Sort->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.b))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection",
+      "IndexReader(Index(t.f)[[NULL,+inf]])->Projection->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(Column#15), merger:none)->Sort->Window(avg(cast(Column#16, decimal(65,4) BINARY))->Column#17 over(partition by Column#15))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection",
       "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(order by test.t.a asc, test.t.b desc range between unbounded preceding and current row))->Projection",
       "TableReader(Table(t))->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.a))->Projection",
       "[planner:1054]Unknown column 'z' in 'field list'",
@@ -297,7 +297,7 @@
       "[planner:1210]Incorrect arguments to nth_value",
       "[planner:1210]Incorrect arguments to ntile",
       "IndexReader(Index(t.f)[[NULL,+inf]])->Window(ntile(<nil>)->Column#14 over())->Projection",
-      "TableReader(Table(t))->Sort->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.b))->Partition(execution info: concurrency:4, data source:TableReader_10)->Projection",
+      "TableReader(Table(t))->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(test.t.b), merger:none)->Sort->Window(avg(cast(test.t.a, decimal(65,30) BINARY))->Column#14 over(partition by test.t.b))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection",
       "TableReader(Table(t))->Window(nth_value(test.t.i_date, 1)->Column#14 over())->Projection",
       "TableReader(Table(t))->Window(sum(cast(test.t.b, decimal(65,0) BINARY))->Column#15, sum(cast(test.t.c, decimal(65,0) BINARY))->Column#16 over(order by test.t.a asc range between unbounded preceding and current row))->Projection",
       "[planner:3593]You cannot use the window function 'sum' in this context.'",
@@ -305,7 +305,7 @@
       "[planner:3593]You cannot use the window function 'row_number' in this context.'",
       "TableReader(Table(t))->Sort->Window(sum(cast(test.t.c, decimal(65,0) BINARY))->Column#17 over(partition by test.t.a order by test.t.c asc range between unbounded preceding and current row))->Sort->Window(sum(cast(test.t.b, decimal(65,0) BINARY))->Column#18 over(order by test.t.a asc, test.t.b asc, test.t.c asc range between unbounded preceding and current row))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#19 over(partition by test.t.a order by test.t.b asc range between unbounded preceding and current row))->Window(sum(cast(test.t.d, decimal(65,0) BINARY))->Column#20 over())->Projection",
       "[planner:3587]Window 'w1' with RANGE N PRECEDING/FOLLOWING frame requires exactly one ORDER BY expression, of numeric or temporal type",
-      "TableReader(Table(t))->Sort->Window(dense_rank()->Column#14 over(partition by test.t.b order by test.t.a desc, test.t.b desc))->Partition(execution info: concurrency:4, data source:TableReader_9)->Projection",
+      "TableReader(Table(t))->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(test.t.b), merger:none)->Sort->Window(dense_rank()->Column#14 over(partition by test.t.b order by test.t.a desc, test.t.b desc))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection",
       "[planner:3587]Window 'w1' with RANGE N PRECEDING/FOLLOWING frame requires exactly one ORDER BY expression, of numeric or temporal type",
       "[planner:3585]Window 'w1': frame end cannot be UNBOUNDED PRECEDING.",
       "[planner:3584]Window 'w1': frame start cannot be UNBOUNDED FOLLOWING.",
@@ -319,7 +319,7 @@
       "[planner:3586]Window 'w': frame start or end is negative, NULL or of non-integral type",
       "[planner:3586]Window 'w': frame start or end is negative, NULL or of non-integral type",
       "[planner:3586]Window 'w': frame start or end is negative, NULL or of non-integral type",
-      "TableReader(Table(t))->Sort->Window(row_number()->Column#14 over(partition by test.t.b))->Partition(execution info: concurrency:4, data source:TableReader_10)->Projection"
+      "TableReader(Table(t))->Shuffle(execution info: concurrency:1, fan out:4, splitter:hash(test.t.b), merger:none)->Sort->Window(row_number()->Column#14 over(partition by test.t.b))->Shuffle(execution info: concurrency:4, fan out:1, splitter:none, merger:random)->Projection"
     ]
   },
   {

--- a/planner/property/physical_property.go
+++ b/planner/property/physical_property.go
@@ -26,6 +26,14 @@ type Item struct {
 	Desc bool
 }
 
+// ItemExpression represents underlying expression of `property.Item`.
+// ONLY used for partition delivering properties.
+// (The same as planner.core.ByItems, but redefine to avoid circular dependency)
+type ItemExpression struct {
+	Expr expression.Expression
+	Desc bool
+}
+
 // PhysicalProperty stands for the required physical property by parents.
 // It contains the orders and the task types.
 type PhysicalProperty struct {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

This PR is the `executor` part of #15370

Issue Number: close #14417

Problem Summary: Improve the performance of `Sort` by parallel.


### What is changed and how it works?

What's Changed:

Refactoring codes of Shuffle executors (#14238, #14453) referring to the paper "Incorporating Partitioning and Parallel Plans into the SCOPE Optimizer", and apply to Sort executor (#14417).

How it Works:

Refactoring codes of Shuffle executor. Seperating Shuffle to lower and upper ones, which splitting and merging tuples respectively.
Moreover, one Shuffle can both split and merge, to support `re-partition` schema, which will be necessary in the intact implementation of the refactored Shuffle.

### Related changes
No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects
No.

### Release note <!-- bugfixes or new feature need a release note -->
