### PR TITLE
ddl: check too long ident for partition

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -278,6 +278,17 @@ func (s *testIntegrationSuite3) TestCreateTableWithPartition(c *C) {
 	// Fix https://github.com/pingcap/tidb/issues/16333
 	tk.MustExec(`create table t35 (dt timestamp) partition by range (unix_timestamp(dt))
 (partition p0 values less than (unix_timestamp('2020-04-15 00:00:00')));`)
+
+	tk.MustExec(`drop table if exists too_long_identifier`)
+	tk.MustGetErrCode(`create table too_long_identifier(a int) 
+partition by range (a) 
+(partition p0pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp values less than (10));`, tmysql.ErrTooLongIdent)
+
+	tk.MustExec(`drop table if exists too_long_identifier`)
+	tk.MustExec("create table too_long_identifier(a int) partition by range(a) (partition p0 values less than(10))")
+	tk.MustGetErrCode("alter table too_long_identifier add partition "+
+		"(partition p0pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp values less than(20))", tmysql.ErrTooLongIdent)
+
 }
 
 func (s *testIntegrationSuite2) TestCreateTableWithHashPartition(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1350,7 +1350,6 @@ func checkTableInfoValidWithStmt(ctx sessionctx.Context, tbInfo *model.TableInfo
 		return errors.Trace(err)
 	}
 	if s.Partition != nil {
-		//err := chec
 		err := checkPartitionExprValid(ctx, tbInfo, s.Partition.Expr)
 		if err != nil {
 			return errors.Trace(err)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1350,6 +1350,7 @@ func checkTableInfoValidWithStmt(ctx sessionctx.Context, tbInfo *model.TableInfo
 		return errors.Trace(err)
 	}
 	if s.Partition != nil {
+		//err := chec
 		err := checkPartitionExprValid(ctx, tbInfo, s.Partition.Expr)
 		if err != nil {
 			return errors.Trace(err)
@@ -4454,6 +4455,9 @@ func buildPartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, d *ddl, s
 	for ith, def := range spec.PartDefinitions {
 		if err := def.Clause.Validate(part.Type, len(part.Columns)); err != nil {
 			return nil, errors.Trace(err)
+		}
+		if err := checkTooLongTable(def.Name); err != nil {
+			return nil, err
 		}
 		// For RANGE partition only VALUES LESS THAN should be possible.
 		clause := def.Clause.(*ast.PartitionDefinitionClauseLessThan)

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -133,9 +133,13 @@ func buildHashPartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStm
 	return nil
 }
 
-func buildRangePartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStmt, pi *model.PartitionInfo) error {
+func buildRangePartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStmt, pi *model.PartitionInfo) (err error) {
 	for _, def := range s.Partition.Definitions {
 		comment, _ := def.Comment()
+		err = checkTooLongTable(def.Name)
+		if err != nil {
+			return err
+		}
 		piDef := model.PartitionDefinition{
 			Name:    def.Name,
 			Comment: comment,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17235 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?
Check the name length of partition when create table and alter table

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->
- Raise an error if the length of the partition name exceeds 64.