### PR TITLE
planner: use the same unique id between schema and column in ProjUponView 

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3246,7 +3246,7 @@ func (b *PlanBuilder) buildProjUponView(ctx context.Context, dbName model.CIStr,
 			DBName:      dbName,
 		})
 		projSchema.Append(&expression.Column{
-			UniqueID: b.ctx.GetSessionVars().AllocPlanColumnID(),
+			UniqueID: cols[i].UniqueID,
 			RetType:  cols[i].GetType(),
 		})
 		projExprs = append(projExprs, cols[i])


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19226 <!-- REMOVE this line if no issue to close -->

Problem Summary: 
1. ProjUponView build a projection, and alloc a unique id for schema.
2. The projection is eliminate by `eliminatePhysicalProjection`, so that upon executor's expr column id is different from the lower executor schema. So that it can't get data correctly.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Use the same uniqueid in ProjUponView.

How it Works:

### Related changes

- Need to cherry-pick to the release branch 4.0, 3.0, 3.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- Fix unexpected panic when using view
