### PR TITLE
types: compare nil after type assertion in Datum.SetValue

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -430,61 +430,14 @@ func (d *Datum) GetValue() interface{} {
 
 // SetValueWithDefaultCollation sets any kind of value.
 func (d *Datum) SetValueWithDefaultCollation(val interface{}) {
-	if val == nil {
-		d.SetNull()
-		return
-	}
-	switch x := val.(type) {
-	case bool:
-		if x {
-			d.SetInt64(1)
-		} else {
-			d.SetInt64(0)
-		}
-	case int:
-		d.SetInt64(int64(x))
-	case int64:
-		d.SetInt64(x)
-	case uint64:
-		d.SetUint64(x)
-	case float32:
-		d.SetFloat32(x)
-	case float64:
-		d.SetFloat64(x)
-	case string:
-		d.SetString(x, mysql.DefaultCollationName)
-	case []byte:
-		d.SetBytes(x)
-	case *MyDecimal:
-		d.SetMysqlDecimal(x)
-	case Duration:
-		d.SetMysqlDuration(x)
-	case Enum:
-		d.SetMysqlEnum(x, mysql.DefaultCollationName)
-	case BinaryLiteral:
-		d.SetBinaryLiteral(x)
-	case BitLiteral: // Store as BinaryLiteral for Bit and Hex literals
-		d.SetBinaryLiteral(BinaryLiteral(x))
-	case HexLiteral:
-		d.SetBinaryLiteral(BinaryLiteral(x))
-	case Set:
-		d.SetMysqlSet(x, mysql.DefaultCollationName)
-	case json.BinaryJSON:
-		d.SetMysqlJSON(x)
-	case Time:
-		d.SetMysqlTime(x)
-	default:
-		d.SetInterface(x)
-	}
+	d.SetValue(val, &types.FieldType{Collate: mysql.DefaultCollationName})
 }
 
 // SetValue sets any kind of value.
 func (d *Datum) SetValue(val interface{}, tp *types.FieldType) {
-	if val == nil {
-		d.SetNull()
-		return
-	}
 	switch x := val.(type) {
+	case nil:
+		d.SetNull()
 	case bool:
 		if x {
 			d.SetInt64(1)
@@ -504,8 +457,16 @@ func (d *Datum) SetValue(val interface{}, tp *types.FieldType) {
 	case string:
 		d.SetString(x, tp.Collate)
 	case []byte:
+		if x == nil {
+			d.SetNull()
+			break
+		}
 		d.SetBytes(x)
 	case *MyDecimal:
+		if x == nil {
+			d.SetNull()
+			break
+		}
 		d.SetMysqlDecimal(x)
 	case Duration:
 		d.SetMysqlDuration(x)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

PR Number: fix #19157 <!-- REMOVE this line if no issue to close -->

Problem Summary:

The #19157 cannot resolve the problem in its description, 
because an `interface{}` referring to an object containing a nil ptr is not equal to nil.

For example, following code will print 'false':

```go
var a interface{} = []byte(nil)
fmt.Println(a == nil)
```

### What is changed and how it works?

We must compare a value with nil after type asserting, following code will print 'true':

```go
var a interface{} = []byte(nil)
fmt.Println(a.([]byte) == nil)
```

What's Changed:

`types.Datum.SetValue` and `types.Datum.SetValueWithDefaultCollation`

### Related changes

### Check List

### Release note
- Datum: setting an `interface{}` referring to a nil object as its value will get a `NULL` instead of a zero value.