### PR TITLE
txn: support pessimistic transaction amend for specific ddls

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"math"
 	"math/rand"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -4880,6 +4881,135 @@ func (s *testDBSuite1) TestAlterTableWithValidation(c *C) {
 	tk.MustExec("alter table t1 without validation")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(1))
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Warning|8200|ALTER TABLE WITHOUT VALIDATION is currently unsupported"))
+}
+
+func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
+	// Prepare work.
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop database if exists test_db")
+	tk.MustExec("create database test_db")
+	tk.MustExec("use test_db")
+	tk.MustExec("create table t1 (c1 int primary key, c2 int, c3 int, index ok2(c2))")
+	tk.MustExec("insert t1 values (1, 10, 100), (2, 20, 200)")
+	tk.MustExec("alter table t1 add index k2(c2)")
+	tk.MustExec("alter table t1 drop index k2")
+	tk.MustExec("alter table t1 add index k2(c2)")
+	tk.MustExec("alter table t1 drop index k2")
+	tk2 := testkit.NewTestKit(c, s.store)
+	tk2.MustExec("use test_db")
+
+	type caseUnit struct {
+		tkSQLs     []string
+		tk2DDL     []string
+		idxDDL     string
+		checkSQLs  []string
+		rowsExps   [][]string
+		failCommit bool
+		stateEnd   model.SchemaState
+	}
+
+	cases := []caseUnit{
+		// Test secondary index
+		{[]string{"insert into t1 values(3, 30, 300)"},
+			[]string{"alter table t1 add index k2(c2)", "alter table t1 drop index k2",
+				"alter table t1 add index kk2(c2, c1)", "alter table t1 add index k2(c2)", "alter table t1 drop index k2"},
+			"alter table t1 add index k2(c2)",
+			[]string{"select c3, c2 from t1 use index(k2) where c2 = 20",
+				"select c3, c2 from t1 use index(k2) where c2 = 10", "select * from t1"},
+			[][]string{{"200 20"}, {"100 10"}, {"1 10 100", "2 20 200", "3 30 300"}},
+			false,
+			model.StateNone},
+		// Test unique index
+		{[]string{"insert into t1 values(3, 30, 300)",
+			"insert into t1 values(4, 40, 400)"},
+			[]string{"alter table t1 add unique index uk3(c3)", "alter table t1 drop index uk3"},
+			"alter table t1 add unique index uk3(c3)",
+			[]string{"select c3, c2 from t1 use index(uk3) where c3 = 200",
+				"select c3, c2 from t1 use index(uk3) where c3 = 300",
+				"select c3, c2 from t1 use index(uk3) where c3 = 400",
+				"select * from t1"},
+			[][]string{{"200 20"}, {"300 30"}, {"400 40"}, {"1 10 100", "2 20 200", "3 30 300", "4 40 400"}},
+			false, model.StateNone},
+		// Test unique index fail to commit, this case needs the new index could be inserted
+		{[]string{"insert into t1 values(3, 30, 300)",
+			"insert into t1 values(4, 40, 300)"},
+			//[]string{"alter table t1 add unique index uk3(c3)", "alter table t1 drop index uk3"},
+			[]string{},
+			"alter table t1 add unique index uk3(c3)",
+			[]string{"select c3, c2 from t1 use index(uk3) where c3 = 200",
+				"select c3, c2 from t1 use index(uk3) where c3 = 300",
+				"select c3, c2 from t1 where c1 = 4",
+				"select * from t1"},
+			[][]string{{"200 20"}, {}, {}, {"1 10 100", "2 20 200"}},
+			true,
+			model.StateWriteOnly},
+	}
+	tk.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
+
+	// Test add index state change
+	do := s.dom.DDL()
+	startStates := []model.SchemaState{model.StateNone, model.StateDeleteOnly}
+	for _, startState := range startStates {
+		endStatMap := session.ConstOpAddIndex[startState]
+		var endStates []model.SchemaState
+		for st := range endStatMap {
+			endStates = append(endStates, st)
+		}
+		sort.Slice(endStates, func(i, j int) bool { return endStates[i] < endStates[j] })
+		for _, endState := range endStates {
+			for _, curCase := range cases {
+				if endState < curCase.stateEnd {
+					break
+				}
+				tk2.MustExec("drop table if exists t1")
+				tk2.MustExec("create table t1 (c1 int primary key, c2 int, c3 int, index ok2(c2))")
+				tk2.MustExec("insert t1 values (1, 10, 100), (2, 20, 200)")
+				tk2.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
+				tk.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
+
+				for _, DDLSQL := range curCase.tk2DDL {
+					tk2.MustExec(DDLSQL)
+				}
+				hook := &ddl.TestDDLCallback{}
+				prepared := false
+				committed := false
+				hook.OnJobUpdatedExported = func(job *model.Job) {
+					if job.SchemaState == startState {
+						if !prepared {
+							tk.MustExec("begin pessimistic")
+							for _, tkSQL := range curCase.tkSQLs {
+								tk.MustExec(tkSQL)
+							}
+							prepared = true
+						}
+					} else if job.SchemaState == endState {
+						if !committed {
+							if curCase.failCommit {
+								_, err := tk.Exec("commit")
+								c.Assert(err, NotNil)
+							} else {
+								tk.MustExec("commit")
+							}
+						}
+						committed = true
+					}
+				}
+				originalCallback := do.GetHook()
+				do.(ddl.DDLForTest).SetHook(hook)
+				tk2.MustExec(curCase.idxDDL)
+				do.(ddl.DDLForTest).SetHook(originalCallback)
+				tk2.MustExec("admin check table t1")
+				for i, checkSQL := range curCase.checkSQLs {
+					if len(curCase.rowsExps[i]) > 0 {
+						tk2.MustQuery(checkSQL).Check(testkit.Rows(curCase.rowsExps[i]...))
+					} else {
+						tk2.MustQuery(checkSQL).Check(nil)
+					}
+				}
+			}
+		}
+	}
+	tk.MustExec("admin check table t1")
 }
 
 func init() {

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4957,6 +4957,7 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 			false,
 			model.StateNone},
 		// Test unique index
