### PR TITLE
range: handle overflow errors when calculating ranges

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6108,6 +6108,22 @@ func (s *testIntegrationSerialSuite) TestIssue16668(c *C) {
 	tk.MustQuery("select count(distinct(b)) from tx").Check(testkit.Rows("4"))
 }
 
+func (s *testIntegrationSerialSuite) TestIssue17253(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a bigint)")
+	tk.MustExec("insert into t values(9223372036854775807)")
+	tk.MustExec("alter table t add unique key idx(a)")
+	tk.MustQuery("select * from t where a != 9223372036854775808").Check(testkit.Rows("9223372036854775807"))
+	tk.MustQuery("select * from t where a <= 9223372036854775808").Check(testkit.Rows("9223372036854775807"))
+	tk.MustQuery("select * from t where a < 9223372036854775808").Check(testkit.Rows("9223372036854775807"))
+	tk.MustQuery("select * from t where a <= 9223372036854775807").Check(testkit.Rows("9223372036854775807"))
+	tk.MustQuery("select * from t where a > 9223372036854775807").Check(testkit.Rows())
+	tk.MustQuery("select * from t where a > 9223372036854775808").Check(testkit.Rows())
+	tk.MustQuery("select * from t where a >= 9223372036854775808").Check(testkit.Rows())
+}
+
 func (s *testIntegrationSerialSuite) TestCollateStringFunction(c *C) {
 	collate.SetNewCollationEnabledForTest(true)
 	defer collate.SetNewCollationEnabledForTest(false)

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -97,14 +97,14 @@ func points2Ranges(sc *stmtctx.StatementContext, rangePoints []point, tp *types.
 //		if the leftPoint is larger than the upperBound of this type, or
 //		the rightPoint is less than the lowerBound of this type,
 //		we think it's an invalid range and return with invalid=true.
-//	Here are some examples with the bound range of this type is [10, 20]:
-//		ranges		results
-//	1:	[0, 15]		[10, 15]
-//	2:	[0, 8]		invalid
-//	3:	[25, 30]	invalid
-//	4:	[12, 30]	[12, 20]
-//	5:	[0, 10)		invalid
-//	5:	(10, 13]	(10, 13]
+//	Here are some examples with the bound range of Tinyint [-128, 127]:
+//		ranges			results
+//	1:	[-200, 15]		[-128, 15]
+//	2:	[-200, -150]	invalid
+//	3:	[200, 230]		invalid
+//	4:	[-150, 300]		[-128, 127]
+//	5:	[-200, -128)	invalid
+//	5:	(-128, 100]		(128, 100]
 func convertPoint(sc *stmtctx.StatementContext, point point, isLeft bool, tp *types.FieldType) (_ point, invalid bool, _ error) {
 	switch point.value.Kind() {
 	case types.KindMaxValue, types.KindMinNotNull:

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -16,6 +16,7 @@ package ranger_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/types"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -29,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/store/mockstore"
-	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/testkit"
@@ -1073,6 +1073,31 @@ func (s *testRangerSuite) TestColumnRange(c *C) {
 			resultStr:   "[[1,1] [2,2] [3,3]]",
 			length:      types.UnspecifiedLength,
 		},
+		These test cases check if we handle overflow errors on bigint rightly
+	{
+		colPos:      0,
+		exprStr:     "a != 9223372036854775808",
+		accessConds: "[ne(test.t.a, 9223372036854775808)]",
+		filterConds: "",
+		resultStr:   "[[-inf,+inf]]",
+		length:      types.UnspecifiedLength,
+	},
+	{
+		colPos:      0,
+		exprStr:     "a > 9223372036854775808",
+		accessConds: "[gt(test.t.a, 9223372036854775808)]",
+		filterConds: "",
+		resultStr:   "[]",
+		length:      types.UnspecifiedLength,
+	},
+	{
+		colPos:      0,
+		exprStr:     "a < 9223372036854775808",
+		accessConds: "[lt(test.t.a, 9223372036854775808)]",
+		filterConds: "",
+		resultStr:   "[[-inf,+inf]]",
+		length:      types.UnspecifiedLength,
+	},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17253 <!-- REMOVE this line if no issue to close -->

Problem Summary: when calculating ranges for expressions like `bigint_column < overflow_value`, we should convert it to `bigint_column <= max_bigint_value` instead of returning an overflow error.

### What is changed and how it works?
Handle this error when calculating ranges.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Handle overflow errors when calculating ranges