### PR TITLE
[DNM] *: a prototype of readonly table

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -120,6 +120,7 @@ func (builder *RequestBuilder) SetStartTS(startTS uint64) *RequestBuilder {
 	return builder
 }
 
+// SetStartTS sets "SnapshotRead" for "kv.Request".
 func (builder *RequestBuilder) SetSnapshotRead(snapshotRead bool) *RequestBuilder {
 	builder.Request.SnapshotRead = snapshotRead
 	return builder

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -120,6 +120,11 @@ func (builder *RequestBuilder) SetStartTS(startTS uint64) *RequestBuilder {
 	return builder
 }
 
+func (builder *RequestBuilder) SetSnapshotRead(snapshotRead bool) *RequestBuilder {
+	builder.Request.SnapshotRead = snapshotRead
+	return builder
+}
+
 // SetDesc sets "Desc" for "kv.Request".
 func (builder *RequestBuilder) SetDesc(desc bool) *RequestBuilder {
 	builder.Request.Desc = desc

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -120,7 +120,7 @@ func (builder *RequestBuilder) SetStartTS(startTS uint64) *RequestBuilder {
 	return builder
 }
 
-// SetStartTS sets "SnapshotRead" for "kv.Request".
+// SetSnapshotRead sets "SnapshotRead" for "kv.Request".
 func (builder *RequestBuilder) SetSnapshotRead(snapshotRead bool) *RequestBuilder {
 	builder.Request.SnapshotRead = snapshotRead
 	return builder

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -130,7 +130,7 @@ func (e *IndexNestedLoopHashJoin) Open(ctx context.Context) error {
 	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached snapshot ts to construct DAG.
-	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
+	_, _, err := e.innerCtx.readerBuilder.getSnapshotTS("", "")
 	if err != nil {
 		return err
 	}

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -159,7 +159,7 @@ func (e *IndexLookUpJoin) Open(ctx context.Context) error {
 	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached snapshot ts to construct DAG.
-	_, err := e.innerCtx.readerBuilder.getSnapshotTS()
+	_, _, err := e.innerCtx.readerBuilder.getSnapshotTS("", "")
 	if err != nil {
 		return err
 	}

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -162,7 +162,7 @@ func (e *IndexLookUpMergeJoin) Open(ctx context.Context) error {
 	// The trick here is `getSnapshotTS` will cache snapshot ts in the dataReaderBuilder,
 	// so even txn is destroyed later, the dataReaderBuilder could still use the
 	// cached snapshot ts to construct DAG.
-	_, err := e.innerMergeCtx.readerBuilder.getSnapshotTS()
+	_, _, err := e.innerMergeCtx.readerBuilder.getSnapshotTS("", "")
 	if err != nil {
 		return err
 	}

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -71,6 +71,7 @@ type IndexMergeReaderExecutor struct {
 	ranges       [][]*ranger.Range
 	dagPBs       []*tipb.DAGRequest
 	startTS      uint64
+	snapshotRead bool
 	tableRequest *tipb.DAGRequest
 	// columns are only required by union scan.
 	columns           []*model.ColumnInfo
@@ -185,6 +186,7 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 	kvReq, err := builder.SetKeyRanges(keyRange).
 		SetDAGRequest(e.dagPBs[workID]).
 		SetStartTS(e.startTS).
+		SetSnapshotRead(e.snapshotRead).
 		SetDesc(e.descs[workID]).
 		SetKeepOrder(false).
 		SetStreaming(e.partialStreamings[workID]).
@@ -244,6 +246,7 @@ func (e *IndexMergeReaderExecutor) buildPartialTableReader(ctx context.Context, 
 		table:        e.table,
 		dagPB:        e.dagPBs[workID],
 		startTS:      e.startTS,
+		snapshotRead: e.snapshotRead,
 		streaming:    e.partialStreamings[workID],
 		feedback:     statistics.NewQueryFeedback(0, nil, 0, false),
 		plans:        e.partialPlans[workID],
@@ -415,6 +418,7 @@ func (e *IndexMergeReaderExecutor) buildFinalTableReader(ctx context.Context, ha
 		table:        e.table,
 		dagPB:        e.tableRequest,
 		startTS:      e.startTS,
+		snapshotRead: e.snapshotRead,
 		streaming:    e.tableStreaming,
 		columns:      e.columns,
 		feedback:     statistics.NewQueryFeedback(0, nil, 0, false),

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -37,7 +37,7 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
 			return nil
 		}
 	}
-	startTS, err := b.getSnapshotTS()
+	startTS, _, err := b.getSnapshotTS("", "")
 	if err != nil {
 		b.err = err
 		return nil

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -60,9 +60,10 @@ type TableReaderExecutor struct {
 	table  table.Table
 	ranges []*ranger.Range
 	// kvRanges are only use for union scan.
-	kvRanges []kv.KeyRange
-	dagPB    *tipb.DAGRequest
-	startTS  uint64
+	kvRanges     []kv.KeyRange
+	dagPB        *tipb.DAGRequest
+	startTS      uint64
+	snapshotRead bool
 	// columns are only required by union scan and virtual column.
 	columns []*model.ColumnInfo
 
@@ -197,6 +198,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	kvReq, err := builder.SetTableRanges(getPhysicalTableID(e.table), ranges, e.feedback).
 		SetDAGRequest(e.dagPB).
 		SetStartTS(e.startTS).
+		SetSnapshotRead(e.snapshotRead).
 		SetDesc(e.desc).
 		SetKeepOrder(e.keepOrder).
 		SetStreaming(e.streaming).

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -283,10 +283,11 @@ func (t StoreType) Name() string {
 // Request represents a kv request.
 type Request struct {
 	// Tp is the request type.
-	Tp        int64
-	StartTs   uint64
-	Data      []byte
-	KeyRanges []KeyRange
+	Tp           int64
+	StartTs      uint64
+	SnapshotRead bool
+	Data         []byte
+	KeyRanges    []KeyRange
 
 	// Concurrency is 1, if it only sends the request to a single storage unit when
 	// ResponseIterator.Next is called. If concurrency is greater than 1, the request will be

--- a/session/session.go
+++ b/session/session.go
@@ -1962,6 +1962,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBEvolvePlanBaselines,
 	variable.TiDBIsolationReadEngines,
 	variable.TiDBStoreLimit,
+	variable.TiDBReadonlyTable,
 }
 
 var (

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1027,7 +1027,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 			return err
 		}
 	case TiDBReadonlyTable:
-		// The format is '<tableName>/<tsoString>,<tableName2>/<tsoString2>'
+		// The format is '<dbName>.<tableName>/<tsoString>,<dbName2>.<tableName2>/<tsoString2>'
 		s.ReadonlyTable = make(map[string]uint64)
 		if val != "" {
 			entris := strings.Split(val, ",")
@@ -1040,7 +1040,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 				if err != nil {
 					return err
 				}
-				s.ReadonlyTable[t[0]] = ts
+				s.ReadonlyTable[strings.ToLower(t[0])] = ts
 			}
 		}
 	case AutoCommit:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -609,6 +609,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, WindowingUseHighPrecision, "ON"},
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
+	{ScopeSession, TiDBReadonlyTable, ""},
 	{ScopeSession, TiDBOptAggPushDown, BoolToIntStr(DefOptAggPushDown)},
 	{ScopeSession, TiDBOptDistinctAggPushDown, BoolToIntStr(config.GetGlobalConfig().Performance.DistinctAggPushDown)},
 	{ScopeSession, TiDBOptWriteRowID, BoolToIntStr(DefOptWriteRowID)},

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -609,7 +609,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, WindowingUseHighPrecision, "ON"},
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
-	{ScopeSession, TiDBReadonlyTable, ""},
+	{ScopeGlobal | ScopeSession, TiDBReadonlyTable, ""},
 	{ScopeSession, TiDBOptAggPushDown, BoolToIntStr(DefOptAggPushDown)},
 	{ScopeSession, TiDBOptDistinctAggPushDown, BoolToIntStr(config.GetGlobalConfig().Performance.DistinctAggPushDown)},
 	{ScopeSession, TiDBOptWriteRowID, BoolToIntStr(DefOptWriteRowID)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -43,7 +43,7 @@ const (
 	TiDBSnapshot = "tidb_snapshot"
 
 	// tidb_readonly_table is used to set some table is readonly.
-	// The format is '<tableName>/<tsoString>,<tableName2>/<tsoString2>'
+	// The format is '<dbName>.<tableName>/<tsoString>,<dbName2>.<tableName2>/<tsoString2>'
 	TiDBReadonlyTable = "tidb_readonly_table"
 
 	// tidb_opt_agg_push_down is used to enable/disable the optimizer rule of aggregation push down.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -42,6 +42,10 @@ const (
 	// The value can be a datetime string like '2017-11-11 20:20:20' or a tso string. When this variable is set, the session reads history data of that time.
 	TiDBSnapshot = "tidb_snapshot"
 
+	// tidb_readonly_table is used to set some table is readonly.
+	// The format is '<tableName>/<tsoString>,<tableName2>/<tsoString2>'
+	TiDBReadonlyTable = "tidb_readonly_table"
+
 	// tidb_opt_agg_push_down is used to enable/disable the optimizer rule of aggregation push down.
 	TiDBOptAggPushDown = "tidb_opt_agg_push_down"
 

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -705,7 +705,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 
 	// If there are many ranges, it is very likely to be a TableLookupRequest. They are not worth to cache since
 	// computing is not the main cost. Ignore such requests directly to avoid slowly building the cache key.
-	if task.cmdType == tikvrpc.CmdCop && worker.store.coprCache != nil && worker.req.Cacheable && len(copReq.Ranges) < 10 {
+	if task.cmdType == tikvrpc.CmdCop && worker.store.coprCache != nil && worker.req.Cacheable {
 		cKey, err := coprCacheBuildKey(&copReq)
 		if err == nil {
 			cacheKey = cKey

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"sort"
 	"strconv"
 	"strings"
@@ -716,7 +715,6 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 			if cValue != nil && cValue.RegionID == task.region.id {
 				if worker.req.SnapshotRead {
 					if cValue.TimeStamp == worker.req.StartTs {
-						log.Println("!!!!!!!!!!!")
 						resp := &copResponse{
 							pbResp: &coprocessor.Response{IsCacheHit: true},
 							detail: &execdetails.ExecDetails{},

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -319,7 +319,7 @@ func (rrs *ReaderRuntimeStats) recordOneCopTask(t time.Duration, detail *ExecDet
 func (rrs *ReaderRuntimeStats) String() string {
 	size := len(rrs.copRespTime)
 	if size == 0 {
-		return ""
+		return "rpc num: 0"
 	}
 	if size == 1 {
 		return fmt.Sprintf("rpc num: 1, rpc time:%v, proc keys:%v", rrs.copRespTime[0], rrs.procKeys[0])

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -113,7 +113,7 @@ func TestCopRuntimeStats(t *testing.T) {
 
 func TestReaderStats(t *testing.T) {
 	r := new(ReaderRuntimeStats)
-	if r.String() != "" {
+	if r.String() != "rpc num: 0" {
 		t.Fatal()
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

```
mysql> explain analyze select * from tcache2 where a = 1;

+-------------+---------+---------+------+------------------------------+-------------------------+---------------+--------+------+
| id          | estRows | actRows | task | access object                | execution info          | operator info | memory | disk |
+-------------+---------+---------+------+------------------------------+-------------------------+---------------+--------+------+
| Point_Get_1 | 1.00    | 1       | root | table:tcache2, index:idx1(a) | time:887.16µs, loops:2  |               | N/A    | N/A  |
+-------------+---------+---------+------+------------------------------+-------------------------+---------------+--------+------+
1 row in set (0.01 sec)

mysql> set session tidb_readonly_table="test.tcache2/416547478332506113,test.tcache/416547076251582469";
Query OK, 0 rows affected (0.00 sec)

mysql> explain analyze select * from tcache2 where a = 1;
+-------------------------------+---------+---------+-----------+------------------------------+------------------------------------------------------------------------+---------------------------------------------+--------------+------+
| id                            | estRows | actRows | task      | access object                | execution info                                                         | operator info                               | memory       | disk |
+-------------------------------+---------+---------+-----------+------------------------------+------------------------------------------------------------------------+---------------------------------------------+--------------+------+
| IndexLookUp_7                 | 1.00    | 1       | root      |                              | time:1.236502ms, loops:2, rpc num: 1, rpc time:494.079µs, proc keys:1  |                                             | 8.7421875 KB | N/A  |
| ├─IndexRangeScan_5(Build)     | 1.00    | 1       | cop[tikv] | table:tcache2, index:idx1(a) | time:1ms, loops:1                                                      | range:[1,1], keep order:false, stats:pseudo | N/A          | N/A  |
| └─TableRowIDScan_6(Probe)     | 1.00    | 1       | cop[tikv] | table:tcache2                | time:0s, loops:1                                                       | keep order:false, stats:pseudo              | N/A          | N/A  |
+-------------------------------+---------+---------+-----------+------------------------------+------------------------------------------------------------------------+---------------------------------------------+--------------+------+
3 rows in set (0.00 sec)

mysql> explain analyze select * from tcache2 where a = 1;
+-------------------------------+---------+---------+-----------+------------------------------+--------------------------------------+---------------------------------------------+--------------+------+
| id                            | estRows | actRows | task      | access object                | execution info                       | operator info                               | memory       | disk |
+-------------------------------+---------+---------+-----------+------------------------------+--------------------------------------+---------------------------------------------+--------------+------+
| IndexLookUp_7                 | 1.00    | 1       | root      |                              | time:235.502µs, loops:2, rpc num: 0  |                                             | 8.7421875 KB | N/A  |
| ├─IndexRangeScan_5(Build)     | 1.00    | 1       | cop[tikv] | table:tcache2, index:idx1(a) | time:0s, loops:0                     | range:[1,1], keep order:false, stats:pseudo | N/A          | N/A  |
| └─TableRowIDScan_6(Probe)     | 1.00    | 1       | cop[tikv] | table:tcache2                | time:0s, loops:0                     | keep order:false, stats:pseudo              | N/A          | N/A  |
+-------------------------------+---------+---------+-----------+------------------------------+--------------------------------------+---------------------------------------------+--------------+------+
3 rows in set (0.00 sec)
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
