### PR TITLE
charset: add missing ascii check(close #17375)

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -276,6 +276,12 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t1(a varchar(10)) charset ascii;`)
 	_, err = tk.Exec(`insert into t1 values('我');`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
+
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1(a char(10) charset utf8);`)
+	tk.MustExec(`insert into t1 values('我');`)
+	tk.MustExec(`alter table t1 add column b char(10) charset ascii as ((a));`)
+	tk.MustQuery(`select * from t1;`).Check(testkit.Rows(`我 `))
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -271,6 +271,11 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t1(a bigint);`)
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
+
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1(a varchar(10)) charset ascii;`)
+	_, err = tk.Exec(`insert into t1 values('我');`)
+	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/statement_context_test.go
+++ b/executor/statement_context_test.go
@@ -83,6 +83,28 @@ func (s *testSuite1) TestStatementContext(c *C) {
 	runeErrStr := string(utf8.RuneError)
 	tk.MustExec(fmt.Sprintf("insert sc2 values ('%s')", runeErrStr))
 
+	// Test invalid ASCII
+	tk.MustExec("create table sc3 (a varchar(255)) charset ascii")
+
+	tk.MustExec(nonStrictModeSQL)
+	tk.MustExec("insert sc3 values (unhex('4040ffff'))")
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Greater, uint16(0))
+	tk.MustQuery("select * from sc3").Check(testkit.Rows("@@"))
+
+	tk.MustExec(strictModeSQL)
+	_, err = tk.Exec("insert sc3 values (unhex('4040ffff'))")
+	c.Assert(err, NotNil)
+	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue, Commentf("err %v", err))
+
+	tk.MustExec("set @@tidb_skip_ascii_check = '1'")
+	_, err = tk.Exec("insert sc3 values (unhex('4040ffff'))")
+	c.Assert(err, IsNil)
+	tk.MustQuery("select length(a) from sc3").Check(testkit.Rows("2", "4"))
+
+	// no placeholder in ASCII, so just insert '@@'...
+	tk.MustExec("set @@tidb_skip_ascii_check = '0'")
+	tk.MustExec("insert sc3 values (unhex('4040'))")
+
 	// Test non-BMP characters.
 	tk.MustExec(nonStrictModeSQL)
 	tk.MustExec("drop table if exists t1")

