### PR TITLE
github-actions: skip features and bugs auto assignment

### DIFF
--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -29,14 +29,6 @@ jobs:
       with:
         project: 'https://github.com/pingcap/tidb/projects/39'
         column_name: 'Issue Backlog: Need Triage'
-    - name: Run issues assignment to Question and Bug Reports Kanban
-      uses: srggrs/assign-one-project-github-action@1.2.0
-      if: |
-        contains(github.event.issue.labels.*.name, 'type/question') ||
-        contains(github.event.issue.labels.*.name, 'type/bug')
-      with:
-        project: 'https://github.com/pingcap/tidb/projects/36'
-        column_name: 'Need Triage'
     - name: Run issues assignment to Feature Request Kanban
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: |


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

I checked with @AndreMouche, and the intended bugs workflow is to move issues to a SIG Kanban once the Community on call person determines which is the appropriate SIG.

The problem with the current auto-assignment, is that *any* issue which contains the labels bug or question, is that they will be added back to the generic "Questions and Bug Reports" Kanban. This leads to duplication.

A better solution would be to auto-assign "Questions and Bug Reports" if there is no other project assigned, but it is not clear to me how to conditionally do this. Instead, I have disabled this auto-assignment, as (with correct triage) this should only handle the issues for which a SIG can not be determined.

### What is changed and how it works?

What's Changed:

GitHub action code.

How it Works:

Auto-assignment to "Questions and Bug Reports" has been disabled.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
