### PR TITLE
ddl: report error for empty name index

### DIFF
--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -151,6 +151,8 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		// issue 3843
 		{"create index `primary` on t (i)", true, errors.New("[ddl:1280]Incorrect index name 'primary'")},
 		{"alter table t add index `primary` (i)", true, errors.New("[ddl:1280]Incorrect index name 'primary'")},
+		// issue 18149
+		{"CREATE TABLE `t` (x INT, KEY ``(x))", true, errors.New("[ddl:1280]Incorrect index name ''")},
 
 		// issue 2273
 		{"create table t(a char, b char, c char, d char, e char, f char, g char, h char ,i char, j char, k int, l char ,m char , n char, o char , p char, q char, index(a,b,c,d,e,f,g,h,i,j,k,l,m,n,o,p,q))", true, errors.New("[schema:1070]Too many key parts specified; max 16 parts allowed")},


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18149  <!-- REMOVE this line if no issue to close -->

Problem Summary: TiDB can create empty name index

### What is changed and how it works?
In mysql grammar, one cannot use empty name index, when `checkIndexInfo`, we should report error for the non-primary indexes.

What's Changed:
when calling the `checkIndexInfo`, we add one more arg  `isPrimary` to tell whether this index is primary, inside the check we report the error for `len(indexName) == 0 && !isPrimary`
How it Works:
```
mysql> CREATE TABLE `t` (x INT, KEY ``(x));
ERROR 1280 (42000): Incorrect index name ''
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
```
mysql> CREATE TABLE `t` (x INT, KEY ``(x));
ERROR 1280 (42000): Incorrect index name ''
```
### Release note <!-- bugfixes or new feature need a release note -->
- Report error for empty name index
