### PR TITLE
txn: try to commit pessimistic txn with concurrent ddl

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -80,14 +80,14 @@ type Domain struct {
 // loadInfoSchema loads infoschema at startTS into handle, usedSchemaVersion is the currently used
 // infoschema version, if it is the same as the schema version at startTS, we don't need to reload again.
 // It returns the latest schema version, the changed table IDs, whether it's a full load and an error.
-func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64, startTS uint64) (int64, []int64, []uint64, bool, error) {
-	var fullLoad bool
+func (do *Domain) loadInfoSchema(handle *infoschema.Handle, usedSchemaVersion int64,
+	startTS uint64) (neededSchemaVersion int64, tblIDs []int64, actionTypes []uint64, fullLoad bool, err error) {
 	snapshot, err := do.store.GetSnapshot(kv.NewVersion(startTS))
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}
 	m := meta.NewSnapshotMeta(snapshot)
-	neededSchemaVersion, err := m.GetSchemaVersion()
+	neededSchemaVersion, err = m.GetSchemaVersion()
 	if err != nil {
 		return 0, nil, nil, fullLoad, err
 	}

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -314,24 +314,24 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(err, IsNil)
 	ts := ver.Ver
 
-	succ := dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ := dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed", `return(true)`), IsNil)
 	err = dom.Reload()
 	c.Assert(err, NotNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 	time.Sleep(ddlLease)
 
 	ver, err = store.CurrentVersion()
 	c.Assert(err, IsNil)
 	ts = ver.Ver
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultUnknown)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed"), IsNil)
 	err = dom.Reload()
 	c.Assert(err, IsNil)
-	succ = dom.SchemaValidator.Check(ts, schemaVer, nil)
+	_, _, succ = dom.SchemaValidator.Check(ts, schemaVer, nil, false)
 	c.Assert(succ, Equals, ResultSucc)
 
 	// For slow query.
@@ -396,7 +396,7 @@ func (*testSuite) TestT(c *C) {
 		SchemaOutOfDateRetryInterval = originalRetryInterval
 	}()
 	dom.SchemaValidator.Stop()
-	err = schemaChecker.Check(uint64(123456))
+	_, _, _, err = schemaChecker.Check(uint64(123456), false)
 	c.Assert(err.Error(), Equals, ErrInfoSchemaExpired.Error())
 	dom.SchemaValidator.Reset()
 

--- a/domain/schema_checker.go
+++ b/domain/schema_checker.go
@@ -44,22 +44,23 @@ func NewSchemaChecker(do *Domain, schemaVer int64, relatedTableIDs []int64) *Sch
 }
 
 // Check checks the validity of the schema version.
