### PR TITLE
*: fix unable prune problem caused by mismatch column infos

### DIFF
--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -359,7 +359,7 @@ insert into th values (0,0),(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8);
 insert into th values (-1,-1),(-2,-2),(-3,-3),(-4,-4),(-5,-5),(-6,-6),(-7,-7),(-8,-8);
 desc select * from th where a=-2;
 id	estRows	task	access object	operator info
-TableReader_7	10.00	root	partition:all	data:Selection_6
+TableReader_7	10.00	root	partition:p2	data:Selection_6
 └─Selection_6	10.00	cop[tikv]		eq(test.th.a, -2)
   └─TableFullScan_5	10000.00	cop[tikv]	table:th	keep order:false, stats:pseudo
 desc select * from th;

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2491,7 +2491,7 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 	}
 
 	nextPartition := nextPartitionForTableReader{ret}
-	exec, err := buildPartitionTable(b, ts.Table, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, ret, nextPartition)
+	exec, err := buildPartitionTable(b, ts.Table, &v.PartitionInfo, ret, nextPartition)
 	if err != nil {
 		b.err = err
 		return nil
@@ -2499,19 +2499,16 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 	return exec
 }
 
-func buildPartitionTable(b *executorBuilder, tblInfo *model.TableInfo, filter []expression.Expression, names []model.CIStr, e Executor, n nextPartition) (Executor, error) {
+func buildPartitionTable(b *executorBuilder, tblInfo *model.TableInfo, partitionInfo *plannercore.PartitionInfo, e Executor, n nextPartition) (Executor, error) {
 	tmp, _ := b.is.TableByID(tblInfo.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, filter, names)
+	partitions, err := partitionPruning(b.ctx, tbl, partitionInfo.PruningConds, partitionInfo.PartitionNames, partitionInfo.Columns, partitionInfo.ColumnNames)
 	if err != nil {
 		return nil, err
 	}
 
 	if len(partitions) == 0 {
 		return &TableDualExec{baseExecutor: *e.base()}, nil
-	}
-	if len(partitions) == 1 {
-		return n.nextPartition(context.Background(), partitions[0])
 	}
 	return &PartitionTableExecutor{
 		baseExecutor:  *e.base(),
@@ -2602,7 +2599,7 @@ func (b *executorBuilder) buildIndexReader(v *plannercore.PhysicalIndexReader) E
 	}
 
 	nextPartition := nextPartitionForIndexReader{exec: ret}
-	exec, err := buildPartitionTable(b, is.Table, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, ret, nextPartition)
+	exec, err := buildPartitionTable(b, is.Table, &v.PartitionInfo, ret, nextPartition)
 	if err != nil {
 		b.err = err
 	}
@@ -2739,7 +2736,7 @@ func (b *executorBuilder) buildIndexLookUpReader(v *plannercore.PhysicalIndexLoo
 	}
 
 	nextPartition := nextPartitionForIndexLookUp{exec: ret}
-	exec, err := buildPartitionTable(b, ts.Table, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, ret, nextPartition)
+	exec, err := buildPartitionTable(b, ts.Table, &v.PartitionInfo, ret, nextPartition)
 	if err != nil {
 		b.err = err
 		return nil
@@ -2849,7 +2846,7 @@ func (b *executorBuilder) buildIndexMergeReader(v *plannercore.PhysicalIndexMerg
 	}
 
 	nextPartition := nextPartitionForIndexMerge{ret}
-	exec, err := buildPartitionTable(b, ts.Table, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, ret, nextPartition)
+	exec, err := buildPartitionTable(b, ts.Table, &v.PartitionInfo, ret, nextPartition)
 	if err != nil {
 		b.err = err
 		return nil
@@ -2951,7 +2948,7 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			return buildKvRangesForIndexJoin(e.ctx, pid, -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 		})
 		nextPartition := nextPartitionForTableReader{e}
-		return buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
+		return buildPartitionTable(builder.executorBuilder, tbInfo, &v.PartitionInfo, e, nextPartition)
 	}
 	handles := make([]kv.Handle, 0, len(lookUpContents))
 	for _, content := range lookUpContents {
@@ -2977,7 +2974,7 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 
 	e.kvRangeBuilder = kvRangeBuilderFromHandles(handles)
 	nextPartition := nextPartitionForTableReader{e}
-	return buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
+	return buildPartitionTable(builder.executorBuilder, tbInfo, &v.PartitionInfo, e, nextPartition)
 }
 
 type kvRangeBuilderFromFunc func(pid int64) ([]kv.KeyRange, error)
@@ -3059,7 +3056,7 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 		return nil, err
 	}
 	nextPartition := nextPartitionForIndexReader{exec: e}
-	ret, err := buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
+	ret, err := buildPartitionTable(builder.executorBuilder, tbInfo, &v.PartitionInfo, e, nextPartition)
 	if err != nil {
 		return nil, err
 	}
@@ -3089,7 +3086,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 		return nil, err
 	}
 	nextPartition := nextPartitionForIndexLookUp{exec: e}
