### PR TITLE
ddl: support reorganization of global index

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -468,6 +468,9 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 			} else {
 				indexInfo.Tp = indexOption.Tp
 			}
+			if indexOption.Locality == ast.IndexLocalityGlobal {
+				indexInfo.Global = true
+			}
 		} else {
 			// Use btree as default index type.
 			indexInfo.Tp = model.IndexTypeBtree

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -971,8 +971,8 @@ func GenIndexKey(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxInfo
 }
 
 // GenIndexValue creates encoded index value and returns the result
-func GenIndexValue(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxInfo *model.IndexInfo,
-	containNonBinaryString bool, distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle) ([]byte, error) {
+func GenIndexValue(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxInfo *model.IndexInfo, containNonBinaryString bool,
+	distinct bool, untouched bool, indexedValues []types.Datum, h kv.Handle, partitionID int64) ([]byte, error) {
 	var idxVal []byte
 	if collate.NewCollationEnabled() && containNonBinaryString {
 		colIds := make([]int64, len(idxInfo.Columns))
@@ -1024,6 +1024,9 @@ func GenIndexValue(sc *stmtctx.StatementContext, tblInfo *model.TableInfo, idxIn
 		if len(idxVal) == 0 {
 			idxVal = []byte{'0'}
 		}
+	}
+	if idxInfo.Global {
+		idxVal = append(idxVal, codec.EncodeInt(nil, partitionID)...)
 	}
 	return idxVal, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

Support reorganization for global index. It is a preparatory work of [#18032 ](https://github.com/pingcap/tidb/issues/18032). 

### What is changed and how it works?

What's Changed:

If parameter `isGlobalIndex` is set, `AddTableIndex` function will add index entries on **table** instead of partitions. So, we can use `AddTableIndex` to build global indices in the future.

How it Works:

When `isGlobalIndex` is set, use  `tableID` instead of `partitionID` as `indexTableID` and pass it down. `AddPhysicalTableIndex` use this id to build `AddIndexWorker`. Also, `indexTableID` is add to `reorgIndexTask`, and worker can pass tableID and partitionID to `index.Create`, and add a global index entry in the future. (Now we has not modified `index.Create`, because it will change index value layout, and perhaps cause serious side effects. We will use another PR to change index value layout after discuss.)

### Related changes

 - No related change.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No side effect.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.

<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
