### PR TITLE
session: do not commit txn if ttl manager stopped

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1240,15 +1240,13 @@ func (s *testPessimisticSuite) TestTxnWithExpiredPessimisticLocks(c *C) {
 	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 1)
 	err := tk.ExecToErr("select * from t1 where c1 in(1, 5)")
 	c.Assert(terror.ErrorEqual(err, tikv.ErrLockExpire), IsTrue)
-	tk.MustExec("commit")
+	c.Assert(terror.ErrorEqual(tk.ExecToErr("commit"), tikv.ErrLockExpire), IsTrue)
 
 	tk.MustExec("begin pessimistic")
 	tk.MustQuery("select * from t1 where c1 in(1, 5) for update").Check(testkit.Rows("1 1 1", "5 5 5"))
 	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 1)
 	err = tk.ExecToErr("update t1 set c2 = c2 + 1")
 	c.Assert(terror.ErrorEqual(err, tikv.ErrLockExpire), IsTrue)
-	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 0)
-	tk.MustExec("update t1 set c2 = c2 + 1")
 	tk.MustExec("rollback")
 }
 

--- a/session/session.go
+++ b/session/session.go
@@ -600,6 +600,7 @@ func (s *session) checkTxnAborted(stmt sqlexec.Statement) error {
 		err = errors.New("current transaction is aborted, commands ignored until end of transaction block:" + s.txn.doNotCommit.Error())
 	} else if atomic.LoadUint32(&s.GetSessionVars().TxnCtx.LockExpire) > 0 {
 		err = tikv.ErrLockExpire
+		s.txn.doNotCommit = err
 	} else {
 		return nil
 	}


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
If the ttl manager stopped (timeout, etc.), the transaction should not be committed.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
Add it to doNotCommit error.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- If the TTL manager stopped (timeout, etc.), the transaction should not be committed.
