### PR TITLE
config: check err != nil after toml.DecodeFile

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -799,6 +799,10 @@ func InitializeConfig(confPath string, configCheck, configStrict bool, reloadFun
 // Load loads config options from a toml file.
 func (c *Config) Load(confFile string) error {
 	metaData, err := toml.DecodeFile(confFile, c)
+	if err != nil {
+		return err
+	}
+
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
 	}
@@ -808,7 +812,7 @@ func (c *Config) Load(confFile string) error {
 	// If any items in confFile file are not mapped into the Config struct, issue
 	// an error and stop the server from starting.
 	undecoded := metaData.Undecoded()
-	if len(undecoded) > 0 && err == nil {
+	if len(undecoded) > 0 {
 		var undecodedItems []string
 		for _, item := range undecoded {
 			undecodedItems = append(undecodedItems, item.String())


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Check err != nil after toml.DecodeFile immediately.

### What is changed and how it works?

Proposal: len(metaData) must be 0, no need to check len(metaData) > 0 if err is nil

### Related changes

### Check List

Tests

- Unit test

### Release note

No release note
