### PR TITLE
tikv: use Split Backoffer to backoff Scatter error

### DIFF
--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -169,7 +169,7 @@ func (s *tikvStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bo
 	}
 
 	for i, r := range spResp.Regions {
-		if err = s.scatterRegion(bo.ctx, r.Id); err == nil {
+		if err = s.scatterRegion(bo, r.Id); err == nil {
 			logutil.BgLogger().Info("batch split regions, scatter region complete",
 				zap.Uint64("batch region ID", batch.regionID.id),
 				zap.Stringer("at", kv.Key(batch.keys[i])),
@@ -207,12 +207,11 @@ func (s *tikvStore) SplitRegions(ctx context.Context, splitKeys [][]byte, scatte
 	return regionIDs, errors.Trace(err)
 }
 
-func (s *tikvStore) scatterRegion(ctx context.Context, regionID uint64) error {
+func (s *tikvStore) scatterRegion(bo *Backoffer, regionID uint64) error {
 	logutil.BgLogger().Info("start scatter region",
 		zap.Uint64("regionID", regionID))
-	bo := NewBackoffer(ctx, scatterRegionBackoff)
 	for {
-		err := s.pdClient.ScatterRegion(ctx, regionID)
+		err := s.pdClient.ScatterRegion(bo.ctx, regionID)
 
 		failpoint.Inject("MockScatterRegionTimeout", func(val failpoint.Value) {
 			if val.(bool) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Scatter backoff max sleep time 20s is not long enough, may exceed if newly split region didn't heartbeat in time.

### What is changed and how it works?

Use Split Backoffer directly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
in a large cluster, truncate a large table and check the scatter success rate.

### Release note <!-- bugfixes or new feature need a release note -->

- no release note
