### PR TITLE
ddl: fix admin repair table will reload fail on the other node

### DIFF
--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -56,7 +56,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	}
 	var oldTableID, newTableID int64
 	switch diff.Type {
-	case model.ActionCreateTable, model.ActionCreateSequence, model.ActionRecoverTable, model.ActionRepairTable:
+	case model.ActionCreateTable, model.ActionCreateSequence, model.ActionRecoverTable:
 		newTableID = diff.TableID
 	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
 		oldTableID = diff.TableID
@@ -75,7 +75,7 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	var allocs autoid.Allocators
 	if tableIDIsValid(oldTableID) {
 		if oldTableID == newTableID && diff.Type != model.ActionRenameTable &&
-			diff.Type != model.ActionExchangeTablePartition {
+			diff.Type != model.ActionExchangeTablePartition && diff.Type != model.ActionRepairTable {
 			oldAllocs, _ := b.is.AllocByID(oldTableID)
 			allocs = filterAllocators(diff, oldAllocs)
 		}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -74,6 +74,10 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var allocs autoid.Allocators
 	if tableIDIsValid(oldTableID) {
+		// For repairing table in TiDB cluster, given 2 normal node and 1 repair node.
+		// For normal node's information schema, repaired table is existed.
+		// For repair node's information schema, repaired table is filtered (couldn't find it in `is`).
+		// So here skip to reserve the allocators when repairing table.
 		if oldTableID == newTableID && diff.Type != model.ActionRenameTable &&
 			diff.Type != model.ActionExchangeTablePartition && diff.Type != model.ActionRepairTable {
 			oldAllocs, _ := b.is.AllocByID(oldTableID)

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -74,12 +74,13 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 	// We try to reuse the old allocator, so the cached auto ID can be reused.
 	var allocs autoid.Allocators
 	if tableIDIsValid(oldTableID) {
-		// For repairing table in TiDB cluster, given 2 normal node and 1 repair node.
-		// For normal node's information schema, repaired table is existed.
-		// For repair node's information schema, repaired table is filtered (couldn't find it in `is`).
-		// So here skip to reserve the allocators when repairing table.
 		if oldTableID == newTableID && diff.Type != model.ActionRenameTable &&
-			diff.Type != model.ActionExchangeTablePartition && diff.Type != model.ActionRepairTable {
+			diff.Type != model.ActionExchangeTablePartition &&
+			// For repairing table in TiDB cluster, given 2 normal node and 1 repair node.
+			// For normal node's information schema, repaired table is existed.
+			// For repair node's information schema, repaired table is filtered (couldn't find it in `is`).
+			// So here skip to reserve the allocators when repairing table.
+			diff.Type != model.ActionRepairTable {
 			oldAllocs, _ := b.is.AllocByID(oldTableID)
 			allocs = filterAllocators(diff, oldAllocs)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Now in TiDB cluster, if config one node as repair-mode node, the other node  could not reload the new schema info after the table has been repaired.

The reason is because
repair-node: information schema has filtered the repaired tables, so for itself, apply the create table logic is ok.
other-node:  information schema has included the repaired tables, so for them, should apply the drop table first, then create new table.

Root cause:
sortedTablesBuckets will append the new repaired table into it, when find table with `TableByID`, then binary search will get the first old one rather the new one with same table ID (so should drop it first)
 

### What is changed and how it works?

How it Works:  drop old table first when apply repaired table in `applydiff`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```
1: tiup playgroumd --db 2 
2: kill the tidb node & subscribe the bin and start it again
3: restart one node with repair-mode
4: conduct the repair SQL on it
5: check whether the node could reload the repaired table 
6: check whether the other node could reload the repaired table 
```

### Release note <!-- bugfixes or new feature need a release note -->
- ddl: fix admin repair table will reload fail on the other node
