### PR TITLE
*: fix update bug in cluster index

### DIFF
--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -284,7 +284,7 @@ func (s *testSuite11) TestUpdateClusterIndex(c *C) {
 	tk.MustExec("create table t(a char(10) primary key, b char(10));")
 	tk.MustExec("insert into t values('a', 'b');")
 	tk.MustExec("update t set a='c' where t.a='a' and b='b';")
-	tk.MustQuery("select * from t").Check(testkit.Rows("'c' ''"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("'c' 'b'"))
 }
 
 func (s *testSuite11) TestDeleteClusterIndex(c *C) {

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -284,7 +284,7 @@ func (s *testSuite11) TestUpdateClusterIndex(c *C) {
 	tk.MustExec("create table t(a char(10) primary key, b char(10));")
 	tk.MustExec("insert into t values('a', 'b');")
 	tk.MustExec("update t set a='c' where t.a='a' and b='b';")
-	tk.MustQuery("select * from t").Check(testkit.Rows("'c' 'b'"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("c b"))
 }
 
 func (s *testSuite11) TestDeleteClusterIndex(c *C) {

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -279,6 +279,11 @@ func (s *testSuite11) TestUpdateClusterIndex(c *C) {
 	tk.MustQuery(`select * from ut1pku`).Check(testkit.Rows("a 3 2", "b 2 3"))
 	tk.MustGetErrCode(`update ut1pku set uk = 2 where id = 'a'`, errno.ErrDupEntry)
 	tk.MustQuery(`select * from ut1pku`).Check(testkit.Rows("a 3 2", "b 2 3"))
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a char(10) primary key, b char(10));")
+	tk.MustExec("insert into t values(\"a\", \"\");")
+	tk.MustExec("update t set a=\"c\" where t.a=\"a\" and b=\"\";")
 }
 
 func (s *testSuite11) TestDeleteClusterIndex(c *C) {

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -282,8 +282,9 @@ func (s *testSuite11) TestUpdateClusterIndex(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a char(10) primary key, b char(10));")
-	tk.MustExec("insert into t values(\"a\", \"\");")
-	tk.MustExec("update t set a=\"c\" where t.a=\"a\" and b=\"\";")
+	tk.MustExec("insert into t values('a', 'b');")
+	tk.MustExec("update t set a='c' where t.a='a' and b='b';")
+	tk.MustQuery("select * from t").Check(testkit.Rows("'c' ''"))
 }
 
 func (s *testSuite11) TestDeleteClusterIndex(c *C) {

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,10 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrU
 github.com/VividCortex/ewma v1.1.1 h1:MnEK4VOv6n0RSY4vtRe3h11qjxL3+t0B8yOL8iMXdcM=
 github.com/VividCortex/ewma v1.1.1/go.mod h1:2Tkkvm3sRDVXaiyucHiACn4cqf7DpdyLvmxzcbUokwA=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4 h1:Hs82Z41s6SdL1CELW+XaDYmOH4hkBN4/N9og/AsOv7E=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/antihax/optional v0.0.0-20180407024304-ca021399b1a6/go.mod h1:V8iCPQYkqmusNa815XgQio277wI47sdRh1dUOLdyC6Q=
 github.com/appleboy/gin-jwt/v2 v2.6.3/go.mod h1:MfPYA4ogzvOcVkRwAxT7quHOtQmVKDpTwxyUrC2DNw0=
@@ -862,6 +864,7 @@ google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQ
 google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 gopkg.in/alecthomas/gometalinter.v2 v2.0.12/go.mod h1:NDRytsqEZyolNuAgTzJkZMkSQM7FIKyzVzGhjB/qfYo=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/alecthomas/kingpin.v3-unstable v3.0.0-20180810215634-df19058c872c/go.mod h1:3HH7i1SgMqlzxCcBmUHW657sD4Kvv9sC3HpL3YukzwA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1195,7 +1195,7 @@ func (ds *DataSource) convertToPointGet(prop *property.PhysicalProperty, candida
 	}
 	rTsk := &rootTask{p: pointGetPlan}
 	var cost float64
-	if candidate.path.IsTablePath() {
+	if candidate.path.IsIntHandlePath {
 		pointGetPlan.Handle = kv.IntHandle(candidate.path.Ranges[0].LowVal[0].GetInt64())
 		pointGetPlan.UnsignedHandle = mysql.HasUnsignedFlag(ds.getHandleCol().RetType.Flag)
 		pointGetPlan.PartitionInfo = partitionInfo

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2827,6 +2827,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 			IsHidden: col.Hidden,
 		}
 
+		// TODO: The common handle may be multi columns, need to change ds.handleCol to a slice.
 		if col.IsPKHandleColumn(tableInfo) || col.IsCommonHandleColumn(tableInfo) {
 			handleCol = newCol
 		}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2827,7 +2827,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 			IsHidden: col.Hidden,
 		}
 
-		if tableInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {
+		if col.IsPKHandleColumn(tableInfo) || col.IsCommonHandleColumn(tableInfo) {
 			handleCol = newCol
 		}
 		schema.Append(newCol)

--- a/util/rowDecoder/decoder.go
+++ b/util/rowDecoder/decoder.go
@@ -99,9 +99,6 @@ func (rd *RowDecoder) DecodeAndEvalRowWithMap(ctx sessionctx.Context, handle kv.
 			rd.mutRow.SetValue(colInfo.Offset, val.GetValue())
 			continue
 		}
-		if rd.tryDecodeFromHandle(dCol, handle) {
-			continue
-		}
 		// Get the default value of the column in the generated column expression.
 		val, err = tables.GetColDefaultValue(ctx, dCol.Col, rd.defaultVals)
 		if err != nil {
@@ -136,22 +133,6 @@ func (rd *RowDecoder) DecodeAndEvalRowWithMap(ctx sessionctx.Context, handle kv.
 		row[id] = val
 	}
 	return row, nil
-}
-
-func (rd *RowDecoder) tryDecodeFromHandle(dCol Column, handle kv.Handle) bool {
-	if handle == nil {
-		return false
-	}
-	colInfo := dCol.Col.ColumnInfo
-	if dCol.Col.IsPKHandleColumn(rd.tbl.Meta()) {
-		if mysql.HasUnsignedFlag(colInfo.Flag) {
-			rd.mutRow.SetValue(colInfo.Offset, uint64(handle.IntValue()))
-		} else {
-			rd.mutRow.SetValue(colInfo.Offset, handle.IntValue())
-		}
-		return true
-	}
-	return false
 }
 
 // BuildFullDecodeColMap build a map that contains [columnID -> struct{*table.Column, expression.Expression}] from

--- a/util/rowcodec/decoder.go
+++ b/util/rowcodec/decoder.go
@@ -113,6 +113,7 @@ func (decoder *DatumMapDecoder) tryDecodeHandleColumn(col *ColInfo, handle kv.Ha
 		}
 		return true
 	}
+	// TODO: support common handle.
 	return false
 }
 


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18043  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

1. In buildDataSource, consider common handle as a handleCol.
2. Implement tryDecodeFromHandle for the common handle. So that we can start a server after ignore the EnableClusterIndex checking in create table.
3. Remove the logic of tryDecodeFromHandle in rowDecoder, it's used only for computer virtual generated column.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No Release note
