### PR TITLE
store/tikv: use resolve lock lite for snapshot.Get()

### DIFF
--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -1004,7 +1004,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 	time.Sleep(time.Duration(atomic.LoadUint64(&ManagedLockTTL)) * time.Millisecond)
 	optimisticLockInfo := s.getLockInfo(c, optimisticLockKey)
 	lock := NewLock(optimisticLockInfo)
-	err = s.store.lockResolver.resolveLock(NewBackoffer(ctx, pessimisticLockMaxBackoff), lock, TxnStatus{}, cleanTxns)
+	err = s.store.lockResolver.resolveLock(NewBackoffer(ctx, pessimisticLockMaxBackoff), lock, TxnStatus{}, false, cleanTxns)
 	c.Assert(err, IsNil)
 
 	// txn2 tries to lock the pessimisticLockKey, the lock should has been resolved in clean whole region resolve

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -797,11 +797,19 @@ type clientHelper struct {
 	*RegionCache
 	*minCommitTSPushed
 	Client
+	resolveLite bool
 }
 
 // ResolveLocks wraps the ResolveLocks function and store the resolved result.
 func (ch *clientHelper) ResolveLocks(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, error) {
-	msBeforeTxnExpired, resolvedLocks, err := ch.LockResolver.ResolveLocks(bo, callerStartTS, locks)
+	var err error
+	var resolvedLocks []uint64
+	var msBeforeTxnExpired int64
+	if ch.resolveLite {
+		msBeforeTxnExpired, resolvedLocks, err = ch.LockResolver.resolveLocksLite(bo, callerStartTS, locks)
+	} else {
+		msBeforeTxnExpired, resolvedLocks, err = ch.LockResolver.ResolveLocks(bo, callerStartTS, locks)
+	}
 	if err != nil {
 		return msBeforeTxnExpired, err
 	}

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -282,10 +282,10 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 // 3) Send `ResolveLock` cmd to the lock's region to resolve all locks belong to
 //    the same transaction.
 func (lr *LockResolver) ResolveLocks(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, []uint64 /*pushed*/, error) {
-	return lr.resolveLocks(bo, callerStartTS, locks, false, false)
+	return lr.resolveLocks(bo, callerStartTS, locks, false)
 }
 
-func (lr *LockResolver) resolveLocks(bo *Backoffer, callerStartTS uint64, locks []*Lock, forWrite bool, lite bool) (int64, []uint64 /*pushed*/, error) {
+func (lr *LockResolver) resolveLocks(bo *Backoffer, callerStartTS uint64, locks []*Lock, forWrite bool) (int64, []uint64 /*pushed*/, error) {
 	var msBeforeTxnExpired txnExpireTime
 	if len(locks) == 0 {
 		return msBeforeTxnExpired.value(), nil, nil
@@ -327,7 +327,7 @@ func (lr *LockResolver) resolveLocks(bo *Backoffer, callerStartTS uint64, locks 
 			if l.LockType == kvrpcpb.Op_PessimisticLock {
 				err = lr.resolvePessimisticLock(bo, l, cleanRegions)
 			} else {
-				err = lr.resolveLock(bo, l, status, lite, cleanRegions)
+				err = lr.resolveLock(bo, l, status, len(locks) <= 1, cleanRegions)
 			}
 			if err != nil {
 				msBeforeTxnExpired.update(0)
@@ -371,12 +371,7 @@ func (lr *LockResolver) resolveLocks(bo *Backoffer, callerStartTS uint64, locks 
 }
 
 func (lr *LockResolver) resolveLocksForWrite(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, error) {
-	msBeforeTxnExpired, _, err := lr.resolveLocks(bo, callerStartTS, locks, true, false)
-	return msBeforeTxnExpired, err
-}
-
-func (lr *LockResolver) resolveLocksLite(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, error) {
-	msBeforeTxnExpired, _, err := lr.resolveLocks(bo, callerStartTS, locks, false, true)
+	msBeforeTxnExpired, _, err := lr.resolveLocks(bo, callerStartTS, locks, true)
 	return msBeforeTxnExpired, err
 }
 
@@ -571,7 +566,7 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 
 func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, lite bool, cleanRegions map[RegionVerID]struct{}) error {
 	tikvLockResolverCountWithResolveLocks.Inc()
-	cleanWholeRegion := l.TxnSize >= bigTxnThreshold
+	resolveLite := lite || l.TxnSize < bigTxnThreshold
 	for {
 		loc, err := lr.store.GetRegionCache().LocateKey(bo, l.Key)
 		if err != nil {
@@ -586,7 +581,8 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, li
 		if status.IsCommitted() {
 			lreq.CommitVersion = status.CommitTS()
 		}
-		if l.TxnSize < bigTxnThreshold || lite {
+
+		if resolveLite {
 			// Only resolve specified keys when it is a small transaction,
 			// prevent from scanning the whole region in this case.
 			tikvLockResolverCountWithResolveLockLite.Inc()
@@ -620,7 +616,7 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, li
 			logutil.BgLogger().Error("resolveLock error", zap.Error(err))
 			return err
 		}
-		if cleanWholeRegion {
+		if !resolveLite {
 			cleanRegions[loc.Region] = struct{}{}
 		}
 		return nil

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -225,7 +225,7 @@ func (s *testLockSuite) TestCheckTxnStatusTTL(c *C) {
 	lock := s.mustGetLock(c, []byte("key"))
 	status = TxnStatus{}
 	cleanRegions := make(map[RegionVerID]struct{})
-	err = newLockResolver(s.store).resolveLock(bo, lock, status, cleanRegions)
+	err = newLockResolver(s.store).resolveLock(bo, lock, status, false, cleanRegions)
 	c.Assert(err, IsNil)
 
 	// Check its status is rollbacked.
@@ -261,7 +261,7 @@ func (s *testLockSuite) TestTxnHeartBeat(c *C) {
 	lock := s.mustGetLock(c, []byte("key"))
 	status := TxnStatus{ttl: newTTL}
 	cleanRegions := make(map[RegionVerID]struct{})
-	err = newLockResolver(s.store).resolveLock(bo, lock, status, cleanRegions)
+	err = newLockResolver(s.store).resolveLock(bo, lock, status, false, cleanRegions)
 	c.Assert(err, IsNil)
 
 	newTTL, err = sendTxnHeartBeat(bo, s.store, []byte("key"), txn.StartTS(), 6666)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -331,6 +331,7 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 		RegionCache:       s.store.regionCache,
 		minCommitTSPushed: &s.minCommitTSPushed,
 		Client:            s.store.client,
+		resolveLite:       true,
 	}
 
 	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet,

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -372,7 +372,7 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			msBeforeExpired, err := cli.ResolveLocks(bo, s.version.Ver, []*Lock{lock})
+			msBeforeExpired, err := cli.resolveLocksLite(bo, s.version.Ver, []*Lock{lock})
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -372,7 +372,7 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			msBeforeExpired, err := cli.resolveLocksLite(bo, s.version.Ver, []*Lock{lock})
+			msBeforeExpired, err := cli.ResolveLocks(bo, s.version.Ver, []*Lock{lock})
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

If a large transaction runs into 2PC commit, at the same time, another transaction read and conflict, the resolve lock process takes too long.

![image](https://user-images.githubusercontent.com/1420062/82667042-a6134000-9c69-11ea-81bd-14c77fb263b8.png)

Note the QPS drop to 0 at 05:25, that is because the resolve lock takes too long.

![image](https://user-images.githubusercontent.com/1420062/82667145-d22ec100-9c69-11ea-8142-d0a5c436f3c4.png)


### What is changed and how it works?


What's Changed:

How it Works:

Use resolve lock lite instead of resolve region for snapshot.Get().
Point get request would benefit from this and do not block too long.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- No code

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note