### PR TITLE
driver: fix auto_random keyword regex

### DIFF
--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -552,6 +552,10 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table t1 (id int primary key /*T![auto_rand] auto_random(2) */ );",
 		},
 		{
+			"create table t1 (id int primary key auto_random);",
+			"create table t1 (id int primary key /*T![auto_rand] auto_random*/ );",
+		},
+		{
 			"create table t1 (id int auto_random ( 4 ) primary key);",
 			"create table t1 (id int /*T![auto_rand] auto_random ( 4 ) */ primary key);",
 		},

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -553,7 +553,7 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 		},
 		{
 			"create table t1 (id int primary key auto_random);",
-			"create table t1 (id int primary key /*T![auto_rand] auto_random*/ );",
+			"create table t1 (id int primary key /*T![auto_rand] auto_random */ );",
 		},
 		{
 			"create table t1 (id int auto_random ( 4 ) primary key);",

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\))?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\(\s*\d+\s*\))?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\(\s*\d+\s*\))?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\(\s*\d+\s*\)){0,1}`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\(\s*\d+\s*\)){0,1}`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\s*\(\s*\d+\s*\))?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\s*((\(\s*\d+\s*\)|\s+)\s*)?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\))?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\s*(\(\s*\d+\s*\)|\s+)\s*`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\s*((\(\s*\d+\s*\)|\s+)\s*)?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\b(\s*\(\s*\d+\s*\)\s*)?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\b\s*(\s*\(\s*\d+\s*\)\s*)?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\s*\(\s*\d+\s*\))?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\s*\(\s*\d+\s*\)\s*)?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(([^_])|(\s*\(\s*\d+\s*\)\s*))`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM\b(\s*\(\s*\d+\s*\)\s*)?`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -62,7 +62,7 @@ const (
 
 // FeatureIDPatterns is used to record special comments patterns.
 var FeatureIDPatterns = map[featureID]*regexp.Regexp{
-	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(\s*\(\s*\d+\s*\)\s*)?`),
+	FeatureIDAutoRandom:     regexp.MustCompile(`(?i)AUTO_RANDOM(([^_])|(\s*\(\s*\d+\s*\)\s*))`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*`),
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

AddSpecialComment does not work for the auto_random keyword unless it is followed by a number in parentheses.

### What is changed and how it works?

What's Changed:
Changes the regex to (?i)AUTO_RANDOM\b\s*(\s*\(\s*\d+\s*\)\s*)?

### Release note

- N/A