### PR TITLE
executor: fix the key representation of 'show table regions'

### DIFF
--- a/executor/split.go
+++ b/executor/split.go
@@ -731,10 +731,14 @@ func (d *regionKeyDecoder) decodeRegionKey(key []byte) string {
 		if len(d.recordPrefix) == len(key) {
 			return fmt.Sprintf("t_%d_r", d.physicalTableID)
 		}
-		_, handle, err := codec.DecodeInt(key[len(d.recordPrefix):])
-		if err == nil {
-			return fmt.Sprintf("t_%d_r_%d", d.physicalTableID, handle)
+		isIntHandle := len(key)-len(d.recordPrefix) == 8
+		if isIntHandle {
+			_, handle, err := codec.DecodeInt(key[len(d.recordPrefix):])
+			if err == nil {
+				return fmt.Sprintf("t_%d_r_%d", d.physicalTableID, handle)
+			}
 		}
+		return fmt.Sprintf("t_%d_r_%x", d.physicalTableID, key[len(d.recordPrefix):])
 	}
 	if len(d.tablePrefix) > 0 && bytes.HasPrefix(key, d.tablePrefix) {
 		key = key[len(d.tablePrefix):]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18673 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


How it Works: If the length of handle part of a key exceeds `8`, it should not be parsed into int64.

### Related changes
N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
```sql
set @@tidb_enable_clustered_index=1;
drop table if exists t;
create table t (a int, b int, c int, primary key(a, b));
insert t values (1, 1, 1), (2, 2, 2);
split table t between (1, 0) and (2, 3) regions 2;
show table t regions;
```

```console
+-----------+------------------------------------------+------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+
| REGION_ID | START_KEY                                | END_KEY                                  | LEADER_ID | LEADER_STORE_ID | PEERS | SCATTERING | WRITTEN_BYTES | READ_BYTES | APPROXIMATE_SIZE(MB) | APPROXIMATE_KEYS |
+-----------+------------------------------------------+------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+
| 154       | t_102_                                   | t_102_r_03800000000000000183800000000000 | 155       | 1               | 155   | 0          | 0             | 0          | 0                    | 0                |
| 156       | t_102_r_03800000000000000183800000000000 |                                          | 157       | 1               | 157   | 0          | 0             | 0          | 0                    | 0                |
+-----------+------------------------------------------+------------------------------------------+-----------+-----------------+-------+------------+---------------+------------+----------------------+------------------+
```


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
