### PR TITLE
util/rowcodec: make IsRowKey() recognize common handles

### DIFF
--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -172,3 +172,12 @@ func (s *testClusteredSuite) TestClusteredPrefixingPrimaryKey(c *C) {
 	tk.MustExec("insert into t values ('aaa', 1), ('bbb', 1);")
 	tk.MustQuery("select group_concat(name separator '.') from t use index(idx);").Check(testkit.Rows("aaa.bbb"))
 }
+
+func (s *testClusteredSuite) TestClusteredWithOldRowFormat(c *C) {
+	tk := s.newTK(c)
+	tk.Se.GetSessionVars().RowEncoder.Enable = false
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t(id varchar(255) primary key, a int, b int, unique index idx(b));")
+	tk.MustExec("insert into t values ('b568004d-afad-11ea-8e4d-d651e3a981b7', 1, -1);")
+	tk.MustQuery("select * from t use index(primary);").Check(testkit.Rows("b568004d-afad-11ea-8e4d-d651e3a981b7 1 -1"))
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1324,7 +1324,9 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.TxnMode = strings.ToUpper(val)
 	case TiDBRowFormatVersion:
 		formatVersion := int(tidbOptInt64(val, DefTiDBRowFormatV1))
-		if formatVersion == DefTiDBRowFormatV2 {
+		if formatVersion == DefTiDBRowFormatV1 {
+			s.RowEncoder.Enable = false
+		} else if formatVersion == DefTiDBRowFormatV2 {
 			s.RowEncoder.Enable = true
 		}
 	case TiDBLowResolutionTSO:

--- a/util/rowcodec/common.go
+++ b/util/rowcodec/common.go
@@ -223,7 +223,7 @@ const (
 // IsRowKey determine whether key is row key.
 // this method will be used in unistore.
 func IsRowKey(key []byte) bool {
-	return len(key) == rowKeyLen && key[0] == 't' && key[recordPrefixIdx] == 'r'
+	return len(key) >= rowKeyLen && key[0] == 't' && key[recordPrefixIdx] == 'r'
 }
 
 // IsNewFormat checks whether row data is in new-format.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19023 <!-- REMOVE this line if no issue to close -->

Problem Summary:

1. The `variable.SessionVars.RowEncoder` does not update when the global variable `tidb_row_format_version` is set to `1`(old row format).
2. `IsRowKey()` does not recognize the common-handle row key in the pre-write phase. The old format row key cannot convert to the new format.

### What is changed and how it works?

What's Changed: Omitted.

How it Works: Omitted.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
