### PR TITLE
util/memory: Use defer to release the lock

### DIFF
--- a/util/memory/action.go
+++ b/util/memory/action.go
@@ -84,16 +84,14 @@ func (a *PanicOnExceed) SetLogHook(hook func(uint64)) {
 // Action panics when memory usage exceeds memory quota.
 func (a *PanicOnExceed) Action(t *Tracker) {
 	a.mutex.Lock()
-	if a.acted {
-		a.mutex.Unlock()
-		return
+	defer a.mutex.Unlock()
+	if !a.acted {
+		a.acted = true
+		if a.logHook != nil {
+			a.logHook(a.ConnID)
+		}
+		panic(PanicMemoryExceed + fmt.Sprintf("[conn_id=%d]", a.ConnID))
 	}
-	a.acted = true
-	a.mutex.Unlock()
-	if a.logHook != nil {
-		a.logHook(a.ConnID)
-	}
-	panic(PanicMemoryExceed + fmt.Sprintf("[conn_id=%d]", a.ConnID))
 }
 
 // SetFallback sets a fallback action.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: 

Use defer instead of manually unlock.

Reference method

```go
// Action logs a warning only once when memory usage exceeds memory quota.
func (a *LogOnExceed) Action(t *Tracker) {
	a.mutex.Lock()
	defer a.mutex.Unlock()
	if !a.acted {
		a.acted = true
		if a.logHook == nil {
			logutil.BgLogger().Warn("memory exceeds quota",
				zap.Error(errMemExceedThreshold.GenWithStackByArgs(t.label, t.BytesConsumed(), t.bytesLimit, t.String())))
			return
		}
		a.logHook(a.ConnID)
	}
}
```

### What is changed and how it works?

What's Changed:

How it Works:

### Related changes

### Check List

Tests

- Unit test

### Release note

No release note
