### PR TITLE
planner:  fix update/delete with the prefix of cluster primary

### DIFF
--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -285,6 +285,12 @@ func (s *testSuite11) TestUpdateClusterIndex(c *C) {
 	tk.MustExec("insert into t values('a', 'b');")
 	tk.MustExec("update t set a='c' where t.a='a' and b='b';")
 	tk.MustQuery("select * from t").Check(testkit.Rows("c b"))
+
+	tk.MustExec("drop table if exists s")
+	tk.MustExec("create table s (a int, b int, c int, primary key (a, b))")
+	tk.MustExec("insert s values (3, 3, 3), (5, 5, 5)")
+	tk.MustExec("update s set c = 10 where a = 3")
+	tk.MustQuery("select * from s").Check(testkit.Rows("3 3 10", "5 5 5"))
 }
 
 func (s *testSuite11) TestDeleteClusterIndex(c *C) {

--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -320,6 +320,12 @@ func (s *testSuite11) TestDeleteClusterIndex(c *C) {
 	tk.MustExec(`delete from dt3pku where id = 'a'`)
 	tk.MustQuery(`select * from dt3pku`).Check(testkit.Rows())
 	tk.MustExec(`insert into dt3pku(id, uk, v) values('a', 1, 2)`)
+
+	tk.MustExec("drop table if exists s1")
+	tk.MustExec("create table s1 (a int, b int, c int, primary key (a, b))")
+	tk.MustExec("insert s1 values (3, 3, 3), (5, 5, 5)")
+	tk.MustExec("delete from s1 where a = 3")
+	tk.MustQuery("select * from s1").Check(testkit.Rows("5 5 5"))
 }
 
 func (s *testSuite11) TestReplaceClusterIndex(c *C) {

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1022,7 +1022,7 @@ type LogicalLock struct {
 	baseLogicalPlan
 
 	Lock             ast.SelectLockType
-	tblID2Handle     map[int64][]*expression.Column
+	tblID2Handle     map[int64][][]*expression.Column
 	partitionedTable []table.PartitionedTable
 }
 

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -766,7 +766,7 @@ type PhysicalLock struct {
 
 	Lock ast.SelectLockType
 
-	TblID2Handle     map[int64][]*expression.Column
+	TblID2Handle     map[int64][][]*expression.Column
 	PartitionedTable []table.PartitionedTable
 }
 

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -532,13 +532,15 @@ func (p *PhysicalLock) ResolveIndices() (err error) {
 	if err != nil {
 		return err
 	}
-	for i, cols := range p.TblID2Handle {
-		for j, col := range cols {
-			resolvedCol, err := col.ResolveIndices(p.children[0].Schema())
-			if err != nil {
-				return err
+	for i, row := range p.TblID2Handle {
+		for j, cols := range row {
+			for k, col := range cols {
+				resolvedCol, err := col.ResolveIndices(p.children[0].Schema())
+				if err != nil {
+					return err
+				}
+				p.TblID2Handle[i][j][k] = resolvedCol.(*expression.Column)
 			}
-			p.TblID2Handle[i][j] = resolvedCol.(*expression.Column)
 		}
 	}
 	return nil

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -366,8 +366,10 @@ func (p *LogicalLock) PruneColumns(parentUsedCols []*expression.Column) error {
 		return p.children[0].PruneColumns(p.Schema().Columns)
 	}
 
-	for _, cols := range p.tblID2Handle {
-		parentUsedCols = append(parentUsedCols, cols...)
+	for _, row := range p.tblID2Handle {
+		for _, cols := range row {
+			parentUsedCols = append(parentUsedCols, cols...)
+		}
 	}
 	return p.children[0].PruneColumns(parentUsedCols)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

```
	tk.MustExec("drop table if exists s")
	tk.MustExec("create table s (a int, b int, c int, primary key (a, b))")
	tk.MustExec("insert s values (3, 3, 3), (5, 5, 5)")
	tk.MustExec("update s set c = 10 where a = 3")
	tk.MustQuery("select * from s").Check(testkit.Rows("3 3 10", "5 5 5"))
```

will fail in master: cannot point-get and combine primary key.

### What is changed and how it works?

What's Changed, How it Works:

UpdateExec relies on planner's tabColsInfo to cal handle, but current it didn't handle multi-columns in the right way.

https://github.com/pingcap/tidb/compare/master...lysu:dev-fix-update-cluster-fail?expand=1#diff-b9e75a99170ea35a67074d5d3d3305adL3283

this just a tiny fix for this, it remains ds.handleCols TODO(added in https://github.com/pingcap/tidb/projects/45)

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18345)
<!-- Reviewable:end -->
