### PR TITLE
ddl: speed up the operation of "drop database" (#17009)

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -92,6 +92,7 @@ func TestT(t *testing.T) {
 	logutil.InitLogger(logutil.NewLogConfig(logLevel, "", "", logutil.EmptyFileLogConfig, false))
 	autoid.SetStep(5000)
 	ReorgWaitTimeout = 30 * time.Millisecond
+	batchInsertDeleteRangeSize = 2
 
 	cfg := config.GetGlobalConfig()
 	newCfg := *cfg

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -34,15 +34,21 @@ import (
 )
 
 const (
-	insertDeleteRangeSQL = `INSERT IGNORE INTO mysql.gc_delete_range VALUES ("%d", "%d", "%s", "%s", "%d")`
+	insertDeleteRangeSQLPrefix = `INSERT IGNORE INTO mysql.gc_delete_range VALUES `
+	insertDeleteRangeSQLValue  = `("%d", "%d", "%s", "%s", "%d")`
+	insertDeleteRangeSQL       = insertDeleteRangeSQLPrefix + insertDeleteRangeSQLValue
 
 	delBatchSize = 65536
 	delBackLog   = 128
 )
 
-// enableEmulatorGC means whether to enable emulator GC. The default is enable.
-// In some unit tests, we want to stop emulator GC, then wen can set enableEmulatorGC to 0.
-var emulatorGCEnable = int32(1)
+var (
+	// enableEmulatorGC means whether to enable emulator GC. The default is enable.
+	// In some unit tests, we want to stop emulator GC, then wen can set enableEmulatorGC to 0.
+	emulatorGCEnable = int32(1)
+	// batchInsertDeleteRangeSize is the maximum size for each batch insert statement in the delete-range.
+	batchInsertDeleteRangeSize = 256
+)
 
 type delRangeManager interface {
 	// addDelRangeJob add a DDL job into gc_delete_range table.
@@ -90,6 +96,7 @@ func (dr *delRange) addDelRangeJob(job *model.Job) error {
 
 	err = insertJobIntoDeleteRangeTable(ctx, job)
 	if err != nil {
+		logutil.BgLogger().Error("[ddl] add job into delete-range table failed", zap.Int64("jobID", job.ID), zap.String("jobType", job.Type.String()), zap.Error(err))
 		return errors.Trace(err)
 	}
 	if !dr.storeSupport {
@@ -251,10 +258,12 @@ func insertJobIntoDeleteRangeTable(ctx sessionctx.Context, job *model.Job) error
 		if err := job.DecodeArgs(&tableIDs); err != nil {
 			return errors.Trace(err)
 		}
-		for _, tableID := range tableIDs {
-			startKey := tablecodec.EncodeTablePrefix(tableID)
-			endKey := tablecodec.EncodeTablePrefix(tableID + 1)
-			if err := doInsert(s, job.ID, tableID, startKey, endKey, now); err != nil {
+		for i := 0; i < len(tableIDs); i += batchInsertDeleteRangeSize {
+			batchEnd := len(tableIDs)
+			if batchEnd > i+batchInsertDeleteRangeSize {
+				batchEnd = i + batchInsertDeleteRangeSize
+			}
+			if err := doBatchInsert(s, job.ID, tableIDs[i:batchEnd], now); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -338,6 +347,23 @@ func doInsert(s sqlexec.SQLExecutor, jobID int64, elementID int64, startKey, end
 	startKeyEncoded := hex.EncodeToString(startKey)
 	endKeyEncoded := hex.EncodeToString(endKey)
 	sql := fmt.Sprintf(insertDeleteRangeSQL, jobID, elementID, startKeyEncoded, endKeyEncoded, ts)
+	_, err := s.Execute(context.Background(), sql)
+	return errors.Trace(err)
+}
+
+func doBatchInsert(s sqlexec.SQLExecutor, jobID int64, tableIDs []int64, ts uint64) error {
+	logutil.BgLogger().Info("[ddl] batch insert into delete-range table", zap.Int64("jobID", jobID), zap.Int64s("elementIDs", tableIDs))
+	sql := insertDeleteRangeSQLPrefix
+	for i, tableID := range tableIDs {
+		startKey := tablecodec.EncodeTablePrefix(tableID)
+		endKey := tablecodec.EncodeTablePrefix(tableID + 1)
+		startKeyEncoded := hex.EncodeToString(startKey)
+		endKeyEncoded := hex.EncodeToString(endKey)
+		sql += fmt.Sprintf(insertDeleteRangeSQLValue, jobID, tableID, startKeyEncoded, endKeyEncoded, ts)
+		if i != len(tableIDs)-1 {
+			sql += ","
+		}
+	}
 	_, err := s.Execute(context.Background(), sql)
 	return errors.Trace(err)
 }


### PR DESCRIPTION
cherry-pick #17009 to release-4.0

---

### What problem does this PR solve?

Issue Number: close #16983 <!-- REMOVE this line if no issue to close -->

Problem Summary:
<img width="1915" alt="Screen Shot 2020-05-07 at 12 42 14" src="https://user-images.githubusercontent.com/4242506/81255646-c5eb1700-9060-11ea-9ecc-0a34278bcdc4.png">
Looking at the logs, this drop schema operation really took almost 1 hour. 
![WeChatWorkScreenshot_b015a9fc-b256-47d1-82e6-8493c00d7890](https://user-images.githubusercontent.com/4242506/81256736-f54f5300-9063-11ea-8a7d-b338bb270d20.png)
The insert statements take more than 50 minutes. The other time consuming is due to the synchronization method of waiting for 2 * lease.
This PR we speed up the insert statements in "drop schema" operation.

### What is changed and how it works?

What's Changed:
In the above case, the database has 1587204 tables, so it needs to execute 1587204 insert statements. In this PR we do batch insertion.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (original tests, and set `BatchInsertDeleteRangeSize` to 2)
- Manual test (add detailed scripts or steps below)

Using TiUP to start a cluster for 3 tikv，1 tidb and 1 pd.

dbx* has 1 table, dby* has 100 tables, dbz* has 10000 tables.

Before this PR:
```
mysql> drop database dbx1;
Query OK, 0 rows affected (0.33 sec)
mysql> drop database dby1;
Query OK, 0 rows affected (0.69 sec)
mysql> drop database dbz1;
Query OK, 0 rows affected (55.89 sec)
```
After this PR:
```
mysql> drop database dbx0;
Query OK, 0 rows affected (0.27 sec)
mysql> drop database dby0;
Query OK, 0 rows affected (0.38 sec)
mysql> drop database dbz0;
Query OK, 0 rows affected (3.77 sec)
```

### Release note <!-- bugfixes or new feature need a release note -->

- Speed up the deletion of databases with a large number of tables