### PR TITLE
ddl: fix max allocation count when create auto_random tables (#18417)

### DIFF
--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -959,6 +959,7 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	}
 	assertShowWarningCorrect("create table t (a bigint auto_random(15) primary key)", 281474976710655)
 	assertShowWarningCorrect("create table t (a bigint unsigned auto_random(15) primary key)", 562949953421311)
+	assertShowWarningCorrect("create table t (a bigint auto_random(1) primary key)", 4611686018427387903)
 
 	// Test insert into auto_random column explicitly is not allowed by default.
 	assertExplicitInsertDisallowed := func(sql string) {

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -951,7 +951,7 @@ func NewAutoRandomIDLayout(fieldType *types.FieldType, shardBits uint64) *AutoRa
 
 // IncrementalBitsCapacity returns the max capacity of incremental section of the current layout.
 func (l *AutoRandomIDLayout) IncrementalBitsCapacity() uint64 {
-	return uint64(math.Pow(2, float64(l.IncrementalBits)) - 1)
+	return uint64(math.Pow(2, float64(l.IncrementalBits))) - 1
 }
 
 // IncrementalMask returns 00..0[11..1], where [xxx] is the incremental section of the current layout.


### PR DESCRIPTION
Cherry-pick #18417 to release-4.0.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
