### PR TITLE
brie: add default backup gc-ttl to 5m

### DIFF
--- a/executor/brie.go
+++ b/executor/brie.go
@@ -22,6 +22,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/br/pkg/backup"
 	"github.com/pingcap/br/pkg/glue"
 	"github.com/pingcap/br/pkg/storage"
 	"github.com/pingcap/br/pkg/task"
@@ -249,6 +250,7 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 	switch s.Kind {
 	case ast.BRIEKindBackup:
 		e.backupCfg = &task.BackupConfig{Config: cfg}
+		e.backupCfg.GCTTL = backup.DefaultBRGCSafePointTTL
 
 		for _, opt := range s.Options {
 			switch opt.Tp {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Problem Summary:
If not set default gc-ttl in backup, it will cause (1105, 'non-positive interval for NewTicker') when use Backup SQL.

### What is changed and how it works?

What's Changed:
Set default gc-ttl when use Backup SQL.


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Without this commit:
```
mysql>   backup database * to "noop://";
ERROR 1105 (HY000): non-positive interval for NewTicker
```

With this commit: 
```
backup database * to "noop://""
mysql>   backup database * to "noop://";
+-------------+------+--------------------+---------------------+---------------------+
| Destination | Size | BackupTS           | Queue Time          | Execution Time      |
+-------------+------+--------------------+---------------------+---------------------+
| noop:       |    0 | 418253639611842562 | 2020-07-23 21:30:15 | 2020-07-23 21:30:15 |
+-------------+------+--------------------+---------------------+---------------------+
1 row in set (0.02 sec)
```



### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
