### PR TITLE
executor: add an option and close sort-spill-disk by defaults.

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -255,7 +255,7 @@ func assertEqualStrings(c *C, got []field, expect []string) {
 }
 
 func (s *testExecSerialSuite) TestSortSpillDisk(c *C) {
-	c.Skip("Closed the feature temporarily.")
+	c.Skip("Close the feature temporarily.")
 	originCfg := config.GetGlobalConfig()
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -255,6 +255,7 @@ func assertEqualStrings(c *C, got []field, expect []string) {
 }
 
 func (s *testExecSerialSuite) TestSortSpillDisk(c *C) {
+	c.Skip("Closed the feature temporarily.")
 	originCfg := config.GetGlobalConfig()
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -243,8 +243,7 @@ func (e *SortExec) fetchRowChunks(ctx context.Context) error {
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel(rowChunksLabel)
 	var onExceededCallback func(rowContainer *chunk.RowContainer)
-	var openSortSpillDisk bool
-	openSortSpillDisk = false
+	var openSortSpillDisk = false
 	if openSortSpillDisk && config.GetGlobalConfig().OOMUseTmpStorage {
 		e.spillAction = e.rowChunks.ActionSpill()
 		e.ctx.GetSessionVars().StmtCtx.MemTracker.FallbackOldAndSetNewAction(e.spillAction)

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -243,7 +243,9 @@ func (e *SortExec) fetchRowChunks(ctx context.Context) error {
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel(rowChunksLabel)
 	var onExceededCallback func(rowContainer *chunk.RowContainer)
-	if config.GetGlobalConfig().OOMUseTmpStorage {
+	var openSortSpillDisk bool
+	openSortSpillDisk = false
+	if openSortSpillDisk && config.GetGlobalConfig().OOMUseTmpStorage {
 		e.spillAction = e.rowChunks.ActionSpill()
 		e.ctx.GetSessionVars().StmtCtx.MemTracker.FallbackOldAndSetNewAction(e.spillAction)
 		onExceededCallback = func(rowContainer *chunk.RowContainer) {
@@ -266,7 +268,7 @@ func (e *SortExec) fetchRowChunks(ctx context.Context) error {
 		if err := e.rowChunks.Add(chk); err != nil {
 			return err
 		}
-		if e.rowChunks.AlreadySpilled() {
+		if openSortSpillDisk && e.rowChunks.AlreadySpilled() {
 			e.rowChunks = chunk.NewRowContainer(retTypes(e), e.maxChunkSize)
 			e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 			e.rowChunks.GetMemTracker().SetLabel(rowChunksLabel)

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -23,6 +23,7 @@ import (
 )
 
 func (s *testSuite) TestSortInDisk(c *C) {
+	c.Skip("Closed the feature temporarily.")
 	originCfg := config.GetGlobalConfig()
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func (s *testSuite) TestSortInDisk(c *C) {
-	c.Skip("Closed the feature temporarily.")
+	c.Skip("Close the feature temporarily.")
 	originCfg := config.GetGlobalConfig()
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Add an option to control sort spill data to disk. The option is close by defaults.

How it Works:

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- No need.
