### PR TITLE
test:stablize test case prewrite secondaries

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -99,6 +99,7 @@ type twoPhaseCommitter struct {
 	testingKnobs struct {
 		acAfterCommitPrimary chan struct{}
 		bkAfterCommitPrimary chan struct{}
+		noFallBack           bool
 	}
 
 	useAsyncCommit uint32

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -47,6 +47,7 @@ var _ = SerialSuites(&testCommitterSuite{})
 func (s *testCommitterSuite) SetUpSuite(c *C) {
 	atomic.StoreUint64(&ManagedLockTTL, 3000) // 3s
 	s.OneByOneSuite.SetUpSuite(c)
+	CommitMaxBackoff = 1000
 }
 
 func (s *testCommitterSuite) SetUpTest(c *C) {
@@ -77,7 +78,6 @@ func (s *testCommitterSuite) SetUpTest(c *C) {
 	// c.Assert(err, IsNil)
 
 	s.store = store
-	CommitMaxBackoff = 1000
 }
 
 func (s *testCommitterSuite) TearDownSuite(c *C) {

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -1137,7 +1137,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 
 // TestSecondaryKeys tests that when async commit is enabled, each prewrite message includes an
 // accurate list of secondary keys.
-func (s *testCommitterSuite) TestPrewiteSecondaryKeys(c *C) {
+func (s *testCommitterSuite) TestPrewriteSecondaryKeys(c *C) {
 	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.EnableAsyncCommit = true
@@ -1169,9 +1169,11 @@ func (s *testCommitterSuite) TestPrewiteSecondaryKeys(c *C) {
 	ctx := context.Background()
 	// TODO remove this when minCommitTS is returned from mockStore prewrite response.
 	committer.minCommitTS = committer.startTS + 10
+	committer.testingKnobs.noFallBack = true
 	err = committer.execute(ctx)
 	c.Assert(err, IsNil)
-	c.Assert(mock.seenPrimaryReq > 0 && mock.seenSecondaryReq > 0, IsTrue)
+	c.Assert(mock.seenPrimaryReq > 0, IsTrue)
+	c.Assert(mock.seenSecondaryReq > 0, IsTrue)
 }
 
 func (s *testCommitterSuite) TestAsyncCommit(c *C) {

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -133,6 +133,9 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 				// commit cannot proceed. The client can then fallback to normal way to
 				// continue committing the transaction if prewrite are all finished.
 				if prewriteResp.MinCommitTs == 0 {
+					if c.testingKnobs.noFallBack {
+						return nil
+					}
 					logutil.Logger(bo.ctx).Warn("async commit cannot proceed since the returned minCommitTS is zero, "+
 						"fallback to normal path", zap.Uint64("startTS", c.startTS))
 					c.setAsyncCommit(false)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

The case may fail like
```
[2020-07-23T11:37:45.570Z] ----------------------------------------------------------------------
[2020-07-23T11:37:45.570Z] FAIL: 2pc_test.go:1140: testCommitterSuite.TestPrewiteSecondaryKeys
[2020-07-23T11:37:45.570Z] 
[2020-07-23T11:37:45.570Z] 2pc_test.go:1174:
[2020-07-23T11:37:45.570Z]     c.Assert(mock.seenPrimaryReq > 0 && mock.seenSecondaryReq > 0, IsTrue)
[2020-07-23T11:37:45.570Z] ... obtained bool = false
[2020-07-23T11:37:45.570Z] 
[2020-07-23T11:37:45.570Z] 
[2020-07-23T11:37:45.570Z] ----------------------------------------------------------------------
```

This is because the `minCommitTS` returned from `mocktikv` is always zero, the prewrite may fallback to the normal path, if the primary key is in the fallback prewrite requests, the `seen` check will fail.

### What is changed and how it works?


What's Changed:
Add flag in `testingknots` to disable fallback in test cases.


How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
