### PR TITLE
executor: modify the default value of actRows to be 0 instead of empty

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -236,3 +236,25 @@ func (s *testSuite2) checkExecutionInfo(c *C, tk *testkit.TestKit, sql string) {
 		c.Assert(strs[executionInfoCol], Not(Equals), "time:0s, loops:0, rows:0")
 	}
 }
+
+func (s *testSuite2) TestExplainAnalyzeActRowsNotEmpty(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int, index (a))")
+	tk.MustExec("insert into t values (1, 1)")
+
+	s.checkActRowsNotEmpty(c, tk, "explain analyze select * from t t1, t t2 where t1.b = t2.a and t1.b = 2333")
+}
+
+func (s *testSuite2) checkActRowsNotEmpty(c *C, tk *testkit.TestKit, sql string) {
+	actRowsCol := 2
+	rows := tk.MustQuery(sql).Rows()
+	for _, row := range rows {
+		strs := make([]string, len(row))
+		for i, c := range row {
+			strs[i] = c.(string)
+		}
+
+		c.Assert(strs[actRowsCol], Not(Equals), "")
+	}
+}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -984,6 +984,7 @@ func getRuntimeInfo(ctx sessionctx.Context, p Plan) (actRows, analyzeInfo, memor
 		actRows = fmt.Sprint(rootstats.GetActRows())
 	} else {
 		analyzeInfo = "time:0ns, loops:0"
+		actRows = "0"
 	}
 	switch p.(type) {
 	case *PhysicalTableReader, *PhysicalIndexReader, *PhysicalIndexLookUpReader:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #18528 

Problem Summary: I modified the default value of actRows to be 0 instead of empty.

### What is changed and how it works?

What's Changed:  Add one line in /planner/core/common_plans.go/getRuntimeInfo()

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- executor: modify the default value of actRows to be 0 instead of empty