### PR TITLE
statistics: avoid large CMSketch affecting the latency of normal query

### DIFF
--- a/statistics/cmsketch.go
+++ b/statistics/cmsketch.go
@@ -60,8 +60,17 @@ func (t *TopNMeta) GetH2() uint64 {
 // NewCMSketch returns a new CM sketch.
 func NewCMSketch(d, w int32) *CMSketch {
 	tbl := make([][]uint32, d)
+	// Background: The Go's memory allocator will ask caller to sweep spans in some scenarios.
+	// This can cause memory allocation request latency unpredictable, if the list of spans which need sweep is too long.
+	// For memory allocation large than 32K, the allocator will never allocate memory from spans list.
+	//
+	// The memory referenced by the CMSketch will never be freed.
+	// If the number of table or index is extremely large, there will be a large amount of spans in global list.
+	// The default value of `d` is 5 and `w` is 2048, if we use a single slice for them the size will be 40K.
+	// This allocation will be handled by mheap and will never have impact on normal allocations.
+	arena := make([]uint32, d*w)
 	for i := range tbl {
-		tbl[i] = make([]uint32, w)
+		tbl[i] = arena[i*int(w) : (i+1)*int(w)]
 	}
 	return &CMSketch{depth: d, width: w, table: tbl}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
We have captured a runtime trace of tidb-server and observed a large latency caused by GC sweep.
![图片](https://user-images.githubusercontent.com/15031522/83343200-bf7f5080-a329-11ea-9d11-3beb20f7e9bc.png)

![图片](https://user-images.githubusercontent.com/15031522/83343249-48968780-a32a-11ea-978c-38e3df98baee.png)

The root cause is the large amount 8K span referenced by `CMSketch` and there is a [limitation of Go's allocator](https://github.com/golang/go/issues/18155). In this case, 8K allocation issued by `IndexLookUpExec` will take a long time to scan memory spans used by `CMSketch`.

### What is changed and how it works?

Memory allocation larger than 32K will never use memory span. The default configuration of `CMSketch` will use 40K memory, so use a single slice is a workaround.

This problem can be solved in Go 1.15, so this simple workaround is a good choice before Go 1.15 release.

![图片](https://user-images.githubusercontent.com/15031522/83343341-a5df0880-a32b-11ea-8b63-0b161cf0c509.png)

This test is using v3.0.14 TiDB compiled with Go 1.13.10, but I believe v4.0 and Go 1.14 have the same problem.

### Release note <!-- bugfixes or new feature need a release note -->
* avoid large CMSketch affecting the latency of normal query