### PR TITLE
*: modify GetGlobalConfig() to provide a thread safe API for unit test

### DIFF
--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -92,7 +92,7 @@ func (s *testStateChangeSuiteBase) TearDownSuite(c *C) {
 
 // TestShowCreateTable tests the result of "show create table" when we are running "add index" or "add column".
 func (s *serialTestStateChangeSuite) TestShowCreateTable(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t (id int)")
@@ -858,7 +858,7 @@ func (s *testStateChangeSuite) TestParallelAlterAddIndex(c *C) {
 }
 
 func (s *serialTestStateChangeSuite) TestParallelAlterAddExpressionIndex(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	sql1 := "ALTER TABLE t add index expr_index_b((b+1));"
 	sql2 := "CREATE INDEX expr_index_b ON t ((c+1));"
 	f := func(c *C, err1, err2 error) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1705,7 +1705,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 	}
 	updateTableInfo(tblInfo)
 	s.tk.MustExec("alter table t add column c varchar(10) character set utf8;") // load latest schema.
-	c.Assert(config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4, IsTrue)
+	c.Assert(config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4, IsTrue)
 	s.tk.MustExec("insert into t set a= x'f09f8c80'")
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
 		"  `a` varchar(10) DEFAULT NULL,\n" +
@@ -1713,7 +1713,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 		"  `c` varchar(10) CHARACTER SET utf8 COLLATE utf8_bin DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = false
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = false
 	s.tk.MustExec("alter table t drop column c;") //  reload schema.
 	s.tk.MustGetErrCode("insert into t set a= x'f09f8c80'", errno.ErrTruncatedWrongValueForField)
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
@@ -1730,7 +1730,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 	tblInfo.Columns[0].Version = model.ColumnInfoVersion0
 	updateTableInfo(tblInfo)
 
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = true
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = true
 	s.tk.MustExec("alter table t add column c varchar(10);") //  load latest schema.
 	s.tk.MustExec("insert into t set a= x'f09f8c80'")
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
@@ -1739,7 +1739,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 		"  `c` varchar(10) DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = false
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = false
 	s.tk.MustExec("alter table t drop column c;") //  reload schema.
 	s.tk.MustGetErrCode("insert into t set a= x'f09f8c80'", errno.ErrTruncatedWrongValueForField)
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
@@ -1748,7 +1748,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"))
 
 	// Test modify column charset.
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = true
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = true
 	s.tk.MustExec("alter table t modify column a varchar(10) character set utf8mb4") //  change column charset.
 	tbl = testGetTableByName(c, s.ctx, "test", "t")
 	c.Assert(tbl.Meta().Columns[0].Charset, Equals, charset.CharsetUTF8MB4)
@@ -1776,7 +1776,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 	tblInfo.Columns[0].Charset = charset.CharsetUTF8
 	tblInfo.Columns[0].Collate = charset.CollationUTF8
 	updateTableInfo(tblInfo)
-	c.Assert(config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4, IsTrue)
+	c.Assert(config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4, IsTrue)
 	s.tk.MustExec("alter table t change column b b varchar(20) character set ascii") // reload schema.
 	s.tk.MustExec("insert into t set a= x'f09f8c80'")
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
@@ -1784,7 +1784,7 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 		"  `b` varchar(20) CHARACTER SET ascii COLLATE ascii_bin DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin"))
 
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = false
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = false
 	s.tk.MustExec("alter table t change column b b varchar(30) character set ascii") // reload schema.
 	s.tk.MustGetErrCode("insert into t set a= x'f09f8c80'", errno.ErrTruncatedWrongValueForField)
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
@@ -1793,11 +1793,11 @@ func (s *testIntegrationSuite1) TestTreatOldVersionUTF8AsUTF8MB4(c *C) {
 		") ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_bin"))
 
 	// Test for alter table convert charset
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = true
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = true
 	s.tk.MustExec("alter table t drop column b") // reload schema.
 	s.tk.MustExec("alter table t convert to charset utf8mb4;")
 
