### PR TITLE
unistore: move coprocessor logic from unistore repo to tidb repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/pingcap/tidb
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d
+	github.com/coocood/badger v1.5.1-0.20200528065104-c02ac3616d04
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8
 	github.com/danjacques/gofslock v0.0.0-20191023191349-0a45f885bc37
@@ -17,10 +18,11 @@ require (
 	github.com/google/uuid v1.1.1
 	github.com/gorilla/mux v1.7.3
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4
+	github.com/juju/errors v0.0.0-20181118221551-089d3ea4e4d5
 	github.com/klauspost/cpuid v1.2.1
 	github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef
-	github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796
+	github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a
 	github.com/opentracing/basictracer-go v1.0.0
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/pingcap/br v0.0.0-20200521085655-53201addd4ad
@@ -57,7 +59,6 @@ require (
 	golang.org/x/tools v0.0.0-20200325203130-f53864d0dba1
 	google.golang.org/grpc v1.26.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
-	honnef.co/go/tools v0.0.1-2020.1.4 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20180531100431-4c381bd170b4
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/pingcap/tidb
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d
-	github.com/coocood/badger v1.5.1-0.20200528065104-c02ac3616d04
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8
 	github.com/danjacques/gofslock v0.0.0-20191023191349-0a45f885bc37
@@ -22,9 +21,10 @@ require (
 	github.com/klauspost/cpuid v1.2.1
 	github.com/ngaut/pools v0.0.0-20180318154953-b7bc8c42aac7
 	github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef
-	github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a
+	github.com/ngaut/unistore v0.0.0-20200604043635-5004cdad650f
 	github.com/opentracing/basictracer-go v1.0.0
 	github.com/opentracing/opentracing-go v1.1.0
+	github.com/pingcap/badger v1.5.1-0.20200604041313-19c397305fcc
 	github.com/pingcap/br v0.0.0-20200521085655-53201addd4ad
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,6 @@ github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef h1:K0Fn+DoFqNqktdZtdV3
 github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef/go.mod h1:7WjlapSfwQyo6LNmIvEWzsW1hbBQfpUO4JWnuQRmva8=
 github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796 h1:mhOUY30ysXVcRuftTiFgbw//GERhoM/65u5jvr9LJ7s=
 github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796/go.mod h1:9mpqZeS1CkNlgZwJ0LZXb+Qd7xVO5o55ngys7T1/oH8=
-github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a h1:A5RXCtZ2usTWL0iUMt3OfcVxWZVFWRy0wakMhXbyBs0=
-github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a/go.mod h1:QrtokFGOTQMCJLbZ3JmtKTlT63WWdSI4QGvuqOqwdsg=
 github.com/ngaut/unistore v0.0.0-20200604043635-5004cdad650f h1:ws3QybMmoXuS3S8tcR7DiFnUfae6yJRRi7I53vjumLI=
 github.com/ngaut/unistore v0.0.0-20200604043635-5004cdad650f/go.mod h1:5Vec+R2BwOyugVQ8Id8uDmlIYbqodCvykM50IpaAjk4=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796 h1:mhOUY30ysXVcRuft
 github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796/go.mod h1:9mpqZeS1CkNlgZwJ0LZXb+Qd7xVO5o55ngys7T1/oH8=
 github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a h1:A5RXCtZ2usTWL0iUMt3OfcVxWZVFWRy0wakMhXbyBs0=
 github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a/go.mod h1:QrtokFGOTQMCJLbZ3JmtKTlT63WWdSI4QGvuqOqwdsg=
+github.com/ngaut/unistore v0.0.0-20200604043635-5004cdad650f h1:ws3QybMmoXuS3S8tcR7DiFnUfae6yJRRi7I53vjumLI=
+github.com/ngaut/unistore v0.0.0-20200604043635-5004cdad650f/go.mod h1:5Vec+R2BwOyugVQ8Id8uDmlIYbqodCvykM50IpaAjk4=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -407,6 +409,8 @@ github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200407064406-b2b8ad403d01/go.mod h1:77fCh8d3oKzC5ceOJWeZXAS/mLzVgdZ7rKniwmOyFuo=
 github.com/pingcap-incubator/tidb-dashboard v0.0.0-20200514075710-eecc9a4525b5/go.mod h1:8q+yDx0STBPri8xS4A2duS1dAf+xO0cMtjwe0t6MWJk=
+github.com/pingcap/badger v1.5.1-0.20200604041313-19c397305fcc h1:aL83XYtYRGJHGruiw5Kk/vJiJl2xFiWfqCgnvHin7ek=
+github.com/pingcap/badger v1.5.1-0.20200604041313-19c397305fcc/go.mod h1:LyrqUOHZrUDf9oGi1yoz1+qw9ckSIhQb5eMa1acOLNQ=
 github.com/pingcap/br v0.0.0-20200426093517-dd11ae28b885 h1:gI14HoGBF9UyECMgqSRZx1ONhREtrZe8JCmZ/6OFilw=
 github.com/pingcap/br v0.0.0-20200426093517-dd11ae28b885/go.mod h1:4w3meMnk7HDNpNgjuRAxavruTeKJvUiXxoEWTjzXPnA=
 github.com/pingcap/br v0.0.0-20200521085655-53201addd4ad h1:nptiQT0kWdIUghh49OyaTBYb4DtdxJmsLHOxbU25kW4=

--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,8 @@ github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef h1:K0Fn+DoFqNqktdZtdV3
 github.com/ngaut/sync2 v0.0.0-20141008032647-7a24ed77b2ef/go.mod h1:7WjlapSfwQyo6LNmIvEWzsW1hbBQfpUO4JWnuQRmva8=
 github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796 h1:mhOUY30ysXVcRuftTiFgbw//GERhoM/65u5jvr9LJ7s=
 github.com/ngaut/unistore v0.0.0-20200603091253-e0b717679796/go.mod h1:9mpqZeS1CkNlgZwJ0LZXb+Qd7xVO5o55ngys7T1/oH8=
+github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a h1:A5RXCtZ2usTWL0iUMt3OfcVxWZVFWRy0wakMhXbyBs0=
+github.com/ngaut/unistore v0.0.0-20200603124755-05e6598d081a/go.mod h1:QrtokFGOTQMCJLbZ3JmtKTlT63WWdSI4QGvuqOqwdsg=
 github.com/nicksnyder/go-i18n v1.10.0/go.mod h1:HrK7VCrbOvQoUAQ7Vpy7i87N7JZZZ7R2xBGjv0j365Q=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
@@ -460,6 +462,7 @@ github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1/go.mod h1:EB/852NM
 github.com/pingcap/tidb v1.1.0-beta.0.20200424154252-5ede18f10eed/go.mod h1:m2VDlJDbUeHPCXAfKPajqLmB1uLvWpkKk3zALNqDYdw=
 github.com/pingcap/tidb v1.1.0-beta.0.20200509133407-a9dc72cf2558/go.mod h1:cXNbVSQAkwwmjFQmEnEPI00Z2/Y/KOhouttUPERiInE=
 github.com/pingcap/tidb v1.1.0-beta.0.20200513065557-5a0787dfa915/go.mod h1:khS9Z9YlbtxsaZsSsSahelgh5L16EtP30QADFmPiI/I=
+github.com/pingcap/tidb v1.1.0-beta.0.20200603101356-552e7709de0d/go.mod h1:wgu4vP3wq+x/l1X3ckOZFvyGKcVIBkq30NQVh0Y+qYA=
 github.com/pingcap/tidb-tools v4.0.0-beta.1.0.20200306084441-875bd09aa3d5+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompatible h1:+K5bqDYG5HT+GqLdx4GH5VmS84+xHgpHbGg6Xt6qQec=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -1,0 +1,879 @@
+package cophandler
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/juju/errors"
+	"github.com/ngaut/unistore/tikv/dbreader"
+	"github.com/ngaut/unistore/tikv/mvcc"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+	mockpkg "github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/rowcodec"
+	"github.com/pingcap/tipb/go-tipb"
+)
+
+const chunkMaxRows = 1024
+
+const (
+	pkColNotExists = iota
+	pkColIsSigned
+	pkColIsUnsigned
+)
+
+// buildClosureExecutor build a closureExecutor for the DAGRequest.
+// Currently the composition of executors are:
+// 	tableScan|indexScan [selection] [topN | limit | agg]
+func buildClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closureExecutor, error) {
+	ce, err := newClosureExecutor(dagCtx, dagReq)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	executors := dagReq.Executors
+	scanExec := executors[0]
+	if scanExec.Tp == tipb.ExecType_TypeTableScan {
+		ce.processor = &tableScanProcessor{closureExecutor: ce}
+	} else {
+		ce.processor = &indexScanProcessor{closureExecutor: ce}
+	}
+	if len(executors) == 1 {
+		return ce, nil
+	}
+	if secondExec := executors[1]; secondExec.Tp == tipb.ExecType_TypeSelection {
+		ce.selectionCtx.conditions, err = convertToExprs(ce.sc, ce.fieldTps, secondExec.Selection.Conditions)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		ce.processor = &selectionProcessor{closureExecutor: ce}
+	}
+	lastExecutor := executors[len(executors)-1]
+	switch lastExecutor.Tp {
+	case tipb.ExecType_TypeLimit:
+		ce.limit = int(lastExecutor.Limit.Limit)
+	case tipb.ExecType_TypeTopN:
+		err = buildTopNProcessor(ce, lastExecutor.TopN)
+	case tipb.ExecType_TypeAggregation:
+		err = buildHashAggProcessor(ce, dagCtx, lastExecutor.Aggregation)
+	case tipb.ExecType_TypeStreamAgg:
+		err = buildStreamAggProcessor(ce, dagCtx, executors)
+	case tipb.ExecType_TypeSelection:
+		ce.processor = &selectionProcessor{closureExecutor: ce}
+	default:
+		panic("unknown executor type " + lastExecutor.Tp.String())
+	}
+	if err != nil {
+		return nil, err
+	}
+	return ce, nil
+}
+
+func convertToExprs(sc *stmtctx.StatementContext, fieldTps []*types.FieldType, pbExprs []*tipb.Expr) ([]expression.Expression, error) {
+	exprs := make([]expression.Expression, 0, len(pbExprs))
+	for _, expr := range pbExprs {
+		e, err := expression.PBToExpr(expr, fieldTps, sc)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		exprs = append(exprs, e)
+	}
+	return exprs, nil
+}
+
+func newClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closureExecutor, error) {
+	e := &closureExecutor{
+		dagContext: dagCtx,
+		outputOff:  dagReq.OutputOffsets,
+		startTS:    dagCtx.startTS,
+		limit:      math.MaxInt64,
+	}
+	seCtx := mockpkg.NewContext()
+	seCtx.GetSessionVars().StmtCtx = e.sc
+	e.seCtx = seCtx
+	executors := dagReq.Executors
+	scanExec := executors[0]
+	switch scanExec.Tp {
+	case tipb.ExecType_TypeTableScan:
+		tblScan := executors[0].TblScan
+		e.unique = true
+		e.scanCtx.desc = tblScan.Desc
+	case tipb.ExecType_TypeIndexScan:
+		idxScan := executors[0].IdxScan
+		e.unique = idxScan.GetUnique()
+		e.scanCtx.desc = idxScan.Desc
+		e.initIdxScanCtx()
+	default:
+		panic(fmt.Sprintf("unknown first executor type %s", executors[0].Tp))
+	}
+	ranges, err := extractKVRanges(dagCtx.dbReader.StartKey, dagCtx.dbReader.EndKey, dagCtx.keyRanges, e.scanCtx.desc)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if dagReq.GetCollectRangeCounts() {
+		e.counts = make([]int64, len(ranges))
+	}
+	e.kvRanges = ranges
+	e.scanCtx.chk = chunk.NewChunkWithCapacity(e.fieldTps, 32)
+	if e.idxScanCtx == nil {
+		e.scanCtx.decoder, err = e.evalContext.newRowDecoder()
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	return e, nil
+}
+
+func (e *closureExecutor) initIdxScanCtx() {
+	e.idxScanCtx = new(idxScanCtx)
+	e.idxScanCtx.columnLen = len(e.columnInfos)
+	e.idxScanCtx.pkStatus = pkColNotExists
+	lastColumn := e.columnInfos[len(e.columnInfos)-1]
+	// The PKHandle column info has been collected in ctx.
+	if lastColumn.GetPkHandle() {
+		if mysql.HasUnsignedFlag(uint(lastColumn.GetFlag())) {
+			e.idxScanCtx.pkStatus = pkColIsUnsigned
+		} else {
+			e.idxScanCtx.pkStatus = pkColIsSigned
+		}
+		e.idxScanCtx.columnLen--
+	} else if lastColumn.ColumnId == model.ExtraHandleID {
+		e.idxScanCtx.pkStatus = pkColIsSigned
+		e.idxScanCtx.columnLen--
+	}
+
+	colInfos := make([]rowcodec.ColInfo, e.idxScanCtx.columnLen)
+	for i := range colInfos {
+		col := e.columnInfos[i]
+		colInfos[i] = rowcodec.ColInfo{
+			ID:         col.ColumnId,
+			Ft:         e.fieldTps[i],
+			IsPKHandle: col.GetPkHandle(),
+		}
+	}
+	e.idxScanCtx.colInfos = colInfos
+
+	colIDs := make(map[int64]int, len(colInfos))
+	for i, col := range colInfos {
+		colIDs[col.ID] = i
+	}
+	e.scanCtx.newCollationIds = colIDs
+
+	// We don't need to decode handle here, and colIDs >= 0 always.
+	e.scanCtx.newCollationRd = rowcodec.NewByteDecoder(colInfos, []int64{-1}, nil, nil)
+}
+
+func isCountAgg(pbAgg *tipb.Aggregation) bool {
+	if len(pbAgg.AggFunc) == 1 && len(pbAgg.GroupBy) == 0 {
+		aggFunc := pbAgg.AggFunc[0]
+		if aggFunc.Tp == tipb.ExprType_Count && len(aggFunc.Children) == 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func tryBuildCountProcessor(e *closureExecutor, executors []*tipb.Executor) (bool, error) {
+	if len(executors) > 2 {
+		return false, nil
+	}
+	agg := executors[1].Aggregation
+	if !isCountAgg(agg) {
+		return false, nil
+	}
+	child := agg.AggFunc[0].Children[0]
+	switch child.Tp {
+	case tipb.ExprType_ColumnRef:
+		_, idx, err := codec.DecodeInt(child.Val)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+		e.aggCtx.col = e.columnInfos[idx]
+		if e.aggCtx.col.PkHandle {
+			e.processor = &countStarProcessor{skipVal: skipVal(true), closureExecutor: e}
+		} else {
+			e.processor = &countColumnProcessor{closureExecutor: e}
+		}
+	case tipb.ExprType_Null, tipb.ExprType_ScalarFunc:
+		return false, nil
+	default:
+		e.processor = &countStarProcessor{skipVal: skipVal(true), closureExecutor: e}
+	}
+	return true, nil
+}
+
+func buildTopNProcessor(e *closureExecutor, topN *tipb.TopN) error {
+	heap, conds, err := getTopNInfo(e.evalContext, topN)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	ctx := &topNCtx{
+		heap:         heap,
+		orderByExprs: conds,
+		sortRow:      e.newTopNSortRow(),
+	}
+
+	e.topNCtx = ctx
+	e.processor = &topNProcessor{closureExecutor: e}
+	return nil
+}
+
+func buildHashAggProcessor(e *closureExecutor, ctx *dagContext, agg *tipb.Aggregation) error {
+	aggs, groupBys, err := getAggInfo(ctx, agg)
+	if err != nil {
+		return err
+	}
+	e.processor = &hashAggProcessor{
+		closureExecutor: e,
+		aggExprs:        aggs,
+		groupByExprs:    groupBys,
+		groups:          map[string]struct{}{},
+		groupKeys:       nil,
+		aggCtxsMap:      map[string][]*aggregation.AggEvaluateContext{},
+	}
+	return nil
+}
+
+func buildStreamAggProcessor(e *closureExecutor, ctx *dagContext, executors []*tipb.Executor) error {
+	ok, err := tryBuildCountProcessor(e, executors)
+	if err != nil || ok {
+		return err
+	}
+	return buildHashAggProcessor(e, ctx, executors[len(executors)-1].Aggregation)
+}
+
+// closureExecutor is an execution engine that flatten the DAGRequest.Executors to a single closure `processor` that
+// process key/value pairs. We can define many closures for different kinds of requests, try to use the specially
+// optimized one for some frequently used query.
+type closureExecutor struct {
+	*dagContext
+	outputOff    []uint32
+	seCtx        sessionctx.Context
+	kvRanges     []kv.KeyRange
+	startTS      uint64
+	ignoreLock   bool
+	lockChecked  bool
+	scanCtx      scanCtx
+	idxScanCtx   *idxScanCtx
+	selectionCtx selectionCtx
+	aggCtx       aggCtx
+	topNCtx      *topNCtx
+
+	rowCount int
+	unique   bool
+	limit    int
+
+	oldChunks []tipb.Chunk
+	oldRowBuf []byte
+	processor closureProcessor
+
+	counts []int64
+}
+
+type closureProcessor interface {
+	dbreader.ScanProcessor
+	Finish() error
+}
+
+type scanCtx struct {
+	count   int
+	limit   int
+	chk     *chunk.Chunk
+	desc    bool
+	decoder *rowcodec.ChunkDecoder
+
+	newCollationRd  *rowcodec.BytesDecoder
+	newCollationIds map[int64]int
+}
+
+type idxScanCtx struct {
+	pkStatus  int
+	columnLen int
+	colInfos  []rowcodec.ColInfo
+}
+
+type aggCtx struct {
+	col *tipb.ColumnInfo
+}
+
+type selectionCtx struct {
+	conditions []expression.Expression
+}
+
+type topNCtx struct {
+	heap         *topNHeap
+	orderByExprs []expression.Expression
+	sortRow      *sortRow
+}
+
+func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
+	err := e.checkRangeLock()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	dbReader := e.dbReader
+	for i, ran := range e.kvRanges {
+		if e.unique && ran.IsPoint() {
+			val, err := dbReader.Get(ran.StartKey, e.startTS)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			if len(val) == 0 {
+				continue
+			}
+			if e.counts != nil {
+				e.counts[i]++
+			}
+			err = e.processor.Process(ran.StartKey, val)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		} else {
+			oldCnt := e.rowCount
+			if e.scanCtx.desc {
+				err = dbReader.ReverseScan(ran.StartKey, ran.EndKey, math.MaxInt64, e.startTS, e.processor)
+			} else {
+				err = dbReader.Scan(ran.StartKey, ran.EndKey, math.MaxInt64, e.startTS, e.processor)
+			}
+			delta := int64(e.rowCount - oldCnt)
+			if e.counts != nil {
+				e.counts[i] += delta
+			}
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+		}
+		if e.rowCount == e.limit {
+			break
+		}
+	}
+	err = e.processor.Finish()
+	return e.oldChunks, err
+}
+
+func (e *closureExecutor) checkRangeLock() error {
+	if !e.ignoreLock && !e.lockChecked {
+		for _, ran := range e.kvRanges {
+			err := e.checkRangeLockForRange(ran)
+			if err != nil {
+				return err
+			}
+		}
+		e.lockChecked = true
+	}
+	return nil
+}
+
+func (e *closureExecutor) checkRangeLockForRange(ran kv.KeyRange) error {
+	it := e.lockStore.NewIterator()
+	for it.Seek(ran.StartKey); it.Valid(); it.Next() {
+		if exceedEndKey(it.Key(), ran.EndKey) {
+			break
+		}
+		lock := mvcc.DecodeLock(it.Value())
+		err := checkLock(lock, it.Key(), e.startTS, e.resolvedLocks)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type countStarProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+// countStarProcess is used for `count(*)`.
+func (e *countStarProcessor) Process(key, value []byte) error {
+	e.rowCount++
+	return nil
+}
+
+func (e *countStarProcessor) Finish() error {
+	return e.countFinish()
+}
+
+// countFinish is used for `count(*)`.
+func (e *closureExecutor) countFinish() error {
+	d := types.NewIntDatum(int64(e.rowCount))
+	rowData, err := codec.EncodeValue(e.sc, nil, d)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	e.oldChunks = appendRow(e.oldChunks, rowData, 0)
+	return nil
+}
+
+type countColumnProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+func (e *countColumnProcessor) Process(key, value []byte) error {
+	if e.idxScanCtx != nil {
+		values, _, err := tablecodec.CutIndexKeyNew(key, e.idxScanCtx.columnLen)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if values[0][0] != codec.NilFlag {
+			e.rowCount++
+		}
+	} else {
+		// Since the handle value doesn't affect the count result, we don't need to decode the handle.
+		isNull, err := e.scanCtx.decoder.ColumnIsNull(value, e.aggCtx.col.ColumnId, e.aggCtx.col.DefaultVal)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if !isNull {
+			e.rowCount++
+		}
+	}
+	return nil
+}
+
+func (e *countColumnProcessor) Finish() error {
+	return e.countFinish()
+}
+
+type skipVal bool
+
+func (s skipVal) SkipValue() bool {
+	return bool(s)
+}
+
+type tableScanProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+func (e *tableScanProcessor) Process(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return dbreader.ScanBreak
+	}
+	e.rowCount++
+	err := e.tableScanProcessCore(key, value)
+	if e.scanCtx.chk.NumRows() == chunkMaxRows {
+		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	return err
+}
+
+func (e *tableScanProcessor) Finish() error {
+	return e.scanFinish()
+}
+
+func (e *closureExecutor) processCore(key, value []byte) error {
+	if e.idxScanCtx != nil {
+		return e.indexScanProcessCore(key, value)
+	}
+	return e.tableScanProcessCore(key, value)
+}
+
+func (e *closureExecutor) hasSelection() bool {
+	return len(e.selectionCtx.conditions) > 0
+}
+
+func (e *closureExecutor) processSelection() (gotRow bool, err error) {
+	chk := e.scanCtx.chk
+	row := chk.GetRow(chk.NumRows() - 1)
+	gotRow = true
+	for _, expr := range e.selectionCtx.conditions {
+		wc := e.sc.WarningCount()
+		d, err := expr.Eval(row)
+		if err != nil {
+			return false, errors.Trace(err)
+		}
+
+		if d.IsNull() {
+			gotRow = false
+		} else {
+			isBool, err := d.ToBool(e.sc)
+			isBool, err = expression.HandleOverflowOnSelection(e.sc, isBool, err)
+			if err != nil {
+				return false, errors.Trace(err)
+			}
+			gotRow = isBool != 0
+		}
+		if !gotRow {
+			if e.sc.WarningCount() > wc {
+				// Deep-copy error object here, because the data it referenced is going to be truncated.
+				warns := e.sc.TruncateWarnings(int(wc))
+				for i, warn := range warns {
+					warns[i].Err = e.copyError(warn.Err)
+				}
+				e.sc.AppendWarnings(warns)
+			}
+			chk.TruncateTo(chk.NumRows() - 1)
+			break
+		}
+	}
+	return
+}
+
+func (e *closureExecutor) copyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	var ret error
+	x := errors.Cause(err)
+	switch y := x.(type) {
+	case *terror.Error:
+		ret = y.ToSQLError()
+	default:
+		ret = errors.New(err.Error())
+	}
+	return ret
+}
+
+func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
+	handle, err := tablecodec.DecodeRowKey(key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = e.scanCtx.decoder.DecodeToChunk(value, handle, e.scanCtx.chk)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+func (e *closureExecutor) scanFinish() error {
+	return e.chunkToOldChunk(e.scanCtx.chk)
+}
+
+type indexScanProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+func (e *indexScanProcessor) Process(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return dbreader.ScanBreak
+	}
+	e.rowCount++
+	err := e.indexScanProcessCore(key, value)
+	if e.scanCtx.chk.NumRows() == chunkMaxRows {
+		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	return err
+}
+
+func (e *indexScanProcessor) Finish() error {
+	return e.scanFinish()
+}
+
+func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
+	if len(value) > tablecodec.MaxOldEncodeValueLen {
+		return e.indexScanProcessNewCollation(key, value)
+	}
+	return e.indexScanProcessOldCollation(key, value)
+}
+
+func (e *closureExecutor) indexScanProcessNewCollation(key, value []byte) error {
+	colLen := e.idxScanCtx.columnLen
+	pkStatus := e.idxScanCtx.pkStatus
+	chk := e.scanCtx.chk
+	rd := e.scanCtx.newCollationRd
+	colIDs := e.scanCtx.newCollationIds
+
+	vLen := len(value)
+	tailLen := int(value[0])
+	values, err := rd.DecodeToBytesNoHandle(colIDs, value[1:vLen-tailLen])
+	if err != nil {
+		return errors.Trace(err)
+	}
+	decoder := codec.NewDecoder(chk, e.sc.TimeZone)
+	for i, colVal := range values {
+		_, err = decoder.DecodeOne(colVal, i, e.fieldTps[i])
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
+	if tailLen < 8 {
+		if pkStatus != pkColNotExists {
+			_, err = decoder.DecodeOne(key[len(key)-9:], colLen, e.fieldTps[colLen])
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	} else if pkStatus != pkColNotExists {
+		chk.AppendInt64(colLen, int64(binary.BigEndian.Uint64(value[vLen-tailLen:])))
+	}
+	return nil
+}
+
+func (e *closureExecutor) indexScanProcessOldCollation(key, value []byte) error {
+	colLen := e.idxScanCtx.columnLen
+	pkStatus := e.idxScanCtx.pkStatus
+	chk := e.scanCtx.chk
+	values, b, err := tablecodec.CutIndexKeyNew(key, colLen)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	decoder := codec.NewDecoder(chk, e.sc.TimeZone)
+	for i, colVal := range values {
+		_, err = decoder.DecodeOne(colVal, i, e.fieldTps[i])
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if len(b) > 0 {
+		if pkStatus != pkColNotExists {
+			_, err = decoder.DecodeOne(b, colLen, e.fieldTps[colLen])
+			if err != nil {
+				return errors.Trace(err)
+			}
+		}
+	} else if pkStatus != pkColNotExists {
+		chk.AppendInt64(colLen, int64(binary.BigEndian.Uint64(value)))
+	}
+	return nil
+}
+
+func (e *closureExecutor) chunkToOldChunk(chk *chunk.Chunk) error {
+	var oldRow []types.Datum
+	for i := 0; i < chk.NumRows(); i++ {
+		oldRow = oldRow[:0]
+		for _, outputOff := range e.outputOff {
+			d := chk.GetRow(i).GetDatum(int(outputOff), e.fieldTps[outputOff])
+			oldRow = append(oldRow, d)
+		}
+		var err error
+		e.oldRowBuf, err = codec.EncodeValue(e.sc, e.oldRowBuf[:0], oldRow...)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		e.oldChunks = appendRow(e.oldChunks, e.oldRowBuf, i)
+	}
+	chk.Reset()
+	return nil
+}
+
+type selectionProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+func (e *selectionProcessor) Process(key, value []byte) error {
+	if e.rowCount == e.limit {
+		return dbreader.ScanBreak
+	}
+	err := e.processCore(key, value)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	gotRow, err := e.processSelection()
+	if err != nil {
+		return err
+	}
+	if gotRow {
+		e.rowCount++
+		if e.scanCtx.chk.NumRows() == chunkMaxRows {
+			err = e.chunkToOldChunk(e.scanCtx.chk)
+		}
+	}
+	return err
+}
+
+func (e *selectionProcessor) Finish() error {
+	return e.scanFinish()
+}
+
+type topNProcessor struct {
+	skipVal
+	*closureExecutor
+}
+
+func (e *topNProcessor) Process(key, value []byte) (err error) {
+	if err = e.processCore(key, value); err != nil {
+		return err
+	}
+	if e.hasSelection() {
+		gotRow, err1 := e.processSelection()
+		if err1 != nil || !gotRow {
+			return err1
+		}
+	}
+
+	ctx := e.topNCtx
+	row := e.scanCtx.chk.GetRow(0)
+	for i, expr := range ctx.orderByExprs {
+		d, err := expr.Eval(row)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		d.Copy(&ctx.sortRow.key[i])
+	}
+	e.scanCtx.chk.Reset()
+
+	if ctx.heap.tryToAddRow(ctx.sortRow) {
+		ctx.sortRow.data[0] = safeCopy(key)
+		ctx.sortRow.data[1] = safeCopy(value)
+		ctx.sortRow = e.newTopNSortRow()
+	}
+	return errors.Trace(ctx.heap.err)
+}
+
+func (e *closureExecutor) newTopNSortRow() *sortRow {
+	return &sortRow{
+		key:  make([]types.Datum, len(e.evalContext.columnInfos)),
+		data: make([][]byte, 2),
+	}
+}
+
+func (e *topNProcessor) Finish() error {
+	ctx := e.topNCtx
+	sort.Sort(&ctx.heap.topNSorter)
+	chk := e.scanCtx.chk
+	for _, row := range ctx.heap.rows {
+		err := e.processCore(row.data[0], row.data[1])
+		if err != nil {
+			return err
+		}
+		if chk.NumRows() == chunkMaxRows {
+			if err = e.chunkToOldChunk(chk); err != nil {
+				return errors.Trace(err)
+			}
+		}
+	}
+	return e.chunkToOldChunk(chk)
+}
+
+type hashAggProcessor struct {
+	skipVal
+	*closureExecutor
+
+	aggExprs     []aggregation.Aggregation
+	groupByExprs []expression.Expression
+	groups       map[string]struct{}
+	groupKeys    [][]byte
+	aggCtxsMap   map[string][]*aggregation.AggEvaluateContext
+}
+
+func (e *hashAggProcessor) Process(key, value []byte) (err error) {
+	err = e.processCore(key, value)
+	if err != nil {
+		return err
+	}
+	if e.hasSelection() {
+		gotRow, err1 := e.processSelection()
+		if err1 != nil || !gotRow {
+			return err1
+		}
+	}
+	row := e.scanCtx.chk.GetRow(e.scanCtx.chk.NumRows() - 1)
+	gk, err := e.getGroupKey(row)
+	if _, ok := e.groups[string(gk)]; !ok {
+		e.groups[string(gk)] = struct{}{}
+		e.groupKeys = append(e.groupKeys, gk)
+	}
+	// Update aggregate expressions.
+	aggCtxs := e.getContexts(gk)
+	for i, agg := range e.aggExprs {
+		err = agg.Update(aggCtxs[i], e.sc, row)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	e.scanCtx.chk.Reset()
+	return nil
+}
+
+func (e *hashAggProcessor) getGroupKey(row chunk.Row) ([]byte, error) {
+	length := len(e.groupByExprs)
+	if length == 0 {
+		return nil, nil
+	}
+	key := make([]byte, 0, 32)
+	for _, item := range e.groupByExprs {
+		v, err := item.Eval(row)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		b, err := codec.EncodeValue(e.sc, nil, v)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+		key = append(key, b...)
+	}
+	return key, nil
+}
+
+func (e *hashAggProcessor) getContexts(groupKey []byte) []*aggregation.AggEvaluateContext {
+	aggCtxs, ok := e.aggCtxsMap[string(groupKey)]
+	if !ok {
+		aggCtxs = make([]*aggregation.AggEvaluateContext, 0, len(e.aggExprs))
+		for _, agg := range e.aggExprs {
+			aggCtxs = append(aggCtxs, agg.CreateContext(e.sc))
+		}
+		e.aggCtxsMap[string(groupKey)] = aggCtxs
+	}
+	return aggCtxs
+}
+
+func (e *hashAggProcessor) Finish() error {
+	for i, gk := range e.groupKeys {
+		aggCtxs := e.getContexts(gk)
+		e.oldRowBuf = e.oldRowBuf[:0]
+		for i, agg := range e.aggExprs {
+			partialResults := agg.GetPartialResult(aggCtxs[i])
+			var err error
+			e.oldRowBuf, err = codec.EncodeValue(e.sc, e.oldRowBuf, partialResults...)
+			if err != nil {
+				return err
+			}
+		}
+		e.oldRowBuf = append(e.oldRowBuf, gk...)
+		e.oldChunks = appendRow(e.oldChunks, e.oldRowBuf, i)
+	}
+	return nil
+}
+
+func safeCopy(b []byte) []byte {
+	return append([]byte{}, b...)
+}
+
+func checkLock(lock mvcc.MvccLock, key []byte, startTS uint64, resolved []uint64) error {
+	if isResolved(startTS, resolved) {
+		return nil
+	}
+	lockVisible := lock.StartTS < startTS
+	isWriteLock := lock.Op == uint8(kvrpcpb.Op_Put) || lock.Op == uint8(kvrpcpb.Op_Del)
+	isPrimaryGet := startTS == math.MaxUint64 && bytes.Equal(lock.Primary, key)
+	if lockVisible && isWriteLock && !isPrimaryGet {
+		return BuildLockErr(key, lock.Primary, lock.StartTS, uint64(lock.TTL), lock.Op)
+	}
+	return nil
+}
+
+func isResolved(startTS uint64, resolved []uint64) bool {
+	for _, v := range resolved {
+		if startTS == v {
+			return true
+		}
+	}
+	return false
+}
+
+func exceedEndKey(current, endKey []byte) bool {
+	if len(endKey) == 0 {
+		return false
+	}
+	return bytes.Compare(current, endKey) >= 0
+}

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cophandler
 
 import (

--- a/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/store/mockstore/unistore/cophandler/cop_handler.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package cophandler
 
 import (

--- a/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/store/mockstore/unistore/cophandler/cop_handler.go
@@ -1,0 +1,361 @@
+package cophandler
+
+import (
+	"bytes"
+	"fmt"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/ngaut/unistore/lockstore"
+	"github.com/ngaut/unistore/tikv/dbreader"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/collate"
+	"github.com/pingcap/tidb/util/rowcodec"
+	"github.com/pingcap/tipb/go-tipb"
+)
+
+type dagContext struct {
+	*evalContext
+	dbReader      *dbreader.DBReader
+	lockStore     *lockstore.MemStore
+	resolvedLocks []uint64
+	dagReq        *tipb.DAGRequest
+	keyRanges     []*coprocessor.KeyRange
+	startTS       uint64
+}
+
+// HandleCopDAGRequest handles coprocessor DAG request.
+func HandleCopDAGRequest(dbReader *dbreader.DBReader, lockStore *lockstore.MemStore, req *coprocessor.Request) *coprocessor.Response {
+	startTime := time.Now()
+	resp := &coprocessor.Response{}
+	dagCtx, dagReq, err := buildDAG(dbReader, lockStore, req)
+	if err != nil {
+		resp.OtherError = err.Error()
+		return resp
+	}
+	closureExec, err := buildClosureExecutor(dagCtx, dagReq)
+	if err != nil {
+		return buildResp(nil, nil, err, dagCtx.sc.GetWarnings(), time.Since(startTime))
+	}
+	chunks, err := closureExec.execute()
+	return buildResp(chunks, closureExec.counts, err, dagCtx.sc.GetWarnings(), time.Since(startTime))
+}
+
+func buildDAG(reader *dbreader.DBReader, lockStore *lockstore.MemStore, req *coprocessor.Request) (*dagContext, *tipb.DAGRequest, error) {
+	if len(req.Ranges) == 0 {
+		return nil, nil, errors.New("request range is null")
+	}
+	if req.GetTp() != kv.ReqTypeDAG {
+		return nil, nil, errors.Errorf("unsupported request type %d", req.GetTp())
+	}
+
+	dagReq := new(tipb.DAGRequest)
+	err := proto.Unmarshal(req.Data, dagReq)
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+	sc := flagsToStatementContext(dagReq.Flags)
+	sc.TimeZone = time.FixedZone("UTC", int(dagReq.TimeZoneOffset))
+	ctx := &dagContext{
+		evalContext:   &evalContext{sc: sc},
+		dbReader:      reader,
+		lockStore:     lockStore,
+		dagReq:        dagReq,
+		keyRanges:     req.Ranges,
+		startTS:       req.StartTs,
+		resolvedLocks: req.Context.ResolvedLocks,
+	}
+	scanExec := dagReq.Executors[0]
+	if scanExec.Tp == tipb.ExecType_TypeTableScan {
+		ctx.setColumnInfo(scanExec.TblScan.Columns)
+	} else {
+		ctx.setColumnInfo(scanExec.IdxScan.Columns)
+	}
+	return ctx, dagReq, err
+}
+
+func getAggInfo(ctx *dagContext, pbAgg *tipb.Aggregation) ([]aggregation.Aggregation, []expression.Expression, error) {
+	length := len(pbAgg.AggFunc)
+	aggs := make([]aggregation.Aggregation, 0, length)
+	var err error
+	for _, expr := range pbAgg.AggFunc {
+		var aggExpr aggregation.Aggregation
+		aggExpr, err = aggregation.NewDistAggFunc(expr, ctx.fieldTps, ctx.sc)
+		if err != nil {
+			return nil, nil, errors.Trace(err)
+		}
+		aggs = append(aggs, aggExpr)
+	}
+	groupBys, err := convertToExprs(ctx.sc, ctx.fieldTps, pbAgg.GetGroupBy())
+	if err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	return aggs, groupBys, nil
+}
+
+func getTopNInfo(ctx *evalContext, topN *tipb.TopN) (heap *topNHeap, conds []expression.Expression, err error) {
+	pbConds := make([]*tipb.Expr, len(topN.OrderBy))
+	for i, item := range topN.OrderBy {
+		pbConds[i] = item.Expr
+	}
+	heap = &topNHeap{
+		totalCount: int(topN.Limit),
+		topNSorter: topNSorter{
+			orderByItems: topN.OrderBy,
+			sc:           ctx.sc,
+		},
+	}
+	if conds, err = convertToExprs(ctx.sc, ctx.fieldTps, pbConds); err != nil {
+		return nil, nil, errors.Trace(err)
+	}
+
+	return heap, conds, nil
+}
+
+type evalContext struct {
+	colIDs      map[int64]int
+	columnInfos []*tipb.ColumnInfo
+	fieldTps    []*types.FieldType
+	sc          *stmtctx.StatementContext
+}
+
+func (e *evalContext) setColumnInfo(cols []*tipb.ColumnInfo) {
+	e.columnInfos = make([]*tipb.ColumnInfo, len(cols))
+	copy(e.columnInfos, cols)
+
+	e.colIDs = make(map[int64]int, len(e.columnInfos))
+	e.fieldTps = make([]*types.FieldType, 0, len(e.columnInfos))
+	for i, col := range e.columnInfos {
+		ft := fieldTypeFromPBColumn(col)
+		e.fieldTps = append(e.fieldTps, ft)
+		e.colIDs[col.GetColumnId()] = i
+	}
+}
+
+func (e *evalContext) newRowDecoder() (*rowcodec.ChunkDecoder, error) {
+	var (
+		handleColID int64
+		cols        = make([]rowcodec.ColInfo, 0, len(e.columnInfos))
+	)
+	for i := range e.columnInfos {
+		info := e.columnInfos[i]
+		ft := e.fieldTps[i]
+		col := rowcodec.ColInfo{
+			ID:         info.ColumnId,
+			Ft:         ft,
+			IsPKHandle: info.PkHandle,
+		}
+		cols = append(cols, col)
+		if info.PkHandle {
+			handleColID = info.ColumnId
+		}
+	}
+	def := func(i int, chk *chunk.Chunk) error {
+		info := e.columnInfos[i]
+		if info.PkHandle || len(info.DefaultVal) == 0 {
+			chk.AppendNull(i)
+			return nil
+		}
+		decoder := codec.NewDecoder(chk, e.sc.TimeZone)
+		_, err := decoder.DecodeOne(info.DefaultVal, i, e.fieldTps[i])
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	return rowcodec.NewChunkDecoder(cols, []int64{handleColID}, def, e.sc.TimeZone), nil
+}
+
+// decodeRelatedColumnVals decodes data to Datum slice according to the row information.
+func (e *evalContext) decodeRelatedColumnVals(relatedColOffsets []int, value [][]byte, row []types.Datum) error {
+	var err error
+	for _, offset := range relatedColOffsets {
+		row[offset], err = tablecodec.DecodeColumnValue(value[offset], e.fieldTps[offset], e.sc.TimeZone)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// flagsToStatementContext creates a StatementContext from a `tipb.SelectRequest.Flags`.
+func flagsToStatementContext(flags uint64) *stmtctx.StatementContext {
+	sc := new(stmtctx.StatementContext)
+	sc.IgnoreTruncate = (flags & model.FlagIgnoreTruncate) > 0
+	sc.TruncateAsWarning = (flags & model.FlagTruncateAsWarning) > 0
+	sc.InInsertStmt = (flags & model.FlagInInsertStmt) > 0
+	sc.InSelectStmt = (flags & model.FlagInSelectStmt) > 0
+	sc.InDeleteStmt = (flags & model.FlagInUpdateOrDeleteStmt) > 0
+	sc.OverflowAsWarning = (flags & model.FlagOverflowAsWarning) > 0
+	sc.IgnoreZeroInDate = (flags & model.FlagIgnoreZeroInDate) > 0
+	sc.DividedByZeroAsWarning = (flags & model.FlagDividedByZeroAsWarning) > 0
+	return sc
+}
+
+// ErrLocked is returned when trying to Read/Write on a locked key. Client should
+// backoff or cleanup the lock then retry.
+type ErrLocked struct {
+	Key      []byte
+	Primary  []byte
+	StartTS  uint64
+	TTL      uint64
+	LockType uint8
+}
+
+// BuildLockErr generates ErrKeyLocked objects
+func BuildLockErr(key []byte, primaryKey []byte, startTS uint64, TTL uint64, lockType uint8) *ErrLocked {
+	errLocked := &ErrLocked{
+		Key:      key,
+		Primary:  primaryKey,
+		StartTS:  startTS,
+		TTL:      TTL,
+		LockType: lockType,
+	}
+	return errLocked
+}
+
+// Error formats the lock to a string.
+func (e *ErrLocked) Error() string {
+	return fmt.Sprintf("key is locked, key: %q, Type: %v, primary: %q, startTS: %v", e.Key, e.LockType, e.Primary, e.StartTS)
+}
+
+func buildResp(chunks []tipb.Chunk, counts []int64, err error, warnings []stmtctx.SQLWarn, dur time.Duration) *coprocessor.Response {
+	resp := &coprocessor.Response{}
+	selResp := &tipb.SelectResponse{
+		Error:        toPBError(err),
+		Chunks:       chunks,
+		OutputCounts: counts,
+	}
+	if len(warnings) > 0 {
+		selResp.Warnings = make([]*tipb.Error, 0, len(warnings))
+		for i := range warnings {
+			selResp.Warnings = append(selResp.Warnings, toPBError(warnings[i].Err))
+		}
+	}
+	if locked, ok := errors.Cause(err).(*ErrLocked); ok {
+		resp.Locked = &kvrpcpb.LockInfo{
+			Key:         locked.Key,
+			PrimaryLock: locked.Primary,
+			LockVersion: locked.StartTS,
+			LockTtl:     locked.TTL,
+		}
+	}
+	resp.ExecDetails = &kvrpcpb.ExecDetails{
+		HandleTime: &kvrpcpb.HandleTime{ProcessMs: int64(dur / time.Millisecond)},
+	}
+	data, err := proto.Marshal(selResp)
+	if err != nil {
+		resp.OtherError = err.Error()
+		return resp
+	}
+	resp.Data = data
+	return resp
+}
+
+func toPBError(err error) *tipb.Error {
+	if err == nil {
+		return nil
+	}
+	perr := new(tipb.Error)
+	e := errors.Cause(err)
+	switch y := e.(type) {
+	case *terror.Error:
+		tmp := y.ToSQLError()
+		perr.Code = int32(tmp.Code)
+		perr.Msg = tmp.Message
+	case *mysql.SQLError:
+		perr.Code = int32(y.Code)
+		perr.Msg = y.Message
+	default:
+		perr.Code = int32(1)
+		perr.Msg = err.Error()
+	}
+	return perr
+}
+
+// extractKVRanges extracts kv.KeyRanges slice from a SelectRequest.
+func extractKVRanges(startKey, endKey []byte, keyRanges []*coprocessor.KeyRange, descScan bool) (kvRanges []kv.KeyRange, err error) {
+	kvRanges = make([]kv.KeyRange, 0, len(keyRanges))
+	for _, kran := range keyRanges {
+		if bytes.Compare(kran.GetStart(), kran.GetEnd()) >= 0 {
+			err = errors.Errorf("invalid range, start should be smaller than end: %v %v", kran.GetStart(), kran.GetEnd())
+			return
+		}
+
+		upperKey := kran.GetEnd()
+		if bytes.Compare(upperKey, startKey) <= 0 {
+			continue
+		}
+		lowerKey := kran.GetStart()
+		if len(endKey) != 0 && bytes.Compare(lowerKey, endKey) >= 0 {
+			break
+		}
+		r := kv.KeyRange{
+			StartKey: kv.Key(maxStartKey(lowerKey, startKey)),
+			EndKey:   kv.Key(minEndKey(upperKey, endKey)),
+		}
+		kvRanges = append(kvRanges, r)
+	}
+	if descScan {
+		reverseKVRanges(kvRanges)
+	}
+	return
+}
+
+func reverseKVRanges(kvRanges []kv.KeyRange) {
+	for i := 0; i < len(kvRanges)/2; i++ {
+		j := len(kvRanges) - i - 1
+		kvRanges[i], kvRanges[j] = kvRanges[j], kvRanges[i]
+	}
+}
+
+func maxStartKey(rangeStartKey kv.Key, regionStartKey []byte) []byte {
+	if bytes.Compare([]byte(rangeStartKey), regionStartKey) > 0 {
+		return []byte(rangeStartKey)
+	}
+	return regionStartKey
+}
+
+func minEndKey(rangeEndKey kv.Key, regionEndKey []byte) []byte {
+	if len(regionEndKey) == 0 || bytes.Compare([]byte(rangeEndKey), regionEndKey) < 0 {
+		return []byte(rangeEndKey)
+	}
+	return regionEndKey
+}
+
+const rowsPerChunk = 64
+
+func appendRow(chunks []tipb.Chunk, data []byte, rowCnt int) []tipb.Chunk {
+	if rowCnt%rowsPerChunk == 0 {
+		chunks = append(chunks, tipb.Chunk{})
+	}
+	cur := &chunks[len(chunks)-1]
+	cur.RowsData = append(cur.RowsData, data...)
+	return chunks
+}
+
+// fieldTypeFromPBColumn creates a types.FieldType from tipb.ColumnInfo.
+func fieldTypeFromPBColumn(col *tipb.ColumnInfo) *types.FieldType {
+	return &types.FieldType{
+		Tp:      byte(col.GetTp()),
+		Flag:    uint(col.Flag),
+		Flen:    int(col.GetColumnLen()),
+		Decimal: int(col.GetDecimal()),
+		Elems:   col.Elems,
+		Collate: mysql.Collations[uint8(collate.RestoreCollationIDIfNeeded(col.GetCollation()))],
+	}
+}

--- a/store/mockstore/unistore/cophandler/cop_handler_test.go
+++ b/store/mockstore/unistore/cophandler/cop_handler_test.go
@@ -1,0 +1,486 @@
+// Copyright 2019-present PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cophandler
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/coocood/badger"
+	"github.com/coocood/badger/y"
+	"github.com/ngaut/unistore/lockstore"
+	"github.com/ngaut/unistore/tikv/dbreader"
+	"github.com/ngaut/unistore/tikv/mvcc"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/coprocessor"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/rowcodec"
+	"github.com/pingcap/tipb/go-tipb"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+type testSuite struct{}
+
+func (ts testSuite) SetUpSuite(c *C) {}
+
+func (ts testSuite) TearDownSuite(c *C) {}
+
+var _ = Suite(testSuite{})
+
+const (
+	keyNumber         = 3
+	tableID           = 0
+	startTs           = 10
+	ttl               = 60000
+	dagRequestStartTs = 100
+)
+
+// wrapper of test data, including encoded data, column types etc.
+type data struct {
+	encodedTestKVDatas []*encodedTestKVData
+	colInfos           []*tipb.ColumnInfo
+	rows               map[int64][]types.Datum    // handle -> row
+	colTypes           map[int64]*types.FieldType // colId -> fieldType
+}
+
+type encodedTestKVData struct {
+	encodedRowKey   []byte
+	encodedRowValue []byte
+}
+
+func initTestData(store *testStore, encodedKVDatas []*encodedTestKVData) []error {
+	i := 0
+	for _, kvData := range encodedKVDatas {
+		mutation := makeATestMutaion(kvrpcpb.Op_Put, kvData.encodedRowKey,
+			kvData.encodedRowValue)
+		req := &kvrpcpb.PrewriteRequest{
+			Mutations:    []*kvrpcpb.Mutation{mutation},
+			PrimaryLock:  kvData.encodedRowKey,
+			StartVersion: uint64(startTs + i),
+			LockTtl:      ttl,
+		}
+		store.prewrite(req)
+		commitError := store.commit([][]byte{kvData.encodedRowKey},
+			uint64(startTs+i), uint64(startTs+i+1))
+		if commitError != nil {
+			return []error{commitError}
+		}
+		i += 2
+	}
+	return nil
+}
+
+func makeATestMutaion(op kvrpcpb.Op, key []byte, value []byte) *kvrpcpb.Mutation {
+	return &kvrpcpb.Mutation{
+		Op:    op,
+		Key:   key,
+		Value: value,
+	}
+}
+
+func prepareTestTableData(c *C, keyNumber int, tableID int64) *data {
+	stmtCtx := new(stmtctx.StatementContext)
+	colIds := []int64{1, 2, 3}
+	colTypes := []*types.FieldType{
+		types.NewFieldType(mysql.TypeLonglong),
+		types.NewFieldType(mysql.TypeString),
+		types.NewFieldType(mysql.TypeDouble),
+	}
+	colInfos := make([]*tipb.ColumnInfo, 3)
+	colTypeMap := map[int64]*types.FieldType{}
+	for i := 0; i < 3; i++ {
+		colInfos[i] = &tipb.ColumnInfo{
+			ColumnId: colIds[i],
+			Tp:       int32(colTypes[i].Tp),
+		}
+		colTypeMap[colIds[i]] = colTypes[i]
+	}
+	rows := map[int64][]types.Datum{}
+	encodedTestKVDatas := make([]*encodedTestKVData, keyNumber)
+	encoder := &rowcodec.Encoder{Enable: true}
+	for i := 0; i < keyNumber; i++ {
+		datum := types.MakeDatums(i, "abc", 10.0)
+		rows[int64(i)] = datum
+		rowEncodedData, err := tablecodec.EncodeRow(stmtCtx, datum, colIds, nil, nil, encoder)
+		c.Assert(err, IsNil)
+		rowKeyEncodedData := tablecodec.EncodeRowKeyWithHandle(tableID, kv.IntHandle(i))
+		encodedTestKVDatas[i] = &encodedTestKVData{encodedRowKey: rowKeyEncodedData, encodedRowValue: rowEncodedData}
+	}
+	return &data{
+		colInfos:           colInfos,
+		encodedTestKVDatas: encodedTestKVDatas,
+		rows:               rows,
+		colTypes:           colTypeMap,
+	}
+}
+
+func getTestPointRange(tableID int64, handle int64) kv.KeyRange {
+	startKey := tablecodec.EncodeRowKeyWithHandle(tableID, kv.IntHandle(handle))
+	endKey := make([]byte, len(startKey))
+	copy(endKey, startKey)
+	convertToPrefixNext(endKey)
+	return kv.KeyRange{
+		StartKey: startKey,
+		EndKey:   endKey,
+	}
+}
+
+// convert this key to the smallest key which is larger than the key given.
+// see tikv/src/coprocessor/util.rs for more detail.
+func convertToPrefixNext(key []byte) []byte {
+	if len(key) == 0 {
+		return []byte{0}
+	}
+	for i := len(key) - 1; i >= 0; i-- {
+		if key[i] == 255 {
+			key[i] = 0
+		} else {
+			key[i] += 1
+			return key
+		}
+	}
+	for i := 0; i < len(key); i++ {
+		key[i] = 255
+	}
+	return append(key, 0)
+}
+
+// return whether these two keys are equal.
+func isPrefixNext(key []byte, expected []byte) bool {
+	key = convertToPrefixNext(key)
+	if len(key) != len(expected) {
+		return false
+	}
+	for i := 0; i < len(key); i++ {
+		if key[i] != expected[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// return a dag context according to dagReq and key ranges.
+func newDagContext(store *testStore, keyRanges []kv.KeyRange, dagReq *tipb.DAGRequest, startTs uint64) *dagContext {
+	sc := flagsToStatementContext(dagReq.Flags)
+	txn := store.db.NewTransaction(false)
+	dagCtx := &dagContext{
+		evalContext: &evalContext{sc: sc},
+		dbReader:    dbreader.NewDBReader(nil, []byte{255}, txn),
+		lockStore:   store.locks,
+		dagReq:      dagReq,
+		startTS:     startTs,
+	}
+	if dagReq.Executors[0].Tp == tipb.ExecType_TypeTableScan {
+		dagCtx.setColumnInfo(dagReq.Executors[0].TblScan.Columns)
+	} else {
+		dagCtx.setColumnInfo(dagReq.Executors[0].IdxScan.Columns)
+	}
+	dagCtx.keyRanges = make([]*coprocessor.KeyRange, len(keyRanges))
+	for i, keyRange := range keyRanges {
+		dagCtx.keyRanges[i] = &coprocessor.KeyRange{
+			Start: keyRange.StartKey,
+			End:   keyRange.EndKey,
+		}
+	}
+	return dagCtx
+}
+
+// build and execute the executors according to the dagRequest and dagContext,
+// return the result chunk data, rows count and err if occurs.
+func buildExecutorsAndExecute(dagRequest *tipb.DAGRequest,
+	dagCtx *dagContext) ([]tipb.Chunk, int, error) {
+	closureExec, err := buildClosureExecutor(dagCtx, dagRequest)
+	if err != nil {
+		return nil, 0, err
+	}
+	if closureExec != nil {
+		chunks, err := closureExec.execute()
+		if err != nil {
+			return nil, 0, err
+		}
+		return chunks, closureExec.rowCount, nil
+	}
+	return nil, 0, errors.New("closureExec creation failed")
+}
+
+// dagBuilder is used to build dag request
+type dagBuilder struct {
+	startTs       uint64
+	executors     []*tipb.Executor
+	outputOffsets []uint32
+}
+
+// return a default dagBuilder
+func newDagBuilder() *dagBuilder {
+	return &dagBuilder{executors: make([]*tipb.Executor, 0)}
+}
+
+func (dagBuilder *dagBuilder) setStartTs(startTs uint64) *dagBuilder {
+	dagBuilder.startTs = startTs
+	return dagBuilder
+}
+
+func (dagBuilder *dagBuilder) setOutputOffsets(outputOffsets []uint32) *dagBuilder {
+	dagBuilder.outputOffsets = outputOffsets
+	return dagBuilder
+}
+
+func (dagBuilder *dagBuilder) addTableScan(colInfos []*tipb.ColumnInfo, tableID int64) *dagBuilder {
+	dagBuilder.executors = append(dagBuilder.executors, &tipb.Executor{
+		Tp: tipb.ExecType_TypeTableScan,
+		TblScan: &tipb.TableScan{
+			Columns: colInfos,
+			TableId: tableID,
+		},
+	})
+	return dagBuilder
+}
+
+func (dagBuilder *dagBuilder) addSelection(expr *tipb.Expr) *dagBuilder {
+	dagBuilder.executors = append(dagBuilder.executors, &tipb.Executor{
+		Tp: tipb.ExecType_TypeSelection,
+		Selection: &tipb.Selection{
+			Conditions:       []*tipb.Expr{expr},
+			XXX_unrecognized: nil,
+		},
+	})
+	return dagBuilder
+}
+
+func (dagBuilder *dagBuilder) addLimit(limit uint64) *dagBuilder {
+	dagBuilder.executors = append(dagBuilder.executors, &tipb.Executor{
+		Tp:    tipb.ExecType_TypeLimit,
+		Limit: &tipb.Limit{Limit: limit},
+	})
+	return dagBuilder
+}
+
+func (dagBuilder *dagBuilder) build() *tipb.DAGRequest {
+	return &tipb.DAGRequest{
+		Executors:     dagBuilder.executors,
+		OutputOffsets: dagBuilder.outputOffsets,
+	}
+}
+
+// see tikv/src/coprocessor/util.rs for more detail
+func (ts testSuite) TestIsPrefixNext(c *C) {
+	c.Assert(isPrefixNext([]byte{}, []byte{0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0}, []byte{1}), IsTrue)
+	c.Assert(isPrefixNext([]byte{1}, []byte{2}), IsTrue)
+	c.Assert(isPrefixNext([]byte{255}, []byte{255, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{255, 255, 255}, []byte{255, 255, 255, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{1, 255}, []byte{2, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0, 1, 255}, []byte{0, 2, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0, 1, 255, 5}, []byte{0, 1, 255, 6}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0, 1, 5, 255}, []byte{0, 1, 6, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0, 1, 255, 255}, []byte{0, 2, 0, 0}), IsTrue)
+	c.Assert(isPrefixNext([]byte{0, 255, 255, 255}, []byte{1, 0, 0, 0}), IsTrue)
+}
+
+func (ts testSuite) TestPointGet(c *C) {
+	// here would build mvccStore and server, and prepare
+	// three rows data, just like the test data of table_scan.rs.
+	// then init the store with the generated data.
+	data := prepareTestTableData(c, keyNumber, tableID)
+	store, err := newTestStore("cop_handler_test_db", "cop_handler_test_log")
+	defer cleanTestStore(store)
+	c.Assert(err, IsNil)
+	errors := initTestData(store, data.encodedTestKVDatas)
+	c.Assert(errors, IsNil)
+
+	// point get should return nothing when handle is math.MinInt64
+	handle := int64(math.MinInt64)
+	dagRequest := newDagBuilder().
+		setStartTs(dagRequestStartTs).
+		addTableScan(data.colInfos, tableID).
+		setOutputOffsets([]uint32{0, 1}).
+		build()
+	dagCtx := newDagContext(store, []kv.KeyRange{getTestPointRange(tableID, handle)},
+		dagRequest, dagRequestStartTs)
+	chunks, rowCount, err := buildExecutorsAndExecute(dagRequest, dagCtx)
+	c.Assert(len(chunks), Equals, 0)
+	c.Assert(err, IsNil)
+	c.Assert(rowCount, Equals, 0)
+
+	// point get should return one row when handle = 0
+	handle = 0
+	dagRequest = newDagBuilder().
+		setStartTs(dagRequestStartTs).
+		addTableScan(data.colInfos, tableID).
+		setOutputOffsets([]uint32{0, 1}).
+		build()
+	dagCtx = newDagContext(store, []kv.KeyRange{getTestPointRange(tableID, handle)},
+		dagRequest, dagRequestStartTs)
+	chunks, rowCount, err = buildExecutorsAndExecute(dagRequest, dagCtx)
+	c.Assert(err, IsNil)
+	c.Assert(rowCount, Equals, 1)
+	returnedRow, err := codec.Decode(chunks[0].RowsData, 2)
+	c.Assert(err, IsNil)
+	// returned row should has 2 cols
+	c.Assert(len(returnedRow), Equals, 2)
+
+	// verify the returned rows value as input
+	expectedRow := data.rows[handle]
+	eq, err := returnedRow[0].CompareDatum(nil, &expectedRow[0])
+	c.Assert(err, IsNil)
+	c.Assert(eq, Equals, 0)
+	eq, err = returnedRow[1].CompareDatum(nil, &expectedRow[1])
+	c.Assert(err, IsNil)
+	c.Assert(eq, Equals, 0)
+}
+
+func (ts testSuite) TestClosureExecutor(c *C) {
+	data := prepareTestTableData(c, keyNumber, tableID)
+	store, err := newTestStore("cop_handler_test_db", "cop_handler_test_log")
+	defer cleanTestStore(store)
+	c.Assert(err, IsNil)
+	errors := initTestData(store, data.encodedTestKVDatas)
+	c.Assert(errors, IsNil)
+
+	dagRequest := newDagBuilder().
+		setStartTs(dagRequestStartTs).
+		addTableScan(data.colInfos, tableID).
+		addSelection(buildEQIntExpr(1, -1)).
+		addLimit(1).
+		setOutputOffsets([]uint32{0, 1}).
+		build()
+
+	dagCtx := newDagContext(store, []kv.KeyRange{getTestPointRange(tableID, 1)},
+		dagRequest, dagRequestStartTs)
+	_, rowCount, err := buildExecutorsAndExecute(dagRequest, dagCtx)
+	c.Assert(err, IsNil)
+	c.Assert(rowCount, Equals, 0)
+}
+
+func buildEQIntExpr(colID, val int64) *tipb.Expr {
+	return &tipb.Expr{
+		Tp:        tipb.ExprType_ScalarFunc,
+		Sig:       tipb.ScalarFuncSig_EQInt,
+		FieldType: expression.ToPBFieldType(types.NewFieldType(mysql.TypeLonglong)),
+		Children: []*tipb.Expr{
+			{
+				Tp:        tipb.ExprType_ColumnRef,
+				Val:       codec.EncodeInt(nil, colID),
+				FieldType: expression.ToPBFieldType(types.NewFieldType(mysql.TypeLonglong)),
+			},
+			{
+				Tp:        tipb.ExprType_Int64,
+				Val:       codec.EncodeInt(nil, val),
+				FieldType: expression.ToPBFieldType(types.NewFieldType(mysql.TypeLonglong)),
+			},
+		},
+	}
+}
+
+type testStore struct {
+	db      *badger.DB
+	locks   *lockstore.MemStore
+	dbPath  string
+	logPath string
+}
+
+func (ts *testStore) prewrite(req *kvrpcpb.PrewriteRequest) {
+	for _, m := range req.Mutations {
+		lock := &mvcc.MvccLock{
+			MvccLockHdr: mvcc.MvccLockHdr{
+				StartTS:     req.StartVersion,
+				ForUpdateTS: req.ForUpdateTs,
+				TTL:         uint32(req.LockTtl),
+				PrimaryLen:  uint16(len(req.PrimaryLock)),
+				MinCommitTS: req.MinCommitTs,
+				Op:          uint8(m.Op),
+			},
+			Primary: req.PrimaryLock,
+			Value:   m.Value,
+		}
+		ts.locks.Put(m.Key, lock.MarshalBinary())
+	}
+}
+
+func (ts *testStore) commit(keys [][]byte, startTS, commitTS uint64) error {
+	return ts.db.Update(func(txn *badger.Txn) error {
+		for _, key := range keys {
+			lock := mvcc.DecodeLock(ts.locks.Get(key, nil))
+			userMeta := mvcc.NewDBUserMeta(startTS, commitTS)
+			err := txn.SetEntry(&badger.Entry{
+				Key:      y.KeyWithTs(key, commitTS),
+				Value:    lock.Value,
+				UserMeta: userMeta,
+			})
+			if err != nil {
+				return err
+			}
+			ts.locks.Delete(key)
+		}
+		return nil
+	})
+}
+
+func newTestStore(dbPrefix string, logPrefix string) (*testStore, error) {
+	dbPath, err := ioutil.TempDir("", dbPrefix)
+	if err != nil {
+		return nil, err
+	}
+	LogPath, err := ioutil.TempDir("", logPrefix)
+	if err != nil {
+		return nil, err
+	}
+	db, err := createTestDB(dbPath, LogPath)
+	if err != nil {
+		return nil, err
+	}
+	// Some raft store path problems could not be found using simple store in tests
+	// writer := NewDBWriter(dbBundle, safePoint)
+	kvPath := filepath.Join(dbPath, "kv")
+	raftPath := filepath.Join(dbPath, "raft")
+	snapPath := filepath.Join(dbPath, "snap")
+	os.MkdirAll(kvPath, os.ModePerm)
+	os.MkdirAll(raftPath, os.ModePerm)
+	os.Mkdir(snapPath, os.ModePerm)
+	return &testStore{
+		db:      db,
+		locks:   lockstore.NewMemStore(4096),
+		dbPath:  dbPath,
+		logPath: LogPath,
+	}, nil
+}
+
+func createTestDB(dbPath, LogPath string) (*badger.DB, error) {
+	subPath := fmt.Sprintf("/%d", 0)
+	opts := badger.DefaultOptions
+	opts.Dir = dbPath + subPath
+	opts.ValueDir = LogPath + subPath
+	opts.ManagedTxns = true
+	return badger.Open(opts)
+}
+
+func cleanTestStore(store *testStore) {
+	os.RemoveAll(store.dbPath)
+	os.RemoveAll(store.logPath)
+}

--- a/store/mockstore/unistore/cophandler/cop_handler_test.go
+++ b/store/mockstore/unistore/cophandler/cop_handler_test.go
@@ -22,11 +22,11 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/coocood/badger"
-	"github.com/coocood/badger/y"
 	"github.com/ngaut/unistore/lockstore"
 	"github.com/ngaut/unistore/tikv/dbreader"
 	"github.com/ngaut/unistore/tikv/mvcc"
+	"github.com/pingcap/badger"
+	"github.com/pingcap/badger/y"
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"

--- a/store/mockstore/unistore/cophandler/topn.go
+++ b/store/mockstore/unistore/cophandler/topn.go
@@ -1,0 +1,139 @@
+// Copyright 2019-present PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cophandler
+
+import (
+	"container/heap"
+
+	"github.com/juju/errors"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/types"
+	tipb "github.com/pingcap/tipb/go-tipb"
+)
+
+type sortRow struct {
+	key  []types.Datum
+	data [][]byte
+}
+
+// topNSorter implements sort.Interface. When all rows have been processed, the topNSorter will sort the whole data in heap.
+type topNSorter struct {
+	orderByItems []*tipb.ByItem
+	rows         []*sortRow
+	err          error
+	sc           *stmtctx.StatementContext
+}
+
+func (t *topNSorter) Len() int {
+	return len(t.rows)
+}
+
+func (t *topNSorter) Swap(i, j int) {
+	t.rows[i], t.rows[j] = t.rows[j], t.rows[i]
+}
+
+func (t *topNSorter) Less(i, j int) bool {
+	for index, by := range t.orderByItems {
+		v1 := t.rows[i].key[index]
+		v2 := t.rows[j].key[index]
+
+		ret, err := v1.CompareDatum(t.sc, &v2)
+		if err != nil {
+			t.err = errors.Trace(err)
+			return true
+		}
+
+		if by.Desc {
+			ret = -ret
+		}
+
+		if ret < 0 {
+			return true
+		} else if ret > 0 {
+			return false
+		}
+	}
+
+	return false
+}
+
+// topNHeap holds the top n elements using heap structure. It implements heap.Interface.
+// When we insert a row, topNHeap will check if the row can become one of the top n element or not.
+type topNHeap struct {
+	topNSorter
+
+	// totalCount is equal to the limit count, which means the max size of heap.
+	totalCount int
+	// heapSize means the current size of this heap.
+	heapSize int
+}
+
+func (t *topNHeap) Len() int {
+	return t.heapSize
+}
+
+func (t *topNHeap) Push(x interface{}) {
+	t.rows = append(t.rows, x.(*sortRow))
+	t.heapSize++
+}
+
+func (t *topNHeap) Pop() interface{} {
+	return nil
+}
+
+func (t *topNHeap) Less(i, j int) bool {
+	for index, by := range t.orderByItems {
+		v1 := t.rows[i].key[index]
+		v2 := t.rows[j].key[index]
+
+		ret, err := v1.CompareDatum(t.sc, &v2)
+		if err != nil {
+			t.err = errors.Trace(err)
+			return true
+		}
+
+		if by.Desc {
+			ret = -ret
+		}
+
+		if ret > 0 {
+			return true
+		} else if ret < 0 {
+			return false
+		}
+	}
+
+	return false
+}
+
+// tryToAddRow tries to add a row to heap.
+// When this row is not less than any rows in heap, it will never become the top n element.
+// Then this function returns false.
+func (t *topNHeap) tryToAddRow(row *sortRow) bool {
+	success := false
+	if t.heapSize == t.totalCount {
+		t.rows = append(t.rows, row)
+		// When this row is less than the top element, it will replace it and adjust the heap structure.
+		if t.Less(0, t.heapSize) {
+			t.Swap(0, t.heapSize)
+			heap.Fix(t, 0)
+			success = true
+		}
+		t.rows = t.rows[:t.heapSize]
+	} else {
+		heap.Push(t, row)
+		success = true
+	}
+	return success
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
So we don't need to change unistore repo to develop clustered index feature.

### What is changed and how it works?

What's Changed:

copy and adapt coprocessor related logic to tidb repo.

How it Works:
unistore would depends on TiDB to handle coprocessor request.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
- No release note
