### PR TITLE
config, store: add `admission-min-result-mb` for coprocessor cache

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -484,7 +484,9 @@ type CoprocessorCache struct {
 	Enable bool `toml:"enable" json:"enable"`
 	// The capacity in MB of the cache.
 	CapacityMB float64 `toml:"capacity-mb" json:"capacity-mb"`
-	// Only cache requests whose result set is small.
+	// Only cache requests whose result set is larger than AdmissionMaxResultMB.
+	AdmissionMinResultMB float64 `toml:"admission-min-result-mb" json:"admission-min-result-mb"`
+	// Only cache requests whose result set is less than AdmissionMaxResultMB.
 	AdmissionMaxResultMB float64 `toml:"admission-max-result-mb" json:"admission-max-result-mb"`
 	// Only cache requests takes notable time to process.
 	AdmissionMinProcessMs uint64 `toml:"admission-min-process-ms" json:"admission-min-process-ms"`
@@ -659,6 +661,7 @@ var defaultConf = Config{
 		CoprCache: CoprocessorCache{
 			Enable:                true,
 			CapacityMB:            1000,
+			AdmissionMinResultMB:  0,
 			AdmissionMaxResultMB:  10,
 			AdmissionMinProcessMs: 5,
 		},


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Add `admission-min-result-mb` for coprocessor cache.

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- Add `admission-min-result-mb` for coprocessor cache.