### PR TITLE
ddl, test: delete unstable code that cause test failed in ddl

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -19,7 +19,6 @@ import (
 	"math"
 	"math/rand"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -2337,9 +2336,7 @@ func (s *testIntegrationSuite3) TestCommitWhenSchemaChange(c *C) {
 
 	tk.MustExec("insert into schema_change values (5, '2019-12-25 13:27:43')")
 	tk.MustExec("insert into schema_change values (9, '2019-12-25 13:27:44')")
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)
 	_, err := tk.Se.Execute(context.Background(), "commit")
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 0)
 	c.Assert(domain.ErrInfoSchemaChanged.Equal(err), IsTrue)
 
 	// Cover a bug that schema validator does not prevent transaction commit when
@@ -2358,9 +2355,7 @@ func (s *testIntegrationSuite3) TestCommitWhenSchemaChange(c *C) {
 	tk2.MustExec("alter table pt exchange partition p1 with table nt;")
 	tk.MustExec("insert into nt values (7), (9);")
 
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)
 	_, err = tk.Se.Execute(context.Background(), "commit")
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 0)
 	c.Assert(domain.ErrInfoSchemaChanged.Equal(err), IsTrue)
 
 	tk.MustExec("admin check table pt")
@@ -2372,9 +2367,7 @@ func (s *testIntegrationSuite3) TestCommitWhenSchemaChange(c *C) {
 	tk.MustExec("insert into pt values (1), (3), (5);")
 	tk2.MustExec("alter table pt exchange partition p1 with table nt;")
 	tk.MustExec("insert into pt values (7), (9);")
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)
 	_, err = tk.Se.Execute(context.Background(), "commit")
-	atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 0)
 	c.Assert(domain.ErrInfoSchemaChanged.Equal(err), IsTrue)
 
 	tk.MustExec("admin check table pt")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18194

Problem Summary:
`atomic.StoreUint32(&session.SchemaChangedWithoutRetry, 1)`  cause test unstable in ddl

### What is changed and how it works?

change `TestCommitWhenSchemaChange` to `testIntegrationSuite7`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
