### PR TITLE
*: annotate execution info in runtime/trace

### DIFF
--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -16,6 +16,7 @@ package planner
 import (
 	"context"
 	"math"
+	"runtime/trace"
 	"strings"
 	"time"
 
@@ -353,6 +354,7 @@ func useMaxTS(ctx sessionctx.Context, p plannercore.Plan) bool {
 // for point select like plan which does not need extra things
 func OptimizeExecStmt(ctx context.Context, sctx sessionctx.Context,
 	execAst *ast.ExecuteStmt, is infoschema.InfoSchema) (plannercore.Plan, error) {
+	defer trace.StartRegion(ctx, "optimize-sql").End()
 	var err error
 	builder := plannercore.NewPlanBuilder(sctx, is, nil)
 	p, err := builder.Build(ctx, execAst)

--- a/session/session.go
+++ b/session/session.go
@@ -23,6 +23,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"runtime/trace"
 	"strconv"
 	"strings"
 	"sync"
@@ -164,6 +165,7 @@ type session struct {
 		values map[fmt.Stringer]interface{}
 	}
 
+	currentCtx  context.Context // only use for runtime.trace, Please NEVER use it.
 	currentPlan plannercore.Plan
 
 	store kv.Storage
@@ -999,6 +1001,7 @@ func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) 
 		span1 := span.Tracer().StartSpan("session.ParseSQL", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
 	}
+	defer trace.StartRegion(ctx, "parse-sql").End()
 	s.parser.SetSQLMode(s.sessionVars.SQLMode)
 	s.parser.EnableWindowFunc(s.sessionVars.EnableWindowFunction)
 	return s.parser.Parse(sql, charset, collation)
@@ -1431,7 +1434,7 @@ func (s *session) Txn(active bool) (kv.Transaction, error) {
 		// Transaction is lazy initialized.
 		// PrepareTxnCtx is called to get a tso future, makes s.txn a pending txn,
 		// If Txn() is called later, wait for the future to get a valid txn.
-		if err := s.txn.changePendingToValid(); err != nil {
+		if err := s.txn.changePendingToValid(s.currentCtx); err != nil {
 			logutil.BgLogger().Error("active transaction fail",
 				zap.Error(err))
 			s.txn.cleanup()
@@ -2162,6 +2165,7 @@ func (s *session) loadCommonGlobalVariablesIfNeeded() error {
 // PrepareTxnCtx starts a goroutine to begin a transaction if needed, and creates a new transaction context.
 // It is called before we execute a sql query.
 func (s *session) PrepareTxnCtx(ctx context.Context) {
+	s.currentCtx = ctx
 	if s.txn.validOrPending() {
 		return
 	}

--- a/session/txn.go
+++ b/session/txn.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/trace"
 	"strings"
 	"sync/atomic"
 
@@ -158,7 +159,7 @@ func (st *TxnState) changeInvalidToPending(future *txnFuture) {
 	st.txnFuture = future
 }
 
-func (st *TxnState) changePendingToValid() error {
+func (st *TxnState) changePendingToValid(ctx context.Context) error {
 	if st.txnFuture == nil {
 		return errors.New("transaction future is not set")
 	}
@@ -166,6 +167,7 @@ func (st *TxnState) changePendingToValid() error {
 	future := st.txnFuture
 	st.txnFuture = nil
 
+	defer trace.StartRegion(ctx, "wait-tso-future").End()
 	txn, err := future.wait()
 	if err != nil {
 		st.Transaction = nil

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -17,6 +17,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"runtime/trace"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -202,6 +203,7 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 		defer span1.Finish()
 		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
+	defer trace.StartRegion(ctx, "commit-txn").End()
 
 	if !txn.valid {
 		return kv.ErrInvalidTxn


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

we often want to know: how much time does this query waste time in runtime, but it's hard to display this number in our slow query.

annotate SQL execution info in runtime/trace maybe "little help" to investigate those problems.

### What is changed and how it works?

What's Changed:

- NewTask  with normalized sql
- Add trace region for parse/compile/waitTso

How it Works:

`trace.IsEnable` will be true when executing "url http://0.0.0.0:10080/debug/pprof/trace\?seconds\=4 --output c1.t" and make code run into trace logic.

then we can see sql in user define task in web

![image](https://user-images.githubusercontent.com/528332/90618394-8678bd00-e242-11ea-8206-0d3722ff57fd.png)

and see log & region for a special query

![image](https://user-images.githubusercontent.com/528332/90618515-b3c56b00-e242-11ea-947f-6452586e571b.png)


### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No logic code

Side effects

- Performance regression in trace period?

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19293)
<!-- Reviewable:end -->
