### PR TITLE
expression: fix data race when simpleRewriter rewrite ast.ColumnNameExpr concurrently

### DIFF
--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -201,6 +201,10 @@ func (sr *simpleRewriter) rewriteColumn(nodeColName *ast.ColumnNameExpr) (*Colum
 }
 
 func (sr *simpleRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
+	if raw, ok := inNode.(*ast.ColumnNameExpr); ok {
+		newNode := *raw
+		return &newNode, false
+	}
 	return inNode, false
 }
 

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -201,10 +201,6 @@ func (sr *simpleRewriter) rewriteColumn(nodeColName *ast.ColumnNameExpr) (*Colum
 }
 
 func (sr *simpleRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
-	if raw, ok := inNode.(*ast.ColumnNameExpr); ok {
-		newNode := *raw
-		return &newNode, false
-	}
 	return inNode, false
 }
 

--- a/planner/core/partition_pruning_test.go
+++ b/planner/core/partition_pruning_test.go
@@ -285,7 +285,7 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2VarChar(c *C) {
 		lessThan[i] = tmp[0]
 	}
 
-	prunner := &rangeColumnPruner{lessThan, tc.columns[0], true}
+	prunner := &rangeColumnsPruner{lessThan, tc.columns[0], true}
 	cases := []struct {
 		input  string
 		result partitionRangeOR
@@ -333,7 +333,7 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2Date(c *C) {
 		lessThan[i] = tmp[0]
 	}
 
-	prunner := &rangeColumnPruner{lessThan, tc.columns[0], false}
+	prunner := &rangeColumnsPruner{lessThan, tc.columns[0], false}
 	cases := []struct {
 		input  string
 		result partitionRangeOR

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -754,16 +754,16 @@ func (s *partitionProcessor) pruneRangeColumnsPartition(ds *DataSource, pi *mode
 	return s.makeUnionAllChildren(ds, pi, result)
 }
 
-var _ partitionRangePruner = &rangeColumnPruner{}
+var _ partitionRangePruner = &rangeColumnsPruner{}
 
-// rangeColumnPruner is used by 'partition by range columns'.
-type rangeColumnPruner struct {
+// rangeColumnsPruner is used by 'partition by range columns'.
+type rangeColumnsPruner struct {
 	data     []expression.Expression
 	partCol  *expression.Column
 	maxvalue bool
 }
 
-func makeRangeColumnPruner(ds *DataSource, pi *model.PartitionInfo, from *tables.ForRangeColumnsPruning) (*rangeColumnPruner, error) {
+func makeRangeColumnPruner(ds *DataSource, pi *model.PartitionInfo, from *tables.ForRangeColumnsPruning) (*rangeColumnsPruner, error) {
 	schema := expression.NewSchema(ds.TblCols...)
 	idx := expression.FindFieldNameIdxByColName(ds.names, pi.Columns[0].L)
 	partCol := schema.Columns[idx]
@@ -773,14 +773,14 @@ func makeRangeColumnPruner(ds *DataSource, pi *model.PartitionInfo, from *tables
 			data[i] = from.LessThan[i].Clone()
 		}
 	}
-	return &rangeColumnPruner{data, partCol, from.MaxValue}, nil
+	return &rangeColumnsPruner{data, partCol, from.MaxValue}, nil
 }
 
-func (p *rangeColumnPruner) fullRange() partitionRangeOR {
+func (p *rangeColumnsPruner) fullRange() partitionRangeOR {
 	return fullRange(len(p.data))
 }
 
-func (p *rangeColumnPruner) partitionRangeForExpr(sctx sessionctx.Context, expr expression.Expression) (int, int, bool) {
+func (p *rangeColumnsPruner) partitionRangeForExpr(sctx sessionctx.Context, expr expression.Expression) (int, int, bool) {
 	op, ok := expr.(*expression.ScalarFunction)
 	if !ok {
 		return 0, len(p.data), false
@@ -819,7 +819,7 @@ func (p *rangeColumnPruner) partitionRangeForExpr(sctx sessionctx.Context, expr 
 	return start, end, true
 }
 
-func (p *rangeColumnPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
+func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
 	var err error
 	var isNull bool
 	compare := func(ith int, op string, v *expression.Constant) bool {

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -124,17 +124,11 @@ type PartitionExpr struct {
 // ForRangeColumnsPruning is used for range partition pruning.
 type ForRangeColumnsPruning struct {
 	LessThan []expression.Expression
-	Column   ast.ExprNode
 	MaxValue bool
 }
 
 func dataForRangeColumnsPruning(ctx sessionctx.Context, pi *model.PartitionInfo, schema *expression.Schema, names []*types.FieldName, p *parser.Parser) (*ForRangeColumnsPruning, error) {
-	col, err := parseExpr(p, pi.Columns[0].L)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	var res ForRangeColumnsPruning
-	res.Column = col
 	res.LessThan = make([]expression.Expression, len(pi.Definitions))
 	for i := 0; i < len(pi.Definitions); i++ {
 		if strings.EqualFold(pi.Definitions[i].LessThan[0], "MAXVALUE") {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

```
[2020-05-22T01:32:46.732Z] ==================
[2020-05-22T01:32:46.732Z] WARNING: DATA RACE
[2020-05-22T01:32:46.732Z] Read at 0x00c00eacc170 by goroutine 431:
[2020-05-22T01:32:46.732Z]   github.com/pingcap/parser/ast.(*ColumnNameExpr).Accept(
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/parser@v0.0.0-20200521064712-8dc0fb6ce6f4/ast/expressions.go:588 +0x99
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/expression.RewriteSimpleExprWithNames()
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/expression/simple_rewriter.go:150 +0x182
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/planner/core.makeRangeColumnPruner()
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:768 +0x20a
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).pruneRangeColumnsPartition()
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:750 +0x137
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).pruneRangePartition()
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:340 +0x6ba
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).prune()
[2020-05-22T01:32:46.732Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:161 +0x116
[2020-05-22T01:32:46.732Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).rewriteDataSource()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:57 +0xa22
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).rewriteDataSource()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:85 +0x130
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).rewriteDataSource()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:85 +0x130
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).optimize()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:50 +0x56
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner/core.logicalOptimize()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/optimizer.go:159 +0x1de
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner/core.DoOptimize()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/optimizer.go:128 +0x9b
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner.optimize()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:189 +0x7d4
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/planner.Optimize()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:63 +0x307
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/executor.(*Compiler).Compile()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/compiler.go:61 +0x298
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/session.(*session).execute()
[2020-05-22T01:32:46.733Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1129 +0x887
[2020-05-22T01:32:46.733Z]   github.com/pingcap/tidb/session.(*session).Execute()
...

[2020-05-22T01:32:46.735Z] Previous write at 0x00c00eacc170 by goroutine 384:
[2020-05-22T01:32:46.735Z]   github.com/pingcap/parser/ast.(*ColumnNameExpr).Accept()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/parser@v0.0.0-20200521064712-8dc0fb6ce6f4/ast/expressions.go:592 +0xfa
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/expression.RewriteSimpleExprWithNames()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/expression/simple_rewriter.go:150 +0x182
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.makeRangeColumnPruner()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:768 +0x20a
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).pruneRangeColumnsPartition()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:750 +0x137
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).pruneRangePartition()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:340 +0x6ba
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).prune()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:161 +0x116
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).rewriteDataSource()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:57 +0xa22
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).rewriteDataSource()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:85 +0x130
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*partitionProcessor).optimize()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/rule_partition_processor.go:50 +0x56
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.logicalOptimize()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/optimizer.go:159 +0x1de
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.DoOptimize()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/optimizer.go:128 +0x9b
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*PlanBuilder).buildDelete()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/logical_plan_builder.go:3625 +0xa70
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner/core.(*PlanBuilder).Build()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/planbuilder.go:471 +0xeeb
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner.optimize()
[2020-05-22T01:32:46.735Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/optimize.go:150 +0x224
[2020-05-22T01:32:46.735Z]   github.com/pingcap/tidb/planner.Optimize()
```

This data race is introduced by the performance optimization https://github.com/pingcap/tidb/pull/17249

### What is changed and how it works?




What's Changed:

How it Works:

`simpleRewriter.Accept(ast.Node)` is not thread safe.

~~At least, I want it to be thread safe for `ColumnNameExpr`, because partition expression depends on it.~~   ... avoid using it.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

I'm not including the test code in this PR but I've verified this change:

```
+func (s *testPartitionPruningSuite) TestXXX(c *C) {
+       p := parser.New()
+        stmt, err := p.ParseOneStmt("create table t (a int, b int)", "", "")
+        c.Assert(err, IsNil)
+        sctx := mock.NewContext()
+        tblInfo, err := ddl.BuildTableInfoFromAST(stmt.(*ast.CreateTableStmt))
+        c.Assert(err, IsNil)
+        columns, names := expression.ColumnInfos2ColumnsAndNames(sctx, model.NewCIStr("t"), tblInfo.Name, tblInfo.Columns)
+        schema := expression.NewSchema(columns...)
+
+       col, err := parseExpr(p, "a")
+       c.Assert(err, IsNil)
+
+       var wg sync.WaitGroup   
+       wg.Add(10)
+       for i:=0; i<10; i++ {
+               go func() {
+                       for j :=0; j<200; j++ {
+                               expression.RewriteSimpleExprWithNames(sctx, col, schema, names)
+                       }
+                       wg.Done()
+               }()
+       }
+       wg.Wait()
+}
+
+func parseExpr(p *parser.Parser, exprStr string) (ast.ExprNode, error) {
+       exprStr = "select " + exprStr
+       stmts, _, err := p.Parse(exprStr, "", "")
+       if err != nil {
+               return nil, err
+       }
+       fields := stmts[0].(*ast.SelectStmt).Fields.Fields
+       return fields[0].Expr, nil
+}
```


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