-func (s *SchemaChecker) Check(txnTS uint64) error {
+func (s *SchemaChecker) Check(txnTS uint64, getAllChangedInfo bool) ([]int64, []uint64, bool, error) {
 	schemaOutOfDateRetryInterval := atomic.LoadInt64(&SchemaOutOfDateRetryInterval)
 	schemaOutOfDateRetryTimes := int(atomic.LoadInt32(&SchemaOutOfDateRetryTimes))
 	for i := 0; i < schemaOutOfDateRetryTimes; i++ {
-		result := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs)
-		switch result {
+		tblIDs, typeActions, CheckResult := s.SchemaValidator.Check(txnTS, s.schemaVer, s.relatedTableIDs, getAllChangedInfo)
+		switch CheckResult {
 		case ResultSucc:
-			return nil
+			return nil, nil, false, nil
 		case ResultFail:
 			metrics.SchemaLeaseErrorCounter.WithLabelValues("changed").Inc()
-			return ErrInfoSchemaChanged
+			amendable := getAllChangedInfo && (len(tblIDs) > 0)
+			return tblIDs, typeActions, amendable, ErrInfoSchemaChanged
 		case ResultUnknown:
 			time.Sleep(time.Duration(schemaOutOfDateRetryInterval))
 		}
 
 	}
 	metrics.SchemaLeaseErrorCounter.WithLabelValues("outdated").Inc()
-	return ErrInfoSchemaExpired
+	return nil, nil, false, ErrInfoSchemaExpired
 }

--- a/domain/schema_checker_test.go
+++ b/domain/schema_checker_test.go
@@ -27,38 +27,38 @@ func (s *testSuite) TestSchemaCheckerSimple(c *C) {
 
 	// Add some schema versions and delta table IDs.
 	ts := uint64(time.Now().UnixNano())
-	validator.Update(ts, 0, 2, []int64{1})
-	validator.Update(ts, 2, 4, []int64{2})
+	validator.Update(ts, 0, 2, []int64{1}, []uint64{1})
+	validator.Update(ts, 2, 4, []int64{2}, []uint64{2})
 
 	// checker's schema version is the same as the current schema version.
 	checker.schemaVer = 4
-	err := checker.Check(ts)
+	_, _, _, err := checker.Check(ts, false)
 	c.Assert(err, IsNil)
 
 	// checker's schema version is less than the current schema version, and it doesn't exist in validator's items.
 	// checker's related table ID isn't in validator's changed table IDs.
 	checker.schemaVer = 2
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	// The checker's schema version isn't in validator's items.
 	checker.schemaVer = 1
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 	// checker's related table ID is in validator's changed table IDs.
 	checker.relatedTableIDs = []int64{2}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(terror.ErrorEqual(err, ErrInfoSchemaChanged), IsTrue)
 
 	// validator's latest schema version is expired.
 	time.Sleep(lease + time.Microsecond)
 	checker.schemaVer = 4
 	checker.relatedTableIDs = []int64{3}
-	err = checker.Check(ts)
+	_, _, _, err = checker.Check(ts, false)
 	c.Assert(err, IsNil)
 	nowTS := uint64(time.Now().UnixNano())
 	// Use checker.SchemaValidator.Check instead of checker.Check here because backoff make CI slow.
-	result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs)
+	_, _, result := checker.SchemaValidator.Check(nowTS, checker.schemaVer, checker.relatedTableIDs, false)
 	c.Assert(result, Equals, ResultUnknown)
 }

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -49,36 +49,36 @@ func (*testSuite) TestSchemaValidator(c *C) {
 		time.Sleep(delay)
 		// Reload can run arbitrarily, at any time.
 		item := <-leaseGrantCh
-		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil)
+		validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, nil, nil)
 	}
 
 	// Take a lease, check it's valid.
 	item := <-leaseGrantCh
-	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10})
-	valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	validator.Update(item.leaseGrantTS, item.oldVer, item.schemaVer, []int64{10}, []uint64{10})
+	_, _, valid := validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultSucc)
 
 	// Stop the validator, validator's items value is nil.
 	validator.Stop()
 	c.Assert(validator.IsStarted(), IsFalse)
-	isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10})
+	_, _, isTablesChanged := validator.isRelatedTablesChanged(item.schemaVer, []int64{10}, false)
 	c.Assert(isTablesChanged, IsTrue)
-	valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(item.leaseGrantTS, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown)
 	validator.Restart()
 
 	// Increase the current time by 2 leases, check schema is invalid.
 	ts := uint64(time.Now().Add(2 * lease).UnixNano()) // Make sure that ts has timed out a lease.
-	valid = validator.Check(ts, item.schemaVer, []int64{10})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{10}, false)
 	c.Assert(valid, Equals, ResultUnknown, Commentf("validator latest schema ver %v, time %v, item schema ver %v, ts %v",
 		validator.latestSchemaVer, validator.latestSchemaExpire, 0, oracle.GetTimeFromTS(ts)))
 	// Make sure newItem's version is greater than item.schema.
 	newItem := getGreaterVersionItem(c, lease, leaseGrantCh, item.schemaVer)
 	currVer := newItem.schemaVer
