### PR TITLE
ddl: fix create table like would not split regions on TiKV （#14904）

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -246,7 +246,6 @@ type DDL interface {
 	DropSchema(ctx sessionctx.Context, schema model.CIStr) error
 	CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
-	CreateTableWithLike(ctx sessionctx.Context, ident, referIdent ast.Ident, ifNotExists bool) error
 	DropTable(ctx sessionctx.Context, tableIdent ast.Ident) (err error)
 	RecoverTable(ctx sessionctx.Context, tbInfo *model.TableInfo, schemaID, autoID, dropJobID int64, snapshotTS uint64) (err error)
 	DropView(ctx sessionctx.Context, tableIdent ast.Ident) (err error)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1203,66 +1203,13 @@ func buildTableInfo(ctx sessionctx.Context, d *ddl, tableName model.CIStr, cols 
 	return
 }
 
-func (d *ddl) CreateTableWithLike(ctx sessionctx.Context, ident, referIdent ast.Ident, ifNotExists bool) error {
-	is := d.GetInfoSchemaWithInterceptor(ctx)
-	_, ok := is.SchemaByName(referIdent.Schema)
-	if !ok {
-		return infoschema.ErrTableNotExists.GenWithStackByArgs(referIdent.Schema, referIdent.Name)
-	}
-	referTbl, err := is.TableByName(referIdent.Schema, referIdent.Name)
-	if err != nil {
-		return infoschema.ErrTableNotExists.GenWithStackByArgs(referIdent.Schema, referIdent.Name)
-	}
-	schema, ok := is.SchemaByName(ident.Schema)
-	if !ok {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(ident.Schema)
-	}
-	if is.TableExists(ident.Schema, ident.Name) {
-		if ifNotExists {
-			ctx.GetSessionVars().StmtCtx.AppendNote(infoschema.ErrTableExists.GenWithStackByArgs(ident))
-			return nil
-		}
-		return infoschema.ErrTableExists.GenWithStackByArgs(ident)
-	}
-
-	tblInfo := buildTableInfoWithLike(ident, referTbl.Meta())
-	count := 1
-	if tblInfo.Partition != nil {
-		count += len(tblInfo.Partition.Definitions)
-	}
-	var genIDs []int64
-	genIDs, err = d.genGlobalIDs(count)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	tblInfo.ID = genIDs[0]
-	if tblInfo.Partition != nil {
-		for i := 0; i < len(tblInfo.Partition.Definitions); i++ {
-			tblInfo.Partition.Definitions[i].ID = genIDs[i+1]
-		}
-	}
-
-	job := &model.Job{
-		SchemaID:   schema.ID,
-		TableID:    tblInfo.ID,
-		SchemaName: schema.Name.L,
-		Type:       model.ActionCreateTable,
-		BinlogInfo: &model.HistoryInfo{},
-		Args:       []interface{}{tblInfo},
-	}
-
-	err = d.doDDLJob(ctx, job)
-	err = d.callHookOnChanged(err)
-	return errors.Trace(err)
-}
-
 // checkTableInfoValid uses to check table info valid. This is used to validate table info.
 func checkTableInfoValid(tblInfo *model.TableInfo) error {
 	_, err := tables.TableFromMeta(nil, tblInfo)
 	return err
 }
 
-func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) model.TableInfo {
+func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) *model.TableInfo {
 	tblInfo := *referTblInfo
 	// Check non-public column and adjust column offset.
 	newColumns := referTblInfo.Cols()
@@ -1283,7 +1230,7 @@ func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) mode
 		copy(pi.Definitions, referTblInfo.Partition.Definitions)
 		tblInfo.Partition = &pi
 	}
-	return tblInfo
+	return &tblInfo
 }
 
 // BuildTableInfoFromAST builds model.TableInfo from a SQL statement.
