### PR TITLE
executor: return an error when updating TiDB instances' config items by `set config`

### DIFF
--- a/executor/set_config.go
+++ b/executor/set_config.go
@@ -101,8 +101,10 @@ func (s *SetConfigExec) Next(ctx context.Context, req *chunk.Chunk) error {
 			url = fmt.Sprintf("%s://%s%s", util.InternalHTTPSchema(), serverInfo.StatusAddr, pdapi.Config)
 		case "tikv":
 			url = fmt.Sprintf("%s://%s/config", util.InternalHTTPSchema(), serverInfo.StatusAddr)
+		case "tidb":
+			return errors.Errorf("TiDB doesn't support to change configs online, please use SQL variables")
 		default:
-			continue
+			return errors.Errorf("Unknown server type %s", serverInfo.ServerType)
 		}
 		if err := s.doRequest(url); err != nil {
 			s.ctx.GetSessionVars().StmtCtx.AppendWarning(err)

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -956,6 +956,7 @@ func (s *testSuite5) TestSetClusterConfig(c *C) {
 
 	c.Assert(tk.ExecToErr("set config xxx log.level='info'"), ErrorMatches, "unknown type xxx")
 	c.Assert(tk.ExecToErr("set config tidb log.level='info'"), ErrorMatches, "TiDB doesn't support to change configs online, please use SQL variables")
+	c.Assert(tk.ExecToErr("set config '127.0.0.1:1111' log.level='info'"), ErrorMatches, "TiDB doesn't support to change configs online, please use SQL variables")
 	c.Assert(tk.ExecToErr("set config '127.a.b.c:1234' log.level='info'"), ErrorMatches, "invalid instance 127.a.b.c:1234")
 	c.Assert(tk.ExecToErr("set config tikv log.level=null"), ErrorMatches, "can't set config to null")
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17097 <!-- REMOVE this line if no issue to close -->

Problem Summary: return an error when updating TiDB instances' config items by `set config`

### What is changed and how it works?
If the target instance is TiDB, return an error.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- return an error when updating TiDB instances' config items by `set config`