### PR TITLE
executor,ddl: update auto_random_base in 'show create table' after insertion

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -314,9 +314,9 @@ func getColumnsTypes(columns []*model.ColumnInfo) []*types.FieldType {
 }
 
 // buildDescTableScan builds a desc table scan upon tblInfo.
-func (d *ddlCtx) buildDescTableScan(ctx context.Context, startTS uint64, tbl table.PhysicalTable,
+func (dc *ddlCtx) buildDescTableScan(ctx context.Context, startTS uint64, tbl table.PhysicalTable,
 	handleCols []*model.ColumnInfo, limit uint64) (distsql.SelectResult, error) {
-	sctx := newContext(d.store)
+	sctx := newContext(dc.store)
 	dagPB, err := buildDescTableScanDAG(sctx, tbl, handleCols, limit)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -346,7 +346,7 @@ func (d *ddlCtx) buildDescTableScan(ctx context.Context, startTS uint64, tbl tab
 }
 
 // GetTableMaxHandle gets the max handle of a PhysicalTable.
-func (d *ddlCtx) GetTableMaxHandle(startTS uint64, tbl table.PhysicalTable) (maxHandle kv.Handle, emptyTable bool, err error) {
+func (dc *ddlCtx) GetTableMaxHandle(startTS uint64, tbl table.PhysicalTable) (maxHandle kv.Handle, emptyTable bool, err error) {
 	var handleCols []*model.ColumnInfo
 	tblInfo := tbl.Meta()
 	switch {
@@ -369,7 +369,7 @@ func (d *ddlCtx) GetTableMaxHandle(startTS uint64, tbl table.PhysicalTable) (max
 
 	ctx := context.Background()
 	// build a desc scan of tblInfo, which limit is 1, we can use it to retrieve the last handle of the table.
-	result, err := d.buildDescTableScan(ctx, startTS, tbl, handleCols, 1)
+	result, err := dc.buildDescTableScan(ctx, startTS, tbl, handleCols, 1)
 	if err != nil {
 		return nil, false, errors.Trace(err)
 	}
@@ -385,7 +385,7 @@ func (d *ddlCtx) GetTableMaxHandle(startTS uint64, tbl table.PhysicalTable) (max
 		// empty table
 		return nil, true, nil
 	}
-	sessCtx := newContext(d.store)
+	sessCtx := newContext(dc.store)
 	row := chk.GetRow(0)
 	if tblInfo.IsCommonHandle {
 		maxHandle, err = buildHandleFromChunkRow(sessCtx.GetSessionVars().StmtCtx, row, handleCols)

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -834,11 +834,11 @@ type testAutoRandomSuite struct {
 	*baseTestSuite
 }
 
-func (s *testAutoRandomSuite)SetupTest()  {
+func (s *testAutoRandomSuite) SetupTest() {
 	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
 }
 
-func(s *testAutoRandomSuite)TeardownTest(){
+func (s *testAutoRandomSuite) TeardownTest() {
 	testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
 }
 

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -857,8 +857,8 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 		return allHds
 	}
 
-	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
-	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+	s.SetupTest()
+	defer s.TeardownTest()
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 
 	tk.MustExec("create table t (a bigint primary key auto_random(15), b int)")
@@ -980,8 +980,8 @@ func (s *testAutoRandomSuite) TestAutoRandomTableOption(c *C) {
 	tk.MustExec("use test")
 
 	// test table option is auto-random
-	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
-	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+	s.SetupTest()
+	defer s.TeardownTest()
 
 	tk.MustExec("drop table if exists auto_random_table_option")
 	tk.MustExec("create table auto_random_table_option (a bigint auto_random(5) key) auto_random_base = 1000")
@@ -1051,8 +1051,8 @@ func (s *testAutoRandomSuite) TestFilterDifferentAllocators(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("drop table if exists t1")
 
-	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
-	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+	s.SetupTest()
+	defer s.TeardownTest()
 
 	tk.MustExec("create table t(a bigint auto_random(5) key, b int auto_increment unique)")
 	tk.MustExec("insert into t values()")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -843,7 +843,6 @@ func(s *testAutoRandomSuite)TeardownTest(){
 }
 
 func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
-	s.SetUpSuite(c);
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("create database if not exists test_auto_random_bits")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -834,7 +834,16 @@ type testAutoRandomSuite struct {
 	*baseTestSuite
 }
 
+func (s *testAutoRandomSuite)SetupTest()  {
+	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
+}
+
+func(s *testAutoRandomSuite)TeardownTest(){
+	testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+}
+
 func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
+	s.SetUpSuite(c);
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("create database if not exists test_auto_random_bits")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -834,11 +834,11 @@ type testAutoRandomSuite struct {
 	*baseTestSuite
 }
 
-func (s *testAutoRandomSuite) SetupTest() {
+func (s *testAutoRandomSuite) SetUpTest() {
 	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
 }
 
-func (s *testAutoRandomSuite) TeardownTest() {
+func (s *testAutoRandomSuite) TearDownTest() {
 	testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
 }
 
@@ -856,8 +856,6 @@ func (s *testAutoRandomSuite) TestAutoRandomBitsData(c *C) {
 		return allHds
 	}
 
-	s.SetupTest()
-	defer s.TeardownTest()
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 
 	tk.MustExec("create table t (a bigint primary key auto_random(15), b int)")
@@ -979,9 +977,6 @@ func (s *testAutoRandomSuite) TestAutoRandomTableOption(c *C) {
 	tk.MustExec("use test")
 
 	// test table option is auto-random
-	s.SetupTest()
-	defer s.TeardownTest()
-
 	tk.MustExec("drop table if exists auto_random_table_option")
 	tk.MustExec("create table auto_random_table_option (a bigint auto_random(5) key) auto_random_base = 1000")
 	t, err := domain.GetDomain(tk.Se).InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("auto_random_table_option"))
@@ -1049,9 +1044,6 @@ func (s *testAutoRandomSuite) TestFilterDifferentAllocators(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("drop table if exists t1")
-
-	s.SetupTest()
-	defer s.TeardownTest()
 
 	tk.MustExec("create table t(a bigint auto_random(5) key, b int auto_increment unique)")
 	tk.MustExec("insert into t values()")

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -834,11 +834,11 @@ type testAutoRandomSuite struct {
 	*baseTestSuite
 }
 
-func (s *testAutoRandomSuite) SetUpTest() {
+func (s *testAutoRandomSuite) SetUpTest(c *C) {
 	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
 }
 
-func (s *testAutoRandomSuite) TearDownTest() {
+func (s *testAutoRandomSuite) TearDownTest(c *C) {
 	testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -919,15 +919,17 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoRandID != 0 {
-		autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
 		autoRandomBase := tableInfo.AutoRandID
 
-		if autoIncID > 1 {
-			autoRandomBase = autoIncID
+		if hasAutoIncID {
+			autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			if autoIncID > 1 {
+				autoRandomBase = autoIncID
+			}
 		}
 
 		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)

--- a/executor/show.go
+++ b/executor/show.go
@@ -918,21 +918,15 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " /*T![auto_id_cache] AUTO_ID_CACHE=%d */", tableInfo.AutoIdCache)
 	}
 
-	if tableInfo.AutoRandID != 0 {
-		autoRandomBase := tableInfo.AutoRandID
-
-		if randomAllocator != nil {
-			autoRandID, err := randomAllocator.NextGlobalAutoID(tableInfo.ID)
-			if err != nil {
-				return errors.Trace(err)
-			}
-
-			if autoRandID > 1 {
-				autoRandomBase = autoRandID
-			}
+	if randomAllocator != nil {
+		autoRandID, err := randomAllocator.NextGlobalAutoID(tableInfo.ID)
+		if err != nil {
+			return errors.Trace(err)
 		}
 
-		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)
+		if autoRandID > 1 {
+			fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandID)
+		}
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -921,13 +921,15 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	if tableInfo.AutoRandID != 0 {
 		autoRandomBase := tableInfo.AutoRandID
 
-		autoRandID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		if hasAutoIncID {
+			autoRandID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
+			if err != nil {
+				return errors.Trace(err)
+			}
 
-		if autoRandID > 1 {
-			autoRandomBase = autoRandID
+			if autoRandID > 1 {
+				autoRandomBase = autoRandID
+			}
 		}
 
 		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)

--- a/executor/show.go
+++ b/executor/show.go
@@ -921,13 +921,15 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	if tableInfo.AutoRandID != 0 {
 		autoRandomBase := tableInfo.AutoRandID
 
-		autoRandID, err := randomAllocator.NextGlobalAutoID(tableInfo.ID)
-		if err != nil {
-			return errors.Trace(err)
-		}
+		if randomAllocator != nil {
+			autoRandID, err := randomAllocator.NextGlobalAutoID(tableInfo.ID)
+			if err != nil {
+				return errors.Trace(err)
+			}
 
-		if autoRandID > 1 {
-			autoRandomBase = autoRandID
+			if autoRandID > 1 {
+				autoRandomBase = autoRandID
+			}
 		}
 
 		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)

--- a/executor/show.go
+++ b/executor/show.go
@@ -921,15 +921,13 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	if tableInfo.AutoRandID != 0 {
 		autoRandomBase := tableInfo.AutoRandID
 
-		if hasAutoIncID {
-			autoRandID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
-			if err != nil {
-				return errors.Trace(err)
-			}
+		autoRandID, err := randomAllocator.NextGlobalAutoID(tableInfo.ID)
+		if err != nil {
+			return errors.Trace(err)
+		}
 
-			if autoRandID > 1 {
-				autoRandomBase = autoRandID
-			}
+		if autoRandID > 1 {
+			autoRandomBase = autoRandID
 		}
 
 		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)

--- a/executor/show.go
+++ b/executor/show.go
@@ -920,7 +920,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoRandID != 0 {
-		var autoRandomBase = tableInfo.AutoRandID
+		autoRandomBase := tableInfo.AutoRandID
 
 		if autoIncID > 1 {
 			autoRandomBase = autoIncID

--- a/executor/show.go
+++ b/executor/show.go
@@ -909,6 +909,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		if err != nil {
 			return errors.Trace(err)
 		}
+
 		// It's compatible with MySQL.
 		if autoIncID > 1 {
 			fmt.Fprintf(buf, " AUTO_INCREMENT=%d", autoIncID)

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,7 +903,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
-	incrementAllocator := allocators.Get(autoid.AutoIncrementType)
+	incrementAllocator := allocators.Get(autoid.RowIDAllocType)
 	if hasAutoIncID && incrementAllocator != nil {
 		autoIncID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
 		if err != nil {

--- a/executor/show.go
+++ b/executor/show.go
@@ -920,7 +920,13 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoRandID != 0 {
-		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoIncID)
+		var autoRandomBase = tableInfo.AutoRandID
+
+		if autoIncID > 1 {
+			autoRandomBase = autoIncID
+		}
+
+		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoRandomBase)
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,11 +903,12 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
+	autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
 	if hasAutoIncID {
-		autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
-		if err != nil {
-			return errors.Trace(err)
-		}
 		// It's compatible with MySQL.
 		if autoIncID > 1 {
 			fmt.Fprintf(buf, " AUTO_INCREMENT=%d", autoIncID)
@@ -919,7 +920,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoRandID != 0 {
-		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", tableInfo.AutoRandID)
+		fmt.Fprintf(buf, " /*T![auto_rand_base] AUTO_RANDOM_BASE=%d */", autoIncID)
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,7 +903,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
-	if hasAutoIncID {
+	if hasAutoIncID && incrementAllocator != nil {
 		autoIncID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
 		if err != nil {
 			return errors.Trace(err)
@@ -1026,7 +1026,7 @@ func (e *ShowExec) fetchShowCreateTable() error {
 	}
 
 	tableInfo := tb.Meta()
-	incrementAllocator := tb.Allocators(e.ctx).Get(autoid.AutoIncrementType)
+	incrementAllocator := tb.Allocators(e.ctx).Get(autoid.RowIDAllocType)
 	randomAllocator := tb.Allocators(e.ctx).Get(autoid.AutoRandomType)
 	var buf bytes.Buffer
 	// TODO: let the result more like MySQL.

--- a/executor/show.go
+++ b/executor/show.go
@@ -903,12 +903,11 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
-	autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
 	if hasAutoIncID {
+		autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		// It's compatible with MySQL.
 		if autoIncID > 1 {
 			fmt.Fprintf(buf, " AUTO_INCREMENT=%d", autoIncID)
@@ -920,6 +919,11 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.AutoRandID != 0 {
+		autoIncID, err := allocator.NextGlobalAutoID(tableInfo.ID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
 		autoRandomBase := tableInfo.AutoRandID
 
 		if autoIncID > 1 {

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -813,8 +813,8 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
 
-	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
-	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+    s.SetupTest()
+	defer s.TeardownTest()
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -708,9 +708,6 @@ func (s *testAutoRandomSuite) TestShowCreateTableAutoRandom(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 
-	s.SetupTest()
-	defer s.TeardownTest()
-
 	// Basic show create table.
 	tk.MustExec("create table auto_random_tbl1 (a bigint primary key auto_random(3), b varchar(255))")
 	tk.MustQuery("show create table `auto_random_tbl1`").Check(testutil.RowsWithSep("|",
@@ -818,9 +815,6 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
-
-	s.SetupTest()
-	defer s.TeardownTest()
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -815,6 +815,16 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
+	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  `a` bigint(20) NOT NULL /*T![auto_rand] AUTO_RANDOM(5) */,\n"+
+			"  `b` int(11) NOT NULL AUTO_INCREMENT,\n"+
+			"  PRIMARY KEY (`a`),\n"+
+			"  UNIQUE KEY `b` (`b`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=100 /*T![auto_rand_base] AUTO_RANDOM_BASE=100 */",
+	))
+
 	tk.MustExec("insert into t(`a`) values (1000)")
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		""+

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,10 +16,10 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/failpoint"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -810,11 +810,6 @@ func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
 }
 
 func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
-	}()
-
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -707,8 +707,8 @@ func (s *testAutoRandomSuite) TestShowCreateTableAutoRandom(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 
-	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
-	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+	s.SetupTest()
+	defer s.TeardownTest()
 
 	// Basic show create table.
 	tk.MustExec("create table auto_random_tbl1 (a bigint primary key auto_random(3), b varchar(255))")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -814,7 +814,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
-	tk.MustExec("insert into t(`a`) values (1000)")
+	tk.MustExec("insert into t values (1000)")
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		""+
 			"t CREATE TABLE `t` (\n"+

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/failpoint"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -809,6 +810,11 @@ func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
 }
 
 func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
+
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -813,6 +813,9 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
 
+	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
+	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -833,7 +833,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 			"  `b` int(11) NOT NULL AUTO_INCREMENT,\n"+
 			"  PRIMARY KEY (`a`),\n"+
 			"  UNIQUE KEY `b` (`b`)\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=6001 */",
 	))
 }
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -810,11 +810,12 @@ func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
 
 func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
-	tk.MustExec("insert into t values (1000)")
+	tk.MustExec("insert into t(`a`) values (1000)")
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		""+
 			"t CREATE TABLE `t` (\n"+

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -823,7 +823,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 			"  `b` int(11) NOT NULL AUTO_INCREMENT,\n"+
 			"  PRIMARY KEY (`a`),\n"+
 			"  UNIQUE KEY `b` (`b`)\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin  AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
 	))
 }
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,8 +16,6 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/failpoint"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/auth"
@@ -814,7 +812,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
 
-    s.SetupTest()
+	s.SetupTest()
 	defer s.TeardownTest()
 
 	tk.MustExec("drop table if exists t")

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/failpoint"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -809,6 +810,11 @@ func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
 }
 
 func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"), IsNil)
+	}()
+
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@allow_auto_random_explicit_insert = true")
 	tk.MustExec("use test")
@@ -836,7 +842,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 			"  `b` int(11) NOT NULL AUTO_INCREMENT,\n"+
 			"  PRIMARY KEY (`a`),\n"+
 			"  UNIQUE KEY `b` (`b`)\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=6001 */",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=5100 /*T![auto_rand_base] AUTO_RANDOM_BASE=6001 */",
 	))
 }
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -808,6 +808,23 @@ func (s *testAutoRandomSuite) TestAutoIdCache(c *C) {
 	))
 }
 
+func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
+	tk.MustExec("insert into t values (1000)")
+	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
+		""+
+			"t CREATE TABLE `t` (\n"+
+			"  b` int(11) NOT NULL AUTO_INCREMENT,\n"+
+			"  PRIMARY KEY (`a`),\n"+
+			"  UNIQUE KEY `b` (`b`)\n"+
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin1  AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
+	))
+}
+
 func (s *testSuite5) TestShowEscape(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -819,10 +819,11 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		""+
 			"t CREATE TABLE `t` (\n"+
-			"  b` int(11) NOT NULL AUTO_INCREMENT,\n"+
+			"  `a` bigint(20) NOT NULL /*T![auto_rand] AUTO_RANDOM(5) */,\n"+
+			"  `b` int(11) NOT NULL AUTO_INCREMENT,\n"+
 			"  PRIMARY KEY (`a`),\n"+
 			"  UNIQUE KEY `b` (`b`)\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin1  AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin  AUTO_INCREMENT=2000100 /*T![auto_rand_base] AUTO_RANDOM_BASE=2000100 */",
 	))
 }
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -814,7 +814,7 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a bigint primary key auto_random(5), b int unique key auto_increment) auto_random_base = 100, auto_increment = 100")
-	tk.MustExec("insert into t values (1000)")
+	tk.MustExec("insert into t(`a`) values (1000)")
 	tk.MustQuery("show create table t").Check(testutil.RowsWithSep("|",
 		""+
 			"t CREATE TABLE `t` (\n"+


### PR DESCRIPTION
Signed-off-by: Rustin-Liu <rustin.liu@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17456。

Problem Summary:

### What is changed and how it works?

What's Changed:

Use Allocator.NextGlobalAutoID() as auto_random_base.

How it Works:

Use Allocator.NextGlobalAutoID() as auto_random_base.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->
- update auto_random_base in 'show create table' after insertion
