### PR TITLE
stmtctx: add TruncateWarnings

### DIFF
--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -326,6 +326,20 @@ func (sc *StatementContext) GetWarnings() []SQLWarn {
 	return warns
 }
 
+// TruncateWarnings truncates wanrings begin from start and returns the truncated warnings.
+func (sc *StatementContext) TruncateWarnings(start int) []SQLWarn {
+	sc.mu.Lock()
+	defer sc.mu.Unlock()
+	sz := len(sc.mu.warnings) - start
+	if sz <= 0 {
+		return nil
+	}
+	ret := make([]SQLWarn, sz)
+	copy(ret, sc.mu.warnings[start:])
+	sc.mu.warnings = sc.mu.warnings[:start]
+	return ret
+}
+
 // WarningCount gets warning count.
 func (sc *StatementContext) WarningCount() uint16 {
 	if sc.InShowWarning {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
The unistore needs to manipulating warnings in some scenarios.

### What is changed and how it works?
Add `TruncateWarnings` to truncate and return the last errors.


### Release note <!-- bugfixes or new feature need a release note -->
* No release note