### PR TITLE
types: improve StrToDate performance

### DIFF
--- a/types/format_test.go
+++ b/types/format_test.go
@@ -14,6 +14,8 @@
 package types_test
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
@@ -142,5 +144,17 @@ func (s *testTimeSuite) TestStrToDate(c *C) {
 	for _, tt := range errTests {
 		var t types.Time
 		c.Assert(t.StrToDate(sc, tt.input, tt.format), IsFalse)
+	}
+}
+
+func BenchmarkStrToDate(b *testing.B) {
+	sc := mock.NewContext().GetSessionVars().StmtCtx
+	date := "15-01-2001 1:9:8.999"
+	format := "%d-%m-%Y %H:%i:%S.%f"
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		var t types.Time
+		t.StrToDate(sc, date, format)
 	}
 }

--- a/types/helper.go
+++ b/types/helper.go
@@ -138,6 +138,25 @@ func myMinInt8(a, b int8) int8 {
 	return b
 }
 
+// Returns the length of the longer prefix of the given string that contains
+// only digits, capped to the given maximum length.
+func digitPrefixLen(s string, maxLen int) int {
+	l := 0
+	if len(s) < maxLen {
+		maxLen = len(s)
+	}
+
+	for l < maxLen {
+		if !isDigit(s[l]) {
+			break
+		}
+
+		l++
+	}
+
+	return l
+}
+
 const (
 	maxUint    = uint64(math.MaxUint64)
 	uintCutOff = maxUint/uint64(10) + 1


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: `StrToDate` is significantly slow due to the usage of regular expressions and maps.

### What is changed and how it works?

What's Changed:
- In `types/time.go`:
  - Parsing functions now use a new function, `digitPrefixLen`, to efficiently determine the number of digits in the next time component. This avoids using regular expressions.
  - The `ctx` object passed around function is now a custom structure `dateTimeParseContext` holding the smallest piece of information that is needed for later processing. This is faster to allocate and modify than `map[string]int`. Member types might be confusing, but hopefully it won't be a problem given they are documented and used in a relatively small scope.
- In `types/format_test.go`:
  - Added `BenchmarkStrToDate`.

How it Works:

```
name         old time/op  new time/op  delta
StrToDate-8  1.93µs ± 0%  0.78µs ± 0%   ~     (p=1.000 n=1+1)
```

### Related changes

- ~This PR is applied on top of https://github.com/pingcap/tidb/pull/17395 which should be merged before. Ping me if you prefer this PR to be rebased directly from master.~

### Check List

Tests

- Unit test

### Release note

* 2x performance improvement for `STR_TO_DATE`
