### PR TITLE
store/tikv: fix bug strip keys cause primary key change during prewrite and commit

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -356,6 +356,21 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	if mutations.len() == 0 {
 		return nil
 	}
+
+	// initialize the primary key if necessary.
+	if c.primaryKey == nil {
+		for i := 0; i < mutations.len(); i++ {
+			key := mutations.keys[i]
+			if _, ok := noNeedCommitKey[string(key)]; !ok {
+				c.primaryKey = mutations.keys[i]
+				break
+			}
+		}
+		// No actural modification? treat it as read-only.
+		if c.primaryKey == nil {
+			return nil
+		}
+	}
 	c.txnSize = size
 
 	if size > int(kv.TxnTotalSizeLimit) {


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

This bug is introduced in https://github.com/pingcap/tidb/pull/14968

We use the first key in the mutations as the primary key, after `stripNoNeedCommitKeys`, 
the first key of the mutations may be striped and primary key change!

Prewrite and commit use the different primary key could lead to serious bug.
For example:
- txn1 prewrite the data
- txn2 meet txn1's lock, and resolve lock success
- txn1 do not know it is rollbacked (because the pk change), commit (fake) primary key success
- txn1 commit secondary keys fail (some keys rollbacked by txn2)

Part of the transaction is success and part of it fail, leads to data corruption.
This kind of log occures in the log: 

> 2PC failed commit key after primary key committed

### What is changed and how it works?


What's Changed:

Specify the primary key in `initKeysAndMutations`.
Choose the first non-"Delete your write" key as the primary key.

How it Works:

If `primary()` function find primaryKey is set in the commiter, it use the primaryKey instead of mutations[0].

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> Fix a bug that delete previous written values within the same transaction may lead to data corruption.
