### PR TITLE
types: ToString() should not return error for datum null

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -1667,6 +1667,8 @@ func (d *Datum) ToString() (string, error) {
 		return d.GetMysqlJSON().String(), nil
 	case KindBinaryLiteral, KindMysqlBit:
 		return d.GetBinaryLiteral().ToString(), nil
+	case KindNull:
+		return "", nil
 	default:
 		return "", errors.Errorf("cannot convert %v(type %T) to string", d.GetValue(), d.GetValue())
 	}

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -307,6 +307,7 @@ func (ts *testDatumSuite) TestToBytes(c *C) {
 		{NewDecimalDatum(NewDecFromInt(1)), []byte("1")},
 		{NewFloat64Datum(1.23), []byte("1.23")},
 		{NewStringDatum("abc"), []byte("abc")},
+		{Datum{}, []byte{}},
 	}
 	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17662 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`datum.ToString()` returns "cannot convert datum from nil(type null) to type string."

### What is changed and how it works?

What's Changed:

Let ToString handle KindNull, return ""

How it Works:


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> No release note
