### PR TITLE
store/tikv: fix BatchPointGet wrong result.

### DIFF
--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -127,3 +127,14 @@ func (s *testBatchPointGetSuite) TestBatchPointGetInTxn(c *C) {
 	tk.MustQuery("select * from s where (a, b) in ((1, 1), (2, 2), (3, 3)) for update").Check(testkit.Rows("1 1 1", "3 3 10"))
 	tk.MustExec("rollback")
 }
+
+func (s *testBatchPointGetSuite) TestBatchPointGetCache(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table customers (id int primary key, token varchar(255) unique)")
+	tk.MustExec("INSERT INTO test.customers (id, token) VALUES (28, '07j')")
+	tk.MustExec("INSERT INTO test.customers (id, token) VALUES (29, '03j')")
+	tk.MustExec("BEGIN")
+	tk.MustQuery("SELECT id, token FROM test.customers WHERE id IN (28)")
+	tk.MustQuery("SELECT id, token FROM test.customers WHERE id IN (28, 29);").Check(testkit.Rows("28 07j", "29 03j"))
+}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -108,7 +108,7 @@ func (s *tikvSnapshot) BatchGet(ctx context.Context, keys []kv.Key) (map[string]
 	m := make(map[string][]byte)
 	s.mu.RLock()
 	if s.mu.cached != nil {
-		tmp := keys[:0]
+		tmp := make([]kv.Key, 0, len(keys))
 		for _, key := range keys {
 			if val, ok := s.mu.cached[string(key)]; ok {
 				atomic.AddInt64(&s.mu.hitCnt, 1)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

in-transaction BatchPointGet returns wrong result in certain case.

### What is changed and how it works?

Do not modify input keys slice when do snapshot batch get.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix BatchPointGet wrong result.
