### PR TITLE
tikv: pre-index stores in region-cache for different access pattern

### DIFF
--- a/executor/split.go
+++ b/executor/split.go
@@ -724,7 +724,7 @@ func getRegionMeta(tikvStore tikv.Storage, regionMetas []*tikv.Region, uniqueReg
 		uniqueRegionMap[r.GetID()] = struct{}{}
 		regions = append(regions, regionMeta{
 			region:   r.GetMeta(),
-			leaderID: r.GetLeaderID(),
+			leaderID: r.GetLeaderPeerID(),
 			storeID:  r.GetLeaderStoreID(),
 		})
 	}

--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -213,10 +213,11 @@ func (c *Cluster) RemoveStore(storeID uint64) {
 }
 
 // UpdateStoreAddr updates store address for cluster.
-func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string) {
+func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string, labels ...*metapb.StoreLabel) {
 	c.Lock()
 	defer c.Unlock()
 	c.stores[storeID] = newStore(storeID, addr)
+	c.stores[storeID].meta.Labels = labels
 }
 
 // GetRegion returns a Region's meta and leader ID.

--- a/store/mockstore/mocktikv/cluster.go
+++ b/store/mockstore/mocktikv/cluster.go
@@ -216,8 +216,7 @@ func (c *Cluster) RemoveStore(storeID uint64) {
 func (c *Cluster) UpdateStoreAddr(storeID uint64, addr string, labels ...*metapb.StoreLabel) {
 	c.Lock()
 	defer c.Unlock()
-	c.stores[storeID] = newStore(storeID, addr)
-	c.stores[storeID].meta.Labels = labels
+	c.stores[storeID] = newStore(storeID, addr, labels...)
 }
 
 // GetRegion returns a Region's meta and leader ID.
@@ -649,11 +648,12 @@ type Store struct {
 	tokenCount atomic.Int64
 }
 
-func newStore(storeID uint64, addr string) *Store {
+func newStore(storeID uint64, addr string, labels ...*metapb.StoreLabel) *Store {
 	return &Store{
 		meta: &metapb.Store{
 			Id:      storeID,
 			Address: addr,
+			Labels:  labels,
 		},
 	}
 }

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -192,10 +192,10 @@ func (r *Region) init(c *RegionCache) error {
 		c.storeMu.RUnlock()
 		if !exists {
 			store = c.getStoreByStoreID(p.StoreId)
-			_, err := store.initResolve(NewNoopBackoff(context.Background()), c)
-			if err != nil {
-				return err
-			}
+		}
+		_, err := store.initResolve(NewNoopBackoff(context.Background()), c)
+		if err != nil {
+			return err
 		}
 		switch store.storeType {
 		case kv.TiKV:

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1087,7 +1087,7 @@ func (c *RegionCache) OnRegionEpochNotMatch(bo *Backoffer, ctx *RPCContext, curr
 		region.init(c)
 		var initLeader uint64
 		if ctx.Store.storeType == kv.TiFlash {
-			initLeader = region.findElectableStoreIndex()
+			initLeader = region.findElectableStoreID()
 		} else {
 			initLeader = ctx.Store.storeID
 		}
@@ -1254,13 +1254,13 @@ func (r *RegionStore) switchNextPeer(rr *Region, currentPeerIdx int) {
 	rr.compareAndSwapStore(r, newRegionStore)
 }
 
-func (r *Region) findElectableStoreIndex() uint64 {
+func (r *Region) findElectableStoreID() uint64 {
 	if len(r.meta.Peers) == 0 {
 		return 0
 	}
-	for i, p := range r.meta.Peers {
+	for _, p := range r.meta.Peers {
 		if !p.IsLearner {
-			return uint64(i)
+			return p.StoreId
 		}
 	}
 	return 0

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -438,7 +438,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 	for i := 0; i < regionStore.accessStoreNum(TiFlashOnly); i++ {
 		accessIdx := (sIdx + i) % regionStore.accessStoreNum(TiFlashOnly)
 		storeIdx, store := regionStore.accessStore(TiFlashOnly, accessIdx)
-		addr, err := c.getStoreAddr(bo, cachedRegion, store, accessIdx)
+		addr, err := c.getStoreAddr(bo, cachedRegion, store, storeIdx)
 		if err != nil {
 			return nil, err
 		}

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -679,10 +679,10 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	// add store3 as tiflash
 	store3 := s.cluster.AllocID()
 	peer3 := s.cluster.AllocID()
+	s.cluster.UpdateStoreAddr(s.store1, s.storeAddr(s.store1), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
 	s.cluster.AddStore(store3, s.storeAddr(store3))
-	s.cluster.UpdateStoreAddr(store3, s.storeAddr(store3), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
 	s.cluster.AddPeer(s.region1, store3, peer3)
-	s.cluster.ChangeLeader(s.region1, s.peer1)
+	s.cluster.ChangeLeader(s.region1, peer3)
 
 	// pre-load region cache
 	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
@@ -690,11 +690,13 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	c.Assert(loc1.Region.id, Equals, s.region1)
 	lctx, err := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
-	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+	c.Assert(lctx.Peer.Id, Equals, peer3)
 
 	// epoch-not-match on tiflash
 	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region)
 	c.Assert(err, IsNil)
+	c.Assert(ctxTiFlash.Peer.Id, Equals, s.peer1)
+	ctxTiFlash.Peer.IsLearner = true
 	r := ctxTiFlash.Meta
 	reqSend := NewRegionRequestSender(s.cache, nil)
 	regionErr := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{r}}}
@@ -703,7 +705,7 @@ func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
 	// check leader read should not go to tiflash
 	lctx, err = s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
-	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+	c.Assert(lctx.Peer.Id, Not(Equals), s.peer1)
 }
 
 const regionSplitKeyFormat = "t%08d"

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -275,7 +275,8 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 
 	addr = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
 	addr2 := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
-	c.Assert(addr, Not(Equals), addr2)
+	c.Assert(addr, Not(Equals), s.storeAddr(store3))
+	c.Assert(addr2, Not(Equals), s.storeAddr(store3))
 	c.Assert(addr, Not(Equals), "")
 	c.Assert(addr2, Not(Equals), "")
 }

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -675,6 +675,37 @@ func (s *testRegionCacheSuite) TestRegionEpochAheadOfTiKV(c *C) {
 	c.Assert(len(bo.errors), Equals, 2)
 }
 
+func (s *testRegionCacheSuite) TestRegionEpochOnTiFlash(c *C) {
+	// add store3 as tiflash
+	store3 := s.cluster.AllocID()
+	peer3 := s.cluster.AllocID()
+	s.cluster.AddStore(store3, s.storeAddr(store3))
+	s.cluster.UpdateStoreAddr(store3, s.storeAddr(store3), &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
+	s.cluster.AddPeer(s.region1, store3, peer3)
+	s.cluster.ChangeLeader(s.region1, s.peer1)
+
+	// pre-load region cache
+	loc1, err := s.cache.LocateKey(s.bo, []byte("a"))
+	c.Assert(err, IsNil)
+	c.Assert(loc1.Region.id, Equals, s.region1)
+	lctx, err := s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+
+	// epoch-not-match on tiflash
+	ctxTiFlash, err := s.cache.GetTiFlashRPCContext(s.bo, loc1.Region)
+	c.Assert(err, IsNil)
+	r := ctxTiFlash.Meta
+	reqSend := NewRegionRequestSender(s.cache, nil)
+	regionErr := &errorpb.Error{EpochNotMatch: &errorpb.EpochNotMatch{CurrentRegions: []*metapb.Region{r}}}
+	reqSend.onRegionError(s.bo, ctxTiFlash, nil, regionErr)
+
+	// check leader read should not go to tiflash
+	lctx, err = s.cache.GetTiKVRPCContext(s.bo, loc1.Region, kv.ReplicaReadLeader, 0)
+	c.Assert(err, IsNil)
+	c.Assert(lctx.Peer.Id, Not(Equals), peer3)
+}
+
 const regionSplitKeyFormat = "t%08d"
 
 func createClusterWithStoresAndRegions(regionCnt, storeCount int) *mocktikv.Cluster {

--- a/store/tikv/region_cache_test.go
+++ b/store/tikv/region_cache_test.go
@@ -129,7 +129,7 @@ func (s *testRegionCacheSuite) TestSimple(c *C) {
 	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed), Equals, s.storeAddr(s.store2))
 	s.checkCache(c, 1)
 	c.Assert(r.GetMeta(), DeepEquals, r.meta)
-	c.Assert(r.GetLeaderID(), Equals, r.meta.Peers[r.getStore().workTiKVIdx].Id)
+	c.Assert(r.GetLeaderPeerID(), Equals, r.meta.Peers[r.getStore().workTiKVIdx].Id)
 	s.cache.mu.regions[r.VerID()].lastAccess = 0
 	r = s.cache.searchCachedRegion([]byte("a"), true)
 	c.Assert(r, IsNil)
@@ -259,16 +259,25 @@ func (s *testRegionCacheSuite) TestUpdateLeader3(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(r, NotNil)
 	c.Assert(r.GetID(), Equals, s.region1)
+	loc, err = s.cache.LocateKey(s.bo, []byte("a"))
+	c.Assert(err, IsNil)
+	// return resolved store2 address and send fail
+	ctx, err := s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, seed)
+	c.Assert(err, IsNil)
+	c.Assert(ctx.Addr, Equals, "store2")
+	s.cache.OnSendFail(NewNoopBackoff(context.Background()), ctx, false, errors.New("send fail"))
+	s.cache.checkAndResolve(nil)
+	s.cache.UpdateLeader(loc.Region, s.store2, 0)
 	addr := s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0)
 	c.Assert(addr, Equals, "")
-	s.getRegion(c, []byte("a"))
-	// pd-server should return the new leader.
-	c.Assert(s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0), Equals, s.storeAddr(store3))
+	addr = s.getAddr(c, []byte("a"), kv.ReplicaReadLeader, 0)
+	c.Assert(addr, Equals, s.storeAddr(store3))
+
 	addr = s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed)
-	c.Assert(addr == s.storeAddr(s.store1) || len(addr) == 0, IsTrue)
 	addr2 := s.getAddr(c, []byte("a"), kv.ReplicaReadFollower, seed+1)
-	c.Assert(addr2 == s.storeAddr(s.store1) || len(addr2) == 0, IsTrue)
-	c.Assert((len(addr2) == 0 && len(addr) == 0) || addr != addr2, IsTrue)
+	c.Assert(addr, Not(Equals), addr2)
+	c.Assert(addr, Not(Equals), "")
+	c.Assert(addr2, Not(Equals), "")
 }
 
 func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
@@ -328,7 +337,7 @@ func (s *testRegionCacheSuite) TestSendFailedButLeaderNotChange(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// access 1 it will return NotLeader, leader back to 2 again
-	s.cache.UpdateLeader(loc.Region, s.store2, ctx.PeerIdx)
+	s.cache.UpdateLeader(loc.Region, s.store2, ctx.AccessIdx)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer2)
@@ -409,7 +418,7 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Not(Equals), ctxFollower2.Peer.Id)
 
 	// access 2, it's in hibernate and return 0 leader, so switch to 3
-	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
+	s.cache.UpdateLeader(loc.Region, 0, ctx.AccessIdx)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, peer3)
@@ -434,7 +443,7 @@ func (s *testRegionCacheSuite) TestSendFailedInHibernateRegion(c *C) {
 	// again peer back to 1
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
-	s.cache.UpdateLeader(loc.Region, 0, ctx.PeerIdx)
+	s.cache.UpdateLeader(loc.Region, 0, ctx.AccessIdx)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
@@ -563,7 +572,7 @@ func (s *testRegionCacheSuite) TestSendFailedInMultipleNode(c *C) {
 	c.Assert(ctxFollower1.Peer.Id, Equals, ctxFollower2.Peer.Id)
 
 	// 3 can be access, so switch to 1
-	s.cache.UpdateLeader(loc.Region, s.store1, ctx.PeerIdx)
+	s.cache.UpdateLeader(loc.Region, s.store1, ctx.AccessIdx)
 	ctx, err = s.cache.GetTiKVRPCContext(s.bo, loc.Region, kv.ReplicaReadLeader, 0)
 	c.Assert(err, IsNil)
 	c.Assert(ctx.Peer.Id, Equals, s.peer1)
@@ -860,7 +869,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 5)
 	for i := 0; i < 5; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _, _ := r.WorkStorePeer(r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -871,7 +880,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 3)
 	for i := 1; i < 4; i++ {
 		r := scannedRegions[i-1]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _, _ := r.WorkStorePeer(r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i])
 		c.Assert(p.Id, Equals, peers[i][0])
@@ -882,7 +891,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(len(scannedRegions), Equals, 1)
 
 	r0 := scannedRegions[0]
-	_, p0, _ := r0.WorkStorePeer(r0.getStore())
+	_, p0, _, _ := r0.WorkStorePeer(r0.getStore())
 	c.Assert(r0.meta.Id, Equals, regions[1])
 	c.Assert(p0.Id, Equals, peers[1][0])
 
@@ -893,7 +902,7 @@ func (s *testRegionCacheSuite) TestScanRegions(c *C) {
 	c.Assert(err, IsNil)
 	for i := 0; i < 3; i++ {
 		r := scannedRegions[i]
-		_, p, _ := r.WorkStorePeer(r.getStore())
+		_, p, _, _ := r.WorkStorePeer(r.getStore())
 
 		c.Assert(r.meta.Id, Equals, regions[i*2])
 		c.Assert(p.Id, Equals, peers[i*2][0])
@@ -1165,19 +1174,20 @@ func BenchmarkOnRequestFail(b *testing.B) {
 	region := cache.getRegionByIDFromCache(loc.Region.id)
 	b.ResetTimer()
 	regionStore := region.getStore()
-	store, peer, idx := region.WorkStorePeer(regionStore)
+	store, peer, accessIdx, _ := region.WorkStorePeer(regionStore)
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {
 			rpcCtx := &RPCContext{
-				Region:  loc.Region,
-				Meta:    region.meta,
-				PeerIdx: idx,
-				Peer:    peer,
-				Store:   store,
+				Region:     loc.Region,
+				Meta:       region.meta,
+				AccessIdx:  accessIdx,
+				Peer:       peer,
+				Store:      store,
+				AccessMode: TiKvOnly,
 			}
 			r := cache.getCachedRegionWithRLock(rpcCtx.Region)
 			if r != nil {
-				r.getStore().switchNextPeer(r, rpcCtx.PeerIdx)
+				r.getStore().switchNextTiKVPeer(r, rpcCtx.AccessIdx)
 			}
 		}
 	})

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -211,6 +211,7 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		logutil.Eventf(bo.ctx, "send %s request to region %d at %s", req.Type, regionID.id, rpcCtx.Addr)
+		rpcCtx.ReqStoreType = sType
 		s.storeAddr = rpcCtx.Addr
 		var retry bool
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -211,7 +211,6 @@ func (s *RegionRequestSender) SendReqCtx(
 		}
 
 		logutil.Eventf(bo.ctx, "send %s request to region %d at %s", req.Type, regionID.id, rpcCtx.Addr)
-		rpcCtx.ReqStoreType = sType
 		s.storeAddr = rpcCtx.Addr
 		var retry bool
 		resp, retry, err = s.sendReqToRegion(bo, rpcCtx, req, timeout)
@@ -362,7 +361,7 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, seed
 			}
 		} else {
 			// don't backoff if a new leader is returned.
-			s.regionCache.UpdateLeader(ctx.Region, notLeader.GetLeader().GetStoreId(), ctx.PeerIdx)
+			s.regionCache.UpdateLeader(ctx.Region, notLeader.GetLeader().GetStoreId(), ctx.AccessIdx)
 		}
 
 		return true, nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/17930

Problem Summary:

- there are many possibilities to retry wrong store type
- we should have more access pattern in future, filter labels at access time are inefficient

### What is changed and how it works?

What's Changed， How it Works:

- add accessIndex field to save idx in regionStore.Stores, and set index in RPCCtx be index of `accessIndex`
- choose any tikv store peer as leader when tiflash return EpochNotMatch

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Pre-index stores in region-cache for different access pattern

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18040)
<!-- Reviewable:end -->
