### PR TITLE
*: fix partition selection for the update statement

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -44,7 +44,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/admin"
@@ -1639,18 +1638,6 @@ func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) Executor 
 		upper:          v.Upper[0],
 		num:            v.Num,
 	}
-}
-
-func partitionNamesToIDs(meta *model.TableInfo, partitionNames []model.CIStr) (map[int64]struct{}, error) {
-	res := make(map[int64]struct{}, len(partitionNames))
-	for i := 0; i < len(partitionNames); i++ {
-		pid, err := tables.FindPartitionByName(meta, partitionNames[i].L)
-		if err != nil {
-			return nil, err
-		}
-		res[pid] = struct{}{}
-	}
-	return res, nil
 }
 
 func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1658,10 +1658,13 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {
 	for _, info := range v.TblColPosInfos {
 		tbl, _ := b.is.TableByID(info.TblID)
 		tblID2table[info.TblID] = tbl
-		if v.PartitionNames != nil && tbl.Meta().GetPartitionInfo() != nil {
-			pids, err := partitionNamesToIDs(tbl.Meta(), v.PartitionNames)
-			if err == nil {
-				tblID2table[info.TblID] = tables.WithPartitionSelection(tbl, pids)
+		if len(v.PartitionedTable) > 0 {
+			// Replace the table to support partition selection.
+			// The v.PartitionedTable collects the partitioned table.
+			for _, p := range v.PartitionedTable {
+				if info.TblID == p.Meta().ID {
+					tblID2table[info.TblID] = p
+				}
 			}
 		}
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1646,8 +1646,10 @@ func (b *executorBuilder) buildUpdate(v *plannercore.Update) Executor {
 		tbl, _ := b.is.TableByID(info.TblID)
 		tblID2table[info.TblID] = tbl
 		if len(v.PartitionedTable) > 0 {
-			// Replace the table to support partition selection.
 			// The v.PartitionedTable collects the partitioned table.
+			// Replace the original table with the partitioned table to support partition selection.
+			// e.g. update t partition (p0, p1), the new values are not belong to the given set p0, p1
+			// Using the table in v.PartitionedTable returns a proper error, while using the original table can't.
 			for _, p := range v.PartitionedTable {
 				if info.TblID == p.Meta().ID {
 					tblID2table[info.TblID] = p

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5597,7 +5597,6 @@ func (s *testSuite1) TestUpdateGivenPartitionSet(c *C) {
 	tk.MustExec("update t1 partition(p0) set a = 3 where a = 2")
 	tk.MustExec("update t1 partition(p0, p3) set a = 33 where a = 1")
 
-
 	// update without partition change
 	tk.MustExec("insert into t2 values(1, 'a'), (2, 'b'), (11, 'c'), (21, 'd')")
 	err = tk.ExecToErr("update t2 partition(p0, p1) set a = 40")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5561,3 +5561,50 @@ func (s *testSuite1) TestInsertValuesWithSubQuery(c *C) {
 	tk.MustExec("insert into t2 set a = 3, b = 5, c = b")
 	tk.MustQuery("select * from t2").Check(testkit.Rows("2 4 2", "3 5 5"))
 }
+
+func (s *testSuite1) TestUpdateGivenPartitionSet(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec(`create table t1(
+	a int(11),
+	b varchar(10) DEFAULT NULL,
+	primary key idx_a (a)) PARTITION BY RANGE (a)
+	(PARTITION p0 VALUES LESS THAN (10) ENGINE = InnoDB,
+	 PARTITION p1 VALUES LESS THAN (20) ENGINE = InnoDB,
+	 PARTITION p2 VALUES LESS THAN (30) ENGINE = InnoDB,
+	 PARTITION p3 VALUES LESS THAN (40) ENGINE = InnoDB,
+	 PARTITION p4 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)`)
+
+	tk.MustExec(`create table t2(
+	a int(11) DEFAULT NULL,
+	b varchar(10) DEFAULT NULL) PARTITION BY RANGE (a)
+	(PARTITION p0 VALUES LESS THAN (10) ENGINE = InnoDB,
+	 PARTITION p1 VALUES LESS THAN (20) ENGINE = InnoDB,
+	 PARTITION p2 VALUES LESS THAN (30) ENGINE = InnoDB,
+	 PARTITION p3 VALUES LESS THAN (40) ENGINE = InnoDB,
+	 PARTITION p4 VALUES LESS THAN MAXVALUE ENGINE = InnoDB)`)
+
+	defer tk.MustExec("drop table if exists t1,t2")
+
+	// update with primary key change
+	tk.MustExec("insert into t1 values(1, 'a'), (2, 'b'), (11, 'c'), (21, 'd')")
+	err := tk.ExecToErr("update t1 partition(p0, p1) set a = 40")
+	c.Assert(err.Error(), Equals, "[table:1748]Found a row not matching the given partition set")
+	err = tk.ExecToErr("update t1 partition(p0) set a = 40 where a = 2")
+	c.Assert(err.Error(), Equals, "[table:1748]Found a row not matching the given partition set")
+
+	tk.MustExec("update t1 partition(p0) set a = 3 where a = 2")
+	tk.MustExec("update t1 partition(p0, p3) set a = 33 where a = 1")
+
+
+	// update without partition change
+	tk.MustExec("insert into t2 values(1, 'a'), (2, 'b'), (11, 'c'), (21, 'd')")
+	err = tk.ExecToErr("update t2 partition(p0, p1) set a = 40")
+	c.Assert(err.Error(), Equals, "[table:1748]Found a row not matching the given partition set")
+	err = tk.ExecToErr("update t2 partition(p0) set a = 40 where a = 2")
+	c.Assert(err.Error(), Equals, "[table:1748]Found a row not matching the given partition set")
+
+	tk.MustExec("update t2 partition(p0) set a = 3 where a = 2")
+	tk.MustExec("update t2 partition(p0, p3) set a = 33 where a = 1")
+}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -657,6 +657,9 @@ type Update struct {
 	SelectPlan PhysicalPlan
 
 	TblColPosInfos TblColPosInfoSlice
+
+	// Partition selection for the update statement if exists.
+	PartitionNames []model.CIStr
 }
 
 // Delete represents a delete plan.

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -658,8 +658,8 @@ type Update struct {
 
 	TblColPosInfos TblColPosInfoSlice
 
-	// Partition selection for the update statement if exists.
-	PartitionNames []model.CIStr
+	// Used by partition selection.
+	PartitionedTable []table.PartitionedTable
 }
 
 // Delete represents a delete plan.

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -658,7 +658,8 @@ type Update struct {
 
 	TblColPosInfos TblColPosInfoSlice
 
-	// Used by partition selection.
+	// Used when partition sets are given.
+	// e.g. update t partition(p0) set a = 1;
 	PartitionedTable []table.PartitionedTable
 }
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3358,6 +3358,7 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 	if err != nil {
 		return nil, err
 	}
+	updt.PartitionNames = hasPartitionSelection(update.TableRefs)
 	err = updt.ResolveIndices()
 	if err != nil {
 		return nil, err
@@ -3375,6 +3376,22 @@ func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (
 		err = checkUpdateList(b.ctx, tblID2table, updt)
 	}
 	return updt, err
+}
+
+func hasPartitionSelection(tblRef *ast.TableRefsClause) []model.CIStr {
+	if tblRef.TableRefs.Right != nil {
+		return nil
+	}
+	tbl := tblRef.TableRefs.Left
+	ts, ok := tbl.(*ast.TableSource)
+	if !ok {
+		return nil
+	}
+	tn, ok := ts.Source.(*ast.TableName)
+	if !ok {
+		return nil
+	}
+	return tn.PartitionNames
 }
 
 // GetUpdateColumns gets the columns of updated lists.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2699,7 +2699,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 				}
 				pids[pid] = struct{}{}
 			}
-			pt = tables.WithPartitionSelection(pt, pids)
+			pt = tables.NewPartitionTableithGivenSets(pt, pids)
 		}
 		b.partitionedTable = append(b.partitionedTable, pt)
 	} else if len(tn.PartitionNames) != 0 {

--- a/table/table.go
+++ b/table/table.go
@@ -102,6 +102,8 @@ var (
 	ErrLockOrActiveTransaction = terror.ClassTable.New(mysql.ErrLockOrActiveTransaction, mysql.MySQLErrName[mysql.ErrLockOrActiveTransaction])
 	// ErrSequenceHasRunOut returns when sequence has run out.
 	ErrSequenceHasRunOut = terror.ClassTable.New(mysql.ErrSequenceRunOut, mysql.MySQLErrName[mysql.ErrSequenceRunOut])
+	// ErrRowDoesNotMatchGivenPartitionSet returns when the destination partition conflict with the partition selection.
+	ErrRowDoesNotMatchGivenPartitionSet = terror.ClassTable.NewStd(mysql.ErrRowDoesNotMatchGivenPartitionSet)
 )
 
 // RecordIterFunc is used for low-level record iteration.

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -363,12 +363,16 @@ func partitionedTableAddRecord(ctx sessionctx.Context, t *partitionedTable, r []
 	return tbl.AddRecord(ctx, r, opts...)
 }
 
+// partitionedTableWithSelection is used for this kind of grammar: partition (p0,p1)
+// Basically it is the same as partitionedTable except that partitionedTableWithSelection
+// checks the given partition set for AddRecord/UpdateRecord operations.
 type partitionedTableWithSelection struct {
 	*partitionedTable
 	partitions map[int64]struct{}
 }
 
-func WithPartitionSelection(tbl table.Table, partitions map[int64]struct{}) table.Table {
+// WithPartitionSelection upgrades a `partitionTable` to a `partitionedTableWithSelection`.
+func WithPartitionSelection(tbl table.PartitionedTable, partitions map[int64]struct{}) table.PartitionedTable {
 	if raw, ok := tbl.(*partitionedTable); ok {
 		return &partitionedTableWithSelection{
 			partitionedTable: raw,

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -344,14 +344,43 @@ func (t *partitionedTable) GetPartitionByRow(ctx sessionctx.Context, r []types.D
 
 // AddRecord implements the AddRecord method for the table.Table interface.
 func (t *partitionedTable) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ...table.AddRecordOption) (recordID kv.Handle, err error) {
+	return partitionedTableAddRecord(ctx, t, r, nil, opts)
+}
+
+func partitionedTableAddRecord(ctx sessionctx.Context, t *partitionedTable, r []types.Datum, partitionSelection map[int64]struct{}, opts []table.AddRecordOption) (recordID kv.Handle, err error) {
 	partitionInfo := t.meta.GetPartitionInfo()
 	pid, err := t.locatePartition(ctx, partitionInfo, r)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 
+	if partitionSelection != nil {
+		if _, ok := partitionSelection[pid]; !ok {
+			return nil, errors.WithStack(table.ErrRowDoesNotMatchGivenPartitionSet)
+		}
+	}
 	tbl := t.GetPartition(pid)
 	return tbl.AddRecord(ctx, r, opts...)
+}
+
+type partitionedTableWithSelection struct {
+	*partitionedTable
+	partitions map[int64]struct{}
+}
+
+func WithPartitionSelection(tbl table.Table, partitions map[int64]struct{}) table.Table {
+	if raw, ok := tbl.(*partitionedTable); ok {
+		return &partitionedTableWithSelection{
+			partitionedTable: raw,
+			partitions:       partitions,
+		}
+	}
+	return tbl
+}
+
+// AddRecord implements the AddRecord method for the table.Table interface.
+func (t *partitionedTableWithSelection) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ...table.AddRecordOption) (recordID kv.Handle, err error) {
+	return partitionedTableAddRecord(ctx, t.partitionedTable, r, t.partitions, opts)
 }
 
 // RemoveRecord implements table.Table RemoveRecord interface.
@@ -370,6 +399,14 @@ func (t *partitionedTable) RemoveRecord(ctx sessionctx.Context, h kv.Handle, r [
 // `touched` means which columns are really modified, used for secondary indices.
 // Length of `oldData` and `newData` equals to length of `t.WritableCols()`.
 func (t *partitionedTable) UpdateRecord(ctx sessionctx.Context, h kv.Handle, currData, newData []types.Datum, touched []bool) error {
+	return partitionedTableUpdateRecord(ctx, t, h, currData, newData, touched, nil)
+}
+
+func (t *partitionedTableWithSelection) UpdateRecord(ctx sessionctx.Context, h kv.Handle, currData, newData []types.Datum, touched []bool) error {
+	return partitionedTableUpdateRecord(ctx, t.partitionedTable, h, currData, newData, touched, t.partitions)
+}
+
+func partitionedTableUpdateRecord(ctx sessionctx.Context, t *partitionedTable, h kv.Handle, currData, newData []types.Datum, touched []bool, partitionSelection map[int64]struct{}) error {
 	partitionInfo := t.meta.GetPartitionInfo()
 	from, err := t.locatePartition(ctx, partitionInfo, currData)
 	if err != nil {
@@ -378,6 +415,11 @@ func (t *partitionedTable) UpdateRecord(ctx sessionctx.Context, h kv.Handle, cur
 	to, err := t.locatePartition(ctx, partitionInfo, newData)
 	if err != nil {
 		return errors.Trace(err)
+	}
+	if partitionSelection != nil {
+		if _, ok := partitionSelection[to]; !ok {
+			return errors.WithStack(table.ErrRowDoesNotMatchGivenPartitionSet)
+		}
 	}
 
 	// The old and new data locate in different partitions.

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -363,18 +363,18 @@ func partitionedTableAddRecord(ctx sessionctx.Context, t *partitionedTable, r []
 	return tbl.AddRecord(ctx, r, opts...)
 }
 
-// partitionedTableWithSelection is used for this kind of grammar: partition (p0,p1)
-// Basically it is the same as partitionedTable except that partitionedTableWithSelection
+// partitionTableWithGivenSets is used for this kind of grammar: partition (p0,p1)
+// Basically it is the same as partitionedTable except that partitionTableWithGivenSets
 // checks the given partition set for AddRecord/UpdateRecord operations.
-type partitionedTableWithSelection struct {
+type partitionTableWithGivenSets struct {
 	*partitionedTable
 	partitions map[int64]struct{}
 }
 
-// WithPartitionSelection upgrades a `partitionTable` to a `partitionedTableWithSelection`.
-func WithPartitionSelection(tbl table.PartitionedTable, partitions map[int64]struct{}) table.PartitionedTable {
+// NewPartitionTableithGivenSets creates a new partition table from a partition table.
+func NewPartitionTableithGivenSets(tbl table.PartitionedTable, partitions map[int64]struct{}) table.PartitionedTable {
 	if raw, ok := tbl.(*partitionedTable); ok {
-		return &partitionedTableWithSelection{
+		return &partitionTableWithGivenSets{
 			partitionedTable: raw,
 			partitions:       partitions,
 		}
@@ -383,7 +383,7 @@ func WithPartitionSelection(tbl table.PartitionedTable, partitions map[int64]str
 }
 
 // AddRecord implements the AddRecord method for the table.Table interface.
-func (t *partitionedTableWithSelection) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ...table.AddRecordOption) (recordID kv.Handle, err error) {
+func (t *partitionTableWithGivenSets) AddRecord(ctx sessionctx.Context, r []types.Datum, opts ...table.AddRecordOption) (recordID kv.Handle, err error) {
 	return partitionedTableAddRecord(ctx, t.partitionedTable, r, t.partitions, opts)
 }
 
@@ -406,7 +406,7 @@ func (t *partitionedTable) UpdateRecord(ctx sessionctx.Context, h kv.Handle, cur
 	return partitionedTableUpdateRecord(ctx, t, h, currData, newData, touched, nil)
 }
 
-func (t *partitionedTableWithSelection) UpdateRecord(ctx sessionctx.Context, h kv.Handle, currData, newData []types.Datum, touched []bool) error {
+func (t *partitionTableWithGivenSets) UpdateRecord(ctx sessionctx.Context, h kv.Handle, currData, newData []types.Datum, touched []bool) error {
 	return partitionedTableUpdateRecord(ctx, t.partitionedTable, h, currData, newData, touched, t.partitions)
 }
 


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

```
create table t1 (a int) partition by range (a) (
    partition p0 values less than (10),
    partition p1 values less than (20),
    partition p2 values less than (30),
    partition p3 values less than (40),
    partition p4 values less than MAXVALUE
);
insert into t1 values(1),(2),(3),(4),(5),(6),(7), (10), (11), (12), (13), (14), (15), (20), (21), (22);
update t1 partition(p0) set a = 40 where a = 5;
```

In MySQL:
Error: Found a row not matching the given partition set

In TiDB:
No error.

Partition selection should not only take effect on the select part, but also on the update part.

### What is changed and how it works?

What's Changed:

If the update statement has partition selection, use `partitionedTableWithSelection` to replace the `partitionedTable`. Implement `UpdateRecord` and `AddRecord` which check the destination partition is located in the given partition set.

How it Works:

add check for the update statement with the given partition set.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix a partition selection bug for the update statement, partition selection should affect the whole update statement