### PR TITLE
meta: fix the allocator batch size compute logic

### DIFF
--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -905,6 +905,7 @@ func DecodeCmpUintToInt(u uint64) int64 {
 	return int64(u ^ signMask)
 }
 
+// TestModifyBaseAndEndInjection exported for testing modifying the base and end.
 func TestModifyBaseAndEndInjection(alloc Allocator, base, end int64) {
 	alloc.(*allocator).mu.Lock()
 	alloc.(*allocator).base = base

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -373,6 +373,11 @@ func (alloc *allocator) GetType() AllocatorType {
 
 // NextStep return new auto id step according to previous step and consuming time.
 func NextStep(curStep int64, consumeDur time.Duration) int64 {
+	failpoint.Inject("mockAutoIDCustomize", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(3)
+		}
+	})
 	failpoint.Inject("mockAutoIDChange", func(val failpoint.Value) {
 		if val.(bool) {
 			failpoint.Return(step)
@@ -898,6 +903,13 @@ func EncodeIntToCmpUint(v int64) uint64 {
 // DecodeCmpUintToInt decodes the u that encoded by EncodeIntToCmpUint
 func DecodeCmpUintToInt(u uint64) int64 {
 	return int64(u ^ signMask)
+}
+
+func TestModifyBaseAndEndInjection(alloc Allocator, base, end int64) {
+	alloc.(*allocator).mu.Lock()
+	alloc.(*allocator).base = base
+	alloc.(*allocator).end = end
+	alloc.(*allocator).mu.Unlock()
 }
 
 // AutoRandomIDLayout is used to calculate the bits length of different section in auto_random id.

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -648,7 +648,7 @@ func (alloc *allocator) alloc4Signed(tableID int64, n uint64, increment, offset 
 				return err1
 			}
 			// CalcNeededBatchSize calculates the total batch size needed on global base.
-			n1 := CalcNeededBatchSize(newBase, int64(n), increment, offset, alloc.isUnsigned)
+			n1 = CalcNeededBatchSize(newBase, int64(n), increment, offset, alloc.isUnsigned)
 			// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
 			if nextStep < n1 {
 				nextStep = n1

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -640,20 +640,18 @@ func (alloc *allocator) alloc4Signed(tableID int64, n uint64, increment, offset 
 			consumeDur := startTime.Sub(alloc.lastAllocTime)
 			nextStep = NextStep(alloc.step, consumeDur)
 		}
-		// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
-		if nextStep <= n1 {
-			nextStep = mathutil.MinInt64(n1*2, maxStep)
-		}
-		// Store the step for non-customized-step allocator to calculate next dynamic step.
-		if !alloc.customStep {
-			alloc.step = nextStep
-		}
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
 			newBase, err1 = getAutoIDByAllocType(m, alloc.dbID, tableID, alloc.allocType)
 			if err1 != nil {
 				return err1
+			}
+			// CalcNeededBatchSize calculates the total batch size needed on global base.
+			n1 := CalcNeededBatchSize(newBase, int64(n), increment, offset, alloc.isUnsigned)
+			// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
+			if nextStep < n1 {
+				nextStep = n1
 			}
 			tmpStep := mathutil.MinInt64(math.MaxInt64-newBase, nextStep)
 			// The global rest is not enough for alloc.
@@ -666,6 +664,10 @@ func (alloc *allocator) alloc4Signed(tableID int64, n uint64, increment, offset 
 		metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDAlloc, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 		if err != nil {
 			return 0, 0, err
+		}
+		// Store the step for non-customized-step allocator to calculate next dynamic step.
+		if !alloc.customStep {
+			alloc.step = nextStep
 		}
 		alloc.lastAllocTime = time.Now()
 		if newBase == math.MaxInt64 {
@@ -707,20 +709,18 @@ func (alloc *allocator) alloc4Unsigned(tableID int64, n uint64, increment, offse
 			consumeDur := startTime.Sub(alloc.lastAllocTime)
 			nextStep = NextStep(alloc.step, consumeDur)
 		}
-		// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
-		if nextStep <= n1 {
-			nextStep = mathutil.MinInt64(n1*2, maxStep)
-		}
-		// Store the step for non-customized-step allocator to calculate next dynamic step.
-		if !alloc.customStep {
-			alloc.step = nextStep
-		}
 		err := kv.RunInNewTxn(alloc.store, true, func(txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
 			var err1 error
 			newBase, err1 = getAutoIDByAllocType(m, alloc.dbID, tableID, alloc.allocType)
 			if err1 != nil {
 				return err1
+			}
+			// CalcNeededBatchSize calculates the total batch size needed on new base.
+			n1 = CalcNeededBatchSize(newBase, int64(n), increment, offset, alloc.isUnsigned)
+			// Although the step is customized by user, we still need to make sure nextStep is big enough for insert batch.
+			if nextStep < n1 {
+				nextStep = n1
 			}
 			tmpStep := int64(mathutil.MinUint64(math.MaxUint64-uint64(newBase), uint64(nextStep)))
 			// The global rest is not enough for alloc.
@@ -733,6 +733,10 @@ func (alloc *allocator) alloc4Unsigned(tableID int64, n uint64, increment, offse
 		metrics.AutoIDHistogram.WithLabelValues(metrics.TableAutoIDAlloc, metrics.RetLabel(err)).Observe(time.Since(startTime).Seconds())
 		if err != nil {
 			return 0, 0, err
+		}
+		// Store the step for non-customized-step allocator to calculate next dynamic step.
+		if !alloc.customStep {
+			alloc.step = nextStep
 		}
 		alloc.lastAllocTime = time.Now()
 		if uint64(newBase) == math.MaxUint64 {

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -825,3 +825,54 @@ func (*testSuite) TestConcurrentAllocSequence(c *C) {
 	err = <-errCh
 	c.Assert(err, IsNil)
 }
+
+// Fix a issue111 in allocator computation.
+func (*testSuite) TestAllocComputationIssue(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDCustomize", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDCustomize"), IsNil)
+	}()
+
+	store, err := mockstore.NewMockStore()
+	c.Assert(err, IsNil)
+	defer store.Close()
+
+	err = kv.RunInNewTxn(store, false, func(txn kv.Transaction) error {
+		m := meta.NewMeta(txn)
+		err = m.CreateDatabase(&model.DBInfo{ID: 1, Name: model.NewCIStr("a")})
+		c.Assert(err, IsNil)
+		err = m.CreateTableOrView(1, &model.TableInfo{ID: 1, Name: model.NewCIStr("t")})
+		c.Assert(err, IsNil)
+		err = m.CreateTableOrView(1, &model.TableInfo{ID: 2, Name: model.NewCIStr("t1")})
+		c.Assert(err, IsNil)
+		return nil
+	})
+	c.Assert(err, IsNil)
+
+	// Since the test here is applicable to any type of allocators, autoid.RowIDAllocType is chosen.
+	unsignedAlloc := autoid.NewAllocator(store, 1, true, autoid.RowIDAllocType)
+	c.Assert(unsignedAlloc, NotNil)
+	signedAlloc := autoid.NewAllocator(store, 1, false, autoid.RowIDAllocType)
+	c.Assert(signedAlloc, NotNil)
+
+	// the next valid two value must be 13 & 16, batch size = 6.
+	err = unsignedAlloc.Rebase(1, 10, false)
+	c.Assert(err, IsNil)
+	// the next valid two value must be 10 & 13, batch size = 6.
+	err = signedAlloc.Rebase(2, 7, false)
+	c.Assert(err, IsNil)
+	// Simulate the rest cache is not enough for next batch, assuming 10 & 13, batch size = 4.
+	autoid.TestModifyBaseAndEndInjection(unsignedAlloc, 9, 9)
+	// Simulate the rest cache is not enough for next batch, assuming 10 & 13, batch size = 4.
+	autoid.TestModifyBaseAndEndInjection(signedAlloc, 4, 6)
+
+	// Here will recompute the new allocator batch size base on new base = 10, which will get 6.
+	min, max, err := unsignedAlloc.Alloc(1, 2, 3, 1)
+	c.Assert(err, IsNil)
+	c.Assert(min, Equals, int64(10))
+	c.Assert(max, Equals, int64(16))
+	min, max, err = signedAlloc.Alloc(2, 2, 3, 1)
+	c.Assert(err, IsNil)
+	c.Assert(min, Equals, int64(7))
+	c.Assert(max, Equals, int64(13))
+}

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -826,7 +826,7 @@ func (*testSuite) TestConcurrentAllocSequence(c *C) {
 	c.Assert(err, IsNil)
 }
 
-// Fix a issue111 in allocator computation.
+// Fix a computation logic bug in allocator computation.
 func (*testSuite) TestAllocComputationIssue(c *C) {
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDCustomize", `return(true)`), IsNil)
 	defer func() {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: fix logic in allocator batch size  computation

### What is changed and how it works?

What's Changed:
when the local cache size if not enough for allocN, do the new batchSize computation based on the global new base in the txn.

so we postpone the NextStep adjustment to meta txn and store it after that.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
- meta: fix the allocator batch size compute logic
