### PR TITLE
*: Show edition information when mysql client login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ GOBUILDCOVERAGE := GOPATH=$(GOPATH) cd tidb-server; $(GO) test -coverpkg="../...
 GOTEST          := $(GO) test -p $(P)
 OVERALLS        := GO111MODULE=on overalls
 STATICCHECK     := GO111MODULE=on staticcheck
+EDITION         ?= Community
 
 ARCH      := "`uname -s`"
 LINUX     := "Linux"
@@ -47,6 +48,7 @@ LDFLAGS += -X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=$(shell git de
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
+LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBEdition=$(EDITION)"
 
 TEST_LDFLAGS =  -X "github.com/pingcap/tidb/config.checkBeforeDropLDFlag=1"
 COVERAGE_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/tidb-server.isCoverageServer=1"

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ GOBUILDCOVERAGE := GOPATH=$(GOPATH) cd tidb-server; $(GO) test -coverpkg="../...
 GOTEST          := $(GO) test -p $(P)
 OVERALLS        := GO111MODULE=on overalls
 STATICCHECK     := GO111MODULE=on staticcheck
-EDITION         ?= Community
+TIDB_EDITION    ?= Community
 
 ARCH      := "`uname -s`"
 LINUX     := "Linux"
@@ -48,7 +48,7 @@ LDFLAGS += -X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=$(shell git de
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-parse HEAD)"
 LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBEdition=$(EDITION)"
+LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBEdition=$(TIDB_EDITION)"
 
 TEST_LDFLAGS =  -X "github.com/pingcap/tidb/config.checkBeforeDropLDFlag=1"
 COVERAGE_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/tidb-server.isCoverageServer=1"

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/printer"
 )
 
 // ScopeFlag is for system variable whether can be changed in global/session dynamically or not.
@@ -385,7 +386,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "binlog_format", "STATEMENT"},
 	{ScopeGlobal | ScopeSession, "optimizer_trace", "enabled=off,one_line=off"},
 	{ScopeGlobal | ScopeSession, "read_rnd_buffer_size", "262144"},
-	{ScopeNone, "version_comment", "TiDB Server (Apache License 2.0), MySQL 5.7 compatible"},
+	{ScopeNone, "version_comment", "TiDB Server (Apache License 2.0) " + printer.TiDBEdition + " Edition, MySQL 5.7 compatible"},
 	{ScopeGlobal | ScopeSession, NetWriteTimeout, "60"},
 	{ScopeGlobal, InnodbBufferPoolLoadAbort, "0"},
 	{ScopeGlobal | ScopeSession, TxnIsolation, "REPEATABLE-READ"},

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -32,6 +32,7 @@ var (
 	TiDBBuildTS   = "None"
 	TiDBGitHash   = "None"
 	TiDBGitBranch = "None"
+	TiDBEdition   = "None"
 	// TiKVMinVersion is the minimum version of TiKV that can be compatible with the current TiDB.
 	TiKVMinVersion = "v3.0.0-60965b006877ca7234adaced7890d7b029ed1306"
 )
@@ -40,6 +41,7 @@ var (
 func PrintTiDBInfo() {
 	logutil.BgLogger().Info("Welcome to TiDB.",
 		zap.String("Release Version", mysql.TiDBReleaseVersion),
+		zap.String("Edition", TiDBEdition),
 		zap.String("Git Commit Hash", TiDBGitHash),
 		zap.String("Git Branch", TiDBGitBranch),
 		zap.String("UTC Build Time", TiDBBuildTS),
@@ -57,6 +59,7 @@ func PrintTiDBInfo() {
 // GetTiDBInfo returns the git hash and build time of this tidb-server binary.
 func GetTiDBInfo() string {
 	return fmt.Sprintf("Release Version: %s\n"+
+		"Edition: %s\n"+
 		"Git Commit Hash: %s\n"+
 		"Git Branch: %s\n"+
 		"UTC Build Time: %s\n"+
@@ -65,6 +68,7 @@ func GetTiDBInfo() string {
 		"TiKV Min Version: %s\n"+
 		"Check Table Before Drop: %v",
 		mysql.TiDBReleaseVersion,
+		TiDBEdition,
 		TiDBGitHash,
 		TiDBGitBranch,
 		TiDBBuildTS,


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Show edition information when MySQL client login and `tidb-server -V`

Problem Summary:

TiDB needs to distinguish `Enterprise` and `Community` editions after v4.0.0 GA, and print the edition information when user login via MySQL client.

### What is changed and how it works?

1. Change the Makefile to change the edition according to environment variables.
2. Change the `version_comment` session variable.

```
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 1
Server version: 5.7.25-TiDB-v4.0.0 TiDB Server (Apache License 2.0) Enterprise Edition, MySQL 5.7 compatible

Copyright (c) 2000, 2019, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.
```

Tests <!-- At least one of them must be included. -->

- Unit test
- No code

### Release note <!-- bugfixes or new feature need a release note -->

- No need
