### PR TITLE
expression: fix data race when simpleRewriter rewrite ast.ColumnNameExpr concurrently (#17353)

### DIFF
--- a/planner/core/partition_pruning_test.go
+++ b/planner/core/partition_pruning_test.go
@@ -285,7 +285,7 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2VarChar(c *C) {
 		lessThan[i] = tmp[0]
 	}
 
-	prunner := &rangeColumnPruner{lessThan, tc.columns[0], true}
+	prunner := &rangeColumnsPruner{lessThan, tc.columns[0], true}
 	cases := []struct {
 		input  string
 		result partitionRangeOR
@@ -333,7 +333,7 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2Date(c *C) {
 		lessThan[i] = tmp[0]
 	}
 
-	prunner := &rangeColumnPruner{lessThan, tc.columns[0], false}
+	prunner := &rangeColumnsPruner{lessThan, tc.columns[0], false}
 	cases := []struct {
 		input  string
 		result partitionRangeOR

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -747,43 +747,40 @@ func (s *partitionProcessor) pruneRangeColumnsPartition(ds *DataSource, pi *mode
 		return s.makeUnionAllChildren(ds, pi, result)
 	}
 
-	pruner, err := makeRangeColumnPruner(ds, pe.ForRangeColumnsPruning)
+	pruner, err := makeRangeColumnPruner(ds, pi, pe.ForRangeColumnsPruning)
 	if err == nil {
 		result = partitionRangeForCNFExpr(ds.ctx, ds.allConds, pruner, result)
 	}
 	return s.makeUnionAllChildren(ds, pi, result)
 }
 
-var _ partitionRangePruner = &rangeColumnPruner{}
+var _ partitionRangePruner = &rangeColumnsPruner{}
 
-// rangeColumnPruner is used by 'partition by range columns'.
-type rangeColumnPruner struct {
+// rangeColumnsPruner is used by 'partition by range columns'.
+type rangeColumnsPruner struct {
 	data     []expression.Expression
 	partCol  *expression.Column
 	maxvalue bool
 }
 
-func makeRangeColumnPruner(ds *DataSource, from *tables.ForRangeColumnsPruning) (*rangeColumnPruner, error) {
+func makeRangeColumnPruner(ds *DataSource, pi *model.PartitionInfo, from *tables.ForRangeColumnsPruning) (*rangeColumnsPruner, error) {
 	schema := expression.NewSchema(ds.TblCols...)
-	expr, err := expression.RewriteSimpleExprWithNames(ds.ctx, from.Column, schema, ds.names)
-	if err != nil {
-		return nil, err
-	}
-	partCol := expr.(*expression.Column)
+	idx := expression.FindFieldNameIdxByColName(ds.names, pi.Columns[0].L)
+	partCol := schema.Columns[idx]
 	data := make([]expression.Expression, len(from.LessThan))
 	for i := 0; i < len(from.LessThan); i++ {
 		if from.LessThan[i] != nil {
 			data[i] = from.LessThan[i].Clone()
 		}
 	}
-	return &rangeColumnPruner{data, partCol, from.MaxValue}, nil
+	return &rangeColumnsPruner{data, partCol, from.MaxValue}, nil
 }
 
-func (p *rangeColumnPruner) fullRange() partitionRangeOR {
+func (p *rangeColumnsPruner) fullRange() partitionRangeOR {
 	return fullRange(len(p.data))
 }
 
-func (p *rangeColumnPruner) partitionRangeForExpr(sctx sessionctx.Context, expr expression.Expression) (int, int, bool) {
+func (p *rangeColumnsPruner) partitionRangeForExpr(sctx sessionctx.Context, expr expression.Expression) (int, int, bool) {
 	op, ok := expr.(*expression.ScalarFunction)
 	if !ok {
 		return 0, len(p.data), false
@@ -822,7 +819,7 @@ func (p *rangeColumnPruner) partitionRangeForExpr(sctx sessionctx.Context, expr 
 	return start, end, true
 }
 
-func (p *rangeColumnPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
+func (p *rangeColumnsPruner) pruneUseBinarySearch(sctx sessionctx.Context, op string, data *expression.Constant) (start int, end int) {
 	var err error
 	var isNull bool
 	compare := func(ith int, op string, v *expression.Constant) bool {

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -124,17 +124,11 @@ type PartitionExpr struct {
 // ForRangeColumnsPruning is used for range partition pruning.
 type ForRangeColumnsPruning struct {
 	LessThan []expression.Expression
-	Column   ast.ExprNode
 	MaxValue bool
 }
 
 func dataForRangeColumnsPruning(ctx sessionctx.Context, pi *model.PartitionInfo, schema *expression.Schema, names []*types.FieldName, p *parser.Parser) (*ForRangeColumnsPruning, error) {
-	col, err := parseExpr(p, pi.Columns[0].L)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
 	var res ForRangeColumnsPruning
-	res.Column = col
 	res.LessThan = make([]expression.Expression, len(pi.Definitions))
 	for i := 0; i < len(pi.Definitions); i++ {
 		if strings.EqualFold(pi.Definitions[i].LessThan[0], "MAXVALUE") {


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Cherry pick https://github.com/pingcap/tidb/pull/17353 to fix a data race

### Release note <!-- bugfixes or new feature need a release note -->

- No release note