### PR TITLE
executor: fix build table reader for index join on partition table

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2943,12 +2943,20 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 	if err != nil {
 		return nil, err
 	}
+	tbInfo := e.table.Meta()
 	if v.IsCommonHandle {
 		kvRanges, err := buildKvRangesForIndexJoin(e.ctx, getPhysicalTableID(e.table), -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 		if err != nil {
 			return nil, err
 		}
-		return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
+		if tbInfo.GetPartitionInfo() == nil {
+			return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
+		}
+		e.kvRangeBuilder = kvRangeBuilderFromFunc(func(pid int64) ([]kv.KeyRange, error) {
+			return buildKvRangesForIndexJoin(e.ctx, pid, -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
+		})
+		nextPartition := nextPartitionForTableReader{e}
+		return buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
 	}
 	handles := make([]kv.Handle, 0, len(lookUpContents))
 	for _, content := range lookUpContents {
@@ -2964,10 +2972,36 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			handles = append(handles, handle)
 		}
 	}
-	return builder.buildTableReaderFromHandles(ctx, e, handles)
+
+	if tbInfo.GetPartitionInfo() == nil {
+		return builder.buildTableReaderFromHandles(ctx, e, handles)
+	}
+	if tryOldPartitionImplementation(builder.ctx) {
+		return builder.buildTableReaderFromHandles(ctx, e, handles)
+	}
+
+	e.kvRangeBuilder = kvRangeBuilderFromHandles(handles)
+	nextPartition := nextPartitionForTableReader{e}
+	return buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
 }
 
-func (builder *dataReaderBuilder) buildTableReaderBase(ctx context.Context, e *TableReaderExecutor, reqBuilderWithRange distsql.RequestBuilder) (Executor, error) {
+type kvRangeBuilderFromFunc func(pid int64) ([]kv.KeyRange, error)
+
+func (h kvRangeBuilderFromFunc) buildKeyRange(pid int64) ([]kv.KeyRange, error) {
+	return h(pid)
+}
+
+type kvRangeBuilderFromHandles []kv.Handle
+
+func (h kvRangeBuilderFromHandles) buildKeyRange(pid int64) ([]kv.KeyRange, error) {
+	handles := []kv.Handle(h)
+	sort.Slice(handles, func(i, j int) bool {
+		return handles[i].Compare(handles[j]) < 0
+	})
+	return distsql.TableHandlesToKVRanges(pid, handles), nil
+}
+
+func (builder *dataReaderBuilder) buildTableReaderBase(ctx context.Context, e *TableReaderExecutor, reqBuilderWithRange distsql.RequestBuilder) (*TableReaderExecutor, error) {
 	startTS, err := builder.getSnapshotTS()
 	if err != nil {
 		return nil, err
@@ -2994,7 +3028,7 @@ func (builder *dataReaderBuilder) buildTableReaderBase(ctx context.Context, e *T
 	return e, nil
 }
 
-func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Context, e *TableReaderExecutor, handles []kv.Handle) (Executor, error) {
+func (builder *dataReaderBuilder) buildTableReaderFromHandles(ctx context.Context, e *TableReaderExecutor, handles []kv.Handle) (*TableReaderExecutor, error) {
 	sort.Slice(handles, func(i, j int) bool {
 		return handles[i].Compare(handles[j]) < 0
 	})

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -53,12 +53,25 @@ func (sr selectResultHook) SelectResult(ctx context.Context, sctx sessionctx.Con
 	return sr.selectResultFunc(ctx, sctx, kvReq, fieldTypes, fb, copPlanIDs)
 }
 
+type kvRangeBuilder interface {
+	buildKeyRange(pid int64) ([]kv.KeyRange, error)
+}
+
 // TableReaderExecutor sends DAG request and reads table data from kv layer.
 type TableReaderExecutor struct {
 	baseExecutor
 
-	table  table.Table
+	table table.Table
+
+	// The source of key ranges varies from case to case.
+	// It may be calculated from PyhsicalPlan by executorBuilder, or calculated from argument by dataBuilder;
+	// It may be calculated from ranger.Ranger, or calculated from handles.
+	// The table ID may also change because of the partition table, and causes the key range to change.
+	// So instead of keeping a `range` struct field, it's better to define a interface.
+	kvRangeBuilder
+	// TODO: remove this field, use the kvRangeBuilder interface.
 	ranges []*ranger.Range
+
 	// kvRanges are only use for union scan.
 	kvRanges []kv.KeyRange
 	dagPB    *tipb.DAGRequest
@@ -200,7 +213,13 @@ func (e *TableReaderExecutor) Close() error {
 func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Range) (distsql.SelectResult, error) {
 	var builder distsql.RequestBuilder
 	var reqBuilder *distsql.RequestBuilder
-	if e.table.Meta() != nil && e.table.Meta().IsCommonHandle {
+	if e.kvRangeBuilder != nil {
+		kvRange, err := e.kvRangeBuilder.buildKeyRange(getPhysicalTableID(e.table))
+		if err != nil {
+			return nil, err
+		}
+		reqBuilder = builder.SetKeyRanges(kvRange)
+	} else if e.table.Meta() != nil && e.table.Meta().IsCommonHandle {
 		reqBuilder = builder.SetCommonHandleRanges(e.ctx.GetSessionVars().StmtCtx, getPhysicalTableID(e.table), ranges)
 	} else {
 		reqBuilder = builder.SetTableRanges(getPhysicalTableID(e.table), ranges, e.feedback)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19145 

Problem Summary:

In `IndexLookUpMergeJoin`,  the inner join table reader executor is built at runtime.
The inner table may be a partition table, but the old logic `dataReaderBuilder.buildTableReaderForIndexJoin` does not handle that.

### What is changed and how it works?


What's Changed:
How it Works:

- Turn the executor TableReader into PartitionTable->TableReader in `buildTableReaderForIndexJoin`
-  Key range calculating logic is moved from dataReaderBuilder to Executor, because table ID is unknown at databReaderBuilder

This fix works on the master branch, 4.0 is fixed by https://github.com/pingcap/tidb/pull/19151

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. --> No release note
