### PR TITLE
planner, expression: use expr.Clone() to create new ScalarFunction in EvaluateExprWithNull()

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -247,6 +247,10 @@ func (b *baseBuiltinFunc) getArgs() []Expression {
 	return b.args
 }
 
+func (b *baseBuiltinFunc) setArgs(args []Expression) {
+	b.args = args
+}
+
 func (b *baseBuiltinFunc) vecEvalInt(input *chunk.Chunk, result *chunk.Column) error {
 	return errors.Errorf("baseBuiltinFunc.vecEvalInt() should never be called, please contact the TiDB team for help")
 }
@@ -482,6 +486,8 @@ type builtinFunc interface {
 	evalJSON(row chunk.Row) (val json.BinaryJSON, isNull bool, err error)
 	// getArgs returns the arguments expressions.
 	getArgs() []Expression
+	// setArgs sets the expression's arguments.
+	setArgs(args []Expression)
 	// equal check if this function equals to another function.
 	equal(builtinFunc) bool
 	// getCtx returns this function's context.

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -697,7 +697,9 @@ func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 		for i, arg := range x.GetArgs() {
 			args[i] = EvaluateExprWithNull(ctx, schema, arg)
 		}
-		return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
+		newExpr := x.Clone().(*ScalarFunction)
+		newExpr.Function.setArgs(args)
+		return FoldConstant(newExpr)
 	case *Column:
 		if !schema.Contains(x) {
 			return x

--- a/planner/core/testdata/plan_suite_unexported_in.json
+++ b/planner/core/testdata/plan_suite_unexported_in.json
@@ -533,7 +533,8 @@
       "select * from t t1 left join t t2 on t1.b = t2.b where not (t1.c > 1 or t2.c > 1);",
       "select * from t t1 left join t t2 on t1.b = t2.b where not (t1.c > 1 and t2.c > 1);",
       "select * from t t1 left join t t2 on t1.b > 1 where t1.c = t2.c;",
-      "select * from t t1 left join t t2 on true where t1.b <=> t2.b;"
+      "select * from t t1 left join t t2 on true where t1.b <=> t2.b;",
+      "select * from t t1 left join t t2 on true where (t2.c_str or \"\") is null"
     ]
   },
   {

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -936,6 +936,10 @@
       {
         "Best": "Join{DataScan(t1)->DataScan(t2)}->Sel([nulleq(test.t.b, test.t.b)])->Projection",
         "JoinType": "left outer join"
+      },
+      {
+        "Best": "Join{DataScan(t1)->DataScan(t2)}->Sel([isnull(or(istrue(cast(test.t.c_str, double BINARY)), istrue(cast(, double BINARY))))])->Projection",
+        "JoinType": "left outer join"
       }
     ]
   },


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17475  <!-- REMOVE this line if no issue to close -->

Problem Summary:

Here is a simple example:
```
create table t(a int, b float);
explain select * from t t1 left join t t2 on true where (t2.b or false) is null;
```

Before this PR, we may get the plan:
```
+------------------------------+-------------+-----------+---------------+------------------------------------+
| id                           | estRows     | task      | access object | operator info                      |
+------------------------------+-------------+-----------+---------------+------------------------------------+
| HashJoin_7                   | 64000000.00 | root      |               | CARTESIAN inner join               |
| ├─TableReader_14(Build)      | 8000.00     | root      |               | data:Selection_13                  |
| │ └─Selection_13             | 8000.00     | cop[tikv] |               | 1, isnull(or(istrue(test.t.b), 0)) |
| │   └─TableFullScan_12       | 10000.00    | cop[tikv] | table:t2      | keep order:false, stats:pseudo     |
| └─TableReader_11(Probe)      | 8000.00     | root      |               | data:Selection_10                  |
|   └─Selection_10             | 8000.00     | cop[tikv] |               | 1                                  |
|     └─TableFullScan_9        | 10000.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo     |
+------------------------------+-------------+-----------+---------------+------------------------------------+
7 rows in set (0.01 sec)
```

We can see that we simplified the `left join` to `inner join` and push down the predicate `(t2.b or false) is null`, which is not right.
The root cause is that when we set `t2.b = null` to test whether `(t2.b or false) is null` returns false or null, the function `IsNullReject()` will return false. That is because when the function `EvaluateExprWithNull` creates a new `isTrue` expression, it will lose the value of `keepNull`(https://github.com/pingcap/tidb/blob/3ab8f34110cb0259e662d2a7eb2c2e866cfb1e27/expression/builtin_op.go#L438).

After this PR:
```
mysql> explain select * from t t1 left join t t2 on true where (t2.b or false) is null;
+--------------------------------+-------------+-----------+---------------+---------------------------------+
| id                             | estRows     | task      | access object | operator info                   |
+--------------------------------+-------------+-----------+---------------+---------------------------------+
| Selection_7                    | 64000000.00 | root      |               | isnull(or(istrue(test.t.b), 0)) |
| └─HashJoin_8                   | 80000000.00 | root      |               | CARTESIAN left outer join       |
|   ├─TableReader_14(Build)      | 8000.00     | root      |               | data:Selection_13               |
|   │ └─Selection_13             | 8000.00     | cop[tikv] |               | 1                               |
|   │   └─TableFullScan_12       | 10000.00    | cop[tikv] | table:t2      | keep order:false, stats:pseudo  |
|   └─TableReader_11(Probe)      | 10000.00    | root      |               | data:TableFullScan_10           |
|     └─TableFullScan_10         | 10000.00    | cop[tikv] | table:t1      | keep order:false, stats:pseudo  |
+--------------------------------+-------------+-----------+---------------+---------------------------------+
7 rows in set (0.00 sec)
```
### What is changed and how it works?
What's Changed:

Use `expr.Clone()` to create new expression in `EvaluateExprWithNull` instead of use `NewFunctionInternal()`.

How it Works:

`expr.Clone()` can reserve the `keepNull` value of `IsTrue` expression.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix some scenarios that outer join might be mistakenly converted to inner join.
