### PR TITLE
planner: copy column info FieldType when build datasoure schema

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2371,7 +2371,6 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 	schema := expression.NewSchema(make([]*expression.Column, 0, len(columns))...)
 	for _, col := range columns {
 		ds.Columns = append(ds.Columns, col.ToInfo())
-		retType := col.FieldType
 		newCol := &expression.Column{
 			UniqueID:    b.ctx.GetSessionVars().AllocPlanColumnID(),
 			DBName:      dbName,
@@ -2380,7 +2379,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 			OrigTblName: tableInfo.Name,
 			OrigColName: col.Name,
 			ID:          col.ID,
-			RetType:     &retType,
+			RetType:     col.FieldType.Clone(),
 		}
 
 		if tableInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2371,6 +2371,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 	schema := expression.NewSchema(make([]*expression.Column, 0, len(columns))...)
 	for _, col := range columns {
 		ds.Columns = append(ds.Columns, col.ToInfo())
+		retType := col.FieldType
 		newCol := &expression.Column{
 			UniqueID:    b.ctx.GetSessionVars().AllocPlanColumnID(),
 			DBName:      dbName,
@@ -2379,7 +2380,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 			OrigTblName: tableInfo.Name,
 			OrigColName: col.Name,
 			ID:          col.ID,
-			RetType:     &col.FieldType,
+			RetType:     &retType,
 		}
 
 		if tableInfo.PKIsHandle && mysql.HasPriKeyFlag(col.Flag) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

In case info schema column type being modified accidentally during execution.

### What is changed and how it works?

Copy the field type from column info when building DataSource schema.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- TODO

### Release note <!-- bugfixes or new feature need a release note -->

- copy column info FieldType when build datasoure schema
