### PR TITLE
expression: enable if/bitxor/bitneg pushdown for TiFlash

### DIFF
--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -606,17 +606,33 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
 	exprs := make([]Expression, 0)
-	function, err := NewFunction(mock.NewContext(), ast.JSONLength, types.NewFieldType(mysql.TypeLonglong), dg.genColumn(mysql.TypeJSON, 1))
+
+	jsonColumn := dg.genColumn(mysql.TypeJSON, 1)
+	intColumn := dg.genColumn(mysql.TypeLonglong, 2)
+	function, err := NewFunction(mock.NewContext(), ast.JSONLength, types.NewFieldType(mysql.TypeLonglong), jsonColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
+
+	function, err = NewFunction(mock.NewContext(), ast.If, types.NewFieldType(mysql.TypeLonglong), intColumn, intColumn, intColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = NewFunction(mock.NewContext(), ast.BitNeg, types.NewFieldType(mysql.TypeLonglong), intColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = NewFunction(mock.NewContext(), ast.Xor, types.NewFieldType(mysql.TypeLonglong), intColumn, intColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
 	canPush := CanExprsPushDown(sc, exprs, client, kv.TiFlash)
 	c.Assert(canPush, Equals, true)
 
-	function, err = NewFunction(mock.NewContext(), ast.JSONDepth, types.NewFieldType(mysql.TypeLonglong), dg.genColumn(mysql.TypeJSON, 2))
+	function, err = NewFunction(mock.NewContext(), ast.JSONDepth, types.NewFieldType(mysql.TypeLonglong), jsonColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 	pushed, remained := PushDownExprs(sc, exprs, client, kv.TiFlash)
-	c.Assert(len(pushed), Equals, 1)
+	c.Assert(len(pushed), Equals, len(exprs)-1)
 	c.Assert(len(remained), Equals, 1)
 }
 

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1120,7 +1120,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.In, ast.Mod, ast.And, ast.LogicOr, ast.LogicAnd,
 		ast.Like, ast.UnaryNot, ast.Case, ast.Month, ast.Substr,
 		ast.Substring, ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime,
-		ast.JSONLength:
+		ast.JSONLength, ast.If, ast.BitNeg, ast.Xor:
 		return true
 	case ast.Cast:
 		switch function.Function.PbCode() {

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1114,10 +1114,9 @@ func scalarExprSupportedByTiDB(function *ScalarFunction) bool {
 
 func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 	switch function.FuncName.L {
-	case ast.Plus, ast.Minus, ast.Div, ast.Mul,
-		ast.NullEQ, ast.GE, ast.LE, ast.EQ, ast.NE,
-		ast.LT, ast.GT, ast.Ifnull, ast.IsNull, ast.Or,
-		ast.In, ast.Mod, ast.And, ast.LogicOr, ast.LogicAnd,
+	case ast.Plus, ast.Minus, ast.Div, ast.Mul, ast.GE, ast.LE,
+		ast.EQ, ast.NE, ast.LT, ast.GT, ast.Ifnull, ast.IsNull,
+		ast.Or, ast.In, ast.Mod, ast.And, ast.LogicOr, ast.LogicAnd,
 		ast.Like, ast.UnaryNot, ast.Case, ast.Month, ast.Substr,
 		ast.Substring, ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime,
 		ast.JSONLength, ast.If, ast.BitNeg, ast.Xor:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?
enable `if/bitxor/bitneg` pushdown for TiFlash, disable `nulleq` pushdown for TiFlash because it is not supported yet


What's Changed:
add `if/bitxor/bitneg` to TiFlash pushdown whitelist, remove `nulleq` from TiFlash pushdown whitelist

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->
- Enable `if/bitxor/bitneg` pushdown to TiFlash
- Disable `nulleq` pushdown to TiFlash