+		/* TODO unique index is not supported now.
 		{[]string{"insert into t1 values(3, 30, 300)",
 			"insert into t1 values(4, 40, 400)",
 			"insert into t2 values(11, 11, 11)",
@@ -5000,6 +5001,7 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 				{"1 10 100", "2 20 200"}},
 			true,
 			model.StateWriteOnly},
+		*/
 	}
 	tk.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
 

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -128,7 +128,7 @@ func (e *BatchPointGetExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 	for !req.IsFull() && e.index < len(e.values) {
 		handle, val := e.handles[e.index], e.values[e.index]
-		err := decodeRowValToChunk(e.base(), e.tblInfo, handle, val, req, e.rowDecoder)
+		err := DecodeRowValToChunk(e.base().ctx, e.schema, e.tblInfo, handle, val, req, e.rowDecoder)
 		if err != nil {
 			return err
 		}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3144,7 +3144,8 @@ func (b *executorBuilder) buildSQLBindExec(v *plannercore.SQLBindPlan) Executor 
 	return e
 }
 
-func newRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model.TableInfo) *rowcodec.ChunkDecoder {
+// NewRowDecoder creates a chunk decoder for new row format row value decode.
+func NewRowDecoder(ctx sessionctx.Context, schema *expression.Schema, tbl *model.TableInfo) *rowcodec.ChunkDecoder {
 	getColInfoByID := func(tbl *model.TableInfo, colID int64) *model.ColumnInfo {
 		for _, col := range tbl.Columns {
 			if col.ID == colID {
@@ -3201,7 +3202,7 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 		b.err = err
 		return nil
 	}
-	decoder := newRowDecoder(b.ctx, plan.Schema(), plan.TblInfo)
+	decoder := NewRowDecoder(b.ctx, plan.Schema(), plan.TblInfo)
 	e := &BatchPointGetExec{
 		baseExecutor: newBaseExecutor(b.ctx, plan.Schema(), plan.ExplainID()),
 		tblInfo:      plan.TblInfo,

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -91,7 +91,7 @@ type PointGetExecutor struct {
 
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field
 func (e *PointGetExecutor) Init(p *plannercore.PointGetPlan, startTs uint64) {
-	decoder := newRowDecoder(e.ctx, p.Schema(), p.TblInfo)
+	decoder := NewRowDecoder(e.ctx, p.Schema(), p.TblInfo)
 	e.tblInfo = p.TblInfo
 	e.handle = p.Handle
 	e.idxInfo = p.IndexInfo
@@ -240,7 +240,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 		return nil
 	}
-	err = decodeRowValToChunk(e.base(), e.tblInfo, e.handle, val, req, e.rowDecoder)
+	err = DecodeRowValToChunk(e.base().ctx, e.schema, e.tblInfo, e.handle, val, req, e.rowDecoder)
 	if err != nil {
 		return err
 	}
@@ -365,17 +365,20 @@ func EncodeUniqueIndexKey(ctx sessionctx.Context, tblInfo *model.TableInfo, idxI
 	return tablecodec.EncodeIndexSeekKey(tID, idxInfo.ID, encodedIdxVals), nil
 }
 
-func decodeRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle kv.Handle, rowVal []byte, chk *chunk.Chunk, rd *rowcodec.ChunkDecoder) error {
+// DecodeRowValToChunk decoes row value into chunk checking row format used.
+func DecodeRowValToChunk(sctx sessionctx.Context, schema *expression.Schema, tblInfo *model.TableInfo,
+	handle kv.Handle, rowVal []byte, chk *chunk.Chunk, rd *rowcodec.ChunkDecoder) error {
 	if rowcodec.IsNewFormat(rowVal) {
 		return rd.DecodeToChunk(rowVal, handle, chk)
 	}
-	return decodeOldRowValToChunk(e, tblInfo, handle, rowVal, chk)
+	return decodeOldRowValToChunk(sctx, schema, tblInfo, handle, rowVal, chk)
 }
 
-func decodeOldRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle kv.Handle, rowVal []byte, chk *chunk.Chunk) error {
+func decodeOldRowValToChunk(sctx sessionctx.Context, schema *expression.Schema, tblInfo *model.TableInfo, handle kv.Handle,
+	rowVal []byte, chk *chunk.Chunk) error {
 	pkCols := tables.TryGetCommonPkColumnIds(tblInfo)
-	colID2CutPos := make(map[int64]int, e.schema.Len())
-	for _, col := range e.schema.Columns {
+	colID2CutPos := make(map[int64]int, schema.Len())
+	for _, col := range schema.Columns {
 		if _, ok := colID2CutPos[col.ID]; !ok {
 			colID2CutPos[col.ID] = len(colID2CutPos)
 		}
@@ -387,8 +390,8 @@ func decodeOldRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle kv
 	if cutVals == nil {
 		cutVals = make([][]byte, len(colID2CutPos))
 	}
-	decoder := codec.NewDecoder(chk, e.ctx.GetSessionVars().Location())
-	for i, col := range e.schema.Columns {
+	decoder := codec.NewDecoder(chk, sctx.GetSessionVars().Location())
+	for i, col := range schema.Columns {
 		// fill the virtual column value after row calculation
 		if col.VirtualExpr != nil {
 			chk.AppendNull(i)
@@ -404,7 +407,7 @@ func decodeOldRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle kv
 		cutPos := colID2CutPos[col.ID]
 		if len(cutVals[cutPos]) == 0 {
 			colInfo := getColInfoByID(tblInfo, col.ID)
-			d, err1 := table.GetColOriginDefaultValue(e.ctx, colInfo)
+			d, err1 := table.GetColOriginDefaultValue(sctx, colInfo)
 			if err1 != nil {
 				return err1
 			}

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -365,7 +365,7 @@ func EncodeUniqueIndexKey(ctx sessionctx.Context, tblInfo *model.TableInfo, idxI
 	return tablecodec.EncodeIndexSeekKey(tID, idxInfo.ID, encodedIdxVals), nil
 }
 
-// DecodeRowValToChunk decoes row value into chunk checking row format used.
+// DecodeRowValToChunk decodes row value into chunk checking row format used.
 func DecodeRowValToChunk(sctx sessionctx.Context, schema *expression.Schema, tblInfo *model.TableInfo,
 	handle kv.Handle, rowVal []byte, chk *chunk.Chunk, rd *rowcodec.ChunkDecoder) error {
 	if rowcodec.IsNewFormat(rowVal) {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -52,6 +52,8 @@ const (
 	InfoSchema
 	// CollectRuntimeStats is used to enable collect runtime stats.
 	CollectRuntimeStats
+	// SchemaAmender is used to amend mutations for pessimistic transactions
+	SchemaAmender
 )
 
 // Priority value for transaction priority.

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1393,3 +1393,29 @@ func (s *testPessimisticSuite) TestPointGetWithDeleteInMem(c *C) {
 	tk2.MustQuery("select * from uk where c1 = 10").Check(testkit.Rows("10 77"))
 	tk.MustExec("drop table if exists uk")
 }
+
+func (s *testPessimisticSuite) TestPessimisticTxnWithDDLAddDropColumn(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (c1 int primary key, c2 int)")
+	tk.MustExec("insert t1 values (1, 77), (2, 88)")
+	tk.MustExec("alter table t1 add index k2(c2)")
+	tk.MustExec("alter table t1 drop index k2")
+
+	// tk2 starts a pessimistic transaction and make some changes on table t1.
+	// tk executes some ddl statements add/drop column on table t1.
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("update t1 set c2 = c1 * 10")
+	tk2.MustExec("alter table t1 add column c3 int after c1")
+	tk.MustExec("commit")
+	tk.MustExec("admin check table t1")
+	tk.MustQuery("select * from t1").Check(testkit.Rows("1 <nil> 10", "2 <nil> 20"))
+
+	tk.MustExec("begin pessimistic")
+	tk.MustExec("insert into t1 values(5, 5, 5)")
+	tk2.MustExec("alter table t1 drop column c3")
+	tk2.MustExec("alter table t1 drop column c2")
+	tk.MustExec("commit")
+	tk.MustQuery("select * from t1").Check(testkit.Rows("1", "2", "5"))
+}

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -285,10 +285,6 @@ func (a *amendOperationAddNewIndex) genMutations(ctx context.Context, sctx sessi
 
 func (a *amendOperationAddIndexInfo) genIndexKeyValue(ctx context.Context, sctx sessionctx.Context, kvMap map[string][]byte,
 	key []byte, kvHandle kv.Handle, keyOnly bool) ([]byte, []byte, error) {
-	colMap := make(map[int64]*types.FieldType)
-	for _, oldCol := range a.tblInfoAtStart.Meta().Cols() {
-		colMap[oldCol.ID] = &oldCol.FieldType
-	}
 	chk := a.chk
 	chk.Reset()
 	// The Op_Put may not exist in old value kv map.

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -134,7 +134,7 @@ func (a *amendCollector) collectIndexAmendOps(phyTblID int64, tblAtStart, tblAtC
 			for _, idxCol := range idxInfoAtCommit.Meta().Columns {
 				colID := tblAtCommit.Meta().Columns[idxCol.Offset].ID
 				oldColInfo := findColByID(tblAtStart, colID)
-				// TODO now index column MUST be found in old table columns
+				// TODO: now index column MUST be found in old table columns.
 				if oldColInfo == nil {
 					return nil, errors.Trace(table.ErrUnsupportedOp)
 				}
@@ -162,7 +162,7 @@ func (a *amendCollector) collectTblAmendOps(sctx sessionctx.Context, phyTblID in
 		}
 		a.tblChk[phyTblID] = chunk.NewChunkWithCapacity(fieldTypes, 4)
 	}
-	// TODO currently only add index is considered
+	// TODO: currently only "add index" is considered.
 	ops, err := a.collectIndexAmendOps(phyTblID, tblInfoAtStart, tblInfoAtCommit)
 	if err != nil {
 		return err
@@ -192,6 +192,7 @@ func (a *amendCollector) genMutationsForTbl(ctx context.Context, sess *session, 
 	return resAddMutations, nil
 }
 
+// amendOp is an amend operation for a specific schema change, new mutations will be generated using input ones.
 type amendOp interface {
 	genMutations(ctx context.Context, sctx sessionctx.Context, commitMutations tikv.CommitterMutations,
 		kvMaps map[string][]byte) (tikv.CommitterMutations, error)
@@ -386,7 +387,7 @@ func (s *SchemaAmender) AmendTxn(ctx context.Context, startInfoSchema tikv.Schem
 	infoSchemaAtStart := startInfoSchema.(infoschema.InfoSchema)
 	infoSchemaAtCheck := change.LatestInfoSchema.(infoschema.InfoSchema)
 
-	// Collect amend operations for each table by physical table id
+	// Collect amend operations for each table by physical table ID.
 	var needAmendMem bool
 	amendCollector := newAmendCollector()
 	for i, tblID := range change.PhyTblIDS {

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -318,7 +318,7 @@ func (a *amendOperationAddIndex) processKey(ctx context.Context, sctx sessionctx
 		// Check if the generated index keys are unique for unique index.
 		if a.indexInfoAtCommit.Meta().Unique {
 			if _, ok := a.processedNewIndexKeys[string(newIdxKey)]; ok {
-				return resAdd, resRemove, errors.Errorf("amend process key same key found")
+				return resAdd, resRemove, errors.Trace(errors.Errorf("amend process key same key found for unique index=%v", a.indexInfoAtCommit.Meta().Name))
 			}
 		}
 		a.processedNewIndexKeys[string(newIdxKey)] = nil
@@ -401,7 +401,7 @@ func (s *SchemaAmender) AmendTxn(ctx context.Context, startInfoSchema tikv.Schem
 		// Partition table is not supported now.
 		tblInfoAtStart, ok := infoSchemaAtStart.TableByID(tblID)
 		if !ok {
-			return nil, nil, errors.Trace(errors.Errorf(fmt.Sprintf("tableID=%d is not found in infoSchema", tblID)))
+			return nil, nil, errors.Trace(errors.Errorf("tableID=%d is not found in infoSchema", tblID))
 		}
 		if tblInfoAtStart.Meta().Partition != nil {
 			logutil.Logger(ctx).Info("Amend for partition table is not supported", zap.Int64("tableID", tblID))
@@ -409,7 +409,7 @@ func (s *SchemaAmender) AmendTxn(ctx context.Context, startInfoSchema tikv.Schem
 		}
 		tblInfoAtCommit, ok := infoSchemaAtCheck.TableByID(tblID)
 		if !ok {
-			return nil, nil, errors.Trace(errors.Errorf(fmt.Sprintf("tableID=%d is not found in infoSchema", tblID)))
+			return nil, nil, errors.Trace(errors.Errorf("tableID=%d is not found in infoSchema", tblID))
 		}
 		if actionType&(memBufAmendType) != 0 {
 			needAmendMem = true

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -1,0 +1,470 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/pingcap/errors"
+	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/table/tables"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/rowcodec"
+	"go.uber.org/zap"
+)
+
+const amendableType = nonMemAmendType | (memBufAmendType)
+const nonMemAmendType = (1 << model.ActionAddColumn) | (1 << model.ActionDropColumn) | (1 << model.ActionDropIndex)
+const memBufAmendType = uint64(1 << model.ActionAddIndex)
+
+// Amend operation types.
+const (
+	AmendNone int = iota
+
+	// For add index.
+	AmendNeedAddDelete
+	AmendNeedAddDeleteAndInsert
+	AmendNeedAddInsert
+)
+
+// ConstOpAddIndex is the possible ddl state changes, and related amend action types.
+var ConstOpAddIndex = map[model.SchemaState]map[model.SchemaState]int{
+	model.StateNone: {
+		model.StateDeleteOnly:          AmendNeedAddDelete,
+		model.StateWriteOnly:           AmendNeedAddDeleteAndInsert,
+		model.StateWriteReorganization: AmendNeedAddDeleteAndInsert,
+		model.StatePublic:              AmendNeedAddDeleteAndInsert,
+	},
+	model.StateDeleteOnly: {
+		model.StateWriteOnly:           AmendNeedAddInsert,
+		model.StateWriteReorganization: AmendNeedAddInsert,
+		model.StatePublic:              AmendNeedAddInsert,
+	},
+	model.StateWriteOnly: {
+		model.StateWriteReorganization: AmendNone,
+		model.StatePublic:              AmendNone,
+	},
+	model.StateWriteReorganization: {
+		model.StatePublic: AmendNone,
+	},
+}
+
+// amendCollector collects all amend operations, row decoders and memory chunks for each table needs amend.
+type amendCollector struct {
+	tblAmendOpMap map[int64][]amendOp
+	tblDecoder    map[int64]*rowcodec.ChunkDecoder
+	tblChk        map[int64]*chunk.Chunk
+}
+
+func newAmendCollector() *amendCollector {
+	res := &amendCollector{
+		tblAmendOpMap: make(map[int64][]amendOp),
+		tblDecoder:    make(map[int64]*rowcodec.ChunkDecoder),
+		tblChk:        make(map[int64]*chunk.Chunk),
+	}
+	return res
+}
+
+func findIndexByID(tbl table.Table, ID int64) table.Index {
+	for _, indexInfo := range tbl.Indices() {
+		if indexInfo.Meta().ID == ID {
+			return indexInfo
+		}
+	}
+	return nil
+}
+
+func findColByID(tbl table.Table, colID int64) *table.Column {
+	for _, colInfo := range tbl.Cols() {
+		if colInfo.ID == colID {
+			return colInfo
+		}
+	}
+	return nil
+}
+
+func (a *amendCollector) collectIndexAmendOps(ctx context.Context, phyTblID int64,
+	tblAtStart, tblAtCommit table.Table) ([]amendOp, error) {
+	res := make([]amendOp, 0, 4)
+	// Check index having state change, collect index column info.
+	for _, idxInfoAtCommit := range tblAtCommit.Indices() {
+		idxInfoAtStart := findIndexByID(tblAtStart, idxInfoAtCommit.Meta().ID)
+		// Try to find index state change.
+		var amendOpType int
+		if idxInfoAtStart == nil {
+			amendOpType = ConstOpAddIndex[model.StateNone][idxInfoAtCommit.Meta().State]
+		} else if idxInfoAtCommit.Meta().State > idxInfoAtStart.Meta().State {
+			amendOpType = ConstOpAddIndex[idxInfoAtStart.Meta().State][idxInfoAtCommit.Meta().State]
+		}
+		if amendOpType != AmendNone {
+			op := amendOperationAddIndex{}
+			op.AmendOpType = amendOpType
+			op.tblInfoAtStart = tblAtStart
+			op.tblInfoAtCommit = tblAtCommit
+			op.indexInfoAtStart = idxInfoAtStart
+			op.indexInfoAtCommit = idxInfoAtCommit
+			for _, idxCol := range idxInfoAtCommit.Meta().Columns {
+				colID := tblAtCommit.Meta().Columns[idxCol.Offset].ID
+				oldColInfo := findColByID(tblAtStart, colID)
+				// TODO now index column MUST be found in old table columns
+				if oldColInfo == nil {
+					return nil, errors.Trace(table.ErrUnsupportedOp)
+				}
+				op.relatedOldIdxCols = append(op.relatedOldIdxCols, oldColInfo)
+			}
+
+			op.decoder = a.tblDecoder[phyTblID]
+			op.chk = a.tblChk[phyTblID]
+			op.processedNewIndexKeys = make(map[string]interface{})
+			res = append(res, &op)
+		}
+	}
+	return res, nil
+}
+
+// collectTblAmendOps collects amend operations for each table using the schema diff between startTS and commitTS.
+func (a *amendCollector) collectTblAmendOps(ctx context.Context, sctx sessionctx.Context, phyTblID int64,
+	tblInfoAtStart, tblInfoAtCommit table.Table) error {
+	if _, ok := a.tblAmendOpMap[phyTblID]; !ok {
+		a.tblAmendOpMap[phyTblID] = make([]amendOp, 0, 4)
+		a.tblDecoder[phyTblID] = newRowChkDecoder(sctx, tblInfoAtStart.Meta())
+		fieldTypes := make([]*types.FieldType, 0, len(tblInfoAtStart.Meta().Columns))
+		for _, col := range tblInfoAtStart.Meta().Columns {
+			fieldTypes = append(fieldTypes, &col.FieldType)
+		}
+		a.tblChk[phyTblID] = chunk.NewChunkWithCapacity(fieldTypes, 4)
+	}
+	// TODO currently only add index is considered
+	ops, err := a.collectIndexAmendOps(ctx, phyTblID, tblInfoAtStart, tblInfoAtCommit)
+	if err != nil {
+		return err
+	}
+	a.tblAmendOpMap[phyTblID] = append(a.tblAmendOpMap[phyTblID], ops...)
+	return nil
+}
+
+func isDeleteOp(keyOp pb.Op) bool {
+	return keyOp == pb.Op_Del
+}
+
+func isInsertOp(keyOp pb.Op) bool {
+	return keyOp == pb.Op_Put || keyOp == pb.Op_Insert
+}
+
+func (a *amendCollector) genMutationsForTbl(ctx context.Context, sess *session, commitMutations tikv.CommitterMutations,
+	kvMaps map[string][]byte, amendOps []amendOp) (tikv.CommitterMutations, tikv.CommitterMutations, error) {
+	resAddMutations := tikv.NewCommiterMutations(8)
+	resRemoveMutations := tikv.NewCommiterMutations(8)
+	for _, curOp := range amendOps {
+		curAddMutations, curRemoveMutations, err := curOp.genMutations(ctx, sess, commitMutations, kvMaps)
+		if err != nil {
+			return resAddMutations, resRemoveMutations, err
+		}
+		resAddMutations.MergeMutations(curAddMutations)
+		resRemoveMutations.MergeMutations(curRemoveMutations)
+	}
+	return resAddMutations, resRemoveMutations, nil
+}
+
+type amendOp interface {
+	genMutations(ctx context.Context, sctx sessionctx.Context, commitMutations tikv.CommitterMutations,
+		kvMaps map[string][]byte) (tikv.CommitterMutations, tikv.CommitterMutations, error)
+}
+
+// amendOperationAddIndex represents one amend operation related to a specific add index change.
+type amendOperationAddIndex struct {
+	AmendOpType       int
+	tblInfoAtStart    table.Table
+	tblInfoAtCommit   table.Table
+	indexInfoAtStart  table.Index
+	indexInfoAtCommit table.Index
+	relatedOldIdxCols []*table.Column
+
+	decoder               *rowcodec.ChunkDecoder
+	chk                   *chunk.Chunk
+	processedNewIndexKeys map[string]interface{}
+}
+
+func (a *amendOperationAddIndex) String() string {
+	var colStr string
+	colStr += "["
+	for _, colInfo := range a.relatedOldIdxCols {
+		colStr += fmt.Sprintf(" %s ", colInfo.Name)
+	}
+	colStr += "]"
+	res := fmt.Sprintf("AmenedOpType=%d phyTblID=%d idxID=%d columns=%v", a.AmendOpType, a.indexInfoAtCommit.Meta().ID,
+		a.indexInfoAtCommit.Meta().ID, colStr)
+	return res
+}
+
+func (a *amendOperationAddIndex) genMutations(ctx context.Context, sctx sessionctx.Context, commitMutations tikv.CommitterMutations,
+	kvMaps map[string][]byte) (tikv.CommitterMutations, tikv.CommitterMutations, error) {
+	resAddMutations := tikv.NewCommiterMutations(8)
+	resRemoveMutations := tikv.NewCommiterMutations(8)
+	for i, key := range commitMutations.GetKeys() {
+		keyOp := commitMutations.GetOps()[i]
+		addMutations, removeMutations, err := a.processKey(ctx, sctx, keyOp, key, kvMaps)
+		if err != nil {
+			return resAddMutations, resRemoveMutations, err
+		}
+		if len(addMutations.GetKeys()) > 0 {
+			resAddMutations.MergeMutations(addMutations)
+		}
+		if len(removeMutations.GetKeys()) > 0 {
+			resRemoveMutations.MergeMutations(removeMutations)
+		}
+	}
+	return resAddMutations, resRemoveMutations, nil
+}
+
+func (a *amendOperationAddIndex) genIndexKeyValue(ctx context.Context, sctx sessionctx.Context, kvMaps map[string][]byte,
+	key []byte, kvHandle kv.Handle, keyOnly bool) ([]byte, []byte, error) {
+	colMap := make(map[int64]*types.FieldType)
+	for _, oldCol := range a.tblInfoAtStart.Meta().Cols() {
+		colMap[oldCol.ID] = &oldCol.FieldType
+	}
+	rowDecoder := a.decoder
+	chk := a.chk
+	chk.Reset()
+	val := kvMaps[string(key)]
+	err := rowDecoder.DecodeToChunk(val, kvHandle, chk)
+	if err != nil {
+		logutil.Logger(ctx).Warn("amend decode value to chunk failed", zap.Error(err))
+		return nil, nil, errors.Trace(err)
+	}
+	idxVals := make([]types.Datum, 0, len(a.indexInfoAtCommit.Meta().Columns))
+	for _, oldCol := range a.relatedOldIdxCols {
+		idxVals = append(idxVals, chk.GetRow(0).GetDatum(oldCol.Offset, &oldCol.FieldType))
+	}
+
+	// Generate index key buf.
+	newIdxKey, distinct, err := tablecodec.GenIndexKey(sctx.GetSessionVars().StmtCtx,
+		a.tblInfoAtCommit.Meta(), a.indexInfoAtCommit.Meta(), a.tblInfoAtCommit.Meta().ID, idxVals, kvHandle, nil)
+	if err != nil {
+		logutil.Logger(ctx).Warn("amend generate index key failed", zap.Error(err))
+		return nil, nil, errors.Trace(err)
+	}
+	if keyOnly {
+		return newIdxKey, []byte{}, nil
+	}
+
+	// Generate index value buf.
+	var containsNonBinaryString bool
+	for _, idxCol := range a.indexInfoAtCommit.Meta().Columns {
+		col := a.tblInfoAtCommit.Meta().Columns[idxCol.Offset]
+		if col.EvalType() == types.ETString && !mysql.HasBinaryFlag(col.Flag) {
+			containsNonBinaryString = true
+			break
+		}
+	}
+	newIdxVal, err := tablecodec.GenIndexValue(sctx.GetSessionVars().StmtCtx, a.tblInfoAtCommit.Meta(),
+		a.indexInfoAtCommit.Meta(), containsNonBinaryString, distinct, false, idxVals, kvHandle)
+	if err != nil {
+		logutil.Logger(ctx).Warn("amend generate index values failed", zap.Error(err))
+		return nil, nil, errors.Trace(err)
+	}
+	return newIdxKey, newIdxVal, nil
+}
+
+func (a *amendOperationAddIndex) processKey(ctx context.Context, sctx sessionctx.Context, keyOp pb.Op, key []byte,
+	kvMaps map[string][]byte) (resAdd tikv.CommitterMutations, resRemove tikv.CommitterMutations, err error) {
+	if a.AmendOpType == AmendNone || tablecodec.IsIndexKey(key) {
+		return
+	}
+	kvHandle, err := tablecodec.DecodeRowKey(key)
+	if err != nil {
+		logutil.Logger(ctx).Error("decode key error", zap.String("key", hex.EncodeToString(key)), zap.Error(err))
+		return resAdd, resRemove, errors.Trace(err)
+	}
+
+	// Generated delete index key value.
+	if (a.AmendOpType == AmendNeedAddDelete || a.AmendOpType == AmendNeedAddDeleteAndInsert) && isDeleteOp(keyOp) {
+		newIdxKey, emptyVal, err := a.genIndexKeyValue(ctx, sctx, kvMaps, key, kvHandle, true)
+		if err != nil {
+			return resAdd, resRemove, errors.Trace(err)
+		}
+		resAdd.Push(keyOp, newIdxKey, emptyVal, false)
+	}
+
+	// Generated insert index key value.
+	if (a.AmendOpType == AmendNeedAddDeleteAndInsert || a.AmendOpType == AmendNeedAddInsert) && isInsertOp(keyOp) {
+		newIdxKey, newIdxValue, err := a.genIndexKeyValue(ctx, sctx, kvMaps, key, kvHandle, false)
+		if err != nil {
+			return resAdd, resRemove, errors.Trace(err)
+		}
+		// Check if the generated index keys are unique for unique index.
+		if a.indexInfoAtCommit.Meta().Unique {
+			if _, ok := a.processedNewIndexKeys[string(newIdxKey)]; ok {
+				return resAdd, resRemove, errors.Errorf("amend process key same key found")
+			}
+		}
+		a.processedNewIndexKeys[string(newIdxKey)] = nil
+		resAdd.Push(keyOp, newIdxKey, newIdxValue, false)
+	}
+	return
+}
+
+// SchemaAmender is used to amend pessimistic transactions for schema change.
+type SchemaAmender struct {
+	sess *session
+}
+
+// NewSchemaAmenderForTikvTxn creates a schema amender for tikvTxn type.
+func NewSchemaAmenderForTikvTxn(sess *session) *SchemaAmender {
+	amender := &SchemaAmender{sess: sess}
+	return amender
+}
+
+func (s *SchemaAmender) getAmendableKeys(commitMutations tikv.CommitterMutations) []kv.Key {
+	kvKeys := make([]kv.Key, 0, len(commitMutations.GetKeys()))
+	for _, byteKey := range commitMutations.GetKeys() {
+		if tablecodec.IsIndexKey(byteKey) {
+			continue
+		}
+		kvKeys = append(kvKeys, byteKey)
+	}
+	return kvKeys
+}
+
+// genAllAmendMutations generates CommitterMutations for all tables and related amend operations.
+func (s *SchemaAmender) genAllAmendMutations(ctx context.Context, commitMutations tikv.CommitterMutations,
+	info *amendCollector) (*tikv.CommitterMutations, *tikv.CommitterMutations, error) {
+	// Get keys need to be considered for the amend operation, currently only row keys.
+	kvKeys := s.getAmendableKeys(commitMutations)
+
+	// BatchGet the key values.
+	txn, err := s.sess.Txn(true)
+	if err != nil {
+		return nil, nil, err
+	}
+	kvMaps, err := txn.BatchGet(ctx, kvKeys)
+	if err != nil {
+		logutil.Logger(ctx).Warn("amend failed to batch get kv keys", zap.Error(err))
+		return nil, nil, errors.Trace(err)
+	}
+
+	// Do generate add/remove mutations processing each key.
+	addMutations := tikv.NewCommiterMutations(8)
+	removeMutations := tikv.NewCommiterMutations(8)
+	for _, amendOps := range info.tblAmendOpMap {
+		resAddMutations, resRemoveMutations, err := info.genMutationsForTbl(ctx, s.sess, commitMutations, kvMaps, amendOps)
+		if err != nil {
+			return nil, nil, err
+		}
+		addMutations.MergeMutations(resAddMutations)
+		removeMutations.MergeMutations(resRemoveMutations)
+	}
+	return &addMutations, &removeMutations, nil
+}
+
+// AmendTxn does check and generate amend mutations based on input infoSchema and mutations, mutations need to prewrite
+// and mutations need to cleanup are returned, the input commitMutations will not be changed.
+func (s *SchemaAmender) AmendTxn(ctx context.Context, startInfoSchema tikv.SchemaVer, change *tikv.RelatedSchemaChange,
+	commitMutations tikv.CommitterMutations) (*tikv.CommitterMutations, *tikv.CommitterMutations, error) {
+	// Get info schema meta
+	infoSchemaAtStart := startInfoSchema.(infoschema.InfoSchema)
+	infoSchemaAtCheck := change.LatestInfoSchema.(infoschema.InfoSchema)
+
+	// Collect amend operations for each table by physical table id
+	var needAmendMem bool
+	amendCollector := newAmendCollector()
+	for i, tblID := range change.PhyTblIDS {
+		actionType := change.ActionTypes[i]
+		// Check amendable flags, return if not supported flags exist.
+		if actionType&(^amendableType) != 0 {
+			logutil.Logger(ctx).Info("amend action type not supported for txn", zap.Int64("tblID", tblID), zap.Uint64("actionType", actionType))
+			return nil, nil, errors.Trace(table.ErrUnsupportedOp)
+		}
+		// Partition table is not supported now.
+		tblInfoAtStart, ok := infoSchemaAtStart.TableByID(tblID)
+		if !ok {
+			return nil, nil, errors.Trace(errors.Errorf(fmt.Sprintf("tableID=%d is not found in infoSchema", tblID)))
+		}
+		if tblInfoAtStart.Meta().Partition != nil {
+			logutil.Logger(ctx).Info("Amend for partition table is not supported", zap.Int64("tableID", tblID))
+			return nil, nil, table.ErrUnsupportedOp
+		}
+		tblInfoAtCommit, ok := infoSchemaAtCheck.TableByID(tblID)
+		if !ok {
+			return nil, nil, errors.Trace(errors.Errorf(fmt.Sprintf("tableID=%d is not found in infoSchema", tblID)))
+		}
+		if actionType&(memBufAmendType) != 0 {
+			needAmendMem = true
+			err := amendCollector.collectTblAmendOps(ctx, s.sess, tblID, tblInfoAtStart, tblInfoAtCommit)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+	}
+	// After amend operations collect, generate related new mutations based on input commitMutations
+	if needAmendMem {
+		return s.genAllAmendMutations(ctx, commitMutations, amendCollector)
+	}
+	return nil, nil, nil
+}
+
+func newRowChkDecoder(ctx sessionctx.Context, tbl *model.TableInfo) *rowcodec.ChunkDecoder {
+	getColInfoByID := func(tbl *model.TableInfo, colID int64) *model.ColumnInfo {
+		for _, col := range tbl.Columns {
+			if col.ID == colID {
+				return col
+			}
+		}
+		return nil
+	}
+	var pkCols []int64
+	reqCols := make([]rowcodec.ColInfo, len(tbl.Columns))
+	for i := range tbl.Columns {
+		idx, col := i, tbl.Columns[i]
+		isPK := (tbl.PKIsHandle && mysql.HasPriKeyFlag(col.FieldType.Flag)) || col.ID == model.ExtraHandleID
+		if isPK {
+			pkCols = append(pkCols, col.ID)
+		}
+
+		isVirtualGenCol := col.IsGenerated() && !col.GeneratedStored
+		reqCols[idx] = rowcodec.ColInfo{
+			ID:            col.ID,
+			VirtualGenCol: isVirtualGenCol,
+			Ft:            &col.FieldType,
+		}
+	}
+	if len(pkCols) == 0 {
+		pkCols = tables.TryGetCommonPkColumnIds(tbl)
+		if len(pkCols) == 0 {
+			pkCols = []int64{0}
+		}
+	}
+	defVal := func(i int, chk *chunk.Chunk) error {
+		ci := getColInfoByID(tbl, reqCols[i].ID)
+		d, err := table.GetColOriginDefaultValue(ctx, ci)
+		if err != nil {
+			return err
+		}
+		chk.AppendDatum(i, &d)
+		return nil
+	}
+	return rowcodec.NewChunkDecoder(reqCols, pkCols, defVal, ctx.GetSessionVars().TimeZone)
+}

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -37,7 +37,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const amendableType = nonMemAmendType | (memBufAmendType)
+const amendableType = nonMemAmendType | memBufAmendType
 const nonMemAmendType = (1 << model.ActionAddColumn) | (1 << model.ActionDropColumn) | (1 << model.ActionDropIndex)
 const memBufAmendType = uint64(1 << model.ActionAddIndex)
 

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -405,7 +405,7 @@ func (s *SchemaAmender) AmendTxn(ctx context.Context, startInfoSchema tikv.Schem
 		}
 		if tblInfoAtStart.Meta().Partition != nil {
 			logutil.Logger(ctx).Info("Amend for partition table is not supported", zap.Int64("tableID", tblID))
-			return nil, nil, table.ErrUnsupportedOp
+			return nil, nil, errors.Trace(table.ErrUnsupportedOp)
 		}
 		tblInfoAtCommit, ok := infoSchemaAtCheck.TableByID(tblID)
 		if !ok {

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -78,7 +78,7 @@ type schemaAndDecoder struct {
 	decoder *rowcodec.ChunkDecoder
 }
 
-// amendCollector collects all amend operations, row decoders and memory chunks for each table needs amend.
+// amendCollector collects all amend operations.
 type amendCollector struct {
 	tblAmendOpMap map[int64][]amendOp
 }

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -343,7 +343,6 @@ func (a *amendOperationAddNewIndex) processRowKey(ctx context.Context, sctx sess
 	if err != nil {
 		return errors.Trace(err)
 	}
-	// Check if the generated index keys are unique for unique index.
 	resAddMutations.Push(pb.Op_Put, newIdxKey, newIdxValue, false)
 	return nil
 }

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -287,10 +287,13 @@ func (a *amendOperationAddIndexInfo) genIndexKeyValue(ctx context.Context, sctx 
 	key []byte, kvHandle kv.Handle, keyOnly bool) ([]byte, []byte, error) {
 	chk := a.chk
 	chk.Reset()
-	// The Op_Put may not exist in old value kv map.
 	val, ok := kvMap[string(key)]
-	if !ok && keyOnly {
-		return nil, nil, nil
+	if !ok {
+		// The Op_Put may not exist in old value kv map.
+		if keyOnly {
+			return nil, nil, nil
+		}
+		return nil, nil, errors.Errorf("key=%v is not found in new row kv map", kv.Key(key).String())
 	}
 	err := executor.DecodeRowValToChunk(sctx, a.schemaAndDecoder.schema, a.tblInfoAtStart.Meta(), kvHandle, val, chk, a.schemaAndDecoder.decoder)
 	if err != nil {

--- a/session/schema_amender_test.go
+++ b/session/schema_amender_test.go
@@ -1,0 +1,236 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session
+
+import (
+	"context"
+	"sort"
+	"strconv"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/rowcodec"
+)
+
+var _ = SerialSuites(&testSchemaAmenderSuite{})
+
+type testSchemaAmenderSuite struct {
+}
+
+func (s *testSchemaAmenderSuite) SetUpSuite(c *C) {
+}
+
+func (s *testSchemaAmenderSuite) TearDownSuite(c *C) {
+}
+
+func initTblColIdxID(metaInfo *model.TableInfo) {
+	for i, col := range metaInfo.Columns {
+		col.ID = int64(i + 1)
+	}
+	for i, idx := range metaInfo.Indices {
+		idx.ID = int64(i + 1)
+	}
+	metaInfo.ID = 1
+	metaInfo.State = model.StatePublic
+}
+
+func mutationsEqual(res *tikv.CommitterMutations, expected *tikv.CommitterMutations, c *C) {
+	c.Assert(len(res.GetKeys()), Equals, len(expected.GetKeys()))
+	for i := 0; i < len(res.GetKeys()); i++ {
+		c.Assert(res.GetOps()[i], Equals, expected.GetOps()[i])
+		c.Assert(res.GetKeys()[i], BytesEquals, expected.GetKeys()[i])
+		c.Assert(res.GetValues()[i], BytesEquals, expected.GetValues()[i])
+		c.Assert(res.GetPessimisticFlags()[i], Equals, expected.GetPessimisticFlags()[i])
+	}
+}
+
+func (s *testSchemaAmenderSuite) TestAmendCollectAndGenMutations(c *C) {
+	ctx := context.Background()
+	store := newStore(c, "test_schema_amender")
+	defer store.Close()
+	se := &session{
+		store:       store,
+		parser:      parser.New(),
+		sessionVars: variable.NewSessionVars(),
+	}
+	startStates := []model.SchemaState{model.StateNone, model.StateDeleteOnly}
+	for _, startState := range startStates {
+		endStatMap := ConstOpAddIndex[startState]
+		var endStates []model.SchemaState
+		for st := range endStatMap {
+			endStates = append(endStates, st)
+		}
+		sort.Slice(endStates, func(i, j int) bool { return endStates[i] < endStates[j] })
+		for _, endState := range endStates {
+			// column: a, b, c, d, e, c_str, d_str, e_str, f, g.
+			// PK: a.
+			// indices: c_d_e, e, f, g, f_g, c_d_e_str, c_d_e_str_prefix.
+			oldTblMeta := core.MockSignedTable()
+			initTblColIdxID(oldTblMeta)
+			// Indices[0] does not exist at the start.
+			oldTblMeta.Indices = oldTblMeta.Indices[1:]
+			oldTbInfo, err := table.TableFromMeta(nil, oldTblMeta)
+			c.Assert(err, IsNil)
+			oldTblMeta.Indices[0].State = startState
+			oldTblMeta.Indices[2].State = endState
+
+			newTblMeta := core.MockSignedTable()
+			initTblColIdxID(newTblMeta)
+			// colh is newly added.
+			colh := &model.ColumnInfo{
+				State:     model.StatePublic,
+				Offset:    12,
+				Name:      model.NewCIStr("b"),
+				FieldType: *(types.NewFieldType(mysql.TypeLong)),
+				ID:        13,
+			}
+			newTblMeta.Columns = append(newTblMeta.Columns, colh)
+			// The last index "c_d_e_str_prefix is dropped.
+			newTblMeta.Indices = newTblMeta.Indices[:len(newTblMeta.Indices)-1]
+			newTblMeta.Indices[0].Unique = false
+			newTblInfo, err := table.TableFromMeta(nil, newTblMeta)
+			c.Assert(err, IsNil)
+			newTblMeta.Indices[0].State = endState
+			// Indices[1] is newly created.
+			newTblMeta.Indices[1].State = endState
+			// Indices[3] is dropped
+			newTblMeta.Indices[3].State = startState
+
+			// Only the add index amend operations is collected in the results.
+			collector := newAmendCollector()
+			tblID := int64(1)
+			err = collector.collectTblAmendOps(se, tblID, oldTbInfo, newTblInfo)
+			c.Assert(err, IsNil)
+			c.Assert(len(collector.tblAmendOpMap[tblID]), Equals, 2)
+			expecetedAmendOps := []amendOperationAddIndex{
+				{AmendOpType: ConstOpAddIndex[model.StateNone][endState],
+					tblInfoAtStart:    oldTbInfo,
+					tblInfoAtCommit:   newTblInfo,
+					indexInfoAtStart:  nil,
+					indexInfoAtCommit: newTblInfo.Indices()[0],
+					relatedOldIdxCols: []*table.Column{oldTbInfo.Cols()[2], oldTbInfo.Cols()[3], oldTbInfo.Cols()[4]},
+				},
+				{AmendOpType: ConstOpAddIndex[startState][endState],
+					tblInfoAtStart:    oldTbInfo,
+					tblInfoAtCommit:   newTblInfo,
+					indexInfoAtStart:  oldTbInfo.Indices()[0],
+					indexInfoAtCommit: newTblInfo.Indices()[1],
+					relatedOldIdxCols: []*table.Column{oldTbInfo.Cols()[4]},
+				},
+			}
+			// Check collect results.
+			for i, amendOp := range collector.tblAmendOpMap[tblID] {
+				curOp, ok := amendOp.(*amendOperationAddIndex)
+				c.Assert(ok, IsTrue)
+				c.Assert(curOp.AmendOpType, Equals, expecetedAmendOps[i].AmendOpType)
+				c.Assert(curOp.tblInfoAtStart, Equals, expecetedAmendOps[i].tblInfoAtStart)
+				c.Assert(curOp.tblInfoAtCommit, Equals, expecetedAmendOps[i].tblInfoAtCommit)
+				c.Assert(curOp.indexInfoAtStart, Equals, expecetedAmendOps[i].indexInfoAtStart)
+				c.Assert(curOp.indexInfoAtCommit, Equals, expecetedAmendOps[i].indexInfoAtCommit)
+				for j, col := range curOp.relatedOldIdxCols {
+					c.Assert(col, Equals, expecetedAmendOps[i].relatedOldIdxCols[j])
+				}
+			}
+			// Check mutation generations.
+			txn, err := se.store.Begin()
+			c.Assert(err, IsNil)
+			se.txn.changeInvalidToValid(txn)
+			txn, err = se.Txn(true)
+			c.Assert(err, IsNil)
+
+			schemaAmender := NewSchemaAmenderForTikvTxn(se)
+			mutations := tikv.NewCommiterMutations(8)
+			colIds := make([]int64, len(oldTbInfo.Meta().Columns))
+			basicRowValue := make([]types.Datum, len(oldTbInfo.Meta().Columns))
+			rd := rowcodec.Encoder{Enable: true}
+			for i, col := range oldTbInfo.Meta().Columns {
+				colIds[i] = oldTbInfo.Meta().Columns[col.Offset].ID
+				if col.FieldType.Tp == mysql.TypeLong {
+					basicRowValue[i] = types.NewIntDatum(int64(col.Offset))
+				} else {
+					basicRowValue[i] = types.NewStringDatum(strconv.Itoa(col.Offset))
+				}
+				c.Assert(err, IsNil)
+			}
+			expecteMutations := tikv.NewCommiterMutations(8)
+			KeyOps := []kvrpcpb.Op{kvrpcpb.Op_Put, kvrpcpb.Op_Del, kvrpcpb.Op_Lock, kvrpcpb.Op_Insert}
+			rowValues := make([][]types.Datum, len(KeyOps))
+			for i := 0; i < len(KeyOps); i++ {
+				rowKey := tablecodec.EncodeRowKeyWithHandle(oldTbInfo.Meta().ID, kv.IntHandle(i+1))
+				thisRowValue := make([]types.Datum, len(basicRowValue))
+				copy(thisRowValue, basicRowValue)
+				thisRowValue[0] = types.NewIntDatum(int64(i + 1))
+				thisRowValue[4] = types.NewIntDatum(int64(i + 1 + 4))
+				rowValue, err := rd.Encode(se.sessionVars.StmtCtx, colIds, thisRowValue, nil)
+				c.Assert(err, IsNil)
+				err = txn.Set(rowKey, rowValue)
+				c.Assert(err, IsNil)
+				keyOp := KeyOps[i]
+				mutations.Push(keyOp, rowKey, rowValue, true)
+				rowValues[i] = thisRowValue
+			}
+			for _, op := range expecetedAmendOps {
+				for rowIdx, curRow := range rowValues {
+					keyOp := KeyOps[rowIdx]
+					indexDatums := make([]types.Datum, len(op.relatedOldIdxCols))
+					for colIdx, col := range op.relatedOldIdxCols {
+						indexDatums[colIdx] = curRow[col.Offset]
+					}
+					kvHandle := kv.IntHandle(curRow[0].GetInt64())
+					idxKey, _, err := tablecodec.GenIndexKey(se.sessionVars.StmtCtx, newTblInfo.Meta(),
+						op.indexInfoAtCommit.Meta(), newTblInfo.Meta().ID, indexDatums, kvHandle, nil)
+					c.Assert(err, IsNil)
+					var idxVal []byte
+					if (op.AmendOpType == AmendNeedAddDelete || op.AmendOpType == AmendNeedAddDeleteAndInsert) && isDeleteOp(keyOp) {
+						expecteMutations.Push(keyOp, idxKey, idxVal, false)
+					}
+					if (op.AmendOpType == AmendNeedAddDeleteAndInsert || op.AmendOpType == AmendNeedAddInsert) && isInsertOp(keyOp) {
+						idxVal, err = tablecodec.GenIndexValue(se.sessionVars.StmtCtx, newTblInfo.Meta(), op.indexInfoAtCommit.Meta(),
+							false, op.indexInfoAtCommit.Meta().Unique, false, indexDatums, kvHandle)
+						c.Assert(err, IsNil)
+						expecteMutations.Push(keyOp, idxKey, idxVal, false)
+					}
+				}
+			}
+			for i := 0; i < 4; i++ {
+				idxValue := []byte("idxValue")
+				idxKey := tablecodec.EncodeIndexSeekKey(oldTbInfo.Meta().ID, oldTbInfo.Indices()[2].Meta().ID, idxValue)
+				err = txn.Set(idxKey, idxKey)
+				c.Assert(err, IsNil)
+				mutations.Push(kvrpcpb.Op_Put, idxKey, idxValue, false)
+			}
+
+			res, err := schemaAmender.genAllAmendMutations(ctx, mutations, collector)
+			c.Assert(err, IsNil)
+
+			// Validate generated results.
+			c.Assert(len(res.GetKeys()), Equals, len(res.GetOps()))
+			c.Assert(len(res.GetValues()), Equals, len(res.GetOps()))
+			c.Assert(len(res.GetPessimisticFlags()), Equals, len(res.GetOps()))
+			mutationsEqual(res, &expecteMutations, c)
+			err = txn.Rollback()
+			c.Assert(err, IsNil)
+		}
+	}
+}

--- a/session/schema_amender_test.go
+++ b/session/schema_amender_test.go
@@ -51,6 +51,8 @@ func initTblColIdxID(metaInfo *model.TableInfo) {
 	}
 	for i, idx := range metaInfo.Indices {
 		idx.ID = int64(i + 1)
+		// TODO unique index is not supported now.
+		idx.Unique = false
 	}
 	metaInfo.ID = 1
 	metaInfo.State = model.StatePublic
@@ -297,8 +299,7 @@ func (s *testSchemaAmenderSuite) TestAmendCollectAndGenMutations(c *C) {
 			}
 			if addIndexNeedAddOp(addIndexOpInfo.AmendOpType) {
 				expectedAmendOps = append(expectedAmendOps, &amendOperationAddNewIndex{
-					info:                  addIndexOpInfo,
-					processedNewIndexKeys: make(map[string]interface{}),
+					info: addIndexOpInfo,
 				})
 			}
 
@@ -318,8 +319,7 @@ func (s *testSchemaAmenderSuite) TestAmendCollectAndGenMutations(c *C) {
 			}
 			if addIndexNeedAddOp(addIndexOpInfo1.AmendOpType) {
 				expectedAmendOps = append(expectedAmendOps, &amendOperationAddNewIndex{
-					info:                  addIndexOpInfo1,
-					processedNewIndexKeys: make(map[string]interface{}),
+					info: addIndexOpInfo1,
 				})
 			}
 			// Check collect results.

--- a/session/session.go
+++ b/session/session.go
@@ -426,6 +426,7 @@ func (s *session) doCommit(ctx context.Context) error {
 	// Set this option for 2 phase commit to validate schema lease.
 	s.txn.SetOption(kv.SchemaChecker, domain.NewSchemaChecker(domain.GetDomain(s), s.sessionVars.TxnCtx.SchemaVersion, physicalTableIDs))
 	s.txn.SetOption(kv.InfoSchema, s.sessionVars.TxnCtx.InfoSchema)
+	s.txn.SetOption(kv.SchemaAmender, NewSchemaAmenderForTikvTxn(s))
 
 	return s.txn.Commit(sessionctx.SetCommitCtx(ctx, s))
 }

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -69,7 +69,7 @@ type twoPhaseCommitter struct {
 	store            *tikvStore
 	txn              *tikvTxn
 	startTS          uint64
-	mutations        committerMutations
+	mutations        CommitterMutations
 	lockTTL          uint64
 	commitTS         uint64
 	priority         pb.CommandPri
@@ -106,15 +106,17 @@ type twoPhaseCommitter struct {
 	minCommitTS    uint64
 }
 
-type committerMutations struct {
+// CommitterMutations contains transaction operations.
+type CommitterMutations struct {
 	ops               []pb.Op
 	keys              [][]byte
 	values            [][]byte
 	isPessimisticLock []bool
 }
 
-func newCommiterMutations(sizeHint int) committerMutations {
-	return committerMutations{
+// NewCommiterMutations creates a CommitterMutations object with sizeHint reserved.
+func NewCommiterMutations(sizeHint int) CommitterMutations {
+	return CommitterMutations{
 		ops:               make([]pb.Op, 0, sizeHint),
 		keys:              make([][]byte, 0, sizeHint),
 		values:            make([][]byte, 0, sizeHint),
@@ -122,8 +124,8 @@ func newCommiterMutations(sizeHint int) committerMutations {
 	}
 }
 
-func (c *committerMutations) subRange(from, to int) committerMutations {
-	var res committerMutations
+func (c *CommitterMutations) subRange(from, to int) CommitterMutations {
+	var res CommitterMutations
 	res.keys = c.keys[from:to]
 	if c.ops != nil {
 		res.ops = c.ops[from:to]
@@ -137,15 +139,39 @@ func (c *committerMutations) subRange(from, to int) committerMutations {
 	return res
 }
 
-func (c *committerMutations) push(op pb.Op, key []byte, value []byte, isPessimisticLock bool) {
+// Push another mutation into mutations.
+func (c *CommitterMutations) Push(op pb.Op, key []byte, value []byte, isPessimisticLock bool) {
 	c.ops = append(c.ops, op)
 	c.keys = append(c.keys, key)
 	c.values = append(c.values, value)
 	c.isPessimisticLock = append(c.isPessimisticLock, isPessimisticLock)
 }
 
-func (c *committerMutations) len() int {
+func (c *CommitterMutations) len() int {
 	return len(c.keys)
+}
+
+// GetKeys returns the keys.
+func (c *CommitterMutations) GetKeys() [][]byte {
+	return c.keys
+}
+
+// GetOps returns the key ops.
+func (c *CommitterMutations) GetOps() []pb.Op {
+	return c.ops
+}
+
+// GetValues returns the key values.
+func (c *CommitterMutations) GetValues() [][]byte {
+	return c.values
+}
+
+// MergeMutations append input mutations into current mutations.
+func (c *CommitterMutations) MergeMutations(mutations CommitterMutations) {
+	c.ops = append(c.ops, mutations.ops...)
+	c.keys = append(c.keys, mutations.keys...)
+	c.values = append(c.values, mutations.values...)
+	c.isPessimisticLock = append(c.isPessimisticLock, mutations.isPessimisticLock...)
 }
 
 // newTwoPhaseCommitter creates a twoPhaseCommitter.
@@ -191,7 +217,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	)
 	txn := c.txn
 	sizeHint := len(txn.lockKeys) + txn.us.GetMemBuffer().Len()
-	mutations := newCommiterMutations(sizeHint)
+	mutations := NewCommiterMutations(sizeHint)
 	c.isPessimistic = txn.IsPessimistic()
 
 	// Merge ordered lockKeys and pairs in the memBuffer into the mutations array
@@ -238,13 +264,13 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 			} else if ord > 0 {
 				break
 			} else {
-				mutations.push(pb.Op_Lock, lockKey, nil, c.isPessimistic)
+				mutations.Push(pb.Op_Lock, lockKey, nil, c.isPessimistic)
 				lockCnt++
 				size += len(lockKey)
 				lockIdx++
 			}
 		}
-		mutations.push(op, k, value, isPessimisticLock)
+		mutations.Push(op, k, value, isPessimisticLock)
 		entrySize := len(k) + len(v)
 		if uint64(entrySize) > kv.TxnEntrySizeLimit {
 			return kv.ErrEntryTooLarge.GenWithStackByArgs(kv.TxnEntrySizeLimit, entrySize)
@@ -257,7 +283,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	}
 	// add the remaining locks to mutations and keys
 	for _, lockKey := range txn.lockKeys[lockIdx:] {
-		mutations.push(pb.Op_Lock, lockKey, nil, c.isPessimistic)
+		mutations.Push(pb.Op_Lock, lockKey, nil, c.isPessimistic)
 		lockCnt++
 		size += len(lockKey)
 	}
@@ -366,7 +392,7 @@ var preSplitSizeThreshold uint32 = 32 << 20
 // doActionOnMutations groups keys into primary batch and secondary batches, if primary batch exists in the key,
 // it does action on primary batch first, then on secondary batches. If action is commit, secondary batches
 // is done in background goroutine.
-func (c *twoPhaseCommitter) doActionOnMutations(bo *Backoffer, action twoPhaseCommitAction, mutations committerMutations) error {
+func (c *twoPhaseCommitter) doActionOnMutations(bo *Backoffer, action twoPhaseCommitAction, mutations CommitterMutations) error {
 	if mutations.len() == 0 {
 		return nil
 	}
@@ -379,7 +405,7 @@ func (c *twoPhaseCommitter) doActionOnMutations(bo *Backoffer, action twoPhaseCo
 }
 
 // groupMutations groups mutations by region, then checks for any large groups and in that case pre-splits the region.
-func (c *twoPhaseCommitter) groupMutations(bo *Backoffer, mutations committerMutations) ([]groupedMutations, error) {
+func (c *twoPhaseCommitter) groupMutations(bo *Backoffer, mutations CommitterMutations) ([]groupedMutations, error) {
 	groups, err := c.store.regionCache.GroupSortedMutationsByRegion(bo, mutations)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -804,17 +830,32 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		logutil.SetTag(ctx, "commitTs", commitTS)
 	}
 
-	// check commitTS
-	if commitTS <= c.startTS {
-		err = errors.Errorf("conn %d Invalid transaction tso with txnStartTS=%v while txnCommitTS=%v",
-			c.connID, c.startTS, commitTS)
-		logutil.BgLogger().Error("invalid transaction", zap.Error(err))
-		return errors.Trace(err)
+	tryAmend := c.isPessimistic && c.connID > 0
+	if !tryAmend {
+		_, _, err = c.checkSchemaValid(ctx, commitTS, c.txn.txnInfoSchema, false)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	} else {
+		relatedSchemaChange, memAmended, err := c.checkSchemaValid(ctx, commitTS, c.txn.txnInfoSchema, true)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if memAmended {
+			// Get new commitTS and check schema valid again.
+			newCommitTS, err := c.getCommitTS(ctx, commitDetail)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			// If schema check failed between commitTS and newCommitTs, report schema change error.
+			_, _, err = c.checkSchemaValid(ctx, newCommitTS, relatedSchemaChange.LatestInfoSchema, false)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			commitTS = newCommitTS
+		}
 	}
 	c.commitTS = commitTS
-	if err = c.checkSchemaValid(); err != nil {
-		return errors.Trace(err)
-	}
 
 	if c.store.oracle.IsExpired(c.startTS, kv.MaxTxnTimeUse) {
 		err = errors.Errorf("conn %d txn takes too much time, txnStartTS: %d, comm: %d",
@@ -926,15 +967,75 @@ type RelatedSchemaChange struct {
 	Amendable        bool
 }
 
-func (c *twoPhaseCommitter) checkSchemaValid() error {
+func (c *twoPhaseCommitter) tryAmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange) (bool, error) {
+	memAmended := false
+	addMutations, _, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, c.mutations)
+	if err != nil {
+		return false, err
+	}
+	// Prewrite new mutations.
+	if addMutations != nil && len(addMutations.keys) > 0 {
+		prewriteBo := NewBackofferWithVars(ctx, PrewriteMaxBackoff, c.txn.vars)
+		err = c.prewriteMutations(prewriteBo, *addMutations)
+		if err != nil {
+			logutil.Logger(ctx).Warn("amend prewrite has failed", zap.Error(err), zap.Uint64("txnStartTS", c.startTS))
+			return false, err
+		}
+		logutil.Logger(ctx).Info("amend prewrite finished", zap.Uint64("txnStartTS", c.startTS))
+		memAmended = true
+	}
+	return memAmended, nil
+}
+
+func (c *twoPhaseCommitter) getCommitTS(ctx context.Context, commitDetail *execdetails.CommitDetails) (uint64, error) {
+	start := time.Now()
+	logutil.Event(ctx, "start get commit ts")
+	commitTS, err := c.store.getTimestampWithRetry(NewBackofferWithVars(ctx, tsoMaxBackoff, c.txn.vars))
+	if err != nil {
+		logutil.Logger(ctx).Warn("2PC get commitTS failed",
+			zap.Error(err),
+			zap.Uint64("txnStartTS", c.startTS))
+		return 0, errors.Trace(err)
+	}
+	commitDetail.GetCommitTsTime = time.Since(start)
+	logutil.Event(ctx, "finish get commit ts")
+	logutil.SetTag(ctx, "commitTs", commitTS)
+
+	// Check commitTS.
+	if commitTS <= c.startTS {
+		err = errors.Errorf("conn %d Invalid transaction tso with txnStartTS=%v while txnCommitTS=%v",
+			c.connID, c.startTS, commitTS)
+		logutil.BgLogger().Error("invalid transaction", zap.Error(err))
+		return 0, errors.Trace(err)
+	}
+	return commitTS, nil
+}
+
+// checkSchemaValid checks if the schema has changed, if tryAmend is set to true, committer will try to amend
+// this transaction using the related schema changes.
+func (c *twoPhaseCommitter) checkSchemaValid(ctx context.Context, checkTS uint64, startInfoSchema SchemaVer,
+	tryAmend bool) (*RelatedSchemaChange, bool, error) {
 	checker, ok := c.txn.us.GetOption(kv.SchemaChecker).(schemaLeaseChecker)
 	if ok {
-		_, err := checker.CheckBySchemaVer(c.commitTS, c.txn.txnInfoSchema)
+		relatedChanges, err := checker.CheckBySchemaVer(checkTS, startInfoSchema)
 		if err != nil {
-			return errors.Trace(err)
+			if tryAmend && relatedChanges != nil && relatedChanges.Amendable && c.txn.schemaAmender != nil {
+				memAmended, amendErr := c.tryAmendTxn(ctx, startInfoSchema, relatedChanges)
+				if amendErr != nil {
+					logutil.BgLogger().Info("txn amend has failed", zap.Uint64("connID", c.connID),
+						zap.Uint64("startTS", c.startTS), zap.Error(amendErr))
+					return nil, false, err
+				}
+				logutil.Logger(ctx).Info("amend txn successfully for pessimistic commit",
+					zap.Uint64("connID", c.connID), zap.Uint64("txn startTS", c.startTS), zap.Bool("memAmended", memAmended),
+					zap.Uint64("checkTS", checkTS), zap.Int64("startInfoSchemaVer", startInfoSchema.SchemaMetaVersion()),
+					zap.Int64s("table ids", relatedChanges.PhyTblIDS), zap.Uint64s("action types", relatedChanges.ActionTypes))
+				return relatedChanges, memAmended, nil
+			}
+			return nil, false, errors.Trace(err)
 		}
 	}
-	return nil
+	return nil, false, nil
 }
 
 func (c *twoPhaseCommitter) prewriteBinlog(ctx context.Context) chan *binloginfo.WriteResult {
@@ -1006,7 +1107,7 @@ const txnCommitBatchSize = 16 * 1024
 
 type batchMutations struct {
 	region    RegionVerID
-	mutations committerMutations
+	mutations CommitterMutations
 	isPrimary bool
 }
 type batched struct {
@@ -1024,7 +1125,7 @@ func newBatched(primaryKey []byte) *batched {
 
 // appendBatchMutationsBySize appends mutations to b. It may split the keys to make
 // sure each batch's size does not exceed the limit.
-func (b *batched) appendBatchMutationsBySize(region RegionVerID, mutations committerMutations, sizeFn func(k, v []byte) int, limit int) {
+func (b *batched) appendBatchMutationsBySize(region RegionVerID, mutations CommitterMutations, sizeFn func(k, v []byte) int, limit int) {
 	var start, end int
 	for start = 0; start < mutations.len(); start = end {
 		var size int

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -969,7 +969,7 @@ type RelatedSchemaChange struct {
 
 func (c *twoPhaseCommitter) tryAmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange) (bool, error) {
 	memAmended := false
-	addMutations, _, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, c.mutations)
+	addMutations, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, c.mutations)
 	if err != nil {
 		return false, err
 	}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -973,7 +973,6 @@ type RelatedSchemaChange struct {
 }
 
 func (c *twoPhaseCommitter) tryAmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange) (bool, error) {
-	memAmended := false
 	addMutations, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, c.mutations)
 	if err != nil {
 		return false, err
@@ -987,9 +986,9 @@ func (c *twoPhaseCommitter) tryAmendTxn(ctx context.Context, startInfoSchema Sch
 			return false, err
 		}
 		logutil.Logger(ctx).Info("amend prewrite finished", zap.Uint64("txnStartTS", c.startTS))
-		memAmended = true
+		return true, nil
 	}
-	return memAmended, nil
+	return false, nil
 }
 
 func (c *twoPhaseCommitter) getCommitTS(ctx context.Context, commitDetail *execdetails.CommitDetails) (uint64, error) {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -835,7 +835,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		logutil.SetTag(ctx, "commitTs", commitTS)
 	}
 
-	tryAmend := c.isPessimistic && c.connID > 0
+	tryAmend := c.isPessimistic && c.connID > 0 && !c.isAsyncCommit()
 	if !tryAmend {
 		_, _, err = c.checkSchemaValid(ctx, commitTS, c.txn.txnInfoSchema, false)
 		if err != nil {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -232,7 +232,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	}
 	committer.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 	c.Assert(err, IsNil)
-	err = committer.commitMutations(NewBackofferWithVars(ctx, CommitMaxBackoff, nil), committerMutations{keys: [][]byte{[]byte("a")}})
+	err = committer.commitMutations(NewBackofferWithVars(ctx, CommitMaxBackoff, nil), CommitterMutations{keys: [][]byte{[]byte("a")}})
 	c.Assert(err, IsNil)
 
 	txn3 := s.begin(c)
@@ -932,7 +932,7 @@ func (s *testCommitterSuite) TestPkNotFound(c *C) {
 	// while the secondary lock operation succeeded
 	bo := NewBackofferWithVars(context.Background(), pessimisticLockMaxBackoff, nil)
 	txn1.committer.ttlManager.close()
-	err = txn1.committer.pessimisticRollbackMutations(bo, committerMutations{keys: [][]byte{k1}})
+	err = txn1.committer.pessimisticRollbackMutations(bo, CommitterMutations{keys: [][]byte{k1}})
 	c.Assert(err, IsNil)
 
 	// Txn2 tries to lock the secondary key k2, dead loop if the left secondary lock by txn1 not resolved
@@ -1005,12 +1005,12 @@ func (s *testCommitterSuite) TestPessimisticLockPrimary(c *C) {
 	c.Assert(ErrLockWaitTimeout.Equal(waitErr), IsTrue)
 }
 
-func (c *twoPhaseCommitter) mutationsOfKeys(keys [][]byte) committerMutations {
-	var res committerMutations
+func (c *twoPhaseCommitter) mutationsOfKeys(keys [][]byte) CommitterMutations {
+	var res CommitterMutations
 	for i := range c.mutations.keys {
 		for _, key := range keys {
 			if bytes.Equal(c.mutations.keys[i], key) {
-				res.push(c.mutations.ops[i], c.mutations.keys[i], c.mutations.values[i], c.mutations.isPessimisticLock[i])
+				res.Push(c.mutations.ops[i], c.mutations.keys[i], c.mutations.values[i], c.mutations.isPessimisticLock[i])
 				break
 			}
 		}
@@ -1156,7 +1156,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 	// stop txn ttl manager and remove primary key, make the other keys left behind
 	bo := NewBackofferWithVars(context.Background(), pessimisticLockMaxBackoff, nil)
 	txn1.committer.ttlManager.close()
-	err = txn1.committer.pessimisticRollbackMutations(bo, committerMutations{keys: [][]byte{pk}})
+	err = txn1.committer.pessimisticRollbackMutations(bo, CommitterMutations{keys: [][]byte{pk}})
 	c.Assert(err, IsNil)
 
 	// try to resolve the left optimistic locks, use clean whole region

--- a/store/tikv/cleanup.go
+++ b/store/tikv/cleanup.go
@@ -67,6 +67,6 @@ func (actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batc
 	return nil
 }
 
-func (c *twoPhaseCommitter) cleanupMutations(bo *Backoffer, mutations committerMutations) error {
+func (c *twoPhaseCommitter) cleanupMutations(bo *Backoffer, mutations CommitterMutations) error {
 	return c.doActionOnMutations(bo, actionCleanup{}, mutations)
 }

--- a/store/tikv/commit.go
+++ b/store/tikv/commit.go
@@ -141,7 +141,7 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 	return nil
 }
 
-func (c *twoPhaseCommitter) commitMutations(bo *Backoffer, mutations committerMutations) error {
+func (c *twoPhaseCommitter) commitMutations(bo *Backoffer, mutations CommitterMutations) error {
 	if span := opentracing.SpanFromContext(bo.ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.commitMutations", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -208,10 +208,10 @@ func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Bac
 	return nil
 }
 
-func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *kv.LockCtx, mutations committerMutations) error {
+func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *kv.LockCtx, mutations CommitterMutations) error {
 	return c.doActionOnMutations(bo, actionPessimisticLock{lockCtx}, mutations)
 }
 
-func (c *twoPhaseCommitter) pessimisticRollbackMutations(bo *Backoffer, mutations committerMutations) error {
+func (c *twoPhaseCommitter) pessimisticRollbackMutations(bo *Backoffer, mutations CommitterMutations) error {
 	return c.doActionOnMutations(bo, actionPessimisticRollback{}, mutations)
 }

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -183,7 +183,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 	}
 }
 
-func (c *twoPhaseCommitter) prewriteMutations(bo *Backoffer, mutations committerMutations) error {
+func (c *twoPhaseCommitter) prewriteMutations(bo *Backoffer, mutations CommitterMutations) error {
 	if span := opentracing.SpanFromContext(bo.ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.prewriteMutations", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -665,11 +665,11 @@ func (c *RegionCache) GroupKeysByRegion(bo *Backoffer, keys [][]byte, filter fun
 
 type groupedMutations struct {
 	region    RegionVerID
-	mutations committerMutations
+	mutations CommitterMutations
 }
 
 // GroupSortedMutationsByRegion separates keys into groups by their belonging Regions.
-func (c *RegionCache) GroupSortedMutationsByRegion(bo *Backoffer, m committerMutations) ([]groupedMutations, error) {
+func (c *RegionCache) GroupSortedMutationsByRegion(bo *Backoffer, m CommitterMutations) ([]groupedMutations, error) {
 	var (
 		groups  []groupedMutations
 		lastLoc *KeyLocation

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -50,7 +50,7 @@ var (
 type SchemaAmender interface {
 	// AmendTxn is the amend entry, new mutations will be generated based on input mutations using schema change info.
 	// The returned results are mutations need to prewrite and mutations need to cleanup.
-	AmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange, mutations CommitterMutations) (*CommitterMutations, *CommitterMutations, error)
+	AmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange, mutations CommitterMutations) (*CommitterMutations, error)
 }
 
 // tikvTxn implements kv.Transaction.

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -46,6 +46,13 @@ var (
 	tikvTxnCmdHistogramWithGet      = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblGet)
 )
 
+// SchemaAmender is used by pessimistic transactions to amend commit mutations for schema change during 2pc.
+type SchemaAmender interface {
+	// AmendTxn is the amend entry, new mutations will be generated based on input mutations using schema change info.
+	// The returned results are mutations need to prewrite and mutations need to cleanup.
+	AmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange, mutations CommitterMutations) (*CommitterMutations, *CommitterMutations, error)
+}
+
 // tikvTxn implements kv.Transaction.
 type tikvTxn struct {
 	snapshot  *tikvSnapshot
@@ -73,6 +80,8 @@ type tikvTxn struct {
 
 	// txnInfoSchema is the infoSchema fetched at startTS.
 	txnInfoSchema SchemaVer
+	// SchemaAmender is used amend pessimistic txn commit mutations for schema change
+	schemaAmender SchemaAmender
 }
 
 func newTiKVTxn(store *tikvStore) (*tikvTxn, error) {
@@ -185,6 +194,8 @@ func (txn *tikvTxn) SetOption(opt kv.Option, val interface{}) {
 		txn.snapshot.setSnapshotTS(val.(uint64))
 	case kv.InfoSchema:
 		txn.txnInfoSchema = val.(SchemaVer)
+	case kv.SchemaAmender:
+		txn.schemaAmender = val.(SchemaAmender)
 	}
 }
 
@@ -314,7 +325,7 @@ func (txn *tikvTxn) rollbackPessimisticLocks() error {
 	if len(txn.lockKeys) == 0 {
 		return nil
 	}
-	return txn.committer.pessimisticRollbackMutations(NewBackofferWithVars(context.Background(), cleanupMaxBackoff, txn.vars), committerMutations{keys: txn.lockKeys})
+	return txn.committer.pessimisticRollbackMutations(NewBackofferWithVars(context.Background(), cleanupMaxBackoff, txn.vars), CommitterMutations{keys: txn.lockKeys})
 }
 
 // lockWaitTime in ms, except that kv.LockAlwaysWait(0) means always wait lock, kv.LockNowait(-1) means nowait lock
@@ -376,7 +387,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 		// If the number of keys greater than 1, it can be on different region,
 		// concurrently execute on multiple regions may lead to deadlock.
 		txn.committer.isFirstLock = len(txn.lockKeys) == 0 && len(keys) == 1
-		err = txn.committer.pessimisticLockMutations(bo, lockCtx, committerMutations{keys: keys})
+		err = txn.committer.pessimisticLockMutations(bo, lockCtx, CommitterMutations{keys: keys})
 		if lockCtx.Killed != nil {
 			// If the kill signal is received during waiting for pessimisticLock,
 			// pessimisticLockKeys would handle the error but it doesn't reset the flag.
@@ -451,7 +462,7 @@ func (txn *tikvTxn) asyncPessimisticRollback(ctx context.Context, keys [][]byte)
 		failpoint.Inject("AsyncRollBackSleep", func() {
 			time.Sleep(100 * time.Millisecond)
 		})
-		err := committer.pessimisticRollbackMutations(NewBackofferWithVars(ctx, pessimisticRollbackMaxBackoff, txn.vars), committerMutations{keys: keys})
+		err := committer.pessimisticRollbackMutations(NewBackofferWithVars(ctx, pessimisticRollbackMaxBackoff, txn.vars), CommitterMutations{keys: keys})
 		if err != nil {
 			logutil.Logger(ctx).Warn("[kv] pessimisticRollback failed.", zap.Error(err))
 		}

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -87,14 +87,20 @@ type index struct {
 	phyTblID               int64
 }
 
-func (c *index) checkContainNonBinaryString() bool {
-	for _, idxCol := range c.idxInfo.Columns {
-		col := c.tblInfo.Columns[idxCol.Offset]
+// ContainsNonBinaryString checks whether the index columns contains non binary string column, the input
+// colInfos should be column info correspond to the table contains the index.
+func ContainsNonBinaryString(idxCols []*model.IndexColumn, colInfos []*model.ColumnInfo) bool {
+	for _, idxCol := range idxCols {
+		col := colInfos[idxCol.Offset]
 		if col.EvalType() == types.ETString && !mysql.HasBinaryFlag(col.Flag) {
 			return true
 		}
 	}
 	return false
+}
+
+func (c *index) checkContainNonBinaryString() bool {
+	return ContainsNonBinaryString(c.idxInfo.Columns, c.tblInfo.Columns)
 }
 
 // NewIndex builds a new Index object.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

project: #18098 
Issue Number: #18354 

Problem Summary:

### What is changed and how it works?

What's Changed:
Support pessimistic transaction amend for `add/drop column` and `add index` DDL types.

How it Works:
1. Change the pessimistic transaction commit process into this.
```
prewrite
get commitTS1
...  // Only for pessimistic transaction commit
    schemaChange <- CheckBySchemaVer(commitTS1,  infoSchemaAtStart)
    amend(schemaChange , infoSchemaAtStart, change.infoSchemaLatest)
    get commitTS2
    change2 <- CheckBySchemaVer(commitTS2, schemaChange .infoSchemaLatest)
    if check fail 
         retry or return error
    commitTS <- commitTS2
...
commit txn
```

2. Introduce `schemaAmender` to generate new mutations based on schema change information, `add index` is considered now. If the transaction is successfully amended, it will commit directly but not return `error info schema has changed`. The amender work process is like this
```
1. Collect `amendOps` by comparing infoSchema with two versions for each related table, `add index` is considered by now.
2. Generate new keys based on amend operations and input transaction mutations, return them to the twoPhaseCommiter.
3. Do prewrite for these new keys, this is the last step in the amend process.
```

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
