### PR TITLE
ddl: add explicit error message when adding index (#18563) (#18634)

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -168,15 +168,16 @@ func (s *testDBSuite5) TestAddIndexWithDupIndex(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use " + s.schemaName)
 
-	err1 := ddl.ErrDupKeyName.GenWithStack("index already exist %s; "+
+	err1 := ddl.ErrDupKeyName.GenWithStack("index already exist %s", "idx")
+	err2 := ddl.ErrDupKeyName.GenWithStack("index already exist %s; "+
 		"a background job is trying to add the same index, "+
 		"please check by `ADMIN SHOW DDL JOBS`", "idx")
-	err2 := ddl.ErrDupKeyName.GenWithStack("index already exist %s", "idx")
 
 	// When there is already an duplicate index, show error message.
 	tk.MustExec("create table test_add_index_with_dup (a int, key idx (a))")
 	_, err := tk.Exec("alter table test_add_index_with_dup add index idx (a)")
 	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
+	c.Assert(errors.Cause(err1).Error() == err.Error(), IsTrue)
 
 	// When there is another session adding duplicate index with state other than
 	// StatePublic, show explicit error message.
@@ -185,6 +186,7 @@ func (s *testDBSuite5) TestAddIndexWithDupIndex(c *C) {
 	indexInfo.State = model.StateNone
 	_, err = tk.Exec("alter table test_add_index_with_dup add index idx (a)")
 	c.Check(errors.Cause(err2).(*terror.Error).Equal(err), Equals, true)
+	c.Assert(errors.Cause(err2).Error() == err.Error(), IsTrue)
 
 	tk.MustExec("drop table test_add_index_with_dup")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -164,6 +164,31 @@ func (s *testDBSuite4) TestAddIndexWithPK(c *C) {
 	s.tk.MustQuery("select * from test_add_index_with_pk2").Check(testkit.Rows("1 1 1 1", "2 2 2 2"))
 }
 
+func (s *testDBSuite5) TestAddIndexWithDupIndex(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use " + s.schemaName)
+
+	err1 := ddl.ErrDupKeyName.GenWithStack("index already exist %s; "+
+		"a background job is trying to add the same index, "+
+		"please check by `ADMIN SHOW DDL JOBS`", "idx")
+	err2 := ddl.ErrDupKeyName.GenWithStack("index already exist %s", "idx")
+
+	// When there is already an duplicate index, show error message.
+	tk.MustExec("create table test_add_index_with_dup (a int, key idx (a))")
+	_, err := tk.Exec("alter table test_add_index_with_dup add index idx (a)")
+	c.Check(errors.Cause(err1).(*terror.Error).Equal(err), Equals, true)
+
+	// When there is another session adding duplicate index with state other than
+	// StatePublic, show explicit error message.
+	t := s.testGetTable(c, "test_add_index_with_dup")
+	indexInfo := t.Meta().FindIndexByName("idx")
+	indexInfo.State = model.StateNone
+	_, err = tk.Exec("alter table test_add_index_with_dup add index idx (a)")
+	c.Check(errors.Cause(err2).(*terror.Error).Equal(err), Equals, true)
+
+	tk.MustExec("drop table test_add_index_with_dup")
+}
+
 func (s *testDBSuite1) TestRenameIndex(c *C) {
 	s.tk = testkit.NewTestKit(c, s.store)
 	s.tk.MustExec("use " + s.schemaName)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3910,7 +3910,14 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast.Inde
 	}
 
 	if indexInfo := t.Meta().FindIndexByName(indexName.L); indexInfo != nil {
-		err = ErrDupKeyName.GenWithStack("index already exist %s", indexName)
+		if indexInfo.State != model.StatePublic {
+			// NOTE: explicit error message. See issue #18363.
+			err = ErrDupKeyName.GenWithStack("index already exist %s; "+
+				"a background job is trying to add the same index, "+
+				"please check by `ADMIN SHOW DDL JOBS`", indexName)
+		} else {
+			err = ErrDupKeyName.GenWithStack("index already exist %s", indexName)
+		}
 		if ifNotExists {
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
 			return nil


### PR DESCRIPTION
cherry-pick #18563 and #18634 to release-4.0

---

Signed-off-by: Wang Ruichao <wangruichao2014@xiaochuankeji.cn>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Close #18363 

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Modify the error message for the "add index" case.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note

- Improve the error message returned by `ALTER TABLE ... ADD INDEX` statement when an index with the same name is adding in the background.