### PR TITLE
planner, util: new unfixed mutrow for TypeNull

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1117,3 +1117,14 @@ func (s *testIntegrationSuite) TestHintParserWarnings(c *C) {
 	rows := tk.MustQuery("show warnings;").Rows()
 	c.Assert(len(rows), Equals, 1)
 }
+
+func (s *testIntegrationSuite) TestIssue16935(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t0;")
+	tk.MustExec("CREATE TABLE t0(c0 INT);")
+	tk.MustExec("INSERT INTO t0(c0) VALUES (1), (1), (1), (1), (1), (1);")
+	tk.MustExec("CREATE definer='root'@'localhost' VIEW v0(c0) AS SELECT NULL FROM t0;")
+
+	tk.MustQuery("SELECT * FROM t0 LEFT JOIN v0 ON TRUE WHERE v0.c0 IS NULL;")
+}

--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -173,7 +173,7 @@ func getFixedLen(colType *types.FieldType) int {
 	case mysql.TypeFloat:
 		return 4
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong,
-		mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeYear, mysql.TypeDuration, mysql.TypeNull:
+		mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeYear, mysql.TypeDuration:
 		return 8
 	case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp:
 		return sizeTime

--- a/util/chunk/mutrow.go
+++ b/util/chunk/mutrow.go
@@ -121,7 +121,7 @@ func zeroValForType(tp *types.FieldType) interface{} {
 func makeMutRowColumn(in interface{}) *Column {
 	switch x := in.(type) {
 	case nil:
-		col := makeMutRowUint64Column(uint64(0))
+		col := makeMutRowBytesColumn(nil)
 		col.nullBitmap[0] = 0
 		return col
 	case int:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16027 #6252 <!-- REMOVE this line if no issue to close -->

Problem Summary:
TypeNull should be handled as unfixedLen field type. refer MySQL: https://github.com/mysql/mysql-server/blob/8.0/sql/field.h#L151

### What is changed and how it works?

What's Changed:
`makeMutRowBytesColumn` for `nil` 

How it Works:
The reason is mentioned in https://github.com/pingcap/tidb/pull/15512#issuecomment-601535697.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix panic when the child of HashJoin returns TypeNull column.