--- a/session/session.go
+++ b/session/session.go
@@ -1994,6 +1994,7 @@ var builtinGlobalVariable = []string{
 	variable.SQLSelectLimit,
 
 	/* TiDB specific global variables: */
+	variable.TiDBSkipASCIICheck,
 	variable.TiDBSkipUTF8Check,
 	variable.TiDBIndexJoinBatchSize,
 	variable.TiDBIndexLookupSize,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -460,6 +460,9 @@ type SessionVars struct {
 
 	/* TiDB system variables */
 
+	// SkipASCIICheck check on input value.
+	SkipASCIICheck bool
+
 	// SkipUTF8Check check on input value.
 	SkipUTF8Check bool
 
@@ -1111,6 +1114,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.WindowingUseHighPrecision = TiDBOptOn(val)
 	case TiDBSkipUTF8Check:
 		s.SkipUTF8Check = TiDBOptOn(val)
+	case TiDBSkipASCIICheck:
+		s.SkipASCIICheck = TiDBOptOn(val)
 	case TiDBOptAggPushDown:
 		s.AllowAggPushDown = TiDBOptOn(val)
 	case TiDBOptDistinctAggPushDown:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -638,6 +638,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBIndexLookupJoinConcurrency, strconv.Itoa(DefIndexLookupJoinConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBIndexSerialScanConcurrency, strconv.Itoa(DefIndexSerialScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBSkipUTF8Check, BoolToIntStr(DefSkipUTF8Check)},
+	{ScopeGlobal | ScopeSession, TiDBSkipASCIICheck, BoolToIntStr(DefSkipASCIICheck)},
 	{ScopeSession, TiDBBatchInsert, BoolToIntStr(DefBatchInsert)},
 	{ScopeSession, TiDBBatchDelete, BoolToIntStr(DefBatchDelete)},
 	{ScopeSession, TiDBBatchCommit, BoolToIntStr(DefBatchCommit)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -267,6 +267,11 @@ const (
 	// the input string values are valid, we can skip the check.
 	TiDBSkipUTF8Check = "tidb_skip_utf8_check"
 
+	// tidb_skip_ascii_check skips the ASCII validate process
+	// old tidb may already have fields with invalid ASCII bytes
+	// disable ASCII validate can guarantee a safe replication
+	TiDBSkipASCIICheck = "tidb_skip_ascii_check"
+
 	// tidb_hash_join_concurrency is used for hash join executor.
 	// The hash join outer executor starts multiple concurrent join workers to probe the hash table.
 	// tidb_hash_join_concurrency is deprecated, use tidb_executor_concurrency instead.
@@ -433,6 +438,7 @@ const (
 	DefAutoIncrementOffset             = 1
 	DefChecksumTableConcurrency        = 4
 	DefSkipUTF8Check                   = false
+	DefSkipASCIICheck                  = false
 	DefOptAggPushDown                  = false
 	DefOptWriteRowID                   = false
 	DefOptCorrelationThreshold         = 0.9

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -435,8 +435,8 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string, scope Sc
 			return "ON", nil
 		}
 		return value, ErrWrongValueForVar.GenWithStackByArgs(name, value)
-	case TiDBSkipUTF8Check, TiDBOptAggPushDown, TiDBOptDistinctAggPushDown,
-		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
+	case TiDBSkipUTF8Check, TiDBSkipASCIICheck, TiDBOptAggPushDown,
+		TiDBOptDistinctAggPushDown, TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming, TiDBEnableChunkRPC,
 		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction, TiDBPProfSQLCPU,
 		TiDBLowResolutionTSO, TiDBEnableIndexMerge, TiDBEnableNoopFuncs,

--- a/table/column.go
+++ b/table/column.go
@@ -210,11 +210,11 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 		truncateTrailingSpaces(&casted)
 	}
 
-	if ctx.GetSessionVars().SkipUTF8Check {
-		return casted, nil
-	}
-
 	if col.Charset == charset.CharsetASCII {
+		if ctx.GetSessionVars().SkipASCIICheck {
+			return casted, nil
+		}
+
 		str := casted.GetString()
 		for i := 0; i < len(str); i++ {
 			if str[i] > unicode.MaxASCII {
@@ -226,6 +226,10 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 			err = nil
 		}
 		return casted, err
+	}
+
+	if ctx.GetSessionVars().SkipUTF8Check {
+		return casted, nil
 	}
 
 	if !mysql.IsUTF8Charset(col.Charset) {

--- a/table/column.go
+++ b/table/column.go
@@ -22,6 +22,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	"github.com/pingcap/parser"
@@ -157,6 +158,15 @@ func CastValues(ctx sessionctx.Context, rec []types.Datum, cols []*Column) (err 
 	return nil
 }
 
+func handleWrongAsciiValue(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
+	sc := ctx.GetSessionVars().StmtCtx
+	err := ErrTruncatedWrongValueForField.FastGen("incorrect ascii value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
+	logutil.BgLogger().Error("incorrect ASCII value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
+	truncateVal := types.NewStringDatum(str[:i])
+	err = sc.HandleTruncate(err)
+	return truncateVal, err
+}
+
 func handleWrongUtf8Value(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
 	sc := ctx.GetSessionVars().StmtCtx
 	err := ErrTruncatedWrongValueForField.FastGen("incorrect utf8 value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
@@ -203,6 +213,21 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 	if ctx.GetSessionVars().SkipUTF8Check {
 		return casted, nil
 	}
+
+	if col.Charset == charset.CharsetASCII {
+		str := casted.GetString()
+		for i := 0; i < len(str); i++ {
+			if str[i] > unicode.MaxASCII {
+				casted, err = handleWrongAsciiValue(ctx, col, &casted, str, i)
+				break
+			}
+		}
+		if forceIgnoreTruncate {
+			err = nil
+		}
+		return casted, err
+	}
+
 	if !mysql.IsUTF8Charset(col.Charset) {
 		return casted, nil
 	}

--- a/table/column.go
+++ b/table/column.go
@@ -158,7 +158,7 @@ func CastValues(ctx sessionctx.Context, rec []types.Datum, cols []*Column) (err 
 	return nil
 }
 
-func handleWrongAsciiValue(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
+func handleWrongASCIIValue(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
 	sc := ctx.GetSessionVars().StmtCtx
 	err := ErrTruncatedWrongValueForField.FastGen("incorrect ascii value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
 	logutil.BgLogger().Error("incorrect ASCII value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
@@ -218,7 +218,7 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 		str := casted.GetString()
 		for i := 0; i < len(str); i++ {
 			if str[i] > unicode.MaxASCII {
-				casted, err = handleWrongAsciiValue(ctx, col, &casted, str, i)
+				casted, err = handleWrongASCIIValue(ctx, col, &casted, str, i)
 				break
 			}
 		}

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -289,9 +289,25 @@ func (t *testTableSuite) TestCastValue(c *C) {
 	_, err = CastValue(ctx, types.NewDatum([]byte{0xf0, 0x9f, 0x8c, 0x80}), &colInfoS, false, false)
 	c.Assert(err, NotNil)
 
+	colInfoS.Charset = mysql.UTF8Charset
+	_, err = CastValue(ctx, types.NewDatum([]byte{0xf0, 0x9f, 0x8c, 0x80}), &colInfoS, false, true)
+	c.Assert(err, IsNil)
+
 	colInfoS.Charset = mysql.UTF8MB4Charset
 	_, err = CastValue(ctx, types.NewDatum([]byte{0xf0, 0x9f, 0x80}), &colInfoS, false, false)
 	c.Assert(err, NotNil)
+
+	colInfoS.Charset = mysql.UTF8MB4Charset
+	_, err = CastValue(ctx, types.NewDatum([]byte{0xf0, 0x9f, 0x80}), &colInfoS, false, true)
+	c.Assert(err, IsNil)
+
+	colInfoS.Charset = charset.CharsetASCII
+	_, err = CastValue(ctx, types.NewDatum([]byte{0x32, 0xf0}), &colInfoS, false, false)
+	c.Assert(err, NotNil)
+
+	colInfoS.Charset = charset.CharsetASCII
+	_, err = CastValue(ctx, types.NewDatum([]byte{0x32, 0xf0}), &colInfoS, false, true)
+	c.Assert(err, IsNil)
 }
 
 func (t *testTableSuite) TestGetDefaultValue(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #17375 

### What is changed and how it works?

This PR/commit add a simple loop to check non-ASCII chars with a charset of ASCII.

### Related changes

None

### Check List

Tests

- Integration test

### Release note

- ASCII charset character validation