### PR TITLE
session: determine if store is nil

### DIFF
--- a/session/tidb.go
+++ b/session/tidb.go
@@ -52,8 +52,12 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
 
+	if store == nil {
+		return
+	}
+
 	// If this is the only domain instance, and the caller doesn't provide store.
-	if len(dm.domains) == 1 && store == nil {
+	if len(dm.domains) == 1 {
 		for _, r := range dm.domains {
 			return r, nil
 		}

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -53,7 +53,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	defer dm.mu.Unlock()
 
 	if store == nil {
-		return
+		return nil, errors.New("kv.Storage is nil")
 	}
 
 	// If this is the only domain instance, and the caller doesn't provide store.


### PR DESCRIPTION
### Release note <!-- bugfixes or new feature need a release note -->
- According to the logic of the code here is not strict, because when `len(dm.domains) != 1` and `store == nil`, `key := store.UUID()` will panic.