### PR TITLE
config: fix incorrect initialization of store-liveness-timeout

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -59,7 +59,7 @@ const (
 	// DefStatusHost is the default status host of TiDB
 	DefStatusHost = "0.0.0.0"
 	// DefStoreLivenessTimeout is the default value for store liveness timeout.
-	DefStoreLivenessTimeout = "120s"
+	DefStoreLivenessTimeout = "5s"
 )
 
 // Valid config maps

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -364,7 +364,7 @@ region-cache-ttl = 600
 store-limit = 0
 
 # store-liveness-timeout is used to control timeout for store liveness after sending request failed.
-store-liveness-timeout = "120s"
+store-liveness-timeout = "5s"
 
 [tikv-client.copr-cache]
 # Whether to enable the copr cache. The copr cache saves the result from TiKV Coprocessor in the memory and

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	pd "github.com/pingcap/pd/v4/client"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util"
@@ -1546,8 +1545,9 @@ retry:
 type livenessState uint32
 
 var (
-	livenessSf           singleflight.Group
-	storeLivenessTimeout time.Duration
+	livenessSf singleflight.Group
+	// StoreLivenessTimeout is the max duration of resolving liveness of a TiKV instance.
+	StoreLivenessTimeout time.Duration
 )
 
 const (
@@ -1557,23 +1557,18 @@ const (
 	offline
 )
 
-func init() {
-	t, err := time.ParseDuration(config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout)
-	if err != nil {
-		logutil.BgLogger().Fatal("invalid duration value for store-liveness-timeout",
-			zap.String("currentValue", config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout))
-	}
-	storeLivenessTimeout = t
-}
-
 func (s *Store) requestLiveness(bo *Backoffer) (l livenessState) {
+	if StoreLivenessTimeout == 0 {
+		return unreachable
+	}
+
 	saddr := s.saddr
 	if len(saddr) == 0 {
 		l = unknown
 		return
 	}
 	rsCh := livenessSf.DoChan(saddr, func() (interface{}, error) {
-		return invokeKVStatusAPI(saddr, storeLivenessTimeout), nil
+		return invokeKVStatusAPI(saddr, StoreLivenessTimeout), nil
 	})
 	var ctx context.Context
 	if bo != nil {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -623,6 +623,13 @@ func setGlobalVars() {
 		executor.GlobalMemoryUsageTracker.SetBytesLimit(int64(c.Performance.ServerMemoryQuota))
 	}
 	kvcache.GlobalLRUMemUsageTracker.AttachToGlobalTracker(executor.GlobalMemoryUsageTracker)
+
+	t, err := time.ParseDuration(cfg.TiKVClient.StoreLivenessTimeout)
+	if err != nil {
+		logutil.BgLogger().Fatal("invalid duration value for store-liveness-timeout",
+			zap.String("currentValue", config.GetGlobalConfig().TiKVClient.StoreLivenessTimeout))
+	}
+	tikv.StoreLivenessTimeout = t
 }
 
 func setupLog() {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
`init` will always be called before `config` is loaded from disk, so `store-liveness-timeout` in the config file will never take effect.

### What is changed and how it works?
Update this value in `main`.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> Make `StoreLivenessTimeout` respects to config file.
