### PR TITLE
*: Add memory information of executors if OOM action fires for debugging

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -816,7 +816,7 @@ func (w *tableWorker) pickAndExecTask(ctx context.Context) {
 			buf := make([]byte, 4096)
 			stackSize := runtime.Stack(buf, false)
 			buf = buf[:stackSize]
-			logutil.Logger(ctx).Error("tableWorker in IndexLookUpExecutor panicked", zap.String("stack", string(buf)))
+			logutil.Logger(ctx).Error("tableWorker in IndexLookUpExecutor panicked", zap.String("r", fmt.Sprint(r)), zap.String("stack", string(buf)))
 			task.doneCh <- errors.Errorf("%v", r)
 		}
 	}()

--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -93,6 +93,8 @@ func (a *PanicOnExceed) Action(t *Tracker) {
 	if a.logHook != nil {
 		a.logHook(a.ConnID)
 	}
+	logutil.BgLogger().Warn("memory exceeds quota",
+		zap.Error(errMemExceedThreshold.GenWithStackByArgs(t.label, t.BytesConsumed(), t.bytesLimit, t.String())))
 	panic(PanicMemoryExceed + fmt.Sprintf("[conn_id=%d]", a.ConnID))
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18914  <!-- REMOVE this line if no issue to close -->

Problem Summary:
Today, we're unable to distinguish memory usage of `selectResult` and `copIterator`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

```
\"explain analyze select * from lineitem\"{
 \"quota\": 143.0511474609375 MB
 \"consumed\": 203.6037073135376 MB
 \"TableReader_5\"{
 \"consumed\": 203.6037073135376 MB
 \"copIterator\"{
 \"consumed\": 131.86926078796387 MB
 }
 \"selectResult\"{
 \"consumed\": 71.73444652557373 MB
 }
 }
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