@@ -1387,14 +1334,23 @@ func buildTableInfoWithCheck(ctx sessionctx.Context, d *ddl, s *ast.CreateTableS
 
 func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err error) {
 	ident := ast.Ident{Schema: s.Table.Schema, Name: s.Table.Name}
-	if s.ReferTable != nil {
-		referIdent := ast.Ident{Schema: s.ReferTable.Schema, Name: s.ReferTable.Name}
-		return d.CreateTableWithLike(ctx, ident, referIdent, s.IfNotExists)
-	}
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	schema, ok := is.SchemaByName(ident.Schema)
 	if !ok {
 		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(ident.Schema)
+	}
+
+	var referTbl table.Table
+	if s.ReferTable != nil {
+		referIdent := ast.Ident{Schema: s.ReferTable.Schema, Name: s.ReferTable.Name}
+		_, ok := is.SchemaByName(referIdent.Schema)
+		if !ok {
+			return infoschema.ErrTableNotExists.GenWithStackByArgs(referIdent.Schema, referIdent.Name)
+		}
+		referTbl, err = is.TableByName(referIdent.Schema, referIdent.Name)
+		if err != nil {
+			return infoschema.ErrTableNotExists.GenWithStackByArgs(referIdent.Schema, referIdent.Name)
+		}
 	}
 	if is.TableExists(ident.Schema, ident.Name) {
 		if s.IfNotExists {
@@ -1404,7 +1360,29 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 		return infoschema.ErrTableExists.GenWithStackByArgs(ident)
 	}
 
-	tbInfo, err := buildTableInfoWithCheck(ctx, d, s, schema.Charset, schema.Collate)
+	// build tableInfo
+	var tbInfo *model.TableInfo
+	if s.ReferTable != nil {
+		tbInfo = buildTableInfoWithLike(ident, referTbl.Meta())
+		count := 1
+		if tbInfo.Partition != nil {
+			count += len(tbInfo.Partition.Definitions)
+		}
+		var genIDs []int64
+		genIDs, err = d.genGlobalIDs(count)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		tbInfo.ID = genIDs[0]
+		if tbInfo.Partition != nil {
+			for i := 0; i < len(tbInfo.Partition.Definitions); i++ {
+				tbInfo.Partition.Definitions[i].ID = genIDs[i+1]
+			}
+		}
+	} else {
+		tbInfo, err = buildTableInfoWithCheck(ctx, d, s, schema.Charset, schema.Collate)
+	}
+
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -19,6 +19,7 @@ import (
 	"math"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -339,7 +340,40 @@ func (s *testSerialSuite) TestCreateTableWithLike(c *C) {
 	tk.MustExec("create table ctwl_db1.pt1 like ctwl_db.pt1;")
 	tk.MustQuery("select * from ctwl_db1.pt1").Check(testkit.Rows())
 
+	// Test create table like for partition table.
+	atomic.StoreUint32(&ddl.EnableSplitTableRegion, 1)
+	tk.MustExec("use test")
+	tk.MustExec("set @@global.tidb_scatter_region=1;")
+	tk.MustExec("drop table if exists partition_t;")
+	tk.MustExec("create table partition_t (a int, b int,index(a)) partition by hash (a) partitions 3")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1 like partition_t")
+	re := tk.MustQuery("show table t1 regions")
+	rows := re.Rows()
+	c.Assert(len(rows), Equals, 3)
+	tbl := testGetTableByName(c, tk.Se, "test", "t1")
+	partitionDef := tbl.Meta().GetPartitionInfo().Definitions
+	c.Assert(rows[0][1], Matches, fmt.Sprintf("t_%d_.*", partitionDef[0].ID))
+	c.Assert(rows[1][1], Matches, fmt.Sprintf("t_%d_.*", partitionDef[1].ID))
+	c.Assert(rows[2][1], Matches, fmt.Sprintf("t_%d_.*", partitionDef[2].ID))
+
+	// Test pre-split table region when create table like.
+	tk.MustExec("drop table if exists t_pre")
+	tk.MustExec("create table t_pre (a int, b int) shard_row_id_bits = 2 pre_split_regions=2;")
+	tk.MustExec("drop table if exists t2;")
+	tk.MustExec("create table t2 like t_pre")
+	re = tk.MustQuery("show table t2 regions")
+	rows = re.Rows()
+	// Table t2 which create like t_pre should have 4 regions now.
+	c.Assert(len(rows), Equals, 4)
+	tbl = testGetTableByName(c, tk.Se, "test", "t2")
+	c.Assert(rows[1][1], Equals, fmt.Sprintf("t_%d_r_2305843009213693952", tbl.Meta().ID))
+	c.Assert(rows[2][1], Equals, fmt.Sprintf("t_%d_r_4611686018427387904", tbl.Meta().ID))
+	c.Assert(rows[3][1], Equals, fmt.Sprintf("t_%d_r_6917529027641081856", tbl.Meta().ID))
+	defer atomic.StoreUint32(&ddl.EnableSplitTableRegion, 0)
+
 	// for failure cases
+	tk.MustExec("use ctwl_db")
 	failSQL := fmt.Sprintf("create table t1 like test_not_exist.t")
 	tk.MustGetErrCode(failSQL, mysql.ErrNoSuchTable)
 	failSQL = fmt.Sprintf("create table t1 like test.t_not_exist")


### PR DESCRIPTION
<!--
Thank you for contributing to TiDB! Please read TiDB's [CONTRIBUTING](https://github.com/pingcap/community/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Fix #14881

### What is changed and how it works?
1. Remove `CreateTableWithLike()` and move the logic from `CreateTableWithLike()` to `CreateTable()`.
2. Make `create table`  and `create table like` share the `split region logic`.

MockTikv could not split region, so test split region in TiDB cluster.

**1. Test split region when create table like:**
```
mysql root@127.0.0.1:test> create table t1(i int);                                                                                                                                                          
Query OK, 0 rows affected
Time: 0.128s

on PD cmd：
[2020/03/05 19:28:21.914 +08:00] [INFO] [cluster_worker.go:213] ["region batch split, generate new regions"] [region-id=2] [origin="id:44 start_key:\"7480000000000000FF2B00000000000000F8\" end_key:\"7480000000000000FF2D00000000000000F8\" region_epoch:<conf_ver:1 version:22 > peers:<id:45 store_id:1 >"] [total=1]
[2020/03/05 19:28:21.915 +08:00] [INFO] [cluster.go:440] ["region Version changed"] [region-id=2] [detail="StartKey Changed:{7480000000000000FF2B00000000000000F8} -> {7480000000000000FF2D00000000000000F8}, EndKey:{}"] [old-version=21] [new-version=22]

no TiKV cmd：
[2020/03/05 19:28:21.900 +08:00] [INFO] [peer.rs:315] ["on split"] [split_keys="key 7480000000000000FF2D00000000000000F8"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:21.901 +08:00] [INFO] [pd.rs:438] ["try to batch split region"] [region="id: 2 start_key: 7480000000000000FF2B00000000000000F8 region_epoch { conf_ver: 1 version: 21 } peers { id: 3 store_id: 1 }"] [new_region_ids="[new_region_id: 44 new_peer_ids: 45]"] [region_id=2]
[2020/03/05 19:28:21.905 +08:00] [INFO] [apply.rs:1100] ["execute admin command"] [command="cmd_type: BatchSplit splits { requests { split_key: 7480000000000000FF2D00000000000000F8 new_region_id: 44 new_peer_ids: 45 } right_derive: true }"] [index=54] [term=7] [peer_id=3] [region_id=2]
[2020/03/05 19:28:21.906 +08:00] [INFO] [apply.rs:1684] ["split region"] [keys="key 7480000000000000FF2D00000000000000F8"] [region="id: 2 start_key: 7480000000000000FF2B00000000000000F8 region_epoch { conf_ver: 1 version: 21 } peers { id: 3 store_id: 1 }"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:21.913 +08:00] [INFO] [peer.rs:1507] ["notify pd with split"] [split_count=2] [peer_id=3] [region_id=2]


mysql root@127.0.0.1:test> create table t2 like t1;                                                                                                                                                         
Query OK, 0 rows affected
Time: 0.122s

on PD cmd：
[2020/03/05 19:28:52.849 +08:00] [INFO] [cluster.go:440] ["region Version changed"] [region-id=2] [detail="StartKey Changed:{7480000000000000FF2D00000000000000F8} -> {7480000000000000FF2F00000000000000F8}, EndKey:{}"] [old-version=22] [new-version=23]
[2020/03/05 19:28:52.849 +08:00] [INFO] [cluster_worker.go:213] ["region batch split, generate new regions"] [region-id=2] [origin="id:46 start_key:\"7480000000000000FF2D00000000000000F8\" end_key:\"7480000000000000FF2F00000000000000F8\" region_epoch:<conf_ver:1 version:23 > peers:<id:47 store_id:1 >"] [total=1]

no TiKV cmd：
[2020/03/05 19:28:52.821 +08:00] [INFO] [peer.rs:315] ["on split"] [split_keys="key 7480000000000000FF2F00000000000000F8"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:52.822 +08:00] [INFO] [peer.rs:2587] ["epoch changed, retry later"] [epoch="conf_ver: 1 version: 21"] [prev_epoch="conf_ver: 1 version: 22"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:52.826 +08:00] [INFO] [peer.rs:315] ["on split"] [split_keys="key 7480000000000000FF2F00000000000000F8"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:52.828 +08:00] [INFO] [pd.rs:438] ["try to batch split region"] [region="id: 2 start_key: 7480000000000000FF2D00000000000000F8 region_epoch { conf_ver: 1 version: 22 } peers { id: 3 store_id: 1 }"] [new_region_ids="[new_region_id: 46 new_peer_ids: 47]"] [region_id=2]
[2020/03/05 19:28:52.832 +08:00] [INFO] [apply.rs:1100] ["execute admin command"] [command="cmd_type: BatchSplit splits { requests { split_key: 7480000000000000FF2F00000000000000F8 new_region_id: 46 new_peer_ids: 47 } right_derive: true }"] [index=55] [term=7] [peer_id=3] [region_id=2]
[2020/03/05 19:28:52.833 +08:00] [INFO] [apply.rs:1684] ["split region"] [keys="key 7480000000000000FF2F00000000000000F8"] [region="id: 2 start_key: 7480000000000000FF2D00000000000000F8 region_epoch { conf_ver: 1 version: 22 } peers { id: 3 store_id: 1 }"] [peer_id=3] [region_id=2]
[2020/03/05 19:28:52.849 +08:00] [INFO] [peer.rs:1507] ["notify pd with split"] [split_count=2] [peer_id=3] [region_id=2]
```

**2. Test pre_split_region when create table like:**
```
mysql> create table t (a int, b int,index idx1(a)) shard_row_id_bits = 4 pre_split_regions=2;
Query OK, 0 rows affected (0.01 sec)
mysql root@127.0.0.1:INFORMATION_SCHEMA> select `REGION_ID`,`DB_NAME`,`TABLE_NAME`,`INDEX_NAME` from TIKV_REGION_STATUS where `DB_NAME` = 'test'and `TABLE_NAME` = 't';                                     
+-------------+-----------+--------------+--------------+
| REGION_ID   | DB_NAME   | TABLE_NAME   | INDEX_NAME   |
|-------------+-----------+--------------+--------------|
| 50          | test      | t            | <null>       |
| 52          | test      | t            | <null>       |
| 48          | test      | t            | idx1         |
| 48          | test      | t            | <null>       |
| 2           | test      | t            | <null>       |
+-------------+-----------+--------------+--------------+
5 rows in set
Time: 0.035s


mysql root@127.0.0.1:(none)> create table test.t3 like test.t;                                                                                                                                              
Query OK, 0 rows affected
Time: 0.115s
mysql root@127.0.0.1:(none)> select `REGION_ID`,`DB_NAME`,`TABLE_NAME`,`INDEX_NAME` from information_schema.TIKV_REGION_STATUS where `DB_NAME` = 'test'and `TABLE_NAME` = 't3';                             
+-------------+-----------+--------------+--------------+
| REGION_ID   | DB_NAME   | TABLE_NAME   | INDEX_NAME   |
|-------------+-----------+--------------+--------------|
| 68          | test      | t3           | <null>       |
| 66          | test      | t3           | <null>       |
| 2           | test      | t3           | <null>       |
| 64          | test      | t3           | idx1         |
| 64          | test      | t3           | <null>       |
+-------------+-----------+--------------+--------------+
5 rows in set
Time: 0.038s
```
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
 - Integration test

### Release note <!-- bugfixes or new feature need a release note -->

-  fix create table like would not split regions on TiKV