-	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil)
-	valid = validator.Check(ts, item.schemaVer, nil)
+	validator.Update(newItem.leaseGrantTS, newItem.oldVer, currVer, nil, nil)
+	_, _, valid = validator.Check(ts, item.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
-	valid = validator.Check(ts, item.schemaVer, []int64{0})
+	_, _, valid = validator.Check(ts, item.schemaVer, []int64{0}, false)
 	c.Assert(valid, Equals, ResultFail, Commentf("currVer %d, newItem %v", currVer, item))
 	// Check the latest schema version must changed.
 	c.Assert(item.schemaVer, Less, validator.latestSchemaVer)
@@ -86,20 +86,20 @@ func (*testSuite) TestSchemaValidator(c *C) {
 	// Make sure newItem's version is greater than currVer.
 	newItem = getGreaterVersionItem(c, lease, leaseGrantCh, currVer)
 	// Update current schema version to newItem's version and the delta table IDs is 1, 2, 3.
-	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3})
+	validator.Update(ts, currVer, newItem.schemaVer, []int64{1, 2, 3}, []uint64{1, 2, 3})
 	// Make sure the updated table IDs don't be covered with the same schema version.
-	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, nil)
+	validator.Update(ts, newItem.schemaVer, newItem.schemaVer, nil, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, nil, false)
 	c.Assert(isTablesChanged, IsFalse)
-	isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2})
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(currVer, []int64{2}, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 	// The current schema version is older than the oldest schema version.
-	isTablesChanged = validator.isRelatedTablesChanged(-1, nil)
+	_, _, isTablesChanged = validator.isRelatedTablesChanged(-1, nil, false)
 	c.Assert(isTablesChanged, IsTrue, Commentf("currVer %d, newItem %v", currVer, newItem))
 
 	// All schema versions is expired.
 	ts = uint64(time.Now().Add(2 * lease).UnixNano())
-	valid = validator.Check(ts, newItem.schemaVer, nil)
+	_, _, valid = validator.Check(ts, newItem.schemaVer, nil, false)
 	c.Assert(valid, Equals, ResultUnknown)
 
 	close(exit)
@@ -155,51 +155,100 @@ func (*testSuite) TestEnqueue(c *C) {
 	c.Assert(validator.IsStarted(), IsTrue)
 	// maxCnt is 0.
 	variable.SetMaxDeltaSchemaCount(0)
-	validator.enqueue(1, []int64{11})
+	validator.enqueue(1, []int64{11}, []uint64{11})
 	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
 
 	// maxCnt is 10.
 	variable.SetMaxDeltaSchemaCount(10)
 	ds := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{1, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{5, []int64{1, 4}},
-		{6, []int64{1, 4}},
-		{7, []int64{3, 1, 3}},
-		{8, []int64{1, 2, 3}},
-		{9, []int64{1, 2, 3}},
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
 	}
 	for _, d := range ds {
-		validator.enqueue(d.schemaVersion, d.relatedIDs)
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
 	}
-	validator.enqueue(10, []int64{1})
+	validator.enqueue(10, []int64{1}, []uint64{1})
 	ret := []deltaSchemaInfo{
-		{0, []int64{1}},
-		{2, []int64{1}},
-		{3, []int64{2, 2}},
-		{4, []int64{2}},
-		{6, []int64{1, 4}},
-		{9, []int64{1, 2, 3}},
-		{10, []int64{1}},
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{10, []int64{1}, []uint64{1}},
 	}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The Items' relatedTableIDs have different order.
-	validator.enqueue(11, []int64{1, 2, 3, 4})
-	validator.enqueue(12, []int64{4, 1, 2, 3, 1})
-	validator.enqueue(13, []int64{4, 1, 3, 2, 5})
-	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}}
+	validator.enqueue(11, []int64{1, 2, 3, 4}, []uint64{1, 2, 3, 4})
+	validator.enqueue(12, []int64{4, 1, 2, 3, 1}, []uint64{4, 1, 2, 3, 1})
+	validator.enqueue(13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5})
+	ret[len(ret)-1] = deltaSchemaInfo{13, []int64{4, 1, 3, 2, 5}, []uint64{4, 1, 3, 2, 5}}
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
 	// The length of deltaSchemaInfos is greater then maxCnt.