-	config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 = false
+	config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 = false
 	s.tk.MustExec("alter table t add column b varchar(50);") // reload schema.
 	s.tk.MustQuery("show create table t").Check(testkit.Rows("t CREATE TABLE `t` (\n" +
 		"  `a` varchar(20) DEFAULT NULL,\n" +
@@ -2044,7 +2044,7 @@ func (s *testIntegrationSuite3) TestParserIssue284(c *C) {
 }
 
 func (s *testIntegrationSuite7) TestAddExpressionIndex(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t;")
@@ -2096,12 +2096,12 @@ func (s *testIntegrationSuite7) TestAddExpressionIndex(c *C) {
 	tk.MustExec("alter table t1 alter index ei_ab invisible;")
 
 	// Test experiment switch.
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = false
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = false
 	tk.MustGetErrMsg("create index d on t((a+1))", "[ddl:8200]Unsupported creating expression index without allow-expression-index in config")
 }
 
 func (s *testIntegrationSuite7) TestCreateExpressionIndexError(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -2263,7 +2263,7 @@ func (s *testIntegrationSuite3) TestCreateTableWithAutoIdCache(c *C) {
 }
 
 func (s *testIntegrationSuite4) TestAlterIndexVisibility(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create database if not exists alter_index_test")
 	tk.MustExec("USE alter_index_test;")

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1138,7 +1138,7 @@ func (s *testIntegrationSuite4) TestExchangePartitionTableCompatiable(c *C) {
 }
 
 func (s *testIntegrationSuite7) TestExchangePartitionExpressIndex(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists pt1;")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -264,7 +264,7 @@ func (s *testDBSuite2) TestAddUniqueIndexRollback(c *C) {
 }
 
 func (s *testSerialDBSuite) TestAddExpressionIndexRollback(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test_db")
 	tk.MustExec("drop table if exists t1")
@@ -4454,7 +4454,7 @@ func (s *testDBSuite2) TestTablesLockDelayClean(c *C) {
 
 	tk.MustExec("lock tables t1 write")
 	checkTableLock(c, tk.Se, "test", "t1", model.TableLockWrite)
-	config.GetGlobalConfig().DelayCleanTableLock = 100
+	config.GetGlobalConfig(context.Background()).DelayCleanTableLock = 100
 	var wg sync.WaitGroup
 	wg.Add(1)
 	var startTime time.Time
@@ -4468,7 +4468,7 @@ func (s *testDBSuite2) TestTablesLockDelayClean(c *C) {
 	wg.Wait()
 	c.Assert(time.Since(startTime).Seconds() > 0.1, IsTrue)
 	checkTableLock(c, tk.Se, "test", "t1", model.TableLockNone)
-	config.GetGlobalConfig().DelayCleanTableLock = 0
+	config.GetGlobalConfig(context.Background()).DelayCleanTableLock = 0
 }
 
 // TestConcurrentLockTables test concurrent lock/unlock tables.

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -94,7 +94,7 @@ func TestT(t *testing.T) {
 	ReorgWaitTimeout = 30 * time.Millisecond
 	batchInsertDeleteRangeSize = 2
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	// Test for table lock.
 	newCfg.EnableTableLock = true

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -78,8 +78,9 @@ func buildIndexColumns(columns []*model.ColumnInfo, indexPartSpecifications []*a
 		sumLength += indexColumnLength
 
 		// The sum of all lengths must be shorter than the max length for prefix.
-		if sumLength > config.GetGlobalConfig().MaxIndexLength {
-			return nil, errTooLongKey.GenWithStackByArgs(config.GetGlobalConfig().MaxIndexLength)
+		maxIndexLengthConfig := config.GetGlobalConfig(context.Background()).MaxIndexLength
+		if sumLength > maxIndexLengthConfig {
+			return nil, errTooLongKey.GenWithStackByArgs(maxIndexLengthConfig)
 		}
 
 		idxParts = append(idxParts, &model.IndexColumn{
@@ -123,8 +124,9 @@ func checkIndexPrefixLength(columns []*model.ColumnInfo, idxColumns []*model.Ind
 		}
 		sumLength += indexColumnLength
 		// The sum of all lengths must be shorter than the max length for prefix.
-		if sumLength > config.GetGlobalConfig().MaxIndexLength {
-			return errTooLongKey.GenWithStackByArgs(config.GetGlobalConfig().MaxIndexLength)
+		maxIndexLengthConfig := config.GetGlobalConfig(context.Background()).MaxIndexLength
+		if sumLength > maxIndexLengthConfig {
+			return errTooLongKey.GenWithStackByArgs(maxIndexLengthConfig)
 		}
 	}
 	return nil
@@ -168,8 +170,9 @@ func checkIndexColumn(col *model.ColumnInfo, ic *ast.IndexPartSpecification) err
 	}
 
 	// Specified length must be shorter than the max length for prefix.
-	if ic.Length > config.GetGlobalConfig().MaxIndexLength {
-		return errTooLongKey.GenWithStackByArgs(config.GetGlobalConfig().MaxIndexLength)
+	maxIndexLength := config.GetGlobalConfig(context.Background()).MaxIndexLength
+	if ic.Length > maxIndexLength {
+		return errTooLongKey.GenWithStackByArgs(maxIndexLength)
 	}
 	return nil
 }

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -63,7 +63,7 @@ func (s *testSerialSuite) SetUpSuite(c *C) {
 	session.SetSchemaLease(200 * time.Millisecond)
 	session.DisableStats4Test()
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	// Test for add/drop primary key.
 	newCfg.AlterPrimaryKey = false
@@ -95,7 +95,7 @@ func (s *testSerialSuite) TearDownSuite(c *C) {
 
 func (s *testSerialSuite) TestChangeMaxIndexLength(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	originalMaxIndexLen := cfg.MaxIndexLength
 	newCfg.MaxIndexLength = config.DefMaxOfMaxIndexLength
@@ -132,7 +132,7 @@ func (s *testSerialSuite) TestPrimaryKey(c *C) {
 	tk.MustExec("create table primary_key_test1 (a int, b varchar(10), primary key(a))")
 	tk.MustExec("create table primary_key_test2 (a int, b varchar(10), primary key(b))")
 	tk.MustExec("create table primary_key_test3 (a int, b varchar(10))")
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	orignalAlterPrimaryKey := newCfg.AlterPrimaryKey
 	newCfg.AlterPrimaryKey = true
@@ -814,7 +814,7 @@ func (s *testSerialSuite) TestTableLocksEnable(c *C) {
 	tk.MustExec("create table t1 (a int)")
 
 	// Test for enable table lock config.
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	newCfg.EnableTableLock = false
 	config.StoreGlobalConfig(&newCfg)
@@ -898,11 +898,11 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertPKIsNotHandle("create table t (a bigint auto_random(3), b int, c char, primary key (a, c))", "a")
 
 	// PKIsNotHandle: table is created when alter-primary-key = true.
-	config.GetGlobalConfig().AlterPrimaryKey = true
+	config.GetGlobalConfig(context.Background()).AlterPrimaryKey = true
 	assertPKIsNotHandle("create table t (a bigint auto_random(3) primary key, b int)", "a")
 	assertPKIsNotHandle("create table t (a bigint auto_random(3) primary key, b int)", "a")
 	assertPKIsNotHandle("create table t (a int, b bigint auto_random(3) primary key)", "b")
-	config.GetGlobalConfig().AlterPrimaryKey = false
+	config.GetGlobalConfig(context.Background()).AlterPrimaryKey = false
 
 	// Can not set auto_random along with auto_increment.
 	assertWithAutoInc("create table t (a bigint auto_random(3) primary key auto_increment)")
@@ -1223,7 +1223,7 @@ func (s *testSerialSuite) TestInvisibleIndex(c *C) {
 	tk.MustExec("insert into t values (11, 12)")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1 2", "3 4", "5 6", "7 8", "9 10", "11 12"))
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	orignalAlterPrimaryKey := newCfg.AlterPrimaryKey
 	newCfg.AlterPrimaryKey = true
@@ -1291,7 +1291,7 @@ func (s *testSerialSuite) TestCreateClusteredIndex(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(tbl.Meta().IsCommonHandle, IsFalse)
 
-	config.GetGlobalConfig().AlterPrimaryKey = true
+	config.GetGlobalConfig(context.Background()).AlterPrimaryKey = true
 	tk.MustExec("CREATE TABLE t5 (a varchar(255) primary key, b int)")
 	tk.MustExec("CREATE TABLE t6 (a int, b int, c int, primary key (a, b))")
 	is = domain.GetDomain(ctx).InfoSchema()
@@ -1301,7 +1301,7 @@ func (s *testSerialSuite) TestCreateClusteredIndex(c *C) {
 	tbl, err = is.TableByName(model.NewCIStr("test"), model.NewCIStr("t6"))
 	c.Assert(err, IsNil)
 	c.Assert(tbl.Meta().IsCommonHandle, IsFalse)
-	config.GetGlobalConfig().AlterPrimaryKey = false
+	config.GetGlobalConfig(context.Background()).AlterPrimaryKey = false
 
 	tk.MustExec("CREATE TABLE t21 like t2")
 	tk.MustExec("CREATE TABLE t31 like t3")

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -195,7 +195,7 @@ func (do *Domain) fetchSchemasWithTables(schemas []*model.DBInfo, m *meta.Meta, 
 			return
 		}
 		// If TreatOldVersionUTF8AsUTF8MB4 was enable, need to convert the old version schema UTF8 charset to UTF8MB4.
-		if config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 {
+		if config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 {
 			for _, tbInfo := range tables {
 				infoschema.ConvertOldVersionUTF8ToUTF8MB4IfNeed(tbInfo)
 			}
@@ -661,7 +661,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 	perfschema.Init()
 	if ebd, ok := do.store.(tikv.EtcdBackend); ok {
 		if addrs := ebd.EtcdAddrs(); addrs != nil {
-			cfg := config.GetGlobalConfig()
+			cfg := config.GetGlobalConfig(context.Background())
 			// silence etcd warn log, when domain closed, it won't randomly print warn log
 			// see details at the issue https://github.com/pingcap/tidb/issues/15479
 			etcdLogCfg := zap.NewProductionConfig()

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -599,7 +599,7 @@ func getInfo(ctx context.Context, etcdCli *clientv3.Client, key string, retryCnt
 
 // getServerInfo gets self tidb server information.
 func getServerInfo(id string) *ServerInfo {
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	info := &ServerInfo{
 		ID:             id,
 		IP:             cfg.AdvertiseAddress,

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -623,7 +623,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 		}
 		return nil, err
 	}
-	if a.retryCount >= config.GetGlobalConfig().PessimisticTxn.MaxRetryCount {
+	if a.retryCount >= config.GetGlobalConfig(ctx).PessimisticTxn.MaxRetryCount {
 		return nil, errors.New("pessimistic lock retry limit reached")
 	}
 	a.retryCount++
@@ -755,7 +755,7 @@ func (a *ExecStmt) logAudit() {
 // FormatSQL is used to format the original SQL, e.g. truncating long SQL, appending prepared arguments.
 func FormatSQL(sql string, pps variable.PreparedParams) stringutil.StringerFunc {
 	return func() string {
-		cfg := config.GetGlobalConfig()
+		cfg := config.GetGlobalConfig(context.Background())
 		length := len(sql)
 		if maxQueryLen := atomic.LoadUint64(&cfg.Log.QueryLogMaxLen); uint64(length) > maxQueryLen {
 			sql = fmt.Sprintf("%.*q(len:%d)", maxQueryLen, sql, length)
@@ -808,7 +808,7 @@ func (a *ExecStmt) CloseRecordSet(txnStartTS uint64, lastErr error) {
 func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	sessVars := a.Ctx.GetSessionVars()
 	level := log.GetLevel()
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
 	threshold := time.Duration(cfg.Log.SlowThreshold) * time.Millisecond
 	enable := cfg.Log.EnableSlowLog
@@ -894,7 +894,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 
 // getPlanTree will try to get the select plan tree if the plan is select or the select plan of delete/update/insert statement.
 func getPlanTree(p plannercore.Plan) string {
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	if atomic.LoadUint32(&cfg.Log.RecordPlanInSlowLog) == 0 {
 		return ""
 	}

--- a/executor/brie.go
+++ b/executor/brie.go
@@ -179,7 +179,7 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 		},
 	}
 
-	tidbCfg := config.GetGlobalConfig()
+	tidbCfg := config.GetGlobalConfig(context.Background())
 	if tidbCfg.Store != "tikv" {
 		b.err = errors.Errorf("%s requires tikv store, not %s", s.Kind, tidbCfg.Store)
 		return nil

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -98,7 +98,7 @@ type MockPhysicalPlan interface {
 }
 
 func (b *executorBuilder) build(p plannercore.Plan) Executor {
-	if config.GetGlobalConfig().EnableCollectExecutionInfo && b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil {
+	if config.GetGlobalConfig(context.Background()).EnableCollectExecutionInfo && b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil {
 		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl()
 	}
 	switch v := p.(type) {

--- a/executor/change.go
+++ b/executor/change.go
@@ -33,7 +33,7 @@ type ChangeExec struct {
 // Next implements the Executor Next interface.
 func (e *ChangeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	kind := strings.ToLower(e.NodeType)
-	urls := config.GetGlobalConfig().Path
+	urls := config.GetGlobalConfig(ctx).Path
 	registry, err := createRegistry(urls)
 	if err != nil {
 		return err

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -108,7 +108,7 @@ func needLowerPriority(p plannercore.Plan) bool {
 }
 
 func isPhysicalPlanNeedLowerPriority(p plannercore.PhysicalPlan) bool {
-	expensiveThreshold := int64(config.GetGlobalConfig().Log.ExpensiveThreshold)
+	expensiveThreshold := int64(config.GetGlobalConfig(context.Background()).Log.ExpensiveThreshold)
 	if int64(p.StatsCount()) > expensiveThreshold {
 		return true
 	}
@@ -154,7 +154,7 @@ func CountStmtNode(stmtNode ast.StmtNode, inRestrictedSQL bool) {
 		metrics.StmtNodeCounter.WithLabelValues(typeLabel).Inc()
 	}
 
-	if !config.GetGlobalConfig().Status.RecordQPSbyDB {
+	if !config.GetGlobalConfig(context.Background()).Status.RecordQPSbyDB {
 		return
 	}
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -95,7 +95,7 @@ func (e *DDLExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	case *ast.DropIndexStmt:
 		err = e.executeDropIndex(x)
 	case *ast.DropDatabaseStmt:
-		err = e.executeDropDatabase(x)
+		err = e.executeDropDatabase(ctx, x)
 	case *ast.DropTableStmt:
 		if x.IsView {
 			err = e.executeDropView(x)
@@ -208,7 +208,7 @@ func (e *DDLExec) executeCreateIndex(s *ast.CreateIndexStmt) error {
 	return err
 }
 
-func (e *DDLExec) executeDropDatabase(s *ast.DropDatabaseStmt) error {
+func (e *DDLExec) executeDropDatabase(ctx context.Context, s *ast.DropDatabaseStmt) error {
 	dbName := model.NewCIStr(s.Name)
 
 	// Protect important system table from been dropped by a mistake.
@@ -576,14 +576,14 @@ func (e *DDLExec) executeFlashbackTable(s *ast.FlashBackTableStmt) error {
 }
 
 func (e *DDLExec) executeLockTables(s *ast.LockTablesStmt) error {
-	if !config.TableLockEnabled() {
+	if !config.TableLockEnabled(context.Background()) {
 		return nil
 	}
 	return domain.GetDomain(e.ctx).DDL().LockTables(e.ctx, s)
 }
 
 func (e *DDLExec) executeUnlockTables(s *ast.UnlockTablesStmt) error {
-	if !config.TableLockEnabled() {
+	if !config.TableLockEnabled(context.Background()) {
 		return nil
 	}
 	lockedTables := e.ctx.GetAllTableLocks()

--- a/executor/delete.go
+++ b/executor/delete.go
@@ -89,7 +89,7 @@ func (e *DeleteExec) deleteSingleTableByChunk(ctx context.Context) error {
 	}
 
 	// If tidb_batch_delete is ON and not in a transaction, we could use BatchDelete mode.
-	batchDelete := e.ctx.GetSessionVars().BatchDelete && !e.ctx.GetSessionVars().InTxn() && config.GetGlobalConfig().EnableBatchDML
+	batchDelete := e.ctx.GetSessionVars().BatchDelete && !e.ctx.GetSessionVars().InTxn() && config.GetGlobalConfig(ctx).EnableBatchDML
 	batchDMLSize := e.ctx.GetSessionVars().DMLBatchSize
 	fields := retTypes(e.children[0])
 	chk := newFirstChunk(e.children[0])

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1570,10 +1570,10 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		TaskID:      stmtctx.AllocateTaskID(),
 	}
 	sc.MemTracker.AttachToGlobalTracker(GlobalMemoryUsageTracker)
-	if config.GetGlobalConfig().OOMUseTmpStorage && GlobalDiskUsageTracker != nil {
+	if config.GetGlobalConfig(context.Background()).OOMUseTmpStorage && GlobalDiskUsageTracker != nil {
 		sc.DiskTracker.AttachToGlobalTracker(GlobalDiskUsageTracker)
 	}
-	switch config.GetGlobalConfig().OOMAction {
+	switch config.GetGlobalConfig(context.Background()).OOMAction {
 	case config.OOMActionCancel:
 		action := &memory.PanicOnExceed{ConnID: ctx.GetSessionVars().ConnectionID}
 		action.SetLogHook(domain.GetDomain(ctx).ExpensiveQueryHandle().LogOnQueryExceedMemQuota)

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -255,7 +255,7 @@ func assertEqualStrings(c *C, got []field, expect []string) {
 }
 
 func (s *testExecSerialSuite) TestSortSpillDisk(c *C) {
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true
 	newConf.MemQuotaQuery = 1

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -121,7 +121,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableConstraints:
 			e.setDataFromTableConstraints(sctx, dbs)
 		case infoschema.TableSessionVar:
-			err = e.setDataFromSessionVar(sctx)
+			err = e.setDataFromSessionVar(ctx, sctx)
 		case infoschema.TableTiDBServersInfo:
 			err = e.setDataForServersInfo()
 		case infoschema.TableTiFlashReplica:
@@ -1562,10 +1562,10 @@ func (e *tableStorageStatsRetriever) setDataForTableStorageStats(ctx sessionctx.
 	return rows, nil
 }
 
-func (e *memtableRetriever) setDataFromSessionVar(ctx sessionctx.Context) error {
+func (e *memtableRetriever) setDataFromSessionVar(ctx context.Context, sctx sessionctx.Context) error {
 	var rows [][]types.Datum
 	var err error
-	sessionVars := ctx.GetSessionVars()
+	sessionVars := sctx.GetSessionVars()
 	for _, v := range variable.SysVars {
 		var value string
 		value, err = variable.GetSessionSystemVar(sessionVars, v.Name)

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -82,7 +82,7 @@ func (s *testInfoschemaTableSuiteBase) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	s.store = store
 	s.dom = dom
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMAction = config.OOMActionLog
 	config.StoreGlobalConfig(&newConf)
@@ -577,14 +577,14 @@ func (s *testInfoschemaClusterTableSuite) setUpRPCService(c *C, addr string) (*g
 		Host:    "127.0.0.1",
 		Command: mysql.ComQuery,
 	}
-	srv := server.NewRPCServer(config.GetGlobalConfig(), s.dom, sm)
+	srv := server.NewRPCServer(config.GetGlobalConfig(context.Background()), s.dom, sm)
 	port := lis.Addr().(*net.TCPAddr).Port
 	addr = fmt.Sprintf("127.0.0.1:%d", port)
 	go func() {
 		err = srv.Serve(lis)
 		c.Assert(err, IsNil)
 	}()
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	cfg.Status.StatusPort = uint(port)
 	config.StoreGlobalConfig(cfg)
 	return srv, addr
@@ -708,7 +708,7 @@ func (s *testInfoschemaClusterTableSuite) TestTiDBClusterInfo(c *C) {
 
 	// information_schema.cluster_info
 	tk := testkit.NewTestKit(c, store)
-	tidbStatusAddr := fmt.Sprintf(":%d", config.GetGlobalConfig().Status.StatusPort)
+	tidbStatusAddr := fmt.Sprintf(":%d", config.GetGlobalConfig(context.Background()).Status.StatusPort)
 	row := func(cols ...string) string { return strings.Join(cols, " ") }
 	tk.MustQuery("select type, instance, status_address, version, git_hash from information_schema.cluster_info").Check(testkit.Rows(
 		row("tidb", ":4000", tidbStatusAddr, "None", "None"),

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -206,7 +206,7 @@ func insertRows(ctx context.Context, base insertCommon) (err error) {
 		return err
 	}
 	sessVars := e.ctx.GetSessionVars()
-	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && config.GetGlobalConfig().EnableBatchDML
+	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && config.GetGlobalConfig(ctx).EnableBatchDML
 	batchSize := sessVars.DMLBatchSize
 
 	e.lazyFillAutoID = true
@@ -404,7 +404,7 @@ func insertRowsFromSelect(ctx context.Context, base insertCommon) error {
 		// If StrictSQLMode is disabled and it is a insert-select statement, it also handle BadNullAsWarning.
 		sessVars.StmtCtx.BadNullAsWarning = true
 	}
-	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && config.GetGlobalConfig().EnableBatchDML
+	batchInsert := sessVars.BatchInsert && !sessVars.InTxn() && config.GetGlobalConfig(ctx).EnableBatchDML
 	batchSize := sessVars.DMLBatchSize
 	memUsageOfRows := int64(0)
 	memTracker := e.memTracker

--- a/executor/join.go
+++ b/executor/join.go
@@ -720,7 +720,7 @@ func (e *HashJoinExec) buildHashTableForList(buildSideResultCh <-chan *chunk.Chu
 	e.rowContainer.GetMemTracker().SetLabel(buildSideResultLabel)
 	e.rowContainer.GetDiskTracker().AttachTo(e.diskTracker)
 	e.rowContainer.GetDiskTracker().SetLabel(buildSideResultLabel)
-	if config.GetGlobalConfig().OOMUseTmpStorage {
+	if config.GetGlobalConfig(context.Background()).OOMUseTmpStorage {
 		actionSpill := e.rowContainer.ActionSpill()
 		e.ctx.GetSessionVars().StmtCtx.MemTracker.FallbackOldAndSetNewAction(actionSpill)
 	}

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -56,7 +56,7 @@ func (s *testSuiteJoin1) TestJoinPanic(c *C) {
 }
 
 func (s *testSuite) TestJoinInDisk(c *C) {
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true
 	config.StoreGlobalConfig(&newConf)

--- a/executor/memtable_reader.go
+++ b/executor/memtable_reader.go
@@ -354,7 +354,7 @@ func serverInfoItemToRows(items []*diagnosticspb.ServerInfoItem, tp, addr string
 
 func getServerInfoByGRPC(ctx context.Context, address string, tp diagnosticspb.ServerInfoType) ([]*diagnosticspb.ServerInfoItem, error) {
 	opt := grpc.WithInsecure()
-	security := config.GetGlobalConfig().Security
+	security := config.GetGlobalConfig(ctx).Security
 	if len(security.ClusterSSLCA) != 0 {
 		tlsConfig, err := security.ToTLSConfig()
 		if err != nil {
@@ -518,7 +518,7 @@ func (e *clusterLogRetriever) startRetrieving(
 	req *diagnosticspb.SearchLogRequest) ([]chan logStreamResult, error) {
 	// gRPC options
 	opt := grpc.WithInsecure()
-	security := config.GetGlobalConfig().Security
+	security := config.GetGlobalConfig(ctx).Security
 	if len(security.ClusterSSLCA) != 0 {
 		tlsConfig, err := security.ToTLSConfig()
 		if err != nil {

--- a/executor/merge_join.go
+++ b/executor/merge_join.go
@@ -97,7 +97,7 @@ func (t *mergeJoinTable) init(exec *MergeJoinExec) {
 		t.rowContainer.GetMemTracker().SetLabel(innerTableLabel)
 		t.rowContainer.GetDiskTracker().AttachTo(exec.diskTracker)
 		t.rowContainer.GetDiskTracker().SetLabel(innerTableLabel)
-		if config.GetGlobalConfig().OOMUseTmpStorage {
+		if config.GetGlobalConfig(context.Background()).OOMUseTmpStorage {
 			actionSpill := t.rowContainer.ActionSpill()
 			exec.ctx.GetSessionVars().StmtCtx.MemTracker.SetActionOnExceed(actionSpill)
 		}

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math/rand"
 	"strings"
@@ -241,7 +242,7 @@ func checkPlanAndRun(tk *testkit.TestKit, c *C, plan string, sql string) *testki
 }
 
 func (s *testSuite2) TestMergeJoinInDisk(c *C) {
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true
 	config.StoreGlobalConfig(&newConf)

--- a/executor/oomtest/oom_test.go
+++ b/executor/oomtest/oom_test.go
@@ -16,6 +16,7 @@
 package oomtest
 
 import (
+	"context"
 	"os"
 	"strings"
 	"sync"
@@ -50,7 +51,7 @@ func (s *testOOMSuite) SetUpSuite(c *C) {
 	domain.RunAutoAnalyze = false
 	s.do, err = session.BootstrapSession(s.store)
 	c.Assert(err, IsNil)
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMAction = config.OOMActionLog
 	config.StoreGlobalConfig(&newConf)

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -173,7 +173,7 @@ func (s stats) Stats(vars *variable.SessionVars) (map[string]interface{}, error)
 }
 
 func (s *seqTestSuite) TestShow(c *C) {
-	config.GetGlobalConfig().Experimental.AllowsExpressionIndex = true
+	config.GetGlobalConfig(context.Background()).Experimental.AllowsExpressionIndex = true
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 
@@ -1009,7 +1009,7 @@ func (s *seqTestSuite) TestBatchInsertDelete(c *C) {
 	r = tk.MustQuery("select count(*) from batch_insert;")
 	r.Check(testkit.Rows("320"))
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	newCfg.EnableBatchDML = true
 	config.StoreGlobalConfig(&newCfg)
@@ -1173,9 +1173,9 @@ func (s *seqTestSuite1) TestCoprocessorPriority(c *C) {
 	// Insert some data to make sure plan build IndexLookup for t.
 	tk.MustExec("insert into t values (1), (2)")
 
-	oldThreshold := config.GetGlobalConfig().Log.ExpensiveThreshold
-	config.GetGlobalConfig().Log.ExpensiveThreshold = 0
-	defer func() { config.GetGlobalConfig().Log.ExpensiveThreshold = oldThreshold }()
+	oldThreshold := config.GetGlobalConfig(context.Background()).Log.ExpensiveThreshold
+	config.GetGlobalConfig(context.Background()).Log.ExpensiveThreshold = 0
+	defer func() { config.GetGlobalConfig(context.Background()).Log.ExpensiveThreshold = oldThreshold }()
 
 	cli.setCheckPriority(pb.CommandPri_High)
 	tk.MustQuery("select id from t where id = 1")

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -260,8 +260,8 @@ func (s *testSuite5) TestSetVar(c *C) {
 	tk.MustExec("set @@sql_log_bin = on")
 	tk.MustQuery(`select @@session.sql_log_bin;`).Check(testkit.Rows("1"))
 
-	tk.MustQuery(`select @@global.log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig().Binlog.Enable)))
-	tk.MustQuery(`select @@log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig().Binlog.Enable)))
+	tk.MustQuery(`select @@global.log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig(context.Background()).Binlog.Enable)))
+	tk.MustQuery(`select @@log_bin;`).Check(testkit.Rows(variable.BoolToIntStr(config.GetGlobalConfig(context.Background()).Binlog.Enable)))
 
 	tk.MustExec("set @@tidb_general_log = 1")
 	tk.MustExec("set @@tidb_general_log = 0")

--- a/executor/show.go
+++ b/executor/show.go
@@ -144,7 +144,7 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowDatabases:
 		return e.fetchShowDatabases()
 	case ast.ShowDrainerStatus:
-		return e.fetchShowPumpOrDrainerStatus(node.DrainerNode)
+		return e.fetchShowPumpOrDrainerStatus(ctx, node.DrainerNode)
 	case ast.ShowEngines:
 		return e.fetchShowEngines()
 	case ast.ShowGrants:
@@ -154,7 +154,7 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowProcedureStatus:
 		return e.fetchShowProcedureStatus()
 	case ast.ShowPumpStatus:
-		return e.fetchShowPumpOrDrainerStatus(node.PumpNode)
+		return e.fetchShowPumpOrDrainerStatus(ctx, node.PumpNode)
 	case ast.ShowStatus:
 		return e.fetchShowStatus()
 	case ast.ShowTables:
@@ -166,7 +166,7 @@ func (e *ShowExec) fetchAll(ctx context.Context) error {
 	case ast.ShowTriggers:
 		return e.fetchShowTriggers()
 	case ast.ShowVariables:
-		return e.fetchShowVariables()
+		return e.fetchShowVariables(ctx)
 	case ast.ShowWarnings:
 		return e.fetchShowWarnings(false)
 	case ast.ShowErrors:
@@ -641,7 +641,7 @@ func (e *ShowExec) fetchShowMasterStatus() error {
 	return nil
 }
 
-func (e *ShowExec) fetchShowVariables() (err error) {
+func (e *ShowExec) fetchShowVariables(ctx context.Context) (err error) {
 	var (
 		value         string
 		ok            bool
@@ -1340,8 +1340,8 @@ func (e *ShowExec) fetchShowWarnings(errOnly bool) error {
 }
 
 // fetchShowPumpOrDrainerStatus gets status of all pumps or drainers and fill them into e.rows.
-func (e *ShowExec) fetchShowPumpOrDrainerStatus(kind string) error {
-	registry, err := createRegistry(config.GetGlobalConfig().Path)
+func (e *ShowExec) fetchShowPumpOrDrainerStatus(ctx context.Context, kind string) error {
+	registry, err := createRegistry(config.GetGlobalConfig(ctx).Path)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -542,7 +542,7 @@ func (s *testFlushSuite) TestFlushPrivilegesPanic(c *C) {
 	c.Assert(err, IsNil)
 	defer store.Close()
 
-	saveConf := config.GetGlobalConfig()
+	saveConf := config.GetGlobalConfig(context.Background())
 	conf := *saveConf
 	conf.Security.SkipGrantTable = true
 	config.StoreGlobalConfig(&conf)

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -243,7 +243,7 @@ func (e *SortExec) fetchRowChunks(ctx context.Context) error {
 	e.rowChunks.GetMemTracker().AttachTo(e.memTracker)
 	e.rowChunks.GetMemTracker().SetLabel(rowChunksLabel)
 	var onExceededCallback func(rowContainer *chunk.RowContainer)
-	if config.GetGlobalConfig().OOMUseTmpStorage {
+	if config.GetGlobalConfig(ctx).OOMUseTmpStorage {
 		e.spillAction = e.rowChunks.ActionSpill()
 		e.ctx.GetSessionVars().StmtCtx.MemTracker.FallbackOldAndSetNewAction(e.spillAction)
 		onExceededCallback = func(rowContainer *chunk.RowContainer) {

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/pingcap/check"
@@ -23,7 +24,7 @@ import (
 )
 
 func (s *testSuite) TestSortInDisk(c *C) {
-	originCfg := config.GetGlobalConfig()
+	originCfg := config.GetGlobalConfig(context.Background())
 	newConf := *originCfg
 	newConf.OOMUseTmpStorage = true
 	config.StoreGlobalConfig(&newConf)

--- a/executor/statement_context_test.go
+++ b/executor/statement_context_test.go
@@ -14,6 +14,7 @@
 package executor_test
 
 import (
+	"context"
 	"fmt"
 	"unicode/utf8"
 
@@ -102,7 +103,7 @@ func (s *testSuite1) TestStatementContext(c *C) {
 	_, err = tk.Exec("insert t1 values (unhex('F0A48BAE'))")
 	c.Assert(err, NotNil)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue, Commentf("err %v", err))
-	old := config.GetGlobalConfig()
+	old := config.GetGlobalConfig(context.Background())
 	conf := *old
 	conf.CheckMb4ValueInUTF8 = false
 	config.StoreGlobalConfig(&conf)

--- a/executor/write_concurrent_test.go
+++ b/executor/write_concurrent_test.go
@@ -30,7 +30,7 @@ func (s *testSuite) TestBatchInsertWithOnDuplicate(c *C) {
 	tk.MustExec(ctx, "create table duplicate_test(id int auto_increment, k1 int, primary key(id), unique key uk(k1))")
 	tk.MustExec(ctx, "insert into duplicate_test(k1) values(?),(?),(?),(?),(?)", tk.PermInt(5)...)
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	newCfg := *cfg
 	newCfg.EnableBatchDML = true
 	config.StoreGlobalConfig(&newCfg)

--- a/expression/helper.go
+++ b/expression/helper.go
@@ -131,14 +131,14 @@ func GetTimeValue(ctx sessionctx.Context, v interface{}, tp byte, fsp int8) (d t
 
 // if timestamp session variable set, use session variable as current time, otherwise use cached time
 // during one sql statement, the "current_time" should be the same
-func getStmtTimestamp(ctx sessionctx.Context) (time.Time, error) {
+func getStmtTimestamp(sctx sessionctx.Context) (time.Time, error) {
 	now := time.Now()
 
-	if ctx == nil {
+	if sctx == nil {
 		return now, nil
 	}
 
-	sessionVars := ctx.GetSessionVars()
+	sessionVars := sctx.GetSessionVars()
 	timestampStr, err := variable.GetSessionSystemVar(sessionVars, "timestamp")
 	if err != nil {
 		return now, err
@@ -154,6 +154,6 @@ func getStmtTimestamp(ctx sessionctx.Context) (time.Time, error) {
 		}
 		return time.Unix(timestamp, 0), nil
 	}
-	stmtCtx := ctx.GetSessionVars().StmtCtx
+	stmtCtx := sctx.GetSessionVars().StmtCtx
 	return stmtCtx.GetNowTsCached(), nil
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20200609110328-c65941b9fbb3
 	github.com/pingcap/pd/v4 v4.0.0-rc.2.0.20200520083007-2c251bd8f181
 	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
-	github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible
+	github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible
 	github.com/pingcap/tipb v0.0.0-20200604070248-508f03b0b342
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
@@ -64,3 +64,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/br => github.com/tiancaiamao/br v0.0.0-20200611041054-11d18947e3ef

--- a/go.sum
+++ b/go.sum
@@ -475,6 +475,8 @@ github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompat
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200421113014-507d2bb3a15e+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible h1:/JKsYjsa5Ug8v5CN4zIbJGIqsvgBUkGwaP/rEScVvWM=
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible h1:e+j+rsJYX+J7eTkgjnGBH2/T3NS6GNSPD6nHA5bPdCI=
+github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200604070248-508f03b0b342 h1:4EfeYX3F2psQLVoWkoN6h4isDKgBsQGdnVNoAJgX8t4=
@@ -580,6 +582,8 @@ github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285 h1:uSDYjYejelKy
 github.com/syndtr/goleveldb v1.0.1-0.20190625010220-02440ea7a285/go.mod h1:9OrXJhf154huy1nPWmuSrkgjPUtUNhA+Zmy+6AESzuA=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
+github.com/tiancaiamao/br v0.0.0-20200611041054-11d18947e3ef h1:B4BRoiypqQliKTG4GE5vG6xwFwXMdKA+brAPJCFClQw=
+github.com/tiancaiamao/br v0.0.0-20200611041054-11d18947e3ef/go.mod h1:TQQg4MqHWWQITy7C9h9x0+6jN8Rjq7TfQ+0Bc/jTB3U=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -14,6 +14,7 @@
 package infoschema
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"strings"
@@ -315,7 +316,7 @@ func ConvertCharsetCollateToLowerCaseIfNeed(tbInfo *model.TableInfo) {
 
 // ConvertOldVersionUTF8ToUTF8MB4IfNeed convert old version UTF8 to UTF8MB4 if config.TreatOldVersionUTF8AsUTF8MB4 is enable.
 func ConvertOldVersionUTF8ToUTF8MB4IfNeed(tbInfo *model.TableInfo) {
-	if tbInfo.Version >= model.TableInfoVersion2 || !config.GetGlobalConfig().TreatOldVersionUTF8AsUTF8MB4 {
+	if tbInfo.Version >= model.TableInfoVersion2 || !config.GetGlobalConfig(context.Background()).TreatOldVersionUTF8AsUTF8MB4 {
 		return
 	}
 	if tbInfo.Charset == charset.CharsetUTF8 {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1214,7 +1214,7 @@ func GetTiDBServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	}
 	var servers []ServerInfo
 	var isDefaultVersion bool
-	if len(config.GetGlobalConfig().ServerVersion) == 0 {
+	if len(config.GetGlobalConfig(context.Background()).ServerVersion) == 0 {
 		isDefaultVersion = true
 	}
 	for _, node := range tidbNodes {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -14,6 +14,7 @@
 package infoschema_test
 
 import (
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math"
@@ -126,14 +127,14 @@ func (s *testClusterTableSuite) setUpRPCService(c *C, addr string) (*grpc.Server
 		Host:    "127.0.0.1",
 		Command: mysql.ComQuery,
 	}
-	srv := server.NewRPCServer(config.GetGlobalConfig(), s.dom, sm)
+	srv := server.NewRPCServer(config.GetGlobalConfig(context.Background()), s.dom, sm)
 	port := lis.Addr().(*net.TCPAddr).Port
 	addr = fmt.Sprintf("127.0.0.1:%d", port)
 	go func() {
 		err = srv.Serve(lis)
 		c.Assert(err, IsNil)
 	}()
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	cfg.Status.StatusPort = uint(port)
 	config.StoreGlobalConfig(cfg)
 	return srv, addr

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -431,7 +431,7 @@ func (s *testAnalyzeSuite) TestPreparedNullParam(c *C) {
 		store.Close()
 	}()
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	orgEnable := cfg.PreparedPlanCache.Enabled
 	orgCapacity := cfg.PreparedPlanCache.Capacity
 	flags := []bool{false, true}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -14,6 +14,7 @@
 package core_test
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/pingcap/check"
@@ -301,10 +302,11 @@ func (s *testIntegrationSerialSuite) TestNoneAccessPathsFoundByIsolationRead(c *
 
 	tk.MustExec("set @@session.tidb_isolation_read_engines = 'tiflash, tikv'")
 	tk.MustExec("select * from t")
-	config.GetGlobalConfig().IsolationRead.Engines = []string{"tiflash"}
-	defer func() { config.GetGlobalConfig().IsolationRead.Engines = []string{"tikv", "tiflash"} }()
+
+	cfg := config.NewConfig()
+	cfg.IsolationRead.Engines = []string{"tiflash"}
 	// Change instance config doesn't affect isolation read.
-	tk.MustExec("select * from t")
+	tk.MustExecWithCtx(config.WithGlobalConfig(context.Background(), cfg), "select * from t")
 }
 
 func (s *testIntegrationSerialSuite) TestSelPushDownTiFlash(c *C) {

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -106,7 +106,7 @@ func CheckPrivilege(activeRoles []*auth.RoleIdentity, pm privilege.Manager, vs [
 
 // CheckTableLock checks the table lock.
 func CheckTableLock(ctx sessionctx.Context, is infoschema.InfoSchema, vs []visitInfo) error {
-	if !config.TableLockEnabled() {
+	if !config.TableLockEnabled(context.Background()) {
 		return nil
 	}
 	checker := lock.NewChecker(ctx, is)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2487,7 +2487,7 @@ func (b *PlanBuilder) buildSplitIndexRegion(node *ast.SplitRegionStmt) (Plan, er
 	p.Lower = lowerValues
 	p.Upper = upperValues
 
-	maxSplitRegionNum := int64(config.GetGlobalConfig().SplitRegionMaxNum)
+	maxSplitRegionNum := int64(config.GetGlobalConfig(context.Background()).SplitRegionMaxNum)
 	if node.SplitOpt.Num > maxSplitRegionNum {
 		return nil, errors.Errorf("Split index region num exceeded the limit %v", maxSplitRegionNum)
 	} else if node.SplitOpt.Num < 1 {
@@ -2600,7 +2600,7 @@ func (b *PlanBuilder) buildSplitTableRegion(node *ast.SplitRegionStmt) (Plan, er
 	p.Lower = []types.Datum{lowerValues}
 	p.Upper = []types.Datum{upperValue}
 
-	maxSplitRegionNum := int64(config.GetGlobalConfig().SplitRegionMaxNum)
+	maxSplitRegionNum := int64(config.GetGlobalConfig(context.Background()).SplitRegionMaxNum)
 	if node.SplitOpt.Num > maxSplitRegionNum {
 		return nil, errors.Errorf("Split table region num exceeded the limit %v", maxSplitRegionNum)
 	} else if node.SplitOpt.Num < 1 {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -14,6 +14,7 @@
 package core
 
 import (
+	"context"
 	"math"
 
 	"github.com/pingcap/parser/ast"
@@ -446,7 +447,7 @@ func (p *PhysicalHashJoin) GetCost(lCnt, rCnt float64) float64 {
 		build = p.children[1]
 	}
 	sessVars := p.ctx.GetSessionVars()
-	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
+	oomUseTmpStorage := config.GetGlobalConfig(context.Background()).OOMUseTmpStorage
 	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
 	rowSize := getAvgRowSize(build.statsInfo(), build.Schema())
 	spill := oomUseTmpStorage && memQuota > 0 && rowSize*buildCnt > float64(memQuota)
@@ -836,7 +837,7 @@ func (p *PhysicalSort) GetCost(count float64, schema *expression.Schema) float64
 	cpuCost := count * math.Log2(count) * sessVars.CPUFactor
 	memoryCost := count * sessVars.MemoryFactor
 
-	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
+	oomUseTmpStorage := config.GetGlobalConfig(context.Background()).OOMUseTmpStorage
 	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
 	rowSize := getAvgRowSize(p.statsInfo(), schema)
 	spill := oomUseTmpStorage && memQuota > 0 && rowSize*count > float64(memQuota)

--- a/server/conn.go
+++ b/server/conn.go
@@ -548,7 +548,7 @@ func (cc *clientConn) readOptionalSSLRequestAndHandshakeResponse(ctx context.Con
 				return err
 			}
 		}
-	} else if config.GetGlobalConfig().Security.RequireSecureTransport {
+	} else if config.GetGlobalConfig(ctx).Security.RequireSecureTransport {
 		err := errSecureTransportRequired.FastGenByArgs()
 		terror.Log(err)
 		return err

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -638,7 +638,7 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			}
 			log.SetLevel(l)
 
-			config.GetGlobalConfig().Log.Level = levelStr
+			config.GetGlobalConfig(context.Background()).Log.Level = levelStr
 		}
 		if generalLog := req.Form.Get("tidb_general_log"); generalLog != "" {
 			switch generalLog {
@@ -664,16 +664,16 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		if checkMb4ValueInUtf8 := req.Form.Get("check_mb4_value_in_utf8"); checkMb4ValueInUtf8 != "" {
 			switch checkMb4ValueInUtf8 {
 			case "0":
-				config.GetGlobalConfig().CheckMb4ValueInUTF8 = false
+				config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8 = false
 			case "1":
-				config.GetGlobalConfig().CheckMb4ValueInUTF8 = true
+				config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8 = true
 			default:
 				writeError(w, errors.New("illegal argument"))
 				return
 			}
 		}
 	} else {
-		writeData(w, config.GetGlobalConfig())
+		writeData(w, config.GetGlobalConfig(context.Background()))
 	}
 }
 

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -123,7 +123,7 @@ func (s *Server) startHTTPServer() {
 
 	// HTTP path for get the TiDB config
 	router.Handle("/config", fn.Wrap(func() (*config.Config, error) {
-		return config.GetGlobalConfig(), nil
+		return config.GetGlobalConfig(context.Background()), nil
 	}))
 
 	// HTTP path for get server info.
@@ -234,7 +234,7 @@ func (s *Server) startHTTPServer() {
 			serveError(w, http.StatusInternalServerError, fmt.Sprintf("Create zipped %s fail: %v", "config", err))
 			return
 		}
-		js, err := json.MarshalIndent(config.GetGlobalConfig(), "", " ")
+		js, err := json.MarshalIndent(config.GetGlobalConfig(context.Background()), "", " ")
 		if err != nil {
 			serveError(w, http.StatusInternalServerError, fmt.Sprintf("get config info fail%v", err))
 			return

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1021,7 +1021,7 @@ func upgradeToVer42(s Session, ver int64) {
 // Convert statement summary global variables to non-empty values.
 func writeStmtSummaryVars(s Session) {
 	sql := fmt.Sprintf("UPDATE %s.%s SET variable_value='%%s' WHERE variable_name='%%s' AND variable_value=''", mysql.SystemDB, mysql.GlobalVariablesTable)
-	stmtSummaryConfig := config.GetGlobalConfig().StmtSummary
+	stmtSummaryConfig := config.GetGlobalConfig(context.Background()).StmtSummary
 	mustExecute(s, fmt.Sprintf(sql, variable.BoolToIntStr(stmtSummaryConfig.Enable), variable.TiDBEnableStmtSummary))
 	mustExecute(s, fmt.Sprintf(sql, variable.BoolToIntStr(stmtSummaryConfig.EnableInternalQuery), variable.TiDBStmtSummaryInternalQuery))
 	mustExecute(s, fmt.Sprintf(sql, strconv.Itoa(stmtSummaryConfig.RefreshInterval), variable.TiDBStmtSummaryRefreshInterval))
@@ -1151,7 +1151,7 @@ func doDMLWorks(s Session) {
 		// Session only variable should not be inserted.
 		if v.Scope != variable.ScopeSession {
 			vVal := v.Value
-			if v.Name == variable.TiDBTxnMode && config.GetGlobalConfig().Store == "tikv" {
+			if v.Name == variable.TiDBTxnMode && config.GetGlobalConfig(context.Background()).Store == "tikv" {
 				vVal = "pessimistic"
 			}
 			if v.Name == variable.TiDBRowFormatVersion {
@@ -1176,7 +1176,7 @@ func doDMLWorks(s Session) {
 
 	writeSystemTZ(s)
 
-	writeNewCollationParameter(s, config.GetGlobalConfig().NewCollationsEnabledOnFirstBootstrap)
+	writeNewCollationParameter(s, config.GetGlobalConfig(context.Background()).NewCollationsEnabledOnFirstBootstrap)
 
 	writeDefaultExprPushDownBlacklist(s)
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -163,7 +163,7 @@ func (s *testSessionSuiteBase) SetUpSuite(c *C) {
 		initPdAddrs()
 		s.pdAddr = <-pdAddrChan
 		var d tikv.Driver
-		config.GetGlobalConfig().TxnLocalLatches.Enabled = false
+		config.GetGlobalConfig(context.Background()).TxnLocalLatches.Enabled = false
 		store, err := d.Open(fmt.Sprintf("tikv://%s", s.pdAddr))
 		c.Assert(err, IsNil)
 		err = clearStorage(store)
@@ -2452,10 +2452,10 @@ func (s *testSessionSuite2) TestStatementErrorInTransaction(c *C) {
 func (s *testSessionSerialSuite) TestStatementCountLimit(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create table stmt_count_limit (id int)")
-	saved := config.GetGlobalConfig().Performance.StmtCountLimit
-	config.GetGlobalConfig().Performance.StmtCountLimit = 3
+	saved := config.GetGlobalConfig(context.Background()).Performance.StmtCountLimit
+	config.GetGlobalConfig(context.Background()).Performance.StmtCountLimit = 3
 	defer func() {
-		config.GetGlobalConfig().Performance.StmtCountLimit = saved
+		config.GetGlobalConfig(context.Background()).Performance.StmtCountLimit = saved
 	}()
 	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
 	tk.MustExec("begin")
@@ -2478,10 +2478,10 @@ func (s *testSessionSerialSuite) TestBatchCommit(c *C) {
 	tk.MustExec("set tidb_batch_commit = 1")
 	tk.MustExec("set tidb_disable_txn_auto_retry = 0")
 	tk.MustExec("create table t (id int)")
-	saved := config.GetGlobalConfig().Performance
-	config.GetGlobalConfig().Performance.StmtCountLimit = 3
+	saved := config.GetGlobalConfig(context.Background()).Performance
+	config.GetGlobalConfig(context.Background()).Performance.StmtCountLimit = 3
 	defer func() {
-		config.GetGlobalConfig().Performance = saved
+		config.GetGlobalConfig(context.Background()).Performance = saved
 	}()
 	tk1 := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("SET SESSION autocommit = 1")
@@ -2765,7 +2765,7 @@ func (s *testSchemaSuite) TestDisableTxnAutoRetry(c *C) {
 
 	// test for disable transaction local latch
 	tk1.Se.GetSessionVars().InRestrictedSQL = false
-	orgCfg := config.GetGlobalConfig()
+	orgCfg := config.GetGlobalConfig(context.Background())
 	disableLatchCfg := *orgCfg
 	disableLatchCfg.TxnLocalLatches.Enabled = false
 	config.StoreGlobalConfig(&disableLatchCfg)

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -244,7 +244,7 @@ func checkStmtLimit(ctx context.Context, se *session) error {
 	var err error
 	sessVars := se.GetSessionVars()
 	history := GetHistory(se)
-	if history.Count() > int(config.GetGlobalConfig().Performance.StmtCountLimit) {
+	if history.Count() > int(config.GetGlobalConfig(ctx).Performance.StmtCountLimit) {
 		if !sessVars.BatchCommit {
 			se.RollbackTxn(ctx)
 			return errors.Errorf("statement count %d exceeds the transaction limitation, autocommit = %t",

--- a/session/txn.go
+++ b/session/txn.go
@@ -497,7 +497,7 @@ func (tf *txnFuture) wait() (kv.Transaction, error) {
 	startTS, err := tf.future.Wait()
 	if err == nil {
 		return tf.store.BeginWithStartTS(startTS)
-	} else if config.GetGlobalConfig().Store == "unistore" {
+	} else if config.GetGlobalConfig(context.Background()).Store == "unistore" {
 		return nil, err
 	}
 

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -14,6 +14,7 @@
 package binloginfo
 
 import (
+	"context"
 	"math"
 	"regexp"
 	"strings"
@@ -203,7 +204,7 @@ func SetIgnoreError(on bool) {
 
 // GetStatus gets the status of binlog
 func GetStatus() BinlogStatus {
-	conf := config.GetGlobalConfig()
+	conf := config.GetGlobalConfig(context.Background())
 	if !conf.Binlog.Enable {
 		return BinlogStatusOff
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -15,6 +15,7 @@ package variable
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"fmt"
 	"math"
@@ -713,7 +714,7 @@ func NewSessionVars() *SessionVars {
 		L2CacheSize:                 cpuid.CPU.Cache.L2,
 		CommandValue:                uint32(mysql.ComSleep),
 		TiDBOptJoinReorderThreshold: DefTiDBOptJoinReorderThreshold,
-		SlowQueryFile:               config.GetGlobalConfig().Log.SlowQueryFile,
+		SlowQueryFile:               config.GetGlobalConfig(context.Background()).Log.SlowQueryFile,
 		WaitSplitRegionFinish:       DefTiDBWaitSplitRegionFinish,
 		WaitSplitRegionTimeout:      DefWaitSplitRegionTimeout,
 		enableIndexMerge:            false,
@@ -748,7 +749,7 @@ func NewSessionVars() *SessionVars {
 		WindowConcurrency:          DefTiDBWindowConcurrency,
 	}
 	vars.MemQuota = MemQuota{
-		MemQuotaQuery: config.GetGlobalConfig().MemQuotaQuery,
+		MemQuotaQuery: config.GetGlobalConfig(context.Background()).MemQuotaQuery,
 
 		// The variables below do not take any effect anymore, it's remaining for compatibility.
 		// TODO: remove them in v4.1
@@ -769,7 +770,7 @@ func NewSessionVars() *SessionVars {
 		DMLBatchSize:       DefDMLBatchSize,
 	}
 	var enableStreaming string
-	if config.GetGlobalConfig().EnableStreaming {
+	if config.GetGlobalConfig(context.Background()).EnableStreaming {
 		enableStreaming = "1"
 	} else {
 		enableStreaming = "0"
@@ -779,13 +780,13 @@ func NewSessionVars() *SessionVars {
 	vars.AllowBatchCop = DefTiDBAllowBatchCop
 
 	var enableChunkRPC string
-	if config.GetGlobalConfig().TiKVClient.EnableChunkRPC {
+	if config.GetGlobalConfig(context.Background()).TiKVClient.EnableChunkRPC {
 		enableChunkRPC = "1"
 	} else {
 		enableChunkRPC = "0"
 	}
 	terror.Log(vars.SetSystemVar(TiDBEnableChunkRPC, enableChunkRPC))
-	for _, engine := range config.GetGlobalConfig().IsolationRead.Engines {
+	for _, engine := range config.GetGlobalConfig(context.Background()).IsolationRead.Engines {
 		switch engine {
 		case kv.TiFlash.Name():
 			vars.IsolationReadEngines[kv.TiFlash] = struct{}{}
@@ -1184,7 +1185,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	case TiDBInitChunkSize:
 		s.InitChunkSize = tidbOptPositiveInt32(val, DefInitChunkSize)
 	case TIDBMemQuotaQuery:
-		s.MemQuotaQuery = tidbOptInt64(val, config.GetGlobalConfig().MemQuotaQuery)
+		s.MemQuotaQuery = tidbOptInt64(val, config.GetGlobalConfig(context.Background()).MemQuotaQuery)
 	case TIDBMemQuotaHashJoin:
 		s.MemQuotaHashJoin = tidbOptInt64(val, DefTiDBMemQuotaHashJoin)
 		s.StmtCtx.AppendWarning(errWarnDeprecatedSyntax.FastGenByArgs(name, TIDBMemQuotaQuery))
@@ -1319,19 +1320,19 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 			logutil.BgLogger().Warn(err.Error())
 		}
 	case TiDBSlowLogThreshold:
-		atomic.StoreUint64(&config.GetGlobalConfig().Log.SlowThreshold, uint64(tidbOptInt64(val, logutil.DefaultSlowThreshold)))
+		atomic.StoreUint64(&config.GetGlobalConfig(context.Background()).Log.SlowThreshold, uint64(tidbOptInt64(val, logutil.DefaultSlowThreshold)))
 	case TiDBRecordPlanInSlowLog:
-		atomic.StoreUint32(&config.GetGlobalConfig().Log.RecordPlanInSlowLog, uint32(tidbOptInt64(val, logutil.DefaultRecordPlanInSlowLog)))
+		atomic.StoreUint32(&config.GetGlobalConfig(context.Background()).Log.RecordPlanInSlowLog, uint32(tidbOptInt64(val, logutil.DefaultRecordPlanInSlowLog)))
 	case TiDBEnableSlowLog:
-		config.GetGlobalConfig().Log.EnableSlowLog = TiDBOptOn(val)
+		config.GetGlobalConfig(context.Background()).Log.EnableSlowLog = TiDBOptOn(val)
 	case TiDBQueryLogMaxLen:
-		atomic.StoreUint64(&config.GetGlobalConfig().Log.QueryLogMaxLen, uint64(tidbOptInt64(val, logutil.DefaultQueryLogMaxLen)))
+		atomic.StoreUint64(&config.GetGlobalConfig(context.Background()).Log.QueryLogMaxLen, uint64(tidbOptInt64(val, logutil.DefaultQueryLogMaxLen)))
 	case TiDBCheckMb4ValueInUTF8:
-		config.GetGlobalConfig().CheckMb4ValueInUTF8 = TiDBOptOn(val)
+		config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8 = TiDBOptOn(val)
 	case TiDBFoundInPlanCache:
 		s.FoundInPlanCache = TiDBOptOn(val)
 	case TiDBEnableCollectExecutionInfo:
-		config.GetGlobalConfig().EnableCollectExecutionInfo = TiDBOptOn(val)
+		config.GetGlobalConfig(context.Background()).EnableCollectExecutionInfo = TiDBOptOn(val)
 	case SQLSelectLimit:
 		result, err := strconv.ParseUint(val, 10, 64)
 		if err != nil {

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -14,6 +14,7 @@
 package variable_test
 
 import (
+	"context"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -233,11 +234,11 @@ select * from t;`
 }
 
 func (*testSessionSuite) TestIsolationRead(c *C) {
-	originIsolationEngines := config.GetGlobalConfig().IsolationRead.Engines
+	originIsolationEngines := config.GetGlobalConfig(context.Background()).IsolationRead.Engines
 	defer func() {
-		config.GetGlobalConfig().IsolationRead.Engines = originIsolationEngines
+		config.GetGlobalConfig(context.Background()).IsolationRead.Engines = originIsolationEngines
 	}()
-	config.GetGlobalConfig().IsolationRead.Engines = []string{"tiflash", "tidb"}
+	config.GetGlobalConfig(context.Background()).IsolationRead.Engines = []string{"tiflash", "tidb"}
 	sessVars := variable.NewSessionVars()
 	_, ok := sessVars.IsolationReadEngines[kv.TiDB]
 	c.Assert(ok, Equals, true)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -14,6 +14,7 @@
 package variable
 
 import (
+	"context"
 	"strconv"
 	"strings"
 	"sync/atomic"
@@ -611,7 +612,7 @@ var defaultSysVars = []*SysVar{
 	/* TiDB specific variables */
 	{ScopeSession, TiDBSnapshot, ""},
 	{ScopeSession, TiDBOptAggPushDown, BoolToIntStr(DefOptAggPushDown)},
-	{ScopeSession, TiDBOptDistinctAggPushDown, BoolToIntStr(config.GetGlobalConfig().Performance.DistinctAggPushDown)},
+	{ScopeSession, TiDBOptDistinctAggPushDown, BoolToIntStr(config.GetGlobalConfig(context.Background()).Performance.DistinctAggPushDown)},
 	{ScopeSession, TiDBOptWriteRowID, BoolToIntStr(DefOptWriteRowID)},
 	{ScopeGlobal | ScopeSession, TiDBBuildStatsConcurrency, strconv.Itoa(DefBuildStatsConcurrency)},
 	{ScopeGlobal, TiDBAutoAnalyzeRatio, strconv.FormatFloat(DefAutoAnalyzeRatio, 'f', -1, 64)},
@@ -647,7 +648,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBInitChunkSize, strconv.Itoa(DefInitChunkSize)},
 	{ScopeGlobal | ScopeSession, TiDBEnableCascadesPlanner, "0"},
 	{ScopeGlobal | ScopeSession, TiDBEnableIndexMerge, "0"},
-	{ScopeSession, TIDBMemQuotaQuery, strconv.FormatInt(config.GetGlobalConfig().MemQuotaQuery, 10)},
+	{ScopeSession, TIDBMemQuotaQuery, strconv.FormatInt(config.GetGlobalConfig(context.Background()).MemQuotaQuery, 10)},
 	{ScopeSession, TIDBMemQuotaHashJoin, strconv.FormatInt(DefTiDBMemQuotaHashJoin, 10)},
 	{ScopeSession, TIDBMemQuotaMergeJoin, strconv.FormatInt(DefTiDBMemQuotaMergeJoin, 10)},
 	{ScopeSession, TIDBMemQuotaSort, strconv.FormatInt(DefTiDBMemQuotaSort, 10)},
@@ -698,27 +699,27 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBEnableNoopFuncs, BoolToIntStr(DefTiDBEnableNoopFuncs)},
 	{ScopeSession, TiDBReplicaRead, "leader"},
 	{ScopeSession, TiDBAllowRemoveAutoInc, BoolToIntStr(DefTiDBAllowRemoveAutoInc)},
-	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, BoolToIntStr(config.GetGlobalConfig().StmtSummary.Enable)},
-	{ScopeGlobal | ScopeSession, TiDBStmtSummaryInternalQuery, BoolToIntStr(config.GetGlobalConfig().StmtSummary.EnableInternalQuery)},
-	{ScopeGlobal | ScopeSession, TiDBStmtSummaryRefreshInterval, strconv.Itoa(config.GetGlobalConfig().StmtSummary.RefreshInterval)},
-	{ScopeGlobal | ScopeSession, TiDBStmtSummaryHistorySize, strconv.Itoa(config.GetGlobalConfig().StmtSummary.HistorySize)},
-	{ScopeGlobal | ScopeSession, TiDBStmtSummaryMaxStmtCount, strconv.FormatUint(uint64(config.GetGlobalConfig().StmtSummary.MaxStmtCount), 10)},
-	{ScopeGlobal | ScopeSession, TiDBStmtSummaryMaxSQLLength, strconv.FormatUint(uint64(config.GetGlobalConfig().StmtSummary.MaxSQLLength), 10)},
+	{ScopeGlobal | ScopeSession, TiDBEnableStmtSummary, BoolToIntStr(config.GetGlobalConfig(context.Background()).StmtSummary.Enable)},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryInternalQuery, BoolToIntStr(config.GetGlobalConfig(context.Background()).StmtSummary.EnableInternalQuery)},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryRefreshInterval, strconv.Itoa(config.GetGlobalConfig(context.Background()).StmtSummary.RefreshInterval)},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryHistorySize, strconv.Itoa(config.GetGlobalConfig(context.Background()).StmtSummary.HistorySize)},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryMaxStmtCount, strconv.FormatUint(uint64(config.GetGlobalConfig(context.Background()).StmtSummary.MaxStmtCount), 10)},
+	{ScopeGlobal | ScopeSession, TiDBStmtSummaryMaxSQLLength, strconv.FormatUint(uint64(config.GetGlobalConfig(context.Background()).StmtSummary.MaxSQLLength), 10)},
 	{ScopeGlobal | ScopeSession, TiDBCapturePlanBaseline, "off"},
 	{ScopeGlobal | ScopeSession, TiDBUsePlanBaselines, boolToOnOff(DefTiDBUsePlanBaselines)},
 	{ScopeGlobal | ScopeSession, TiDBEvolvePlanBaselines, boolToOnOff(DefTiDBEvolvePlanBaselines)},
 	{ScopeGlobal, TiDBEvolvePlanTaskMaxTime, strconv.Itoa(DefTiDBEvolvePlanTaskMaxTime)},
 	{ScopeGlobal, TiDBEvolvePlanTaskStartTime, DefTiDBEvolvePlanTaskStartTime},
 	{ScopeGlobal, TiDBEvolvePlanTaskEndTime, DefTiDBEvolvePlanTaskEndTime},
-	{ScopeSession, TiDBIsolationReadEngines, strings.Join(config.GetGlobalConfig().IsolationRead.Engines, ", ")},
-	{ScopeGlobal | ScopeSession, TiDBStoreLimit, strconv.FormatInt(atomic.LoadInt64(&config.GetGlobalConfig().TiKVClient.StoreLimit), 10)},
+	{ScopeSession, TiDBIsolationReadEngines, strings.Join(config.GetGlobalConfig(context.Background()).IsolationRead.Engines, ", ")},
+	{ScopeGlobal | ScopeSession, TiDBStoreLimit, strconv.FormatInt(atomic.LoadInt64(&config.GetGlobalConfig(context.Background()).TiKVClient.StoreLimit), 10)},
 	{ScopeSession, TiDBMetricSchemaStep, strconv.Itoa(DefTiDBMetricSchemaStep)},
 	{ScopeSession, TiDBMetricSchemaRangeDuration, strconv.Itoa(DefTiDBMetricSchemaRangeDuration)},
 	{ScopeSession, TiDBSlowLogThreshold, strconv.Itoa(logutil.DefaultSlowThreshold)},
 	{ScopeSession, TiDBRecordPlanInSlowLog, strconv.Itoa(logutil.DefaultRecordPlanInSlowLog)},
 	{ScopeSession, TiDBEnableSlowLog, BoolToIntStr(logutil.DefaultTiDBEnableSlowLog)},
 	{ScopeSession, TiDBQueryLogMaxLen, strconv.Itoa(logutil.DefaultQueryLogMaxLen)},
-	{ScopeSession, TiDBCheckMb4ValueInUTF8, BoolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUTF8)},
+	{ScopeSession, TiDBCheckMb4ValueInUTF8, BoolToIntStr(config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8)},
 	{ScopeSession, TiDBFoundInPlanCache, BoolToIntStr(DefTiDBFoundInPlanCache)},
 	{ScopeSession, TiDBEnableCollectExecutionInfo, BoolToIntStr(logutil.DefaultTiDBEnableSlowLog)},
 	{ScopeSession, TiDBAllowAutoRandExplicitInsert, boolToOnOff(DefTiDBAllowAutoRandExplicitInsert)},

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -14,6 +14,7 @@
 package variable
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -127,7 +128,7 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 	case TiDBExpensiveQueryTimeThreshold:
 		return fmt.Sprintf("%d", atomic.LoadUint64(&ExpensiveQueryTimeThreshold)), true, nil
 	case TiDBConfig:
-		conf := config.GetGlobalConfig()
+		conf := config.GetGlobalConfig(context.Background())
 		j, err := json.MarshalIndent(conf, "", "\t")
 		if err != nil {
 			return "", false, err
@@ -138,25 +139,25 @@ func GetSessionOnlySysVars(s *SessionVars, key string) (string, bool, error) {
 	case TiDBDDLSlowOprThreshold:
 		return strconv.FormatUint(uint64(atomic.LoadUint32(&DDLSlowOprThreshold)), 10), true, nil
 	case PluginDir:
-		return config.GetGlobalConfig().Plugin.Dir, true, nil
+		return config.GetGlobalConfig(context.Background()).Plugin.Dir, true, nil
 	case PluginLoad:
-		return config.GetGlobalConfig().Plugin.Load, true, nil
+		return config.GetGlobalConfig(context.Background()).Plugin.Load, true, nil
 	case TiDBSlowLogThreshold:
-		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.SlowThreshold), 10), true, nil
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig(context.Background()).Log.SlowThreshold), 10), true, nil
 	case TiDBRecordPlanInSlowLog:
-		return strconv.FormatUint(uint64(atomic.LoadUint32(&config.GetGlobalConfig().Log.RecordPlanInSlowLog)), 10), true, nil
+		return strconv.FormatUint(uint64(atomic.LoadUint32(&config.GetGlobalConfig(context.Background()).Log.RecordPlanInSlowLog)), 10), true, nil
 	case TiDBEnableSlowLog:
-		return BoolToIntStr(config.GetGlobalConfig().Log.EnableSlowLog), true, nil
+		return BoolToIntStr(config.GetGlobalConfig(context.Background()).Log.EnableSlowLog), true, nil
 	case TiDBQueryLogMaxLen:
-		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig().Log.QueryLogMaxLen), 10), true, nil
+		return strconv.FormatUint(atomic.LoadUint64(&config.GetGlobalConfig(context.Background()).Log.QueryLogMaxLen), 10), true, nil
 	case TiDBCheckMb4ValueInUTF8:
-		return BoolToIntStr(config.GetGlobalConfig().CheckMb4ValueInUTF8), true, nil
+		return BoolToIntStr(config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8), true, nil
 	case TiDBCapturePlanBaseline:
 		return CapturePlanBaseline.GetVal(), true, nil
 	case TiDBFoundInPlanCache:
 		return BoolToIntStr(s.PrevFoundInPlanCache), true, nil
 	case TiDBEnableCollectExecutionInfo:
-		return BoolToIntStr(config.GetGlobalConfig().EnableCollectExecutionInfo), true, nil
+		return BoolToIntStr(config.GetGlobalConfig(context.Background()).EnableCollectExecutionInfo), true, nil
 	}
 	sVal, ok := s.GetSystemVar(key)
 	if ok {

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -14,6 +14,7 @@
 package variable
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"time"
@@ -72,7 +73,7 @@ func (s *testVarsutilSuite) TestNewSessionVars(c *C) {
 	c.Assert(vars.DistSQLScanConcurrency, Equals, DefDistSQLScanConcurrency)
 	c.Assert(vars.MaxChunkSize, Equals, DefMaxChunkSize)
 	c.Assert(vars.DMLBatchSize, Equals, DefDMLBatchSize)
-	c.Assert(vars.MemQuotaQuery, Equals, config.GetGlobalConfig().MemQuotaQuery)
+	c.Assert(vars.MemQuotaQuery, Equals, config.GetGlobalConfig(context.Background()).MemQuotaQuery)
 	c.Assert(vars.MemQuotaHashJoin, Equals, int64(DefTiDBMemQuotaHashJoin))
 	c.Assert(vars.MemQuotaMergeJoin, Equals, int64(DefTiDBMemQuotaMergeJoin))
 	c.Assert(vars.MemQuotaSort, Equals, int64(DefTiDBMemQuotaSort))
@@ -220,7 +221,7 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	c.Assert(terror.ErrorEqual(err, ErrReadOnly), IsTrue)
 	val, err = GetSessionSystemVar(v, TiDBConfig)
 	c.Assert(err, IsNil)
-	bVal, err := json.MarshalIndent(config.GetGlobalConfig(), "", "\t")
+	bVal, err := json.MarshalIndent(config.GetGlobalConfig(context.Background()), "", "\t")
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, string(bVal))
 
@@ -273,13 +274,13 @@ func (s *testVarsutilSuite) TestVarsutil(c *C) {
 	val, err = GetSessionSystemVar(v, TiDBCheckMb4ValueInUTF8)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "1")
-	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUTF8, Equals, true)
+	c.Assert(config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8, Equals, true)
 	err = SetSessionSystemVar(v, TiDBCheckMb4ValueInUTF8, types.NewStringDatum("0"))
 	c.Assert(err, IsNil)
 	val, err = GetSessionSystemVar(v, TiDBCheckMb4ValueInUTF8)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, "0")
-	c.Assert(config.GetGlobalConfig().CheckMb4ValueInUTF8, Equals, false)
+	c.Assert(config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8, Equals, false)
 
 	SetSessionSystemVar(v, TiDBLowResolutionTSO, types.NewStringDatum("1"))
 	val, err = GetSessionSystemVar(v, TiDBLowResolutionTSO)

--- a/store/mockstore/mockstore.go
+++ b/store/mockstore/mockstore.go
@@ -14,6 +14,7 @@
 package mockstore
 
 import (
+	"context"
 	"net/url"
 	"strings"
 
@@ -41,7 +42,7 @@ func (d MockTiKVDriver) Open(path string) (kv.Storage, error) {
 	}
 
 	opts := []MockTiKVStoreOption{WithPath(u.Path), WithStoreType(MockTiKV)}
-	txnLocalLatches := config.GetGlobalConfig().TxnLocalLatches
+	txnLocalLatches := config.GetGlobalConfig(context.Background()).TxnLocalLatches
 	if txnLocalLatches.Enabled {
 		opts = append(opts, WithTxnLocalLatches(txnLocalLatches.Capacity))
 	}
@@ -63,7 +64,7 @@ func (d EmbedUnistoreDriver) Open(path string) (kv.Storage, error) {
 	}
 
 	opts := []MockTiKVStoreOption{WithPath(u.Path), WithStoreType(EmbedUnistore)}
-	txnLocalLatches := config.GetGlobalConfig().TxnLocalLatches
+	txnLocalLatches := config.GetGlobalConfig(context.Background()).TxnLocalLatches
 	if txnLocalLatches.Enabled {
 		opts = append(opts, WithTxnLocalLatches(txnLocalLatches.Capacity))
 	}

--- a/store/mockstore/tikv_test.go
+++ b/store/mockstore/tikv_test.go
@@ -31,7 +31,7 @@ func (s testSuite) SetUpSuite(c *C) {}
 var _ = Suite(testSuite{})
 
 func (s testSuite) TestConfig(c *C) {
-	config.GetGlobalConfig().TxnLocalLatches = config.TxnLocalLatches{
+	config.GetGlobalConfig(context.Background()).TxnLocalLatches = config.TxnLocalLatches{
 		Enabled:  true,
 		Capacity: 10240,
 	}
@@ -46,7 +46,7 @@ func (s testSuite) TestConfig(c *C) {
 	c.Assert(store.(LatchEnableChecker).IsLatchEnabled(), IsTrue)
 	store.Close()
 
-	config.GetGlobalConfig().TxnLocalLatches = config.TxnLocalLatches{
+	config.GetGlobalConfig(context.Background()).TxnLocalLatches = config.TxnLocalLatches{
 		Enabled:  false,
 		Capacity: 10240,
 	}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -624,8 +624,9 @@ func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseComm
 	// If the rate limit is too high, tikv will report service is busy.
 	// If the rate limit is too low, we can't full utilize the tikv's throughput.
 	// TODO: Find a self-adaptive way to control the rate limit here.
-	if rateLim > config.GetGlobalConfig().Performance.CommitterConcurrency {
-		rateLim = config.GetGlobalConfig().Performance.CommitterConcurrency
+	rateLimitConfig := config.GetGlobalConfig(bo.ctx).Performance.CommitterConcurrency
+	if rateLim > rateLimitConfig {
+		rateLim = rateLimitConfig
 	}
 	batchExecutor := newBatchExecutor(rateLim, c, action, bo)
 	err := batchExecutor.process(batches)
@@ -811,13 +812,13 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 			}
 
 			uptime := uint64(oracle.ExtractPhysical(now) - oracle.ExtractPhysical(c.startTS))
-			if uptime > config.GetGlobalConfig().Performance.MaxTxnTTL {
+			if uptime > config.GetGlobalConfig(context.Background()).Performance.MaxTxnTTL {
 				// Checks maximum lifetime for the ttlManager, so when something goes wrong
 				// the key will not be locked forever.
 				logutil.Logger(bo.ctx).Info("ttlManager live up to its lifetime",
 					zap.Uint64("txnStartTS", c.startTS),
 					zap.Uint64("uptime", uptime),
-					zap.Uint64("maxTxnTTL", config.GetGlobalConfig().Performance.MaxTxnTTL))
+					zap.Uint64("maxTxnTTL", config.GetGlobalConfig(context.Background()).Performance.MaxTxnTTL))
 				metrics.TiKVTTLLifeTimeReachCounter.Inc()
 				// the pessimistic locks may expire if the ttl manager has timed out, set `LockExpired` flag
 				// so that this transaction could only commit or rollback with no more statement executions

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -111,7 +111,7 @@ func (a *connArray) Init(addr string, security config.Security, idleNotify *uint
 		opt = grpc.WithTransportCredentials(credentials.NewTLS(tlsConfig))
 	}
 
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	var (
 		unaryInterceptor  grpc.UnaryClientInterceptor
 		streamInterceptor grpc.StreamClientInterceptor
@@ -256,7 +256,7 @@ func (c *rpcClient) createConnArray(addr string, enableBatch bool) (*connArray, 
 	array, ok := c.conns[addr]
 	if !ok {
 		var err error
-		connCount := config.GetGlobalConfig().TiKVClient.GrpcConnectionCount
+		connCount := config.GetGlobalConfig(context.Background()).TiKVClient.GrpcConnectionCount
 		array, err = newConnArray(connCount, addr, c.security, &c.idleNotify, enableBatch)
 		if err != nil {
 			return nil, err
@@ -326,7 +326,7 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	// TiDB RPC server supports batch RPC, but batch connection will send heart beat, It's not necessary since
 	// request to TiDB is not high frequency.
-	if config.GetGlobalConfig().TiKVClient.MaxBatchSize > 0 && enableBatch {
+	if config.GetGlobalConfig(ctx).TiKVClient.MaxBatchSize > 0 && enableBatch {
 		if batchReq := req.ToBatchCommandsRequest(); batchReq != nil {
 			return sendBatchRequest(ctx, addr, connArray.batchConn, batchReq, timeout)
 		}

--- a/store/tikv/client_fail_test.go
+++ b/store/tikv/client_fail_test.go
@@ -51,7 +51,7 @@ func (s *testClientFailSuite) TestPanicInRecvLoop(c *C) {
 	server, port := startMockTikvService()
 	c.Assert(port > 0, IsTrue)
 
-	grpcConnectionCount := config.GetGlobalConfig().TiKVClient.GrpcConnectionCount
+	grpcConnectionCount := config.GetGlobalConfig(context.Background()).TiKVClient.GrpcConnectionCount
 	setGrpcConnectionCount(1)
 	addr := fmt.Sprintf("%s:%d", "127.0.0.1", port)
 	rpcClient := newRPCClient(config.Security{})

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -53,7 +53,7 @@ func setMaxBatchSize(size uint) {
 }
 
 func (s *testClientSerialSuite) TestConn(c *C) {
-	maxBatchSize := config.GetGlobalConfig().TiKVClient.MaxBatchSize
+	maxBatchSize := config.GetGlobalConfig(context.Background()).TiKVClient.MaxBatchSize
 	setMaxBatchSize(0)
 
 	client := newRPCClient(config.Security{})

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -53,7 +53,7 @@ type Driver struct {
 }
 
 func createEtcdKV(addrs []string, tlsConfig *tls.Config) (*clientv3.Client, error) {
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	cli, err := clientv3.New(clientv3.Config{
 		Endpoints:            addrs,
 		AutoSyncInterval:     30 * time.Second,
@@ -75,9 +75,9 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 	mc.Lock()
 	defer mc.Unlock()
 
-	security := config.GetGlobalConfig().Security
-	tikvConfig := config.GetGlobalConfig().TiKVClient
-	txnLocalLatches := config.GetGlobalConfig().TxnLocalLatches
+	security := config.GetGlobalConfig(context.Background()).Security
+	tikvConfig := config.GetGlobalConfig(context.Background()).TiKVClient
+	txnLocalLatches := config.GetGlobalConfig(context.Background()).TxnLocalLatches
 	etcdAddrs, disableGC, err := config.ParsePath(path)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -115,7 +115,7 @@ func (d Driver) Open(path string) (kv.Storage, error) {
 		return nil, errors.Trace(err)
 	}
 
-	coprCacheConfig := &config.GetGlobalConfig().TiKVClient.CoprCache
+	coprCacheConfig := &config.GetGlobalConfig(context.Background()).TiKVClient.CoprCache
 	s, err := newTikvStore(uuid, &codecPDClient{pdCli}, spkv, newRPCClient(security), !disableGC, coprCacheConfig)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1473,10 +1473,10 @@ const (
 )
 
 func init() {
-	t, err := time.ParseDuration(config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout)
+	t, err := time.ParseDuration(config.GetGlobalConfig(context.Background()).TiKVClient.StoreLivenessTimeout)
 	if err != nil {
 		logutil.BgLogger().Fatal("invalid duration value for store-liveness-timeout",
-			zap.String("currentValue", config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout))
+			zap.String("currentValue", config.GetGlobalConfig(context.Background()).TiKVClient.StoreLivenessTimeout))
 	}
 	storeLivenessTimeout = t
 }

--- a/table/column.go
+++ b/table/column.go
@@ -18,6 +18,7 @@
 package table
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -208,7 +209,7 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 	}
 	str := casted.GetString()
 	utf8Charset := col.Charset == mysql.UTF8Charset
-	doMB4CharCheck := utf8Charset && config.GetGlobalConfig().CheckMb4ValueInUTF8
+	doMB4CharCheck := utf8Charset && config.GetGlobalConfig(context.Background()).CheckMb4ValueInUTF8
 	for i, w := 0, 0; i < len(str); i += w {
 		runeValue, width := utf8.DecodeRuneInString(str[i:])
 		if runeValue == utf8.RuneError {

--- a/tidb-server/main_test.go
+++ b/tidb-server/main_test.go
@@ -43,8 +43,8 @@ func (t *testMainSuite) TestSetGlobalVars(c *C) {
 	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines].Value, Equals, "tikv, tiflash, tidb")
 	c.Assert(variable.SysVars[variable.TIDBMemQuotaQuery].Value, Equals, "1073741824")
 
-	config.GetGlobalConfig().IsolationRead.Engines = []string{"tikv", "tidb"}
-	config.GetGlobalConfig().MemQuotaQuery = 9999999
+	config.GetGlobalConfig(context.Background()).IsolationRead.Engines = []string{"tikv", "tidb"}
+	config.GetGlobalConfig(context.Background()).MemQuotaQuery = 9999999
 	setGlobalVars()
 
 	c.Assert(variable.SysVars[variable.TiDBIsolationReadEngines].Value, Equals, "tikv, tidb")

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -36,7 +36,7 @@ import (
 )
 
 func TestT(t *testing.T) {
-	cfg := config.GetGlobalConfig()
+	cfg := config.GetGlobalConfig(context.Background())
 	conf := *cfg
 	conf.TempStoragePath, _ = ioutil.TempDir("", "oom-use-tmp-storage")
 	config.StoreGlobalConfig(&conf)

--- a/util/chunk/disk.go
+++ b/util/chunk/disk.go
@@ -15,6 +15,7 @@ package chunk
 
 import (
 	"bufio"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -71,7 +72,7 @@ func NewListInDisk(fieldTypes []*types.FieldType) *ListInDisk {
 }
 
 func (l *ListInDisk) initDiskFile() (err error) {
-	l.disk, err = ioutil.TempFile(config.GetGlobalConfig().TempStoragePath, l.diskTracker.Label().String())
+	l.disk, err = ioutil.TempFile(config.GetGlobalConfig(context.Background()).TempStoragePath, l.diskTracker.Label().String())
 	if err != nil {
 		return
 	}

--- a/util/misc.go
+++ b/util/misc.go
@@ -14,6 +14,7 @@
 package util
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -435,7 +436,7 @@ func LoadTLSCertificates(ca, key, cert string) (tlsConfig *tls.Config, err error
 		return
 	}
 
-	requireTLS := config.GetGlobalConfig().Security.RequireSecureTransport
+	requireTLS := config.GetGlobalConfig(context.Background()).Security.RequireSecureTransport
 
 	// Try loading CA cert.
 	clientAuthPolicy := tls.NoClientCert
@@ -496,7 +497,7 @@ func InternalHTTPSchema() string {
 }
 
 func initInternalClient() {
-	tlsCfg, err := config.GetGlobalConfig().Security.ToTLSConfig()
+	tlsCfg, err := config.GetGlobalConfig(context.Background()).Security.ToTLSConfig()
 	if err != nil {
 		logutil.BgLogger().Fatal("could not load cluster ssl", zap.Error(err))
 	}

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -15,6 +15,7 @@ package printer
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	_ "runtime" // import link package
@@ -49,7 +50,7 @@ func PrintTiDBInfo() {
 		zap.Bool("Race Enabled", israce.RaceEnabled),
 		zap.Bool("Check Table Before Drop", config.CheckTableBeforeDrop),
 		zap.String("TiKV Min Version", TiKVMinVersion))
-	configJSON, err := json.Marshal(config.GetGlobalConfig())
+	configJSON, err := json.Marshal(config.GetGlobalConfig(context.Background()))
 	if err != nil {
 		panic(err)
 	}

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -666,13 +666,13 @@ func (s *testStmtSummarySuite) TestMaxStmtCount(c *C) {
 
 	// Test the original value and modify it.
 	maxStmtCount := s.ssMap.maxStmtCount()
-	c.Assert(maxStmtCount, Equals, int(config.GetGlobalConfig().StmtSummary.MaxStmtCount))
+	c.Assert(maxStmtCount, Equals, int(config.GetGlobalConfig(context.Background()).StmtSummary.MaxStmtCount))
 	c.Assert(s.ssMap.SetMaxStmtCount("10", false), IsNil)
 	c.Assert(s.ssMap.maxStmtCount(), Equals, 10)
 	defer func() {
 		c.Assert(s.ssMap.SetMaxStmtCount("", false), IsNil)
 		c.Assert(s.ssMap.SetMaxStmtCount("", true), IsNil)
-		c.Assert(maxStmtCount, Equals, int(config.GetGlobalConfig().StmtSummary.MaxStmtCount))
+		c.Assert(maxStmtCount, Equals, int(config.GetGlobalConfig(context.Background()).StmtSummary.MaxStmtCount))
 	}()
 
 	// 100 digests
@@ -724,7 +724,7 @@ func (s *testStmtSummarySuite) TestMaxSQLLength(c *C) {
 
 	// Test the original value and modify it.
 	maxSQLLength := s.ssMap.maxSQLLength()
-	c.Assert(maxSQLLength, Equals, int(config.GetGlobalConfig().StmtSummary.MaxSQLLength))
+	c.Assert(maxSQLLength, Equals, int(config.GetGlobalConfig(context.Background()).StmtSummary.MaxSQLLength))
 
 	// Create a long SQL
 	length := maxSQLLength * 10

--- a/util/stmtsummary/variables.go
+++ b/util/stmtsummary/variables.go
@@ -14,6 +14,7 @@
 package stmtsummary
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -138,7 +139,7 @@ func getIntFinalVariable(varType int, sessionValue, globalValue string, minValue
 
 func getConfigValue(varType int) int64 {
 	var valueInt int64
-	stmtSummaryConfig := config.GetGlobalConfig().StmtSummary
+	stmtSummaryConfig := config.GetGlobalConfig(context.Background()).StmtSummary
 	switch varType {
 	case typeEnable:
 		if stmtSummaryConfig.Enable {

--- a/util/stmtsummary/variables_test.go
+++ b/util/stmtsummary/variables_test.go
@@ -26,7 +26,7 @@ type testVariablesSuite struct {
 func (s *testVariablesSuite) TestSetInVariable(c *C) {
 	sv := newSysVars()
 	st := sv.getVariable(typeMaxStmtCount)
-	c.Assert(st, Equals, int64(config.GetGlobalConfig().StmtSummary.MaxStmtCount))
+	c.Assert(st, Equals, int64(config.GetGlobalConfig(context.Background()).StmtSummary.MaxStmtCount))
 
 	sv.setVariable(typeMaxStmtCount, "10", false)
 	st = sv.getVariable(typeMaxStmtCount)
@@ -48,13 +48,13 @@ func (s *testVariablesSuite) TestSetInVariable(c *C) {
 	c.Assert(st, Equals, int64(10))
 	sv.setVariable(typeMaxStmtCount, "", false)
 	st = sv.getVariable(typeMaxStmtCount)
-	c.Assert(st, Equals, int64(config.GetGlobalConfig().StmtSummary.MaxStmtCount))
+	c.Assert(st, Equals, int64(config.GetGlobalConfig(context.Background()).StmtSummary.MaxStmtCount))
 }
 
 func (s *testVariablesSuite) TestSetBoolVariable(c *C) {
 	sv := newSysVars()
 	en := sv.getVariable(typeEnable)
-	c.Assert(en > 0, Equals, config.GetGlobalConfig().StmtSummary.Enable)
+	c.Assert(en > 0, Equals, config.GetGlobalConfig(context.Background()).StmtSummary.Enable)
 
 	sv.setVariable(typeEnable, "OFF", false)
 	en = sv.getVariable(typeEnable)
@@ -79,7 +79,7 @@ func (s *testVariablesSuite) TestSetBoolVariable(c *C) {
 	c.Assert(en > 0, Equals, true)
 	sv.setVariable(typeEnable, "", false)
 	en = sv.getVariable(typeEnable)
-	c.Assert(en > 0, Equals, config.GetGlobalConfig().StmtSummary.Enable)
+	c.Assert(en > 0, Equals, config.GetGlobalConfig(context.Background()).StmtSummary.Enable)
 }
 
 func (s *testVariablesSuite) TestMinValue(c *C) {

--- a/util/testkit/testkit.go
+++ b/util/testkit/testkit.go
@@ -139,13 +139,17 @@ func (tk *TestKit) GetConnectionID() {
 
 // Exec executes a sql statement.
 func (tk *TestKit) Exec(sql string, args ...interface{}) (sqlexec.RecordSet, error) {
+	return tk.ExecWithCtx(context.Background(), sql, args)
+}
+
+// ExecWithCtx executes a sql statement.
+func (tk *TestKit) ExecWithCtx(ctx context.Context, sql string, args ...interface{}) (sqlexec.RecordSet, error) {
 	var err error
 	if tk.Se == nil {
 		tk.Se, err = session.CreateSession4Test(tk.store)
 		tk.c.Assert(err, check.IsNil)
 		tk.GetConnectionID()
 	}
-	ctx := context.Background()
 	if len(args) == 0 {
 		sc := tk.Se.GetSessionVars().StmtCtx
 		prevWarns := sc.GetWarnings()
@@ -203,7 +207,12 @@ func (tk *TestKit) CheckLastMessage(msg string) {
 
 // MustExec executes a sql statement and asserts nil error.
 func (tk *TestKit) MustExec(sql string, args ...interface{}) {
-	res, err := tk.Exec(sql, args...)
+	tk.MustExecWithCtx(context.Background(), sql, args)
+}
+
+// MustExecWithCtx executes a sql statement and asserts nil error.
+func (tk *TestKit) MustExecWithCtx(ctx context.Context, sql string, args ...interface{}) {
+	res, err := tk.ExecWithCtx(ctx, sql, args...)
 	tk.c.Assert(err, check.IsNil, check.Commentf("sql:%s, %v, error stack %v", sql, args, errors.ErrorStack(err)))
 	if res != nil {
 		tk.c.Assert(res.Close(), check.IsNil)

--- a/util/testutil/testutil.go
+++ b/util/testutil/testutil.go
@@ -17,6 +17,7 @@ package testutil
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -327,7 +328,7 @@ type autoRandom struct {
 // SetupAutoRandomTestConfig set alter-primary-key to false and save its origin values.
 // This method should only be used for the tests in SerialSuite.
 func (a *autoRandom) SetupAutoRandomTestConfig() {
-	globalCfg := config.GetGlobalConfig()
+	globalCfg := config.GetGlobalConfig(context.Background())
 	a.originAlterPrimaryKey = globalCfg.AlterPrimaryKey
 	globalCfg.AlterPrimaryKey = false
 }
@@ -335,7 +336,7 @@ func (a *autoRandom) SetupAutoRandomTestConfig() {
 // RestoreAutoRandomTestConfig restore the values had been saved in SetupTestConfig.
 // This method should only be used for the tests in SerialSuite.
 func (a *autoRandom) RestoreAutoRandomTestConfig() {
-	globalCfg := config.GetGlobalConfig()
+	globalCfg := config.GetGlobalConfig(context.Background())
 	globalCfg.AlterPrimaryKey = a.originAlterPrimaryKey
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
[2020-06-10T08:16:47.771Z] ==================
[2020-06-10T08:16:47.771Z] WARNING: DATA RACE
[2020-06-10T08:16:47.771Z] Write at 0x00c000232ed0 by goroutine 204:
[2020-06-10T08:16:47.771Z]   github.com/pingcap/tidb/planner/core_test.(*testIntegrationSerialSuite).TestNoneAccessPathsFoundByIsolationRead()
[2020-06-10T08:16:47.771Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/integration_test.go:304 +0x614
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/planner/core_test.(*testIntegrationSerialSuite).TestNoneAccessPathsFoundByIsolationRead()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/planner/core/integration_test.go:286 +0x166
[2020-06-10T08:16:47.772Z]   runtime.call32()
[2020-06-10T08:16:47.772Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2020-06-10T08:16:47.772Z]   reflect.Value.Call()
[2020-06-10T08:16:47.772Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2020-06-10T08:16:47.772Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:850 +0x9aa
[2020-06-10T08:16:47.772Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:739 +0x113
[2020-06-10T08:16:47.772Z] 

[2020-06-10T08:16:47.772Z] Previous read at 0x00c000232ed0 by goroutine 313:
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/sessionctx/variable.NewSessionVars()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/variable/session.go:788 +0x1090
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/util/mock.NewContext()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/mock/context.go:272 +0x9f
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/mockstore/unistore/cophandler.newClosureExecutor()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/mockstore/unistore/cophandler/closure_exec.go:118 +0x1eb
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/mockstore/unistore/cophandler.buildClosureExecutor()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/mockstore/unistore/cophandler/closure_exec.go:57 +0x60
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/mockstore/unistore/cophandler.handleCopDAGRequest()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/mockstore/unistore/cophandler/cop_handler.go:75 +0x1cb
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/mockstore/unistore/cophandler.HandleCopRequest()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/mockstore/unistore/cophandler/cop_handler.go:47 +0x269
[2020-06-10T08:16:47.772Z]   github.com/ngaut/unistore/tikv.(*Server).Coprocessor()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/ngaut/unistore@v0.0.0-20200604061006-d8e9dc0ad154/tikv/server.go:474 +0x3ff
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/mockstore/unistore.(*RPCClient).SendRequest()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/mockstore/unistore/rpc.go:161 +0x2cde
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.reqCollapse.SendRequest()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/client_collapse.go:49 +0x17d
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*reqCollapse).SendRequest()
[2020-06-10T08:16:47.772Z]       <autogenerated>:1 +0xc5
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).sendReqToRegion()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:253 +0x1d0
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*RegionRequestSender).SendReqCtx()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/region_request.go:216 +0x52f
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*clientHelper).SendReqCtx()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:844 +0x1fd
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTaskOnce()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:751 +0x948
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).handleTask()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:686 +0x205
[2020-06-10T08:16:47.772Z]   github.com/pingcap/tidb/store/tikv.(*copIteratorWorker).run()
[2020-06-10T08:16:47.772Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/coprocessor.go:493 +0x141
```

Problem Summary:

There is only one instance of global config, providing that many test cases run concurrently, 
when an unit test modify the global config, it is easy to DATA RACE.

We have been struggle with this problem, in this commit I modify the `GetGlobalConfig` API to provide a thread safe mechanism for each test to use its own config.

### What is changed and how it works?

What's Changed:

- Change `GetGlobalConfig()` to `GetGlobalConfig(ctx)`
- Provide `config.WithGlobalConfig()` function

How it Works:

GetGlobalConfig will check the context first, if it find the `overrideConfigForTest` from the context, use that.

Each test can use `MustExecWithCtx()` to override the global config for testing.



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Breaking backward compatibility

Modify exposed API break code compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> No release note
