### PR TITLE
executor: make memory tracing in ProjectionExec more accurate

### DIFF
--- a/executor/projection.go
+++ b/executor/projection.go
@@ -421,10 +421,9 @@ func (w *projectionWorker) run(ctx context.Context) {
 			return
 		}
 
-		mSize := output.chk.MemoryUsage()
-		// TODO: trace memory used by the evaluatorSuit including all temporal buffers it uses
+		mSize := output.chk.MemoryUsage() + input.chk.MemoryUsage()
 		err := w.evaluatorSuit.Run(w.sctx, input.chk, output.chk)
-		w.proj.memTracker.Consume(output.chk.MemoryUsage() - mSize)
+		w.proj.memTracker.Consume(output.chk.MemoryUsage() + input.chk.MemoryUsage() - mSize)
 		output.done <- err
 
 		if err != nil {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6379,6 +6379,26 @@ func (s *testIntegrationSuite) TestIssue16779(c *C) {
 	tk.MustQuery("SELECT * FROM t1 LEFT JOIN t0 ON TRUE WHERE BINARY EXPORT_SET(0, 0, 0 COLLATE 'binary', t0.c0, 0 COLLATE 'binary')")
 }
 
+func (s *testIntegrationSuite) TestIssue16697(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (`a` int(11) DEFAULT NULL,`b` int(11) DEFAULT NULL)")
+	tk.MustExec("insert into t values (1, 1)")
+	for i := 0; i < 8; i++ {
+		tk.MustExec("insert into t select * from t")
+	}
+	rows := tk.MustQuery("explain analyze  select t1.a, t1.a +1 from t t1 join t t2 join t t3 order by t1.a").Rows()
+	for _, row := range rows {
+		line := fmt.Sprintf("%v", row)
+		if strings.Contains(line, "Projection") {
+			c.Assert(strings.Contains(line, "KB"), IsTrue)
+			c.Assert(strings.Contains(line, "MB"), IsFalse)
+			c.Assert(strings.Contains(line, "GB"), IsFalse)
+		}
+	}
+}
+
 func (s *testIntegrationSuite) TestIssue17045(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16697 <!-- REMOVE this line if no issue to close -->

Problem Summary: make memory tracing in ProjectionExec more accurate

### What is changed and how it works?
`projectionWorker` may change the size of its input data chunk, but we don't trace this memory change.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Make memory tracing in `ProjectionExec` more accurate