### PR TITLE
executor: bootstrap SQLs are not treated as internal queries in statement summary

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -903,8 +903,13 @@ func getPlanDigest(sctx sessionctx.Context, p plannercore.Plan) (normalized, pla
 // SummaryStmt collects statements for information_schema.statements_summary
 func (a *ExecStmt) SummaryStmt(succ bool) {
 	sessVars := a.Ctx.GetSessionVars()
+	var userString string
+	if sessVars.User != nil {
+		userString = sessVars.User.Username
+	}
+
 	// Internal SQLs must also be recorded to keep the consistency of `PrevStmt` and `PrevStmtDigest`.
-	if !stmtsummary.StmtSummaryByDigestMap.Enabled() || (sessVars.InRestrictedSQL && !stmtsummary.StmtSummaryByDigestMap.EnabledInternal()) {
+	if !stmtsummary.StmtSummaryByDigestMap.Enabled() || ((sessVars.InRestrictedSQL) && !stmtsummary.StmtSummaryByDigestMap.EnabledInternal()) {
 		sessVars.SetPrevStmtDigest("")
 		return
 	}
@@ -944,10 +949,6 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	execDetail := stmtCtx.GetExecDetails()
 	copTaskInfo := stmtCtx.CopTasksDetails()
 	memMax := stmtCtx.MemTracker.MaxConsumed()
-	var userString string
-	if sessVars.User != nil {
-		userString = sessVars.User.Username
-	}
 
 	stmtsummary.StmtSummaryByDigestMap.AddStatement(&stmtsummary.StmtExecInfo{
 		SchemaName:     strings.ToLower(sessVars.CurrentDB),

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -909,7 +909,7 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	}
 
 	// Internal SQLs must also be recorded to keep the consistency of `PrevStmt` and `PrevStmtDigest`.
-	if !stmtsummary.StmtSummaryByDigestMap.Enabled() || ((sessVars.InRestrictedSQL) && !stmtsummary.StmtSummaryByDigestMap.EnabledInternal()) {
+	if !stmtsummary.StmtSummaryByDigestMap.Enabled() || ((sessVars.InRestrictedSQL || len(userString) == 0) && !stmtsummary.StmtSummaryByDigestMap.EnabledInternal()) {
 		sessVars.SetPrevStmtDigest("")
 		return
 	}

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -78,6 +78,12 @@ func (s *testTableSuiteBase) TearDownSuite(c *C) {
 	testleak.AfterTest(c)()
 }
 
+func (s *testTableSuiteBase) newTestKitWithRoot(c *C) *testkit.TestKit {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	return tk
+}
+
 type testClusterTableSuite struct {
 	*testTableSuiteBase
 	rpcserver  *grpc.Server
@@ -745,7 +751,7 @@ func (s *testTableSuite) checkSystemSchemaTableID(c *C, dbName string, dbID, sta
 }
 
 func (s *testClusterTableSuite) TestSelectClusterTable(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
+	tk := s.newTestKitWithRoot(c)
 	slowLogFileName := "tidb-slow.log"
 	prepareSlowLogfile(c, slowLogFileName)
 	defer os.Remove(slowLogFileName)
@@ -873,7 +879,7 @@ func (s *testTableSuite) TestFormatVersion(c *C) {
 
 // Test statements_summary.
 func (s *testTableSuite) TestStmtSummaryTable(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk := s.newTestKitWithRoot(c)
 
 	tk.MustQuery("select column_comment from information_schema.columns " +
 		"where table_name='STATEMENTS_SUMMARY' and column_name='STMT_TYPE'",
@@ -896,7 +902,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustQuery("select @@global.tidb_stmt_summary_refresh_interval").Check(testkit.Rows("999999999"))
 
 	// Create a new session to test.
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	// Test INSERT
 	tk.MustExec("insert into t values(1, 'a')")
@@ -979,7 +985,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustQuery("select @@global.tidb_enable_stmt_summary").Check(testkit.Rows("0"))
 
 	// Create a new session to test
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	// This statement shouldn't be summarized.
 	tk.MustQuery("select * from t where a=2")
@@ -1024,7 +1030,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	tk.MustExec("set global tidb_enable_stmt_summary = false")
 
 	// Create a new session to test.
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	tk.MustQuery("select * from t where a=2")
 
@@ -1050,7 +1056,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	).Check(testkit.Rows())
 
 	// Create a new session to test
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	tk.MustExec("set global tidb_enable_stmt_summary = on")
 	tk.MustExec("set global tidb_stmt_summary_history_size = 24")
@@ -1116,8 +1122,7 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 
 // Test statements_summary_history.
 func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
-
+	tk := s.newTestKitWithRoot(c)
 	tk.MustExec("drop table if exists test_summary")
 	tk.MustExec("create table test_summary(a int, b varchar(10), key k(a))")
 
@@ -1131,7 +1136,7 @@ func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 	tk.MustQuery("select @@global.tidb_stmt_summary_refresh_interval").Check(testkit.Rows("999999999"))
 
 	// Create a new session to test.
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	// Test INSERT
 	tk.MustExec("insert into test_summary values(1, 'a')")
@@ -1155,7 +1160,7 @@ func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 
 // Test statements_summary_history.
 func (s *testTableSuite) TestStmtSummaryInternalQuery(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk := s.newTestKitWithRoot(c)
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b varchar(10), key k(a))")
@@ -1175,7 +1180,7 @@ func (s *testTableSuite) TestStmtSummaryInternalQuery(c *C) {
 	// Test Internal
 
 	// Create a new session to test.
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	tk.MustExec("select * from t where t.a = 1")
 	tk.MustQuery(`select exec_count, digest_text
@@ -1187,7 +1192,7 @@ func (s *testTableSuite) TestStmtSummaryInternalQuery(c *C) {
 	defer tk.MustExec("set global tidb_stmt_summary_internal_query = false")
 
 	// Create a new session to test.
-	tk = testkit.NewTestKitWithInit(c, s.store)
+	tk = s.newTestKitWithRoot(c)
 
 	tk.MustExec("admin flush bindings")
 	tk.MustExec("admin evolve bindings")
@@ -1201,7 +1206,7 @@ func (s *testTableSuite) TestStmtSummaryInternalQuery(c *C) {
 
 // Test error count and warning count.
 func (s *testTableSuite) TestStmtSummaryErrorCount(c *C) {
-	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk := s.newTestKitWithRoot(c)
 
 	// Clear summaries.
 	tk.MustExec("set global tidb_enable_stmt_summary = 0")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Some SQLs executed in bootstrap phase are not marked as internal queries. By default, internal queries are ignored in statement summary. But these SQLs still appear in statement summary.
For example, these SQLs are executed in bootstrap:
```sql
select variable_value from mysql.tidb where variable_name = 'system_tz'
select variable_value from mysql.tidb where variable_name = 'new_collation_enabled'
```

After This PR (after bootstrap):
```sql
mysql> select sample_user, exec_count, digest_text from information_schema.statements_summary\G
*************************** 1. row ***************************
sample_user: root
 exec_count: 1
digest_text: show tables
*************************** 2. row ***************************
sample_user: root
 exec_count: 1
digest_text: show databases
*************************** 3. row ***************************
sample_user: root
 exec_count: 1
digest_text: use test
*************************** 4. row ***************************
sample_user: NULL
 exec_count: 2
digest_text: select variable_value from mysql . tidb where variable_name = ?
4 rows in set (0.04 sec)
```

### What is changed and how it works?

What's Changed:
Treat the SQLs whose users are empty as internal queries.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
After(after bootstrap):
```sql
mysql> select sample_user, digest_text from information_schema.statements_summary\G
*************************** 1. row ***************************
sample_user: root
digest_text: show tables
*************************** 2. row ***************************
sample_user: root
digest_text: show databases
*************************** 3. row ***************************
sample_user: root
digest_text: use test
3 rows in set (0.01 sec)
```

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Mark bootstrap statements as internal queries in statement summary.