### PR TITLE
planner: make a copy of column before modifying its InOperand

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -1879,6 +1879,15 @@ func (s *testSuiteJoin2) TestNullEmptyAwareSemiJoin(c *C) {
 			result.Check(results[i].result)
 		}
 	}
+
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("create table t2(a int)")
+	tk.MustExec("insert into t1 values(1),(2)")
+	tk.MustExec("insert into t2 values(1),(null)")
+	tk.MustQuery("select * from t1 where a not in (select a from t2 where t1.a = t2.a)").Check(testkit.Rows(
+		"2",
+	))
 }
 
 func (s *testSuiteJoin1) TestScalarFuncNullSemiJoin(c *C) {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -787,12 +787,12 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, v *ast.Patte
 		// For AntiSemiJoin/LeftOuterSemiJoin/AntiLeftOuterSemiJoin, we cannot treat `in` expression as
 		// normal column equal condition, so we specially mark the inner operand here.
 		if v.Not || asScalar {
-			rCol.InOperand = true
 			// If both input columns of `in` expression are not null, we can treat the expression
 			// as normal column equal condition instead.
-			lCol, ok := lexpr.(*expression.Column)
-			if ok && mysql.HasNotNullFlag(lCol.GetType().Flag) && mysql.HasNotNullFlag(rCol.GetType().Flag) {
-				rCol.InOperand = false
+			if !mysql.HasNotNullFlag(lexpr.GetType().Flag) || !mysql.HasNotNullFlag(rCol.GetType().Flag) {
+				rColCopy := *rCol
+				rColCopy.InOperand = true
+				rexpr = &rColCopy
 			}
 		}
 	} else {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19423

Problem Summary:

Incorrect of anti-semi-join query caused by incorrect `OtherConditions` of the LogicalJoin plan.

### What is changed and how it works?


What's Changed:

After https://github.com/pingcap/tidb/pull/13406, `LogicalProjection` would not allocate new `Column` for column -> column projection, so if we directly modify `InOperand` of a `Column`, it may effect the filters in the subquery. Make a copy of this column before modifying this field.

How it Works:

The filters in the subquery would stay untouched, so they can correctly be put into `EqualConditions` / `OtherConditions` later.

### Related changes

- Need to cherry-pick to the release branch: 4.0 has this problem, but 3.0 doesn't, because 3.0 has no https://github.com/pingcap/tidb/pull/13406 changes.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix incorrect result of anti-semi-join query