### PR TITLE
telemetry: disable telemetry by default for non-community edition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,13 @@ OVERALLS        := GO111MODULE=on overalls
 STATICCHECK     := GO111MODULE=on staticcheck
 TIDB_EDITION    ?= Community
 
+# Ensure TIDB_EDITION is set to Community or Enterprise before running build process.
+ifneq "$(TIDB_EDITION)" "Community"
+ifneq "$(TIDB_EDITION)" "Enterprise"
+  $(error Please set the correct environment variable TIDB_EDITION before running `make`)
+endif
+endif
+
 ARCH      := "`uname -s`"
 LINUX     := "Linux"
 MAC       := "Darwin"

--- a/Makefile
+++ b/Makefile
@@ -45,10 +45,10 @@ FAILPOINT_ENABLE  := $$(find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs t
 FAILPOINT_DISABLE := $$(find $$PWD/ -type d | grep -vE "(\.git|tools)" | xargs tools/bin/failpoint-ctl disable)
 
 LDFLAGS += -X "github.com/pingcap/parser/mysql.TiDBReleaseVersion=$(shell git describe --tags --dirty --always)"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitHash=$(shell git rev-parse HEAD)"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
-LDFLAGS += -X "github.com/pingcap/tidb/util/printer.TiDBEdition=$(TIDB_EDITION)"
+LDFLAGS += -X "github.com/pingcap/tidb/util/versioninfo.TiDBBuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
+LDFLAGS += -X "github.com/pingcap/tidb/util/versioninfo.TiDBGitHash=$(shell git rev-parse HEAD)"
+LDFLAGS += -X "github.com/pingcap/tidb/util/versioninfo.TiDBGitBranch=$(shell git rev-parse --abbrev-ref HEAD)"
+LDFLAGS += -X "github.com/pingcap/tidb/util/versioninfo.TiDBEdition=$(TIDB_EDITION)"
 
 TEST_LDFLAGS =  -X "github.com/pingcap/tidb/config.checkBeforeDropLDFlag=1"
 COVERAGE_SERVER_LDFLAGS =  -X "github.com/pingcap/tidb/tidb-server.isCoverageServer=1"

--- a/config/config.go
+++ b/config/config.go
@@ -961,7 +961,7 @@ func (t *OpenTracing) ToTracingConfig() *tracing.Configuration {
 }
 
 func init() {
-	initByLDFlags(versioninfo.CommunityEdition, checkBeforeDropLDFlag)
+	initByLDFlags(versioninfo.TiDBEdition, checkBeforeDropLDFlag)
 }
 
 func initByLDFlags(edition, checkBeforeDropLDFlag string) {

--- a/config/config.go
+++ b/config/config.go
@@ -961,7 +961,11 @@ func (t *OpenTracing) ToTracingConfig() *tracing.Configuration {
 }
 
 func init() {
-	if versioninfo.TiDBEdition != versioninfo.CommunityEdition {
+	initByLDFlags(versioninfo.CommunityEdition, checkBeforeDropLDFlag)
+}
+
+func initByLDFlags(edition, checkBeforeDropLDFlag string) {
+	if edition != versioninfo.CommunityEdition {
 		defaultConf.EnableTelemetry = false
 	}
 	conf := defaultConf

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/versioninfo"
 	tracing "github.com/uber/jaeger-client-go/config"
 
 	"go.uber.org/zap"
@@ -960,6 +961,9 @@ func (t *OpenTracing) ToTracingConfig() *tracing.Configuration {
 }
 
 func init() {
+	if versioninfo.TiDBEdition != versioninfo.CommunityEdition {
+		defaultConf.EnableTelemetry = false
+	}
 	conf := defaultConf
 	StoreGlobalConfig(&conf)
 	if checkBeforeDropLDFlag == "1" {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -459,7 +459,6 @@ func (s *testConfigSuite) TestParsePath(c *C) {
 }
 
 func (s *testConfigSuite) TestEncodeDefTempStorageDir(c *C) {
-
 	tests := []struct {
 		host       string
 		statusHost string
@@ -485,4 +484,37 @@ func (s *testConfigSuite) TestEncodeDefTempStorageDir(c *C) {
 		tempStorageDir := encodeDefTempStorageDir(test.host, test.statusHost, test.port, test.statusPort)
 		c.Assert(tempStorageDir, Equals, filepath.Join(dirPrefix, test.expect, "tmp-storage"))
 	}
+}
+
+func (s *testConfigSuite) TestModifyThroughLDFlags(c *C) {
+	tests := []struct {
+		Edition               string
+		CheckBeforeDropLDFlag string
+		EnableTelemetry       bool
+		CheckTableBeforeDrop  bool
+	}{
+		{"Community", "None", true, false},
+		{"Community", "1", true, true},
+		{"Enterprise", "None", false, false},
+		{"Enterprise", "1", false, true},
+	}
+
+	originalEnableTelemetry := defaultConf.EnableTelemetry
+	originalCheckTableBeforeDrop := CheckTableBeforeDrop
+	originalGlobalConfig := GetGlobalConfig()
+
+	for _, test := range tests {
+		defaultConf.EnableTelemetry = originalEnableTelemetry
+		CheckTableBeforeDrop = originalCheckTableBeforeDrop
+		initByLDFlags(test.Edition, test.CheckBeforeDropLDFlag)
+
+		conf := GetGlobalConfig()
+		c.Assert(conf.EnableTelemetry, Equals, test.EnableTelemetry)
+		c.Assert(defaultConf.EnableTelemetry, Equals, test.EnableTelemetry)
+		c.Assert(CheckTableBeforeDrop, Equals, test.CheckTableBeforeDrop)
+	}
+
+	defaultConf.EnableTelemetry = originalEnableTelemetry
+	CheckTableBeforeDrop = originalCheckTableBeforeDrop
+	StoreGlobalConfig(originalGlobalConfig)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -504,8 +504,9 @@ func (s *testConfigSuite) TestModifyThroughLDFlags(c *C) {
 	originalGlobalConfig := GetGlobalConfig()
 
 	for _, test := range tests {
-		defaultConf.EnableTelemetry = originalEnableTelemetry
-		CheckTableBeforeDrop = originalCheckTableBeforeDrop
+		defaultConf.EnableTelemetry = true
+		CheckTableBeforeDrop = false
+
 		initByLDFlags(test.Edition, test.CheckBeforeDropLDFlag)
 
 		conf := GetGlobalConfig()

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -41,7 +41,7 @@ import (
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/pdapi"
-	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tidb/util/versioninfo"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
 	"go.uber.org/zap"
@@ -613,7 +613,7 @@ func getServerInfo(id string) *ServerInfo {
 		StartTimestamp: time.Now().Unix(),
 	}
 	info.Version = mysql.ServerVersion
-	info.GitHash = printer.TiDBGitHash
+	info.GitHash = versioninfo.TiDBGitHash
 
 	failpoint.Inject("mockServerInfo", func(val failpoint.Value) {
 		if val.(bool) {

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -55,8 +55,8 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
-	"github.com/pingcap/tidb/util/printer"
 	"github.com/pingcap/tidb/util/rowcodec"
+	"github.com/pingcap/tidb/util/versioninfo"
 	log "github.com/sirupsen/logrus"
 	"go.uber.org/zap"
 )
@@ -1046,7 +1046,7 @@ func (ts *HTTPHandlerTestSuite) TestServerInfo(c *C) {
 	c.Assert(info.StatusPort, Equals, cfg.Status.StatusPort)
 	c.Assert(info.Lease, Equals, cfg.Lease)
 	c.Assert(info.Version, Equals, mysql.ServerVersion)
-	c.Assert(info.GitHash, Equals, printer.TiDBGitHash)
+	c.Assert(info.GitHash, Equals, versioninfo.TiDBGitHash)
 
 	store := ts.server.newTikvHandlerTool().Store.(kv.Storage)
 	do, err := session.GetDomain(store.(kv.Storage))
@@ -1084,7 +1084,7 @@ func (ts *HTTPHandlerTestSuite) TestAllServerInfo(c *C) {
 	c.Assert(serverInfo.StatusPort, Equals, cfg.Status.StatusPort)
 	c.Assert(serverInfo.Lease, Equals, cfg.Lease)
 	c.Assert(serverInfo.Version, Equals, mysql.ServerVersion)
-	c.Assert(serverInfo.GitHash, Equals, printer.TiDBGitHash)
+	c.Assert(serverInfo.GitHash, Equals, versioninfo.TiDBGitHash)
 	c.Assert(serverInfo.ID, Equals, ddl.GetID())
 }
 

--- a/server/http_status.go
+++ b/server/http_status.go
@@ -42,6 +42,7 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tidb/util/versioninfo"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/soheilhy/cmux"
 	"github.com/tiancaiamao/appdash/traceapp"
@@ -364,7 +365,7 @@ func (s *Server) handleStatus(w http.ResponseWriter, req *http.Request) {
 	st := status{
 		Connections: s.ConnectionCount(),
 		Version:     mysql.ServerVersion,
-		GitHash:     printer.TiDBGitHash,
+		GitHash:     versioninfo.TiDBGitHash,
 	}
 	js, err := json.Marshal(st)
 	if err != nil {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tidb/util/versioninfo"
 	"go.uber.org/zap"
 )
 
@@ -1085,7 +1085,7 @@ func (cli *testServerClient) runTestStatusAPI(c *C) {
 	err = decoder.Decode(&data)
 	c.Assert(err, IsNil)
 	c.Assert(data.Version, Equals, tmysql.ServerVersion)
-	c.Assert(data.GitHash, Equals, printer.TiDBGitHash)
+	c.Assert(data.GitHash, Equals, versioninfo.TiDBGitHash)
 }
 
 func (cli *testServerClient) runTestMultiStatements(c *C) {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/logutil"
-	"github.com/pingcap/tidb/util/printer"
+	"github.com/pingcap/tidb/util/versioninfo"
 )
 
 // ScopeFlag is for system variable whether can be changed in global/session dynamically or not.
@@ -386,7 +386,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, "binlog_format", "STATEMENT"},
 	{ScopeGlobal | ScopeSession, "optimizer_trace", "enabled=off,one_line=off"},
 	{ScopeGlobal | ScopeSession, "read_rnd_buffer_size", "262144"},
-	{ScopeNone, "version_comment", "TiDB Server (Apache License 2.0) " + printer.TiDBEdition + " Edition, MySQL 5.7 compatible"},
+	{ScopeNone, "version_comment", "TiDB Server (Apache License 2.0) " + versioninfo.TiDBEdition + " Edition, MySQL 5.7 compatible"},
 	{ScopeGlobal | ScopeSession, NetWriteTimeout, "60"},
 	{ScopeGlobal, InnodbBufferPoolLoadAbort, "0"},
 	{ScopeGlobal | ScopeSession, TxnIsolation, "REPEATABLE-READ"},

--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -24,31 +24,22 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util/israce"
 	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/versioninfo"
 	"go.uber.org/zap"
-)
-
-// Version information.
-var (
-	TiDBBuildTS   = "None"
-	TiDBGitHash   = "None"
-	TiDBGitBranch = "None"
-	TiDBEdition   = "None"
-	// TiKVMinVersion is the minimum version of TiKV that can be compatible with the current TiDB.
-	TiKVMinVersion = "v3.0.0-60965b006877ca7234adaced7890d7b029ed1306"
 )
 
 // PrintTiDBInfo prints the TiDB version information.
 func PrintTiDBInfo() {
 	logutil.BgLogger().Info("Welcome to TiDB.",
 		zap.String("Release Version", mysql.TiDBReleaseVersion),
-		zap.String("Edition", TiDBEdition),
-		zap.String("Git Commit Hash", TiDBGitHash),
-		zap.String("Git Branch", TiDBGitBranch),
-		zap.String("UTC Build Time", TiDBBuildTS),
+		zap.String("Edition", versioninfo.TiDBEdition),
+		zap.String("Git Commit Hash", versioninfo.TiDBGitHash),
+		zap.String("Git Branch", versioninfo.TiDBGitBranch),
+		zap.String("UTC Build Time", versioninfo.TiDBBuildTS),
 		zap.String("GoVersion", buildVersion),
 		zap.Bool("Race Enabled", israce.RaceEnabled),
 		zap.Bool("Check Table Before Drop", config.CheckTableBeforeDrop),
-		zap.String("TiKV Min Version", TiKVMinVersion))
+		zap.String("TiKV Min Version", versioninfo.TiKVMinVersion))
 	configJSON, err := json.Marshal(config.GetGlobalConfig())
 	if err != nil {
 		panic(err)
@@ -68,13 +59,13 @@ func GetTiDBInfo() string {
 		"TiKV Min Version: %s\n"+
 		"Check Table Before Drop: %v",
 		mysql.TiDBReleaseVersion,
-		TiDBEdition,
-		TiDBGitHash,
-		TiDBGitBranch,
-		TiDBBuildTS,
+		versioninfo.TiDBEdition,
+		versioninfo.TiDBGitHash,
+		versioninfo.TiDBGitBranch,
+		versioninfo.TiDBBuildTS,
 		buildVersion,
 		israce.RaceEnabled,
-		TiKVMinVersion,
+		versioninfo.TiKVMinVersion,
 		config.CheckTableBeforeDrop)
 }
 

--- a/util/versioninfo/versioninfo.go
+++ b/util/versioninfo/versioninfo.go
@@ -14,6 +14,7 @@
 package versioninfo
 
 const (
+	// CommunityEdition is the default edition for building.
 	CommunityEdition = "Community"
 )
 

--- a/util/versioninfo/versioninfo.go
+++ b/util/versioninfo/versioninfo.go
@@ -1,0 +1,28 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package versioninfo
+
+const (
+	CommunityEdition = "Community"
+)
+
+// Version information.
+var (
+	TiDBBuildTS   = "None"
+	TiDBGitHash   = "None"
+	TiDBGitBranch = "None"
+	TiDBEdition   = CommunityEdition
+	// TiKVMinVersion is the minimum version of TiKV that can be compatible with the current TiDB.
+	TiKVMinVersion = "v3.0.0-60965b006877ca7234adaced7890d7b029ed1306"
+)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: Disable telemetry by default for non-community edition

### What is changed and how it works?

What's Changed:

* move some variables under `printer` to `versioninfo`
* Disable telemetry by default if edition is non-community

### Related changes

- Need to cherry-pick to the release branch 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
  - `make server`
  - Start the cluster
  - `admin show telemetry;`

### Release note <!-- bugfixes or new feature need a release note -->

No release note
