### PR TITLE
expression: add cast to comparison between bit and int

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -1824,6 +1824,19 @@ func WrapWithCastAsInt(ctx sessionctx.Context, expr Expression) Expression {
 	return BuildCastFunction(ctx, expr, tp)
 }
 
+// WrapWithCastAsFixLenInt wraps `expr` with `cast` if the return type of expr is not
+// type int or is hybrid, otherwise, returns `expr` directly.
+func WrapWithCastAsFixLenInt(ctx sessionctx.Context, expr Expression) Expression {
+	if expr.GetType().EvalType() == types.ETInt && !expr.GetType().Hybrid() {
+		return expr
+	}
+	tp := types.NewFieldType(mysql.TypeLonglong)
+	tp.Flen, tp.Decimal = expr.GetType().Flen, 0
+	types.SetBinChsClnFlag(tp)
+	tp.Flag |= expr.GetType().Flag & mysql.UnsignedFlag
+	return BuildCastFunction(ctx, expr, tp)
+}
+
 // WrapWithCastAsReal wraps `expr` with `cast` if the return type of expr is not
 // type real, otherwise, returns `expr` directly.
 func WrapWithCastAsReal(ctx sessionctx.Context, expr Expression) Expression {

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -1176,8 +1176,13 @@ func (s *testEvaluatorSuite) TestWrapWithCastAsTypesClasses(c *C) {
 		},
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeBit), Index: 0},
-			chunk.MutRowFromDatums([]types.Datum{types.NewDatum(123)}),
-			123, 123, types.NewDecFromInt(123), "123",
+			chunk.MutRowFromDatums([]types.Datum{types.NewMysqlBitDatum([]byte{123})}),
+			123, 123, types.NewDecFromInt(123), "{",
+		},
+		{
+			&Column{RetType: types.NewFieldType(mysql.TypeBit), Index: 0},
+			chunk.MutRowFromDatums([]types.Datum{types.NewMysqlBitDatum([]byte{65, 66})}),
+			16706, 16706, types.NewDecFromInt(16706), "AB",
 		},
 		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -1175,6 +1175,11 @@ func (s *testEvaluatorSuite) TestWrapWithCastAsTypesClasses(c *C) {
 			123, 123, types.NewDecFromInt(123), "123",
 		},
 		{
+			&Column{RetType: types.NewFieldType(mysql.TypeBit), Index: 0},
+			chunk.MutRowFromDatums([]types.Datum{types.NewDatum(123)}),
+			123, 123, types.NewDecFromInt(123), "123",
+		},
+		{
 			&Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0},
 			chunk.MutRowFromDatums([]types.Datum{types.NewDatum(123.555)}),
 			124, 123.555, types.NewDecFromFloatForTest(123.555), "123.555",
@@ -1238,6 +1243,14 @@ func (s *testEvaluatorSuite) TestWrapWithCastAsTypesClasses(c *C) {
 		c.Assert(err, IsNil, Commentf("cast[%v]: %#v", i, t))
 		c.Assert(isNull, Equals, false)
 		c.Assert(intRes, Equals, t.intRes)
+
+		// Test wrapping with CastAsFixLenInt.
+		fixLenIntExpr := WrapWithCastAsFixLenInt(ctx, t.expr)
+		c.Assert(intExpr.GetType().EvalType(), Equals, types.ETInt)
+		fixLenIntRes, isNull, err := fixLenIntExpr.EvalInt(ctx, t.row.ToRow())
+		c.Assert(err, IsNil, Commentf("cast[%v]: %#v", i, t))
+		c.Assert(isNull, Equals, false)
+		c.Assert(fixLenIntRes, Equals, t.intRes)
 
 		// Test wrapping with CastAsReal.
 		realExpr := WrapWithCastAsReal(ctx, t.expr)

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1303,6 +1303,14 @@ func (c *compareFunctionClass) generateCmpSigs(ctx sessionctx.Context, args []Ex
 		for i := range args {
 			DisableParseJSONFlag4Expr(args[i])
 		}
+	} else if tp == types.ETInt && args[0].GetType().Tp != args[1].GetType().Tp {
+		// Cast arg type from BIT to fix-length int for the correctness of hash join,
+		// if one arg has type BIT and the other has different int type
+		for i := range args {
+			if args[i].GetType().Tp == mysql.TypeBit {
+				args[i] = WrapWithCastAsFixLenInt(ctx, args[i])
+			}
+		}
 	}
 	bf.tp.Flen = 1
 	switch tp {

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -80,6 +80,7 @@ func (s *testEvaluatorSuite) TestCompareFunctionWithRefine(c *C) {
 
 func (s *testEvaluatorSuite) TestCompare(c *C) {
 	intVal, uintVal, realVal, stringVal, decimalVal := 1, uint64(1), 1.1, "123", types.NewDecFromFloatForTest(123.123)
+	bitVal := types.BinaryLiteral([]byte{1})
 	timeVal := types.NewTime(types.FromGoTime(time.Now()), mysql.TypeDatetime, 6)
 	durationVal := types.Duration{Duration: 12*time.Hour + 1*time.Minute + 1*time.Second}
 	jsonVal := json.CreateBinary("123")
@@ -116,6 +117,9 @@ func (s *testEvaluatorSuite) TestCompare(c *C) {
 		{uintVal, intVal, ast.EQ, mysql.TypeLonglong, 1},
 		{intVal, uintVal, ast.NullEQ, mysql.TypeLonglong, 1},
 		{intVal, uintVal, ast.EQ, mysql.TypeLonglong, 1},
+		{bitVal, intVal, ast.EQ, mysql.TypeLonglong, 1},
+		{intVal, bitVal, ast.EQ, mysql.TypeLonglong, 1},
+		{bitVal, bitVal, ast.EQ, mysql.TypeBit, 1},
 		{timeVal, timeVal, ast.LT, mysql.TypeDatetime, 0},
 		{timeVal, timeVal, ast.LE, mysql.TypeDatetime, 1},
 		{timeVal, timeVal, ast.GT, mysql.TypeDatetime, 0},


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18830  <!-- REMOVE this line if no issue to close -->

Problem Summary: 

- hash join computes different hash code for bit and int join keys because different flags are given to the hash function

### What is changed and how it works?

What's Changed:

- cast bit as int in comparisons (EQ, LT, NE, ...) of type ETINT

How it Works:

- adding casts in equal comparisons so that we have join keys with the same type, then get the same hash code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

- fixed the problem that hash join return wrong result when the types of join keys are bit and int