### PR TITLE
Planner: chose the indexScan when the limit count cannot reach

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1227,9 +1227,15 @@ func (ds *DataSource) crossEstimateRowCount(path *util.AccessPath, expectedCnt f
 	if err != nil {
 		return 0, false, corr
 	}
-	scanCount := rangeCount + expectedCnt - count
-	if len(remained) > 0 {
-		scanCount = scanCount / SelectionFactor
+	var scanCount float64
+	// if cannot reach the expectedCnt, it should fully scan the full table
+	if rangeCount < expectedCnt {
+		scanCount = path.CountAfterAccess
+	} else {
+		scanCount = rangeCount + expectedCnt - count
+		if len(remained) > 0 {
+			scanCount = scanCount / SelectionFactor
+		}
 	}
 	scanCount = math.Min(scanCount, path.CountAfterAccess)
 	return scanCount, true, 0


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18460 <!-- REMOVE this line if no issue to close -->

Problem Summary: correct the row count estimation 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test TODO
- Integration test
- Manual test (add detailed scripts or steps below)
- No code


### Release note <!-- bugfixes or new feature need a release note -->
- chose the indexScan when the limite count cannot reach

