### PR TITLE
[WIP] planner: fix hash partition pruning for `in` expression 

### DIFF
--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"fmt"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -23,11 +24,35 @@ import (
 
 type hashPartitionPruner struct {
 	unionSet    *disjointset.IntSet // unionSet stores the relations like col_i = col_j
-	constantMap []*Constant
+	constantMap [][]*Constant
 	conditions  []Expression
 	colMapper   map[int64]int
 	numColumn   int
 	ctx         sessionctx.Context
+}
+
+func Equal(a, b []*Constant, ctx sessionctx.Context) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i, x := range a {
+		if !x.Equal(ctx, b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func Intersect(a, b []*Constant, ctx sessionctx.Context) []*Constant {
+	ret := make([]*Constant, 0, len(a))
+	for _, c := range a {
+		for _, cb := range b {
+			if c.Equal(ctx, cb) {
+				ret = append(ret, c)
+			}
+		}
+	}
+	return ret
 }
 
 func (p *hashPartitionPruner) getColID(col *Column) int {
@@ -60,7 +85,14 @@ func (p *hashPartitionPruner) reduceColumnEQ() bool {
 		if p.constantMap[i] != nil {
 			if p.constantMap[father] != nil {
 				// May has conflict here.
-				if !p.constantMap[father].Equal(p.ctx, p.constantMap[i]) {
+				// if !p.constantMap[father].Equal(p.ctx, p.constantMap[i]) {
+				// 	return true
+				// }
+				// if !Equal(p.constantMap[father], p.constantMap[i], p.ctx) {
+				//	return true
+				// }
+				p.constantMap[father] = Intersect(p.constantMap[father], p.constantMap[i], p.ctx)
+				if len(p.constantMap[father]) == 0 {
 					return true
 				}
 			} else {
@@ -82,78 +114,170 @@ func (p *hashPartitionPruner) reduceConstantEQ() bool {
 		col, cond := validEqualCond(p.ctx, con)
 		if col != nil {
 			id := p.getColID(col)
+			tmp := []*Constant{cond}
 			if p.constantMap[id] != nil {
-				if p.constantMap[id].Equal(p.ctx, cond) {
+				// if p.constantMap[id].Equal(p.ctx, cond) {
+				//	 continue
+				// }
+				tmp = Intersect(p.constantMap[id], tmp, p.ctx)
+				if len(tmp) != 0 {
+					p.constantMap[id] = tmp
 					continue
 				}
 				return true
 			}
-			p.constantMap[id] = cond
+			p.constantMap[id] = tmp
+		} else {
+			if in, ok := con.(*ScalarFunction); ok {
+				fmt.Println(in)
+				if in.FuncName.L == ast.In {
+					tmp := make([]*Constant, 0, len(in.GetArgs()))
+					col := in.GetArgs()[0].(*Column)
+					id := p.getColID(col)
+					flag := true
+					for i := 1; i < len(in.GetArgs()); i++ {
+						exp := in.GetArgs()[i]
+						if cons, ok := exp.(*Constant); ok {
+							tmp = append(tmp, cons)
+						} else {
+							flag = false
+						}
+					}
+					if flag {
+						if p.constantMap[id] != nil {
+							tmp = Intersect(tmp, p.constantMap[id], p.ctx)
+							if len(tmp) == 0 {
+								p.constantMap[id] = nil
+								return true
+							}
+						}
+						p.constantMap[id] = tmp
+					}
+				}
+			}
 		}
 	}
 	return false
 }
 
-func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64, success bool, isNil bool) {
+func calc(a, b []int64, op string) []int64 {
+	ret := make([]int64, 0, len(a)*len(b))
+	switch op {
+	case ast.Plus:
+		for _, x := range a {
+			for _, y := range b {
+				ret = append(ret, x + y)
+			}
+		}
+	case ast.Minus:
+		for _, x := range a {
+			for _, y := range b {
+				ret = append(ret, x - y)
+			}
+		}
+	case ast.Mul:
+		for _, x := range a {
+			for _, y := range b {
+				ret = append(ret, x * y)
+			}
+		}
+	case ast.Div:
+		for _, x := range a {
+			for _, y := range b {
+				ret = append(ret, x / y)
+			}
+		}
+	}
+	if len(ret) == 0 {
+		return nil
+	}
+	return ret
+}
+
+func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val []int64, success bool, isNil bool) {
 	switch pi := piExpr.(type) {
 	case *ScalarFunction:
 		if pi.FuncName.L == ast.Plus || pi.FuncName.L == ast.Minus || pi.FuncName.L == ast.Mul || pi.FuncName.L == ast.Div {
 			left, right := pi.GetArgs()[0], pi.GetArgs()[1]
 			leftVal, ok, isNil := p.tryEvalPartitionExpr(left)
 			if !ok {
-				return 0, ok, isNil
+				return nil, ok, isNil
 			}
 			rightVal, ok, isNil := p.tryEvalPartitionExpr(right)
 			if !ok {
-				return 0, ok, isNil
+				return nil, ok, isNil
 			}
-			switch pi.FuncName.L {
-			case ast.Plus:
-				return rightVal + leftVal, true, false
-			case ast.Minus:
-				return rightVal - leftVal, true, false
-			case ast.Mul:
-				return rightVal * leftVal, true, false
-			case ast.Div:
-				return rightVal / leftVal, true, false
-			}
+			return calc(rightVal, leftVal, pi.FuncName.L), true, false
 		} else if pi.FuncName.L == ast.Year || pi.FuncName.L == ast.Month || pi.FuncName.L == ast.ToDays {
 			col := pi.GetArgs()[0].(*Column)
 			idx := p.getColID(col)
 			val := p.constantMap[idx]
 			if val != nil {
-				pi.GetArgs()[0] = val
-				ret, _, err := pi.EvalInt(p.ctx, chunk.Row{})
-				if err != nil {
-					return 0, false, false
+				ret := make([]int64, 0, len(val))
+				for _, ele := range val {
+					pi.GetArgs()[0] = ele
+					retVal, _, err := pi.EvalInt(p.ctx, chunk.Row{})
+					if err != nil {
+						return nil, false, false
+					}
+					ret = append(ret, retVal)
+				}
+				if len(ret) == 0 {
+					return nil, false, false
 				}
 				return ret, true, false
 			}
-			return 0, false, false
+			return nil, false, false
 		}
 	case *Constant:
 		val, err := pi.Eval(chunk.Row{})
 		if err != nil {
-			return 0, false, false
+			return nil, false, false
 		}
 		if val.IsNull() {
-			return 0, false, true
+			return nil, false, true
 		}
 		if val.Kind() == types.KindInt64 {
-			return val.GetInt64(), true, false
+			return []int64{val.GetInt64()}, true, false
 		} else if val.Kind() == types.KindUint64 {
-			return int64(val.GetUint64()), true, false
+			return []int64{int64(val.GetUint64())}, true, false
 		}
+		return nil, false, true
 	case *Column:
 		// Look up map
 		idx := p.getColID(pi)
 		val := p.constantMap[idx]
 		if val != nil {
-			return p.tryEvalPartitionExpr(val)
+			// return p.tryEvalPartitionExpr(val)
+			ret := make([]int64, 0, len(val))
+			for _, ele := range val {
+				v, succ, _ := evalConstantToInt(ele)
+				if !succ {
+					return nil, false, false
+				}
+				ret = append(ret, v)
+			}
+			return ret, true, false
 		}
+		return nil, false, false
+	}
+	return nil, false, false
+}
+
+func evalConstantToInt(pi *Constant) (ret int64, success bool, isNil bool)  {
+	val, err := pi.Eval(chunk.Row{})
+	if err != nil {
 		return 0, false, false
 	}
-	return 0, false, false
+	if val.IsNull() {
+		return 0, false, true
+	}
+	if val.Kind() == types.KindInt64 {
+		return val.GetInt64(), true, false
+	} else if val.Kind() == types.KindUint64 {
+		return int64(val.GetUint64()), true, false
+	}
+	return 0, false, true
 }
 
 func newHashPartitionPruner() *hashPartitionPruner {
@@ -165,7 +289,7 @@ func newHashPartitionPruner() *hashPartitionPruner {
 
 // solve eval the hash partition expression, the first return value represent the result of partition expression. The second
 // return value is whether eval success. The third return value represent whether the eval result of partition value is null.
-func (p *hashPartitionPruner) solve(ctx sessionctx.Context, conds []Expression, piExpr Expression) (val int64, ok bool, isNil bool) {
+func (p *hashPartitionPruner) solve(ctx sessionctx.Context, conds []Expression, piExpr Expression) (val []int64, ok bool, isNil bool) {
 	p.ctx = ctx
 	for _, cond := range conds {
 		p.conditions = append(p.conditions, SplitCNFItems(cond)...)
@@ -176,20 +300,41 @@ func (p *hashPartitionPruner) solve(ctx sessionctx.Context, conds []Expression, 
 	for _, col := range ExtractColumns(piExpr) {
 		p.insertCol(col)
 	}
-	p.constantMap = make([]*Constant, p.numColumn)
+	p.constantMap = make([][]*Constant, p.numColumn)
 	conflict := p.reduceConstantEQ()
 	if conflict {
-		return 0, false, conflict
+		return nil, false, conflict
 	}
 	conflict = p.reduceColumnEQ()
 	if conflict {
-		return 0, false, conflict
+		return nil, false, conflict
 	}
 	res, ok, isNil := p.tryEvalPartitionExpr(piExpr)
+	fmt.Println(res)
 	return res, ok, isNil
 }
 
+func intersect(a, b []int64) []int64 {
+	ret := make([]int64, 0, len(a))
+	for _, ea := range a {
+		for _, eb := range b {
+			if  ea == eb {
+				ret = append(ret, ea)
+				break
+			}
+		}
+	}
+	return ret
+}
+
 // FastLocateHashPartition is used to get hash partition quickly.
-func FastLocateHashPartition(ctx sessionctx.Context, conds []Expression, piExpr Expression) (int64, bool, bool) {
-	return newHashPartitionPruner().solve(ctx, conds, piExpr)
+func FastLocateHashPartition(ctx sessionctx.Context, conds []Expression, piExpr Expression) ([]int64, bool, bool) {
+	var ret []int64
+	for _, cond := range conds {
+		cnfs := SplitDNFItems(cond)
+		for _, cnf := range cnfs {
+			newHashPartitionPruner().solve(ctx, cnf, piExpr)
+		}
+	}
+	return
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16681 <!-- REMOVE this line if no issue to close -->

Problem Summary:

Partition pruning will fail when `in` expression in query conditions 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Originally, every column has only one possible value in partition pruning. To support `in` expression, every column may has many value and calculate as vector calculation.

How it Works:

after fix:

```
MySQL [test]> create table t (x int, y int) partition by hash(X) partitions 10;

MySQL [test]> explain select * from t where y in (3,7) and x = y;
+-----------------------------+----------+-----------+-----------------------+--------------------------------------------+
| id                          | estRows  | task      | access object         | operator info                              |
+-----------------------------+----------+-----------+-----------------------+--------------------------------------------+
| Union_8                     | 32.00    | root      |                       |                                            |
| ├─TableReader_11            | 16.00    | root      |                       | data:Selection_10                          |
| │ └─Selection_10            | 16.00    | cop[tikv] |                       | eq(test.t.x, test.t.y), in(test.t.y, 3, 7) |
| │   └─TableFullScan_9       | 10000.00 | cop[tikv] | table:t, partition:p3 | keep order:false, stats:pseudo             |
| └─TableReader_14            | 16.00    | root      |                       | data:Selection_13                          |
|   └─Selection_13            | 16.00    | cop[tikv] |                       | eq(test.t.x, test.t.y), in(test.t.y, 3, 7) |
|     └─TableFullScan_12      | 10000.00 | cop[tikv] | table:t, partition:p7 | keep order:false, stats:pseudo             |
+-----------------------------+----------+-----------+-----------------------+--------------------------------------------+
7 rows in set (0.001 sec)
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (will be add later)

Side effects

- Performance regression
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- planner: fix hash partition pruning for `in` expression 