### PR TITLE
RFC: update standardize error codes and messages

### DIFF
--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -193,7 +193,7 @@ Where `Component` field is the abbreviated component name of the error source, w
 - TiFlash: FLASH
 - Dumpling: DP
 
-The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by `errors.RegisterErrorClass` or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
+The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by `[errors.RegisterErrorClass](https://github.com/pingcap/errors/blob/f9054262e67a3704a936a6ea216e73287486490d/terror/terror.go#L41)` or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
 
 The `ErrorCode` is the identity of this error. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase named to identity the error.
 
@@ -217,9 +217,10 @@ Dumpling: DP:{class}:{code}
 {class}, {code} ~= [A-Za-z0-9]+
 
 For mysql protocol compatible components, table below shows the available purely numeric codes for each component.
-MySQL error code range <-> TiDB Family Component
-[0, 9000)              <-> TiDB
-[9000, 9010)           <-> TiKV / PD / TiFlash
+MySQL error code range  | TiDB Family Component
+[0, 9000)               | TiDB
+[9000, 9010)            | TiKV / PD / TiFlash
+[9900, 10000)           | Ecosystem Productions
 ```
 
 ### How It Works

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -217,7 +217,7 @@ Dumpling: DP:{class}:{code}
 {class}, {code} ~= [A-Za-z0-9]+
 
 For mysql protocol compatible components, table below shows the available purely numeric codes for each component.
-MySQL error code raneg <-> TiDB Family Component
+MySQL error code range <-> TiDB Family Component
 [0, 9000)              <-> TiDB
 [9000, 9010)           <-> TiKV / PD / TiFlash
 ```

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -164,7 +164,7 @@ In addition, the error codes should be append only in case of conflict between v
 In the discussion above, an error has at least 4 parts:
 - The error code: it's the identity of an error.
 - The error field: it's the error itself the user can view in TiDB system. Like `err.Error()`.
-- The description field: the description of the error, what happened and why happened? This could be written by developer outside the code, and the more detail this field explaining the better, even some guess of cause could be included.
+- The description field: the expanded detail of why this error occurred. This could be written by developer outside the code, and the more detail this field explaining the better, even some guess of the cause could be included.
 - The workaround filed: how to work around this error. It's used to teach the users how to solve the error if occurring in the real environment.
 
 Besides, we can append a optional tags field to it:

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -195,7 +195,7 @@ Where `Component` field is the abbreviated component name of the error source, w
 
 The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by `[errors.RegisterErrorClass](https://github.com/pingcap/errors/blob/f9054262e67a3704a936a6ea216e73287486490d/terror/terror.go#L41)` or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
 
-The `InnerErrorCode` is the identity of this error internally, note that this error code can be duplicated in different component or `ErrorClass`. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase named to identity the error.
+The `InnerErrorCode` is the identity of this error internally, note that this error code can be duplicated in different component or `ErrorClass`. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase to identity the error.
 
 The content of `ErrorClass` and `InnerErrorCode` must matches `[0-9a-zA-Z]+`.
 
@@ -205,6 +205,12 @@ Here are some examples:
 - KV:Region:EpochNotMatch
 - KV:Region:NotLeader
 - DB:BRIE:BackupFailed
+
+When logging, the format `[ErrorCode] message` should be used, for example:
+
+```
+[2020/07/17 18:38:06.461 +08:00] [ERROR] [import.go:259] ["failed to download file"] [error="[BR:Internal:DownloadFileFailed] failed to download foo.sst : File not found"] [errVerbose="..."]
+```
 
 For compatibility with MySQL protocol, the code transmitted through the mysql protocol should be number only, others can be a number with a prefix string.
 

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -165,7 +165,7 @@ In the discussion above, an error has at least 4 parts:
 - The error code: it's the identity of an error.
 - The error field: it's the error itself the user can view in TiDB system. Like `err.Error()`.
 - The description field: the description of the error, what happened and why happened? This could be written by developer outside the code, and the more detail this field explaining the better, even some guess of cause could be included.
-- The workaround filed: how to workaround this error.
+- The workaround filed: how to work around this error. It's used to teach the users how to solve the error if occurring in the real environment.
 
 Besides, we can append a optional tags field to it:
 ```toml

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -216,9 +216,10 @@ Dumpling: DP:{class}:{code}
 
 {class}, {code} ~= [A-Za-z0-9]+
 
-MySQL error code <-> TiDB error code
-[0, 9000) <-> {class}:{code}
-[9000, 9010) <-> KV:{class}:{code} / PD:{class}:{code} / Flash:{class}:{code}
+For mysql protocol compatible components, table below shows the available purely numeric codes for each component.
+MySQL error code raneg <-> TiDB Family Component
+[0, 9000)              <-> TiDB
+[9000, 9010)           <-> TiKV / PD / TiFlash
 ```
 
 ### How It Works

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -180,7 +180,7 @@ The tags is used to classify errors (e.g. the level of seriousness). At the very
 
 #### The Error Code Range
 
