### PR TITLE
privilege: support login limit when password error too many times.

### DIFF
--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -71,7 +71,7 @@ type Manager interface {
 	// GetAllRoles return all roles of user.
 	GetAllRoles(user, host string) []*auth.RoleIdentity
 
-	// CheckAccountLock return if the account has been locked.
+	// CheckAccountLocked return if the account has been locked.
 	CheckAccountLocked(ctx sessionctx.Context, user, host string) bool
 
 	// IncFailTimer is used to increase lock timer.

--- a/privilege/privilege.go
+++ b/privilege/privilege.go
@@ -70,6 +70,12 @@ type Manager interface {
 
 	// GetAllRoles return all roles of user.
 	GetAllRoles(user, host string) []*auth.RoleIdentity
+
+	// CheckAccountLock return if the account has been locked.
+	CheckAccountLocked(ctx sessionctx.Context, user, host string) bool
+
+	// IncFailTimer is used to increase lock timer.
+	IncFailTimer(ctx sessionctx.Context, user, host string)
 }
 
 const key keyType = 0

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -244,7 +244,6 @@ type MySQLPrivilege struct {
 	RoleGraph     map[string]roleGraphEdgesTable
 	PwdErrorCnt   map[string]int
 	BlackList     map[string][]blackListItem
-
 }
 
 // FindAllRole is used to find all roles grant to this user.

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -244,6 +244,7 @@ type MySQLPrivilege struct {
 	RoleGraph     map[string]roleGraphEdgesTable
 	PwdErrorCnt   map[string]int
 	BlackList     map[string][]blackListItem
+
 }
 
 // FindAllRole is used to find all roles grant to this user.
@@ -308,7 +309,7 @@ func (p *MySQLPrivilege) CheckAccountLock(user, host string, sctx sessionctx.Con
 		for _, r := range recs {
 			if r.Host == host {
 				t := r.startTime
-				if time.Now().Sub(t) > limit*time.Second {
+				if time.Since(t) > limit*time.Second {
 					ctx := context.Background()
 					sql := fmt.Sprintf("delete from mysql.login_blacklist where user = '%s' and host = '%s'", user, host)
 					_, err := sctx.(sqlexec.SQLExecutor).Execute(ctx, sql)

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -149,7 +149,7 @@ func (p *UserPrivileges) GetAuthWithoutVerification(user, host string) (u string
 	return
 }
 
-// CheckAccountLock return if the account has been locked.
+// CheckAccountLocked return if the account has been locked.
 func (p *UserPrivileges) CheckAccountLocked(ctx sessionctx.Context, user, host string) bool {
 	if SkipWithGrant {
 		return false
@@ -184,6 +184,7 @@ func (p *UserPrivileges) CheckAccountLocked(ctx sessionctx.Context, user, host s
 	return false
 }
 
+// IncFailTimer is used to increase lock timer.
 func (p *UserPrivileges) IncFailTimer(ctx sessionctx.Context, user, host string) {
 	if SkipWithGrant {
 		return

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -286,6 +286,7 @@ const (
 		name char(100) NOT NULL
 	);`
 
+	// CreateLoginBlackList stores the list of blocked user.
 	CreateLoginBlackList = `CREATE TABLE IF NOT EXISTS mysql.login_blacklist (
 		HOST char(60) COLLATE utf8_bin NOT NULL DEFAULT '',
 		USER char(32) COLLATE utf8_bin NOT NULL DEFAULT '',

--- a/session/session.go
+++ b/session/session.go
@@ -1586,6 +1586,12 @@ func (s *session) GetSessionVars() *variable.SessionVars {
 func (s *session) Auth(user *auth.UserIdentity, authentication []byte, salt []byte) bool {
 	pm := privilege.GetPrivilegeManager(s)
 
+	// check account lock.
+	locked := pm.CheckAccountLocked(s, user.Username, user.Hostname)
+	if locked {
+		return false
+	}
+
 	// Check IP or localhost.
 	var success bool
 	user.AuthUsername, user.AuthHostname, success = pm.ConnectionVerification(user.Username, user.Hostname, authentication, salt, s.sessionVars.TLSConnectionState)
@@ -1594,6 +1600,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication []byte, salt []by
 		s.sessionVars.ActiveRoles = pm.GetDefaultRoles(user.AuthUsername, user.AuthHostname)
 		return true
 	} else if user.Hostname == variable.DefHostname {
+		pm.IncFailTimer(s, user.AuthUsername, user.AuthHostname)
 		return false
 	}
 
@@ -1611,6 +1618,7 @@ func (s *session) Auth(user *auth.UserIdentity, authentication []byte, salt []by
 			return true
 		}
 	}
+	pm.IncFailTimer(s, user.AuthUsername, user.AuthHostname)
 	return false
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -728,6 +728,9 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, TiDBSlowLogMasking, BoolToIntStr(DefTiDBSlowLogMasking)},
 	{ScopeGlobal | ScopeSession, TiDBShardAllocateStep, strconv.Itoa(DefTiDBShardAllocateStep)},
 	{ScopeGlobal, TiDBEnableTelemetry, BoolToIntStr(DefTiDBEnableTelemetry)},
+	// Used to block DoS.
+	{ScopeGlobal, MaxLoginAttempts, strconv.Itoa(DefMaxLoginAttempts)},
+	{ScopeGlobal, LoginBlockInterval, strconv.Itoa(DefLoginBlockInterval)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.
@@ -995,6 +998,10 @@ const (
 	ThreadPoolSize = "thread_pool_size"
 	// WindowingUseHighPrecision is the name of 'windowing_use_high_precision' system variable.
 	WindowingUseHighPrecision = "windowing_use_high_precision"
+	// MaxLoginAttempts is the name for 'max_login_attempts' system variable.
+	MaxLoginAttempts = "max_login_attempts"
+	// LoginBlockInterval is the name for 'login_block_interval' system variable.
+	LoginBlockInterval = "login_block_interval"
 )
 
 // GlobalVarAccessor is the interface for accessing global scope system and status variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -525,6 +525,8 @@ const (
 	DefTiDBSlowLogMasking              = false
 	DefTiDBShardAllocateStep           = math.MaxInt64
 	DefTiDBEnableTelemetry             = true
+	DefMaxLoginAttempts                = 10
+	DefLoginBlockInterval              = 3600
 )
 
 // Process global variables.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: TiDB didn't support block login when password error too many times. Hacker can try brute force to attack TiDB server.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Add a memory table to record each account login fail times.
By default, if a account login fail 10 times, it will be locked an hour.

How it Works:

Using a map to record login fail times. If the value exceed the limit.
Record the account into physical table.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- PR to update `pingcap/tidb-ansible`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
