### PR TITLE
executor: fix wrong results when index join on union scan partition table

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -900,6 +900,13 @@ func (b *executorBuilder) buildUnionScanExec(v *plannercore.PhysicalUnionScan) E
 		return nil
 	}
 
+	return b.buildUnionScanFromReader(reader, v)
+}
+
+// buildUnionScanFromReader builds union scan executor from child executor.
+// Note that this function may be called by inner workers of index lookup join concurrently.
+// Be careful to avoid data race.
+func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannercore.PhysicalUnionScan) Executor {
 	// Adjust UnionScan->PartitionTable->Reader
 	// to PartitionTable->UnionScan->Reader
 	// The build of UnionScan executor is delay to the nextPartition() function
@@ -913,14 +920,6 @@ func (b *executorBuilder) buildUnionScanExec(v *plannercore.PhysicalUnionScan) E
 		}
 		return x
 	}
-
-	return b.buildUnionScanFromReader(reader, v)
-}
-
-// buildUnionScanFromReader builds union scan executor from child executor.
-// Note that this function may be called by inner workers of index lookup join concurrently.
-// Be careful to avoid data race.
-func (b *executorBuilder) buildUnionScanFromReader(reader Executor, v *plannercore.PhysicalUnionScan) Executor {
 	us := &UnionScanExec{baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID(), reader)}
 	// Get the handle column index of the below Plan.
 	us.belowHandleCols = v.HandleCols
@@ -2921,19 +2920,6 @@ func (builder *dataReaderBuilder) buildUnionScanForIndexJoin(ctx context.Context
 	reader, err := childBuilder.buildExecutorForIndexJoin(ctx, values, indexRanges, keyOff2IdxOff, cwc)
 	if err != nil {
 		return nil, err
-	}
-	// Adjust UnionScan->PartitionTable->Reader
-	// to PartitionTable->UnionScan->Reader
-	// The build of UnionScan executor is delay to the nextPartition() function
-	// because the Reader executor is available there.
-	if x, ok := reader.(*PartitionTableExecutor); ok {
-		nextPartitionForReader := x.nextPartition
-		x.nextPartition = nextPartitionForUnionScan{
-			b:     builder.executorBuilder,
-			us:    v,
-			child: nextPartitionForReader,
-		}
-		return x, nil
 	}
 
 	ret := builder.buildUnionScanFromReader(reader, v)


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19411

### What is changed and how it works?


What's Changed: When building union scan for index join, it should check whether the child executor is `partitionTableScan`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- none.
