### PR TITLE
planner: make every plan explainable (#12183)

### DIFF
--- a/cmd/explaintest/r/explain-non-select-stmt.result
+++ b/cmd/explaintest/r/explain-non-select-stmt.result
@@ -1,0 +1,29 @@
+use test;
+drop table if exists t;
+create table t(a bigint, b bigint);
+explain insert into t values(1, 1);
+id	count	task	operator info
+Insert_1	N/A	root	N/A
+explain insert into t select * from t;
+id	count	task	operator info
+Insert_1	N/A	root	N/A
+└─TableReader_7	10000.00	root	data:TableScan_6
+  └─TableScan_6	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain delete from t where a > 100;
+id	count	task	operator info
+Delete_3	N/A	root	N/A
+└─TableReader_6	3333.33	root	data:Selection_5
+  └─Selection_5	3333.33	cop	gt(Column#1, 100)
+    └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain update t set b = 100 where a = 200;
+id	count	task	operator info
+Update_3	N/A	root	N/A
+└─TableReader_6	10.00	root	data:Selection_5
+  └─Selection_5	10.00	cop	eq(Column#1, 200)
+    └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
+explain replace into t select a, 100 from t;
+id	count	task	operator info
+Insert_1	N/A	root	N/A
+└─Projection_5	10000.00	root	Column#3, 100
+  └─TableReader_7	10000.00	root	data:TableScan_6
+    └─TableScan_6	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain-non-select-stmt.result
+++ b/cmd/explaintest/r/explain-non-select-stmt.result
@@ -13,17 +13,17 @@ explain delete from t where a > 100;
 id	count	task	operator info
 Delete_3	N/A	root	N/A
 └─TableReader_6	3333.33	root	data:Selection_5
-  └─Selection_5	3333.33	cop	gt(Column#1, 100)
+  └─Selection_5	3333.33	cop	gt(test.t.a, 100)
     └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
 explain update t set b = 100 where a = 200;
 id	count	task	operator info
 Update_3	N/A	root	N/A
 └─TableReader_6	10.00	root	data:Selection_5
-  └─Selection_5	10.00	cop	eq(Column#1, 200)
+  └─Selection_5	10.00	cop	eq(test.t.a, 200)
     └─TableScan_4	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
 explain replace into t select a, 100 from t;
 id	count	task	operator info
 Insert_1	N/A	root	N/A
-└─Projection_5	10000.00	root	Column#3, 100
+└─Projection_5	10000.00	root	test.t.a, 100
   └─TableReader_7	10000.00	root	data:TableScan_6
     └─TableScan_6	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -51,12 +51,14 @@ IndexJoin_12	4166.67	root	left outer join, inner:IndexLookUp_11, outer key:test.
   └─TableScan_9	9.99	cop	table:t2, keep order:false, stats:pseudo
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	count	task	operator info
-Point_Get_1	1.00	root	table:t1, handle:1
+Update_2	N/A	root	N/A
+└─Point_Get_1	1.00	root	table:t1, handle:1
 explain delete from t1 where t1.c2 = 1;
 id	count	task	operator info
-IndexLookUp_9	10.00	root	
-├─IndexScan_7	10.00	cop	table:t1, index:c2, range:[1,1], keep order:false, stats:pseudo
-└─TableScan_8	10.00	cop	table:t1, keep order:false, stats:pseudo
+Delete_3	N/A	root	N/A
+└─IndexLookUp_9	10.00	root	
+  ├─IndexScan_7	10.00	cop	table:t1, index:c2, range:[1,1], keep order:false, stats:pseudo
+  └─TableScan_8	10.00	cop	table:t1, keep order:false, stats:pseudo
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	count	task	operator info
 Projection_11	9990.00	root	cast(join_agg_0)
@@ -696,7 +698,8 @@ begin;
 insert into t values (1, 1);
 explain update t set j = -j where i = 1 and j = 1;
 id	count	task	operator info
-Point_Get_1	1.00	root	table:t, index:i j
+Update_2	N/A	root	N/A
+└─Point_Get_1	1.00	root	table:t, index:i j
 rollback;
 drop table if exists t;
 create table t(a int);

--- a/cmd/explaintest/r/explain_easy_stats.result
+++ b/cmd/explaintest/r/explain_easy_stats.result
@@ -56,12 +56,14 @@ MergeJoin_7	2481.25	root	left outer join, left key:test.t1.c2, right key:test.t2
     └─TableScan_20	1985.00	cop	table:t2, keep order:false
 explain update t1 set t1.c2 = 2 where t1.c1 = 1;
 id	count	task	operator info
-Point_Get_1	1.00	root	table:t1, handle:1
+Update_2	N/A	root	N/A
+└─Point_Get_1	1.00	root	table:t1, handle:1
 explain delete from t1 where t1.c2 = 1;
 id	count	task	operator info
-IndexLookUp_9	0.00	root	
-├─IndexScan_7	0.00	cop	table:t1, index:c2, range:[1,1], keep order:false
-└─TableScan_8	0.00	cop	table:t1, keep order:false
+Delete_3	N/A	root	N/A
+└─IndexLookUp_9	0.00	root	
+  ├─IndexScan_7	0.00	cop	table:t1, index:c2, range:[1,1], keep order:false
+  └─TableScan_8	0.00	cop	table:t1, keep order:false
 explain select count(b.c2) from t1 a, t2 b where a.c1 = b.c2 group by a.c1;
 id	count	task	operator info
 Projection_11	1985.00	root	cast(join_agg_0)

--- a/cmd/explaintest/t/explain-non-select-stmt.test
+++ b/cmd/explaintest/t/explain-non-select-stmt.test
@@ -1,0 +1,8 @@
+use test;
+drop table if exists t;
+create table t(a bigint, b bigint);
+explain insert into t values(1, 1);
+explain insert into t select * from t;
+explain delete from t where a > 100;
+explain update t set b = 100 where a = 200;
+explain replace into t select a, 100 from t;

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -800,7 +800,7 @@ func (b *executorBuilder) buildExplain(v *plannercore.Explain) Executor {
 	}
 	if v.Analyze {
 		b.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl()
-		explainExec.analyzeExec = b.build(v.ExecPlan)
+		explainExec.analyzeExec = b.build(v.TargetPlan)
 	}
 	return explainExec
 }

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -34,6 +34,7 @@ import (
 type Plan interface {
 	// Get the schema.
 	Schema() *expression.Schema
+
 	// Get the ID.
 	ID() int
 
@@ -42,6 +43,10 @@ type Plan interface {
 
 	// Get the ID in explain statement
 	ExplainID() fmt.Stringer
+
+	// ExplainInfo returns operator information to be explained.
+	ExplainInfo() string
+
 	// replaceExprColumns replace all the column reference in the plan's expression node.
 	replaceExprColumns(replace map[string]*expression.Column)
 
@@ -133,9 +138,6 @@ type PhysicalPlan interface {
 
 	// ToPB converts physical plan to tipb executor.
 	ToPB(ctx sessionctx.Context) (*tipb.Executor, error)
-
-	// ExplainInfo returns operator information to be explained.
-	ExplainInfo() string
 
 	// getChildReqProps gets the required property by child index.
 	GetChildReqProps(idx int) *property.PhysicalProperty
@@ -288,6 +290,9 @@ func (p *basePlan) ExplainID() fmt.Stringer {
 // TP implements Plan interface.
 func (p *basePlan) TP() string {
 	return p.tp
+}
+func (p *basePlan) ExplainInfo() string {
+	return "N/A"
 }
 
 // Schema implements Plan Schema interface.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2358,30 +2358,14 @@ func (b *PlanBuilder) buildTrace(trace *ast.TraceStmt) (Plan, error) {
 }
 
 func (b *PlanBuilder) buildExplainPlan(targetPlan Plan, format string, analyze bool, execStmt ast.StmtNode) (Plan, error) {
-	pp, ok := targetPlan.(PhysicalPlan)
-	if !ok {
-		switch x := targetPlan.(type) {
-		case *Delete:
-			pp = x.SelectPlan
-		case *Update:
-			pp = x.SelectPlan
-		case *Insert:
-			if x.SelectPlan != nil {
-				pp = x.SelectPlan
-			}
-		}
-		if pp == nil {
-			return nil, ErrUnsupportedType.GenWithStackByArgs(targetPlan)
-		}
+	p := &Explain{
+		TargetPlan: targetPlan,
+		Format:     format,
+		Analyze:    analyze,
+		ExecStmt:   execStmt,
 	}
-
-	p := &Explain{StmtPlan: pp, Analyze: analyze, Format: format, ExecStmt: execStmt, ExecPlan: targetPlan}
 	p.ctx = b.ctx
-	err := p.prepareSchema()
-	if err != nil {
-		return nil, err
-	}
-	return p, nil
+	return p, p.prepareSchema()
 }
 
 // buildExplainFor gets *last* (maybe running or finished) query plan from connection #connection id.

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -82,13 +82,16 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 		"Point_Get_1 1.00 root table:t, handle:1",
 	))
 	tk.MustQuery("explain update t set b=b+1, c=c+1 where a = 1").Check(testkit.Rows(
-		"Point_Get_1 1.00 root table:t, handle:1",
+		"Update_2 N/A root N/A",
+		"└─Point_Get_1 1.00 root table:t, handle:1",
 	))
 	tk.MustQuery("explain delete from t where a = 1").Check(testkit.Rows(
-		"Point_Get_1 1.00 root table:t, handle:1",
+		"Delete_2 N/A root N/A",
+		"└─Point_Get_1 1.00 root table:t, handle:1",
 	))
 	tk.MustQuery("explain select a from t where a = -1").Check(testkit.Rows(
-		"TableDual_5 0.00 root rows:0"))
+		"TableDual_5 0.00 root rows:0",
+	))
 	tk.MustExec(`prepare stmt0 from "select a from t where a = ?"`)
 	tk.MustExec("set @p0 = -1")
 	tk.MustQuery("execute stmt0 using @p0").Check(testkit.Rows())


### PR DESCRIPTION
Cherry-pick #12183

### What problem does this PR solve? <!--add issue link with summary if exists-->

Only a few non-physical plans can be explained at present. This PR removes the restrictions that only the physical plan can be explained. For example:

In the master branch, `insert` statements can not be explained:
```sql
TiDB(root@127.0.0.1:test) > desc insert into t values(1, 1);
ERROR 1105 (HY000): Unsupported type *core.Insert
```

While in this PR, we can explain the `insert` statement:
```sql
TiDB(root@127.0.0.1:test) > desc insert into t values(1, 1);
+----------+-------+------+---------------+
| id       | count | task | operator info |
+----------+-------+------+---------------+
| Insert_1 | N/A   | root | N/A           |
+----------+-------+------+---------------+
1 row in set (0.00 sec)
```

### What is changed and how it works?

Move the `ExplainInfo()` function from the `PhysicalPlan` interface to the `Plan` interface.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Integration test

Code changes

 - Has exported function/method change
 - Has exported variable/fields change

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

Release note

```md
Make every statement explainable. For example, `insert` statement can be
explained after this refactoring.
```
