### PR TITLE
Planner:eliminate redundant projection (#11920)

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -110,14 +110,13 @@ Projection_9	9990.00	root	test.t1.c1
           └─TableScan_18	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select (select count(1) k from t1 s where s.c1 = t1.c1 having k != 0) from t1;
 id	count	task	operator info
-Projection_12	10000.00	root	k
-└─Projection_13	10000.00	root	test.t1.c1, ifnull(5_col_0, 0)
-  └─MergeJoin_14	10000.00	root	left outer join, left key:test.t1.c1, right key:test.s.c1
-    ├─TableReader_17	10000.00	root	data:TableScan_16
-    │ └─TableScan_16	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
-    └─Projection_18	8000.00	root	1, test.s.c1
-      └─TableReader_20	10000.00	root	data:TableScan_19
-        └─TableScan_19	10000.00	cop	table:s, range:[-inf,+inf], keep order:true, stats:pseudo
+Projection_12	10000.00	root	ifnull(5_col_0, 0)
+└─MergeJoin_13	10000.00	root	left outer join, left key:test.t1.c1, right key:test.s.c1
+  ├─TableReader_16	10000.00	root	data:TableScan_15
+  │ └─TableScan_15	10000.00	cop	table:t1, range:[-inf,+inf], keep order:true, stats:pseudo
+  └─Projection_17	8000.00	root	1, test.s.c1
+    └─TableReader_19	10000.00	root	data:TableScan_18
+      └─TableScan_18	10000.00	cop	table:s, range:[-inf,+inf], keep order:true, stats:pseudo
 explain select * from information_schema.columns;
 id	count	task	operator info
 MemTableScan_4	10000.00	root	
@@ -677,22 +676,19 @@ id	count	task	operator info
 Sort_13	2.00	root	a:asc
 └─HashAgg_17	2.00	root	group by:a, funcs:firstrow(join_agg_0)
   └─Union_18	2.00	root	
-    ├─HashAgg_21	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
-    │ └─Projection_22	1.00	root	0
-    │   └─TableDual_23	1.00	root	rows:1
-    └─HashAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
-      └─Projection_27	1.00	root	1
-        └─TableDual_28	1.00	root	rows:1
+    ├─HashAgg_19	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
+    │ └─TableDual_22	1.00	root	rows:1
+    └─HashAgg_25	1.00	root	group by:1, funcs:firstrow(1), firstrow(1)
+      └─TableDual_28	1.00	root	rows:1
 explain SELECT 0 AS a FROM dual UNION (SELECT 1 AS a FROM dual ORDER BY a);
 id	count	task	operator info
 HashAgg_15	2.00	root	group by:a, funcs:firstrow(join_agg_0)
 └─Union_16	2.00	root	
-  ├─HashAgg_19	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
-  │ └─Projection_20	1.00	root	0
-  │   └─TableDual_21	1.00	root	rows:1
-  └─StreamAgg_26	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
-    └─Projection_31	1.00	root	1
-      └─TableDual_32	1.00	root	rows:1
+  ├─HashAgg_17	1.00	root	group by:0, funcs:firstrow(0), firstrow(0)
+  │ └─TableDual_20	1.00	root	rows:1
+  └─StreamAgg_27	1.00	root	group by:a, funcs:firstrow(a), firstrow(a)
+    └─Projection_32	1.00	root	1
+      └─TableDual_33	1.00	root	rows:1
 create table t (i int key, j int, unique key (i, j));
 begin;
 insert into t values (1, 1);

--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -506,17 +506,16 @@ EXPLAIN SELECT COUNT(1) FROM (SELECT COALESCE(b.region_name, '不详') region_na
 id	count	task	operator info
 StreamAgg_22	1.00	root	funcs:count(1)
 └─HashAgg_25	1.00	root	group by:col_0, col_1, col_2, funcs:firstrow(1)
-  └─Projection_41	0.01	root	a.stat_date, a.show_date, coalesce(test.b.region_name, "不详")
+  └─Projection_40	0.01	root	a.stat_date, a.show_date, coalesce(test.b.region_name, "不详")
     └─IndexJoin_28	0.01	root	left outer join, inner:TableReader_27, outer key:a.region_id, inner key:test.b.id
       ├─Union_30	0.01	root	
-      │ ├─Projection_31	0.00	root	test.test01.stat_date, test.test01.show_date, test.test01.region_id, cast(registration_num)
-      │ │ └─Projection_32	0.00	root	test.test01.stat_date, test.test01.show_date, test.test01.region_id, 0
-      │ │   └─TableDual_33	0.00	root	rows:0
-      │ └─Projection_34	0.01	root	test.test01.stat_date, test.test01.show_date, test.test01.region_id, cast(test.test01.registration_num)
-      │   └─Selection_35	0.01	root	gt(cast(test.test01.registration_num), 0)
-      │     └─TableReader_38	0.01	root	data:Selection_37
-      │       └─Selection_37	0.01	cop	eq(test.test01.period, 1), ge(test.test01.stat_date, 20191202), ge(test.test01.stat_date, 20191202), le(test.test01.stat_date, 20191202), le(test.test01.stat_date, 20191202)
-      │         └─TableScan_36	10000.00	cop	table:test01, range:[-inf,+inf], keep order:false, stats:pseudo
+      │ ├─Projection_31	0.00	root	test.test01.stat_date, test.test01.show_date, test.test01.region_id, cast(0)
+      │ │ └─TableDual_32	0.00	root	rows:0
+      │ └─Projection_33	0.01	root	test.test01.stat_date, test.test01.show_date, test.test01.region_id, cast(test.test01.registration_num)
+      │   └─Selection_34	0.01	root	gt(cast(test.test01.registration_num), 0)
+      │     └─TableReader_37	0.01	root	data:Selection_36
+      │       └─Selection_36	0.01	cop	eq(test.test01.period, 1), ge(test.test01.stat_date, 20191202), ge(test.test01.stat_date, 20191202), le(test.test01.stat_date, 20191202), le(test.test01.stat_date, 20191202)
+      │         └─TableScan_35	10000.00	cop	table:test01, range:[-inf,+inf], keep order:false, stats:pseudo
       └─TableReader_27	1.00	root	data:TableScan_26
         └─TableScan_26	1.00	cop	table:b, range: decided by [a.region_id], keep order:false, stats:pseudo
 drop table if exists t;

--- a/cmd/explaintest/r/partition_pruning.result
+++ b/cmd/explaintest/r/partition_pruning.result
@@ -3845,11 +3845,11 @@ create table t1 (s1 int);
 explain select 1 from t1 union all select 2;
 id	count	task	operator info
 Union_8	10001.00	root	
-├─Projection_10	10000.00	root	1
-│ └─TableReader_12	10000.00	root	data:TableScan_11
-│   └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-└─Projection_14	1.00	root	2
-  └─TableDual_15	1.00	root	rows:1
+├─Projection_9	10000.00	root	1
+│ └─TableReader_11	10000.00	root	data:TableScan_10
+│   └─TableScan_10	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+└─Projection_12	1.00	root	2
+  └─TableDual_13	1.00	root	rows:1
 drop table t1;
 create table t1 (a int)
 partition by range(a) (

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -443,8 +443,8 @@ PRIMARY KEY (`id`)
 );
 explain select row_number() over( partition by i ) - x as rnk from t;
 id	count	task	operator info
-Projection_8	10000.00	root	minus(4_window_3, test.t.x)
-└─Window_9	10000.00	root	row_number() over(partition by test.t.i)
-  └─Sort_12	10000.00	root	test.t.i:asc
-    └─TableReader_11	10000.00	root	data:TableScan_10
-      └─TableScan_10	10000.00	cop	table:t, range:[0,+inf], keep order:false, stats:pseudo
+Projection_7	10000.00	root	minus(4_window_3, test.t.x)
+└─Window_8	10000.00	root	row_number() over(partition by test.t.i)
+  └─Sort_11	10000.00	root	test.t.i:asc
+    └─TableReader_10	10000.00	root	data:TableScan_9
+      └─TableScan_9	10000.00	cop	table:t, range:[0,+inf], keep order:false, stats:pseudo

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -380,24 +380,24 @@ drop table if exists t;
 create table t(a int, b int);
 explain select a != any (select a from t t2) from t t1;
 id	count	task	operator info
-Projection_9	10000.00	root	and(or(or(gt(col_count, 1), ne(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 0)), and(ne(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 1)))
-└─HashLeftJoin_10	10000.00	root	CARTESIAN inner join, inner:StreamAgg_17
-  ├─TableReader_13	10000.00	root	data:TableScan_12
-  │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_17	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)
-    └─Projection_27	10000.00	root	test.t2.a, test.t2.a, cast(isnull(test.t2.a))
-      └─TableReader_24	10000.00	root	data:TableScan_23
-        └─TableScan_23	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+Projection_8	10000.00	root	and(or(or(gt(col_count, 1), ne(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 0)), and(ne(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 1)))
+└─HashLeftJoin_9	10000.00	root	CARTESIAN inner join, inner:StreamAgg_16
+  ├─TableReader_12	10000.00	root	data:TableScan_11
+  │ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─StreamAgg_16	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)
+    └─Projection_26	10000.00	root	test.t2.a, test.t2.a, cast(isnull(test.t2.a))
+      └─TableReader_23	10000.00	root	data:TableScan_22
+        └─TableScan_22	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 explain select a = all (select a from t t2) from t t1;
 id	count	task	operator info
-Projection_9	10000.00	root	or(and(and(le(col_count, 1), eq(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 1)), or(eq(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 0)))
-└─HashLeftJoin_10	10000.00	root	CARTESIAN inner join, inner:StreamAgg_17
-  ├─TableReader_13	10000.00	root	data:TableScan_12
-  │ └─TableScan_12	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
-  └─StreamAgg_17	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)
-    └─Projection_27	10000.00	root	test.t2.a, test.t2.a, cast(isnull(test.t2.a))
-      └─TableReader_24	10000.00	root	data:TableScan_23
-        └─TableScan_23	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
+Projection_8	10000.00	root	or(and(and(le(col_count, 1), eq(test.t1.a, col_firstrow)), if(ne(agg_col_sum, 0), NULL, 1)), or(eq(agg_col_cnt, 0), if(isnull(test.t1.a), NULL, 0)))
+└─HashLeftJoin_9	10000.00	root	CARTESIAN inner join, inner:StreamAgg_16
+  ├─TableReader_12	10000.00	root	data:TableScan_11
+  │ └─TableScan_11	10000.00	cop	table:t1, range:[-inf,+inf], keep order:false, stats:pseudo
+  └─StreamAgg_16	1.00	root	funcs:firstrow(col_0), count(distinct col_1), sum(col_2), count(1)
+    └─Projection_26	10000.00	root	test.t2.a, test.t2.a, cast(isnull(test.t2.a))
+      └─TableReader_23	10000.00	root	data:TableScan_22
+        └─TableScan_22	10000.00	cop	table:t2, range:[-inf,+inf], keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int);
 drop table if exists s;

--- a/cmd/explaintest/r/topn_pushdown.result
+++ b/cmd/explaintest/r/topn_pushdown.result
@@ -2,8 +2,7 @@ explain select * from ((select 4 as a) union all (select 33 as a)) tmp order by 
 id	count	task	operator info
 TopN_17	1.00	root	tmp.a:desc, offset:0, count:1
 └─Union_21	2.00	root	
-  ├─Projection_22	1.00	root	cast(a)
-  │ └─Projection_23	1.00	root	4
-  │   └─TableDual_24	1.00	root	rows:1
-  └─Projection_26	1.00	root	33
-    └─TableDual_27	1.00	root	rows:1
+  ├─Projection_22	1.00	root	cast(4)
+  │ └─TableDual_23	1.00	root	rows:1
+  └─Projection_24	1.00	root	33
+    └─TableDual_25	1.00	root	rows:1

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -5068,3 +5068,38 @@ func (s *testIntegrationSuite) TestIssue15986(c *C) {
 		"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
 		"00000000000000000000000000000000000000000000000000000000000000000000000000000000000009';").Check(testkit.Rows("0"))
 }
