### PR TITLE
github: update bug report template to ask fewer questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,10 +16,7 @@ Please answer these questions before submitting your issue. Thanks!
 
 ### 3. What did you see instead (Required)
 
-### 4. Affected version (Required)
+### 4. What is your TiDB version? (Required)
 
-<!-- v3.0.0, v4.0.0, etc -->
+<!-- Paste the output of SELECT tidb_version() -->
 
-### 5. Root Cause Analysis
-
-<!-- should be filled by the investigator before it's closed -->


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: Fixes https://github.com/pingcap/tidb/issues/18908

Problem Summary:

### What is changed and how it works?

I agree with the issue #18908 that reporting a bug is more intimidating than it needs to be. It is hard for users to dissect and tell which versions of TiDB an issue affects. The root cause can also be added later without the user needing to see this question.

We should test bug reports against master to confirm they can be reproduced, in which case we can paste versions. Even if old versions are affected, it is not always an important question unless the issue is serious enough to warrant a back-port.

What's Changed:

How it Works:

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note