### PR TITLE
refine the standardize-error-codes-and-messages RFC

### DIFF
--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -24,15 +24,15 @@ keep a metafile in the code repository. The metafile should be a toml file which
 
 ```toml
 [error.8005]
-error = '''Write Conflict, txnStartTS is stale'''
-message = '''Transactions in TiDB encounter write conflicts.'''
+message = '''Write Conflict, txnStartTS is stale'''
+description = '''Transactions in TiDB encounter write conflicts.'''
 workaround = '''
 Check whether `tidb_disable_txn_auto_retry` is set to `on`. If so, set it to `off`; if it is already `off`, increase the value of `tidb_retry_limit` until the error no longer occurs.
 '''
 
 [error.9005]
-error = '''Region is unavailable'''
-message = '''
+message = '''Region is unavailable'''
+description = '''
 A certain Raft Group is not available, such as the number of replicas is not enough.
 This error usually occurs when the TiKV server is busy or the TiKV node is down.
 '''
@@ -60,14 +60,14 @@ The json format of metafile is like:
 [
     {
         "code": 8005,
-        "error": "Write Conflict, txnStartTS is stale",
-        "message": "Transactions in TiDB encounter write conflicts.",
+        "message": "Write Conflict, txnStartTS is stale",
+        "description": "Transactions in TiDB encounter write conflicts.",
         "workaround": "Check whether `tidb_disable_txn_auto_retry` is set to `on`. If so, set it to `off`; if it is already `off`, increase the value of `tidb_retry_limit` until the error no longer occurs."
     },
     {
         "code": 9005,
-        "error": "Region is unavailable",
-        "message": "A certain Raft Group is not available, such as the number of replicas is not enough.\nThis error usually occurs when the TiKV server is busy or the TiKV node is down.",
+        "message": "Region is unavailable",
+        "description": "A certain Raft Group is not available, such as the number of replicas is not enough.\nThis error usually occurs when the TiKV server is busy or the TiKV node is down.",
         "workaround": "Check the status, monitoring data and log of the TiKV server."
     }
 ]
@@ -136,8 +136,8 @@ As the syntax above, the 9005 block is the message part of 8005 block, so we exp
 
 ```toml
 [error.8005]
-error = '''Write Conflict, txnStartTS is stale'''
-message = '''Transactions in TiDB encounter write conflicts.'''
+message = '''Write Conflict, txnStartTS is stale'''
+description = '''Transactions in TiDB encounter write conflicts.'''
 workaround = '''
 ## Code: 9005
 ### Error
@@ -170,8 +170,8 @@ In the discussion above, an error has at least 4 parts:
 Besides, we can append a optional tags field to it:
 ```toml
 [error.9005]
-error = ""
 message = ""
+description = ""
 workaround = ""
 tags = ["tikv"]
 ```


### PR DESCRIPTION
Signed-off-by: Lonng <heng@lonng.org>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

The meaning of some field names contained in the RFC(`standardize-error-codes-and-messages`) is confused.

### What is changed and how it works?

This PR changes the `error` to `message` and changes the `message` to `description` to make the meaning more clear.

### Release note <!-- bugfixes or new feature need a release note -->

No need
