### PR TITLE
ddl: fix admin repair table with range partition expr will parseInt fail

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1466,10 +1466,13 @@ func buildTableInfoWithCheck(ctx sessionctx.Context, s *ast.CreateTableStmt, dbC
 	if err != nil {
 		return nil, err
 	}
-	if err = checkTableInfoValidExtra(tbInfo); err != nil {
+	// Fix issue 17952 which will cause partition range expr can't be parsed as Int.
+	// checkTableInfoValidWithStmt will do the constant fold the partition expression first,
+	// then checkTableInfoValidExtra will pass the tableInfo check successfully.
+	if err = checkTableInfoValidWithStmt(ctx, tbInfo, s); err != nil {
 		return nil, err
 	}
-	if err = checkTableInfoValidWithStmt(ctx, tbInfo, s); err != nil {
+	if err = checkTableInfoValidExtra(tbInfo); err != nil {
 		return nil, err
 	}
 	return tbInfo, nil

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -210,7 +210,9 @@ func checkAndOverridePartitionID(newTableInfo, oldTableInfo *model.TableInfo) er
 	for i, newOne := range newTableInfo.Partition.Definitions {
 		found := false
 		for _, oldOne := range oldTableInfo.Partition.Definitions {
-			if newOne.Name.L == oldOne.Name.L && stringSliceEqual(newOne.LessThan, oldOne.LessThan) {
+			// Fix issue 17952 which wanna substitute partition range expr.
+			// So eliminate stringSliceEqual(newOne.LessThan, oldOne.LessThan) here.
+			if newOne.Name.L == oldOne.Name.L {
 				newTableInfo.Partition.Definitions[i].ID = oldOne.ID
 				found = true
 				break


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close part of https://github.com/pingcap/tidb/issues/17952 <!-- REMOVE this line if no issue to close -->

Problem Summary: partition expr will parse int fail while create table directly can be successfully

### What is changed and how it works?

How it Works:
in function `buildTableInfoWithCheck`

`checkTableInfoValidWithStmt` should do the constant fold the partition expression **firstly**,
then `checkTableInfoValidExtra` will pass the tableInfo check successfully **secondly**.

while create table logic is different with this

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
1: open repair mode and fill the repair list in config.toml
2: use SQL below to test admin repair action will work well rather than occur parseInt error.
```
admin repair table test222 CREATE TABLE `test222` ( `bucket_id` VARCHAR(200) NOT NULL DEFAULT 'zhu' COMMENT '分桶id', `creative_id` VARCHAR(32)  COMMENT '创意id',   `day` datetime  COMMENT '日志时间'   ) PARTITION BY RANGE (TO_SECONDS(day)) (    PARTITION p20190414 VALUES LESS THAN (TO_SECONDS('20190414')))
```

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- ddl: fix admin repair table with range partition expr will parseInt fail