### PR TITLE
executor, planner: support split table regions on clustered index

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1411,7 +1411,7 @@ func loadDDLReorgVars(w *worker) error {
 // For a partitioned table, it should be handled partition by partition.
 //
 // How to add index in reorganization state?
-// Concurrently process the defaultTaskHandleCnt tasks. Each task deals with a handle range of the index record.
+// Concurrently process the @@tidb_ddl_reorg_worker_cnt tasks. Each task deals with a handle range of the index record.
 // The handle range is split from PD regions now. Each worker deal with a region table key range one time.
 // Each handle range by estimation, concurrent processing needs to perform after the handle range has been acquired.
 // The operation flow is as follows:

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1645,7 +1645,7 @@ func buildHandleCols(sc *stmtctx.StatementContext, tbInfo *model.TableInfo) plan
 	intCol := &expression.Column{
 		RetType: types.NewFieldType(mysql.TypeLonglong),
 	}
-	return plannercore.NewIntHandleCol(intCol)
+	return plannercore.NewIntHandleCols(intCol)
 }
 
 func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) Executor {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -41,6 +41,7 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	plannerutil "github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -1626,6 +1627,27 @@ func (b *executorBuilder) buildUnionAll(v *plannercore.PhysicalUnionAll) Executo
 	return e
 }
 
+func buildHandleCols(sc *stmtctx.StatementContext, tbInfo *model.TableInfo) plannercore.HandleCols {
+	if tbInfo.IsCommonHandle {
+		primaryIdx := tables.FindPrimaryIndex(tbInfo)
+		tableCols := make([]*expression.Column, len(tbInfo.Columns))
+		for i, col := range tbInfo.Columns {
+			tableCols[i] = &expression.Column{
+				ID:      col.ID,
+				RetType: &col.FieldType,
+			}
+		}
+		for i, pkCol := range primaryIdx.Columns {
+			tableCols[pkCol.Offset].Index = i
+		}
+		return plannercore.NewCommonHandleCols(sc, tbInfo, primaryIdx, tableCols)
+	}
+	intCol := &expression.Column{
+		RetType: types.NewFieldType(mysql.TypeLonglong),
+	}
+	return plannercore.NewIntHandleCol(intCol)
+}
+
 func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) Executor {
 	base := newBaseExecutor(b.ctx, v.Schema(), v.ExplainID())
 	base.initCap = 1
@@ -1642,11 +1664,13 @@ func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) Executor 
 			valueLists:     v.ValueLists,
 		}
 	}
+	handleCols := buildHandleCols(b.ctx.GetSessionVars().StmtCtx, v.TableInfo)
 	if len(v.ValueLists) > 0 {
 		return &SplitTableRegionExec{
 			baseExecutor:   base,
 			tableInfo:      v.TableInfo,
 			partitionNames: v.PartitionNames,
+			handleCols:     handleCols,
 			valueLists:     v.ValueLists,
 		}
 	}
@@ -1654,8 +1678,9 @@ func (b *executorBuilder) buildSplitRegion(v *plannercore.SplitRegion) Executor 
 		baseExecutor:   base,
 		tableInfo:      v.TableInfo,
 		partitionNames: v.PartitionNames,
-		lower:          v.Lower[0],
-		upper:          v.Upper[0],
+		handleCols:     handleCols,
+		lower:          v.Lower,
+		upper:          v.Upper,
 		num:            v.Num,
 	}
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4269,6 +4269,49 @@ func (s *testSuiteP2) TestSplitRegion(c *C) {
 	tk.MustQuery("split region for partition table t partition (p3,p4) between (100000000) and (1000000000) regions 5;").Check(testkit.Rows("8 1"))
 }
 