-The error code is a 3-tuple of abbreviated component name, error class and error code, joined by a colon like `{Component}:{ErrorClass}:{ErrorCode}`.
+The error code is a 3-tuple of abbreviated component name, error class and error code, joined by a colon like `{Component}:{ErrorClass}:{InnerErrorCode}`.
 
 Where `Component` field is the abbreviated component name of the error source, wrote as upper case, component names are mapped as below:
 
@@ -195,9 +195,9 @@ Where `Component` field is the abbreviated component name of the error source, w
 
 The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by `[errors.RegisterErrorClass](https://github.com/pingcap/errors/blob/f9054262e67a3704a936a6ea216e73287486490d/terror/terror.go#L41)` or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
 
-The `ErrorCode` is the identity of this error. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase named to identity the error.
+The `InnerErrorCode` is the identity of this error internally, note that this error code can be duplicated in different component or `ErrorClass`. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase named to identity the error.
 
-The content of `ErrorClass` and `ErrorCode` must matches `[0-9a-zA-Z]+`.
+The content of `ErrorClass` and `InnerErrorCode` must matches `[0-9a-zA-Z]+`.
 
 For compatibility with MySQL protocol, the code transmitted through the mysql protocol should be number only, others can be a number with a prefix string.
 
@@ -220,7 +220,6 @@ For mysql protocol compatible components, table below shows the available purely
 MySQL error code range  | TiDB Family Component
 [0, 9000)               | TiDB
 [9000, 9010)            | TiKV / PD / TiFlash
-[9900, 10000)           | Ecosystem Productions
 ```
 
 ### How It Works

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -199,6 +199,13 @@ The `InnerErrorCode` is the identity of this error internally, note that this er
 
 The content of `ErrorClass` and `InnerErrorCode` must matches `[0-9a-zA-Z]+`.
 
+Here are some examples:
+
+- BR:Internal:FileNotFound
+- KV:Region:EpochNotMatch
+- KV:Region:NotLeader
+- DB:BRIE:BackupFailed
+
 For compatibility with MySQL protocol, the code transmitted through the mysql protocol should be number only, others can be a number with a prefix string.
 
 The code of each components looks like:
@@ -215,12 +222,15 @@ Lightning: LN:{class}:{code}
 Dumpling: DP:{class}:{code}
 
 {class}, {code} ~= [A-Za-z0-9]+
+```
 
 For mysql protocol compatible components, table below shows the available purely numeric codes for each component.
-MySQL error code range  | TiDB Family Component
-[0, 9000)               | TiDB
-[9000, 9010)            | TiKV / PD / TiFlash
-```
+
+| MySQL error code range  | TiDB Family Component |
+| ----------------------- | ------- |
+| [0, 9000)               | TiDB |
+| [8124, 8200)            | Ecosystem Productions in TiDB |
+| [9000, 9010)            | TiKV / PD / TiFlash |
 
 ### How It Works
 

--- a/docs/design/2020-05-08-standardize-error-codes-and-messages.md
+++ b/docs/design/2020-05-08-standardize-error-codes-and-messages.md
@@ -193,7 +193,7 @@ Where `Component` field is the abbreviated component name of the error source, w
 - TiFlash: FLASH
 - Dumpling: DP
 
-The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by `[errors.RegisterErrorClass](https://github.com/pingcap/errors/blob/f9054262e67a3704a936a6ea216e73287486490d/terror/terror.go#L41)` or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
+The `ErrorClass` is the name of the `ErrClass` the error belongs to, which defined by [`errors.RegisterErrorClass`](https://github.com/pingcap/errors/blob/f9054262e67a3704a936a6ea216e73287486490d/terror/terror.go#L41) or someway likewise. If this is unacceptable (for projects not written with golang), anything that can classify the "type" of this error (e.g., package name.) would also be good. 
 
 The `InnerErrorCode` is the identity of this error internally, note that this error code can be duplicated in different component or `ErrorClass`. Both numeric and textual code are acceptable, but it would be better to provide textual code, which should be one or two short words with PascalCase to identity the error.
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
1. change the format of error code.
2. rename message back to description.

Problem Summary:
We prefer to use textual error code then numeric code. But the old RFC doesn't allow us to omit the numeric error code.

And the `message` field is confusing, so we rename it back to `description`.

[Discussion (Internal only)](https://docs.google.com/document/d/1gjBLv_TJ9qB4Lp_AYsuBzjIE_CAfx58MfjSfKfQBinU/edit?ts=5f16f144)

### What is changed and how it works?

What's Changed: the standardize error codes and messages RFC.

How it Works: We make a new format of error codes.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
