### PR TITLE
ddl: limit the range of auto_random_base

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2346,7 +2346,7 @@ func (d *ddl) RebaseAutoID(ctx sessionctx.Context, ident ast.Ident, newBase int6
 			}
 		}
 		layout := autoid.NewAutoRandomIDLayout(&autoRandColTp, tbInfo.AutoRandomBits)
-		if layout.IncrementalMask() & newBase != newBase {
+		if layout.IncrementalMask()&newBase != newBase {
 			errMsg := fmt.Sprintf(autoid.AutoRandomRebaseOverflow, newBase, layout.IncrementalBitsCapacity())
 			return errors.Trace(ErrInvalidAutoRandom.GenWithStackByArgs(errMsg))
 		}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2335,8 +2335,20 @@ func (d *ddl) RebaseAutoID(ctx sessionctx.Context, ident ast.Ident, newBase int6
 	var actionType model.ActionType
 	switch tp {
 	case autoid.AutoRandomType:
-		if t.Meta().AutoRandomBits == 0 {
+		tbInfo := t.Meta()
+		if tbInfo.AutoRandomBits == 0 {
 			return errors.Trace(ErrInvalidAutoRandom.GenWithStackByArgs(autoid.AutoRandomRebaseNotApplicable))
+		}
+		var autoRandColTp types.FieldType
+		for _, c := range tbInfo.Columns {
+			if mysql.HasPriKeyFlag(c.Flag) {
+				autoRandColTp = c.FieldType
+			}
+		}
+		layout := autoid.NewAutoRandomIDLayout(&autoRandColTp, tbInfo.AutoRandomBits)
+		if layout.IncrementalMask() & newBase != newBase {
+			errMsg := fmt.Sprintf(autoid.AutoRandomRebaseOverflow, newBase, layout.IncrementalBitsCapacity())
+			return errors.Trace(ErrInvalidAutoRandom.GenWithStackByArgs(errMsg))
 		}
 		actionType = model.ActionRebaseAutoRandomBase
 	case autoid.RowIDAllocType:

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2343,6 +2343,7 @@ func (d *ddl) RebaseAutoID(ctx sessionctx.Context, ident ast.Ident, newBase int6
 		for _, c := range tbInfo.Columns {
 			if mysql.HasPriKeyFlag(c.Flag) {
 				autoRandColTp = c.FieldType
+				break
 			}
 		}
 		layout := autoid.NewAutoRandomIDLayout(&autoRandColTp, tbInfo.AutoRandomBits)

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -15,7 +15,6 @@ package executor_test
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/meta/autoid"
 	"strconv"
 	"strings"
 	"sync"
@@ -23,6 +22,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/errno"
+	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/meta/autoid"
 	"strconv"
 	"strings"
 	"sync"
@@ -1003,6 +1004,12 @@ func (s *testSuite9) TestAutoRandomID(c *C) {
 	tk.MustQuery(`select last_insert_id()`).Check(testkit.Rows(fmt.Sprintf("%d", firstValue)))
 
 	tk.MustExec(`drop table ar`)
+	tk.MustExec(`create table ar (id bigint key auto_random(15), name char(10))`)
+	overflowVal := 1 << (64 - 5)
+	errMsg := fmt.Sprintf(autoid.AutoRandomRebaseOverflow, overflowVal, 1 << (64 - 16) - 1)
+	_, err = tk.Exec(fmt.Sprintf("alter table ar auto_random_base = %d", overflowVal))
+	c.Assert(err, NotNil)
+	c.Assert(strings.Contains(err.Error(), errMsg), IsTrue)
 }
 
 func (s *testSuite9) TestMultiAutoRandomID(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1006,7 +1006,7 @@ func (s *testSuite9) TestAutoRandomID(c *C) {
 	tk.MustExec(`drop table ar`)
 	tk.MustExec(`create table ar (id bigint key auto_random(15), name char(10))`)
 	overflowVal := 1 << (64 - 5)
-	errMsg := fmt.Sprintf(autoid.AutoRandomRebaseOverflow, overflowVal, 1 << (64 - 16) - 1)
+	errMsg := fmt.Sprintf(autoid.AutoRandomRebaseOverflow, overflowVal, 1<<(64-16)-1)
 	_, err = tk.Exec(fmt.Sprintf("alter table ar auto_random_base = %d", overflowVal))
 	c.Assert(err, NotNil)
 	c.Assert(strings.Contains(err.Error(), errMsg), IsTrue)

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -53,4 +53,6 @@ const (
 	AutoRandomOnNonBigIntColumn = "auto_random option must be defined on `bigint` column, but not on `%s` column"
 	// AutoRandomRebaseNotApplicable is reported when alter auto_random base on a non auto_random table.
 	AutoRandomRebaseNotApplicable = "alter auto_random_base of a non auto_random table"
+	// AutoRandomRebaseOverflow is reported when alter auto_random_base to a value that overflows the incremental bits.
+	AutoRandomRebaseOverflow = "alter auto_random_base to %d overflows the incremental bits, max allowed base is %d"
 )


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18187 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?
Check the incremental bits part of auto_random_base.

```sql
alter table t auto_random_base = ?;
```
The above statement should only succeed when shard bits of `?` are all zero.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

- A check at `RebaseAutoID()`.
- A tiny test case.


Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
