### PR TITLE
[release-4.0] Disable Coprocessor Cache by default in GA

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -473,7 +473,7 @@ type TiKVClient struct {
 type CoprocessorCache struct {
 	// Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
 	// reuses the result when corresponding data in TiKV is unchanged, on a region basis.
-	Enabled bool `toml:"enabled" json:"enabled"`
+	Enable bool `toml:"enable" json:"enable"`
 	// The capacity in MB of the cache.
 	CapacityMB float64 `toml:"capacity-mb" json:"capacity-mb"`
 	// Only cache requests whose result set is small.
@@ -648,7 +648,7 @@ var defaultConf = Config{
 		StoreLivenessTimeout: DefStoreLivenessTimeout,
 
 		CoprCache: CoprocessorCache{
-			Enabled:               true,
+			Enable:                true,
 			CapacityMB:            1000,
 			AdmissionMaxResultMB:  10,
 			AdmissionMinProcessMs: 5,

--- a/config/config.go
+++ b/config/config.go
@@ -648,7 +648,7 @@ var defaultConf = Config{
 		StoreLivenessTimeout: DefStoreLivenessTimeout,
 
 		CoprCache: CoprocessorCache{
-			Enable:                true,
+			Enable:                false,
 			CapacityMB:            1000,
 			AdmissionMaxResultMB:  10,
 			AdmissionMinProcessMs: 5,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -354,7 +354,7 @@ store-liveness-timeout = "120s"
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
 # reuses the result when corresponding data in TiKV is unchanged, on a region basis.
-enabled = true
+enable = true
 
 # The capacity in MB of the cache.
 capacity-mb = 1000.0

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -354,7 +354,7 @@ store-liveness-timeout = "120s"
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and
 # reuses the result when corresponding data in TiKV is unchanged, on a region basis.
-enable = true
+enable = false
 
 # The capacity in MB of the cache.
 capacity-mb = 1000.0

--- a/store/tikv/coprocessor_cache.go
+++ b/store/tikv/coprocessor_cache.go
@@ -56,7 +56,7 @@ func (v *coprCacheValue) Len() int {
 }
 
 func newCoprCache(config *config.CoprocessorCache) (*coprCache, error) {
-	if config == nil || !config.Enabled {
+	if config == nil || !config.Enable {
 		return nil, nil
 	}
 	capacityInBytes := int64(config.CapacityMB * 1024.0 * 1024.0)

--- a/store/tikv/coprocessor_cache_test.go
+++ b/store/tikv/coprocessor_cache_test.go
@@ -73,7 +73,7 @@ func (s *testCoprocessorSuite) TestBuildCacheKey(c *C) {
 }
 
 func (s *testCoprocessorSuite) TestDisable(c *C) {
-	cache, err := newCoprCache(&config.CoprocessorCache{Enabled: false})
+	cache, err := newCoprCache(&config.CoprocessorCache{Enable: false})
 	c.Assert(err, IsNil)
 	c.Assert(cache, IsNil)
 
@@ -86,21 +86,21 @@ func (s *testCoprocessorSuite) TestDisable(c *C) {
 	v = cache.CheckAdmission(1024, time.Second*5)
 	c.Assert(v, Equals, false)
 
-	cache, err = newCoprCache(&config.CoprocessorCache{Enabled: true, CapacityMB: 0, AdmissionMaxResultMB: 1})
+	cache, err = newCoprCache(&config.CoprocessorCache{Enable: true, CapacityMB: 0, AdmissionMaxResultMB: 1})
 	c.Assert(err, NotNil)
 	c.Assert(cache, IsNil)
 
-	cache, err = newCoprCache(&config.CoprocessorCache{Enabled: true, CapacityMB: 0.001})
+	cache, err = newCoprCache(&config.CoprocessorCache{Enable: true, CapacityMB: 0.001})
 	c.Assert(err, NotNil)
 	c.Assert(cache, IsNil)
 
-	cache, err = newCoprCache(&config.CoprocessorCache{Enabled: true, CapacityMB: 0.001, AdmissionMaxResultMB: 1})
+	cache, err = newCoprCache(&config.CoprocessorCache{Enable: true, CapacityMB: 0.001, AdmissionMaxResultMB: 1})
 	c.Assert(err, IsNil)
 	c.Assert(cache, NotNil)
 }
 
 func (s *testCoprocessorSuite) TestAdmission(c *C) {
-	cache, err := newCoprCache(&config.CoprocessorCache{Enabled: true, AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
+	cache, err := newCoprCache(&config.CoprocessorCache{Enable: true, AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
 	c.Assert(err, IsNil)
 	c.Assert(cache, NotNil)
 
@@ -155,7 +155,7 @@ func (s *testCoprocessorSuite) TestCacheValueLen(c *C) {
 }
 
 func (s *testCoprocessorSuite) TestGetSet(c *C) {
-	cache, err := newCoprCache(&config.CoprocessorCache{Enabled: true, AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
+	cache, err := newCoprCache(&config.CoprocessorCache{Enable: true, AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
 	c.Assert(err, IsNil)
 	c.Assert(cache, NotNil)
 

--- a/store/tikv/coprocessor_cache_test.go
+++ b/store/tikv/coprocessor_cache_test.go
@@ -73,7 +73,7 @@ func (s *testCoprocessorSuite) TestBuildCacheKey(c *C) {
 }
 
 func (s *testCoprocessorSuite) TestDisable(c *C) {
-	cache, err := newCoprCache(&config.CoprocessorCache{Enable: false})
+	cache, err := newCoprCache(&config.CoprocessorCache{})
 	c.Assert(err, IsNil)
 	c.Assert(cache, IsNil)
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16711

Problem Summary:

Currently Coprocessor Cache does not have very comprehensive test suites, as well as lack of observability. It would be better to mark it as an experimental feature and disable it by default in the GA version. We can enable it by default in later versions when these parts are ready.

### What is changed and how it works?

What's Changed: Cherry pick https://github.com/pingcap/tidb/pull/17227 and then disable it by default.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: No need. The documentation is already using the word `enable` instead of `enabled`. Also the documentation has already describing this feature as an experimental feature and not enabled by default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

Mark Coprocessor Cache as an experimental feature.