### PR TITLE
table/tables: fix load partition when upgrade from an old TiDB

### DIFF
--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -163,7 +163,7 @@ type ForRangePruning struct {
 }
 
 // dataForRangePruning extracts the less than parts from 'partition p0 less than xx ... partitoin p1 less than ...'
-func dataForRangePruning(pi *model.PartitionInfo) (*ForRangePruning, error) {
+func dataForRangePruning(sctx sessionctx.Context, pi *model.PartitionInfo) (*ForRangePruning, error) {
 	var maxValue bool
 	var unsigned bool
 	lessThan := make([]int64, len(pi.Definitions))
@@ -182,7 +182,12 @@ func dataForRangePruning(pi *model.PartitionInfo) (*ForRangePruning, error) {
 				unsigned = true
 			}
 			if err != nil {
-				return nil, errors.WithStack(err)
+				val, ok := fixOldVersionPartitionInfo(sctx, pi.Definitions[i].LessThan[0])
+				if !ok {
+					logutil.BgLogger().Error("wrong partition definition", zap.String("less than", pi.Definitions[i].LessThan[0]))
+					return nil, errors.WithStack(err)
+				}
+				lessThan[i] = val
 			}
 		}
 	}
@@ -191,6 +196,17 @@ func dataForRangePruning(pi *model.PartitionInfo) (*ForRangePruning, error) {
 		MaxValue: maxValue,
 		Unsigned: unsigned,
 	}, nil
+}
+
+func fixOldVersionPartitionInfo(sctx sessionctx.Context, str string) (int64, bool) {
+	// less than value should be calculate to integer before persistent.
+	// Old version TiDB may not do it and store the raw expression.
+	tmp, err := parseSimpleExprWithNames(parser.New(), sctx, str, nil, nil)
+	ret, isNull, err := tmp.EvalInt(sctx, chunk.Row{})
+	if err == nil && !isNull {
+		return ret, true
+	}
+	return ret, false
 }
 
 // rangePartitionString returns the partition string for a range typed partition.
@@ -240,7 +256,7 @@ func generateRangePartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,
 
 	switch len(pi.Columns) {
 	case 0:
-		tmp, err := dataForRangePruning(pi)
+		tmp, err := dataForRangePruning(ctx, pi)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -202,11 +202,14 @@ func fixOldVersionPartitionInfo(sctx sessionctx.Context, str string) (int64, boo
 	// less than value should be calculate to integer before persistent.
 	// Old version TiDB may not do it and store the raw expression.
 	tmp, err := parseSimpleExprWithNames(parser.New(), sctx, str, nil, nil)
-	ret, isNull, err := tmp.EvalInt(sctx, chunk.Row{})
-	if err == nil && !isNull {
-		return ret, true
+	if err != nil {
+		return 0, false
 	}
-	return ret, false
+	ret, isNull, err := tmp.EvalInt(sctx, chunk.Row{})
+	if err != nil || isNull {
+		return 0, false
+	}
+	return ret, true
 }
 
 // rangePartitionString returns the partition string for a range typed partition.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17952 <!-- REMOVE this line if no issue to close -->

Problem Summary:

In the old version TiDB, partition definition store the less than XXX as raw expression.
It should be integer, the new version TiDB assert XXX is an integer.

### What is changed and how it works?


What's Changed:

Add some code to handle compatibility.

How it Works:

If the less than expression is not an integer, try to parser it as expression and calculate the integer.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

I have manually test the binary with issue https://github.com/pingcap/tidb/issues/17952 and it works.

Side effects

Ugly code

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> Fix a compatibility bug that partition table created in old version TiDB can not be loaded in 4.0, this bug makes the server fail to start.