+
+func (s *testIntegrationSuite) TestIssue19012(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`id` int(11) NOT NULL AUTO_INCREMENT," +
+		"	`province` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL," +
+		"	`city` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL," +
+		"	`s1should_count` int(11) DEFAULT NULL," +
+		"	`s1complete_count` int(11) DEFAULT NULL," +
+		"	PRIMARY KEY (`id`)" +
+		");")
+	for i := 0; i < 5; i++ {
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "徐州市", -1, 8);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "无锡市", 1, 6);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "盐城市", 1, 6);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "南京市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "南通市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "泰州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "连云港市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "宿迁市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "淮安市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "扬州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "苏州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "常州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "镇江市", 1, 9);`)
+	}
+	tk.Se.GetSessionVars().MaxChunkSize = 2
+	tk.Se.GetSessionVars().InitChunkSize = 2
+	rs := tk.MustQuery(`select a.province, a.city, case when sum(s1should_count) = 0 then 0 else sum(s1complete_count)/sum(s1should_count) end as aa from t a where a.province = "江苏省" group by a.province, a.city
+union all 
+select a.province, a.province city, case when sum(s1should_count) = 0 then 0 else sum(s1complete_count)/sum(s1should_count) end as aa from t a where a.province = "江苏省" group by a.province, a.province;`)
+	rs.Sort().Check(testkit.Rows("江苏省 南京市 9.0000", "江苏省 南通市 9.0000", "江苏省 宿迁市 9.0000", "江苏省 常州市 9.0000", "江苏省 徐州市 -8.0000", "江苏省 扬州市 9.0000", "江苏省 无锡市 6.0000", "江苏省 江苏省 10.0000", "江苏省 泰州市 9.0000", "江苏省 淮安市 9.0000", "江苏省 盐城市 6.0000", "江苏省 苏州市 9.0000", "江苏省 连云港市 9.0000", "江苏省 镇江市 9.0000"))
+}

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1287,6 +1287,32 @@ func (s *testPlanSuite) TestColumnPruning(c *C) {
 	}
 }
 
