### PR TITLE
planner, expression: set avoidColEvaluator when eliminate proj

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -5068,3 +5068,38 @@ func (s *testIntegrationSuite) TestIssue15986(c *C) {
 		"000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
 		"00000000000000000000000000000000000000000000000000000000000000000000000000000000000009';").Check(testkit.Rows("0"))
 }
+
+func (s *testIntegrationSuite) TestIssue19012(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE `t` (" +
+		"`id` int(11) NOT NULL AUTO_INCREMENT," +
+		"	`province` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL," +
+		"	`city` varchar(20) COLLATE utf8mb4_bin DEFAULT NULL," +
+		"	`s1should_count` int(11) DEFAULT NULL," +
+		"	`s1complete_count` int(11) DEFAULT NULL," +
+		"	PRIMARY KEY (`id`)" +
+		");")
+	for i := 0; i < 5; i++ {
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "徐州市", -1, 8);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "无锡市", 1, 6);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "盐城市", 1, 6);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "南京市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "南通市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "泰州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "连云港市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "宿迁市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "淮安市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "扬州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "苏州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "常州市", 1, 9);`)
+		tk.MustExec(`insert into t(province, city, s1should_count, s1complete_count) values("江苏省", "镇江市", 1, 9);`)
+	}
+	tk.Se.GetSessionVars().MaxChunkSize = 1
+	tk.Se.GetSessionVars().InitChunkSize = 1
+	rs := tk.MustQuery(`select a.province, a.city, case when sum(s1should_count) = 0 then 0 else sum(s1complete_count)/sum(s1should_count) end as aa from t a where a.province = "江苏省" group by a.province, a.city
+union all 
+select a.province, a.province city, case when sum(s1should_count) = 0 then 0 else sum(s1complete_count)/sum(s1should_count) end as aa from t a where a.province = "江苏省" group by a.province, a.province;`)
+	rs.Sort().Check(testkit.Rows("江苏省 南京市 9.0000", "江苏省 南通市 9.0000", "江苏省 宿迁市 9.0000", "江苏省 常州市 9.0000", "江苏省 徐州市 -8.0000", "江苏省 扬州市 9.0000", "江苏省 无锡市 6.0000", "江苏省 江苏省 10.0000", "江苏省 泰州市 9.0000", "江苏省 淮安市 9.0000", "江苏省 盐城市 6.0000", "江苏省 苏州市 9.0000", "江苏省 连云港市 9.0000", "江苏省 镇江市 9.0000"))
+}

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -86,6 +86,11 @@ func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 		return p
 	}
 	child := p.Children()[0]
+	if childProj, ok := child.(*PhysicalProjection); ok {
+		if proj.AvoidColumnEvaluator {
+			childProj.AvoidColumnEvaluator = true
+		}
+	}
 	return child
 }
 
@@ -144,6 +149,12 @@ func (pe *projectionEliminater) eliminate(p LogicalPlan, replace map[string]*exp
 	exprs := proj.Exprs
 	for i, col := range proj.Schema().Columns {
 		replace[string(col.HashCode(nil))] = exprs[i].(*expression.Column)
+	}
+	child := p.Children()[0]
+	if childProj, ok := child.(*LogicalProjection); ok {
+		if proj.avoidColumnEvaluator {
+			childProj.avoidColumnEvaluator = true
+		}
 	}
 	return p.Children()[0]
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19012  <!-- REMOVE this line if no issue to close -->
related PR: https://github.com/pingcap/tidb/pull/8142

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
When eliminating projection, take the attribute `avoidColumnEvaluator` into consideration.

How it Works:
This bug is caused by the same reason described in https://github.com/pingcap/tidb/pull/8142.

### Related changes

master and release-4.0 do not have this problem after https://github.com/pingcap/tidb/pull/11920.
I'll cherry-pick this commit after this PR is merged.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the error when union has a child plan like `Proj <- Agg`, and there are at least two same `firstrow` function in aggregation.
