### PR TITLE
unistore: fix clustered index point range check.

### DIFF
--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -550,8 +550,10 @@ func (s *testPointGetSuite) TestClusterIndexPointGet(c *C) {
 
 	tk.MustExec(`drop table if exists snp`)
 	tk.MustExec(`create table snp(id1 int, id2 int, v int, primary key(id1, id2))`)
+	tk.MustExec(`insert snp values (1, 1, 1), (2, 2, 2), (2, 3, 3)`)
 	tk.MustQuery(`explain select * from snp where id1 = 1`).Check(testkit.Rows("TableReader_6 10.00 root  data:TableRangeScan_5",
 		"└─TableRangeScan_5 10.00 cop[tikv] table:snp range:[1,1], keep order:false, stats:pseudo"))
 	tk.MustQuery(`explain select * from snp where id1 in (1, 100)`).Check(testkit.Rows("TableReader_6 20.00 root  data:TableRangeScan_5",
 		"└─TableRangeScan_5 20.00 cop[tikv] table:snp range:[1,1], [100,100], keep order:false, stats:pseudo"))
+	tk.MustQuery("select * from snp where id1 = 2").Check(testkit.Rows("2 2 2", "2 3 3"))
 }

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -351,7 +351,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	}
 	dbReader := e.dbReader
 	for i, ran := range e.kvRanges {
-		if e.isPointRange(ran) {
+		if e.isPointGetRange(ran) {
 			val, err := dbReader.Get(ran.StartKey, e.startTS)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -389,7 +389,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	return e.oldChunks, err
 }
 
-func (e *closureExecutor) isPointRange(ran kv.KeyRange) bool {
+func (e *closureExecutor) isPointGetRange(ran kv.KeyRange) bool {
 	if e.idxScanCtx != nil || len(e.primaryCols) == 0 {
 		return e.unique && ran.IsPoint()
 	}

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -351,7 +351,7 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	}
 	dbReader := e.dbReader
 	for i, ran := range e.kvRanges {
-		if e.unique && ran.IsPoint() {
+		if e.isPointRange(ran) {
 			val, err := dbReader.Get(ran.StartKey, e.startTS)
 			if err != nil {
 				return nil, errors.Trace(err)
@@ -387,6 +387,27 @@ func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
 	}
 	err = e.processor.Finish()
 	return e.oldChunks, err
+}
+
+func (e *closureExecutor) isPointRange(ran kv.KeyRange) bool {
+	if e.idxScanCtx != nil || len(e.primaryCols) == 0 {
+		return e.unique && ran.IsPoint()
+	}
+	// For common handle table scan, we also need to check if the column count of the start key equals.
+	if len(ran.StartKey) < tablecodec.RecordRowKeyLen {
+		return false
+	}
+	keyColValues := tablecodec.CutRowKeyPrefix(ran.StartKey)
+	var colCnt int
+	for len(keyColValues) > 0 {
+		var err error
+		_, keyColValues, err = codec.CutOne(keyColValues)
+		if err != nil {
+			return false
+		}
+		colCnt++
+	}
+	return colCnt == len(e.primaryCols) && ran.IsPoint()
 }
 
 func (e *closureExecutor) checkRangeLock() error {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

unistore executor incorrectly check range IsPoint, cause incorrect result.

### What is changed and how it works?

extract a method that also check that the number of column equals to the number of primaryCols for clustered index.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
