### PR TITLE
planner: invalidate cached plan if no UnionScan for tables that need it (#15429)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1554,6 +1554,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	} else if vars.StmtCtx.InSelectStmt {
 		sc.PrevAffectedRows = -1
 	}
+	sc.TblInfo2UnionScan = make(map[*model.TableInfo]bool)
 	errCount, warnCount := vars.StmtCtx.NumErrorWarnings()
 	err = vars.SetSystemVar("warning_count", warnCount)
 	if err != nil {

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/codec"
@@ -122,12 +123,18 @@ func NewPSTMTPlanCacheKey(sessionVars *variable.SessionVars, pstmtID uint32, sch
 
 // PSTMTPlanCacheValue stores the cached Statement and StmtNode.
 type PSTMTPlanCacheValue struct {
-	Plan Plan
+	Plan              Plan
+	TblInfo2UnionScan map[*model.TableInfo]bool
 }
 
 // NewPSTMTPlanCacheValue creates a SQLCacheValue.
-func NewPSTMTPlanCacheValue(plan Plan) *PSTMTPlanCacheValue {
+func NewPSTMTPlanCacheValue(plan Plan, srcMap map[*model.TableInfo]bool) *PSTMTPlanCacheValue {
+	dstMap := make(map[*model.TableInfo]bool)
+	for k, v := range srcMap {
+		dstMap[k] = v
+	}
 	return &PSTMTPlanCacheValue{
-		Plan: plan,
+		Plan:              plan,
+		TblInfo2UnionScan: dstMap,
 	}
 }

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2295,8 +2295,9 @@ func getStatsTable(ctx sessionctx.Context, tblInfo *model.TableInfo, pid int64) 
 
 func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (LogicalPlan, error) {
 	dbName := tn.Schema
+	sessionVars := b.ctx.GetSessionVars()
 	if dbName.L == "" {
-		dbName = model.NewCIStr(b.ctx.GetSessionVars().CurrentDB)
+		dbName = model.NewCIStr(sessionVars.CurrentDB)
 	}
 
 	tbl, err := b.is.TableByName(dbName, tn.Name)
@@ -2405,27 +2406,16 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName) (L
 	}
 
 	var result LogicalPlan = ds
-
-	needUS := false
-	if pi := tableInfo.GetPartitionInfo(); pi == nil {
-		if b.ctx.HasDirtyContent(tableInfo.ID) {
-			needUS = true
-		}
-	} else {
-		// Currently, we'll add a UnionScan on every partition even though only one partition's data is changed.
-		// This is limited by current implementation of Partition Prune. It'll updated once we modify that part.
-		for _, partition := range pi.Definitions {
-			if b.ctx.HasDirtyContent(partition.ID) {
-				needUS = true
-				break
-			}
-		}
-	}
-	if needUS {
+	dirty := tableHasDirtyContent(b.ctx, tableInfo)
+	if dirty {
 		us := LogicalUnionScan{}.Init(b.ctx)
 		us.SetChildren(ds)
 		result = us
 	}
+	if sessionVars.StmtCtx.TblInfo2UnionScan == nil {
+		sessionVars.StmtCtx.TblInfo2UnionScan = make(map[*model.TableInfo]bool)
+	}
+	sessionVars.StmtCtx.TblInfo2UnionScan[tableInfo] = dirty
 
 	// If this table contains any virtual generated columns, we need a
 	// "Projection" to calculate these columns.

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/pingcap/parser"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
@@ -137,9 +138,10 @@ type StatementContext struct {
 	PessimisticLockWaited int32
 	LockKeysDuration      time.Duration
 	// planNormalized use for cache the normalized plan, avoid duplicate builds.
-	planNormalized string
-	planDigest     string
-	LockKeysCount  int32
+	planNormalized    string
+	planDigest        string
+	LockKeysCount     int32
+	TblInfo2UnionScan map[*model.TableInfo]bool
 }
 
 // GetNowTsCached getter for nowTs, if not set get now time and cache it


### PR DESCRIPTION
Cherry-pick PR
---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #14969 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Plan cache mechanism is broken across transaction boundary, i.e, when UnionScan is needed for tables.

### What is changed and how it works?

What's Changed:

Collect `TableInfo` and whether it has been built `UnionScan` during plan building, and store this map into `StatementContext`, then this map is further stored into LRUCache when the plan is put into cache. In `getPhysicalPlan`, if the cached plan contains no `UnionScan` for any query table which has been modified in the transaction, invalidate this cached plan and build a new one.

How it Works:

It can solve cases where the table needs `UnionScan` but the plan doesn't contain one, for cases where the table does not need `UnionScan` but the plan contains one, it does not impact result, so I don't invalidate those plans for a higher cache hit ratio.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more MEM: an additional small map is stored in plan cache for each plan

### Release note <!-- bugfixes or new feature need a release note -->
- Fix wrong result for some cached plans used in transaction.