### PR TITLE
store/tikv: reduce lock scope

### DIFF
--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -330,11 +330,11 @@ func (txn *tikvTxn) rollbackPessimisticLocks() error {
 
 // lockWaitTime in ms, except that kv.LockAlwaysWait(0) means always wait lock, kv.LockNowait(-1) means nowait lock
 func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput ...kv.Key) error {
-	txn.mu.Lock()
-	defer txn.mu.Unlock()
 	// Exclude keys that are already locked.
 	var err error
 	keys := make([][]byte, 0, len(keysInput))
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
 	defer func() {
 		if err == nil {
 			if lockCtx.PessimisticLockWaited != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Even though the lock contention is very low in this method, but it's hard to trace all bad lock usage, so we better keep a good code pattern of using locks.

### What is changed and how it works?

move memory allocation out of the lock scope.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- no release note