+func (s *testSplitTable) TestClusterIndexSplitTableIntegration(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop database if exists test_cluster_index_index_split_table_integration;")
+	tk.MustExec("create database test_cluster_index_index_split_table_integration;")
+	tk.MustExec("use test_cluster_index_index_split_table_integration;")
+	tk.MustExec("set @@tidb_enable_clustered_index=1;")
+
+	tk.MustExec("create table t (a varchar(255), b double, c int, primary key (a, b));")
+
+	// Value list length not match.
+	lowerMsg := "Split table region lower value count should be 2"
+	upperMsg := "Split table region upper value count should be 2"
+	tk.MustGetErrMsg("split table t between ('aaa') and ('aaa', 100.0) regions 10;", lowerMsg)
+	tk.MustGetErrMsg("split table t between ('aaa', 1.0) and ('aaa', 100.0, 11) regions 10;", upperMsg)
+
+	// Value type not match.
+	errMsg := "[types:1265]Incorrect value: 'aaa' for column 'b'"
+	tk.MustGetErrMsg("split table t between ('aaa', 0.0) and (100.0, 'aaa') regions 10;", errMsg)
+
+	// lower bound >= upper bound.
+	errMsg = "Split table `t` region lower value (aaa,0) should less than the upper value (aaa,0)"
+	tk.MustGetErrMsg("split table t between ('aaa', 0.0) and ('aaa', 0.0) regions 10;", errMsg)
+	errMsg = "Split table `t` region lower value (bbb,0) should less than the upper value (aaa,0)"
+	tk.MustGetErrMsg("split table t between ('bbb', 0.0) and ('aaa', 0.0) regions 10;", errMsg)
+
+	// Exceed limit 1000.
+	errMsg = "Split table region num exceeded the limit 1000"
+	tk.MustGetErrMsg("split table t between ('aaa', 0.0) and ('aaa', 0.1) regions 100000;", errMsg)
+
+	// Success.
+	tk.MustExec("split table t between ('aaa', 0.0) and ('aaa', 100.0) regions 10;")
+	tk.MustExec("split table t by ('aaa', 0.0), ('aaa', 20.0), ('aaa', 100.0);")
+	tk.MustExec("split table t by ('aaa', 100.0), ('qqq', 20.0), ('zzz', 100.0), ('zzz', 1000.0);")
+
+	tk.MustExec("drop table t;")
+	tk.MustExec("create table t (a int, b int, c int, d int, primary key(a, c, d));")
+	tk.MustQuery("split table t between (0, 0, 0) and (0, 0, 1) regions 1000;").Check(testkit.Rows("999 1"))
+
+	tk.MustExec("drop table t;")
+	tk.MustExec("create table t (a int, b int, c int, d int, primary key(d, a, c));")
+	tk.MustQuery("split table t by (0, 0, 0), (1, 2, 3), (65535, 65535, 65535);").Check(testkit.Rows("3 1"))
+}
+
 func (s *testSplitTable) TestShowTableRegion(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/executor/split.go
+++ b/executor/split.go
@@ -27,6 +27,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/store/tikv"
@@ -49,6 +50,7 @@ type SplitIndexRegionExec struct {
 	lower          []types.Datum
 	upper          []types.Datum
 	num            int
+	handleCols     core.HandleCols
 	valueLists     [][]types.Datum
 	splitIdxKeys   [][]byte
 
@@ -173,7 +175,7 @@ func (e *SplitIndexRegionExec) getSplitIdxPhysicalKeysFromValueList(physicalID i
 
 func (e *SplitIndexRegionExec) getSplitIdxPhysicalStartAndOtherIdxKeys(physicalID int64, keys [][]byte) [][]byte {
 	// 1. Split in the start key for the index if the index is not the first index.
-	// For the first index, split the start key is useless.
+	// For the first index, splitting the start key can produce the region [tid, tid_i_1), which is useless.
 	if len(e.tableInfo.Indices) > 0 && e.tableInfo.Indices[0].ID != e.indexInfo.ID {
 		startKey := tablecodec.EncodeTableIndexPrefix(physicalID, e.indexInfo.ID)
 		keys = append(keys, startKey)
@@ -249,7 +251,7 @@ func (e *SplitIndexRegionExec) getSplitIdxPhysicalKeysFromBound(physicalID int64
 // To Simplify the explain, suppose lower and upper value type is int64, and lower=0, upper=100, num=10,
 // then calculate the step=(upper-lower)/num=10, then the function should return 0+10, 10+10, 20+10... all together 9 (num-1) values.
 // Then the function will return [10,20,30,40,50,60,70,80,90].
-// The difference is the value type of upper,lower is []byte, So I use getUint64FromBytes to convert []byte to uint64.
+// The difference is the value type of upper, lower is []byte, So I use getUint64FromBytes to convert []byte to uint64.
 func getValuesList(lower, upper []byte, num int, valuesList [][]byte) [][]byte {
 	commonPrefixIdx := longestCommonPrefixLen(lower, upper)
 	step := getStepValue(lower[commonPrefixIdx:], upper[commonPrefixIdx:], num)
@@ -323,9 +325,10 @@ type SplitTableRegionExec struct {
 
 	tableInfo      *model.TableInfo
 	partitionNames []model.CIStr
-	lower          types.Datum
-	upper          types.Datum
+	lower          []types.Datum
+	upper          []types.Datum
 	num            int
+	handleCols     core.HandleCols
 	valueLists     [][]types.Datum
 	splitKeys      [][]byte
 
@@ -452,14 +455,18 @@ func (e *SplitTableRegionExec) getSplitTableKeysFromValueList() ([][]byte, error
 	pi := e.tableInfo.GetPartitionInfo()
 	if pi == nil {
 		keys = make([][]byte, 0, len(e.valueLists))
-		return e.getSplitTablePhysicalKeysFromValueList(e.tableInfo.ID, keys), nil
+		return e.getSplitTablePhysicalKeysFromValueList(e.tableInfo.ID, keys)
 	}
 
 	// Split for all table partitions.
 	if len(e.partitionNames) == 0 {
 		keys = make([][]byte, 0, len(e.valueLists)*len(pi.Definitions))
 		for _, p := range pi.Definitions {
-			keys = e.getSplitTablePhysicalKeysFromValueList(p.ID, keys)
+			var err error
+			keys, err = e.getSplitTablePhysicalKeysFromValueList(p.ID, keys)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return keys, nil
 	}
@@ -471,37 +478,44 @@ func (e *SplitTableRegionExec) getSplitTableKeysFromValueList() ([][]byte, error
 		if err != nil {
 			return nil, err
 		}
-		keys = e.getSplitTablePhysicalKeysFromValueList(pid, keys)
+		keys, err = e.getSplitTablePhysicalKeysFromValueList(pid, keys)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return keys, nil
 }
 
-func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromValueList(physicalID int64, keys [][]byte) [][]byte {
+func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromValueList(physicalID int64, keys [][]byte) ([][]byte, error) {
 	recordPrefix := tablecodec.GenTableRecordPrefix(physicalID)
 	for _, v := range e.valueLists {
-		key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(v[0].GetInt64()))
+		handle, err := e.handleCols.BuildHandleByDatums(v)
+		if err != nil {
+			return nil, err
+		}
+		key := tablecodec.EncodeRecordKey(recordPrefix, handle)
 		keys = append(keys, key)
 	}
-	return keys
+	return keys, nil
 }
 
 func (e *SplitTableRegionExec) getSplitTableKeysFromBound() ([][]byte, error) {
-	low, step, err := e.calculateBoundValue()
-	if err != nil {
-		return nil, err
-	}
 	var keys [][]byte
 	pi := e.tableInfo.GetPartitionInfo()
 	if pi == nil {
 		keys = make([][]byte, 0, e.num)
-		return e.getSplitTablePhysicalKeysFromBound(e.tableInfo.ID, low, step, keys), nil
+		return e.getSplitTablePhysicalKeysFromBound(e.tableInfo.ID, keys)
 	}
 
 	// Split for all table partitions.
 	if len(e.partitionNames) == 0 {
 		keys = make([][]byte, 0, e.num*len(pi.Definitions))
 		for _, p := range pi.Definitions {
-			keys = e.getSplitTablePhysicalKeysFromBound(p.ID, low, step, keys)
+			var err error
+			keys, err = e.getSplitTablePhysicalKeysFromBound(p.ID, keys)
+			if err != nil {
+				return nil, err
+			}
 		}
 		return keys, nil
 	}
@@ -513,12 +527,15 @@ func (e *SplitTableRegionExec) getSplitTableKeysFromBound() ([][]byte, error) {
 		if err != nil {
 			return nil, err
 		}
-		keys = e.getSplitTablePhysicalKeysFromBound(pid, low, step, keys)
+		keys, err = e.getSplitTablePhysicalKeysFromBound(pid, keys)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return keys, nil
 }
 
-func (e *SplitTableRegionExec) calculateBoundValue() (lowerValue int64, step int64, err error) {
+func (e *SplitTableRegionExec) calculateIntBoundValue() (lowerValue int64, step int64, err error) {
 	isUnsigned := false
 	if e.tableInfo.PKIsHandle {
 		if pkCol := e.tableInfo.GetPkColInfo(); pkCol != nil {
@@ -526,16 +543,16 @@ func (e *SplitTableRegionExec) calculateBoundValue() (lowerValue int64, step int
 		}
 	}
 	if isUnsigned {
-		lowerRecordID := e.lower.GetUint64()
-		upperRecordID := e.upper.GetUint64()
+		lowerRecordID := e.lower[0].GetUint64()
+		upperRecordID := e.upper[0].GetUint64()
 		if upperRecordID <= lowerRecordID {
 			return 0, 0, errors.Errorf("Split table `%s` region lower value %v should less than the upper value %v", e.tableInfo.Name, lowerRecordID, upperRecordID)
 		}
 		step = int64((upperRecordID - lowerRecordID) / uint64(e.num))
 		lowerValue = int64(lowerRecordID)
 	} else {
-		lowerRecordID := e.lower.GetInt64()
-		upperRecordID := e.upper.GetInt64()
+		lowerRecordID := e.lower[0].GetInt64()
+		upperRecordID := e.upper[0].GetInt64()
 		if upperRecordID <= lowerRecordID {
 			return 0, 0, errors.Errorf("Split table `%s` region lower value %v should less than the upper value %v", e.tableInfo.Name, lowerRecordID, upperRecordID)
 		}
@@ -548,19 +565,49 @@ func (e *SplitTableRegionExec) calculateBoundValue() (lowerValue int64, step int
 	return lowerValue, step, nil
 }
 
-func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromBound(physicalID, low, step int64, keys [][]byte) [][]byte {
+func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromBound(physicalID int64, keys [][]byte) ([][]byte, error) {
 	recordPrefix := tablecodec.GenTableRecordPrefix(physicalID)
 	// Split a separate region for index.
-	if len(e.tableInfo.Indices) > 0 {
+
+	containsIndex := len(e.tableInfo.Indices) > 0 && !(e.tableInfo.IsCommonHandle && len(e.tableInfo.Indices) == 1)
+	if containsIndex {
 		keys = append(keys, recordPrefix)
 	}
-	recordID := low
-	for i := 1; i < e.num; i++ {
-		recordID += step
-		key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(recordID))
-		keys = append(keys, key)
+
+	if e.handleCols.IsInt() {
+		low, step, err := e.calculateIntBoundValue()
+		if err != nil {
+			return nil, err
+		}
+		recordID := low
+		for i := 1; i < e.num; i++ {
+			recordID += step
+			key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(recordID))
+			keys = append(keys, key)
+		}
+		return keys, nil
 	}
-	return keys
+	lowerHandle, err := e.handleCols.BuildHandleByDatums(e.lower)
+	if err != nil {
+		return nil, err
+	}
+	upperHandle, err := e.handleCols.BuildHandleByDatums(e.upper)
+	if err != nil {
+		return nil, err
+	}
+	if lowerHandle.Compare(upperHandle) >= 0 {
+		lowerStr, err1 := datumSliceToString(e.lower)
+		upperStr, err2 := datumSliceToString(e.upper)
+		if err1 != nil || err2 != nil {
+			return nil, errors.Errorf("Split table `%v` region lower value %v should less than the upper value %v",
+				e.tableInfo.Name.O, e.lower, e.upper)
+		}
+		return nil, errors.Errorf("Split table `%v` region lower value %v should less than the upper value %v",
+			e.tableInfo.Name.O, lowerStr, upperStr)
+	}
+	low := tablecodec.EncodeRecordKey(recordPrefix, lowerHandle)
+	up := tablecodec.EncodeRecordKey(recordPrefix, upperHandle)
+	return getValuesList(low, up, e.num, keys), nil
 }
 
 // RegionMeta contains a region's peer detail

--- a/executor/split.go
+++ b/executor/split.go
@@ -568,7 +568,6 @@ func (e *SplitTableRegionExec) calculateIntBoundValue() (lowerValue int64, step 
 func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromBound(physicalID int64, keys [][]byte) ([][]byte, error) {
 	recordPrefix := tablecodec.GenTableRecordPrefix(physicalID)
 	// Split a separate region for index.
-
 	containsIndex := len(e.tableInfo.Indices) > 0 && !(e.tableInfo.IsCommonHandle && len(e.tableInfo.Indices) == 1)
 	if containsIndex {
 		keys = append(keys, recordPrefix)

--- a/executor/split_test.go
+++ b/executor/split_test.go
@@ -19,11 +19,15 @@ import (
 	"math"
 	"math/rand"
 	"sort"
+	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -321,8 +325,9 @@ func (s *testSplitIndex) TestSplitTable(c *C) {
 	e := &SplitTableRegionExec{
 		baseExecutor: newBaseExecutor(ctx, nil, nil),
 		tableInfo:    tbInfo,
-		lower:        types.NewDatum(0),
-		upper:        types.NewDatum(100),
+		handleCols:   core.NewIntHandleCol(&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong)}),
+		lower:        []types.Datum{types.NewDatum(0)},
+		upper:        []types.Datum{types.NewDatum(100)},
 		num:          10,
 	}
 	valueList, err := e.getSplitTableKeys()
@@ -355,6 +360,99 @@ func (s *testSplitIndex) TestSplitTable(c *C) {
 	for _, ca := range cases {
 		// test for minInt64 handle
 		key := tablecodec.EncodeRecordKey(recordPrefix, kv.IntHandle(ca.value))
+		c.Assert(err, IsNil)
+		idx := searchLessEqualIdx(valueList, key)
+		c.Assert(idx, Equals, ca.lessEqualIdx, Commentf("%#v", ca))
+	}
+}
+
+func (s *testSplitIndex) TestClusterIndexSplitTable(c *C) {
+	tbInfo := &model.TableInfo{
+		Name:           model.NewCIStr("t"),
+		ID:             1,
+		IsCommonHandle: true,
+		Indices: []*model.IndexInfo{
+			{
+				ID:      1,
+				Primary: true,
+				State:   model.StatePublic,
+				Columns: []*model.IndexColumn{
+					{Offset: 1},
+					{Offset: 2},
+				},
+			},
+		},
+		Columns: []*model.ColumnInfo{
+			{
+				Name:      model.NewCIStr("c0"),
+				ID:        1,
+				Offset:    0,
+				State:     model.StatePublic,
+				FieldType: *types.NewFieldType(mysql.TypeDouble),
+			},
+			{
+				Name:      model.NewCIStr("c1"),
+				ID:        2,
+				Offset:    1,
+				State:     model.StatePublic,
+				FieldType: *types.NewFieldType(mysql.TypeLonglong),
+			},
+			{
+				Name:      model.NewCIStr("c2"),
+				ID:        3,
+				Offset:    2,
+				State:     model.StatePublic,
+				FieldType: *types.NewFieldType(mysql.TypeLonglong),
+			},
+		},
+	}
+	defer func(originValue int64) {
+		minRegionStepValue = originValue
+	}(minRegionStepValue)
+	minRegionStepValue = 3
+	ctx := mock.NewContext()
+	sc := &stmtctx.StatementContext{TimeZone: time.Local}
+	e := &SplitTableRegionExec{
+		baseExecutor: newBaseExecutor(ctx, nil, nil),
+		tableInfo:    tbInfo,
+		handleCols:   buildHandleCols(sc, tbInfo),
+		lower:        types.MakeDatums(1, 0),
+		upper:        types.MakeDatums(1, 100),
+		num:          10,
+	}
+	valueList, err := e.getSplitTableKeys()
+	c.Assert(err, IsNil)
+	c.Assert(len(valueList), Equals, e.num-1)
+
+	cases := []struct {
+		value        []types.Datum
+		lessEqualIdx int
+	}{
+		// For lower-bound and upper-bound, because 0 and 100 are padding with 7 zeros,
+		// the split points are not (i * 10) but approximation.
+		{types.MakeDatums(1, -1), -1},
+		{types.MakeDatums(1, 0), -1},
+		{types.MakeDatums(1, 10), -1},
+		{types.MakeDatums(1, 11), 0},
+		{types.MakeDatums(1, 20), 0},
+		{types.MakeDatums(1, 21), 1},
+
+		{types.MakeDatums(1, 31), 2},
+		{types.MakeDatums(1, 41), 3},
+		{types.MakeDatums(1, 51), 4},
+		{types.MakeDatums(1, 61), 5},
+		{types.MakeDatums(1, 71), 6},
+		{types.MakeDatums(1, 81), 7},
+		{types.MakeDatums(1, 91), 8},
+		{types.MakeDatums(1, 100), 8},
+		{types.MakeDatums(1, 101), 8},
+	}
+
+	recordPrefix := tablecodec.GenTableRecordPrefix(e.tableInfo.ID)
+	for _, ca := range cases {
+		h, err := e.handleCols.BuildHandleByDatums(ca.value)
+		c.Assert(err, IsNil)
+		key := tablecodec.EncodeRecordKey(recordPrefix, h)
 		c.Assert(err, IsNil)
 		idx := searchLessEqualIdx(valueList, key)
 		c.Assert(idx, Equals, ca.lessEqualIdx, Commentf("%#v", ca))

--- a/executor/split_test.go
+++ b/executor/split_test.go
@@ -325,7 +325,7 @@ func (s *testSplitIndex) TestSplitTable(c *C) {
 	e := &SplitTableRegionExec{
 		baseExecutor: newBaseExecutor(ctx, nil, nil),
 		tableInfo:    tbInfo,
-		handleCols:   core.NewIntHandleCol(&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong)}),
+		handleCols:   core.NewIntHandleCols(&expression.Column{RetType: types.NewFieldType(mysql.TypeLonglong)}),
 		lower:        []types.Datum{types.NewDatum(0)},
 		upper:        []types.Datum{types.NewDatum(100)},
 		num:          10,

--- a/planner/core/handle_cols.go
+++ b/planner/core/handle_cols.go
@@ -219,3 +219,7 @@ func (ib *IntHandleCols) Compare(a, b []types.Datum) (int, error) {
 	}
 	return 1, nil
 }
+
+func NewIntHandleCol(col *expression.Column) HandleCols {
+	return &IntHandleCols{col: col}
+}

--- a/planner/core/handle_cols.go
+++ b/planner/core/handle_cols.go
@@ -220,6 +220,7 @@ func (ib *IntHandleCols) Compare(a, b []types.Datum) (int, error) {
 	return 1, nil
 }
 
-func NewIntHandleCol(col *expression.Column) HandleCols {
+// NewIntHandleCols creates a new IntHandleCols.
+func NewIntHandleCols(col *expression.Column) HandleCols {
 	return &IntHandleCols{col: col}
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2649,19 +2649,14 @@ func (b *PlanBuilder) convertValue(valueItem ast.ExprNode, mockTablePlan Logical
 
 func (b *PlanBuilder) buildSplitTableRegion(node *ast.SplitRegionStmt) (Plan, error) {
 	tblInfo := node.Table.TableInfo
-	var pkCol *model.ColumnInfo
-	if tblInfo.PKIsHandle {
-		if col := tblInfo.GetPkColInfo(); col != nil {
-			pkCol = col
-		}
-	}
-	if pkCol == nil {
-		pkCol = model.NewExtraHandleColInfo()
-	}
+	handleColInfos := buildHandleColumnInfos(tblInfo)
 	mockTablePlan := LogicalTableDual{}.Init(b.ctx, b.getSelectOffset())
 	schema, names := expression.TableInfo2SchemaAndNames(b.ctx, node.Table.Schema, tblInfo)
 	mockTablePlan.SetSchema(schema)
 	mockTablePlan.names = names
+	convertFn := func(v ast.ExprNode, c *model.ColumnInfo) (types.Datum, error) {
+		return b.convertValue(v, mockTablePlan, c)
+	}
 
 	p := &SplitRegion{
 		TableInfo:      tblInfo,
@@ -2671,35 +2666,25 @@ func (b *PlanBuilder) buildSplitTableRegion(node *ast.SplitRegionStmt) (Plan, er
 	if len(node.SplitOpt.ValueLists) > 0 {
 		values := make([][]types.Datum, 0, len(node.SplitOpt.ValueLists))
 		for i, valuesItem := range node.SplitOpt.ValueLists {
-			if len(valuesItem) > 1 {
-				return nil, ErrWrongValueCountOnRow.GenWithStackByArgs(i + 1)
-			}
-			value, err := b.convertValue(valuesItem[0], mockTablePlan, pkCol)
+			data, err := convertValueListToData(valuesItem, handleColInfos, i, convertFn)
 			if err != nil {
 				return nil, err
 			}
-			values = append(values, []types.Datum{value})
+			values = append(values, data)
 		}
 		p.ValueLists = values
 		return p, nil
 	}
 
-	checkLowerUpperValue := func(valuesItem []ast.ExprNode, name string) (types.Datum, error) {
-		if len(valuesItem) != 1 {
-			return types.Datum{}, errors.Errorf("Split table region %s value count should be 1", name)
-		}
-		return b.convertValue(valuesItem[0], mockTablePlan, pkCol)
-	}
-	lowerValues, err := checkLowerUpperValue(node.SplitOpt.Lower, "lower")
+	var err error
+	p.Lower, err = convertValueListToData(node.SplitOpt.Lower, handleColInfos, lowerBound, convertFn)
 	if err != nil {
 		return nil, err
 	}
-	upperValue, err := checkLowerUpperValue(node.SplitOpt.Upper, "upper")
+	p.Upper, err = convertValueListToData(node.SplitOpt.Upper, handleColInfos, upperBound, convertFn)
 	if err != nil {
 		return nil, err
 	}
-	p.Lower = []types.Datum{lowerValues}
-	p.Upper = []types.Datum{upperValue}
 
 	maxSplitRegionNum := int64(config.GetGlobalConfig().SplitRegionMaxNum)
 	if node.SplitOpt.Num > maxSplitRegionNum {
@@ -2709,6 +2694,56 @@ func (b *PlanBuilder) buildSplitTableRegion(node *ast.SplitRegionStmt) (Plan, er
 	}
 	p.Num = int(node.SplitOpt.Num)
 	return p, nil
+}
+
+func buildHandleColumnInfos(tblInfo *model.TableInfo) []*model.ColumnInfo {
+	switch {
+	case tblInfo.PKIsHandle:
+		if col := tblInfo.GetPkColInfo(); col != nil {
+			return []*model.ColumnInfo{col}
+		}
+	case tblInfo.IsCommonHandle:
+		pkIdx := tables.FindPrimaryIndex(tblInfo)
+		pkCols := make([]*model.ColumnInfo, 0, len(pkIdx.Columns))
+		cols := tblInfo.Columns
+		for _, idxCol := range pkIdx.Columns {
+			pkCols = append(pkCols, cols[idxCol.Offset])
+		}
+		return pkCols
+	default:
+		return []*model.ColumnInfo{model.NewExtraHandleColInfo()}
+	}
+	return nil
+}
+
+const (
+	lowerBound int = -1
+	upperBound int = -2
+)
+
+func convertValueListToData(valueList []ast.ExprNode, handleColInfos []*model.ColumnInfo, rowIdx int,
+	convertFn func(ast.ExprNode, *model.ColumnInfo) (types.Datum, error)) ([]types.Datum, error) {
+	if len(valueList) != len(handleColInfos) {
+		var err error
+		switch rowIdx {
+		case lowerBound:
+			err = errors.Errorf("Split table region lower value count should be %d", len(handleColInfos))
+		case upperBound:
+			err = errors.Errorf("Split table region upper value count should be %d", len(handleColInfos))
+		default:
+			err = ErrWrongValueCountOnRow.GenWithStackByArgs(rowIdx)
+		}
+		return nil, err
+	}
+	data := make([]types.Datum, 0, len(handleColInfos))
+	for i, v := range valueList {
+		convertedDatum, err := convertFn(v, handleColInfos[i])
+		if err != nil {
+			return nil, err
+		}
+		data = append(data, convertedDatum)
+	}
+	return data, nil
 }
 
 func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (Plan, error) {

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -163,9 +163,6 @@ func (s *tikvStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bo
 		zap.Int("new region count", len(spResp.Regions)))
 
 	if !scatter {
-		if len(spResp.Regions) == 0 {
-			return batchResp
-		}
 		return batchResp
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: 
`SPLIT TABLE` only supports specifying exactly one value as the split point:
```sql
set @@tidb_enable_clustered_index=1;
create table t (a int, b int, c varchar(255), primary key (b, c));
split table t between (0, 'aa') and (0, 'zz') regions 10;
```
```console
(1105, 'Split table region lower value count should be 1')
```

### What is changed and how it works?

What's Changed:

`split table` now can be used on the clustered index tables:

```sql
set @@tidb_enable_clustered_index=1;
create table t (a int, b int, c varchar(255), primary key (b, c));
split table t between (0, 'aa') and (0, 'zz') regions 10;
split table t by (10, 'a'), (100, 'a'), (500, 'a');
```
```console
+--------------------+----------------------+
| TOTAL_SPLIT_REGION | SCATTER_FINISH_RATIO |
+--------------------+----------------------+
| 9                  | 1.0                  |
+--------------------+----------------------+
+--------------------+----------------------+
| TOTAL_SPLIT_REGION | SCATTER_FINISH_RATIO |
+--------------------+----------------------+
| 3                  | 1.0                  |
+--------------------+----------------------+

```

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