-	validator.enqueue(14, []int64{1})
-	validator.enqueue(15, []int64{2})
-	validator.enqueue(16, []int64{3})
-	validator.enqueue(17, []int64{4})
-	ret = append(ret, deltaSchemaInfo{14, []int64{1}})
-	ret = append(ret, deltaSchemaInfo{15, []int64{2}})
-	ret = append(ret, deltaSchemaInfo{16, []int64{3}})
-	ret = append(ret, deltaSchemaInfo{17, []int64{4}})
+	validator.enqueue(14, []int64{1}, []uint64{1})
+	validator.enqueue(15, []int64{2}, []uint64{2})
+	validator.enqueue(16, []int64{3}, []uint64{3})
+	validator.enqueue(17, []int64{4}, []uint64{4})
+	ret = append(ret, deltaSchemaInfo{14, []int64{1}, []uint64{1}})
+	ret = append(ret, deltaSchemaInfo{15, []int64{2}, []uint64{2}})
+	ret = append(ret, deltaSchemaInfo{16, []int64{3}, []uint64{3}})
+	ret = append(ret, deltaSchemaInfo{17, []int64{4}, []uint64{4}})
 	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret[1:])
+}
+
+func (*testSuite) TestEnqueueActionType(c *C) {
+	lease := 10 * time.Millisecond
+	originalCnt := variable.GetMaxDeltaSchemaCount()
+	defer variable.SetMaxDeltaSchemaCount(originalCnt)
+
+	validator := NewSchemaValidator(lease).(*schemaValidator)
+	c.Assert(validator.IsStarted(), IsTrue)
+	// maxCnt is 0.
+	variable.SetMaxDeltaSchemaCount(0)
+	validator.enqueue(1, []int64{11}, []uint64{11})
+	c.Assert(validator.deltaSchemaInfos, HasLen, 0)
+
+	// maxCnt is 10.
+	variable.SetMaxDeltaSchemaCount(10)
+	ds := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{1, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{5, []int64{1, 4}, []uint64{1, 4}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{7, []int64{3, 1, 3}, []uint64{3, 1, 3}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+	}
+	for _, d := range ds {
+		validator.enqueue(d.schemaVersion, d.relatedIDs, d.relatedActions)
+	}
+	validator.enqueue(10, []int64{1}, []uint64{15})
+	ret := []deltaSchemaInfo{
+		{0, []int64{1}, []uint64{1}},
+		{2, []int64{1}, []uint64{1}},
+		{3, []int64{2, 2}, []uint64{2, 2}},
+		{4, []int64{2}, []uint64{2}},
+		{6, []int64{1, 4}, []uint64{1, 4}},
+		{8, []int64{1, 2, 3}, []uint64{1, 2, 3}},
+		{9, []int64{1, 2, 3}, []uint64{1, 2, 4}},
+		{10, []int64{1}, []uint64{15}},
+	}
+	c.Assert(validator.deltaSchemaInfos, DeepEquals, ret)
+	// Check the flag set by schema diff, note tableID = 3 has been set flag 0x3 in schema version 9, and flag 0x4
+	// in schema version 10, so the resActions for tableID = 3 should be 0x3 & 0x4 = 0x7
+	resTblIDs, resActions, isTablesChanged := validator.isRelatedTablesChanged(5, []int64{1, 3, 4}, true)
+	c.Assert(isTablesChanged, Equals, true)
+	c.Assert(resTblIDs, DeepEquals, []int64{1, 3, 4})
+	c.Assert(resActions, DeepEquals, []uint64{15, 7, 4})
 }

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -59,7 +59,7 @@ func (e *DDLExec) toErr(err error) error {
 		logutil.BgLogger().Error("active txn failed", zap.Error(err))
 		return err1
 	}
-	schemaInfoErr := checker.Check(txn.StartTS())
+	_, _, _, schemaInfoErr := checker.Check(txn.StartTS(), false)
 	if schemaInfoErr != nil {
 		return errors.Trace(schemaInfoErr)
 	}


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:  #17932

Problem Summary:
Try to commit pessimistic transactions with related table schema changes by concurrent DDLs

### What is changed and how it works?

Proposal: #17932 
This is the first part

What's Changed:

1. Try to record `ActionType` for each schema change, return both the changed table id array, as well as the changed action type array.(Maybe some schema change diff merge could be done by their type relation)
2. Use the changed type array to check if this schema change for the current pessimistic transaction is amendable. If so, try to amend the transaction memory buffer based on the schema change type, and then try to commit the pessimistic transaction as usual but not report `ErrSchemaChanged`.
3. Try to implement `add column` and `drop column` for the amend logic by now. No memory buffer amendation is needed for these two types.

How it Works:

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
