### PR TITLE
add background goroutine to auto free os memory when process resident memory exceeds the `tidb_free_os_memory_threshold` value.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,6 +134,8 @@ type Config struct {
 	EnableDynamicConfig bool `toml:"enable-dynamic-config" json:"enable-dynamic-config"`
 	// EnableCollectExecutionInfo enables the TiDB to collect execution info.
 	EnableCollectExecutionInfo bool `toml:"enable-collect-execution-info" json:"enable-collect-execution-info"`
+	// FreeOSMemoryThreshold is the threshold that auto free os memory.
+	FreeOSMemoryThreshold uint64
 }
 
 // UpdateTempStoragePath is to update the `TempStoragePath` if port/statusPort was changed

--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/prometheus/client_golang v1.0.0
 	github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4
 	github.com/prometheus/common v0.4.1
+	github.com/prometheus/procfs v0.0.2
 	github.com/shirou/gopsutil v2.19.10+incompatible
 	github.com/shurcooL/httpfs v0.0.0-20171119174359-809beceb2371 // indirect
 	github.com/shurcooL/vfsgen v0.0.0-20181020040650-a97a25d856ca // indirect

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1279,6 +1279,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		} else {
 			s.StmtCtx.AppendWarning(errors.Errorf("cannot update %s when enabling dynamic configs", TiDBEnableCollectExecutionInfo))
 		}
+	case TiDBFreeOSMemoryThreshold:
+		atomic.StoreUint64(&config.GetGlobalConfig().FreeOSMemoryThreshold, uint64(tidbOptInt64(val, 0)))
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1279,7 +1279,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		} else {
 			s.StmtCtx.AppendWarning(errors.Errorf("cannot update %s when enabling dynamic configs", TiDBEnableCollectExecutionInfo))
 		}
-	case TiDBFreeOSMemoryThreshold:
+	case TiDBAutoFreeOSMemoryThreshold:
 		atomic.StoreUint64(&config.GetGlobalConfig().FreeOSMemoryThreshold, uint64(tidbOptInt64(val, 0)))
 	}
 	s.systems[name] = val

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -714,6 +714,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBMetricSchemaStep, strconv.Itoa(DefTiDBMetricSchemaStep)},
 	{ScopeSession, TiDBMetricSchemaRangeDuration, strconv.Itoa(DefTiDBMetricSchemaRangeDuration)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},
+	{ScopeSession, TiDBFreeOSMemoryThreshold, "0"},
 	{ScopeSession, TiDBRecordPlanInSlowLog, strconv.Itoa(logutil.DefaultRecordPlanInSlowLog)},
 	{ScopeSession, TiDBEnableSlowLog, BoolToIntStr(logutil.DefaultTiDBEnableSlowLog)},
 	{ScopeSession, TiDBQueryLogMaxLen, strconv.Itoa(logutil.DefaultQueryLogMaxLen)},

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -714,7 +714,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBMetricSchemaStep, strconv.Itoa(DefTiDBMetricSchemaStep)},
 	{ScopeSession, TiDBMetricSchemaRangeDuration, strconv.Itoa(DefTiDBMetricSchemaRangeDuration)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},
-	{ScopeSession, TiDBFreeOSMemoryThreshold, "0"},
+	{ScopeSession, TiDBAutoFreeOSMemoryThreshold, "0"},
 	{ScopeSession, TiDBRecordPlanInSlowLog, strconv.Itoa(logutil.DefaultRecordPlanInSlowLog)},
 	{ScopeSession, TiDBEnableSlowLog, BoolToIntStr(logutil.DefaultTiDBEnableSlowLog)},
 	{ScopeSession, TiDBQueryLogMaxLen, strconv.Itoa(logutil.DefaultQueryLogMaxLen)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -169,6 +169,9 @@ const (
 
 	// TiDBCheckMb4ValueInUTF8 is used to control whether to enable the check wrong utf8 value.
 	TiDBCheckMb4ValueInUTF8 = "tidb_check_mb4_value_in_utf8"
+
+	// TiDBFreeOSMemoryThreshold is used to set the auto free os memory threshold.
+	TiDBFreeOSMemoryThreshold = "tidb_free_os_memory_threshold"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -170,8 +170,8 @@ const (
 	// TiDBCheckMb4ValueInUTF8 is used to control whether to enable the check wrong utf8 value.
 	TiDBCheckMb4ValueInUTF8 = "tidb_check_mb4_value_in_utf8"
 
-	// TiDBFreeOSMemoryThreshold is used to set the auto free os memory threshold.
-	TiDBFreeOSMemoryThreshold = "tidb_free_os_memory_threshold"
+	// TiDBAutoFreeOSMemoryThreshold is used to set the auto free os memory threshold.
+	TiDBAutoFreeOSMemoryThreshold = "tidb_auto_free_os_memory_threshold"
 )
 
 // TiDB system variable names that both in session and global scope.

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -657,6 +657,7 @@ func setupMetrics() {
 		}
 	}
 	go systimemon.StartMonitor(time.Now, systimeErrHandler, sucessCallBack)
+	go systimemon.StartAutoFreeOSMemory()
 
 	pushMetric(cfg.Status.MetricsAddr, time.Duration(cfg.Status.MetricsInterval)*time.Second)
 }

