### PR TITLE
ddl: save and restore auto_random id when rename table

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -641,11 +641,17 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		return ver, errors.Trace(err)
 	}
 
-	var baseID int64
+	var autoTableID int64
+	var autoRandID int64
 	shouldDelAutoID := false
 	if newSchemaID != oldSchemaID {
 		shouldDelAutoID = true
-		baseID, err = t.GetAutoTableID(tblInfo.GetDBID(oldSchemaID), tblInfo.ID)
+		autoTableID, err = t.GetAutoTableID(tblInfo.GetDBID(oldSchemaID), tblInfo.ID)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
+		autoRandID, err = t.GetAutoRandomID(tblInfo.GetDBID(oldSchemaID), tblInfo.ID)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
@@ -676,7 +682,12 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	}
 	// Update the table's auto-increment ID.
 	if newSchemaID != oldSchemaID {
-		_, err = t.GenAutoTableID(newSchemaID, tblInfo.ID, baseID)
+		_, err = t.GenAutoTableID(newSchemaID, tblInfo.ID, autoTableID)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
+		_, err = t.GenAutoRandomID(newSchemaID, tblInfo.ID, autoRandID)
 		if err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -842,6 +842,12 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	tk.MustExec("use test_auto_random_bits")
 	tk.MustExec("drop table if exists t")
 
+	extractAllHandles := func() []int64 {
+		allHds, err := ddltestutil.ExtractAllTableHandles(tk.Se, "test_auto_random_bits", "t")
+		c.Assert(err, IsNil)
+		return allHds
+	}
+
 	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
 	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
@@ -850,8 +856,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	for i := 0; i < 100; i++ {
 		tk.MustExec("insert into t(b) values (?)", i)
 	}
-	allHandles, err := ddltestutil.ExtractAllTableHandles(tk.Se, "test_auto_random_bits", "t")
-	c.Assert(err, IsNil)
+	allHandles := extractAllHandles()
 	tk.MustExec("drop table t")
 
 	// Test auto random id number.
@@ -875,7 +880,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	for i := -10; i < 10; i++ {
 		tk.MustExec(fmt.Sprintf("insert into t values(%d, %d)", i+autoRandBitsUpperBound, i))
 	}
-	_, err = tk.Exec("insert into t (b) values (0)")
+	_, err := tk.Exec("insert into t (b) values (0)")
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, autoid.ErrAutoRandReadFailed.GenWithStackByArgs().Error())
 	tk.MustExec("drop table t")
@@ -904,10 +909,8 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 		tk.MustExec("insert into t(b) values (?)", i)
 		tk.MustExec("insert into t(a, b) values (?, ?)", -i, i)
 	}
-	allHandles, err = ddltestutil.ExtractAllTableHandles(tk.Se, "test_auto_random_bits", "t")
-	c.Assert(err, IsNil)
 	// orderedHandles should be [-100, -99, ..., -2, -1, 1, 2, ..., 99, 100]
-	orderedHandles = testutil.ConfigTestUtils.MaskSortHandles(allHandles, 15, mysql.TypeLonglong)
+	orderedHandles = testutil.ConfigTestUtils.MaskSortHandles(extractAllHandles(), 15, mysql.TypeLonglong)
 	size = int64(len(allHandles))
 	for i := int64(0); i < 100; i++ {
 		c.Assert(orderedHandles[i], Equals, i-100)
@@ -922,8 +925,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	for i := 0; i < 100; i++ {
 		tk.MustExec("insert into t (b) values(?)", i)
 	}
-	allHandles, err = ddltestutil.ExtractAllTableHandles(tk.Se, "test_auto_random_bits", "t")
-	for _, h := range allHandles {
+	for _, h := range extractAllHandles() {
 		// Sign bit should be reserved.
 		c.Assert(h > 0, IsTrue)
 	}
@@ -933,14 +935,35 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	for i := 0; i < 100; i++ {
 		tk.MustExec("insert into t (b) values(?)", i)
 	}
-	allHandles, err = ddltestutil.ExtractAllTableHandles(tk.Se, "test_auto_random_bits", "t")
 	signBitUnused := true
-	for _, h := range allHandles {
+	for _, h := range extractAllHandles() {
 		signBitUnused = signBitUnused && (h > 0)
 	}
 	// Sign bit should be used for shard.
 	c.Assert(signBitUnused, IsFalse)
-	tk.MustExec("drop table t")
+	tk.MustExec("drop table t;")
+
+	// Test rename rename table does not affect incremental part of auto_random ID.
+	tk.MustExec("create database test_auto_random_bits_rename;")
+	tk.MustExec("create table t (a bigint auto_random primary key);")
+	for i := 0; i < 10; i++ {
+		tk.MustExec("insert into t values ();")
+	}
+	tk.MustExec("alter table t rename to test_auto_random_bits_rename.t1;")
+	for i := 0; i < 10; i++ {
+		tk.MustExec("insert into test_auto_random_bits_rename.t1 values ();")
+	}
+	tk.MustExec("alter table test_auto_random_bits_rename.t1 rename to t;")
+	for i := 0; i < 10; i++ {
+		tk.MustExec("insert into t values ();")
+	}
+	uniqueHandles := make(map[int64]struct{})
+	for _, h := range extractAllHandles() {
+		uniqueHandles[h & ((1 << (63 - 5)) - 1)] = struct{}{}
+	}
+	c.Assert(len(uniqueHandles), Equals, 30)
+	tk.MustExec("drop database test_auto_random_bits_rename;")
+	tk.MustExec("drop table t;")
 }
 
 func (s *testAutoRandomSuite) TestAutoRandomTableOption(c *C) {

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -943,7 +943,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	c.Assert(signBitUnused, IsFalse)
 	tk.MustExec("drop table t;")
 
-	// Test rename rename table does not affect incremental part of auto_random ID.
+	// Test rename table does not affect incremental part of auto_random ID.
 	tk.MustExec("create database test_auto_random_bits_rename;")
 	tk.MustExec("create table t (a bigint auto_random primary key);")
 	for i := 0; i < 10; i++ {

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -959,7 +959,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 	}
 	uniqueHandles := make(map[int64]struct{})
 	for _, h := range extractAllHandles() {
-		uniqueHandles[h & ((1 << (63 - 5)) - 1)] = struct{}{}
+		uniqueHandles[h&((1<<(63-5))-1)] = struct{}{}
 	}
 	c.Assert(len(uniqueHandles), Equals, 30)
 	tk.MustExec("drop database test_auto_random_bits_rename;")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18211 <!-- REMOVE this line if no issue to close -->

Problem Summary: 

`auto_random` ID should be kept when renaming tables.

### What is changed and how it works?

What's Changed:

- Save and restore `auto_random` ID in `onRenameTable()`.
- Add a test for renaming `auto_random` table

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- fix duplicate entry when renaming `auto_random` tables.
