### PR TITLE
plan, expression: support `is null` in hash partition pruning

### DIFF
--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -111,17 +111,13 @@ func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64
 		if pi.FuncName.L == ast.Plus || pi.FuncName.L == ast.Minus || pi.FuncName.L == ast.Mul || pi.FuncName.L == ast.Div {
 			left, right := pi.GetArgs()[0], pi.GetArgs()[1]
 			leftVal, ok, isNull := p.tryEvalPartitionExpr(left)
-			if !ok {
-				return 0, ok, isNull
-			} else if isNull {
+			if !ok || isNull{
 				return 0, ok, isNull
 			}
 			rightVal, ok, isNull := p.tryEvalPartitionExpr(right)
-			if !ok {
+			if !ok || isNull{
 				return 0, ok, isNull
-			} else if isNull {
-				return 0, ok, isNull
-			}
+			} 
 			switch pi.FuncName.L {
 			case ast.Plus:
 				return rightVal + leftVal, true, false
@@ -181,7 +177,7 @@ func newHashPartitionPruner() *hashPartitionPruner {
 }
 
 // solve eval the hash partition expression, the first return value represent the result of partition expression. The second
-// return value is whether eval success. The third return value represent whether the eval result of partition value is null.
+// return value is whether eval success. The third return value represent whether there is conflict in query conditions.
 func (p *hashPartitionPruner) solve(ctx sessionctx.Context, conds []Expression, piExpr Expression) (val int64, ok bool, conflict bool) {
 	p.ctx = ctx
 	for _, cond := range conds {

--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -87,9 +87,9 @@ func (p *hashPartitionPruner) reduceConstantEQ() bool {
 				if ok {
 					cond = NewNull()
 				}
+			} else {
+				col, cond = validEqualCond(p.ctx, con)
 			}
-		} else {
-			col, cond = validEqualCond(p.ctx, con)
 		}
 		if col != nil {
 			id := p.getColID(col)

--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -137,10 +137,8 @@ func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64
 				ret, isNull, err := pi.EvalInt(p.ctx, chunk.Row{})
 				if err != nil {
 					return 0, false, false
-				} else if isNull {
-					return 0, true, isNull
 				}
-				return ret, true, false
+				return ret, true, isNull
 			}
 			return 0, false, false
 		}

--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -138,7 +138,7 @@ func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64
 				if err != nil {
 					return 0, false, false
 				} else if isNull {
-					return 0, true, true
+					return 0, true, isNull
 				}
 				return ret, true, false
 			}

--- a/expression/partition_pruner.go
+++ b/expression/partition_pruner.go
@@ -111,11 +111,11 @@ func (p *hashPartitionPruner) tryEvalPartitionExpr(piExpr Expression) (val int64
 		if pi.FuncName.L == ast.Plus || pi.FuncName.L == ast.Minus || pi.FuncName.L == ast.Mul || pi.FuncName.L == ast.Div {
 			left, right := pi.GetArgs()[0], pi.GetArgs()[1]
 			leftVal, ok, isNull := p.tryEvalPartitionExpr(left)
-			if !ok || isNull{
+			if !ok || isNull {
 				return 0, ok, isNull
 			}
 			rightVal, ok, isNull := p.tryEvalPartitionExpr(right)
-			if !ok || isNull{
+			if !ok || isNull {
 				return 0, ok, isNull
 			}
 			switch pi.FuncName.L {

--- a/expression/partition_pruner_test.go
+++ b/expression/partition_pruner_test.go
@@ -69,7 +69,7 @@ func (s *testSuite2) TestHashPartitionPruner(c *C) {
 	tk.MustExec("create table t3(id int, a int, b int, primary key(id, a)) partition by hash(id) partitions 10;")
 	tk.MustExec("create table t4(d datetime, a int, b int, primary key(d, a)) partition by hash(year(d)) partitions 10;")
 	tk.MustExec("create table t5(d date, a int, b int, primary key(d, a)) partition by hash(month(d)) partitions 10;")
-	tk.MustExec("create table t6(a int, b int) partition by hash(a) partitions 10;")
+	tk.MustExec("create table t6(a int, b int) partition by hash(a) partitions 3;")
 	tk.MustExec("create table t7(a int, b int) partition by hash(a + b) partitions 10;")
 
 	var input []string

--- a/expression/partition_pruner_test.go
+++ b/expression/partition_pruner_test.go
@@ -69,6 +69,8 @@ func (s *testSuite2) TestHashPartitionPruner(c *C) {
 	tk.MustExec("create table t3(id int, a int, b int, primary key(id, a)) partition by hash(id) partitions 10;")
 	tk.MustExec("create table t4(d datetime, a int, b int, primary key(d, a)) partition by hash(year(d)) partitions 10;")
 	tk.MustExec("create table t5(d date, a int, b int, primary key(d, a)) partition by hash(month(d)) partitions 10;")
+	tk.MustExec("create table t6(a int, b int) partition by hash(a) partitions 10;")
+	tk.MustExec("create table t7(a int, b int) partition by hash(a + b) partitions 10;")
 
 	var input []string
 	var output []struct {

--- a/expression/testdata/partition_pruner_in.json
+++ b/expression/testdata/partition_pruner_in.json
@@ -2,23 +2,22 @@
   {
     "name": "TestHashPartitionPruner",
     "cases": [
-      // Point Select.
       "explain select * from t1 where id = 7 and a = 6",
       "explain select * from t3 where id = 9 and a = 1",
       "explain select * from t2 where id = 9 and a = -110",
       "explain select * from t1 where id = -17",
       "explain select * from t2 where id = a and a = b and b = 2",
-      // Join.
       "explain select * from t1 join t2 on (t1.id = t2.id) where t1.id = 5 and t2.a = 7",
       "explain select * from t1 left join t2 on t1.id = 1 and t2.a = 2 where t2.id = 7",
       "explain select * from t2 join t1 on t1.id = t2.id and t2.a = t1.id and t2.id = 12",
-      // Negtive cases.
       "explain select * from t1 left join t2 on true where t1.a = 1 and false",
       "explain select * from t1 left join t2 on true where t1.a = 1 and null",
       "explain select * from t1 left join t2 on true where t1.a = null",
-      // Case with date.
       "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
-      "explain select * from t5 where d = '2019-10-07'"
+      "explain select * from t5 where d = '2019-10-07'",
+      "explain select * from t6 where a is null",
+      "explain select * from t5 where d is null",
+      "explain select * from t7 where b = -3 and a is null"
     ]
   }
 ]

--- a/expression/testdata/partition_pruner_in.json
+++ b/expression/testdata/partition_pruner_in.json
@@ -16,6 +16,7 @@
       "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
       "explain select * from t5 where d = '2019-10-07'",
       "explain select * from t6 where a is null",
+      "explain select * from t6 where b is null",
       "explain select * from t5 where d is null",
       "explain select * from t7 where b = -3 and a is null"
     ]

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -100,6 +100,21 @@
         ]
       },
       {
+        "SQL": "explain select * from t6 where b is null",
+        "Result": [
+          "Union_9 30.00 root  ",
+          "├─TableReader_12 10.00 root  data:Selection_11",
+          "│ └─Selection_11 10.00 cop[tikv]  isnull(test_partition.t6.b)",
+          "│   └─TableFullScan_10 10000.00 cop[tikv] table:t6, partition:p0 keep order:false, stats:pseudo",
+          "├─TableReader_15 10.00 root  data:Selection_14",
+          "│ └─Selection_14 10.00 cop[tikv]  isnull(test_partition.t6.b)",
+          "│   └─TableFullScan_13 10000.00 cop[tikv] table:t6, partition:p1 keep order:false, stats:pseudo",
+          "└─TableReader_18 10.00 root  data:Selection_17",
+          "  └─Selection_17 10.00 cop[tikv]  isnull(test_partition.t6.b)",
+          "    └─TableFullScan_16 10000.00 cop[tikv] table:t6, partition:p2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "explain select * from t5 where d is null",
         "Result": [
           "TableDual_6 0.00 root  rows:0"

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -90,6 +90,28 @@
           "├─IndexRangeScan_9(Build) 10.00 cop[tikv] table:t5, partition:p0, index:PRIMARY(d, a) range:[2019-10-07,2019-10-07], keep order:false, stats:pseudo",
           "└─TableRowIDScan_10(Probe) 10.00 cop[tikv] table:t5, partition:p0 keep order:false, stats:pseudo"
         ]
+      },
+      {
+        "SQL": "explain select * from t6 where a is null",
+        "Result": [
+          "TableReader_8 10.00 root  data:Selection_7",
+          "└─Selection_7 10.00 cop[tikv]  isnull(test_partition.t6.a)",
+          "  └─TableFullScan_6 10000.00 cop[tikv] table:t6, partition:p0 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t5 where d is null",
+        "Result": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t7 where b = -3 and a is null",
+        "Result": [
+          "TableReader_8 0.01 root  data:Selection_7",
+          "└─Selection_7 0.01 cop[tikv]  eq(test_partition.t7.b, -3), isnull(test_partition.t7.a)",
+          "  └─TableFullScan_6 10000.00 cop[tikv] table:t7, partition:p0 keep order:false, stats:pseudo"
+        ]
       }
     ]
   }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

SQL like `select * from t where a is null` will produce a full table scan plan in hash partition. For example:

```
create table t (a int, b int) partition by hash(a + b) partitions 10;
explain select * from t where a is null and b = 2;
```

This SQL will produce following result:

```
MySQL [test]> explain select * from t where a is null and b = 2;
+------------------------------+----------+-----------+-----------------------+-----------------------------------+
| id                           | estRows  | task      | access object         | operator info                     |
+------------------------------+----------+-----------+-----------------------+-----------------------------------+
| Union_16                     | 0.10     | root      |                       |                                   |
| ├─TableReader_19             | 0.01     | root      |                       | data:Selection_18                 |
| │ └─Selection_18             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_17       | 10000.00 | cop[tikv] | table:t, partition:p0 | keep order:false, stats:pseudo    |
| ├─TableReader_22             | 0.01     | root      |                       | data:Selection_21                 |
| │ └─Selection_21             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_20       | 10000.00 | cop[tikv] | table:t, partition:p1 | keep order:false, stats:pseudo    |
| ├─TableReader_25             | 0.01     | root      |                       | data:Selection_24                 |
| │ └─Selection_24             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_23       | 10000.00 | cop[tikv] | table:t, partition:p2 | keep order:false, stats:pseudo    |
| ├─TableReader_28             | 0.01     | root      |                       | data:Selection_27                 |
| │ └─Selection_27             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_26       | 10000.00 | cop[tikv] | table:t, partition:p3 | keep order:false, stats:pseudo    |
| ├─TableReader_31             | 0.01     | root      |                       | data:Selection_30                 |
| │ └─Selection_30             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_29       | 10000.00 | cop[tikv] | table:t, partition:p4 | keep order:false, stats:pseudo    |
| ├─TableReader_34             | 0.01     | root      |                       | data:Selection_33                 |
| │ └─Selection_33             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_32       | 10000.00 | cop[tikv] | table:t, partition:p5 | keep order:false, stats:pseudo    |
| ├─TableReader_37             | 0.01     | root      |                       | data:Selection_36                 |
| │ └─Selection_36             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_35       | 10000.00 | cop[tikv] | table:t, partition:p6 | keep order:false, stats:pseudo    |
| ├─TableReader_40             | 0.01     | root      |                       | data:Selection_39                 |
| │ └─Selection_39             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_38       | 10000.00 | cop[tikv] | table:t, partition:p7 | keep order:false, stats:pseudo    |
| ├─TableReader_43             | 0.01     | root      |                       | data:Selection_42                 |
| │ └─Selection_42             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
| │   └─TableFullScan_41       | 10000.00 | cop[tikv] | table:t, partition:p8 | keep order:false, stats:pseudo    |
| └─TableReader_46             | 0.01     | root      |                       | data:Selection_45                 |
|   └─Selection_45             | 0.01     | cop[tikv] |                       | eq(test.t.b, 2), isnull(test.t.a) |
|     └─TableFullScan_44       | 10000.00 | cop[tikv] | table:t, partition:p9 | keep order:false, stats:pseudo    |
+------------------------------+----------+-----------+-----------------------+-----------------------------------+
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

During partition pruning, if a column is equal to `NULL`, all calculation relating to it will produce null result and set a `NULL` flag.

How it Works:

If pruning result with a `NULL` flag, it will be point to `p0`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- planner: support `is null` filter condition in hash partition pruning 