-	ret, err := buildPartitionTable(builder.executorBuilder, tbInfo, v.PartitionTable.PruningConds, v.PartitionTable.PartitionNames, e, nextPartition)
+	ret, err := buildPartitionTable(builder.executorBuilder, tbInfo, &v.PartitionInfo, e, nextPartition)
 	if err != nil {
 		return nil, err
 	}
@@ -3505,8 +3502,9 @@ func tryOldPartitionImplementation(sctx sessionctx.Context) bool {
 	return ok
 }
 
-func partitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds []expression.Expression, partitionNames []model.CIStr) ([]table.PhysicalTable, error) {
-	idxArr, err := plannercore.PartitionPruning(ctx, tbl, conds, partitionNames)
+func partitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds []expression.Expression, partitionNames []model.CIStr,
+	columns []*expression.Column, columnNames types.NameSlice) ([]table.PhysicalTable, error) {
+	idxArr, err := plannercore.PartitionPruning(ctx, tbl, conds, partitionNames, columns, columnNames)
 	if err != nil {
 		return nil, err
 	}

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -5,7 +5,7 @@
       {
         "SQL": "explain select * from t1 where id = 7 and a = 6",
         "Result": [
-          "TableReader_7 0.00 root partition:all data:Selection_6",
+          "TableReader_7 0.00 root partition:p7 data:Selection_6",
           "└─Selection_6 0.00 cop[tikv]  eq(test_partition.t1.a, 6)",
           "  └─TableRangeScan_5 1.00 cop[tikv] table:t1 range:[7,7], keep order:false, stats:pseudo"
         ]
@@ -19,7 +19,7 @@
       {
         "SQL": "explain select * from t2 where id = 9 and a = -110",
         "Result": [
-          "IndexLookUp_7 1.00 root partition:all ",
+          "IndexLookUp_7 1.00 root partition:p1 ",
           "├─IndexRangeScan_5(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[9 -110,9 -110], keep order:false, stats:pseudo",
           "└─TableRowIDScan_6(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ]
@@ -27,14 +27,14 @@
       {
         "SQL": "explain select * from t1 where id = -17",
         "Result": [
-          "TableReader_6 1.00 root partition:all data:TableRangeScan_5",
+          "TableReader_6 1.00 root partition:p7 data:TableRangeScan_5",
           "└─TableRangeScan_5 1.00 cop[tikv] table:t1 range:[-17,-17], keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "explain select * from t2 where id = a and a = b and b = 2",
         "Result": [
-          "TableReader_7 8.00 root partition:all data:Selection_6",
+          "TableReader_7 8.00 root partition:p4 data:Selection_6",
           "└─Selection_6 8.00 cop[tikv]  eq(test_partition.t2.a, test_partition.t2.b), eq(test_partition.t2.b, 2), eq(test_partition.t2.id, test_partition.t2.a)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ]
@@ -43,10 +43,10 @@
         "SQL": "explain select * from t1 join t2 on (t1.id = t2.id) where t1.id = 5 and t2.a = 7",
         "Result": [
           "HashJoin_8 1.00 root  CARTESIAN inner join",
-          "├─IndexLookUp_14(Build) 1.00 root partition:all ",
+          "├─IndexLookUp_14(Build) 1.00 root partition:p2 ",
           "│ ├─IndexRangeScan_12(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[5 7,5 7], keep order:false, stats:pseudo",
           "│ └─TableRowIDScan_13(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_11(Probe) 1.00 root partition:all data:TableRangeScan_10",
+          "└─TableReader_11(Probe) 1.00 root partition:p5 data:TableRangeScan_10",
           "  └─TableRangeScan_10 1.00 cop[tikv] table:t1 range:[5,5], keep order:false, stats:pseudo"
         ]
       },
@@ -54,10 +54,10 @@
         "SQL": "explain select * from t1 left join t2 on t1.id = 1 and t2.a = 2 where t2.id = 7",
         "Result": [
           "HashJoin_7 1.00 root  CARTESIAN inner join",
-          "├─IndexLookUp_13(Build) 1.00 root partition:all ",
+          "├─IndexLookUp_13(Build) 1.00 root partition:p9 ",
           "│ ├─IndexRangeScan_11(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[7 2,7 2], keep order:false, stats:pseudo",
           "│ └─TableRowIDScan_12(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_10(Probe) 1.00 root partition:all data:TableRangeScan_9",
+          "└─TableReader_10(Probe) 1.00 root partition:p1 data:TableRangeScan_9",
           "  └─TableRangeScan_9 1.00 cop[tikv] table:t1 range:[1,1], keep order:false, stats:pseudo"
         ]
       },
@@ -65,9 +65,9 @@
         "SQL": "explain select * from t2 join t1 on t1.id = t2.id and t2.a = t1.id and t2.id = 12",
         "Result": [
           "HashJoin_7 1.00 root  CARTESIAN inner join",
-          "├─TableReader_13(Build) 1.00 root partition:all data:TableRangeScan_12",
+          "├─TableReader_13(Build) 1.00 root partition:p2 data:TableRangeScan_12",
           "│ └─TableRangeScan_12 1.00 cop[tikv] table:t1 range:[12,12], keep order:false, stats:pseudo",
-          "└─IndexLookUp_11(Probe) 1.00 root partition:all ",
+          "└─IndexLookUp_11(Probe) 1.00 root partition:p4 ",
           "  ├─IndexRangeScan_9(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[12 12,12 12], keep order:false, stats:pseudo",
           "  └─TableRowIDScan_10(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ]
@@ -93,7 +93,7 @@
       {
         "SQL": "explain select * from t4 where d = '2019-10-07 10:40:00' and a = 1",
         "Result": [
-          "IndexLookUp_7 1.00 root partition:all ",
+          "IndexLookUp_7 1.00 root partition:p9 ",
           "├─IndexRangeScan_5(Build) 1.00 cop[tikv] table:t4, index:PRIMARY(d, a) range:[2019-10-07 10:40:00 1,2019-10-07 10:40:00 1], keep order:false, stats:pseudo",
           "└─TableRowIDScan_6(Probe) 1.00 cop[tikv] table:t4 keep order:false, stats:pseudo"
         ]
@@ -101,7 +101,7 @@
       {
         "SQL": "explain select * from t5 where d = '2019-10-07'",
         "Result": [
-          "IndexLookUp_10 10.00 root partition:all ",
+          "IndexLookUp_10 10.00 root partition:p0 ",
           "├─IndexRangeScan_8(Build) 10.00 cop[tikv] table:t5, index:PRIMARY(d, a) range:[2019-10-07,2019-10-07], keep order:false, stats:pseudo",
           "└─TableRowIDScan_9(Probe) 10.00 cop[tikv] table:t5 keep order:false, stats:pseudo"
         ]
@@ -109,7 +109,7 @@
       {
         "SQL": "explain select * from t6 where a is null",
         "Result": [
-          "TableReader_7 10.00 root partition:all data:Selection_6",
+          "TableReader_7 10.00 root partition:p0 data:Selection_6",
           "└─Selection_6 10.00 cop[tikv]  isnull(test_partition.t6.a)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t6 keep order:false, stats:pseudo"
         ]
@@ -131,7 +131,7 @@
       {
         "SQL": "explain select * from t7 where b = -3 and a is null",
         "Result": [
-          "TableReader_7 0.01 root partition:all data:Selection_6",
+          "TableReader_7 0.01 root partition:p0 data:Selection_6",
           "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t7.b, -3), isnull(test_partition.t7.a)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t7 keep order:false, stats:pseudo"
         ]

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -877,6 +877,12 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 		tblColHists:       ds.TblColHists,
 		keepOrder:         ts.KeepOrder,
 	}
+	copTask.partitionInfo = PartitionInfo{
+		PruningConds:   ds.allConds,
+		PartitionNames: ds.partitionNames,
+		Columns:        ds.TblCols,
+		ColumnNames:    ds.names,
+	}
 	selStats := ts.stats.Scale(selectivity)
 	ts.addPushedDownSelection(copTask, selStats)
 	t := finishCopTask(ds.ctx, copTask).(*rootTask)
@@ -933,6 +939,12 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 		tblColHists: ds.TblColHists,
 		tblCols:     ds.TblCols,
 		keepOrder:   is.KeepOrder,
+	}
+	cop.partitionInfo = PartitionInfo{
+		PruningConds:   ds.allConds,
+		PartitionNames: ds.partitionNames,
+		Columns:        ds.TblCols,
+		ColumnNames:    ds.names,
 	}
 	if !ds.isCoveringIndex(ds.schema.Columns, path.FullIdxCols, path.FullIdxColLens, is.Table) {
 		// On this way, it's double read case.

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -283,12 +283,12 @@ func (p *PhysicalTableReader) accessObject(sctx sessionctx.Context) string {
 	}
 	tbl := tmp.(table.PartitionedTable)
 
-	return partitionAccessObject(sctx, tbl, pi, p.PartitionTable.PruningConds, p.PartitionTable.PartitionNames)
+	return partitionAccessObject(sctx, tbl, pi, &p.PartitionInfo)
 }
 
-func partitionAccessObject(sctx sessionctx.Context, tbl table.PartitionedTable, pi *model.PartitionInfo, conds []expression.Expression, names []model.CIStr) string {
+func partitionAccessObject(sctx sessionctx.Context, tbl table.PartitionedTable, pi *model.PartitionInfo, partTable *PartitionInfo) string {
 	var buffer bytes.Buffer
-	idxArr, err := PartitionPruning(sctx, tbl, conds, names)
+	idxArr, err := PartitionPruning(sctx, tbl, partTable.PruningConds, partTable.PartitionNames, partTable.Columns, partTable.ColumnNames)
 	if err != nil {
 		return "partition pruning error" + err.Error()
 	}
@@ -344,7 +344,7 @@ func (p *PhysicalIndexReader) accessObject(sctx sessionctx.Context) string {
 	}
 
 	tbl := tmp.(table.PartitionedTable)
-	return partitionAccessObject(sctx, tbl, pi, p.PartitionTable.PruningConds, p.PartitionTable.PartitionNames)
+	return partitionAccessObject(sctx, tbl, pi, &p.PartitionInfo)
 }
 
 // ExplainInfo implements Plan interface.
@@ -372,7 +372,7 @@ func (p *PhysicalIndexLookUpReader) accessObject(sctx sessionctx.Context) string
 	}
 
 	tbl := tmp.(table.PartitionedTable)
-	return partitionAccessObject(sctx, tbl, pi, p.PartitionTable.PruningConds, p.PartitionTable.PartitionNames)
+	return partitionAccessObject(sctx, tbl, pi, &p.PartitionInfo)
 }
 
 // ExplainInfo implements Plan interface.
@@ -394,7 +394,7 @@ func (p *PhysicalIndexMergeReader) accessObject(sctx sessionctx.Context) string 
 	}
 	tbl := tmp.(table.PartitionedTable)
 
-	return partitionAccessObject(sctx, tbl, pi, p.PartitionTable.PruningConds, p.PartitionTable.PartitionNames)
+	return partitionAccessObject(sctx, tbl, pi, &p.PartitionInfo)
 }
 
 // ExplainInfo implements Plan interface.

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -767,8 +767,12 @@ func (ds *DataSource) convertToIndexMergeScan(prop *property.PhysicalProperty, c
 		indexPlanFinished: true,
 		tblColHists:       ds.TblColHists,
 	}
-	cop.partitionTable.pruningConds = ds.allConds
-	cop.partitionTable.partitionNames = ds.partitionNames
+	cop.partitionInfo = PartitionInfo{
+		PruningConds:   ds.allConds,
+		PartitionNames: ds.partitionNames,
+		Columns:        ds.TblCols,
+		ColumnNames:    ds.names,
+	}
 	for _, partPath := range path.PartialIndexPaths {
 		var scan PhysicalPlan
 		var partialCost, rowCount float64
@@ -961,8 +965,12 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 		tblColHists: ds.TblColHists,
 		tblCols:     ds.TblCols,
 	}
-	cop.partitionTable.pruningConds = ds.allConds
-	cop.partitionTable.partitionNames = ds.partitionNames
+	cop.partitionInfo = PartitionInfo{
+		PruningConds:   ds.allConds,
+		PartitionNames: ds.partitionNames,
+		Columns:        ds.TblCols,
+		ColumnNames:    ds.names,
+	}
 	if !candidate.isSingleScan {
 		// On this way, it's double read case.
 		ts := PhysicalTableScan{
@@ -1365,8 +1373,12 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 		tblColHists:       ds.TblColHists,
 		cst:               cost,
 	}
-	copTask.partitionTable.pruningConds = ds.allConds
-	copTask.partitionTable.partitionNames = ds.partitionNames
+	copTask.partitionInfo = PartitionInfo{
+		PruningConds:   ds.allConds,
+		PartitionNames: ds.partitionNames,
+		Columns:        ds.TblCols,
+		ColumnNames:    ds.names,
+	}
 	task = copTask
 	if candidate.isMatchProp {
 		copTask.keepOrder = true

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -728,9 +728,12 @@ func (s *testIntegrationSuite) TestPartitionPruningForEQ(c *C) {
 	pt := tbl.(table.PartitionedTable)
 	query, err := expression.ParseSimpleExprWithTableInfo(tk.Se, "a = '2020-01-01 00:00:00'", tbl.Meta())
 	c.Assert(err, IsNil)
+	dbName := model.NewCIStr(tk.Se.GetSessionVars().CurrentDB)
+	columns, names, err := expression.ColumnInfos2ColumnsAndNames(tk.Se, dbName, tbl.Meta().Name, tbl.Meta().Columns, tbl.Meta())
+	c.Assert(err, IsNil)
 	// Even the partition is not monotonous, EQ condition should be prune!
 	// select * from t where a = '2020-01-01 00:00:00'
-	res, err := core.PartitionPruning(tk.Se, pt, []expression.Expression{query}, nil)
+	res, err := core.PartitionPruning(tk.Se, pt, []expression.Expression{query}, nil, columns, names)
 	c.Assert(err, IsNil)
 	c.Assert(res, HasLen, 1)
 	c.Assert(res[0], Equals, 0)

--- a/planner/core/partition_prune.go
+++ b/planner/core/partition_prune.go
@@ -17,20 +17,16 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/types"
 )
 
 // PartitionPruning finds all used partitions according to query conditions, it will
 // return nil if condition match none of partitions. The return value is a array of the
 // idx in the partition definitions array, use pi.Definitions[idx] to get the partition ID
-func PartitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds []expression.Expression, partitionNames []model.CIStr) ([]int, error) {
+func PartitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds []expression.Expression, partitionNames []model.CIStr,
+	columns []*expression.Column, names types.NameSlice) ([]int, error) {
 	s := partitionProcessor{}
-	tblInfo := tbl.Meta()
-	dbName := model.NewCIStr(ctx.GetSessionVars().CurrentDB)
-	columns, names, err := expression.ColumnInfos2ColumnsAndNames(ctx, dbName, tblInfo.Name, tblInfo.Columns, tblInfo)
-	if err != nil {
-		return nil, err
-	}
-	pi := tblInfo.Partition
+	pi := tbl.Meta().Partition
 	switch pi.Type {
 	case model.PartitionTypeHash:
 		return s.pruneHashPartition(ctx, tbl, partitionNames, conds, columns, names)

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -77,10 +77,15 @@ type PhysicalTableReader struct {
 	IsCommonHandle bool
 
 	// Used by partition table.
-	PartitionTable struct {
-		PruningConds   []expression.Expression
-		PartitionNames []model.CIStr
-	}
+	PartitionInfo PartitionInfo
+}
+
+// PartitionInfo indicates partition helper info in physical plan.
+type PartitionInfo struct {
+	PruningConds   []expression.Expression
+	PartitionNames []model.CIStr
+	Columns        []*expression.Column
+	ColumnNames    types.NameSlice
 }
 
 // GetTablePlan exports the tablePlan.
@@ -107,6 +112,12 @@ func (p *PhysicalTableReader) GetTableScan() *PhysicalTableScan {
 // GetPhysicalTableReader returns PhysicalTableReader for logical TiKVSingleGather.
 func (sg *TiKVSingleGather) GetPhysicalTableReader(schema *expression.Schema, stats *property.StatsInfo, props ...*property.PhysicalProperty) *PhysicalTableReader {
 	reader := PhysicalTableReader{}.Init(sg.ctx, sg.blockOffset)
+	reader.PartitionInfo = PartitionInfo{
+		PruningConds:   sg.Source.allConds,
+		PartitionNames: sg.Source.partitionNames,
+		Columns:        sg.Source.TblCols,
+		ColumnNames:    sg.Source.names,
+	}
 	reader.stats = stats
 	reader.SetSchema(schema)
 	reader.childrenReqProps = props
@@ -167,10 +178,7 @@ type PhysicalIndexReader struct {
 	OutputColumns []*expression.Column
 
 	// Used by partition table.
-	PartitionTable struct {
-		PruningConds   []expression.Expression
-		PartitionNames []model.CIStr
-	}
+	PartitionInfo PartitionInfo
 }
 
 // Clone implements PhysicalPlan interface.
@@ -251,10 +259,7 @@ type PhysicalIndexLookUpReader struct {
 	CommonHandleCols []*expression.Column
 
 	// Used by partition table.
-	PartitionTable struct {
-		PruningConds   []expression.Expression
-		PartitionNames []model.CIStr
-	}
+	PartitionInfo PartitionInfo
 }
 
 // Clone implements PhysicalPlan interface.
@@ -311,10 +316,7 @@ type PhysicalIndexMergeReader struct {
 	tablePlan PhysicalPlan
 
 	// Used by partition table.
-	PartitionTable struct {
-		PruningConds   []expression.Expression
-		PartitionNames []model.CIStr
-	}
+	PartitionInfo PartitionInfo
 }
 
 // ExtractCorrelatedCols implements PhysicalPlan interface.

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/charset"
-	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
@@ -72,10 +71,7 @@ type copTask struct {
 	rootTaskConds []expression.Expression
 
 	// For table partition.
-	partitionTable struct {
-		pruningConds   []expression.Expression
-		partitionNames []model.CIStr
-	}
+	partitionInfo PartitionInfo
 }
 
 func (t *copTask) invalid() bool {
@@ -661,8 +657,7 @@ func buildIndexLookUpTask(ctx sessionctx.Context, t *copTask) *rootTask {
 		ExtraHandleCol:   t.extraHandleCol,
 		CommonHandleCols: t.commonHandleCols,
 	}.Init(ctx, t.tablePlan.SelectBlockOffset())
-	p.PartitionTable.PruningConds = t.partitionTable.pruningConds
-	p.PartitionTable.PartitionNames = t.partitionTable.partitionNames
+	p.PartitionInfo = t.partitionInfo
 	setTableScanToTableRowIDScan(p.tablePlan)
 	p.stats = t.tablePlan.statsInfo()
 	// Add cost of building table reader executors. Handles are extracted in batch style,
@@ -731,8 +726,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 			partialPlans: t.idxMergePartPlans,
 			tablePlan:    t.tablePlan,
 		}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
-		p.PartitionTable.PruningConds = t.partitionTable.pruningConds
-		p.PartitionTable.PartitionNames = t.partitionTable.partitionNames
+		p.PartitionInfo = t.partitionInfo
 		setTableScanToTableRowIDScan(p.tablePlan)
 		newTask.p = p
 		return newTask
@@ -741,8 +735,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 		newTask = buildIndexLookUpTask(ctx, t)
 	} else if t.indexPlan != nil {
 		p := PhysicalIndexReader{indexPlan: t.indexPlan}.Init(ctx, t.indexPlan.SelectBlockOffset())
-		p.PartitionTable.PruningConds = t.partitionTable.pruningConds
-		p.PartitionTable.PartitionNames = t.partitionTable.partitionNames
+		p.PartitionInfo = t.partitionInfo
 		p.stats = t.indexPlan.statsInfo()
 		newTask.p = p
 	} else {
@@ -761,8 +754,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 			StoreType:      ts.StoreType,
 			IsCommonHandle: ts.Table.IsCommonHandle,
 		}.Init(ctx, t.tablePlan.SelectBlockOffset())
-		p.PartitionTable.PruningConds = t.partitionTable.pruningConds
-		p.PartitionTable.PartitionNames = t.partitionTable.partitionNames
+		p.PartitionInfo = t.partitionInfo
 		p.stats = t.tablePlan.statsInfo()
 		ts.Columns = ExpandVirtualColumn(ts.Columns, ts.schema, ts.Table.Columns)
 		newTask.p = p


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19348<!-- REMOVE this line if no issue to close -->

Problem Summary:

```
create table t(a int, b int) partition by hash(a) partitions 4;
explain select * from t  where a = 1;
```

can not be pruned, due to master refactor that make column id mismatch, so ***ONLY MASTER***

### What is changed and how it works?

What's Changed, How it Works::

pass Datasource's schema column and names to the executor to make column info matched

### Related changes

- only master bug

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19391)
<!-- Reviewable:end -->
