### PR TITLE
planner: support keep order for clustered index

### DIFF
--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -161,7 +161,9 @@
       "select t1.a, t1.b, t1.c from t1 where t1.c = 3.3",
       "select t1.b, t1.c from t1 where t1.c = 2.2",
       "select /*+ use_index(t1, c) */ * from t1",
-      "select * from t1 use index(c) where t1.c in (2.2, 3.3)"
+      "select * from t1 use index(c) where t1.c in (2.2, 3.3)",
+      "select * from t1 where t1.a = 1 order by b",
+      "select * from t1 order by a, b limit 1"
     ]
   },
   {

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -880,6 +880,28 @@
           "2 222 2.2000000000 12",
           "3 333 3.3000000000 13"
         ]
+      },
+      {
+        "SQL": "select * from t1 where t1.a = 1 order by b",
+        "Plan": [
+          "TableReader_12 1.00 root  data:TableRangeScan_11",
+          "└─TableRangeScan_11 1.00 cop[tikv] table:t1 range:[1,1], keep order:true"
+        ],
+        "Res": [
+          "1 111 1.1000000000 11"
+        ]
+      },
+      {
+        "SQL": "select * from t1 order by a, b limit 1",
+        "Plan": [
+          "Limit_10 1.00 root  offset:0, count:1",
+          "└─TableReader_20 1.00 root  data:Limit_19",
+          "  └─Limit_19 1.00 cop[tikv]  offset:0, count:1",
+          "    └─TableFullScan_18 1.00 cop[tikv] table:t1 keep order:true"
+        ],
+        "Res": [
+          "1 111 1.1000000000 11"
+        ]
       }
     ]
   },


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: make table scan can keep order for clustered index.

### What is changed and how it works?

What's Changed: like the index, check the properties when filter candidate paths.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- none.
