### PR TITLE
executor: BatchPointGet supports clustered index on partitioned tables.

### DIFF
--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -103,3 +103,12 @@ func (s *testClusteredSuite) TestClusteredHint(c *C) {
 	tk.MustExec("create table ht (a varchar(64) primary key, b int)")
 	tk.MustQuery("select * from ht use index (`PRIMARY`)")
 }
+
+func (s *testClusteredSuite) TestClusteredBatchPointGet(c *C) {
+	tk := s.newTK(c)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (a int,b int,c int, PRIMARY KEY (a,b)) PARTITION BY HASH(a) PARTITIONS 3")
+	tk.MustExec("insert t values (1, 1, 1), (3, 3, 3), (5, 5, 5)")
+	tk.MustQuery("select * from t where (a, b) in ((1, 1), (3, 3), (5, 5))").Check(
+		testkit.Rows("1 1 1", "3 3 3", "5 5 5"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

BatchPointGet supports clustered index on partitioned tables.

### What is changed and how it works?

Get the int value from CommonHandle.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- BatchPointGet supports clustered index on partitioned tables
