### PR TITLE
ddl: shouldn't ignore change when the job state is rollback done

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -474,11 +474,12 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 				err = w.finishDDLJob(t, job)
 				return errors.Trace(err)
 			}
-			if runJobErr != nil && !job.IsRollingback() {
+			if runJobErr != nil && !job.IsRollingback() && !job.IsRollbackDone() {
 				// If the running job meets an error
 				// and the job state is rolling back, it means that we have already handled this error.
 				// Some DDL jobs (such as adding indexes) may need to update the table info and the schema version,
 				// then shouldn't discard the KV modification.
+				// And the job state is rollback done, it means the job was already finished, also shouldn't discard too.
 				// Otherwise, we should discard the KV modification when running job.
 				txn.Discard()
 			}


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>


### What problem does this PR solve?

When I cherry-pick the https://github.com/pingcap/tidb/pull/17341 to release-3.1（https://github.com/pingcap/tidb/pull/17607）, there is a unit-test failed. The reason is that https://github.com/pingcap/tidb/pull/17341 only not discard the modification of run-job transaction when the job state is `rollingback`. Actually, we should not discard too when the job state is `rollbackdone`. Otherwise, the unit-test `TestCancelDropIndex` will fail in release-3.1.

In https://github.com/pingcap/tidb/pull/17341, the unit-test doesn't fail, because the `cancel drop index` logic in the master is different from the old version.


### What is changed and how it works?

### Related changes

- No test to test for this, but just incase for future.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- No
