### PR TITLE
planner: clustered index support `primary` index hint

### DIFF
--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -96,3 +96,10 @@ func (s *testClusteredSuite) TestClusteredTopN(c *C) {
 	tk.MustExec("insert o3 values (1, 6, 9, 3), (2, 6, 9, 5), (3, 6, 9, 7)")
 	tk.MustQuery("SELECT max(o_id) max_order FROM o3 use index (idx_order)").Check(testkit.Rows("3"))
 }
+
+func (s *testClusteredSuite) TestClusteredHint(c *C) {
+	tk := s.newTK(c)
+	tk.MustExec("drop table if exists ht")
+	tk.MustExec("create table ht (a varchar(64) primary key, b int)")
+	tk.MustQuery("select * from ht use index (`PRIMARY`)")
+}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -768,7 +768,7 @@ func getPathByIndexName(paths []*util.AccessPath, idxName model.CIStr, tblInfo *
 			return path
 		}
 	}
-	if isPrimaryIndex(idxName) && tblInfo.PKIsHandle {
+	if isPrimaryIndex(idxName) && (tblInfo.PKIsHandle || tblInfo.IsCommonHandle) {
 		return tablePath
 	}
 	return nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Clustered index return error if specify `use index (PRIMARY)`

### What is changed and how it works?

Return tablePath if table is common handle table.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- no release note
