### PR TITLE
expression: make tidb_decode_key return json type and support escape string

### DIFF
--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -758,7 +758,7 @@ func (b *builtinTiDBDecodeKeySig) evalJSON(row chunk.Row) (res json.BinaryJSON, 
 	}
 	keyjson := decodeKey(b.ctx, s)
 	if keyjson == nil {
-		return json.BinaryJSON{}, true, nil
+		return json.BinaryJSON{}, false, nil
 	}
 	return json.CreateBinary(keyjson), false, nil
 }
@@ -769,7 +769,7 @@ func decodeKey(ctx sessionctx.Context, s string) map[string]interface{} {
 	if err != nil {
 		escapeString, err := codec.DecodeEscapeString(s)
 		if err != nil {
-			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("invalid record/index key: %X", key))
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("invalid record/index key: %X", s))
 			return nil
 		}
 		key = []byte(escapeString)

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -19,7 +19,6 @@ package expression
 
 import (
 	"encoding/hex"
-	"github.com/pingcap/tidb/types/json"
 	"sort"
 	"strings"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -767,8 +767,12 @@ func (b *builtinTiDBDecodeKeySig) evalJSON(row chunk.Row) (res json.BinaryJSON, 
 func decodeKey(ctx sessionctx.Context, s string) map[string]interface{} {
 	key, err := hex.DecodeString(s)
 	if err != nil {
-		ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("invalid record/index key: %X", key))
-		return nil
+		escapeString, err := codec.DecodeEscapeString(s)
+		if err != nil {
+			ctx.GetSessionVars().StmtCtx.AppendWarning(errors.Errorf("invalid record/index key: %X", key))
+			return nil
+		}
+		key = []byte(escapeString)
 	}
 	// Auto decode byte if needed.
 	_, bs, err := codec.DecodeBytes(key, nil)

--- a/expression/builtin_info.go
+++ b/expression/builtin_info.go
@@ -795,7 +795,7 @@ func decodeKey(ctx sessionctx.Context, s string) map[string]interface{} {
 		return map[string]interface{}{
 			"tableID":     tableID,
 			"indexID":     indexID,
-			"indexValues": indexValues,
+			"indexValues": strings.Join(indexValues, ","),
 		}
 	}
 	// TODO: try to decode other type key.

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -14,13 +14,13 @@
 package expression
 
 import (
-	"github.com/pingcap/tidb/types/json"
 	"sort"
 	"strings"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/printer"
 )

--- a/expression/builtin_info_vec.go
+++ b/expression/builtin_info_vec.go
@@ -14,6 +14,7 @@
 package expression
 
 import (
+	"github.com/pingcap/tidb/types/json"
 	"sort"
 	"strings"
 
@@ -329,7 +330,7 @@ func (b *builtinTiDBDecodeKeySig) vectorized() bool {
 	return true
 }
 
-func (b *builtinTiDBDecodeKeySig) vecEvalString(input *chunk.Chunk, result *chunk.Column) error {
+func (b *builtinTiDBDecodeKeySig) vecEvalJSON(input *chunk.Chunk, result *chunk.Column) error {
 	n := input.NumRows()
 	buf, err := b.bufAllocator.get(types.ETString, n)
 	if err != nil {
@@ -339,13 +340,13 @@ func (b *builtinTiDBDecodeKeySig) vecEvalString(input *chunk.Chunk, result *chun
 	if err := b.args[0].VecEvalString(b.ctx, input, buf); err != nil {
 		return err
 	}
-	result.ReserveString(n)
+	result.ReserveJSON(n)
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		result.AppendString(decodeKey(b.ctx, buf.GetString(i)))
+		result.AppendJSON(json.CreateBinary(decodeKey(b.ctx, buf.GetString(i))))
 	}
 	return nil
 }

--- a/expression/builtin_info_vec_test.go
+++ b/expression/builtin_info_vec_test.go
@@ -66,7 +66,7 @@ var vecBuiltinInfoCases = map[string][]vecExprBenchCase{
 	},
 	ast.TiDBDecodeKey: {
 		{
-			retEvalType:   types.ETString,
+			retEvalType:   types.ETJson,
 			childrenTypes: []types.EvalType{types.ETString},
 			geners: []dataGenerator{&tidbKeyGener{
 				inner: newDefaultGener(0, types.ETInt),

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4426,18 +4426,18 @@ func (s *testIntegrationSuite) TestTiDBInternalFunc(c *C) {
 	defer s.cleanEnv(c)
 	var result *testkit.Result
 	result = tk.MustQuery("select tidb_decode_key( '74800000000000002B5F72800000000000A5D3' )")
-	result.Check(testkit.Rows("tableID=43, _tidb_rowid=42451"))
+	result.Check(testkit.Rows(`{"_tidb_rowid": 42451, "tableID": 43}`))
 	result = tk.MustQuery("select tidb_decode_key( '7480000000000000325f7205bff199999999999a013131000000000000f9' )")
-	result.Check(testkit.Rows("tableID=50, clusterHandle={1.1, 11}"))
+	result.Check(testkit.Rows(`{"clusterHandle": "{1.1, 11}", "tableID": 50}`))
 
 	result = tk.MustQuery("select tidb_decode_key( '74800000000000019B5F698000000000000001015257303100000000FB013736383232313130FF3900000000000000F8010000000000000000F7' )")
-	result.Check(testkit.Rows("tableID=411, indexID=1, indexValues=RW01,768221109,"))
+	result.Check(testkit.Rows(`{"indexID": 1, "indexValues": "RW01,768221109,", "tableID": 411}`))
 	result = tk.MustQuery("select tidb_decode_key( '7480000000000000695F698000000000000001038000000000004E20' )")
-	result.Check(testkit.Rows("tableID=105, indexID=1, indexValues=20000"))
+	result.Check(testkit.Rows(`{"indexID": 1, "indexValues": "20000", "tableID": 105}`))
 
 	// Test invalid record/index key.
 	result = tk.MustQuery("select tidb_decode_key( '7480000000000000FF2E5F728000000011FFE1A3000000000000' )")
-	result.Check(testkit.Rows("7480000000000000FF2E5F728000000011FFE1A3000000000000"))
+	result.Check(testkit.Rows("<nil>"))
 	warns := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
 	c.Assert(warns, HasLen, 1)
 	c.Assert(warns[0].Err.Error(), Equals, "invalid record/index key: 7480000000000000FF2E5F728000000011FFE1A3000000000000")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

part of #15951. 

Problem Summary:

### What is changed and how it works?

What's Changed:
- make `tidb_deocde_key` return json type
- add escape string support for `tidb_deocde_key`

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- make `tidb_deocde_key` return json type and support escape string <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
