### PR TITLE
ddl : fix enum element length limit

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -905,6 +905,9 @@ func checkColumnValueConstraint(col *table.Column, collation string) error {
 	ctor := collate.GetCollator(collation)
 	for i := range col.Elems {
 		val := string(ctor.Key(col.Elems[i]))
+		if len(val) > 255 || len(val)*4 > 1020 {
+			return types.ErrTooLongValueInType.GenWithStack("Too long enumeration/set value for column %s", col.Name)
+		}
 		if _, ok := valueMap[val]; ok {
 			tpStr := "ENUM"
 			if col.Tp == mysql.TypeSet {

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -907,6 +907,7 @@ const (
 	ErrUserAlreadyExists                                            = 3163
 	ErrInvalidJSONPathArrayCell                                     = 3165
 	ErrInvalidEncryptionOption                                      = 3184
+	ErrTooLongValueInType                                           = 3505
 	ErrPKIndexCantBeInvisible                                       = 3522
 	ErrRoleNotGranted                                               = 3530
 	ErrLockAcquireFailAndNoWaitSet                                  = 3572

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -903,6 +903,7 @@ var MySQLErrName = map[uint16]string{
 	ErrUserAlreadyExists:                                     "User %s already exists.",
 	ErrInvalidJSONPathArrayCell:                              "A path expression is not a path to a cell in an array.",
 	ErrInvalidEncryptionOption:                               "Invalid encryption option.",
+	ErrTooLongValueInType:                                    "Too long enumeration/set value for column %s",
 	ErrPKIndexCantBeInvisible:                                "A primary key index cannot be invisible",
 	ErrWindowNoSuchWindow:                                    "Window name '%s' is not defined.",
 	ErrWindowCircularityInWindowGraph:                        "There is a circularity in the window dependency graph.",

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -180,6 +180,10 @@ func (s *testSuite6) TestCreateTable(c *C) {
 	tk.MustExec("create table if not exists t1_if_exists(c int)")
 	tk.MustExec("drop table if exists t1_if_exists,t2_if_exists,t3_if_exists")
 	tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|", "Note|1051|Unknown table 'test.t2_if_exists'", "Note|1051|Unknown table 'test.t3_if_exists'"))
+
+	// Test for enum type long
+	_, err = tk.Exec("create table t (a enum('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))")
+	c.Assert(err, NotNil)
 }
 
 func (s *testSuite6) TestCreateView(c *C) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -75,4 +75,7 @@ var (
 	ErrInvalidWeekModeFormat = terror.ClassTypes.New(mysql.ErrInvalidWeekModeFormat, mysql.MySQLErrName[mysql.ErrInvalidWeekModeFormat])
 	// ErrWrongValue is returned when the input value is in wrong format.
 	ErrWrongValue = terror.ClassTypes.New(mysql.ErrTruncatedWrongValue, mysql.MySQLErrName[mysql.ErrWrongValue])
+	// ErrTooLongValueInType is returned when enum column M <= 255 and (M x w) <= 1020.
+	// See https://dev.mysql.com/doc/refman/8.0/en/string-type-syntax.html for details
+	ErrTooLongValueInType = terror.ClassTypes.New(mysql.ErrTooLongValueInType, mysql.MySQLErrName[mysql.ErrTooLongValueInType])
 )


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: #19018

Problem Summary:  create table not compatible mysql8
create table t (a enum('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa')) ;

### What is changed and how it works?

add errno.ErrTooLongValueInType to compatible mysql8 error

What's Changed:

How it Works:

### Related changes

n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
mysql> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v4.0.0-beta.2-920-g07ae6078e-dirty
Edition: Community
Git Commit Hash: 07ae6078e887f42ff74a2787a9f9db3895f639d4
Git Branch: myfeature
UTC Build Time: 2020-08-08 10:23:55
GoVersion: go1.13.8
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
1 row in set (0.00 sec)

mysql> create table t (a enum('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'));
ERROR 3505 (HY000): Too long enumeration/set value for column a
mysql>

 
Side effects

n/a

### Release note

n/a
