### PR TITLE
kv: fix variable `tidb_backoff_weight` does not take effect

### DIFF
--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -125,6 +125,10 @@ func (t *mockTxn) SetVars(vars *Variables) {
 
 }
 
+func (t *mockTxn) GetVars() *Variables {
+	return nil
+}
+
 // newMockTxn new a mockTxn.
 func newMockTxn() Transaction {
 	return &mockTxn{

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -202,6 +202,8 @@ type Transaction interface {
 	GetSnapshot() Snapshot
 	// SetVars sets variables to the transaction.
 	SetVars(vars *Variables)
+	// GetVars gets variables from the transaction.
+	GetVars() *Variables
 	// BatchGet gets kv from the memory buffer of statement and transaction, and the kv storage.
 	// Do not use len(value) == 0 or value == nil to represent non-exist.
 	// If a key doesn't exist, there shouldn't be any corresponding entry in the result map.

--- a/session/session.go
+++ b/session/session.go
@@ -1450,6 +1450,7 @@ func (s *session) Txn(active bool) (kv.Transaction, error) {
 			s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
 		}
 		s.sessionVars.TxnCtx.CouldRetry = s.isTxnRetryable()
+		s.txn.SetVars(s.sessionVars.KVVars)
 		if s.sessionVars.GetReplicaRead().IsFollowerRead() {
 			s.txn.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
 		}

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -109,6 +109,10 @@ func (txn *tikvTxn) SetVars(vars *kv.Variables) {
 	txn.snapshot.vars = vars
 }
 
+func (txn *tikvTxn) GetVars() *kv.Variables {
+	return txn.vars
+}
+
 // tikvTxnStagingBuffer is the staging buffer returned to tikvTxn user.
 // Because tikvTxn needs to maintain dirty state when Flush staging data into txn.
 type tikvTxnStagingBuffer struct {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

variable `tidb_backoff_weight` does not take effect.

### What is changed and how it works?

- Set KVVars for transaction in `session.Txn` method.
- Add GetKVVars method in Transaction interface for unit test.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix variable `tidb_backoff_weight` does not take effect
