### PR TITLE
test: make runGCJobFailure test stable by enlarging wait timeout

### DIFF
--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -538,7 +538,7 @@ func (w *GCWorker) setGCWorkerServiceSafePoint(ctx context.Context, safePoint ui
 
 func (w *GCWorker) runGCJob(ctx context.Context, safePoint uint64, concurrency int) error {
 	failpoint.Inject("mockRunGCJobFail", func() {
-		failpoint.Return(errors.New("mock failure of runGCJoB"))
+		failpoint.Return(errors.New("mock failure of runGCJob"))
 	})
 	metrics.GCWorkerCounter.WithLabelValues("run_job").Inc()
 	usePhysical, err := w.checkUsePhysicalScanLock()

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -980,7 +980,7 @@ func (s *testGCWorkerSuite) TestStartWithRunGCJobFailures(c *C) {
 
 	for i := 0; i < 3; i++ {
 		select {
-		case <-time.After(100 * time.Millisecond):
+		case <-time.After(time.Second):
 			c.Fatal("gc worker failed to handle errors")
 		case s.gcWorker.done <- errors.New("mock error"):
 		}


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19304 <!-- REMOVE this line if no issue to close -->

Problem Summary: `testGCWorkerSuite.TestStartWithRunGCJobFailures` may fail when runing with race detector.
* https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/45190/pipeline/83
* https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_unit_test/detail/tidb_ghpr_unit_test/46770/pipeline/83/

There are only 2 failures in last 90 days, so it seems that 100ms is not long enough for race test.

### What is changed and how it works?

What's Changed: increase the wait timeout to 1s.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
