### PR TITLE
ddl: skip region not found error in WaitScatterRegionFinish

### DIFF
--- a/store/tikv/error.go
+++ b/store/tikv/error.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/kvproto/pkg/pdpb"
 	"github.com/pingcap/parser/terror"
 	mysql "github.com/pingcap/tidb/errno"
 )
@@ -63,4 +64,13 @@ type ErrDeadlock struct {
 
 func (d *ErrDeadlock) Error() string {
 	return d.Deadlock.String()
+}
+
+// PDError wraps *pdpb.Error to implement the error interface.
+type PDError struct {
+	Err *pdpb.Error
+}
+
+func (d *PDError) Error() string {
+	return d.Err.String()
 }

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -293,6 +293,14 @@ func (s *tikvStore) WaitScatterRegionFinish(ctx context.Context, regionID uint64
 					zap.Uint64("regionID", regionID))
 				return nil
 			}
+			if resp.GetHeader().GetError() != nil {
+				err = errors.AddStack(&PDError{
+					Err: resp.Header.Error,
+				})
+				logutil.BgLogger().Warn("wait scatter region error",
+					zap.Uint64("regionID", regionID), zap.Error(err))
+				return err
+			}
 			if logFreq%10 == 0 {
 				logutil.BgLogger().Info("wait scatter region",
 					zap.Uint64("regionID", regionID),


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
`region not found error` may end the waiting early. this error is irrelevant. we need to wait for all regions to be responded before ending the waiting.

### What is changed and how it works?

check the error and skip it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

the pre-split more stable.
### Release note <!-- bugfixes or new feature need a release note -->

- ddl: Do not end the scatter wait early when receiving a PD error
