### PR TITLE
executor : fix refill table id bug for tiflash partition reading

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -130,6 +130,7 @@ var _ = Suite(&testSuiteWithData{baseTestSuite: &baseTestSuite{}})
 var _ = SerialSuites(&testSerialSuite1{&baseTestSuite{}})
 var _ = SerialSuites(&testSlowQuery{&baseTestSuite{}})
 var _ = Suite(&partitionTableSuite{&baseTestSuite{}})
+var _ = SerialSuites(&tiflashTestSuite{})
 
 type testSuite struct{ *baseTestSuite }
 type testSuiteP1 struct{ *baseTestSuite }

--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -143,16 +143,12 @@ func updateExecutorTableID(ctx context.Context, exec *tipb.Executor, tableID, pa
 		exec.IdxScan.TableId = partitionID
 	case tipb.ExecType_TypeSelection:
 		child = exec.Selection.Child
-	case tipb.ExecType_TypeAggregation:
+	case tipb.ExecType_TypeAggregation, tipb.ExecType_TypeStreamAgg:
 		child = exec.Aggregation.Child
 	case tipb.ExecType_TypeTopN:
 		child = exec.TopN.Child
 	case tipb.ExecType_TypeLimit:
 		child = exec.Limit.Child
-	case tipb.ExecType_TypeStreamAgg:
-		if exec.StreamAgg != nil {
-			child = exec.StreamAgg.Child
-		}
 	case tipb.ExecType_TypeJoin:
 		// TiFlash currently does not support Join on partition table.
 		// The planner should not generate this kind of plan.

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -2,6 +2,7 @@ package executor_test
 
 import (
 	"fmt"
+
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/parser"

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -1,3 +1,16 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package executor_test
 
 import (

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -37,14 +37,14 @@ type tiflashTestSuite struct {
 	ctx *mock.Context
 }
 
-func (s *tiflashTestSuite) SetUpSuite(c *C, tiflashNum int) {
+func (s *tiflashTestSuite) SetUpSuite(c *C) {
 	var err error
 	s.store, err = mockstore.NewMockStore(
 		mockstore.WithClusterInspector(func(c cluster.Cluster) {
 			mockCluster := c.(*mocktikv.Cluster)
 			_, _, region1 := mockstore.BootstrapWithSingleStore(c)
 			tiflashIdx := 0
-			for tiflashIdx < tiflashNum {
+			for tiflashIdx < 2 {
 				store2 := c.AllocID()
 				peer2 := c.AllocID()
 				addr2 := fmt.Sprintf("tiflash%d", tiflashIdx)

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -1,0 +1,69 @@
+package executor_test
+
+import (
+	"fmt"
+	. "github.com/pingcap/check"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/parser"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
+	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+type tiflashTestSuite struct {
+	cluster cluster.Cluster
+	store   kv.Storage
+	dom     *domain.Domain
+	*parser.Parser
+	ctx *mock.Context
+}
+
+func (s *tiflashTestSuite) SetUpSuite(c *C, tiflashNum int) {
+	var err error
+	s.store, err = mockstore.NewMockStore(
+		mockstore.WithClusterInspector(func(c cluster.Cluster) {
+			mockCluster := c.(*mocktikv.Cluster)
+			_, _, region1 := mockstore.BootstrapWithSingleStore(c)
+			tiflashIdx := 0
+			for tiflashIdx < tiflashNum {
+				store2 := c.AllocID()
+				peer2 := c.AllocID()
+				addr2 := fmt.Sprintf("tiflash%d", tiflashIdx)
+				mockCluster.AddStore(store2, addr2)
+				mockCluster.UpdateStoreAddr(store2, addr2, &metapb.StoreLabel{Key: "engine", Value: "tiflash"})
+				mockCluster.AddPeer(region1, store2, peer2)
+				tiflashIdx++
+			}
+		}),
+		mockstore.WithStoreType(mockstore.MockTiKV),
+	)
+
+	c.Assert(err, IsNil)
+
+	session.SetSchemaLease(0)
+	session.DisableStats4Test()
+
+	s.dom, err = session.BootstrapSession(s.store)
+	c.Assert(err, IsNil)
+	s.dom.SetStatsUpdating(true)
+}
+
+func (s *tiflashTestSuite) TestReadPartitionTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int not null primary key, b int not null) partition by hash(a) partitions 2")
+	tk.MustExec("alter table t set tiflash replica 1")
+	tb := testGetTableByName(c, tk.Se, "test", "t")
+	err := domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
+	c.Assert(err, IsNil)
+	tk.MustExec("insert into t values(1,0)")
+	tk.MustExec("insert into t values(2,0)")
+	tk.MustExec("insert into t values(3,0)")
+	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
+	tk.MustQuery("select /*+ STREAM_AGG() */ count(*) from t").Check(testkit.Rows("3"))
+}

--- a/store/mockstore/mocktikv/cop_handler_dag.go
+++ b/store/mockstore/mocktikv/cop_handler_dag.go
@@ -697,9 +697,6 @@ func (h *rpcHandler) fillUpData4SelectResponse(selResp *tipb.SelectResponse, dag
 func (h *rpcHandler) constructRespSchema(dagCtx *dagContext) []*types.FieldType {
 	root := dagCtx.dagReq.Executors[len(dagCtx.dagReq.Executors)-1]
 	agg := root.Aggregation
-	if root.StreamAgg != nil {
-		agg = root.StreamAgg
-	}
 	if agg == nil {
 		return dagCtx.evalCtx.fieldTps
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
When refill partition tables' id, the executor with stream_agg will be the 'Aggregation' instance, stream_agg in tipb never be used and should be removed.

### What is changed and how it works?



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- executor : fix refill table id bug for tiflash partition reading
