### PR TITLE
executor: resolve errors caused by `in null` in point/batch ...

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -150,8 +150,8 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		keys := make([]kv.Key, 0, len(e.idxVals))
 		for _, idxVals := range e.idxVals {
 			physID := getPhysID(e.tblInfo, idxVals[e.partPos].GetInt64())
-			idxKey, nonExist, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
-			if nonExist {
+			idxKey, hasNull, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
+			if hasNull {
 				continue
 			}
 			if err1 != nil && !kv.ErrNotExist.Equal(err1) {

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -150,7 +150,10 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		keys := make([]kv.Key, 0, len(e.idxVals))
 		for _, idxVals := range e.idxVals {
 			physID := getPhysID(e.tblInfo, idxVals[e.partPos].GetInt64())
-			idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
+			idxKey, nonExist, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
+			if nonExist {
+				continue
+			}
 			if err1 != nil && !kv.ErrNotExist.Equal(err1) {
 				return err1
 			}

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -302,6 +302,9 @@ func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) ([]byte, error) 
 func encodeIndexKey(e *baseExecutor, tblInfo *model.TableInfo, idxInfo *model.IndexInfo, idxVals []types.Datum, tID int64) (_ []byte, err error) {
 	sc := e.ctx.GetSessionVars().StmtCtx
 	for i := range idxVals {
+		if idxVals[i].IsNull() {
+			continue
+		}
 		colInfo := tblInfo.Columns[idxInfo.Columns[i].Offset]
 		// table.CastValue will append 0x0 if the string value's length is smaller than the BINARY column's length.
 		// So we don't use CastValue for string value for now.

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -512,6 +512,16 @@ func (s *testPointGetSuite) TestSelectCheckVisibility(c *C) {
 	checkSelectResultError("select * from t", tikv.ErrGCTooEarly)
 }
 
+func (s *testPointGetSuite) TestNullValues(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t ( id bigint(10) primary key, f varchar(191) default null, unique key `idx_f` (`f`))")
+	tk.MustExec(`insert into t values (1, "")`)
+	rs := tk.MustQuery(`select * from t where f in (null)`).Rows()
+	c.Assert(len(rs), Equals, 0)
+}
+
 func (s *testPointGetSuite) TestReturnValues(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18839 <!-- REMOVE this line if no issue to close -->

Problem Summary: resolve errors caused by `in null` in point/batch get operators

### What is changed and how it works?
Skip null values when casting.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
### Release note <!-- bugfixes or new feature need a release note -->

- executor: resolve errors caused by `in null` in point/batch get operators