### PR TITLE
session,executor: tiny clean up the runStmt function

### DIFF
--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -107,8 +107,9 @@ func (s *seqTestSuite) TestPrepared(c *C) {
 		query = "select c1 from prepare_test where c1 = (select c1 from prepare_test where c1 = ?)"
 		stmtID, _, _, err = tk.Se.PrepareStmt(query)
 		c.Assert(err, IsNil)
-		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
 		c.Assert(err, IsNil)
+		c.Assert(rs.Close(), IsNil)
 		tk1.MustExec("insert prepare_test (c1) values (3)")
 		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
 		c.Assert(err, IsNil)
@@ -118,8 +119,9 @@ func (s *seqTestSuite) TestPrepared(c *C) {
 		query = "select c1 from prepare_test where c1 in (select c1 from prepare_test where c1 = ?)"
 		stmtID, _, _, err = tk.Se.PrepareStmt(query)
 		c.Assert(err, IsNil)
-		_, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
+		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
 		c.Assert(err, IsNil)
+		c.Assert(rs.Close(), IsNil)
 		tk1.MustExec("insert prepare_test (c1) values (3)")
 		rs, err = tk.Se.ExecutePreparedStmt(ctx, stmtID, []types.Datum{types.NewDatum(3)})
 		c.Assert(err, IsNil)

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -23,7 +23,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/ast"
@@ -258,58 +257,6 @@ func checkStmtLimit(ctx context.Context, se *session) error {
 		sessVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
 	}
 	return err
-}
-
-// runStmt executes the sqlexec.Statement and commit or rollback the current transaction.
-func runStmt(ctx context.Context, sctx sessionctx.Context, s sqlexec.Statement) (rs sqlexec.RecordSet, err error) {
-	if span := opentracing.SpanFromContext(ctx); span != nil && span.Tracer() != nil {
-		span1 := span.Tracer().StartSpan("session.runStmt", opentracing.ChildOf(span.Context()))
-		span1.LogKV("sql", s.OriginText())
-		defer span1.Finish()
-		ctx = opentracing.ContextWithSpan(ctx, span1)
-	}
-	sctx.SetValue(sessionctx.QueryString, s.OriginText())
-	if _, ok := s.(*executor.ExecStmt).StmtNode.(ast.DDLNode); ok {
-		sctx.SetValue(sessionctx.LastExecuteDDL, true)
-	} else {
-		sctx.ClearValue(sessionctx.LastExecuteDDL)
-	}
-
-	se := sctx.(*session)
-	sessVars := se.GetSessionVars()
-	// Save origTxnCtx here to avoid it reset in the transaction retry.
-	origTxnCtx := sessVars.TxnCtx
-	defer func() {
-		// If it is not a select statement, we record its slow log here,
-		// then it could include the transaction commit time.
-		if rs == nil {
-			s.(*executor.ExecStmt).FinishExecuteStmt(origTxnCtx.StartTS, err == nil, false)
-		}
-	}()
-
-	err = se.checkTxnAborted(s)
-	if err != nil {
-		return nil, err
-	}
-	rs, err = s.Exec(ctx)
-	sessVars.TxnCtx.StatementCount++
-	if !s.IsReadOnly(sessVars) {
-		// All the history should be added here.
-		if err == nil && sessVars.TxnCtx.CouldRetry {
-			GetHistory(sctx).Add(s, sessVars.StmtCtx)
-		}
-
-		// Handle the stmt commit/rollback.
-		if se.txn.Valid() {
-			if err != nil {
-				sctx.StmtRollback()
-			} else {
-				err = sctx.StmtCommit(sctx.GetSessionVars().StmtCtx.MemTracker)
-			}
-		}
-	}
-	err = finishStmt(ctx, se, err, s)
-	return rs, err
 }
 
 // GetHistory get all stmtHistory in current txn. Exported only for test.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

Tiny clean up code after https://github.com/pingcap/tidb/pull/17678

### What is changed and how it works?


What's Changed:

- Clean up the old `runStmt`, use `runStmtWrap` to replace it.
- rename `CommonExec` to `preparedStmtExec` which is only used by ExecPreparedStmt
- unexport `CachedPlanExec` which is not used outside the session package

How it Works:

Clean up

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> No release note
