### PR TITLE
expression: push down expr json_length to tiflash

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1059,7 +1059,7 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 }
 
 func canExprPushDown(expr Expression, pc PbConverter, storeType kv.StoreType) bool {
-	if storeType == kv.TiFlash && (expr.GetType().Tp == mysql.TypeDuration || expr.GetType().Tp == mysql.TypeJSON || collate.NewCollationEnabled()) {
+	if storeType == kv.TiFlash && (expr.GetType().Tp == mysql.TypeDuration || collate.NewCollationEnabled()) {
 		return false
 	}
 	switch x := expr.(type) {
@@ -1119,7 +1119,8 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.LT, ast.GT, ast.Ifnull, ast.IsNull, ast.Or,
 		ast.In, ast.Mod, ast.And, ast.LogicOr, ast.LogicAnd,
 		ast.Like, ast.UnaryNot, ast.Case, ast.Month, ast.Substr,
-		ast.Substring, ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime:
+		ast.Substring, ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime,
+		ast.JSONLength:
 		return true
 	case ast.Cast:
 		switch function.Function.PbCode() {


### PR DESCRIPTION
Signed-off-by: Tong Zhigao <tongzhigao@pingcap.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

- tiflash has implemented expression `json_length` in PR: https://github.com/pingcap/tics/pull/741.

- Make tidb can push down scalar function `json_length` to tiflash.

### What is changed and how it works?

What's Changed:

- Add `json_length` to white list which can be pushed down to tiflash.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->
- No release note