### PR TITLE
executor: return an error if the target instance is not found in 'set config' statements

### DIFF
--- a/executor/set_config.go
+++ b/executor/set_config.go
@@ -93,6 +93,9 @@ func (s *SetConfigExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		nodeAddrs.Insert(s.p.Instance)
 	}
 	serversInfo = filterClusterServerInfo(serversInfo, nodeTypes, nodeAddrs)
+	if s.p.Instance != "" && len(serversInfo) == 0 {
+		return errors.Errorf("instance %v is not found in this cluster", s.p.Instance)
+	}
 
 	for _, serverInfo := range serversInfo {
 		var url string

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -959,6 +959,7 @@ func (s *testSuite5) TestSetClusterConfig(c *C) {
 	c.Assert(tk.ExecToErr("set config '127.0.0.1:1111' log.level='info'"), ErrorMatches, "TiDB doesn't support to change configs online, please use SQL variables")
 	c.Assert(tk.ExecToErr("set config '127.a.b.c:1234' log.level='info'"), ErrorMatches, "invalid instance 127.a.b.c:1234")
 	c.Assert(tk.ExecToErr("set config tikv log.level=null"), ErrorMatches, "can't set config to null")
+	c.Assert(tk.ExecToErr("set config '1.1.1.1:1111' log.level='info'"), ErrorMatches, "instance 1.1.1.1:1111 is not found in this cluster")
 
 	httpCnt := 0
 	tk.Se.SetValue(executor.TestSetConfigHTTPHandlerKey, func(*http.Request) (*http.Response, error) {


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17134 <!-- REMOVE this line if no issue to close -->

Problem Summary: When using `set config {addr} ...`, if the target instance is not found in this cluster, return an error.

### What is changed and how it works?
If the target instance is not found in this cluster, return an error to notify the user.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- return an error if the target instance is not found in 'set config' statements