### PR TITLE
Revert "ddl: check too long ident for partition (#17236) (#17261)"

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -278,17 +278,6 @@ func (s *testIntegrationSuite3) TestCreateTableWithPartition(c *C) {
 	// Fix https://github.com/pingcap/tidb/issues/16333
 	tk.MustExec(`create table t35 (dt timestamp) partition by range (unix_timestamp(dt))
 (partition p0 values less than (unix_timestamp('2020-04-15 00:00:00')));`)
-
-	tk.MustExec(`drop table if exists too_long_identifier`)
-	tk.MustGetErrCode(`create table too_long_identifier(a int) 
-partition by range (a) 
-(partition p0pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp values less than (10));`, tmysql.ErrTooLongIdent)
-
-	tk.MustExec(`drop table if exists too_long_identifier`)
-	tk.MustExec("create table too_long_identifier(a int) partition by range(a) (partition p0 values less than(10))")
-	tk.MustGetErrCode("alter table too_long_identifier add partition "+
-		"(partition p0pppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppppp values less than(20))", tmysql.ErrTooLongIdent)
-
 }
 
 func (s *testIntegrationSuite2) TestCreateTableWithHashPartition(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -4207,9 +4207,6 @@ func buildPartitionInfo(ctx sessionctx.Context, meta *model.TableInfo, d *ddl, s
 		if err := def.Clause.Validate(part.Type, len(part.Columns)); err != nil {
 			return nil, errors.Trace(err)
 		}
-		if err := checkTooLongTable(def.Name); err != nil {
-			return nil, err
-		}
 		// For RANGE partition only VALUES LESS THAN should be possible.
 		clause := def.Clause.(*ast.PartitionDefinitionClauseLessThan)
 		if len(part.Columns) > 0 {

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -133,13 +133,9 @@ func buildHashPartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStm
 	return nil
 }
 
-func buildRangePartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStmt, pi *model.PartitionInfo) (err error) {
+func buildRangePartitionDefinitions(ctx sessionctx.Context, s *ast.CreateTableStmt, pi *model.PartitionInfo) error {
 	for _, def := range s.Partition.Definitions {
 		comment, _ := def.Comment()
-		err = checkTooLongTable(def.Name)
-		if err != nil {
-			return err
-		}
 		piDef := model.PartitionDefinition{
 			Name:    def.Name,
 			Comment: comment,


### PR DESCRIPTION
This reverts commit 539eb43701a5b4039bbe022850da79bfd5de4522.

We'll support this limitation after supporting rename partition.


### Release note <!-- bugfixes or new feature need a release note -->
- No release note.