### PR TITLE
gc_worker: reduce GC scan locks when meeting region cache miss

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1104,12 +1104,7 @@ func (w *GCWorker) tryRelocateLocksRegion(bo *tikv.Backoffer, locks []*tikv.Lock
 	if err != nil {
 		return
 	}
-	for i := len(locks) - 1; i > 0; i-- {
-		if !refreshedLoc.Contains(locks[i].Key) {
-			return
-		}
-	}
-	stillInSameRegion = true
+	stillInSameRegion = refreshedLoc.Contains(locks[len(locks)-1].Key)
 	return
 }
 

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1073,6 +1073,7 @@ retryScanAndResolve:
 				}
 				continue retryScanAndResolve
 			}
+			break
 		}
 		if len(locks) < gcScanLockLimit {
 			stat.CompletedRegions++

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1043,6 +1043,7 @@ func (w *GCWorker) resolveLocksForRange(ctx context.Context, safePoint uint64, s
 			locks[i] = tikv.NewLock(locksInfo[i])
 		}
 
+	retryResolveLockBatch:
 		ok, err1 := w.store.GetLockResolver().BatchResolveLocks(bo, locks, loc.Region)
 		if err1 != nil {
 			return stat, errors.Trace(err1)
@@ -1051,6 +1052,14 @@ func (w *GCWorker) resolveLocksForRange(ctx context.Context, safePoint uint64, s
 			err = bo.Backoff(tikv.BoTxnLock, errors.Errorf("remain locks: %d", len(locks)))
 			if err != nil {
 				return stat, errors.Trace(err)
+			}
+			stillInSame, refreshedLoc, err := w.tryRelocateLockRegion(bo, locks)
+			if err != nil {
+				return stat, errors.Trace(err)
+			}
+			if stillInSame {
+				loc = refreshedLoc
+				goto retryResolveLockBatch
 			}
 			continue
 		}
@@ -1076,6 +1085,23 @@ func (w *GCWorker) resolveLocksForRange(ctx context.Context, safePoint uint64, s
 		})
 	}
 	return stat, nil
+}
+
+func (w *GCWorker) tryRelocateLockRegion(bo *tikv.Backoffer, locks []*tikv.Lock) (stillInSameRegion bool, refreshedLoc *tikv.KeyLocation, err error) {
+	if len(locks) == 0 {
+		return
+	}
+	refreshedLoc, err = w.store.GetRegionCache().LocateKey(bo, locks[0].Key)
+	if err != nil {
+		return
+	}
+	for _, l := range locks {
+		if !refreshedLoc.Contains(l.Key) {
+			return
+		}
+	}
+	stillInSameRegion = true
+	return
 }
 
 // resolveLocksPhysical uses TiKV's `PhysicalScanLock` to scan stale locks in the cluster and resolve them. It tries to

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -1053,7 +1053,7 @@ func (w *GCWorker) resolveLocksForRange(ctx context.Context, safePoint uint64, s
 			if err != nil {
 				return stat, errors.Trace(err)
 			}
-			stillInSame, refreshedLoc, err := w.tryRelocateLockRegion(bo, locks)
+			stillInSame, refreshedLoc, err := w.tryRelocateLocksRegion(bo, locks)
 			if err != nil {
 				return stat, errors.Trace(err)
 			}
@@ -1087,7 +1087,7 @@ func (w *GCWorker) resolveLocksForRange(ctx context.Context, safePoint uint64, s
 	return stat, nil
 }
 
-func (w *GCWorker) tryRelocateLockRegion(bo *tikv.Backoffer, locks []*tikv.Lock) (stillInSameRegion bool, refreshedLoc *tikv.KeyLocation, err error) {
+func (w *GCWorker) tryRelocateLocksRegion(bo *tikv.Backoffer, locks []*tikv.Lock) (stillInSameRegion bool, refreshedLoc *tikv.KeyLocation, err error) {
 	if len(locks) == 0 {
 		return
 	}
@@ -1095,8 +1095,8 @@ func (w *GCWorker) tryRelocateLockRegion(bo *tikv.Backoffer, locks []*tikv.Lock)
 	if err != nil {
 		return
 	}
-	for _, l := range locks {
-		if !refreshedLoc.Contains(l.Key) {
+	for i := len(locks) - 1; i > 0; i-- {
+		if !refreshedLoc.Contains(locks[i].Key) {
 			return
 		}
 	}

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -839,6 +839,39 @@ func (s *testGCWorkerSuite) TestResolveLockRangeInfine(c *C) {
 	c.Assert(err, NotNil)
 }
 
+func (s *testGCWorkerSuite) TestResolveLockRangeMeetRegionCacheMiss(c *C) {
+	var (
+		scanCnt       int
+		scanCntRef    = &scanCnt
+		resolveCnt    int
+		resolveCntRef = &resolveCnt
+	)
+	s.gcWorker.testingKnobs.scanLocks = func(key []byte) []*tikv.Lock {
+		*scanCntRef = *scanCntRef + 1
+		return []*tikv.Lock{
+			{
+				Key: []byte{1},
+			},
+			{
+				Key: []byte{1},
+			},
+		}
+	}
+	s.gcWorker.testingKnobs.resolveLocks = func(regionID tikv.RegionVerID) (ok bool, err error) {
+		*resolveCntRef = *resolveCntRef + 1
+		if *resolveCntRef == 1 {
+			s.gcWorker.store.GetRegionCache().InvalidateCachedRegion(regionID)
+			// mock the region cache miss error
+			return false, nil
+		}
+		return true, nil
+	}
+	_, err := s.gcWorker.resolveLocksForRange(context.Background(), 1, []byte{0}, []byte{10})
+	c.Assert(err, IsNil)
+	c.Assert(resolveCnt, Equals, 2)
+	c.Assert(scanCnt, Equals, 1)
+}
+
 func (s *testGCWorkerSuite) TestRunGCJob(c *C) {
 	gcSafePointCacheInterval = 0
 

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -847,7 +847,7 @@ func (s *testGCWorkerSuite) TestResolveLockRangeMeetRegionCacheMiss(c *C) {
 		resolveCntRef = &resolveCnt
 	)
 	s.gcWorker.testingKnobs.scanLocks = func(key []byte) []*tikv.Lock {
-		*scanCntRef = *scanCntRef + 1
+		*scanCntRef++
 		return []*tikv.Lock{
 			{
 				Key: []byte{1},
@@ -858,7 +858,7 @@ func (s *testGCWorkerSuite) TestResolveLockRangeMeetRegionCacheMiss(c *C) {
 		}
 	}
 	s.gcWorker.testingKnobs.resolveLocks = func(regionID tikv.RegionVerID) (ok bool, err error) {
-		*resolveCntRef = *resolveCntRef + 1
+		*resolveCntRef++
 		if *resolveCntRef == 1 {
 			s.gcWorker.store.GetRegionCache().InvalidateCachedRegion(regionID)
 			// mock the region cache miss error


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

currently, gc worker will rescan locks when meet region cache miss error which makes slow scan job become more slow.

### What is changed and how it works?

What's Changed, How it Works:

when region cache miss error(current is a fake epochNotMatch), it just indicates "maybe region has changed and we need to reload region from PD", we can continue resolve scan lock result if all lock still in that region.

this can help situations like:

- lock and region hasn't changed but region cache expired
- lock's region's key range didn't change but maybe add new peer(id is same but confVer or ver changed)
- all lock has changed from region A to region B

but it didn't help the situation that:

- lock's region has been split into two region

maybe we can improve it later(to avoid complex modification)

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Reduce GC scan locks when meeting region cache miss<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/18385)
<!-- Reviewable:end -->
