### PR TITLE
grafana: fix wrong panic metric title

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -3053,7 +3053,7 @@
           "timeFrom": null,
           "timeRegions": [],
           "timeShift": null,
-          "title": "Write Binlog Error",
+          "title": "Panic And Critial Error",
           "tooltip": {
             "shared": true,
             "sort": 0,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

TiDB Panic metric name is wrong

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed, How it Works:

fix Panic metric title

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18274)
<!-- Reviewable:end -->
