### PR TITLE
executor: make index merge join close gracefully when tasks not finish

### DIFF
--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -702,7 +702,6 @@ func (imw *innerMergeWorker) fetchNextInnerResult(ctx context.Context, task *loo
 
 // Close implements the Executor interface.
 func (e *IndexLookUpMergeJoin) Close() error {
-	close(e.closeCh)
 	if e.cancelFunc != nil {
 		e.cancelFunc()
 		e.cancelFunc = nil

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -715,6 +715,9 @@ func (e *IndexLookUpMergeJoin) Close() error {
 		close(e.joinChkResourceCh[i])
 	}
 	e.joinChkResourceCh = nil
+	// joinChkResourceCh is to recycle result chunks, used by inner worker.
+	// resultCh is the main thread get the results, used by main thread and inner worker.
+	// cancelFunc control the outer worker and outer worker close the task channel.
 	e.workerWg.Wait()
 	e.memTracker = nil
 	if e.runtimeStats != nil {

--- a/executor/index_lookup_merge_join.go
+++ b/executor/index_lookup_merge_join.go
@@ -222,6 +222,9 @@ func (e *IndexLookUpMergeJoin) newOuterWorker(resultCh, innerCh chan *lookUpMerg
 		parentMemTracker:      e.memTracker,
 		nextColCompareFilters: e.lastColHelper,
 	}
+	failpoint.Inject("testIssue18068", func() {
+		omw.batchSize = 1
+	})
 	return omw
 }
 

--- a/executor/index_lookup_merge_join_test.go
+++ b/executor/index_lookup_merge_join_test.go
@@ -23,3 +23,26 @@ func (s *testSuite9) TestIndexLookupMergeJoinHang(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "OOM test index merge join doesn't hang here.")
 }
+
+func (s *testSuite9) TestIssue18068(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/testIssue18068", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/testIssue18068"), IsNil)
+	}()
+
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t, s")
+	tk.MustExec("create table t (a int, index idx(a))")
+	tk.MustExec("create table s (a int, index idx(a))")
+	tk.MustExec("insert into t values(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1);")
+	tk.MustExec("insert into s values(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1),(1);")
+	tk.MustExec("set @@tidb_index_join_batch_size=1")
+	tk.MustExec("set @@tidb_max_chunk_size=32")
+	tk.MustExec("set @@tidb_init_chunk_size=1")
+	tk.MustExec("set @@tidb_index_lookup_join_concurrency=2")
+
+	tk.MustExec("select  /*+ inl_merge_join(s)*/ 1 from t join s on t.a = s.a limit 1")
+	// Do not hang in index merge join when the second and third execute.
+	tk.MustExec("select  /*+ inl_merge_join(s)*/ 1 from t join s on t.a = s.a limit 1")
+	tk.MustExec("select  /*+ inl_merge_join(s)*/ 1 from t join s on t.a = s.a limit 1")
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18068 

Problem Summary: PTAL at the #18068 

### What is changed and how it works?

What's Changed: make it close outer worker gracefully.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- make index merge join executor close gracefully when tasks not finish
