### PR TITLE
planner: correct ResolveIndices on common handles for index lookup reader

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -15,6 +15,7 @@ package executor_test
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 	"sync"
@@ -1258,4 +1259,38 @@ func (s *testSuite10) TestClusterPrimaryKeyForIndexScan(c *C) {
 	tk.MustExec("CREATE TABLE pkt2 (a varchar(255), b int, unique index idx(b), primary key(a,b));")
 	tk.MustExec("insert into pkt2 values ('aaa',1);")
 	tk.MustQuery(`select b from pkt2 where b = 1;`).Check(testkit.Rows("1"))
+
+	tk.MustExec("drop table if exists issue_18232;")
+	tk.MustExec("create table issue_18232 (a int, b int, c int, d int, primary key (a, b), index idx(c));")
+
+	iter, cnt := combination([]string{"a", "b", "c", "d"}), 0
+	for {
+		comb := iter()
+		if comb == nil {
+			break
+		}
+		selField := strings.Join(comb, ",")
+		sql := fmt.Sprintf("select %s from issue_18232 use index (idx);", selField)
+		tk.MustExec(sql)
+		cnt++
+	}
+	c.Assert(cnt, Equals, 15)
+}
+
+func combination(items []string) func() []string {
+	current := 1
+	buf := make([]string, len(items))
+	return func() []string {
+		if current >= int(math.Pow(2, float64(len(items)))) {
+			return nil
+		}
+		buf = buf[:0]
+		for i, e := range items {
+			if (1<<i)&current != 0 {
+				buf = append(buf, e)
+			}
+		}
+		current++
+		return buf
+	}
 }

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -858,7 +858,7 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 		}.Init(ds.ctx, ds.blockOffset)
 		ts.schema = is.dataSourceSchema.Clone()
 		if ds.tableInfo.IsCommonHandle {
-			cop.commonHandleCols = ts.appendCommonHandleCols(ds)
+			cop.commonHandleCols = ds.commonHandleCols
 		}
 		// If inner cop task need keep order, the extraHandleCol should be set.
 		if cop.keepOrder {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
@@ -727,12 +726,6 @@ func (ds *DataSource) isCoveringIndex(columns, indexColumns []*expression.Column
 	return true
 }
 
-func (ts *PhysicalTableScan) appendCommonHandleCols(ds *DataSource) []*expression.Column {
-	pk := tables.FindPrimaryIndex(ds.tableInfo)
-	cols, _ := expression.IndexInfo2Cols(ds.Columns, ds.schema.Columns, pk)
-	return cols
-}
-
 // If there is a table reader which needs to keep order, we should append a pk to table scan.
 func (ts *PhysicalTableScan) appendExtraHandleCol(ds *DataSource) (*expression.Column, bool) {
 	handleCol := ds.handleCol
@@ -782,7 +775,7 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 	cop.cst = cost
 	task = cop
 	if cop.tablePlan != nil && ds.tableInfo.IsCommonHandle {
-		cop.commonHandleCols = cop.tablePlan.(*PhysicalTableScan).appendCommonHandleCols(ds)
+		cop.commonHandleCols = ds.commonHandleCols
 	}
 	if candidate.isMatchProp {
 		if cop.tablePlan != nil && !ds.tableInfo.IsCommonHandle {

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -296,7 +296,7 @@ func (p *PhysicalIndexLookUpReader) ResolveIndices() (err error) {
 		p.ExtraHandleCol = newCol.(*expression.Column)
 	}
 	for i, commonHandleCol := range p.CommonHandleCols {
-		newCol, err := commonHandleCol.ResolveIndices(p.tablePlan.Schema())
+		newCol, err := commonHandleCol.ResolveIndices(p.indexPlan.Schema())
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18232 <!-- REMOVE this line if no issue to close -->

Problem Summary: 

- Because `DataSource.schema` is pruned before building a `copTask`, it is not enough to initialize the `copTask.commonHandleCols` (otherwise, `nil` handles is possible to be created). Fortunately, `DataSource` itself has the field `commonHandleCols` and it is properly initialized, we can use it.

- When resolving indices on common handle columns, we should use `IndexPlan.schema` instead of `TablePlan.schema`. For example,
  ```sql
  create table t (a int, b int, c int, d int, primary key(a, b), index idx(c));
  select d from t use index (idx);
  ```
  In double read case above, `TablePlan.schema == {d}`, and `IndexPlan.schema == {a, b}`.

  Using `TablePlan` to resolve indices will lead to the error
  ```console
  Can't find column %s in schema %s
  ```

### What is changed and how it works?

What's Changed:
- correct ResolveIndices on common handles with `IndexPlan`
- remove no usage function `appendCommonHandleCols`
- add a simple test

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
