### PR TITLE
.build: add timeout for make gotest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,9 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 else
 	@echo "Running in native mode."
 	@export log_level=fatal; export TZ='Asia/Shanghai'; \
-	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) -check.p true -check.timeout 4s || { $(FAILPOINT_DISABLE); exit 1; }
+	set -x
+	$(GOTEST) -timeout 6m -ldflags '$(TEST_LDFLAGS)' -cover $(PACKAGES) -check.p true -check.timeout 4s || { $(FAILPOINT_DISABLE); exit 1; }
+	set +x
 endif
 	@$(FAILPOINT_DISABLE)
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

See https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/44576/pipeline/45, the test is killed by ci environment, currently. The in-flight goroutines could be printed if it is killed by the `timeout` flag provided by `go test`

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
