### PR TITLE
session: add no register API for using TiDB as a library

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,6 +138,8 @@ type Config struct {
 	Experimental Experimental `toml:"experimental" json:"experimental"`
 	// EnableCollectExecutionInfo enables the TiDB to collect execution info.
 	EnableCollectExecutionInfo bool `toml:"enable-collect-execution-info" json:"enable-collect-execution-info"`
+	// SkipRegisterToDashboard tells TiDB don't register itself to the dashboard.
+	SkipRegisterToDashboard bool `toml:"skip-register-to-dashboard" json:"skip-register-to-dashboard"`
 	// EnableTelemetry enables the usage data report to PingCAP.
 	EnableTelemetry bool `toml:"enable-telemetry" json:"enable-telemetry"`
 }

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -106,6 +106,11 @@ max-server-connections = 0
 # Whether new collations are enabled, as indicated by its name, this configuration entry take effect ONLY when a TiDB cluster bootstraps for the first time.
 new_collations_enabled_on_first_bootstrap = false
 
+# Don't register information of this TiDB to etcd, so this instance of TiDB won't appear in the services like dashboard.
+# This option is useful when you want to embed TiDB into your service(i.e. use TiDB as a library).
+# *If you want to start a TiDB service, NEVER enable this.*
+skip-register-to-dashboard = false
+
 # When enabled, usage data (for example, instance versions) will be reported to PingCAP periodically for user experience analytics.
 # If this config is set to `false` on all TiDB servers, telemetry will be always disabled regardless of the value of the global variable `tidb_enable_telemetry`.
 # See PingCAP privacy policy for details: https://pingcap.com/en/privacy-policy/

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -189,6 +189,7 @@ repair-mode = true
 max-server-connections = 200
 mem-quota-query = 10000
 max-index-length = 3080
+skip-register-to-dashboard = true
 [performance]
 txn-total-size-limit=2000
 [tikv-client]
@@ -247,6 +248,7 @@ engines = ["tiflash"]
 	c.Assert(conf.Experimental.AllowAutoRandom, IsTrue)
 	c.Assert(conf.IsolationRead.Engines, DeepEquals, []string{"tiflash"})
 	c.Assert(conf.MaxIndexLength, Equals, 3080)
+	c.Assert(conf.SkipRegisterToDashboard, Equals, true)
 
 	_, err = f.WriteString(`
 [log.file]

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -128,14 +128,14 @@ func setGlobalInfoSyncer(is *InfoSyncer) {
 }
 
 // GlobalInfoSyncerInit return a new InfoSyncer. It is exported for testing.
-func GlobalInfoSyncerInit(ctx context.Context, id string, etcdCli *clientv3.Client) (*InfoSyncer, error) {
+func GlobalInfoSyncerInit(ctx context.Context, id string, etcdCli *clientv3.Client, skipRegisterToDashBoard bool) (*InfoSyncer, error) {
 	is := &InfoSyncer{
 		etcdCli:        etcdCli,
 		info:           getServerInfo(id),
 		serverInfoPath: fmt.Sprintf("%s/%s", ServerInformationPath, id),
 		minStartTSPath: fmt.Sprintf("%s/%s", ServerMinStartTSPath, id),
 	}
-	err := is.init(ctx)
+	err := is.init(ctx, skipRegisterToDashBoard)
 	if err != nil {
 		return nil, err
 	}
@@ -144,10 +144,13 @@ func GlobalInfoSyncerInit(ctx context.Context, id string, etcdCli *clientv3.Clie
 }
 
 // Init creates a new etcd session and stores server info to etcd.
-func (is *InfoSyncer) init(ctx context.Context) error {
+func (is *InfoSyncer) init(ctx context.Context, skipRegisterToDashboard bool) error {
 	err := is.newSessionAndStoreServerInfo(ctx, owner.NewSessionDefaultRetryCnt)
 	if err != nil {
 		return err
+	}
+	if skipRegisterToDashboard {
+		return nil
 	}
 	return is.newTopologySessionAndStoreServerInfo(ctx, owner.NewSessionDefaultRetryCnt)
 }

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -86,7 +86,7 @@ func TestTopology(t *testing.T) {
 	failpoint.Enable("github.com/pingcap/tidb/domain/infosync/mockServerInfo", "return(true)")
 	defer failpoint.Disable("github.com/pingcap/tidb/domain/infosync/mockServerInfo")
 
-	info, err := GlobalInfoSyncerInit(ctx, currentID, cli)
+	info, err := GlobalInfoSyncerInit(ctx, currentID, cli, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
cherry-pick #17513

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close [br#299](https://github.com/pingcap/br/issues/299)

Problem Summary: 

BR uses TiDB as a library, but currently when we call `session.GetDomain`, `domap.Get` will automatically register itself to PD. Then a strange TiDB will present at dashboard.

see more at br#299.

### What is changed and how it works?
What's Changed:

I added a config option `no-register` to TiDB.

Then, when this is enabled, `topologySyncer` won't be started, hence this TiDB won't register itself to dashboard.

How it Works:

We add a if-guard to where initializing `topologySyncer` at `infoSyncer.Init` and `Session.Init`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

+ Manual test (add detailed scripts or steps below)
  - I replace this version of TiDB to BR, and set `no-register = true`, then BR won't register it self as a TiDB anymore.

### More things

Maybe we have more things to do, for now please add `WIP` tag for this: 

- ~~Add test cases.~~ (IMO, this is too hard to be tested automatically.)
- ~~Don't make `NoRegister`ed TiDB become DDL owner.~~ (We can set `run-DDL = false`)

### Release note

- No release note
