### PR TITLE
server: fix region table http response

### DIFF
--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -1387,6 +1387,9 @@ func (h regionHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	// 		`for id in [frameRange.firstTableID,frameRange.endTableID]`
 	// on [frameRange.firstTableID,frameRange.endTableID] is small enough.
 	for _, db := range schema.AllSchemas() {
+		if util.IsMemDB(db.Name.L) {
+			continue
+		}
 		for _, tableVal := range db.Tables {
 			regionDetail.addTableInRange(db.Name.String(), tableVal, frameRange)
 		}

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -227,7 +227,8 @@ func (ts *HTTPHandlerTestSuite) TestRegionIndexRangeWithStartNoLimit(c *C) {
 func (ts *HTTPHandlerTestSuite) TestRegionsAPI(c *C) {
 	ts.startServer(c)
 	defer ts.stopServer(c)
-	resp, err := ts.fetchStatus("/tables/information_schema/SCHEMATA/regions")
+	ts.prepareData(c)
+	resp, err := ts.fetchStatus("/tables/tidb/t/regions")
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
 	defer resp.Body.Close()

--- a/util/misc.go
+++ b/util/misc.go
@@ -196,10 +196,14 @@ var (
 
 // IsMemOrSysDB uses to check whether dbLowerName is memory database or system database.
 func IsMemOrSysDB(dbLowerName string) bool {
+	return IsMemDB(dbLowerName) || dbLowerName == mysql.SystemDB
+}
+
+// IsMemDB checks whether dbLowerName is memory database.
+func IsMemDB(dbLowerName string) bool {
 	switch dbLowerName {
 	case InformationSchemaName.L,
 		PerformanceSchemaName.L,
-		mysql.SystemDB,
 		MetricSchemaName.L:
 		return true
 	}


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Issue Number: close #11918
Problem Summary: `/regions/{region}` API outputs many memory database tables.

### What is changed and how it works?

What's Changed: Skip memory dbs.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)
```
start 1pd+1tikv+1tidb
curl http://127.0.0.1:10080/regions/2
check output
```

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
