### PR TITLE
Concurrent hash build

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -917,16 +917,15 @@ func BenchmarkHashJoinExec(b *testing.B) {
 
 	b.ReportAllocs()
 	cas := defaultHashJoinTestCase(cols, 0, false)
-	buildConcurrency := []int{1}
+	buildConcurrency := []int{1, 2, 4}
 	for _, con := range buildConcurrency {
 		cas.concurrency = con
 		cas.disk = false
+		cas.keyIdx = []int{0, 1}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
 		})
-	}
-	return
-	{
+
 		cas.keyIdx = []int{0}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
@@ -957,6 +956,7 @@ func BenchmarkHashJoinExec(b *testing.B) {
 	cas = defaultHashJoinTestCase(cols, 0, false)
 	for _, con := range buildConcurrency {
 		cas.concurrency = con
+		cas.keyIdx = []int{0, 1}
 		b.Run(fmt.Sprintf("%v", cas), func(b *testing.B) {
 			benchmarkHashJoinExecWithCase(b, cas)
 		})

--- a/executor/concurrent_map.go
+++ b/executor/concurrent_map.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 )
 
-// control the shard maps within the concurrent map
+// ShardCount controls the shard maps within the concurrent map
 var ShardCount = 320
 
 // A "thread" safe map of type string:Anything.

--- a/executor/concurrent_map.go
+++ b/executor/concurrent_map.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 )
 
+// control the shard maps within the concurrent map
 var ShardCount = 320
 
 // A "thread" safe map of type string:Anything.

--- a/executor/concurrent_map.go
+++ b/executor/concurrent_map.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"sync"
+)
+
+var SHARD_COUNT = 320
+
+// A "thread" safe map of type string:Anything.
+// To avoid lock bottlenecks this map is dived to several (SHARD_COUNT) map shards.
+type concurrentMap []*concurrentMapShared
+
+// A "thread" safe string to anything map.
+type concurrentMapShared struct {
+	items        map[uint64]*entry
+	sync.RWMutex // Read Write mutex, guards access to internal map.
+}
+
+// Creates a new concurrent map.
+func NewConcMap() concurrentMap {
+	m := make(concurrentMap, SHARD_COUNT)
+	for i := 0; i < SHARD_COUNT; i++ {
+		m[i] = &concurrentMapShared{items: make(map[uint64]*entry)}
+	}
+	return m
+}
+
+// GetShard returns shard under given key
+func (m concurrentMap) GetShard(hashKey uint64) *concurrentMapShared {
+	return m[hashKey%uint64(SHARD_COUNT)]
+}
+
+// Callback to return new element to be inserted into the map
+// It is called while lock is held, therefore it MUST NOT
+// try to access other keys in same map, as it can lead to deadlock since
+// Go sync.RWLock is not reentrant
+type UpsertCb func(exist bool, valueInMap, newValue *entry) *entry
+
+// Insert or Update - updates existing element or inserts a new one using UpsertCb
+func (m concurrentMap) Upsert(key uint64, value *entry, cb UpsertCb) (res *entry) {
+	shard := m.GetShard(key)
+	shard.Lock()
+	v, ok := shard.items[key]
+	res = cb(ok, v, value)
+	shard.items[key] = res
+	shard.Unlock()
+	return res
+}
+
+// Get retrieves an element from map under given key.
+func (m concurrentMap) Get(key uint64) (*entry, bool) {
+	// Get shard
+	shard := m.GetShard(key)
+	//	shard.RLock()
+	// Get item from shard.
+	val, ok := shard.items[key]
+	//	shard.RUnlock()
+	return val, ok
+}
+
+// Iterator callback,called for every key,value found in
+// maps. RLock is held for all calls for a given shard
+// therefore callback sess consistent view of a shard,
+// but not across the shards
+type IterCb func(key uint64, e *entry)
+
+// Callback based iterator, cheapest way to read
+// all elements in a map.
+func (m concurrentMap) IterCb(fn IterCb) {
+	for idx := range m {
+		shard := (m)[idx]
+		shard.RLock()
+		for key, value := range shard.items {
+			fn(key, value)
+		}
+		shard.RUnlock()
+	}
+}

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -259,7 +259,7 @@ func (c *hashRowContainer) ActionSpill() memory.ActionOnExceed {
 
 const (
 	initialEntrySliceLen = 64
-	maxEntrySliceLen     = 8 * 1024
+	maxEntrySliceLen     = 8192
 )
 
 type entry struct {
@@ -274,7 +274,7 @@ type entryStore struct {
 
 func newEntryStore() *entryStore {
 	es := new(entryStore)
-	es.slices = [][]entry{make([]entry, initialEntrySliceLen, initialEntrySliceLen)}
+	es.slices = [][]entry{make([]entry, initialEntrySliceLen)}
 	es.cursor = 0
 	return es
 }
@@ -287,7 +287,7 @@ func (es *entryStore) GetStore() (e *entry) {
 		if size >= maxEntrySliceLen {
 			size = maxEntrySliceLen
 		}
-		slice = make([]entry, size, size)
+		slice = make([]entry, size)
 		es.slices = append(es.slices, slice)
 		sliceIdx++
 		es.cursor = 0

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -179,8 +179,6 @@ func (c *hashRowContainer) PutChunk(chk *chunk.Chunk, workID uint, useOuterToBui
 // key of hash table: hash value of key columns
 // value of hash table: RowPtr of the corresponded row
 func (c *hashRowContainer) PutChunkSelected(chk *chunk.Chunk, selected []bool, workID uint, useOuterToBuild bool) error {
-	start := time.Now()
-	defer func() { c.stat.buildTableElapse += time.Since(start) }()
 	// safely add chunks
 	c.lock.Lock()
 	chkIdx := uint32(c.rowContainer.NumChunks())

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -15,7 +15,6 @@ package executor
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/bitmap"
 	"hash"
 	"hash/fnv"
 	"sync"
@@ -25,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/bitmap"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/disk"

--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *pkgTestSuite) TestRowHashMap(c *C) {
-	m := newUnsafeHashTable(0)
+	m := newUnsafeHashTable(0, true)
 	m.Put(1, chunk.RowPtr{ChkIdx: 1, RowIdx: 1})
 	c.Check(m.Get(1), DeepEquals, []chunk.RowPtr{{ChkIdx: 1, RowIdx: 1}})
 
@@ -37,7 +37,7 @@ func (s *pkgTestSuite) TestRowHashMap(c *C) {
 			rawData[i] = append(rawData[i], chunk.RowPtr{ChkIdx: uint32(i), RowIdx: uint32(j)})
 		}
 	}
-	m = newUnsafeHashTable(0)
+	m = newUnsafeHashTable(0, true)
 	// put all rawData into m vertically
 	for j := uint64(0); j < initialEntrySliceLen*9; j++ {
 		for i := 9; i >= 0; i-- {
@@ -54,7 +54,7 @@ func (s *pkgTestSuite) TestRowHashMap(c *C) {
 		totalCount += len(rawData[i])
 		c.Check(m.Get(i), DeepEquals, rawData[i])
 	}
-	c.Check(m.Len(), Equals, totalCount)
+	c.Check(m.Len(), Equals, uint64(totalCount))
 }
 
 func initBuildChunk(numRows int) (*chunk.Chunk, []*types.FieldType) {

--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -26,35 +26,43 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 )
 
-func (s *pkgTestSuite) TestRowHashMap(c *C) {
-	m := newUnsafeHashTable(0, true)
-	m.Put(1, chunk.RowPtr{ChkIdx: 1, RowIdx: 1})
-	c.Check(m.Get(1), DeepEquals, []chunk.RowPtr{{ChkIdx: 1, RowIdx: 1}})
+func (s *pkgTestSuite) testHashTables(c *C) {
+	var ht baseHashTable
+	test := func() {
+		ht.Put(1, chunk.RowPtr{ChkIdx: 1, RowIdx: 1})
+		c.Check(ht.Get(1), DeepEquals, []chunk.RowPtr{{ChkIdx: 1, RowIdx: 1}})
 
-	rawData := map[uint64][]chunk.RowPtr{}
-	for i := uint64(0); i < 10; i++ {
-		for j := uint64(0); j < initialEntrySliceLen*i; j++ {
-			rawData[i] = append(rawData[i], chunk.RowPtr{ChkIdx: uint32(i), RowIdx: uint32(j)})
-		}
-	}
-	m = newUnsafeHashTable(0, true)
-	// put all rawData into m vertically
-	for j := uint64(0); j < initialEntrySliceLen*9; j++ {
-		for i := 9; i >= 0; i-- {
-			i := uint64(i)
-			if !(j < initialEntrySliceLen*i) {
-				break
+		rawData := map[uint64][]chunk.RowPtr{}
+		for i := uint64(0); i < 10; i++ {
+			for j := uint64(0); j < initialEntrySliceLen*i; j++ {
+				rawData[i] = append(rawData[i], chunk.RowPtr{ChkIdx: uint32(i), RowIdx: uint32(j)})
 			}
-			m.Put(i, rawData[i][j])
 		}
+		ht = newUnsafeHashTable(0, true)
+		// put all rawData into ht vertically
+		for j := uint64(0); j < initialEntrySliceLen*9; j++ {
+			for i := 9; i >= 0; i-- {
+				i := uint64(i)
+				if !(j < initialEntrySliceLen*i) {
+					break
+				}
+				ht.Put(i, rawData[i][j])
+			}
+		}
+		// check
+		totalCount := 0
+		for i := uint64(0); i < 10; i++ {
+			totalCount += len(rawData[i])
+			c.Check(ht.Get(i), DeepEquals, rawData[i])
+		}
+		c.Check(ht.Len(), Equals, uint64(totalCount))
 	}
-	// check
-	totalCount := 0
-	for i := uint64(0); i < 10; i++ {
-		totalCount += len(rawData[i])
-		c.Check(m.Get(i), DeepEquals, rawData[i])
-	}
-	c.Check(m.Len(), Equals, uint64(totalCount))
+	// test unsafeHashTable
+	ht = newUnsafeHashTable(0, true)
+	test()
+	// test unsafeHashTable
+	ht = newConcurrentMapHashTable(0)
+	test()
 }
 
 func initBuildChunk(numRows int) (*chunk.Chunk, []*types.FieldType) {

--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *pkgTestSuite) TestRowHashMap(c *C) {
-	m := newRowHashMap(0)
+	m := newUnsafeHashTable(0)
 	m.Put(1, chunk.RowPtr{ChkIdx: 1, RowIdx: 1})
 	c.Check(m.Get(1), DeepEquals, []chunk.RowPtr{{ChkIdx: 1, RowIdx: 1}})
 
@@ -37,7 +37,7 @@ func (s *pkgTestSuite) TestRowHashMap(c *C) {
 			rawData[i] = append(rawData[i], chunk.RowPtr{ChkIdx: uint32(i), RowIdx: uint32(j)})
 		}
 	}
-	m = newRowHashMap(0)
+	m = newUnsafeHashTable(0)
 	// put all rawData into m vertically
 	for j := uint64(0); j < initialEntrySliceLen*9; j++ {
 		for i := 9; i >= 0; i-- {

--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -150,16 +150,18 @@ func (s *pkgTestSuite) testHashRowContainer(c *C, hashFunc func() hash.Hash64, s
 	for i := 0; i < numRows; i++ {
 		hCtx.hashVals = append(hCtx.hashVals, hashFunc())
 	}
-	rowContainer := newHashRowContainer(sctx, 0, hCtx)
+	var hCtxArray []*hashContext
+	hCtxArray = append(hCtxArray, hCtx)
+	rowContainer := newHashRowContainer(sctx, 0, hCtxArray)
 	tracker := rowContainer.GetMemTracker()
 	tracker.SetLabel(buildSideResultLabel)
 	if spill {
 		rowContainer.ActionSpill().Action(tracker)
 		tracker.SetBytesLimit(1)
 	}
-	err = rowContainer.PutChunk(chk0)
+	err = rowContainer.PutChunk(chk0, 0, false)
 	c.Assert(err, IsNil)
-	err = rowContainer.PutChunk(chk1)
+	err = rowContainer.PutChunk(chk1, 0, false)
 	c.Assert(err, IsNil)
 
 	c.Assert(rowContainer.alreadySpilled(), Equals, spill)

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -98,7 +98,7 @@ type indexHashJoinResult struct {
 type indexHashJoinTask struct {
 	*lookUpJoinTask
 	outerRowStatus [][]outerRowStatusFlag
-	lookupMap      *unsafeHashTable
+	lookupMap      baseHashTable
 	err            error
 	keepOuterOrder bool
 	// resultCh is only used when the outer order needs to be promised.

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -98,7 +98,7 @@ type indexHashJoinResult struct {
 type indexHashJoinTask struct {
 	*lookUpJoinTask
 	outerRowStatus [][]outerRowStatusFlag
-	lookupMap      *rowHashMap
+	lookupMap      *unsafeHashTable
 	err            error
 	keepOuterOrder bool
 	// resultCh is only used when the outer order needs to be promised.
@@ -494,7 +494,7 @@ func (iw *indexHashJoinInnerWorker) getNewJoinResult(ctx context.Context) (*inde
 
 func (iw *indexHashJoinInnerWorker) buildHashTableForOuterResult(ctx context.Context, cancelFunc context.CancelFunc, task *indexHashJoinTask, h hash.Hash64) {
 	buf, numChks := make([]byte, 1), task.outerResult.NumChunks()
-	task.lookupMap = newRowHashMap(task.outerResult.Len())
+	task.lookupMap = newUnsafeHashTable(task.outerResult.Len())
 	for chkIdx := 0; chkIdx < numChks; chkIdx++ {
 		chk := task.outerResult.GetChunk(chkIdx)
 		numRows := chk.NumRows()

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -494,7 +494,7 @@ func (iw *indexHashJoinInnerWorker) getNewJoinResult(ctx context.Context) (*inde
 
 func (iw *indexHashJoinInnerWorker) buildHashTableForOuterResult(ctx context.Context, cancelFunc context.CancelFunc, task *indexHashJoinTask, h hash.Hash64) {
 	buf, numChks := make([]byte, 1), task.outerResult.NumChunks()
-	task.lookupMap = newUnsafeHashTable(task.outerResult.Len())
+	task.lookupMap = newUnsafeHashTable(task.outerResult.Len(), true)
 	for chkIdx := 0; chkIdx < numChks; chkIdx++ {
 		chk := task.outerResult.GetChunk(chkIdx)
 		numRows := chk.NumRows()

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -81,7 +81,8 @@ func (s *testSuite1) TestIndexJoinUnionScan(c *C) {
 		"2 2 2 2 2",
 		"2 2 4 2 4",
 	))
-	tk.MustQuery("select /*+ INL_MERGE_JOIN(t1, t2)*/ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows(
+	// INL_MERGE_JOIN is invalid
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(t1, t2)*/ * from t1 join t2 on t1.a = t2.a").Sort().Check(testkit.Rows(
 		"2 2 2 2 2",
 		"2 2 4 2 4",
 	))

--- a/executor/join.go
+++ b/executor/join.go
@@ -239,7 +239,7 @@ func (e *HashJoinExec) wait4BuildSide() (emptyBuild bool, err error) {
 			return false, err
 		}
 	}
-	if e.rowContainer.Len() == 0 && (e.joinType == plannercore.InnerJoin || e.joinType == plannercore.SemiJoin) {
+	if e.rowContainer.Len() == uint64(0) && (e.joinType == plannercore.InnerJoin || e.joinType == plannercore.SemiJoin) {
 		return true, nil
 	}
 	return false, nil

--- a/executor/join.go
+++ b/executor/join.go
@@ -16,7 +16,6 @@ package executor
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/config"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -24,6 +23,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/types"

--- a/executor/join.go
+++ b/executor/join.go
@@ -684,7 +684,7 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 		},
 	)
 
-	// TODO: Parallel build hash table. Currently not support because `rowHashMap` is not thread-safe.
+	// TODO: Parallel build hash table. Currently not support because `unsafeHashTable` is not thread-safe.
 	err := e.buildHashTableForList(buildSideResultCh)
 	if err != nil {
 		e.buildFinished <- errors.Trace(err)

--- a/executor/join.go
+++ b/executor/join.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -678,6 +679,8 @@ func (e *HashJoinExec) fetchAndBuildHashTable(ctx context.Context) {
 
 	// e.concurrency goroutines concurrently fetch chunks from e.buildSideResultCh
 	// and put chunks into a hashtable
+	start := time.Now()
+	defer func() { e.rowContainer.stat.buildTableElapse += time.Since(start) }()
 	for i := uint(0); i < e.concurrency; i++ {
 		e.buildWorkerWaitGroup.Add(1)
 		workID := i

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -1909,11 +1909,13 @@ func (s *testSuiteJoin1) TestIssue11544(c *C) {
 	tk.MustExec("insert into 11544tt values(1, 'aaaaaaa'), (1, 'aaaabbb'), (1, 'aaaacccc')")
 	tk.MustQuery("select /*+ INL_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and (tt.b = 'aaaaaaa' or tt.b = 'aaaabbb')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb"))
 	tk.MustQuery("select /*+ INL_HASH_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and (tt.b = 'aaaaaaa' or tt.b = 'aaaabbb')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb"))
-	tk.MustQuery("select /*+ INL_MERGE_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and (tt.b = 'aaaaaaa' or tt.b = 'aaaabbb')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb"))
+	// INL_MERGE_JOIN is invalid
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and (tt.b = 'aaaaaaa' or tt.b = 'aaaabbb')").Sort().Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb"))
 
 	tk.MustQuery("select /*+ INL_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and tt.b in ('aaaaaaa', 'aaaabbb', 'aaaacccc')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb", "1 1 aaaacccc"))
 	tk.MustQuery("select /*+ INL_HASH_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and tt.b in ('aaaaaaa', 'aaaabbb', 'aaaacccc')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb", "1 1 aaaacccc"))
-	tk.MustQuery("select /*+ INL_MERGE_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and tt.b in ('aaaaaaa', 'aaaabbb', 'aaaacccc')").Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb", "1 1 aaaacccc"))
+	// INL_MERGE_JOIN is invalid
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(tt) */ * from 11544t t, 11544tt tt where t.a=tt.a and tt.b in ('aaaaaaa', 'aaaabbb', 'aaaacccc')").Sort().Check(testkit.Rows("1 1 aaaaaaa", "1 1 aaaabbb", "1 1 aaaacccc"))
 }
 
 func (s *testSuiteJoin1) TestIssue11390(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16618

Problem Summary:

### What is changed and how it works?

merge 
https://github.com/pingcap/tidb/pull/16773
https://github.com/pingcap/tidb/pull/16678

for performance test.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Performance 
```
pkg: github.com/pingcap/tidb/executor
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12         	       2	 681971770 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12           	      52	  23941129 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:true)-12            	       2	 547962348 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12         	       3	 341962765 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12           	      73	  16978800 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:true)-12            	       3	 532048178 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12         	       6	 191822008 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12           	     100	  10872441 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-12            	       2	 540410948 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                       	   17800	     66284 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                       	   16092	     74825 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                       	   14254	     85551 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12                	      54	  21393011 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                  	      57	  19869470 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12                	      72	  15441830 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                  	      74	  14241424 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12                	     100	  10598360 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                  	     100	  10272791 ns/op
PASS

```

### Release note <!-- bugfixes or new feature need a release note -->

- concurrently building hash tables