+func (s *testPlanSuite) TestProjectionEliminater(c *C) {
+	defer testleak.AfterTest(c)()
+	tests := []struct {
+		sql  string
+		best string
+	}{
+		{
+			sql:  "select 1+num from (select 1+a as num from t) t1;",
+			best: "DataScan(t)->Projection",
+		},
+	}
+
+	ctx := context.Background()
+	for ith, tt := range tests {
+		comment := Commentf("for %s", tt.sql)
+		stmt, err := s.ParseOneStmt(tt.sql, "", "")
+		c.Assert(err, IsNil, comment)
+
+		p, err := BuildLogicalPlan(ctx, s.ctx, stmt, s.is)
+		c.Assert(err, IsNil)
+		p, err = logicalOptimize(context.TODO(), flagBuildKeyInfo|flagPrunColumns|flagEliminateProjection, p.(LogicalPlan))
+		c.Assert(err, IsNil)
+		c.Assert(ToString(p), Equals, tt.best, Commentf("for %s %d", tt.sql, ith))
+	}
+}
+
 func (s *testPlanSuite) TestAllocID(c *C) {
 	ctx := MockContext()
 	pA := DataSource{}.Init(ctx)
@@ -1605,7 +1631,7 @@ func (s *testPlanSuite) TestAggPrune(c *C) {
 	}{
 		{
 			sql:  "select a, count(b) from t group by a",
-			best: "DataScan(t)->Projection->Projection",
+			best: "DataScan(t)->Projection",
 		},
 		{
 			sql:  "select sum(b) from t group by c, d, e",
@@ -1613,19 +1639,19 @@ func (s *testPlanSuite) TestAggPrune(c *C) {
 		},
 		{
 			sql:  "select tt.a, sum(tt.b) from (select a, b from t) tt group by tt.a",
-			best: "DataScan(t)->Projection->Projection",
+			best: "DataScan(t)->Projection",
 		},
 		{
 			sql:  "select count(1) from (select count(1), a as b from t group by a) tt group by b",
-			best: "DataScan(t)->Projection->Projection",
+			best: "DataScan(t)->Projection",
 		},
 		{
 			sql:  "select a, count(b) from t group by a",
-			best: "DataScan(t)->Projection->Projection",
+			best: "DataScan(t)->Projection",
 		},
 		{
 			sql:  "select a, count(distinct a, b) from t group by a",
-			best: "DataScan(t)->Projection->Projection",
+			best: "DataScan(t)->Projection",
 		},
 	}
 
@@ -1946,12 +1972,12 @@ func (s *testPlanSuite) TestUnion(c *C) {
 		},
 		{
 			sql:  "select * from (select 1 as a  union select 1 union all select 2) t order by a",
-			best: "UnionAll{UnionAll{Dual->Projection->Projection->Dual->Projection->Projection}->Aggr(firstrow(a))->Projection->Dual->Projection->Projection}->Projection->Sort",
+			best: "UnionAll{UnionAll{Dual->Projection->Dual->Projection}->Aggr(firstrow(a))->Projection->Dual->Projection}->Projection->Sort",
 			err:  false,
 		},
 		{
 			sql:  "select * from (select 1 as a  union select 1 union all select 2) t order by (select a)",
-			best: "Apply{UnionAll{UnionAll{Dual->Projection->Projection->Dual->Projection->Projection}->Aggr(firstrow(a))->Projection->Dual->Projection->Projection}->Dual->Projection->MaxOneRow}->Sort->Projection",
+			best: "Apply{UnionAll{UnionAll{Dual->Projection->Dual->Projection}->Aggr(firstrow(a))->Projection->Dual->Projection}->Dual->Projection->MaxOneRow}->Sort->Projection",
 			err:  false,
 		},
 	}

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -2576,7 +2576,7 @@ func (s *testPlanSuite) TestWindowFunction(c *C) {
 		// Test issue 11943
 		{
 			sql:    "SELECT ROW_NUMBER() OVER (partition by b) + a FROM t",
-			result: "TableReader(Table(t))->Sort->Window(row_number() over(partition by test.t.b))->Projection->Projection",
+			result: "TableReader(Table(t))->Sort->Window(row_number() over(partition by test.t.b))->Projection",
 		},
 	}
 

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -142,15 +142,55 @@ func (s *testPlanSuite) TestDAGPlanBuilderSubquery(c *C) {
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.HashAggFinalConcurrency = 1
 	sessionVars.HashAggPartialConcurrency = 1
-	var input []string
-	var output []struct {
-		SQL  string
-		Best string
+	tests := []struct {
+		sql  string
+		best string
+	}{
+		// Test join key with cast.
+		{
+			sql:  "select * from t where exists (select s.a from t s having sum(s.a) = t.a )",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->TableReader(Table(t)->StreamAgg)->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
+		},
+		{
+			sql:  "select * from t where exists (select s.a from t s having sum(s.a) = t.a ) order by t.a",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->TableReader(Table(t)->StreamAgg)->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection->Sort",
+		},
+		// FIXME: Report error by resolver.
+		//{
+		//	sql:  "select * from t where exists (select s.a from t s having s.a = t.a ) order by t.a",
+		//	best: "SemiJoin{TableReader(Table(t))->Projection->TableReader(Table(t)->HashAgg)->HashAgg}(cast(test.t.a),sel_agg_1)->Projection->Sort",
+		//},
+		{
+			sql:  "select * from t where a in (select s.a from t s) order by t.a",
+			best: "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.s.a)->Projection",
+		},
+		// Test Nested sub query.
+		{
+			sql:  "select * from t where exists (select s.a from t s where s.c in (select c from t as k where k.d = s.d) having sum(s.a) = t.a )",
+			best: "LeftHashJoin{TableReader(Table(t))->Projection->MergeSemiJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->IndexReader(Index(t.c_d_e)[[NULL,+inf]])}(test.s.c,test.k.c)(test.s.d,test.k.d)->Projection->StreamAgg}(cast(test.t.a),sel_agg_1)->Projection",
+		},
+		// Test Semi Join + Order by.
+		{
+			sql:  "select * from t where a in (select a from t) order by b",
+			best: "MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.t.a)->Projection->Sort",
+		},
+		// Test Apply.
+		{
+			sql:  "select t.c in (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t",
+			best: "Apply{TableReader(Table(t))->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.s.a,test.t1.a)->StreamAgg}->Projection",
+		},
+		{
+			sql:  "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t",
+			best: "LeftHashJoin{TableReader(Table(t))->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.s.a,test.t1.a)->StreamAgg}(test.t.a,test.s.a)->Projection",
+		},
+		{
+			sql:  "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t order by t.a",
+			best: "LeftHashJoin{TableReader(Table(t))->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.s.a,test.t1.a)->StreamAgg}(test.t.a,test.s.a)->Projection->Sort->Projection",
+		},
 	}
-	s.testData.GetTestCases(c, &input, &output)
-	for i, tt := range input {
-		comment := Commentf("for %s", tt)
-		stmt, err := s.ParseOneStmt(tt, "", "")
+	for _, tt := range tests {
+		comment := Commentf("for %s", tt.sql)
+		stmt, err := s.ParseOneStmt(tt.sql, "", "")
 		c.Assert(err, IsNil, comment)
 
 		p, err := planner.Optimize(context.TODO(), se, stmt, s.is)
@@ -321,10 +361,141 @@ func (s *testPlanSuite) TestDAGPlanBuilderAgg(c *C) {
 	se.Execute(context.Background(), "set sql_mode='STRICT_TRANS_TABLES'") // disable only full group by
 	c.Assert(err, IsNil)
 
-	var input []string
-	var output []struct {
-		SQL  string
-		Best string
+	tests := []struct {
+		sql  string
+		best string
+	}{
+		// Test distinct.
+		{
+			sql:  "select distinct b from t",
+			best: "TableReader(Table(t)->HashAgg)->HashAgg",
+		},
+		{
+			sql:  "select count(*) from (select * from t order by b) t group by b",
+			best: "TableReader(Table(t))->Sort->StreamAgg",
+		},
+		{
+			sql:  "select count(*), x from (select b as bbb, a + 1 as x from (select * from t order by b) t) t group by bbb",
+			best: "TableReader(Table(t))->Sort->Projection->StreamAgg",
+		},
+		// Test agg + table.
+		{
+			sql:  "select sum(a), avg(b + c) from t group by d",
+			best: "TableReader(Table(t))->Projection->HashAgg",
+		},
+		{
+			sql:  "select sum(distinct a), avg(b + c) from t group by d",
+			best: "TableReader(Table(t))->Projection->HashAgg",
+		},
+		//  Test group by (c + d)
+		{
+			sql:  "select sum(e), avg(e + c) from t where c = 1 group by (c + d)",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]]->HashAgg)->HashAgg",
+		},
+		// Test stream agg + index single.
+		{
+			sql:  "select sum(e), avg(e + c) from t where c = 1 group by c",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]]->StreamAgg)->StreamAgg",
+		},
+		// Test hash agg + index single.
+		{
+			sql:  "select sum(e), avg(e + c) from t where c = 1 group by e",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]]->HashAgg)->HashAgg",
+		},
+		// Test hash agg + index double.
+		{
+			sql:  "select sum(e), avg(b + c) from t where c = 1 and e = 1 group by d",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t))->Projection->HashAgg",
+		},
+		// Test stream agg + index double.
+		{
+			sql:  "select sum(e), avg(b + c) from t where c = 1 and b = 1",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]], Table(t)->Sel([eq(test.t.b, 1)]))->Projection->StreamAgg",
+		},
+		// Test hash agg + order.
+		{
+			sql:  "select sum(e) as k, avg(b + c) from t where c = 1 and b = 1 and e = 1 group by d order by k",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->Projection->StreamAgg->Sort",
+		},
+		// Test stream agg + order.
+		{
+			sql:  "select sum(e) as k, avg(b + c) from t where c = 1 and b = 1 and e = 1 group by c order by k",
+			best: "IndexLookUp(Index(t.c_d_e)[[1,1]]->Sel([eq(test.t.e, 1)]), Table(t)->Sel([eq(test.t.b, 1)]))->Projection->Projection->StreamAgg->Sort",
+		},
+		// Test agg can't push down.
+		{
+			sql:  "select sum(to_base64(e)) from t where c = 1",
+			best: "IndexReader(Index(t.c_d_e)[[1,1]])->Projection->StreamAgg",
+		},
+		{
+			sql:  "select (select count(1) k from t s where s.a = t.a having k != 0) from t",
+			best: "MergeLeftOuterJoin{TableReader(Table(t))->TableReader(Table(t))->Projection}(test.t.a,test.s.a)->Projection",
+		},
+		// Test stream agg with multi group by columns.
+		{
+			sql:  "select sum(to_base64(e)) from t group by e,d,c order by c",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->Projection->StreamAgg->Projection",
+		},
+		{
+			sql:  "select sum(e+1) from t group by e,d,c order by c",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->StreamAgg)->StreamAgg->Projection",
+		},
+		{
+			sql:  "select sum(to_base64(e)) from t group by e,d,c order by c,e",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]])->Projection->StreamAgg->Sort->Projection",
+		},
+		{
+			sql:  "select sum(e+1) from t group by e,d,c order by c,e",
+			best: "IndexReader(Index(t.c_d_e)[[NULL,+inf]]->StreamAgg)->StreamAgg->Sort->Projection",
+		},
+		// Test stream agg + limit or sort
+		{
+			sql:  "select count(*) from t group by g order by g limit 10",
+			best: "IndexReader(Index(t.g)[[NULL,+inf]]->StreamAgg)->StreamAgg->Limit->Projection",
+		},
+		{
+			sql:  "select count(*) from t group by g limit 10",
+			best: "IndexReader(Index(t.g)[[NULL,+inf]]->StreamAgg)->StreamAgg->Limit",
+		},
+		{
+			sql:  "select count(*) from t group by g order by g",
+			best: "IndexReader(Index(t.g)[[NULL,+inf]]->StreamAgg)->StreamAgg->Projection",
+		},
+		{
+			sql:  "select count(*) from t group by g order by g desc limit 1",
+			best: "IndexReader(Index(t.g)[[NULL,+inf]]->StreamAgg)->StreamAgg->Limit->Projection",
+		},
+		// Test hash agg + limit or sort
+		{
+			sql:  "select count(*) from t group by b order by b limit 10",
+			best: "TableReader(Table(t)->HashAgg)->HashAgg->TopN([test.t.b],0,10)->Projection",
+		},
+		{
+			sql:  "select count(*) from t group by b order by b",
+			best: "TableReader(Table(t)->HashAgg)->HashAgg->Sort->Projection",
+		},
+		{
+			sql:  "select count(*) from t group by b limit 10",
+			best: "TableReader(Table(t)->HashAgg)->HashAgg->Limit",
+		},
+		// Test merge join + stream agg
+		{
+			sql:  "select sum(a.g), sum(b.g) from t a join t b on a.g = b.g group by a.g",
+			best: "MergeInnerJoin{IndexReader(Index(t.g)[[NULL,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]])}(test.a.g,test.b.g)->Projection->StreamAgg",
+		},
+		// Test index join + stream agg
+		{
+			sql:  "select /*+ tidb_inlj(a,b) */ sum(a.g), sum(b.g) from t a join t b on a.g = b.g and a.g > 60 group by a.g order by a.g limit 1",
+			best: "IndexJoin{IndexReader(Index(t.g)[(60,+inf]])->IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(test.b.g, 60)]))}(test.a.g,test.b.g)->Projection->StreamAgg->Limit->Projection",
+		},
+		{
+			sql:  "select sum(a.g), sum(b.g) from t a join t b on a.g = b.g and a.a>5 group by a.g order by a.g limit 1",
+			best: "MergeInnerJoin{IndexReader(Index(t.g)[[NULL,+inf]]->Sel([gt(test.a.a, 5)]))->IndexReader(Index(t.g)[[NULL,+inf]])}(test.a.g,test.b.g)->Projection->StreamAgg->Limit->Projection",
+		},
+		{
+			sql:  "select sum(d) from t",
+			best: "TableReader(Table(t)->StreamAgg)->StreamAgg",
+		},
 	}
 	s.testData.GetTestCases(c, &input, &output)
 	for i, tt := range input {

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -54,6 +54,16 @@ func getUsedList(usedCols []*expression.Column, schema *expression.Schema) ([]bo
 	return used, nil
 }
 
+// exprsHasSideEffects checks if any of the expressions has side effects.
+func exprsHasSideEffects(exprs []expression.Expression) bool {
+	for _, expr := range exprs {
+		if exprHasSetVarOrSleep(expr) {
+			return true
+		}
+	}
+	return false
+}
+
 // exprHasSetVarOrSleep checks if the expression has SetVar function or Sleep function.
 func exprHasSetVarOrSleep(expr expression.Expression) bool {
 	scalaFunc, isScalaFunc := expr.(*expression.ScalarFunction)

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -137,6 +137,14 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 		}
 	}
 	p.replaceExprColumns(replace)
