### PR TITLE
tikv: fix switch region leader to TiFlash when TiFlash return EpochNotMatch

### DIFF
--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -213,10 +213,11 @@ func (c *Cluster) RemoveStore(storeID uint64) {
 }
 
 // UpdateStoreAddr updates store address for cluster.
-func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string) {
+func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string, labels ...*metapb.StoreLabel) {
 	c.Lock()
 	defer c.Unlock()
 	c.stores[storeID] = newStore(storeID, addr)
+	c.stores[storeID].meta.Labels = labels
 }
 
 // GetRegion returns a Region's meta and leader ID.

--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -216,8 +216,7 @@ func (c *Cluster) RemoveStore(storeID uint64) {
 func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string, labels ...*metapb.StoreLabel) {
 	c.Lock()
 	defer c.Unlock()
-	c.stores[storeID] = newStore(storeID, addr)
-	c.stores[storeID].meta.Labels = labels
+	c.stores[storeID] = newStore(storeID, addr, labels...)
 }
 
 // GetRegion returns a Region's meta and leader ID.
@@ -649,11 +648,12 @@ type Store struct {
 	tokenCount atomic.Int64
 }
 
-func newStore(storeID uint64, addr string) *Store {
+func newStore(storeID uint64, addr string, labels ...*metapb.StoreLabel) *Store {
 	return &Store{
 		meta: &metapb.Store{
 			Id:      storeID,
 			Address: addr,
+			Labels:  labels,
 		},
 	}
 }

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1087,7 +1087,7 @@ func (c *RegionCache) OnRegionEpochNotMatch(bo *Backoffer, ctx *RPCContext, curr
 		region.init(c)
 		var initLeader uint64
 		if ctx.Store.storeType == kv.TiFlash {
-			initLeader = region.findElectableStoreIndex()
+			initLeader = region.findElectableStoreID()
 		} else {
 			initLeader = ctx.Store.storeID
 		}
@@ -1254,13 +1254,13 @@ func (r *RegionStore) switchNextPeer(rr *Region, currentPeerIdx int) {
 	rr.compareAndSwapStore(r, newRegionStore)
 }
 
-func (r *Region) findElectableStoreIndex() uint64 {
+func (r *Region) findElectableStoreID() uint64 {
 	if len(r.meta.Peers) == 0 {
 		return 0
 	}
-	for i, p := range r.meta.Peers {
+	for _, p := range r.meta.Peers {
 		if !p.IsLearner {
-			return uint64(i)
+			return p.StoreId
 		}
 	}
 	return 0

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -679,10 +679,10 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	// add store3 as tiflash
 	store3 := s.cluster.AllocID()
 	peer3 := s.cluster.AllocID()
+	s.cluster.UpdateStoreAddr(s.store1, s.storeAddr(s.store1), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
 	s.cluster.AddStore(store3, s.storeAddr(store3))
-	s.cluster.UpdateStoreAddr(store3, s.storeAddr(store3), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
 	s.cluster.AddPeer(s.region1, store3, peer3)
-	s.cluster.ChangeLeader(s.region1, s.peer1)
+	s.cluster.ChangeLeader(s.region1, peer3)
 
 	// pre-load region cache
 	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
@@ -690,11 +690,13 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	c.Assert(loc1.Region.id, Equals, s.region1)
 	lctx, err := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
-	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+	c.Assert(lctx.Peer.Id, Equals, peer3)
 
 	// epoch-not-match on tiflash
 	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region)
 	c.Assert(err, IsNil)
+	c.Assert(ctxTiFlash.Peer.Id, Equals, s.peer1)
+	ctxTiFlash.Peer.IsLearner = true
 	r := ctxTiFlash.Meta
 	reqSend := NewRegionRequestSender(s.cache, nil)
 	regionErr := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{r}}}
@@ -703,7 +705,7 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	// check leader read should not go to tiflash
 	lctx, err = s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
-	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+	c.Assert(lctx.Peer.Id, Not(Equals), s.peer1)
 }
 
 const regionSplitKeyFormat = "t%08d"

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -675,6 +675,37 @@ func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 	c.Assert(len(bo.errors), Equals, 2)
 }
 
+func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
+	// add store3 as tiflash
+	store3 := s.cluster.AllocID()
+	peer3 := s.cluster.AllocID()
+	s.cluster.AddStore(store3, s.storeAddr(store3))
+	s.cluster.UpdateStoreAddr(store3, s.storeAddr(store3), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
+	s.cluster.AddPeer(s.region1, store3, peer3)
+	s.cluster.ChangeLeader(s.region1, s.peer1)
+
+	// pre-load region cache
+	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
+	c.Assert(err, IsNil)
+	c.Assert(loc1.Region.id, Equals, s.region1)
+	lctx, err := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+
+	// epoch-not-match on tiflash
+	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region)
+	c.Assert(err, IsNil)
+	r := ctxTiFlash.Meta
+	reqSend := NewRegionRequestSender(s.cache, nil)
+	regionErr := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{r}}}
+	reqSend.onRegionError(s.bo, ctxTiFlash, nil, regionErr)
+
+	// check leader read should not go to tiflash
+	lctx, err = s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+}
+
 const regionSplitKeyFormat = "t%08d"
 
 func createClusterWithStoresAndRegions(regionCnt, storeCount int) *mocktikv.Cluster {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -211,6 +211,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		logutil.Eventf(bo.ctx, "send %s request to region %d at %s", req.Type, regionID.id, rpcCtx.Addr)
+		rpcCtx.ReqStoreType = sType
 		s.storeAddr = rpcCtx.Addr
 		var retry bool
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/17930

Problem Summary:

see detail in issue 

### What is changed and how it works?

What's Changed, How it Works:

we cannot get leader info from epochNotMatchError, but we can choose any tikv store peer as leader.

region cache find leader with one NotLeader resp from any tikv peer.

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix switch region leader to TiFlash when TiFlash return EpochNotMatch

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/17931)
<!-- Reviewable:end -->
