### PR TITLE
ddl: fix db charset modification panic in an uppercase schema

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1933,6 +1933,16 @@ func (s *testIntegrationSuite5) TestChangingDBCharset(c *C) {
 	verifyDBCharsetAndCollate("alterdb2", "utf8mb4", "utf8mb4_general_ci")
 }
 
+func (s *testIntegrationSuite5) TestChangingUppercaseDBCharset(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop database if exists TEST_UPPERCASE_DB_CHARSET;")
+	tk.MustExec("create database TEST_UPPERCASE_DB_CHARSET;")
+	tk.MustExec("use TEST_UPPERCASE_DB_CHARSET;")
+
+	tk.MustExec("alter database TEST_UPPERCASE_DB_CHARSET default character set utf8;")
+	tk.MustExec("alter database TEST_UPPERCASE_DB_CHARSET default character set utf8mb4;")
+}
+
 func (s *testIntegrationSuite4) TestDropAutoIncrementIndex(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("create database if not exists test")

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1931,14 +1931,11 @@ func (s *testIntegrationSuite5) TestChangingDBCharset(c *C) {
 
 	tk.MustExec("ALTER SCHEMA CHARACTER SET = 'utf8mb4' COLLATE = 'utf8mb4_general_ci'")
 	verifyDBCharsetAndCollate("alterdb2", "utf8mb4", "utf8mb4_general_ci")
-}
 
-func (s *testIntegrationSuite5) TestChangingUppercaseDBCharset(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
+	// Test changing charset of schema with uppercase name. See https://github.com/pingcap/tidb/issues/19273.
 	tk.MustExec("drop database if exists TEST_UPPERCASE_DB_CHARSET;")
 	tk.MustExec("create database TEST_UPPERCASE_DB_CHARSET;")
 	tk.MustExec("use TEST_UPPERCASE_DB_CHARSET;")
-
 	tk.MustExec("alter database TEST_UPPERCASE_DB_CHARSET default character set utf8;")
 	tk.MustExec("alter database TEST_UPPERCASE_DB_CHARSET default character set utf8mb4;")
 }

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -206,7 +206,7 @@ func (b *Builder) applyModifySchemaCharsetAndCollate(m *meta.Meta, diff *model.S
 			fmt.Sprintf("(Schema ID %d)", diff.SchemaID),
 		)
 	}
-	newDbInfo := b.copySchemaTables(di.Name.O)
+	newDbInfo := b.copySchemaTables(di.Name.L)
 	newDbInfo.Charset = di.Charset
 	newDbInfo.Collate = di.Collate
 	return nil
@@ -381,6 +381,7 @@ func (b *Builder) copySchemasMap(oldIS *infoSchema) {
 
 // copySchemaTables creates a new schemaTables instance when a table in the database has changed.
 // It also does modifications on the new one because old schemaTables must be read-only.
+// Note: please make sure the dbName is in lowercase.
 func (b *Builder) copySchemaTables(dbName string) *model.DBInfo {
 	oldSchemaTables := b.is.schemaMap[dbName]
 	newSchemaTables := &schemaTables{


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19273 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The database name should be changed to lower case before passing it into `copySchemaTables`.

### What is changed and how it works?

What's Changed: Omitted.

How it Works: Omitted.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a schema charset modification panic bug in an uppercase schema.
