### PR TITLE
store/tikv: do not send batch commands to tiflash

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -317,7 +317,8 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		c.recycleIdleConnArray()
 	}
 
-	enableBatch := req.StoreTp != kv.TiDB
+	// TiDB will not send batch commands to TiFlash, to resolve the conflict with Batch Cop Request.
+	enableBatch := req.StoreTp != kv.TiDB && req.StoreTp != kv.TiFlash
 	connArray, err := c.getConnArray(addr, enableBatch)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve?


Problem Summary:

After set @@global.tidb_allow_batch_cop = true and send query to tiflash; Sometimes it will report TiKV server timeout error. Observing the tidb log, it has many ["receive a grpc cancel signal from remote"] [error="rpc error: code = Canceled desc = grpc: the client connection is closing"].

It's because client_batch.go will recycle "idle" connection, but TiFlash request does not use client_batch request, its connection is deleted by mistake.

What's Changed:

After discussion, we decide not to send batch commands to tiflash


Tests <!-- At least one of them must be included. -->

- Manual test 

Side effects

This is not a important feature fot tiflash, so it has no side effects

### Release note <!-- bugfixes or new feature need a release note -->
- Do not send batch commands to tiflash, to fix unpredictable timeout for tiflash engine.
