### PR TITLE
session: fix a bug that upgrading from 3.1.1 to 4.0 fails (#17293)

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -384,6 +384,8 @@ const (
 	version44 = 44
 	// version45 introduces CONFIG_PRIV for SET CONFIG statements.
 	version45 = 45
+	// version46 fix a bug in v3.1.1.
+	version46 = 46
 )
 
 var (
@@ -432,6 +434,7 @@ var (
 		upgradeToVer43,
 		upgradeToVer44,
 		upgradeToVer45,
+		upgradeToVer46,
 	}
 )
 
@@ -1043,6 +1046,16 @@ func upgradeToVer45(s Session, ver int64) {
 	}
 	doReentrantDDL(s, "ALTER TABLE mysql.user ADD COLUMN `Config_priv` ENUM('N','Y') DEFAULT 'N'", infoschema.ErrColumnExists)
 	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET Config_priv='Y' where Super_priv='Y'")
+}
+
+func upgradeToVer46(s Session, ver int64) {
+	if ver >= version46 {
+		return
+	}
+	doReentrantDDL(s, "ALTER TABLE mysql.user ADD COLUMN `Reload_priv` ENUM('N','Y') DEFAULT 'N'", infoschema.ErrColumnExists)
+	doReentrantDDL(s, "ALTER TABLE mysql.user ADD COLUMN `File_priv` ENUM('N','Y') DEFAULT 'N'", infoschema.ErrColumnExists)
+	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET Reload_priv='Y' where Super_priv='Y'")
+	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET File_priv='Y' where Super_priv='Y'")
 }
 
 // updateBootstrapVer updates bootstrap version variable in mysql.TiDB table.

--- a/session/session.go
+++ b/session/session.go
@@ -1829,7 +1829,7 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = version45
+	currentBootstrapVersion = version46
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:#17292 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The server version 39 in v3.1.1 is not consistent with v4.0+
### What is changed and how it works?

Add a new server version 46, and redo version 39.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
git checkout v3.1.1
make && run
exit
git checkout this_pr
make && run
success


Side effects


### Release note <!-- bugfixes or new feature need a release note -->
- fix a bug that upgrading from 3.1.1 to 4.0 fails