### PR TITLE
executor: 'select * from information_schema.tables' fail after setting @@tidb_snapshot

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -271,7 +271,7 @@ func (c *statsCache) get(ctx sessionctx.Context) (map[int64]uint64, map[tableHis
 }
 
 func getAutoIncrementID(ctx sessionctx.Context, schema *model.DBInfo, tblInfo *model.TableInfo) (int64, error) {
-	is := ctx.GetSessionVars().TxnCtx.InfoSchema.(infoschema.InfoSchema)
+	is := infoschema.GetInfoSchema(ctx)
 	tbl, err := is.TableByName(schema.Name, tblInfo.Name)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close --> https://github.com/pingcap/tidb/issues/18347

Problem Summary:

The reproduce steps:

```
	create database gzj_test_db
	create table gzj_test_db.ad_account_record_log (id int auto_increment primary key)
	select now()
	drop database gzj_test_db
        set @@tidb_snapshot = '2020-07-18 23:56:05'   // now() 
	select * from information_schema.tables
```

'Table gzj_test_db.ad_account_record_log' doesn't exist

### What is changed and how it works?


What's Changed:

`getAutoIncrementID` should consider the @@tidb_snapshot variable, use `infoschema.GetInfoSchema(ctx)`

How it Works:

```
func GetInfoSchemaBySessionVars(sessVar *variable.SessionVars) InfoSchema {
	var is InfoSchema
	if snap := sessVar.SnapshotInfoschema; snap != nil {
		is = snap.(InfoSchema)
		logutil.BgLogger().Info("use snapshot schema", zap.Uint64("conn", sessVar.ConnectionID), zap.Int64("schemaVersion", is.SchemaMetaVersion()))
	} else {
		is = sessVar.TxnCtx.InfoSchema.(InfoSchema)
	}
	return is
}
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

It's no written as an unit test, because the test case depends on TiKV.

```
func (s *testInfoschemaTableSuite) TestWrongSnapshotSchema(c *C) {
	// Test case for https://github.com/pingcap/tidb/issues/18347
	// getAutoIncrementID does not use the snapshot infoschema and cause this bug.
	tk := testkit.NewTestKit(c, s.store)
	tk.MustExec("create database gzj_test_db")
	tk.MustExec("create table gzj_test_db.ad_account_record_log (id int auto_increment primary key)")
	rs := tk.MustQuery("select now()").Rows()
	tk.MustExec("drop database gzj_test_db")

	tk.MustExec("set @@tidb_snapshot = ?", rs[0][0])
	// Before the bug fix, this query get "'Table gzj_test_db.ad_account_record_log' doesn't exist"
	tk.MustQuery("select * from information_schema.tables;")
}
```


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> Fix a bug `getAutoIncrementID()` function does not consider the `tidb_snapshot` session variable, this bug may cause dumper tool fail with 'table not exist' error.