### PR TITLE
infoschema: fix select * from inspection_summary would return null. (#16099)

### DIFF
--- a/executor/inspection_result.go
+++ b/executor/inspection_result.go
@@ -480,7 +480,6 @@ type inspectSwapMemoryUsed struct{}
 
 func (inspectSwapMemoryUsed) genSQL(timeRange plannercore.QueryTimeRange) string {
 	sql := fmt.Sprintf("select instance, max(value) as max_used from metrics_schema.node_memory_swap_used %s group by instance having max_used > 0", timeRange.Condition())
-	fmt.Println(sql)
 	return sql
 }
 

--- a/executor/inspection_summary.go
+++ b/executor/inspection_summary.go
@@ -422,7 +422,7 @@ func (e *inspectionSummaryRetriever) retrieve(ctx context.Context, sctx sessionc
 	condition := e.timeRange.Condition()
 	var finalRows [][]types.Datum
 	for rule, tables := range inspectionSummaryRules {
-		if !rules.exist(rule) {
+		if len(rules.set) != 0 && !rules.set.Exist(rule) {
 			continue
 		}
 		for _, name := range tables {
@@ -435,6 +435,7 @@ func (e *inspectionSummaryRetriever) retrieve(ctx context.Context, sctx sessionc
 				continue
 			}
 			cols := def.Labels
+			comment := def.Comment
 			cond := condition
 			if def.Quantile > 0 {
 				cols = append(cols, "quantile")
@@ -493,6 +494,7 @@ func (e *inspectionSummaryRetriever) retrieve(ctx context.Context, sctx sessionc
 					row.GetFloat64(0), // avg
 					row.GetFloat64(1), // min
 					row.GetFloat64(2), // max
+					comment,
 				))
 			}
 		}

--- a/executor/inspection_summary_test.go
+++ b/executor/inspection_summary_test.go
@@ -101,11 +101,22 @@ func (s *inspectionSummarySuite) TestInspectionSummary(c *C) {
 	result := tk.ResultSetToResultWithCtx(ctx, rs[0], Commentf("execute inspect SQL failed"))
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(0), Commentf("unexpected warnings: %+v", tk.Se.GetSessionVars().StmtCtx.GetWarnings()))
 	result.Check(testkit.Rows(
-		"query-summary tikv-0 tidb_query_duration Select 0.99 0 0 0",
-		"query-summary tikv-1 tidb_query_duration Update 0.99 2 1 3",
-		"query-summary tikv-2 tidb_query_duration Delete 0.99 5 5 5",
-		"query-summary tidb-0 tidb_qps Query, Error <nil> 1 1 1",
-		"query-summary tidb-0 tidb_qps Query, OK <nil> 0 0 0",
-		"query-summary tidb-1 tidb_qps Quit, Error <nil> 7 5 9",
+		"query-summary tikv-0 tidb_query_duration Select 0.99 0 0 0 The quantile of TiDB query durations(second)",
+		"query-summary tikv-1 tidb_query_duration Update 0.99 2 1 3 The quantile of TiDB query durations(second)",
+		"query-summary tikv-2 tidb_query_duration Delete 0.99 5 5 5 The quantile of TiDB query durations(second)",
+		"query-summary tidb-0 tidb_qps Query, Error <nil> 1 1 1 TiDB query processing numbers per second",
+		"query-summary tidb-0 tidb_qps Query, OK <nil> 0 0 0 TiDB query processing numbers per second",
+		"query-summary tidb-1 tidb_qps Quit, Error <nil> 7 5 9 TiDB query processing numbers per second",
+	))
+
+	// Test for select * from information_schema.inspection_summary without specify rules.
+	rs, err = tk.Se.Execute(ctx, "select * from information_schema.inspection_summary where metrics_name = 'tidb_qps'")
+	c.Assert(err, IsNil)
+	result = tk.ResultSetToResultWithCtx(ctx, rs[0], Commentf("execute inspect SQL failed"))
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(0), Commentf("unexpected warnings: %+v", tk.Se.GetSessionVars().StmtCtx.GetWarnings()))
+	result.Check(testkit.Rows(
+		"query-summary tidb-0 tidb_qps Query, Error <nil> 1 1 1 TiDB query processing numbers per second",
+		"query-summary tidb-0 tidb_qps Query, OK <nil> 0 0 0 TiDB query processing numbers per second",
+		"query-summary tidb-1 tidb_qps Quit, Error <nil> 7 5 9 TiDB query processing numbers per second",
 	))
 }

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -962,6 +962,7 @@ var tableInspectionSummaryCols = []columnInfo{
 	{name: "AVG_VALUE", tp: mysql.TypeDouble, size: 22, decimal: 6},
 	{name: "MIN_VALUE", tp: mysql.TypeDouble, size: 22, decimal: 6},
 	{name: "MAX_VALUE", tp: mysql.TypeDouble, size: 22, decimal: 6},
+	{name: "COMMENT", tp: mysql.TypeVarchar, size: 256},
 }
 
 var tableInspectionRulesCols = []columnInfo{


### PR DESCRIPTION
cherry-pick #16254 #16099

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
1. Currently it would return empty results without rule condition.
### What is changed and how it works?
1. Make it return all the results for  `select * from inspection`.
2. Add a column name `COMMENT` to explain the row.

What's Changed:
before:
```
mysql> select * from inspection_summary;
Empty set (0.00 sec)
```

this pr :
```
mysql> select * from inspection_summary limit 10;
+-------+------------------+------------------------------------------+----------------+----------+-----------+-----------+-----------+------------------------------------------------------------------------------------------------------+
| RULE  | INSTANCE         | METRICS_NAME                             | LABEL          | QUANTILE | AVG_VALUE | MIN_VALUE | MAX_VALUE | COMMENT                                                                                              |
+-------+------------------+------------------------------------------+----------------+----------+-----------+-----------+-----------+------------------------------------------------------------------------------------------------------+
| stats | gncluster-tidb-0 | tidb_statistics_auto_analyze_duration    |                |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB auto analyze time durations within 95 percent histogram buckets                 |
| stats | gncluster-tidb-0 | tidb_statistics_fast_analyze_status      | access_regions |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB fast analyze statistics                                                         |
| stats | gncluster-tidb-0 | tidb_statistics_fast_analyze_status      | region_error   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB fast analyze statistics                                                         |
| stats | gncluster-tidb-0 | tidb_statistics_fast_analyze_status      | sample         |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB fast analyze statistics                                                         |
| stats | gncluster-tidb-0 | tidb_statistics_fast_analyze_status      | scan_keys      |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB fast analyze statistics                                                         |
| stats | gncluster-tidb-0 | tidb_statistics_fast_analyze_status      | seek_keys      |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB fast analyze statistics                                                         |
| stats |                  | tidb_statistics_pseudo_estimation_ops    |                |     NULL |  0.000000 |  0.000000 |  0.000000 | TiDB optimizer using pseudo estimation counts                                                        |
| stats |                  | tidb_statistics_significant_feedback     |                |     NULL |  0.000000 |  0.000000 |  0.000000 | Counter of query feedback whose actual count is much different than calculated by current statistics |
| stats | gncluster-tidb-0 | tidb_statistics_stats_inaccuracy_rate    |                |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB statistics inaccurate rate                                                      |
| stats | gncluster-tidb-0 | tidb_statistics_store_query_feedback_qps | ok             |     NULL |  0.044445 |  0.044443 |  0.044445 | TiDB store quering feedback counts                                                                   |
+-------+------------------+------------------------------------------+----------------+----------+-----------+-----------+-----------+------------------------------------------------------------------------------------------------------+
10 rows in set (21.26 sec)

mysql> select * from inspection_summary where rule='query-summary' and metrics_name='tidb_query_duration';
+---------------+------------------+---------------------+----------+----------+-----------+-----------+-----------+----------------------------------------------+
| RULE          | INSTANCE         | METRICS_NAME        | LABEL    | QUANTILE | AVG_VALUE | MIN_VALUE | MAX_VALUE | COMMENT                                      |
+---------------+------------------+---------------------+----------+----------+-----------+-----------+-----------+----------------------------------------------+
| query-summary | gncluster-tidb-0 | tidb_query_duration | Begin    |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Commit   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Delete   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Execute  |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Insert   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Replace  |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Rollback |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Select   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Set      |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Show     |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Update   |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | Use      |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | general  |     0.99 |  0.000000 |  0.000000 |  0.000000 | The quantile of TiDB query durations(second) |
| query-summary | gncluster-tidb-0 | tidb_query_duration | internal |     0.99 |  0.004050 |  0.003934 |  0.005480 | The quantile of TiDB query durations(second) |
+---------------+------------------+---------------------+----------+----------+-----------+-----------+-----------+----------------------------------------------+
14 rows in set (0.09 sec)

```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->
- fix query inspection_summary without condition would return null.