### PR TITLE
planner: stable the test introduced by #18474

### DIFF
--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -56,11 +56,6 @@ func (s *testValidatorSuite) SetUpTest(c *C) {
 	s.is = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable()})
 }
 
-func (s *testValidatorSuite) TearDownTest(c *C) {
-	s.dom.Close()
-	s.store.Close()
-}
-
 func (s *testValidatorSuite) runSQL(c *C, sql string, inPrepare bool, terr error) {
 	stmts, err1 := session.Parse(s.ctx, sql)
 	c.Assert(err1, IsNil)
@@ -76,6 +71,10 @@ func (s *testValidatorSuite) runSQL(c *C, sql string, inPrepare bool, terr error
 
 func (s *testValidatorSuite) TestValidator(c *C) {
 	defer testleak.AfterTest(c)()
+	defer func() {
+		s.dom.Close()
+		s.store.Close()
+	}()
 	tests := []struct {
 		sql       string
 		inPrepare bool
@@ -268,6 +267,10 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 
 func (s *testValidatorSuite) TestForeignKey(c *C) {
 	defer testleak.AfterTest(c)()
+	defer func() {
+		s.dom.Close()
+		s.store.Close()
+	}()
 
 	_, err := s.se.Execute(context.Background(), "create table test.t1(a int, b int, c int)")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Reported by @wjhuang2016 , it seems that 18474 introduced an unstable test. The error from jenkin/unit-test/47817 comes from the original test `TestValidator`. And I only did some code refactor/function encapsulation. The only logic difference is that I moved a defered function to `TearDownTest`.

I can not reproduce the error. But my guess is that the dom loop goroutine is not disabled due to the lack of `s.dom.Close()`.

### Check List

Tests

- Unit test
- Integration test

### Release note

- No release note
