### PR TITLE
tikv: don't collapse batch resolve locks

### DIFF
--- a/store/tikv/client_collapse.go
+++ b/store/tikv/client_collapse.go
@@ -57,6 +57,10 @@ func (r reqCollapse) tryCollapseRequest(ctx context.Context, addr string, req *t
 			// can not collapse resolve lock lite
 			return
 		}
+		if len(resolveLock.TxnInfos) > 0 {
+			// can not collapse batch resolve locks which is only used by GC worker.
+			return
+		}
 		canCollapse = true
 		key := strconv.FormatUint(resolveLock.Context.RegionId, 10) + "-" + strconv.FormatUint(resolveLock.StartVersion, 10)
 		resp, err = r.collapse(ctx, key, &resolveRegionSf, addr, req, timeout)


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Problem Summary:
https://github.com/pingcap/tidb/pull/16838 collapses the same resolve lock requests. However, it uses `RegionId + StartVersion` as the key:
https://github.com/pingcap/tidb/blob/e3e51b4663d11aa7caaf4d2a084c793560a4d983/store/tikv/client_collapse.go#L61

When doing GC, GC worker calls `BatchResolveLocks` whose `StartVersion` is always 0. It results in unexpected collapses:
https://github.com/pingcap/tidb/blob/e3e51b4663d11aa7caaf4d2a084c793560a4d983/store/tikv/lock_resolver.go#L241

### What is changed and how it works?
What's Changed:
Don't collapse batch resolve locks.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit tests

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* No release note