### PR TITLE
planner: do not construct index merge join when inner is partition table

### DIFF
--- a/executor/index_lookup_merge_join_test.go
+++ b/executor/index_lookup_merge_join_test.go
@@ -95,7 +95,8 @@ func (s *testSuiteWithData) TestIndexJoinOnSinglePartitionTable(c *C) {
 		sql := "select /*+ INL_MERGE_JOIN(t1,t2) */ * from t1 join t2 partition(p0) on t1.c_int = t2.c_int and t1.c_str < t2.c_str"
 		tk.MustQuery(sql).Check(testkit.Rows("1 Alice 1 Bob"))
 		rows := s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + sql).Rows())
-		c.Assert(strings.Index(rows[0], "IndexMergeJoin"), Equals, 0)
+		// Partition table can't be inner side of index merge join, because it can't keep order.
+		c.Assert(strings.Index(rows[0], "IndexMergeJoin"), Equals, -1)
 
 		sql = "select /*+ INL_HASH_JOIN(t1,t2) */ * from t1 join t2 partition(p0) on t1.c_int = t2.c_int and t1.c_str < t2.c_str"
 		tk.MustQuery(sql).Check(testkit.Rows("1 Alice 1 Bob"))

--- a/executor/index_lookup_merge_join_test.go
+++ b/executor/index_lookup_merge_join_test.go
@@ -74,7 +74,17 @@ func (s *testSuite9) TestIssue19408(c *C) {
 	tk.MustExec("insert into t2 select * from t1")
 	tk.MustExec("begin")
 	tk.MustExec("delete from t1 where c_int = 1")
-	tk.MustQuery("select /*+ INL_MERGE_JOIN(t1,t2) */ * from t1, t2 where t1.c_int = t2.c_int").Check(testkit.Rows(
+	tk.MustQuery("select /*+ INL_MERGE_JOIN(t1,t2) */ * from t1, t2 where t1.c_int = t2.c_int").Sort().Check(testkit.Rows(
+		"2 2",
+		"3 3",
+		"4 4",
+		"5 5"))
+	tk.MustQuery("select /*+ INL_JOIN(t1,t2) */ * from t1, t2 where t1.c_int = t2.c_int").Sort().Check(testkit.Rows(
+		"2 2",
+		"3 3",
+		"4 4",
+		"5 5"))
+	tk.MustQuery("select /*+ INL_HASH_JOIN(t1,t2) */ * from t1, t2 where t1.c_int = t2.c_int").Sort().Check(testkit.Rows(
 		"2 2",
 		"3 3",
 		"4 4",
@@ -97,6 +107,7 @@ func (s *testSuiteWithData) TestIndexJoinOnSinglePartitionTable(c *C) {
 		rows := s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + sql).Rows())
 		// Partition table can't be inner side of index merge join, because it can't keep order.
 		c.Assert(strings.Index(rows[0], "IndexMergeJoin"), Equals, -1)
+		c.Assert(len(tk.MustQuery("show warnings").Rows()) > 0, Equals, true)
 
 		sql = "select /*+ INL_HASH_JOIN(t1,t2) */ * from t1 join t2 partition(p0) on t1.c_int = t2.c_int and t1.c_str < t2.c_str"
 		tk.MustQuery(sql).Check(testkit.Rows("1 Alice 1 Bob"))

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -827,10 +827,10 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 	desc bool,
 	rowCount float64,
 ) task {
-	// If `ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx)`,
+	// If `ds.tableInfo.GetPartitionInfo() != nil`,
 	// it means the data source is a partition table reader.
 	// If the inner task need to keep order, the partition table reader can't satisfy it.
-	if keepOrder && ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx) {
+	if keepOrder && ds.tableInfo.GetPartitionInfo() != nil {
 		return nil
 	}
 	var ranges []*ranger.Range
@@ -926,10 +926,10 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 	rowCount float64,
 	maxOneRow bool,
 ) task {
-	// If `ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx)`,
+	// If `ds.tableInfo.GetPartitionInfo() != nil`,
 	// it means the data source is a partition table reader.
 	// If the inner task need to keep order, the partition table reader can't satisfy it.
-	if keepOrder && ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx) {
+	if keepOrder && ds.tableInfo.GetPartitionInfo() != nil {
 		return nil
 	}
 	is := PhysicalIndexScan{

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -834,8 +834,8 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 	} else {
 		ranges = ranger.FullIntRange(mysql.HasUnsignedFlag(pk.RetType.Flag))
 	}
-	// If the inner task need to keep order, then only range partition supports it.
-	if keepOrder && ds.tableInfo.Partition != nil && ds.tableInfo.Partition.Type != model.PartitionTypeRange {
+	// If the inner task need to keep order, the partition table reader can't satisfy it.
+	if keepOrder && ds.tableInfo.Partition != nil {
 		return nil
 	}
 	ts := PhysicalTableScan{
@@ -924,8 +924,8 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 	rowCount float64,
 	maxOneRow bool,
 ) task {
-	// If the inner task need to keep order, then only range partition supports it.
-	if keepOrder && ds.tableInfo.Partition != nil && ds.tableInfo.Partition.Type != model.PartitionTypeRange {
+	// If the inner task need to keep order, the partition table reader can't satisfy it.
+	if keepOrder && ds.tableInfo.Partition != nil {
 		return nil
 	}
 	is := PhysicalIndexScan{

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -827,9 +827,10 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 	desc bool,
 	rowCount float64,
 ) task {
-	// If ds.tableInfo.Partition != nil && !ds.isPartition, it means the data source is a partition table reader.
+	// If `ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx)`,
+	// it means the data source is a partition table reader.
 	// If the inner task need to keep order, the partition table reader can't satisfy it.
-	if keepOrder && ds.tableInfo.Partition != nil && !ds.isPartition {
+	if keepOrder && ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx) {
 		return nil
 	}
 	var ranges []*ranger.Range
@@ -925,9 +926,10 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 	rowCount float64,
 	maxOneRow bool,
 ) task {
-	// If ds.tableInfo.Partition != nil && !ds.isPartition, it means the data source is a partition table reader.
+	// If `ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx)`,
+	// it means the data source is a partition table reader.
 	// If the inner task need to keep order, the partition table reader can't satisfy it.
-	if keepOrder && ds.tableInfo.Partition != nil && !ds.isPartition {
+	if keepOrder && ds.tableInfo.Partition != nil && !tryOldPartitionImplementation(ds.ctx) {
 		return nil
 	}
 	is := PhysicalIndexScan{


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19408 

### What is changed and how it works?

What's Changed: If the inner table is a partition table, the index merge join can't be constructed because it requires inner table to keep order.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- none.
