### PR TITLE
expression: speed up the test TestIssue16697

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6394,12 +6394,12 @@ func (s *testIntegrationSuite) TestIssue16697(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("CREATE TABLE `t` (`a` int(11) DEFAULT NULL,`b` int(11) DEFAULT NULL)")
-	tk.MustExec("insert into t values (1, 1)")
-	for i := 0; i < 8; i++ {
+	tk.MustExec("CREATE TABLE t (v varchar(1024))")
+	tk.MustExec("insert into t values (space(1024))")
+	for i := 0; i < 5; i++ {
 		tk.MustExec("insert into t select * from t")
 	}
-	rows := tk.MustQuery("explain analyze  select t1.a, t1.a +1 from t t1 join t t2 join t t3 order by t1.a").Rows()
+	rows := tk.MustQuery("explain analyze select * from t").Rows()
 	for _, row := range rows {
 		line := fmt.Sprintf("%v", row)
 		if strings.Contains(line, "Projection") {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17399 <!-- REMOVE this line if no issue to close -->

Problem Summary: the test `TestIssue16697` costs 40+s in our data race test, so we need to speed up it.

### What is changed and how it works?
Using `varchar(1024)` with a few rows to construct memory usage in `Projection` instead of using `Join` to generate lots of rows.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- Speed up the test `TestIssue16697`