### PR TITLE
executor: Concurrently fetch chunks and insert them to a concurrent hash table in hash build

### DIFF
--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -15,7 +15,6 @@ package executor
 
 import (
 	"fmt"
-	"github.com/pingcap/tidb/util/bitmap"
 	"hash"
 	"hash/fnv"
 	"sync"
@@ -26,6 +25,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/bitmap"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/disk"

--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -532,7 +532,7 @@ func (iw *indexHashJoinInnerWorker) buildHashTableForOuterResult(ctx context.Con
 				panic(err.Error())
 			}
 			rowPtr := chunk.RowPtr{ChkIdx: uint32(chkIdx), RowIdx: uint32(rowIdx)}
-			task.lookupMap.Put(h.Sum64(), rowPtr)
+			task.lookupMap.Put(h.Sum64(), rowPtr, 0)
 		}
 	}
 }

--- a/executor/join.go
+++ b/executor/join.go
@@ -257,7 +257,6 @@ var buildSideResultLabel fmt.Stringer = stringutil.StringerStr("hashJoin.buildSi
 // to e.buildSideResult.
 func (e *HashJoinExec) fetchBuildSideRows(ctx context.Context) {
 	defer close(e.buildSideResultCh)
-	defer close(e.buildFinished)
 	var err error
 	for {
 		if e.finished.Load().(bool) {

--- a/executor/join.go
+++ b/executor/join.go
@@ -693,6 +693,12 @@ func (e *HashJoinExec) prepareForBuild() {
 	e.rowContainer.GetDiskTracker().SetLabel(buildSideResultLabel)
 	if config.GetGlobalConfig().OOMUseTmpStorage {
 		actionSpill := e.rowContainer.ActionSpill()
+		failpoint.Inject("testRowContainerSpill", func(val failpoint.Value) {
+			if val.(bool) {
+				actionSpill = e.rowContainer.rowContainer.ActionSpillForTest()
+				defer actionSpill.(*chunk.SpillDiskAction).WaitForTest()
+			}
+		})
 		e.ctx.GetSessionVars().StmtCtx.MemTracker.FallbackOldAndSetNewAction(actionSpill)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16618, following https://github.com/pingcap/tidb/pull/16678
this PR concurrently fetch chunks, but inseting a hash table using a lock; then merge the concurrent hash table, to achieve concurrent build.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- update original test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- supporting concurrently building hash tables in hash joins.

```
mac:executor fzh$ GO111MODULE=on go test -bench=BenchmarkHashJoinExec -run=benchmark_test.go
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/executor
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12                   1        1651156792 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12                   2         875115518 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12                   2         572805819 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                     6         199510053 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                     7         149599528 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                     7         147609291 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:1,_joinKeyIdx:_[0],_disk:true)-12                      1        3336751882 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:2,_joinKeyIdx:_[0],_disk:true)-12                      1        2812985649 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-12                      1        2718938728 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                             18619             64417 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                             17521             68751 ns/op
BenchmarkHashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                             15794             76382 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0_1],_disk:false)-12                         20          56679880 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0_1],_disk:false)-12                         32          37311673 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-12                         48          24606730 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:1,_joinKeyIdx:_[0],_disk:false)-12                           22          49804462 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:2,_joinKeyIdx:_[0],_disk:false)-12                           34          33123555 ns/op
BenchmarkHashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-12                           51          23309903 ns/op
PASS
ok      github.com/pingcap/tidb/executor        79.345s

```



