### PR TITLE
executor: stop using the deprecated Filter field in BRIE statements (#18172)

### DIFF
--- a/executor/brie.go
+++ b/executor/brie.go
@@ -32,7 +32,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	pd "github.com/pingcap/pd/v4/client"
-	"github.com/pingcap/tidb-tools/pkg/filter"
+	filter "github.com/pingcap/tidb-tools/pkg/table-filter"
 
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
@@ -192,15 +192,11 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 			Cert: tidbCfg.Security.ClusterSSLCert,
 			Key:  tidbCfg.Security.ClusterSSLKey,
 		},
-		PD:            strings.Split(tidbCfg.Path, ","),
-		Concurrency:   4,
-		Checksum:      true,
-		SendCreds:     true,
-		LogProgress:   true,
-		CaseSensitive: tidbCfg.LowerCaseTableNames == 0,
-		Filter: filter.Rules{
-			DoDBs: s.Schemas,
-		},
+		PD:          strings.Split(tidbCfg.Path, ","),
+		Concurrency: 4,
+		Checksum:    true,
+		SendCreds:   true,
+		LogProgress: true,
 	}
 
 	storageURL, err := url.Parse(s.Storage)
@@ -234,16 +230,21 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 		}
 	}
 
-	if len(s.Tables) != 0 {
-		cfg.Filter.DoTables = make([]*filter.Table, 0, len(s.Tables))
+	switch {
+	case len(s.Tables) != 0:
+		tables := make([]filter.Table, 0, len(s.Tables))
 		for _, tbl := range s.Tables {
-			// the `tbl.Schema` is always not empty if a database is used.
-			// this is handled by (*preprocessor).handleTableName().
-			cfg.Filter.DoTables = append(cfg.Filter.DoTables, &filter.Table{
-				Name:   tbl.Name.O,
-				Schema: tbl.Schema.O,
-			})
+			tables = append(tables, filter.Table{Name: tbl.Name.O, Schema: tbl.Schema.O})
 		}
+		cfg.TableFilter = filter.NewTablesFilter(tables...)
+	case len(s.Schemas) != 0:
+		cfg.TableFilter = filter.NewSchemasFilter(s.Schemas...)
+	default:
+		cfg.TableFilter = filter.All()
+	}
+
+	if tidbCfg.LowerCaseTableNames != 0 {
+		cfg.TableFilter = filter.CaseInsensitive(cfg.TableFilter)
 	}
 
 	switch s.Kind {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20200623164729-3a18f1e5dceb
 	github.com/pingcap/pd/v4 v4.0.0-rc.2.0.20200520083007-2c251bd8f181
 	github.com/pingcap/sysutil v0.0.0-20200408114249-ed3bd6f7fdb1
-	github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible
+	github.com/pingcap/tidb-tools v4.0.1-0.20200530144555-cdec43635625+incompatible
 	github.com/pingcap/tipb v0.0.0-20200522051215-f31a15d98fce
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompat
 github.com/pingcap/tidb-tools v4.0.0-rc.1.0.20200514040632-f76b3e428e19+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible h1:e+j+rsJYX+J7eTkgjnGBH2/T3NS6GNSPD6nHA5bPdCI=
 github.com/pingcap/tidb-tools v4.0.0-rc.2.0.20200521050818-6dd445d83fe0+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
+github.com/pingcap/tidb-tools v4.0.1-0.20200530144555-cdec43635625+incompatible h1:ASydCeg5/hgglsRYtZp31UF5jQeJfZ350Sy1+GFnpnk=
+github.com/pingcap/tidb-tools v4.0.1-0.20200530144555-cdec43635625+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200522051215-f31a15d98fce h1:LDyY6Xh/Z/SHVQ10erWtoOwIxHSTtlpPQ9cvS+BfRMY=


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Cherry-pick #18172 to release-4.0 since the BR dependency is now updated to use the TableFilter field.

### What is changed and how it works?

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
    * run BACKUP manually.

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note (part of #18754).
