### PR TITLE
transaction: always lock keys with presume not exists flag

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
 )
 
 type testBypassSuite struct{}
@@ -836,6 +837,16 @@ func (s *testSuite4) TestInsertOnDupUpdateDefault(c *C) {
 	tk.MustGetErrCode("insert into t2 values (4,default,default) on duplicate key update a=default(a), c=default(c);", mysql.ErrBadGeneratedColumn)
 	tk.MustGetErrCode("insert into t2 values (4,default,default) on duplicate key update a=default(a), c=default(a);", mysql.ErrBadGeneratedColumn)
 	tk.MustExec("drop table t1, t2")
+
+	tk.MustExec("set @@tidb_txn_mode = 'pessimistic'")
+	tk.MustExec("create table t ( c_int int, c_string varchar(40) collate utf8mb4_bin , primary key (c_string), unique key (c_int));")
+	tk.MustExec("insert into t values (22, 'gold witch'), (24, 'gray singer'), (21, 'silver sight');")
+	tk.MustExec("begin;")
+	err := tk.ExecToErr("insert into t values (21,'black warlock'), (22, 'dark sloth'), (21,  'cyan song') on duplicate key update c_int = c_int + 1, c_string = concat(c_int, ':', c_string);")
+	c.Assert(kv.ErrKeyExists.Equal(err), IsTrue)
+	tk.MustExec("commit;")
+	tk.MustQuery("select * from t order by c_int;").Check(testutil.RowsWithSep("|", "21|silver sight", "22|gold witch", "24|gray singer"))
+	tk.MustExec("drop table t;")
 }
 
 func (s *testSuite4) TestReplace(c *C) {

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -196,6 +196,9 @@ func (s *testMainSuite) TestKeysNeedLock(c *C) {
 		{indexKey, deleteVal, false},
 	}
 	for _, tt := range tests {
-		c.Assert(keyNeedToLock(tt.key, tt.val), Equals, tt.need)
+		c.Assert(keyNeedToLock(tt.key, tt.val, 0), Equals, tt.need)
 	}
+	flag := kv.KeyFlags(1)
+	c.Assert(flag.HasPresumeKeyNotExists(), IsTrue)
+	c.Assert(keyNeedToLock(indexKey, deleteVal, flag), IsTrue)
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -294,7 +294,7 @@ func (st *TxnState) KeysNeedToLock() ([]kv.Key, error) {
 	keys := make([]kv.Key, 0, st.countHint())
 	buf := st.Transaction.GetMemBuffer()
 	buf.InspectStage(st.stagingHandle, func(k kv.Key, flags kv.KeyFlags, v []byte) {
-		if !keyNeedToLock(k, v) {
+		if !keyNeedToLock(k, v, flags) {
 			return
 		}
 		keys = append(keys, k)
@@ -302,11 +302,19 @@ func (st *TxnState) KeysNeedToLock() ([]kv.Key, error) {
 	return keys, nil
 }
 
-func keyNeedToLock(k, v []byte) bool {
+func keyNeedToLock(k, v []byte, flags kv.KeyFlags) bool {
 	isTableKey := bytes.HasPrefix(k, tablecodec.TablePrefix())
 	if !isTableKey {
 		// meta key always need to lock.
 		return true
+	}
+	if flags.HasPresumeKeyNotExists() {
+		return true
+	}
+	isDelete := len(v) == 0
+	if isDelete {
+		// only need to delete row key.
+		return k[10] == 'r'
 	}
 	if tablecodec.IsUntouchedIndexKValue(k, v) {
 		return false

--- a/session/txn.go
+++ b/session/txn.go
@@ -308,11 +308,6 @@ func keyNeedToLock(k, v []byte) bool {
 		// meta key always need to lock.
 		return true
 	}
-	isDelete := len(v) == 0
-	if isDelete {
-		// only need to delete row key.
-		return k[10] == 'r'
-	}
 	if tablecodec.IsUntouchedIndexKValue(k, v) {
 		return false
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19063

### What is changed and how it works?

always lock for key with presume not exists flag.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- always lock keys with presume not exists flag
