### PR TITLE
grafana: add GC trigger size

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -1819,6 +1819,13 @@
               "interval": "",
               "legendFormat": "HeapReleased-{{instance}}",
               "refId": "F"
+            },
+            {
+              "expr": "go_memstats_next_gc_bytes{job=\"tidb\"}",
+              "hide": true,
+              "interval": "",
+              "legendFormat": "GCTrigger-{{instance}}",
+              "refId": "G"
             }
           ],
           "thresholds": [],


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
![图片](https://user-images.githubusercontent.com/15031522/86714782-20e5be00-c052-11ea-9e15-bc7b9246ff70.png)

GC will be triggered when
1. Heap in use is reach `NextGC`
2. 2 minutes after the last GC runs

With this metric, we can know more details about the possible causes of jagged memory usage

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> Add GC trigger size in Grafana panel
