### PR TITLE
types: fix mergeTypeFlag to consider UnsignedFlag

### DIFF
--- a/types/field_type.go
+++ b/types/field_type.go
@@ -310,10 +310,19 @@ func MergeFieldType(a byte, b byte) byte {
 }
 
 // mergeTypeFlag merges two MySQL type flag to a new one
-// currently only NotNullFlag is checked
-// todo more flag need to be checked, for example: UnsignedFlag
+// currently only NotNullFlag and UnsignedFlag are checked
+// todo more flag need to be checked
 func mergeTypeFlag(a, b uint) uint {
-	return a & (b&mysql.NotNullFlag | ^mysql.NotNullFlag)
+	c := a
+	if !mysql.HasNotNullFlag(b) {
+		c &= ^mysql.NotNullFlag
+	}
+
+	if !mysql.HasUnsignedFlag(b) {
+		c &= ^mysql.UnsignedFlag
+	}
+
+	return c
 }
 
 func getFieldTypeIndex(tp byte) int {

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -325,6 +325,28 @@ func (s *testFieldTypeSuite) TestAggFieldTypeForTypeFlag(c *C) {
 	aggTp = AggFieldType(types)
 	c.Assert(aggTp.Tp, Equals, mysql.TypeLonglong)
 	c.Assert(aggTp.Flag, Equals, mysql.NotNullFlag)
+
+	types[0].Flag = mysql.UnsignedFlag
+	aggTp = AggFieldType(types)
+	c.Assert(aggTp.Tp, Equals, mysql.TypeLonglong)
+	c.Assert(aggTp.Flag, Equals, uint(0))
+
+	types[0].Flag = 0
+	types[1].Flag = mysql.UnsignedFlag
+	aggTp = AggFieldType(types)
+	c.Assert(aggTp.Tp, Equals, mysql.TypeLonglong)
+	c.Assert(aggTp.Flag, Equals, uint(0))
+
+	types[0].Flag = mysql.UnsignedFlag
+	aggTp = AggFieldType(types)
+	c.Assert(aggTp.Tp, Equals, mysql.TypeLonglong)
+	c.Assert(aggTp.Flag, Equals, mysql.UnsignedFlag)
+
+	types[0].Flag = mysql.UnsignedFlag | mysql.NotNullFlag
+	types[1].Flag = mysql.UnsignedFlag | mysql.NotNullFlag
+	aggTp = AggFieldType(types)
+	c.Assert(aggTp.Tp, Equals, mysql.TypeLonglong)
+	c.Assert(aggTp.Flag, Equals, mysql.UnsignedFlag|mysql.NotNullFlag)
 }
 
 func (s *testFieldTypeSuite) TestAggregateEvalType(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #15771

Problem Summary: when merging type flags, unsigned is always set if left hand side is unsigned, but it should be set only if both sides are unsigned.

### What is changed and how it works?

* In `field_type.go`, `mergeTypeFlag` now considers `mysql.UnsignedFlag`. The flag will be set only if it is set for both sides.
* This is used in `AggFieldType`, so the fix propagates to this function.
* Other flags are not considered, but the same fix may apply to others too.

### Check List

- Unit tests

### Release note

* Fix type merging of signed and unsigned integers.
