### PR TITLE
executor: optimize the get snapshot table meta for tiflash/replica HTTP API

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -35,6 +35,7 @@ import (
 	testddlutil "github.com/pingcap/tidb/ddl/testutil"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/errno"
+	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -194,6 +195,16 @@ func testGetTableByName(c *C, ctx sessionctx.Context, db, table string) table.Ta
 	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr(db), model.NewCIStr(table))
 	c.Assert(err, IsNil)
 	return tbl
+}
+
+func testGetSchemaByName(c *C, ctx sessionctx.Context, db string) *model.DBInfo {
+	dom := domain.GetDomain(ctx)
+	// Make sure the table schema is the new schema.
+	err := dom.Reload()
+	c.Assert(err, IsNil)
+	dbInfo, ok := dom.InfoSchema().SchemaByName(model.NewCIStr(db))
+	c.Assert(ok, IsTrue)
+	return dbInfo
 }
 
 func (s *testDBSuite) testGetTable(c *C, name string) table.Table {
@@ -672,6 +683,53 @@ func (s *testDBSuite5) TestCancelTruncateTable(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[ddl:8214]Cancelled DDL job")
 	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
+}
+
+func (s *testDBSuite5) TestParallelDropSchemaAndDropTable(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.mustExec(c, "create database if not exists test_drop_schema_table")
+	s.mustExec(c, "use test_drop_schema_table")
+	s.mustExec(c, "create table t(c1 int, c2 int)")
+	var checkErr error
+	hook := &ddl.TestDDLCallback{}
+	dbInfo := testGetSchemaByName(c, s.tk.Se, "test_drop_schema_table")
+	done := false
+	var wg sync.WaitGroup
+	tk2 := testkit.NewTestKit(c, s.store)
+	tk2.MustExec("use test_drop_schema_table")
+	hook.OnJobUpdatedExported = func(job *model.Job) {
+		if job.Type == model.ActionDropSchema && job.State == model.JobStateRunning &&
+			job.SchemaState == model.StateWriteOnly && job.SchemaID == dbInfo.ID && done == false {
+			wg.Add(1)
+			done = true
+			go func() {
+				_, checkErr = tk2.Exec("drop table t")
+				wg.Done()
+			}()
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	originalHook := s.dom.DDL().GetHook()
+	s.dom.DDL().(ddl.DDLForTest).SetHook(hook)
+	s.mustExec(c, "drop database test_drop_schema_table")
+	s.dom.DDL().(ddl.DDLForTest).SetHook(originalHook)
+	wg.Wait()
+	c.Assert(done, IsTrue)
+	c.Assert(checkErr, NotNil)
+	c.Assert(checkErr.Error(), Equals, "[schema:1051]Unknown table 'test_drop_schema_table.t'")
+
+	// Below behaviour is use to mock query `curl "http://$IP:10080/tiflash/replica"`
+	fn := func(jobs []*model.Job) (bool, error) {
+		return executor.GetDropOrTruncateTableInfoFromJobs(jobs, 0, s.dom, func(job *model.Job, info *model.TableInfo) (bool, error) {
+			return false, nil
+		})
+	}
+	err := s.tk.Se.NewTxn(context.Background())
+	c.Assert(err, IsNil)
+	txn, err := s.tk.Se.Txn(true)
+	c.Assert(err, IsNil)
+	err = admin.IterHistoryDDLJobs(txn, fn)
+	c.Assert(err, IsNil)
 }
 
 // TestCancelRenameIndex tests cancel ddl job which type is rename index.

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -471,21 +471,28 @@ func GetDropOrTruncateTableInfoFromJobs(jobs []*model.Job, gcSafePoint uint64, d
 		if err != nil {
 			return false, err
 		}
-		// Get the snapshot infoSchema before drop table.
-		// TODO: only get the related database info and table info.
-		snapInfo, err := dom.GetSnapshotInfoSchema(job.StartTS)
+
+		snapMeta, err := dom.GetSnapshotMeta(job.StartTS)
 		if err != nil {
 			return false, err
 		}
-		// Get table meta from snapshot infoSchema.
-		table, ok := snapInfo.TableByID(job.TableID)
-		if !ok {
+		tbl, err := snapMeta.GetTable(job.SchemaID, job.TableID)
+		if err != nil {
+			if meta.ErrDBNotExists.Equal(err) {
+				// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,
+				// then can't find the table from the snapshot info-schema. Should just ignore error here,
+				// see more in TestParallelDropSchemaAndDropTable.
+				continue
+			}
+			return false, err
+		}
+		if tbl == nil {
 			// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,
 			// then can't find the table from the snapshot info-schema. Should just ignore error here,
 			// see more in TestParallelDropSchemaAndDropTable.
 			continue
 		}
-		finish, err := fn(job, table.Meta())
+		finish, err := fn(job, tbl)
 		if err != nil || finish {
 			return finish, err
 		}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -480,10 +480,10 @@ func GetDropOrTruncateTableInfoFromJobs(jobs []*model.Job, gcSafePoint uint64, d
 		// Get table meta from snapshot infoSchema.
 		table, ok := snapInfo.TableByID(job.TableID)
 		if !ok {
-			return false, infoschema.ErrTableNotExists.GenWithStackByArgs(
-				fmt.Sprintf("(Schema ID %d)", job.SchemaID),
-				fmt.Sprintf("(Table ID %d)", job.TableID),
-			)
+			// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,
+			// then can't find the table from the snapshot info-schema. Should just ignore error here,
+			// see more in TestParallelDropSchemaAndDropTable.
+			continue
 		}
 		finish, err := fn(job, table.Meta())
 		if err != nil || finish {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

User for user  to test. DNM.

Before this PR, `GetSnapshotInfoSchema` will be blocking progress of query `tiflash/replica` HTTP API when there a too many DDL history and GC safe time is very large.
