### PR TITLE
tikv: fix primary selection when delete-your-writes

### DIFF
--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -681,6 +681,50 @@ func (s *testCommitterSuite) TestElapsedTTL(c *C) {
 	c.Assert(lockInfo.LockTtl-atomic.LoadUint64(&ManagedLockTTL), Less, uint64(150))
 }
 
+func (s *testCommitterSuite) TestNoPrimary(c *C) {
+	s.cluster.SplitKeys(kv.Key("d"), kv.Key("a"), 4)
+	k1 := kv.Key("a") // insert but deleted key at first pos in txn1
+	k2 := kv.Key("b") // insert key at second pos in txn1
+	k3 := kv.Key("c") // insert key in txn1 and will be conflict read by txn2
+
+	// insert k1, k2, k2 and delete k1
+	txn1 := s.begin(c)
+	txn1.DelOption(kv.Pessimistic)
+	txn1.SetOption(kv.PresumeKeyNotExists, nil)
+	txn1.SetOption(kv.PresumeKeyNotExistsError, kv.NewExistErrInfo("name", "value"))
+	txn1.store.txnLatches = nil
+	txn1.Get(context.Background(), k1)
+	txn1.Set(k1, []byte{0})
+	txn1.Set(k2, []byte{1})
+	txn1.Set(k3, []byte{2})
+	txn1.Delete(k1)
+	committer1, err := newTwoPhaseCommitter(txn1, 0)
+	c.Assert(err, IsNil)
+	// setup test knob in txn's committer
+	committer1.testingKnobs.acAfterCommitPrimary = make(chan struct{})
+	committer1.testingKnobs.bkAfterCommitPrimary = make(chan struct{})
+	txn1.committer = committer1
+	var txn1Done sync.WaitGroup
+	txn1Done.Add(1)
+	go func() {
+		err1 := txn1.Commit(context.Background())
+		c.Assert(err1, IsNil)
+		txn1Done.Done()
+	}()
+	// resume after after primary key be committed
+	<-txn1.committer.testingKnobs.acAfterCommitPrimary
+
+	// start txn2 to read k3(prewrite success and primary should be commited)
+	txn2 := s.begin(c)
+	txn2.DelOption(kv.Pessimistic)
+	txn2.store.txnLatches = nil
+	v, err := txn2.Get(context.Background(), k3)
+	c.Assert(err, IsNil) // should resolve lock and read txn1 k3 result instead of rollback it.
+	c.Assert(v[0], Equals, byte(2))
+	txn1.committer.testingKnobs.bkAfterCommitPrimary <- struct{}{}
+	txn1Done.Wait()
+}
+
 // TestAcquireFalseTimeoutLock tests acquiring a key which is a secondary key of another transaction.
 // The lock's own TTL is expired but the primary key is still alive due to heartbeats.
 func (s *testCommitterSuite) TestAcquireFalseTimeoutLock(c *C) {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -681,7 +681,7 @@ func (s *testCommitterSuite) TestElapsedTTL(c *C) {
 	c.Assert(lockInfo.LockTtl-atomic.LoadUint64(&ManagedLockTTL), Less, uint64(150))
 }
 
-func (s *testCommitterSuite) TestNoPrimary(c *C) {
+func (s *testCommitterSuite) TestDeleteYourWriteCauseGhostPrimary(c *C) {
 	s.cluster.SplitKeys(kv.Key("d"), kv.Key("a"), 4)
 	k1 := kv.Key("a") // insert but deleted key at first pos in txn1
 	k2 := kv.Key("b") // insert key at second pos in txn1
@@ -714,7 +714,7 @@ func (s *testCommitterSuite) TestNoPrimary(c *C) {
 	// resume after after primary key be committed
 	<-txn1.committer.testingKnobs.acAfterCommitPrimary
 
-	// start txn2 to read k3(prewrite success and primary should be commited)
+	// start txn2 to read k3(prewrite success and primary should be committed)
 	txn2 := s.begin(c)
 	txn2.DelOption(kv.Pessimistic)
 	txn2.store.txnLatches = nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

1. https://github.com/pingcap/tidb/pull/9127 introduce addition useless but sometime wrong DEL mutation for delete-your-writes
2. https://github.com/pingcap/tidb/pull/14968 try to remove wrong DEL mutation
3. but wrong DEL mutation can take role as 2pc primary key(or transaction record) to works well in some situation, but https://github.com/pingcap/tidb/pull/14968 remove it will cause prewrite locks's primary property point to a unwriten primary key
4. any read-write request see those uncommited lock with wrong primary key value will treat them belong rollbacked transaction, but real transaction invoker maybe think transaction has be success.

so it will cause read/write inconsistent result when meet lock that point to a primary key has be insert/delete in own txn. 

https://github.com/pingcap/tidb/pull/18244/files#diff-d11e207d2529a00e79d72b84ae5172caR722 will fail and read nothing to reproduce it in 2pc test case level.
 
### What is changed and how it works?

What's Changed, How it Works:

choose first key didn't be delete by itself as primary key.

### Related changes

- Need to cherry-pick to the release branch 3.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix read/write inconsistent result when meet lock that point to a primary key has be insert/delete in own txn

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18244)
<!-- Reviewable:end -->
