### PR TITLE
store/tikv: skip a test case to make race test more stable

### DIFF
--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/israce"
 )
 
 // TestFailCommitPrimaryRpcErrors tests rpc errors are handled properly when

--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -119,6 +119,9 @@ func (s *testCommitterSuite) TestFailCommitTimeout(c *C) {
 
 // TestFailPrewriteRegionError tests data race does not happen on retries
 func (s *testCommitterSuite) TestFailPrewriteRegionError(c *C) {
+	if israce.RaceEnabled {
+		c.Skip("skip race test")
+	}
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteResult", `return("notLeader")`), IsNil)
 	defer func() {
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteResult"), IsNil)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

Make the race test CI more stable.
I meet this CI fail and there is no error information, no `FAIL:` keyword in the log.

https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/46496/pipeline



### What is changed and how it works?

I manually run the command

> go test -v -vet=off -p 10 -timeout 15m -race github.com/pingcap/tidb/store/tikv github.com/pingcap/tidb/store/tikv/gcworker github.com/pingcap/tidb/store/tikv/latch github.com/pingcap/tidb/store/tikv/oracle github.com/pingcap/tidb/store/tikv/oracle/oracles github.com/pingcap/tidb/store/tikv/tikvrpc

and find `github.com/pingcap/tidb/store/tikv`  is easy to fail on my laptop.
Due to the lack of memory, the test process is killed, and there is no `FAIL:` keywords.

What's Changed:

Skip `TestFailPrewriteRegionError` which use too much memory with `race` flag.
Other TestFailXXX also require a large amount of memory, but not so much as `TestFailPrewriteRegionError`.

How it Works:

Reduce test program memory to avoid OOM and make CI more stable.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write ``. --> No release note
