### PR TITLE
[store/tikv] avoid too many times of backoff when we retry for batch cop

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -459,7 +459,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 			logutil.BgLogger().Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
 				zap.String("store", store.addr))
-			return nil, nil
+			continue
 		}
 		return &RPCContext{
 			Region:     id,

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -459,6 +459,7 @@ func (c *RegionCache) GetTiFlashRPCContext(bo *Backoffer, id RegionVerID) (*RPCC
 			logutil.BgLogger().Info("invalidate current region, because others failed on same store",
 				zap.Uint64("region", id.GetID()),
 				zap.String("store", store.addr))
+			// TiFlash will always try to find out a valid peer, avoiding to retry too many times.
 			continue
 		}
 		return &RPCContext{

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -102,11 +102,9 @@ func (ss *RegionBatchRequestSender) sendStreamReqToAddr(bo *Backoffer, ctxs []co
 	if err != nil {
 		cancel()
 		ss.rpcError = err
-		for _, failedCtx := range ctxs {
-			e := ss.onSendFail(bo, failedCtx.ctx, err)
-			if e != nil {
-				return nil, false, func() {}, errors.Trace(e)
-			}
+		e := ss.onSendFail(bo, ctxs, err)
+		if e != nil {
+			return nil, false, func() {}, errors.Trace(e)
 		}
 		return nil, true, func() {}, nil
 	}
@@ -127,7 +125,7 @@ func recordRegionRequestRuntimeStats(stats map[tikvrpc.CmdType]*RegionRequestRun
 	stat.consume += int64(d)
 }
 
-func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err error) error {
+func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndRPCContext, err error) error {
 	// If it failed because the context is cancelled by ourself, don't retry.
 	if errors.Cause(err) == context.Canceled || status.Code(errors.Cause(err)) == codes.Canceled {
 		return errors.Trace(err)
@@ -135,15 +133,18 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, e
 		return errTiDBShuttingDown
 	}
 
-	if ctx.Meta != nil {
-		ss.regionCache.OnSendFail(bo, ctx, ss.needReloadRegion(ctx), err)
+	for _, failedCtx := range ctxs {
+		ctx := failedCtx.ctx
+		if ctx.Meta != nil {
+			ss.regionCache.OnSendFail(bo, ctx, ss.needReloadRegion(ctx), err)
+		}
 	}
 
 	// Retry on send request failure when it's not canceled.
 	// When a store is not available, the leader of related region should be elected quickly.
 	// TODO: the number of retry time should be limited:since region may be unavailable
 	// when some unrecoverable disaster happened.
-	err = bo.Backoff(boTiKVRPC, errors.Errorf("send tikv request error: %v, ctx: %v, try next peer later", err, ctx))
+	err = bo.Backoff(boTiKVRPC, errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
 	return errors.Trace(err)
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -136,7 +136,8 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndR
 	for _, failedCtx := range ctxs {
 		ctx := failedCtx.ctx
 		if ctx.Meta != nil {
-			ss.regionCache.OnSendFail(bo, ctx, ss.needReloadRegion(ctx), err)
+			// If multiple regions fail on same store, we must reload it sooner or later.
+			ss.regionCache.OnSendFail(bo, ctx, true, err)
 		}
 	}
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -136,8 +136,7 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndR
 	for _, failedCtx := range ctxs {
 		ctx := failedCtx.ctx
 		if ctx.Meta != nil {
-			// If multiple regions fail on same store, we must reload it sooner or later.
-			ss.regionCache.OnSendFail(bo, ctx, true, err)
+			ss.regionCache.OnSendFail(bo, ctx, ss.needReloadRegion(ctx), err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

When a store has failed and we retry a batch cop request, we apply backoff for every region, which results in too long wait-time. Indeed we should backoff once for every store fail.

### What is changed and how it works?
we should backoff once for every store fail.


What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test
    - we simulate the batch cop request which many regions and a store crashes. After change, tidb can switch to another store rapidly.

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

- avoid too many times of backoff when we retry for batch cop
