### PR TITLE
executor: padding short common handle

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -202,6 +202,16 @@ func (s *testSuite8) TestInsertOnDuplicateKey(c *C) {
 	tk.MustQuery(`select * from t1 use index(primary)`).Check(testkit.Rows(`1.0000`))
 }
 
+func (s *testSuite10) TestPaddingCommonHandle(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_clustered_index = 1")
+	tk.MustExec(`create table t1(c1 decimal(6,4), primary key(c1))`)
+	tk.MustExec(`insert into t1 set c1 = 0.1`)
+	tk.MustExec(`insert into t1 set c1 = 0.1 on duplicate key update c1 = 1`)
+	tk.MustQuery(`select * from t1`).Check(testkit.Rows(`1.0000`))
+}
+
 func (s *testSuite2) TestInsertReorgDelete(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/kv/key.go
+++ b/kv/key.go
@@ -224,9 +224,18 @@ type CommonHandle struct {
 // NewCommonHandle creates a CommonHandle from a encoded bytes which is encoded by code.EncodeKey.
 func NewCommonHandle(encoded []byte) (*CommonHandle, error) {
 	ch := &CommonHandle{encoded: encoded}
+	if len(encoded) < 9 {
+		padded := make([]byte, 9)
+		copy(padded, encoded)
+		ch.encoded = padded
+	}
 	remain := encoded
 	endOff := uint16(0)
 	for len(remain) > 0 {
+		if remain[0] == 0 {
+			// padded data
+			break
+		}
 		var err error
 		var col []byte
 		col, remain, err = codec.CutOne(remain)

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -140,6 +140,20 @@ func (s *testKeySuite) TestHandle(c *C) {
 	c.Assert(ch.String(), Equals, "{100, abc}")
 }
 
+func (s *testKeySuite) TestPaddingHandle(c *C) {
+	dec := types.NewDecFromInt(1)
+	encoded, err := codec.EncodeKey(new(stmtctx.StatementContext), nil, types.NewDecimalDatum(dec))
+	c.Assert(err, IsNil)
+	c.Assert(len(encoded), Less, 9)
+	handle, err := NewCommonHandle(encoded)
+	c.Assert(err, IsNil)
+	c.Assert(handle.Encoded(), HasLen, 9)
+	c.Assert(handle.EncodedCol(0), BytesEquals, encoded)
+	newHandle, err := NewCommonHandle(handle.Encoded())
+	c.Assert(err, IsNil)
+	c.Assert(newHandle.EncodedCol(0), BytesEquals, handle.EncodedCol(0))
+}
+
 func (s *testKeySuite) TestHandleMap(c *C) {
 	m := NewHandleMap()
 	h := IntHandle(1)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

If the value type is decimal, the encoded value may be less than 8 bytes.
It breaks our assumption that row key length is greater or equal to 19.

### What is changed and how it works?

What's Changed:
padding the common handle to length 9 if it is less than 9.

How it Works:
maintains the assumption that the common handle is greater or equal to 9.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

-  padding short common handle to 9 bytes.