+	if isProj {
+		if child, ok := p.Children()[0].(*LogicalProjection); ok && !exprsHasSideEffects(child.Exprs) {
+			for i := range proj.Exprs {
+				proj.Exprs[i] = replaceColumnOfExpr(proj.Exprs[i], child)
+			}
+			p.Children()[0] = child.Children()[0]
+		}
+	}
 
 	if !(isProj && canEliminate && canProjectionBeEliminatedLoose(proj)) {
 		return p
@@ -146,6 +154,21 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 		replace[string(col.HashCode(nil))] = exprs[i].(*expression.Column)
 	}
 	return p.Children()[0]
+}
+
+func replaceColumnOfExpr(expr expression.Expression, proj *LogicalProjection) expression.Expression {
+	switch v := expr.(type) {
+	case *expression.Column:
+		idx := proj.Schema().ColumnIndex(v)
+		if idx != -1 && idx < len(proj.Exprs) {
+			return proj.Exprs[idx]
+		}
+	case *expression.ScalarFunction:
+		for i := range v.GetArgs() {
+			v.GetArgs()[i] = replaceColumnOfExpr(v.GetArgs()[i], proj)
+		}
+	}
+	return expr
 }
 
 func (p *LogicalJoin) replaceExprColumns(replace map[string]*expression.Column) {

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -370,7 +370,7 @@
       },
       {
         "SQL": "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t",
-        "Best": "LeftHashJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.s.a,test.t1.a)->StreamAgg}(test.t.a,test.s.a)->Projection->Projection"
+        "Best": "LeftHashJoin{IndexReader(Index(t.c_d_e)[[NULL,+inf]])->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.s.a,test.t1.a)->StreamAgg}(test.t.a,test.s.a)->Projection"
       },
       {
         "SQL": "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t order by t.a",
@@ -558,7 +558,7 @@
       },
       {
         "SQL": "select (select count(1) k from t s where s.a = t.a having k != 0) from t",
-        "Best": "MergeLeftOuterJoin{TableReader(Table(t))->TableReader(Table(t))->Projection}(test.t.a,test.s.a)->Projection->Projection"
+        "Best": "MergeLeftOuterJoin{TableReader(Table(t))->TableReader(Table(t))->Projection}(test.t.a,test.s.a)->Projection"
       },
       {
         "SQL": "select sum(to_base64(e)) from t group by e,d,c order by c",


### PR DESCRIPTION
cherry-pick #11920
fix #19012 
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/tidb/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
If projection plan have a projection child.Then eliminate the child.fix https://github.com/pingcap/tidb/issues/11863

### What is changed and how it works?
Mater:
```shell
Projection_4	10000.00	root	plus(1, t.num)
└─Projection_5	10000.00	root	plus(1, test.t.a)
  └─TableReader_7	10000.00	root	data:TableScan_6
    └─TableScan_6	10000.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
```
This pr.
```shell
Projection_4	4.00	root	plus(1, plus(1, test.t.a))
└─TableReader_6	4.00	root	data:TableScan_5
  └─TableScan_5	4.00	cop	table:t, range:[-inf,+inf], keep order:false, stats:pseudo
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test:Yes 
 - Integration tes:Maybe


Code changes

Simple change

Side effects

Not konwn
Related changes

Maybe not.
Release note

 - Write release note for bug-fix or new feature.