### PR TITLE
executor: fix issue of getting stuck when querying information_schema.columns

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -541,12 +541,12 @@ func (e *hugeMemTableRetriever) setDataForColumns(ctx sessionctx.Context) error 
 		schema := e.dbs[e.dbsIdx]
 		for e.tblIdx < len(schema.Tables) {
 			table := schema.Tables[e.tblIdx]
+			e.tblIdx++
 			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask) {
 				continue
 			}
 
 			e.dataForColumnsInTable(schema, table)
-			e.tblIdx++
 			if len(e.rows) >= batch {
 				return nil
 			}

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1144,6 +1144,18 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	}, nil, nil)
 }
 
+func (s *testTableSuite) TestIssue18845(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`CREATE USER 'user18845'@'localhost';`)
+	tk.Se.Auth(&auth.UserIdentity{
+		Username:     "user18845",
+		Hostname:     "localhost",
+		AuthUsername: "user18845",
+		AuthHostname: "localhost",
+	}, nil, nil)
+	tk.MustQuery(`select count(*) from information_schema.columns;`)
+}
+
 // Test statements_summary_history.
 func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 	tk := s.newTestKitWithRoot(c)


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

fix https://github.com/pingcap/tidb/issues/18845

### What is changed and how it works?

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- 

### Release note <!-- bugfixes or new feature need a release note -->

- fix the issue of getting stuck when querying information_schema.columns