### PR TITLE
server: return the actual error when conn panic

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -669,6 +669,8 @@ func (cc *clientConn) Run(ctx context.Context) {
 				zap.String("err", fmt.Sprintf("%v", r)),
 				zap.String("stack", string(buf)),
 			)
+			err := cc.writeError(errors.New(fmt.Sprintf("%v", r)))
+			terror.Log(err)
 			metrics.PanicCounter.WithLabelValues(metrics.LabelSession).Inc()
 		}
 		if atomic.LoadInt32(&cc.status) != connStatusShutdown {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18112  <!-- REMOVE this line if no issue to close -->

Problem Summary:
TiDB does not return the actual error when recovering a goroutine.

### What is changed and how it works?

What's Changed:

How it Works:
As the title says.

### Related changes


- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
As the description in the related issue.
We'll get `ERROR 1105 (HY000): Out Of Memory Quota![conn_id=1]` after this commit.

Side effects
N/A

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- Return the actual error message when a query connection panics.