### PR TITLE
executor: fix the bug: can not join if join keys are type bigint and type bit

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -2178,3 +2178,57 @@ func (s *testSuite9) TestIssue19112(c *C) {
 		"1 4.064000 1 4.064000",
 		"3 1.010000 3 1.010000"))
 }
+
+func (s *testSuiteJoin3) TestIssue11896(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+
+	// compare bigint to bit(64)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 bigint)")
+	tk.MustExec("create table t1(c1 bit(64))")
+	tk.MustExec("insert into t value(1)")
+	tk.MustExec("insert into t1 value(1)")
+	tk.MustQuery("select * from t, t1 where t.c1 = t1.c1").Check(
+		testkit.Rows("1 \x00\x00\x00\x00\x00\x00\x00\x01"))
+
+	// compare int to bit(32)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 int)")
+	tk.MustExec("create table t1(c1 bit(32))")
+	tk.MustExec("insert into t value(1)")
+	tk.MustExec("insert into t1 value(1)")
+	tk.MustQuery("select * from t, t1 where t.c1 = t1.c1").Check(
+		testkit.Rows("1 \x00\x00\x00\x01"))
+
+	// compare mediumint to bit(24)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 mediumint)")
+	tk.MustExec("create table t1(c1 bit(24))")
+	tk.MustExec("insert into t value(1)")
+	tk.MustExec("insert into t1 value(1)")
+	tk.MustQuery("select * from t, t1 where t.c1 = t1.c1").Check(
+		testkit.Rows("1 \x00\x00\x01"))
+
+	// compare smallint to bit(16)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 smallint)")
+	tk.MustExec("create table t1(c1 bit(16))")
+	tk.MustExec("insert into t value(1)")
+	tk.MustExec("insert into t1 value(1)")
+	tk.MustQuery("select * from t, t1 where t.c1 = t1.c1").Check(
+		testkit.Rows("1 \x00\x01"))
+
+	// compare tinyint to bit(8)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t(c1 tinyint)")
+	tk.MustExec("create table t1(c1 bit(8))")
+	tk.MustExec("insert into t value(1)")
+	tk.MustExec("insert into t1 value(1)")
+	tk.MustQuery("select * from t, t1 where t.c1 = t1.c1").Check(
+		testkit.Rows("1 \x01"))
+}

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -300,11 +300,9 @@ func encodeHashChunkRowIdx(sc *stmtctx.StatementContext, row chunk.Row, tp *type
 	}
 	switch tp.Tp {
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
-		flag = varintFlag
-		if mysql.HasUnsignedFlag(tp.Flag) {
-			if integer := row.GetInt64(idx); integer < 0 {
-				flag = uvarintFlag
-			}
+		flag = uvarintFlag
+		if !mysql.HasUnsignedFlag(tp.Flag) && row.GetInt64(idx) < 0 {
+			flag = varintFlag
 		}
 		b = row.GetRaw(idx)
 	case mysql.TypeFloat:
@@ -406,9 +404,9 @@ func HashChunkSelected(sc *stmtctx.StatementContext, h []hash.Hash64, chk *chunk
 				buf[0], b = NilFlag, nil
 				isNull[i] = !ignoreNull
 			} else {
-				buf[0] = varintFlag
-				if mysql.HasUnsignedFlag(tp.Flag) && v < 0 {
-					buf[0] = uvarintFlag
+				buf[0] = uvarintFlag
+				if !mysql.HasUnsignedFlag(tp.Flag) && v < 0 {
+					buf[0] = varintFlag
 				}
 				b = column.GetRaw(i)
 			}


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #11896  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: 

Only if integers have no unsigned flag and are negative, treat them as signed integers. Otherwise, just treat them as unsigned numbers so that the comparison between an integer and a bit set will be as expected.

How it Works:

```
tidb [test]> drop table if exists t;
Query OK, 0 rows affected (0.02 sec)

tidb [test]> drop table if exists t1;
Query OK, 0 rows affected (0.01 sec)

tidb [test]> create table t(c1 bigint);
Query OK, 0 rows affected (0.01 sec)

tidb [test]> create table t1(c1 bit(64));
Query OK, 0 rows affected (0.00 sec)

tidb [test]> insert into t value(1);
Query OK, 1 row affected (0.00 sec)

tidb [test]> insert into t1 value(1);
Query OK, 1 row affected (0.00 sec)

tidb [test]> select * from t, t1 where t.c1 = t1.c1;
+------+--------------------+
| c1   | c1                 |
+------+--------------------+
|    1 | 0x0000000000000001 |
+------+--------------------+
1 row in set (0.00 sec)
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
