### PR TITLE
tikv: fix "Got too many pings" GRPC error in PD-server follower

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -674,9 +674,8 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 				DialOptions: []grpc.DialOption{
 					grpc.WithBackoffMaxDelay(time.Second * 3),
 					grpc.WithKeepaliveParams(keepalive.ClientParameters{
-						Time:                time.Duration(cfg.TiKVClient.GrpcKeepAliveTime) * time.Second,
-						Timeout:             time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout) * time.Second,
-						PermitWithoutStream: true,
+						Time:    time.Duration(cfg.TiKVClient.GrpcKeepAliveTime) * time.Second,
+						Timeout: time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout) * time.Second,
 					}),
 				},
 				TLS: ebd.TLSConfig(),

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -89,9 +89,8 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 		KeyPath:  security.ClusterSSLKey,
 	}, pd.WithGRPCDialOptions(
 		grpc.WithKeepaliveParams(keepalive.ClientParameters{
-			Time:                time.Duration(tikvConfig.GrpcKeepAliveTime) * time.Second,
-			Timeout:             time.Duration(tikvConfig.GrpcKeepAliveTimeout) * time.Second,
-			PermitWithoutStream: true,
+			Time:    time.Duration(tikvConfig.GrpcKeepAliveTime) * time.Second,
+			Timeout: time.Duration(tikvConfig.GrpcKeepAliveTimeout) * time.Second,
 		}),
 	))
 

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -61,7 +61,6 @@ func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, erro
 		TLS:                  tlsConfig,
 		DialKeepAliveTime:    time.Second * time.Duration(cfg.TiKVClient.GrpcKeepAliveTime),
 		DialKeepAliveTimeout: time.Second * time.Duration(cfg.TiKVClient.GrpcKeepAliveTimeout),
-		PermitWithoutStream:  true,
 	})
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/17870

Problem Summary:

In PD(etcd) server side,  `PermitWithoutStream` values is `false` https://github.com/etcd-io/etcd/blob/master/embed/etcd.go#L641, means 

> and client sends ping when there are no active streams, server will send GOAWAY and close the connection.

but in TiDB client side, `PermitWithoutStream` values is `true` means 

> client sends keepalive pings even with no active RPCs

so, with those conflict configuration, grpc server side will count pingStrike with wrong value.

https://github.com/grpc/grpc-go/blob/master/internal/transport/http2_server.go#L711

and report "transport: Got too many pings from the client, closing the connection." error.

### What is changed and how it works?

What's Changed, How it Works:

we need keep them both as true or false, but etcd write it with magic value(false)

so we only can change tidb-side to false

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test
```
setup a cluster, some tidb node use this fix
"Got too many pings" will happen but only in node that without this patch.
```

Side effects

- ?

### Release note <!-- bugfixes or new feature need a release note -->


- Fix "Got too many pings" grpc error log in PD-server follower
- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/17885)
<!-- Reviewable:end -->
