### PR TITLE
logutil: redirect stderr to tidb_stderr_<pid>.log

### DIFF
--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -195,10 +195,10 @@ func exit() {
 }
 
 func syncLog() {
-	if err := log.Sync(); err != nil {
-		fmt.Fprintln(os.Stderr, "sync log err:", err)
-		os.Exit(1)
+	if ignoredErr := log.Sync(); ignoredErr != nil {
+		// it's save to ignore zaplog Sync error https://github.com/uber-go/zap/pull/347
 	}
+	logutil.RemoveStderrIfEmpty()
 }
 
 func initializeTempDir() {
@@ -638,6 +638,9 @@ func setupLog() {
 	terror.MustNil(err)
 
 	err = logutil.InitLogger(cfg.Log.ToLogConfig())
+	terror.MustNil(err)
+
+	err = logutil.RedirectStderrToPidFile(filepath.Dir(cfg.Log.SlowQueryFile))
 	terror.MustNil(err)
 
 	if len(os.Getenv("GRPC_DEBUG")) > 0 {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -196,7 +196,7 @@ func exit() {
 
 func syncLog() {
 	if ignoredErr := log.Sync(); ignoredErr != nil {
-		// it's save to ignore zaplog Sync error https://github.com/uber-go/zap/pull/347
+		// it's safe to ignore zaplog Sync error https://github.com/uber-go/zap/pull/347
 	}
 	logutil.RemoveStderrIfEmpty()
 }

--- a/util/logutil/stderrlog.go
+++ b/util/logutil/stderrlog.go
@@ -1,0 +1,58 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by aprettyPrintlicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package logutil
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/pingcap/errors"
+)
+
+const stderrName = "tidb_stderr_%d.log"
+
+var currentStdErrFileName string
+
+// RedirectStderrToPidFile redirects stderr to a file with pid suffix.
+func RedirectStderrToPidFile(baseFolder string) error {
+	fileName := filepath.Join(baseFolder, fmt.Sprintf(stderrName, os.Getpid()))
+	logFile, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE|os.O_SYNC, 0644)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	err = sysDup(int(logFile.Fd()), 2)
+	if err != nil {
+		return err
+	}
+	currentStdErrFileName = fileName
+	return nil
+}
+
+// RemoveStderrIfEmpty removes stderr log if it's empty
+func RemoveStderrIfEmpty() {
+	if len(currentStdErrFileName) == 0 {
+		return
+	}
+	f, ignoredErr := os.Stat(currentStdErrFileName)
+	if ignoredErr != nil {
+		return
+	}
+	if f.Size() == 0 {
+		ignoredErr := os.Remove(currentStdErrFileName)
+		if ignoredErr == nil {
+			return
+		}
+	}
+}

--- a/util/logutil/sys_dup_linux_arm64.go
+++ b/util/logutil/sys_dup_linux_arm64.go
@@ -1,0 +1,27 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by aprettyPrintlicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// (linux AND arm64) OR (linux AND riscv64)
+// +build linux,arm64 linux,riscv64
+
+package logutil
+
+import (
+	"syscall"
+
+	"github.com/pingcap/errors"
+)
+
+func sysDup(oldfd int, newfd int) error {
+	return errors.Trace(syscall.Dup3(oldfd, newfd, 0))
+}

--- a/util/logutil/sys_dup_other.go
+++ b/util/logutil/sys_dup_other.go
@@ -1,0 +1,20 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by aprettyPrintlicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build windows wasm solaris
+
+package logutil
+
+func sysDup(oldfd int, newfd int) error {
+	return nil
+}

--- a/util/logutil/sys_dup_unix.go
+++ b/util/logutil/sys_dup_unix.go
@@ -1,0 +1,31 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by aprettyPrintlicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// (NOT (linux and arm64)) AND (NOT (linux and riscv64)) AND (NOT windows) AND (NOT solaris)
+// +build !linux !arm64
+// +build !linux !riscv64
+// +build !windows
+// +build !solaris
+// +build !wasm
+
+package logutil
+
+import (
+	"syscall"
+
+	"github.com/pingcap/errors"
+)
+
+func sysDup(oldfd int, newfd int) error {
+	return errors.Trace(syscall.Dup2(oldfd, newfd))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

when tidb-server crash and restart many times, we are hard to distinguish stderr backtrace belong to which crash. 

### What is changed and how it works?

What's Changed:

redirect stderr to a stderr log file with PID suffix

How it Works:

so every restart will create different stderr log, then we can use file modification time to distinguish crash round.

redirect happened during startup time, so it will overwrite tidb-ansible, tiup or tidb-operator's shell redirect(`2>> x.log`)

at last it only works for linux/darwin, window will keep old logic.

why not use "exec bin/tidb-server 2>> tidb_stderr_$$.log", it need modify many place and produce many empty log file if no crash.
 
### Related changes

- PR to update `pingcap/tidb-ansible`: it will overwrite https://github.com/pingcap/tidb-ansible/blob/53b2f2797bdf1b40c08a7b5d5be8e43ce514242e/roles/tidb/templates/run_tidb_binary.sh.j2#L64 's config

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

on linux

- modify code to produce un-catched panic to crash it and see log file
- run tidb and manual stop it and see no log file

Side effects

-  complex for system detective

### Release note <!-- bugfixes or new feature need a release note -->

- Redirect stderr to tidb_stderr_<pid>.log

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18310)
<!-- Reviewable:end -->
