### PR TITLE
test: stabilize TestClusterIndexShowTableRegion

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4395,6 +4395,7 @@ func (s *testSplitTable) TestClusterIndexSplitTableIntegration(c *C) {
 func (s *testSplitTable) TestClusterIndexShowTableRegion(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
+	tk.MustExec("set global tidb_scatter_region = 1")
 	tk.MustExec("drop database if exists cluster_index_regions;")
 	tk.MustExec("create database cluster_index_regions;")
 	tk.MustExec("use cluster_index_regions;")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #18778 <!-- REMOVE this line if no issue to close -->

Problem Summary:

A patch for #18721: To make sure a region is split for a newly created table, the global variable `tidb_scatter_region` should be set to `1`.

### What is changed and how it works?

What's Changed:
Add `set global tidb_scatter_region = 1` before testing `show table regions`.


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
