### PR TITLE
kv: make txn entry size limit configurable

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,8 @@ import (
 // Config number limitations
 const (
 	MaxLogFileSize = 4096 // MB
+	// DefTxnEntrySizeLimit is the default value of TxnEntrySizeLimit.
+	DefTxnEntrySizeLimit = 6 * 1024 * 1024
 	// DefTxnTotalSizeLimit is the default value of TxnTxnTotalSizeLimit.
 	DefTxnTotalSizeLimit = 100 * 1024 * 1024
 	// DefMaxIndexLength is the maximum index length(in bytes). This value is consistent with MySQL.
@@ -376,6 +378,7 @@ type Performance struct {
 	PseudoEstimateRatio  float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
 	ForcePriority        string  `toml:"force-priority" json:"force-priority"`
 	BindInfoLease        string  `toml:"bind-info-lease" json:"bind-info-lease"`
+	TxnEntrySizeLimit    uint64  `toml:"txn-entry-size-limit" json:"txn-entry-size-limit"`
 	TxnTotalSizeLimit    uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
 	TCPKeepAlive         bool    `toml:"tcp-keep-alive" json:"tcp-keep-alive"`
 	CrossJoin            bool    `toml:"cross-join" json:"cross-join"`
@@ -618,6 +621,7 @@ var defaultConf = Config{
 		PseudoEstimateRatio:  0.8,
 		ForcePriority:        "NO_PRIORITY",
 		BindInfoLease:        "3s",
+		TxnEntrySizeLimit:    DefTxnEntrySizeLimit,
 		TxnTotalSizeLimit:    DefTxnTotalSizeLimit,
 		DistinctAggPushDown:  false,
 		CommitterConcurrency: 16,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -250,6 +250,10 @@ distinct-agg-push-down = false
 # If binlog is disabled or binlog is enabled without Kafka, this value should be less than 10737418240(10G).
 txn-total-size-limit = 104857600
 
+# The limitation of the size in byte for each entry in one transaction.
+# NOTE: Increasing this limit may cause performance problems.
+txn-entry-size-limit = 6291456
+
 # The max number of running concurrency two phase committer request for an SQL.
 committer-concurrency = 16
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -109,7 +109,7 @@ func (r ReplicaReadType) IsFollowerRead() bool {
 // Those limits is enforced to make sure the transaction can be well handled by TiKV.
 var (
 	// TxnEntrySizeLimit is limit of single entry size (len(key) + len(value)).
-	TxnEntrySizeLimit = 6 * 1024 * 1024
+	TxnEntrySizeLimit uint64 = config.DefTxnEntrySizeLimit
 	// TxnTotalSizeLimit is limit of the sum of all entry size.
 	TxnTotalSizeLimit uint64 = config.DefTxnTotalSizeLimit
 )

--- a/kv/memdb_buffer.go
+++ b/kv/memdb_buffer.go
@@ -27,7 +27,7 @@ import (
 // memDbBuffer implements the MemBuffer interface.
 type memDbBuffer struct {
 	sandbox         *memdb.Sandbox
-	entrySizeLimit  int
+	entrySizeLimit  uint64
 	bufferLenLimit  uint64
 	bufferSizeLimit uint64
 }
@@ -43,7 +43,7 @@ type memDbIter struct {
 func NewMemDbBuffer() MemBuffer {
 	return &memDbBuffer{
 		sandbox:         memdb.NewSandbox(),
-		entrySizeLimit:  TxnEntrySizeLimit,
+		entrySizeLimit:  atomic.LoadUint64(&TxnEntrySizeLimit),
 		bufferSizeLimit: atomic.LoadUint64(&TxnTotalSizeLimit),
 	}
 }
@@ -93,7 +93,7 @@ func (m *memDbBuffer) Set(k Key, v []byte) error {
 	if len(v) == 0 {
 		return errors.Trace(ErrCannotSetNilValue)
 	}
-	if len(k)+len(v) > m.entrySizeLimit {
+	if uint64(len(k)+len(v)) > m.entrySizeLimit {
 		return ErrEntryTooLarge.GenWithStackByArgs(m.entrySizeLimit, len(k)+len(v))
 	}
 
@@ -126,7 +126,7 @@ func (m *memDbBuffer) Len() int {
 func (m *memDbBuffer) NewStagingBuffer() MemBuffer {
 	return &memDbBuffer{
 		sandbox:         m.sandbox.Derive(),
-		entrySizeLimit:  TxnEntrySizeLimit,
+		entrySizeLimit:  m.entrySizeLimit,
 		bufferSizeLimit: m.bufferSizeLimit - uint64(m.sandbox.Size()),
 	}
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -42,7 +42,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	util2 "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/hint"
@@ -1527,8 +1527,8 @@ var cmSketchSizeLimit = kv.TxnEntrySizeLimit / binary.MaxVarintLen32
 var analyzeOptionLimit = map[ast.AnalyzeOptionType]uint64{
 	ast.AnalyzeOptNumBuckets:    1024,
 	ast.AnalyzeOptNumTopN:       1024,
-	ast.AnalyzeOptCMSketchWidth: uint64(cmSketchSizeLimit),
-	ast.AnalyzeOptCMSketchDepth: uint64(cmSketchSizeLimit),
+	ast.AnalyzeOptCMSketchWidth: cmSketchSizeLimit,
+	ast.AnalyzeOptCMSketchDepth: cmSketchSizeLimit,
 	ast.AnalyzeOptNumSamples:    100000,
 }
 
@@ -1557,7 +1557,7 @@ func handleAnalyzeOptions(opts []ast.AnalyzeOpt) (map[ast.AnalyzeOptionType]uint
 		}
 		optMap[opt.Type] = opt.Value
 	}
-	if optMap[ast.AnalyzeOptCMSketchWidth]*optMap[ast.AnalyzeOptCMSketchDepth] > uint64(cmSketchSizeLimit) {
+	if optMap[ast.AnalyzeOptCMSketchWidth]*optMap[ast.AnalyzeOptCMSketchDepth] > cmSketchSizeLimit {
 		return nil, errors.Errorf("cm sketch size(depth * width) should not larger than %d", cmSketchSizeLimit)
 	}
 	return optMap, nil

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -330,7 +330,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 		}
 		mutations.push(op, k, value, isPessimisticLock)
 		entrySize := len(k) + len(v)
-		if entrySize > kv.TxnEntrySizeLimit {
+		if uint64(entrySize) > kv.TxnEntrySizeLimit {
 			return kv.ErrEntryTooLarge.GenWithStackByArgs(kv.TxnEntrySizeLimit, entrySize)
 		}
 		size += entrySize

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -574,6 +574,10 @@ func setGlobalVars() {
 	plannercore.AllowCartesianProduct.Store(cfg.Performance.CrossJoin)
 	privileges.SkipWithGrant = cfg.Security.SkipGrantTable
 	kv.TxnTotalSizeLimit = cfg.Performance.TxnTotalSizeLimit
+	if cfg.Performance.TxnEntrySizeLimit > 120*1024*1024 {
+		log.Fatal("cannot set txn entry size limit larger than 120M")
+	}
+	kv.TxnEntrySizeLimit = cfg.Performance.TxnEntrySizeLimit
 
 	priority := mysql.Str2Priority(cfg.Performance.ForcePriority)
 	variable.ForcePriority = int32(priority)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Make txn entry size limit configurable

Due to the limitation in `memdb`, the upper limit of this option is set to 120Mb

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> make txn entry size limit configurable
