### PR TITLE
config: deprecate allow-auto-random option

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -553,7 +553,7 @@ type IsolationRead struct {
 // Experimental controls the features that are still experimental: their semantics, interfaces are subject to change.
 // Using these features in the production environment is not recommended.
 type Experimental struct {
-	// Whether enable the syntax like `auto_random(3)` on the primary key column.
+	// Deprecated, it is not required to enable the auto_random feature.
 	AllowAutoRandom bool `toml:"allow-auto-random" json:"allow-auto-random"`
 	// Whether enable creating expression index.
 	AllowsExpressionIndex bool `toml:"allow-expression-index" json:"allow-expression-index"`

--- a/config/config.go
+++ b/config/config.go
@@ -553,8 +553,6 @@ type IsolationRead struct {
 // Experimental controls the features that are still experimental: their semantics, interfaces are subject to change.
 // Using these features in the production environment is not recommended.
 type Experimental struct {
-	// Deprecated, it is not required to enable the auto_random feature.
-	AllowAutoRandom bool `toml:"allow-auto-random" json:"allow-auto-random"`
 	// Whether enable creating expression index.
 	AllowsExpressionIndex bool `toml:"allow-expression-index" json:"allow-expression-index"`
 }
@@ -700,7 +698,6 @@ var defaultConf = Config{
 		Engines: []string{"tikv", "tiflash", "tidb"},
 	},
 	Experimental: Experimental{
-		AllowAutoRandom:       true,
 		AllowsExpressionIndex: false,
 	},
 	EnableCollectExecutionInfo: true,

--- a/config/config.go
+++ b/config/config.go
@@ -553,6 +553,8 @@ type IsolationRead struct {
 // Experimental controls the features that are still experimental: their semantics, interfaces are subject to change.
 // Using these features in the production environment is not recommended.
 type Experimental struct {
+	// Whether enable the syntax like `auto_random(3)` on the primary key column.
+	AllowAutoRandom bool `toml:"allow-auto-random" json:"allow-auto-random"`
 	// Whether enable creating expression index.
 	AllowsExpressionIndex bool `toml:"allow-expression-index" json:"allow-expression-index"`
 }
@@ -698,6 +700,7 @@ var defaultConf = Config{
 		Engines: []string{"tikv", "tiflash", "tidb"},
 	},
 	Experimental: Experimental{
+		AllowAutoRandom:       true,
 		AllowsExpressionIndex: false,
 	},
 	EnableCollectExecutionInfo: true,
@@ -727,14 +730,15 @@ func StoreGlobalConfig(config *Config) {
 }
 
 var deprecatedConfig = map[string]struct{}{
-	"pessimistic-txn.ttl":        {},
-	"log.file.log-rotate":        {},
-	"log.log-slow-query":         {},
-	"txn-local-latches":          {},
-	"txn-local-latches.enabled":  {},
-	"txn-local-latches.capacity": {},
-	"performance.max-memory":     {},
-	"max-txn-time-use":           {},
+	"pessimistic-txn.ttl":            {},
+	"log.file.log-rotate":            {},
+	"log.log-slow-query":             {},
+	"txn-local-latches":              {},
+	"txn-local-latches.enabled":      {},
+	"txn-local-latches.capacity":     {},
+	"performance.max-memory":         {},
+	"max-txn-time-use":               {},
+	"experimental.allow-auto-random": {},
 }
 
 func isAllDeprecatedConfigItems(items []string) bool {

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -439,7 +439,7 @@ history-size = 24
 # experimental section controls the features that are still experimental: their semantics,
 # interfaces are subject to change, using these features in the production environment is not recommended.
 [experimental]
-# enable column attribute `auto_random` to be defined on the primary key column.
+# deprecated, it is not required to enable the `auto_random` feature.
 allow-auto-random = true
 # enable creating expression index.
 allow-expression-index = false

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -439,8 +439,6 @@ history-size = 24
 # experimental section controls the features that are still experimental: their semantics,
 # interfaces are subject to change, using these features in the production environment is not recommended.
 [experimental]
-# deprecated, it is not required to enable the `auto_random` feature.
-allow-auto-random = true
 # enable creating expression index.
 allow-expression-index = false
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -439,6 +439,8 @@ history-size = 24
 # experimental section controls the features that are still experimental: their semantics,
 # interfaces are subject to change, using these features in the production environment is not recommended.
 [experimental]
+# enable column attribute `auto_random` to be defined on the primary key column.
+allow-auto-random = true
 # enable creating expression index.
 allow-expression-index = false
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Fix https://github.com/pingcap/tiup/issues/598


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: Add `allow-auto-random` to deprecate config option to avoid config-check failed.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test

Now it will return `0` if we provide allow-auto-random configuration.

```console
$ ./bin/tidb-server -config ~/.config/tidb/config.toml.example -config-check true
config file /home/tangenta/.config/tidb/config.toml.example contained unknown configuration options: experimental.allow-auto-random
config check successful
```

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
