### PR TITLE
ddl: fix a panic when creating key partition table (#16260)

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -471,6 +471,9 @@ func (s *testIntegrationSuite3) TestCreateTableWithKeyPartition(c *C) {
 		s1 char(32) primary key
 	)
 	partition by key(s1) partitions 10;`)
+
+	tk.MustExec(`drop table if exists tm2`)
+	tk.MustExec(`create table tm2 (a char(5), unique key(a(5))) partition by key() partitions 5;`)
 }
 
 func (s *testIntegrationSuite5) TestAlterTableAddPartition(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1313,7 +1313,7 @@ func checkTableInfoValidWithStmt(ctx sessionctx.Context, tbInfo *model.TableInfo
 			}
 		}
 
-		if err = checkRangePartitioningKeysConstraints(ctx, s, tbInfo); err != nil {
+		if err = checkPartitioningKeysConstraints(ctx, s, tbInfo); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -54,19 +54,23 @@ func buildTablePartitionInfo(ctx sessionctx.Context, s *ast.CreateTableStmt) (*m
 	var enable bool
 	// When tidb_enable_table_partition is 'on' or 'auto'.
 	if s.Partition.Tp == model.PartitionTypeRange {
-		// Partition by range expression is enabled by default.
-		if s.Partition.ColumnNames == nil {
-			enable = true
-		}
-		// Partition by range columns and just one column.
-		if len(s.Partition.ColumnNames) == 1 {
-			enable = true
+		if s.Partition.Sub == nil {
+			// Partition by range expression is enabled by default.
+			if s.Partition.ColumnNames == nil {
+				enable = true
+			}
+			// Partition by range columns and just one column.
+			if len(s.Partition.ColumnNames) == 1 {
+				enable = true
+			}
 		}
 	}
 	// Partition by hash is enabled by default.
 	// Note that linear hash is not enabled.
 	if s.Partition.Tp == model.PartitionTypeHash {
-		enable = true
+		if !s.Partition.Linear && s.Partition.Sub == nil {
+			enable = true
+		}
 	}
 
 	if !enable {
@@ -713,8 +717,8 @@ func getPartitionIDs(table *model.TableInfo) []int64 {
 	return physicalTableIDs
 }
 
-// checkRangePartitioningKeysConstraints checks that the range partitioning key is included in the table constraint.
-func checkRangePartitioningKeysConstraints(sctx sessionctx.Context, s *ast.CreateTableStmt, tblInfo *model.TableInfo) error {
+// checkPartitioningKeysConstraints checks that the range partitioning key is included in the table constraint.
+func checkPartitioningKeysConstraints(sctx sessionctx.Context, s *ast.CreateTableStmt, tblInfo *model.TableInfo) error {
 	// Returns directly if there are no unique keys in the table.
 	if len(tblInfo.Indices) == 0 && !tblInfo.PKIsHandle {
 		return nil
@@ -732,6 +736,9 @@ func checkRangePartitioningKeysConstraints(sctx sessionctx.Context, s *ast.Creat
 		partCols = columnInfoSlice(partColumns)
 	} else if len(s.Partition.ColumnNames) > 0 {
 		partCols = columnNameSlice(s.Partition.ColumnNames)
+	} else {
+		// TODO: Check keys constraints for list, key partition type and so on.
+		return nil
 	}
 
 	// Checks that the partitioning key is included in the constraint.


### PR DESCRIPTION
Cherry pick https://github.com/pingcap/tidb/pull/16260

mysql> create table t(a char(5), unique key(a(5))) partition by key() partitions 5;
ERROR 2013 (HY000): Lost connection to MySQL server during query

### Release note <!-- bugfixes or new feature need a release note -->

- Fix panic when creating a key partition table