### PR TITLE
ddl: fix creating partition table with unique prefix index

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -874,13 +874,13 @@ func generateOriginDefaultValue(col *model.ColumnInfo) (interface{}, error) {
 	return odValue, nil
 }
 
-func findColumnInIndexCols(c string, cols []*model.IndexColumn) bool {
+func findColumnInIndexCols(c string, cols []*model.IndexColumn) *model.IndexColumn {
 	for _, c1 := range cols {
 		if c == c1.Name.L {
-			return true
+			return c1
 		}
 	}
-	return false
+	return nil
 }
 
 func getColumnInfoByName(tbInfo *model.TableInfo, column string) *model.ColumnInfo {

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1218,6 +1218,11 @@ func (s *testIntegrationSuite5) TestPartitionUniqueKeyNeedAllFieldsInPf(c *C) {
 			partition p1 values less than ('bbbbb'),
 			partition p2 values less than ('ccccc'))`)
 	tk.MustGetErrCode("alter table part12 add unique index (a(5))", tmysql.ErrUniqueKeyNeedAllFieldsInPf)
+	sql13 := `create table part13 (a varchar(20), b varchar(10), unique index (a(5),b)) partition by range columns (b) (
+			partition p0 values less than ('aaaaa'),
+			partition p1 values less than ('bbbbb'),
+			partition p2 values less than ('ccccc'))`
+	tk.MustExec(sql13)
 }
 
 func (s *testIntegrationSuite2) TestPartitionDropPrimaryKey(c *C) {

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1207,6 +1207,17 @@ func (s *testIntegrationSuite5) TestPartitionUniqueKeyNeedAllFieldsInPf(c *C) {
                partition p2 values less than (11, 22)
         )`
 	tk.MustGetErrCode(sql11, tmysql.ErrUniqueKeyNeedAllFieldsInPf)
+
+	sql12 := `create table part12 (a varchar(20), b binary, unique index (a(5))) partition by range columns (a) (
+			partition p0 values less than ('aaaaa'),
+			partition p1 values less than ('bbbbb'),
+			partition p2 values less than ('ccccc'))`
+	tk.MustGetErrCode(sql12, tmysql.ErrUniqueKeyNeedAllFieldsInPf)
+	tk.MustExec(`create table part12 (a varchar(20), b binary) partition by range columns (a) (
+			partition p0 values less than ('aaaaa'),
+			partition p1 values less than ('bbbbb'),
+			partition p2 values less than ('ccccc'))`)
+	tk.MustGetErrCode("alter table part12 add unique index (a(5))", tmysql.ErrUniqueKeyNeedAllFieldsInPf)
 }
 
 func (s *testIntegrationSuite2) TestPartitionDropPrimaryKey(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
create table t1 (a varchar(20), b binary, unique index (a(5))) partition by range columns (a) (
    partition p0 values less than ('aaaaa'),
    partition p1 values less than ('bbbbb'),
    partition p2 values less than ('ccccc')
);
```

MySQL: A UNIQUE INDEX must include all columns in the table's partitioning function
TiDB: no error

Problem Summary:

Unique prefix index can't be used on the partition table.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

Add check

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- Fix the check of create and alter table, unique prefix index must not be used on the partition table