### PR TITLE
executor: optimize the get snapshot table meta for tiflash/replica HTTP API

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -471,21 +471,28 @@ func GetDropOrTruncateTableInfoFromJobs(jobs []*model.Job, gcSafePoint uint64, d
 		if err != nil {
 			return false, err
 		}
-		// Get the snapshot infoSchema before drop table.
-		// TODO: only get the related database info and table info.
-		snapInfo, err := dom.GetSnapshotInfoSchema(job.StartTS)
+
+		snapMeta, err := dom.GetSnapshotMeta(job.StartTS)
 		if err != nil {
 			return false, err
 		}
-		// Get table meta from snapshot infoSchema.
-		table, ok := snapInfo.TableByID(job.TableID)
-		if !ok {
+		tbl, err := snapMeta.GetTable(job.SchemaID, job.TableID)
+		if err != nil {
+			if meta.ErrDBNotExists.Equal(err) {
+				// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,
+				// then can't find the table from the snapshot info-schema. Should just ignore error here,
+				// see more in TestParallelDropSchemaAndDropTable.
+				continue
+			}
+			return false, err
+		}
+		if tbl == nil {
 			// The dropped/truncated DDL maybe execute failed that caused by the parallel DDL execution,
 			// then can't find the table from the snapshot info-schema. Should just ignore error here,
 			// see more in TestParallelDropSchemaAndDropTable.
 			continue
 		}
-		finish, err := fn(job, table.Meta())
+		finish, err := fn(job, tbl)
 		if err != nil || finish {
 			return finish, err
 		}


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>


### What problem does this PR solve?

#### backaground

`/tiflash/replica` HTTP API needs to read the dropped or truncated table information with snapshot.

Before this PR, TiDB will use `GetSnapshotInfoSchema` to generate a snapshot information schema, then read the dropped or truncated table from this snapshot information.

The problem is, if there are too many dropped/truncated DDL history jobs, and the GC life is too long, then query `/tiflash/replica` HTTP API will be very slow, the most of time is spent on the generate many snapshot information schema.

This PR just use the schema ID and table ID to load the table information with snapshot, avoid the expensive generated snapshot information schema process.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

- optimize the get snapshot table meta for tiflash/replica HTTP API.
