### PR TITLE
brie: set default config for backup and restore

### DIFF
--- a/executor/brie.go
+++ b/executor/brie.go
@@ -250,6 +250,7 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 	switch s.Kind {
 	case ast.BRIEKindBackup:
 		e.backupCfg = &task.BackupConfig{Config: cfg}
+		// TODO adapt new backup config in br.
 		e.backupCfg.GCTTL = backup.DefaultBRGCSafePointTTL
 
 		for _, opt := range s.Options {
@@ -279,6 +280,10 @@ func (b *executorBuilder) buildBRIE(s *ast.BRIEStmt, schema *expression.Schema) 
 
 	case ast.BRIEKindRestore:
 		e.restoreCfg = &task.RestoreConfig{Config: cfg}
+		// TODO adapt new restore config in br. now give these with default value
+		e.restoreCfg.SwitchModeInterval = backup.DefaultBRGCSafePointTTL
+		e.restoreCfg.CheckRequirements = false
+		e.restoreCfg.RemoveTiFlash = true
 		for _, opt := range s.Options {
 			switch opt.Tp {
 			case ast.BRIEOptionOnline:


### PR DESCRIPTION
cherry-pick #18768 to release-4.0

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

BR and BR in SQL both use the same function `RunBackup` `RunRestore` as the entrance of backup/restore job.
BR add some new config and check then adjust these configs before entrance, so the adjust step is not included in BR in SQL.it will cause the bug as same as #18750 

### What is changed and how it works?

What's Changed:
Set all new created config with default value in BR in SQL

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
