### PR TITLE
sessionctx/variable: open batch_cop for tiflash by default

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -472,7 +472,7 @@ const (
 	DefTiDBHashJoinConcurrency         = 5
 	DefTiDBProjectionConcurrency       = ConcurrencyUnset
 	DefTiDBOptimizerSelectivityLevel   = 0
-	DefTiDBAllowBatchCop               = 0
+	DefTiDBAllowBatchCop               = 1
 	DefTiDBTxnMode                     = ""
 	DefTiDBRowFormatV1                 = 1
 	DefTiDBRowFormatV2                 = 2


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Open tidb_allow_batch_cop by default

Problem Summary:

batch cop is added by https://github.com/pingcap/tidb/pull/16030 and its doc is https://github.com/pingcap/docs-cn/pull/3265
After POC for a long time, we decide to open this feature by default.

What's Changed:

Only a default value for variable is changed.

Side effects

- Only involve risk to tiflash.
### Release note <!-- bugfixes or new feature need a release note -->

active tidb_allow_batch_cop by default.
