### PR TITLE
planner: add explain information for slow_query extractor

### DIFF
--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -109,11 +109,11 @@ func (s *testSuite) TestIssue11124(c *C) {
 	}
 }
 
-func (s *testSuite) TestExplainMetricTable(c *C) {
+func (s *testSuite) TestExplainMemTablePredicate(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustQuery(fmt.Sprintf("desc select * from METRICS_SCHEMA.tidb_query_duration where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13' ")).Check(testkit.Rows(
+	tk.MustQuery("desc select * from METRICS_SCHEMA.tidb_query_duration where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13' ").Check(testkit.Rows(
 		"MemTableScan_5 10000.00 root table:tidb_query_duration PromQL:histogram_quantile(0.9, sum(rate(tidb_server_handle_query_duration_seconds_bucket{}[60s])) by (le,sql_type,instance)), start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13, step:1m0s"))
-	tk.MustQuery(fmt.Sprintf("desc select * from METRICS_SCHEMA.up where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13' ")).Check(testkit.Rows(
+	tk.MustQuery("desc select * from METRICS_SCHEMA.up where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13' ").Check(testkit.Rows(
 		"MemTableScan_5 10000.00 root table:up PromQL:up{}, start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13, step:1m0s"))
 	tk.MustQuery("desc select * from information_schema.cluster_log where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13'").Check(testkit.Rows(
 		"MemTableScan_5 10000.00 root table:CLUSTER_LOG start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13"))
@@ -121,6 +121,13 @@ func (s *testSuite) TestExplainMetricTable(c *C) {
 		`MemTableScan_5 10000.00 root table:CLUSTER_LOG start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13, log_levels:["error","warn"]`))
 	tk.MustQuery("desc select * from information_schema.cluster_log where type in ('high_cpu_1','high_memory_1') and time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13'").Check(testkit.Rows(
 		`MemTableScan_5 10000.00 root table:CLUSTER_LOG start_time:2019-12-23 16:10:13, end_time:2019-12-23 16:30:13, node_types:["high_cpu_1","high_memory_1"]`))
+	tk.MustQuery("desc select * from information_schema.slow_query").Check(testkit.Rows(
+		"MemTableScan_4 10000.00 root table:SLOW_QUERY only search in the current 'tidb-slow.log' file"))
+	tk.MustQuery("desc select * from information_schema.slow_query where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13'").Check(testkit.Rows(
+		"MemTableScan_5 10000.00 root table:SLOW_QUERY start_time:2019-12-23 16:10:13.000000, end_time:2019-12-23 16:30:13.000000"))
+	tk.MustExec("set @@time_zone = '+00:00';")
+	tk.MustQuery("desc select * from information_schema.slow_query where time >= '2019-12-23 16:10:13' and time <= '2019-12-23 16:30:13'").Check(testkit.Rows(
+		"MemTableScan_5 10000.00 root table:SLOW_QUERY start_time:2019-12-23 16:10:13.000000, end_time:2019-12-23 16:30:13.000000"))
 }
 
 func (s *testSuite) TestExplainClusterTable(c *C) {

--- a/planner/core/memtable_predicate_extractor.go
+++ b/planner/core/memtable_predicate_extractor.go
@@ -950,5 +950,15 @@ func (e *SlowQueryExtractor) setTimeRange(start, end int64) {
 }
 
 func (e *SlowQueryExtractor) explainInfo(p *PhysicalMemTable) string {
-	return ""
+	if e.SkipRequest {
+		return "skip_request: true"
+	}
+	if !e.Enable {
+		return fmt.Sprintf("only search in the current '%v' file", p.ctx.GetSessionVars().SlowQueryFile)
+	}
+	startTime := e.StartTime.In(p.ctx.GetSessionVars().StmtCtx.TimeZone)
+	endTime := e.EndTime.In(p.ctx.GetSessionVars().StmtCtx.TimeZone)
+	return fmt.Sprintf("start_time:%v, end_time:%v",
+		types.NewTime(types.FromGoTime(startTime), mysql.TypeDatetime, types.MaxFsp).String(),
+		types.NewTime(types.FromGoTime(endTime), mysql.TypeDatetime, types.MaxFsp).String())
 }


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Close https://github.com/pingcap/tidb/issues/15385

eg
```sql
mysql>desc select max(time) from `SLOW_QUERY` where time > "2020-05-12 10:06:00.999" and time<"2020-05-12 11:06:00.999"
+-----------------------+----------+------+------------------+-----------------------------------------------------------------------------+
| id                    | estRows  | task | access object    | operator info                                                               |
+-----------------------+----------+------+------------------+-----------------------------------------------------------------------------+
| StreamAgg_14          | 1.00     | root |                  | funcs:max(Column#1)->Column#48                                              |
| └─TopN_17             | 1.00     | root |                  | Column#1:desc, offset:0, count:1                                            |
|   └─Selection_21      | 8000.00  | root |                  | not(isnull(Column#1))                                                       |
|     └─MemTableScan_22 | 10000.00 | root | table:SLOW_QUERY | start_time:2020-05-12 10:06:01.000000, end_time:2020-05-12 11:06:00.998000  |
+-----------------------+----------+------+------------------+-----------------------------------------------------------------------------+
4 rows in set
Time: 0.009s
mysql>desc select max(time) from `SLOW_QUERY`
+-----------------------+----------+------+------------------+-------------------------------------------------+
| id                    | estRows  | task | access object    | operator info                                   |
+-----------------------+----------+------+------------------+-------------------------------------------------+
| StreamAgg_13          | 1.00     | root |                  | funcs:max(Column#1)->Column#48                  |
| └─TopN_16             | 1.00     | root |                  | Column#1:desc, offset:0, count:1                |
|   └─Selection_20      | 8000.00  | root |                  | not(isnull(Column#1))                           |
|     └─MemTableScan_21 | 10000.00 | root | table:SLOW_QUERY | only search in the current 'tidb-slow.log' file |
+-----------------------+----------+------+------------------+-------------------------------------------------+

```

### What is changed and how it works?


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- Add explain information for slow_query extractor.
