### PR TITLE
transaction: lazy check key not exists for pessimistic transaction

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1457,6 +1457,11 @@ func (s *SessionVars) GetPrevStmtDigest() string {
 	return s.prevStmtDigest
 }
 
+// LazyCheckKeyNotExists returns if we can lazy check key not exists.
+func (s *SessionVars) LazyCheckKeyNotExists() bool {
+	return s.PresumeKeyNotExists || s.TxnCtx.IsPessimistic
+}
+
 // SetLocalSystemVar sets values of the local variables which in "server" scope.
 func SetLocalSystemVar(name string, val string) {
 	switch name {

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -270,7 +270,7 @@ func (c *index) Create(sctx sessionctx.Context, us kv.UnionStore, indexedValues 
 	}
 
 	var value []byte
-	if sctx.GetSessionVars().PresumeKeyNotExists {
+	if sctx.GetSessionVars().LazyCheckKeyNotExists() {
 		value, err = us.GetMemBuffer().Get(ctx, key)
 	} else {
 		value, err = us.Get(ctx, key)
@@ -280,7 +280,7 @@ func (c *index) Create(sctx sessionctx.Context, us kv.UnionStore, indexedValues 
 	}
 	if err != nil || len(value) == 0 {
 		var keyFlags kv.KeyFlags
-		if sctx.GetSessionVars().PresumeKeyNotExists && err != nil {
+		if sctx.GetSessionVars().LazyCheckKeyNotExists() && err != nil {
 			keyFlags = keyFlags.MarkPresumeKeyNotExists()
 		}
 		err = us.GetMemBuffer().SetWithFlags(key, keyFlags, idxVal)

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -680,7 +680,7 @@ func (t *TableCommon) AddRecord(sctx sessionctx.Context, r []types.Datum, opts .
 	}
 	skipCheck := sctx.GetSessionVars().StmtCtx.BatchCheck
 	if (t.meta.IsCommonHandle || t.meta.PKIsHandle) && !skipCheck && !opt.SkipHandleCheck {
-		if sctx.GetSessionVars().PresumeKeyNotExists {
+		if sctx.GetSessionVars().LazyCheckKeyNotExists() {
 			var v []byte
 			v, err = txn.GetMemBuffer().Get(ctx, key)
 			if err != nil {


### PR DESCRIPTION

### What problem does this PR solve?

Pessimistic transactions can do exists check when locking the key, we don't need to send Get request to check not exists.

### What is changed and how it works?

Added a function `LazyCheckKeyNotExists` in session vars, use it instead of `PresumeKeyNotExists`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

-   lazy check key not exists for pessimistic transactions.