--- a/util/systimemon/systime_mon.go
+++ b/util/systimemon/systime_mon.go
@@ -85,7 +85,7 @@ func StartAutoFreeOSMemory() {
 			runtime.GC()
 			debug.FreeOSMemory()
 			count++
-			logutil.BgLogger().Warn("auto free os memory", zap.Int("count", count))
+			logutil.BgLogger().Warn("auto free os memory", zap.Int("rss", rss), zap.Int("threshold", threshold), zap.Int("count", count))
 		}
 	}
 }

--- a/util/systimemon/systime_mon.go
+++ b/util/systimemon/systime_mon.go
@@ -51,19 +51,18 @@ func StartMonitor(now func() time.Time, systimeErrHandler func(), successCallbac
 // StartAutoFreeOSMemory used to auto free os memory when exceed the threshold.
 func StartAutoFreeOSMemory() {
 	logutil.BgLogger().Info("start process memory monitor")
-	tick := time.NewTicker(1 * time.Second)
+	tick := time.NewTicker(5 * time.Second)
 	defer tick.Stop()
 	var lastLogErrTime time.Time
 	logErrFn := func(msg string, fields ...zap.Field) {
-		if time.Since(lastLogErrTime).Seconds() < 10 {
+		if time.Since(lastLogErrTime).Seconds() < 30 {
 			return
 		}
 		lastLogErrTime = time.Now()
 		logutil.BgLogger().Error(msg, fields...)
 	}
 	count := 0
-	for {
-		<-tick.C
+	for _ = range tick.C {
 		threshold := int(atomic.LoadUint64(&config.GetGlobalConfig().FreeOSMemoryThreshold))
 		if threshold <= 0 {
 			continue

--- a/util/systimemon/systime_mon.go
+++ b/util/systimemon/systime_mon.go
@@ -14,9 +14,15 @@
 package systimemon
 
 import (
+	"os"
+	"runtime"
+	"runtime/debug"
+	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/prometheus/procfs"
 	"go.uber.org/zap"
 )
 
@@ -38,6 +44,48 @@ func StartMonitor(now func() time.Time, systimeErrHandler func(), successCallbac
 		if tickCount >= 10 {
 			tickCount = 0
 			successCallback()
+		}
+	}
+}
+
+// StartAutoFreeOSMemory used to auto free os memory when exceed the threshold.
+func StartAutoFreeOSMemory() {
+	logutil.BgLogger().Info("start process memory monitor")
+	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
+	var lastLogErrTime time.Time
+	logErrFn := func(msg string, fields ...zap.Field) {
+		if time.Since(lastLogErrTime).Seconds() < 10 {
+			return
+		}
+		lastLogErrTime = time.Now()
+		logutil.BgLogger().Error(msg, fields...)
+	}
+	count := 0
+	for {
+		<-tick.C
+		threshold := int(atomic.LoadUint64(&config.GetGlobalConfig().FreeOSMemoryThreshold))
+		if threshold <= 0 {
+			continue
+		}
+		pid := os.Getpid()
+		p, err := procfs.NewProc(pid)
+		if err != nil {
+			logErrFn("get process failed", zap.Error(err))
+			continue
+		}
+
+		stat, err := p.Stat()
+		if err != nil {
+			logErrFn("get process stat failed", zap.Int("pid", pid), zap.Error(err))
+			continue
+		}
+		rss := stat.ResidentMemory()
+		if rss > threshold {
+			runtime.GC()
+			debug.FreeOSMemory()
+			count++
+			logutil.BgLogger().Warn("auto free os memory", zap.Int("count", count))
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

#### background
 
Go1.13 runtime will not give back the idle memory to system, this may cause oom problem.

Related issue: 
* https://github.com/golang/go/issues/30333
* https://github.com/prometheus/prometheus/issues/5524
* http://www.zenlife.tk/go-scavenge.md

#### manual free os memory

This PR adds  `tidb_free_os_memory_threshold` variable, the scope is `server` when the TiDB process resident memory exceeds this variable value, TiDB will auto free the memory to the system(`debug.FreeOSMemory()`). The variable unit is `byte`, default value is `0`. `0` means diable the auto-free os memory behavior.

This PR adds a background goroutine to check the TiDB process resident memory every 1 second when the resident memory of TiDB process exceeds `tidb_free_os_memory_threshold`, TiDB will call `debug.FreeOSMemory()` to free os memory. 

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```go
[2020/06/01 11:29:56.064 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=45178880] [threshold=1024000] [count=52]
[2020/06/01 11:29:57.062 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=34603008] [threshold=1024000] [count=53]
[2020/06/01 11:29:58.063 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=34209792] [threshold=1024000] [count=54]
[2020/06/01 11:29:59.063 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=34553856] [threshold=1024000] [count=55]
[2020/06/01 11:30:00.063 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=34168832] [threshold=1024000] [count=56]
[2020/06/01 11:30:01.062 +08:00] [WARN] [systime_mon.go:88] ["auto free os memory"] [rss=33906688] [threshold=1024000] [count=57]
[2020/06/01 11:30:01.209 +08:00] [INFO] [set.go:201] ["set session var"] [conn=3] [name=tidb_free_os_memory_threshold] [val=1024000000]
```

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- Add background goroutine to auto free os memory when process resident memory exceeds the `tidb_free_os_memory_threshold` value.
