### PR TITLE
ddl, executor: fix clustered prefix primary key truncation

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -346,8 +346,8 @@ func CommonHandleRangesToKVRanges(sc *stmtctx.StatementContext, tid int64, range
 			low = kv.Key(low).PrefixNext()
 		}
 		ran.LowVal[0].SetBytes(low)
-		startKey := tablecodec.EncodeCommonHandleSeekKey(tid, low)
-		endKey := tablecodec.EncodeCommonHandleSeekKey(tid, high)
+		startKey := tablecodec.EncodeRowKey(tid, low)
+		endKey := tablecodec.EncodeRowKey(tid, high)
 		krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 	}
 	return krs, nil

--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -166,11 +166,22 @@ func (s *testClusteredSuite) TestClusteredPrefixingPrimaryKey(c *C) {
 	tk.MustGetErrCode("insert into t values ('aac', 1, 'aac');", errno.ErrDupEntry)
 	tk.MustGetErrCode("insert into t values ('bb', 1, 'bb');", errno.ErrDupEntry)
 	tk.MustGetErrCode("insert into t values ('bbc', 1, 'bbc');", errno.ErrDupEntry)
+	tk.MustGetErrCode("update t set name = 'aa', c = 'aa' where c = 'ccc'", errno.ErrDupEntry)
+	tk.MustExec("update t set name = 'ccc' where name = 'aa'")
+	tk.MustQuery("select group_concat(name order by name separator '.') from t use index(idx);").
+		Check(testkit.Rows("aaa.bbb.bbb.ccc"))
+	tk.MustExec("admin check table t;")
 
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(name varchar(255), b int, primary key(name(2)), index idx(b));")
 	tk.MustExec("insert into t values ('aaa', 1), ('bbb', 1);")
-	tk.MustQuery("select group_concat(name separator '.') from t use index(idx);").Check(testkit.Rows("aaa.bbb"))
+	tk.MustQuery("select group_concat(name order by name separator '.') from t use index(idx);").
+		Check(testkit.Rows("aaa.bbb"))
+
+	tk.MustGetErrCode("update t set name = 'aaaaa' where name = 'bbb'", errno.ErrDupEntry)
+	tk.MustExec("update ignore t set name = 'aaaaa' where name = 'bbb'")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1062 Duplicate entry '{aa}' for key 'PRIMARY'"))
+	tk.MustExec("admin check table t;")
 }
 
 func (s *testClusteredSuite) TestClusteredWithOldRowFormat(c *C) {

--- a/executor/write.go
+++ b/executor/write.go
@@ -124,6 +124,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 				for _, idxCol := range pkIdx.Columns {
 					pkDts = append(pkDts, newData[idxCol.Offset])
 				}
+				tablecodec.TruncateIndexValues(t.Meta(), pkIdx, pkDts)
 				handleBytes, err := codec.EncodeKey(sctx.GetSessionVars().StmtCtx, nil, pkDts...)
 				if err != nil {
 					return false, err

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -622,14 +622,6 @@ func EncodeIndexSeekKey(tableID int64, idxID int64, encodedValue []byte) kv.Key 
 	return key
 }
 
-// EncodeCommonHandleSeekKey encodes a common handle value to kv.Key.
-func EncodeCommonHandleSeekKey(tableID int64, encodedValue []byte) kv.Key {
-	key := make([]byte, 0, prefixLen+len(encodedValue))
-	key = appendTableRecordPrefix(key, tableID)
-	key = append(key, encodedValue...)
-	return key
-}
-
 // CutIndexKey cuts encoded index key into colIDs to bytes slices map.
 // The returned value b is the remaining bytes of the key which would be empty if it is unique index or handle data
 // if it is non-unique index.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: 
- In `UpdateRecord`, the updating common handle should be truncated. Otherwise, the update-ignore statement fails to throw a warning. 

```sql
drop table if exists t;
set tidb_enable_clustered_index=1;
create table t(a varchar(255), b int, primary key (a(2)));
insert into t values ('aaa', 1), ('bbb', 1);
update ignore t set a = 'aaaaa' where a = 'bbb';
show warnings;
```

Expected
```
+---------+------+----------------------------------------+
| Level   | Code | Message                                |
+---------+------+----------------------------------------+
| Warning | 1062 | Duplicate entry 'aa' for key 'PRIMARY' |
+---------+------+----------------------------------------+
```

Got
```
+-------+------+---------+
| Level | Code | Message |
+-------+------+---------+
```

### What is changed and how it works?

What's Changed: Truncate the updating common handle if necessary.

How it Works: Omitted.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
