### PR TITLE
ddl: fix sequence cache negative problem

### DIFF
--- a/ddl/sequence.go
+++ b/ddl/sequence.go
@@ -144,6 +144,10 @@ func validateSequenceOptions(seqInfo *model.SequenceInfo) bool {
 		// Increment shouldn't be set as 0.
 		return false
 	}
+	if seqInfo.CacheValue <= 0 {
+		// Cache value should be bigger than 0.
+		return false
+	}
 	maxIncrement = math2.Abs(seqInfo.Increment)
 
 	return seqInfo.MaxValue >= seqInfo.Start &&


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/17945 <!-- REMOVE this line if no issue to close -->

### What is changed and how it works?

What's Changed:
check cache shouldn't be negative when create sequence

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- ddl: fix sequence cache negative problem
