### PR TITLE
types: revoke #19157, compare nil by type assertion in datum value setting

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -430,11 +430,9 @@ func (d *Datum) GetValue() interface{} {
 
 // SetValueWithDefaultCollation sets any kind of value.
 func (d *Datum) SetValueWithDefaultCollation(val interface{}) {
-	if val == nil {
-		d.SetNull()
-		return
-	}
 	switch x := val.(type) {
+	case nil:
+		d.SetNull()
 	case bool:
 		if x {
 			d.SetInt64(1)
@@ -480,11 +478,9 @@ func (d *Datum) SetValueWithDefaultCollation(val interface{}) {
 
 // SetValue sets any kind of value.
 func (d *Datum) SetValue(val interface{}, tp *types.FieldType) {
-	if val == nil {
-		d.SetNull()
-		return
-	}
 	switch x := val.(type) {
+	case nil:
+		d.SetNull()
 	case bool:
 		if x {
 			d.SetInt64(1)


### PR DESCRIPTION
Signed-off-by: hexilee <i@hexilee.me>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

The #19157 cannot resolve the problem in its description, 
because an `interface{}` referring to an object containing a nil ptr is not equal to nil.

For example, following code will print 'false':

```go
var a interface{} = []byte(nil)
fmt.Println(a == nil)
```

What's Changed:

`types.Datum.SetValue` and `types.Datum.SetValueWithDefaultCollation`


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
