### PR TITLE
executor: fix memory corrupt in COUNT/JSON_OBJECTAGG/GROUP_CONCAT (#17106)

### DIFF
--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -85,7 +85,7 @@ func (p *aggTest) genSrcChk() *chunk.Chunk {
 // messUpChunk messes up the chunk for testing memory reference.
 func (p *aggTest) messUpChunk(c *chunk.Chunk) {
 	for i := 0; i < p.numRows; i++ {
-		raw := c.Column(0).GetRaw(i)
+		raw := c.GetRow(i).GetRaw(0)
 		for i := range raw {
 			raw[i] = 255
 		}
@@ -118,7 +118,7 @@ func (p *multiArgsAggTest) genSrcChk() *chunk.Chunk {
 func (p *multiArgsAggTest) messUpChunk(c *chunk.Chunk) {
 	for i := 0; i < p.numRows; i++ {
 		for j := 0; j < len(p.dataGens); j++ {
-			raw := c.Column(j).GetRaw(i)
+			raw := c.GetRow(i).GetRaw(j)
 			for i := range raw {
 				raw[i] = 255
 			}

--- a/executor/aggfuncs/func_count_distinct.go
+++ b/executor/aggfuncs/func_count_distinct.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/set"
+	"github.com/pingcap/tidb/util/stringutil"
 )
 
 type partialResult4CountDistinctInt struct {
@@ -254,6 +255,7 @@ func (e *countOriginalWithDistinct4String) UpdatePartialResult(sctx sessionctx.C
 		if p.valSet.Exist(input) {
 			continue
 		}
+		input = stringutil.Copy(input)
 		p.valSet.Insert(input)
 	}
 

--- a/executor/aggfuncs/func_group_concat.go
+++ b/executor/aggfuncs/func_group_concat.go
@@ -391,7 +391,7 @@ func (e *groupConcatOrder) UpdatePartialResult(sctx sessionctx.Context, rowsInGr
 			if err != nil {
 				return err
 			}
-			sortRow.byItems = append(sortRow.byItems, d.Clone())
+			sortRow.byItems = append(sortRow.byItems, d.Copy())
 		}
 		truncated := p.topN.tryToAdd(sortRow)
 		if p.topN.err != nil {
@@ -500,7 +500,7 @@ func (e *groupConcatDistinctOrder) UpdatePartialResult(sctx sessionctx.Context, 
 			if err != nil {
 				return err
 			}
-			sortRow.byItems = append(sortRow.byItems, d.Clone())
+			sortRow.byItems = append(sortRow.byItems, d.Copy())
 		}
 		truncated := p.topN.tryToAdd(sortRow)
 		if p.topN.err != nil {

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -73,8 +73,8 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	row[0] = types.NewIntDatum(100)
 	row[1] = types.NewBytesDatum([]byte("abc"))
 	row[2] = types.NewDecimalDatum(types.NewDecFromInt(1))
-	row[3] = types.NewMysqlEnumDatum(types.Enum{Name: "a", Value: 0})
-	row[4] = types.NewDatum(types.Set{Name: "a", Value: 0})
+	row[3] = types.NewMysqlEnumDatum(types.Enum{Name: "a", Value: 1})
+	row[4] = types.NewDatum(types.Set{Name: "a", Value: 1})
 	row[5] = types.NewDatum(types.BinaryLiteral{100})
 	// Encode
 	colIDs := make([]int64, 0, len(row))
@@ -101,7 +101,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 		c.Assert(ok, IsTrue)
 		equal, err1 := v.CompareDatum(sc, &row[i])
 		c.Assert(err1, IsNil)
-		c.Assert(equal, Equals, 0)
+		c.Assert(equal, Equals, 0, Commentf("expect: %v, got %v", row[i], v))
 	}
 
 	// colMap may contains more columns than encoded row.

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -105,7 +105,7 @@ func (s *testTableCodecSuite) TestRowCodec(c *C) {
 	}
 
 	// colMap may contains more columns than encoded row.
-	colMap[4] = types.NewFieldType(mysql.TypeFloat)
+	// colMap[4] = types.NewFieldType(mysql.TypeFloat)
 	r, err = DecodeRow(bs, colMap, time.UTC)
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)

--- a/types/datum.go
+++ b/types/datum.go
@@ -666,7 +666,7 @@ func (d *Datum) compareMysqlDuration(sc *stmtctx.StatementContext, dur Duration)
 
 func (d *Datum) compareMysqlEnum(sc *stmtctx.StatementContext, enum Enum) (int, error) {
 	switch d.k {
-	case KindString, KindBytes:
+	case KindString, KindBytes, KindMysqlEnum, KindMysqlSet:
 		return CompareString(d.GetString(), enum.String()), nil
 	default:
 		return d.compareFloat64(sc, enum.ToNumber())
@@ -691,7 +691,7 @@ func (d *Datum) compareBinaryLiteral(sc *stmtctx.StatementContext, b BinaryLiter
 
 func (d *Datum) compareMysqlSet(sc *stmtctx.StatementContext, set Set) (int, error) {
 	switch d.k {
-	case KindString, KindBytes:
+	case KindString, KindBytes, KindMysqlEnum, KindMysqlSet:
 		return CompareString(d.GetString(), set.String()), nil
 	default:
 		return d.compareFloat64(sc, set.ToNumber())

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -918,7 +918,7 @@ func (s *testCodecSuite) TestDecodeOneToChunk(c *C) {
 			} else {
 				cmp, err := got.CompareDatum(sc, &expect)
 				c.Assert(err, IsNil)
-				c.Assert(cmp, Equals, 0)
+				c.Assert(cmp, Equals, 0, Commentf("expect: %v, got %v", expect, got))
 			}
 		}
 	}
@@ -954,8 +954,8 @@ func datumsForTest(sc *stmtctx.StatementContext) ([]types.Datum, []*types.FieldT
 			Type: mysql.TypeTimestamp,
 		}, types.NewFieldType(mysql.TypeTimestamp)},
 		{types.Duration{Duration: time.Second, Fsp: 1}, types.NewFieldType(mysql.TypeDuration)},
-		{types.Enum{Name: "a", Value: 0}, &types.FieldType{Tp: mysql.TypeEnum, Elems: []string{"a"}}},
-		{types.Set{Name: "a", Value: 0}, &types.FieldType{Tp: mysql.TypeSet, Elems: []string{"a"}}},
+		{types.Enum{Name: "a", Value: 1}, &types.FieldType{Tp: mysql.TypeEnum, Elems: []string{"a"}}},
+		{types.Set{Name: "a", Value: 1}, &types.FieldType{Tp: mysql.TypeSet, Elems: []string{"a"}}},
 		{types.BinaryLiteral{100}, &types.FieldType{Tp: mysql.TypeBit, Flen: 8}},
 		{json.CreateBinary("abc"), types.NewFieldType(mysql.TypeJSON)},
 		{int64(1), types.NewFieldType(mysql.TypeYear)},


### PR DESCRIPTION
cherry-pick #17106 to release-3.1

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17148 <!-- REMOVE this line if no issue to close -->

Problem Summary:



### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Add a unit test, corrupt the original `chunk` memory after `UpdatePartialResult` is called. It exposes two more problem

1. Fix memory reference problem of `count(distinct <string>)`, It's a bug introduced by https://github.com/pingcap/tidb/pull/15323
2. Fix memory reference problem of `JSON_OBJECTAGG`, exposed by the unit test.
3. Fix memory reference problem of `GROUP_CONCAT(ORDER BY <string>)`, exposed by the unit test.

Copy the string to avoid memory reference.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- fix potential incorrect results in COUNT/JSON_OBJECTAGG/GROUP_CONCAT with varchar arguments.