### PR TITLE
ddl: disallow change auto_random default value by 'ALTER COLUMN'

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3376,9 +3376,7 @@ func processColumnOptions(ctx sessionctx.Context, col *table.Column, options []*
 	}
 
 	if hasDefaultValue {
-
-		err := checkDefaultValue(ctx, col, true)
-		return errors.Trace(err)
+		return errors.Trace(checkDefaultValue(ctx, col, true))
 	}
 
 	return nil

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -928,7 +928,7 @@ func containsColumnOption(colDef *ast.ColumnDef, opTp ast.ColumnOptionType) bool
 	return false
 }
 
-// IsAutoRandomColumnID returns true if the given column ID belongs to a auto_random column.
+// IsAutoRandomColumnID returns true if the given column ID belongs to an auto_random column.
 func IsAutoRandomColumnID(tblInfo *model.TableInfo, colID int64) bool {
 	return tblInfo.PKIsHandle && tblInfo.ContainsAutoRandomBits() && tblInfo.GetPkColInfo().ID == colID
 }

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -1005,6 +1005,7 @@ func (s *testSerialSuite) TestAutoRandom(c *C) {
 	assertDefault("create table t (a bigint auto_random(2) primary key default 5)")
 	mustExecAndDrop("create table t (a bigint auto_random primary key)", func() {
 		assertDefault("alter table t modify column a bigint auto_random default 3")
+		assertDefault("alter table t alter column a set default 3")
 	})
 
 	// Overflow data type max length.

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -526,7 +526,7 @@ func (e *InsertValues) fillColValue(ctx context.Context, datum types.Datum, idx 
 		return d, nil
 	}
 	tblInfo := e.Table.Meta()
-	if tblInfo.PKIsHandle && tblInfo.ContainsAutoRandomBits() && column.ID == tblInfo.GetPkColInfo().ID {
+	if ddl.IsAutoRandomColumnID(tblInfo, column.ID) {
 		d, err := e.adjustAutoRandomDatum(ctx, datum, hasValue, column)
 		if err != nil {
 			return types.Datum{}, err

--- a/executor/show.go
+++ b/executor/show.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb-tools/tidb-binlog/node"
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
@@ -823,7 +824,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 				buf.WriteString(table.OptionalFsp(&col.FieldType))
 			}
 		}
-		if tableInfo.PKIsHandle && tableInfo.ContainsAutoRandomBits() && tableInfo.GetPkName().L == col.Name.L {
+		if ddl.IsAutoRandomColumnID(tableInfo, col.ID) {
 			buf.WriteString(fmt.Sprintf(" /*T![auto_rand] AUTO_RANDOM(%d) */", tableInfo.AutoRandomBits))
 		}
 		if len(col.Comment) > 0 {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19350 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`auto_random` columns cannot have a default value.

There are 3 ways to set a default value for a column, and all of them should be disallowed:
- `CREATE TABLE`
- `ALTER TABLE MODIFY/CHANGE`
- `ALTER TABLE ALTER COLUMN SET DEFAULT`

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
- Add a check at `AlterColumn`.
- Add a simple test case.

How it Works: Omitted.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
