### PR TITLE
tikv: do not backoff on ScatterRegion error

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2239,21 +2239,6 @@ func (s *testSuite7) TestSplitRegionTimeout(c *C) {
 	// result 0 0 means split 0 region and 0 region finish scatter regions before timeout.
 	tk.MustQuery(`split table t between (0) and (10000) regions 10`).Check(testkit.Rows("0 0"))
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/MockSplitRegionTimeout"), IsNil)
-
-	// Test scatter regions timeout.
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/MockScatterRegionTimeout", `return(true)`), IsNil)
-	tk.MustQuery(`split table t between (0) and (10000) regions 10`).Check(testkit.Rows("10 1"))
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/MockScatterRegionTimeout"), IsNil)
-
-	// Test pre-split with timeout.
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("set @@global.tidb_scatter_region=1;")
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/MockScatterRegionTimeout", `return(true)`), IsNil)
-	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
-	start := time.Now()
-	tk.MustExec("create table t (a int, b int) partition by hash(a) partitions 5;")
-	c.Assert(time.Since(start).Seconds(), Less, 10.0)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/MockScatterRegionTimeout"), IsNil)
 }
 
 func (s *testSuiteP2) TestRow(c *C) {

--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/parser/terror"
 	mysql "github.com/pingcap/tidb/errno"
 )
@@ -63,4 +64,13 @@ type ErrDeadlock struct {
 
 func (d *ErrDeadlock) Error() string {
 	return d.Deadlock.String()
+}
+
+// PDError wraps *pdpb.Error to implement the error interface.
+type PDError struct {
+	Err *pdpb.Error
+}
+
+func (d *PDError) Error() string {
+	return d.Err.String()
 }

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -222,6 +222,14 @@ func (s *tikvStore) WaitScatterRegionFinish(ctx context.Context, regionID uint64
 					zap.Uint64("regionID", regionID))
 				return nil
 			}
+			if resp.GetHeader().GetError() != nil {
+				err = errors.AddStack(&PDError{
+					Err: resp.Header.Error,
+				})
+				logutil.BgLogger().Warn("wait scatter region error",
+					zap.Uint64("regionID", regionID), zap.Error(err))
+				return err
+			}
 			if logFreq%10 == 0 {
 				logutil.BgLogger().Info("wait scatter region",
 					zap.Uint64("regionID", regionID),


### PR DESCRIPTION
### What problem does this PR solve?

ScatterRegion may return non-retryable error, if we backoff on it, the error is converted to PDTimeout error,
Then the caller stop early, leave other splitted regions un-scattered, cause tikv workload unbalanced.

### What is changed and how it works?

Do not backoff and retry ScatterRegion error, only log it.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
run this binary on a cluster that truncate tables and scatter regions.

### Release note <!-- bugfixes or new feature need a release note -->

- tikv: do not backoff on ScatterRegion error
