### PR TITLE
Revert "config: set the default value of OOMAction to OOMActionCancel"

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -559,7 +559,7 @@ var defaultConf = Config{
 	OOMUseTmpStorage:             true,
 	TempStorageQuota:             -1,
 	TempStoragePath:              tempStorageDirName,
-	OOMAction:                    OOMActionCancel,
+	OOMAction:                    OOMActionLog,
 	MemQuotaQuery:                1 << 30,
 	EnableStreaming:              false,
 	EnableBatchDML:               false,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -49,7 +49,7 @@ tmp-storage-quota = -1
 
 # Specifies what operation TiDB performs when a single SQL statement exceeds the memory quota specified by mem-quota-query and cannot be spilled over to disk.
 # Valid options: ["log", "cancel"]
-oom-action = "cancel"
+oom-action = "log"
 
 # Enable coprocessor streaming.
 enable-streaming = false


### PR DESCRIPTION
Reverts pingcap/tidb#18502

It'll be reopened later after https://github.com/pingcap/tidb/issues/16104 is fixed completely.

### Release note <!-- bugfixes or new feature need a release note -->
- Revert "config: set the default value of OOMAction to OOMActionCancel"