### PR TITLE
executor: reduce parameter count for detach ranges methods

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3162,7 +3162,7 @@ func buildRangesForIndexJoin(ctx sessionctx.Context, lookUpContents []*indexJoin
 		return retRanges, nil
 	}
 
-	return ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges)
+	return ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges, true)
 }
 
 // buildKvRangesForIndexJoin builds kv ranges for index join when the inner plan is index scan plan.
@@ -3216,7 +3216,7 @@ func buildKvRangesForIndexJoin(ctx sessionctx.Context, tableID, indexID int64, l
 		return kvRanges, nil
 	}
 
-	tmpDatumRanges, err = ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges)
+	tmpDatumRanges, err = ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges, true)
 	if err != nil {
 		return nil, err
 	}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -173,8 +173,7 @@ func getEqOrInColOffset(expr expression.Expression, cols []*expression.Column) i
 // detachCNFCondAndBuildRangeForIndex will detach the index filters from table filters. These conditions are connected with `and`
 // It will first find the point query column and then extract the range query column.
 // considerDNF is true means it will try to extract access conditions from the DNF expressions.
-func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column,
-	tpSlice []*types.FieldType, lengths []int, considerDNF bool) (*DetachRangeResult, error) {
+func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expression.Expression, tpSlice []*types.FieldType, considerDNF bool) (*DetachRangeResult, error) {
 	var (
 		eqCount int
 		ranges  []*Range
@@ -182,7 +181,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 	)
 	res := &DetachRangeResult{}
 
-	accessConds, filterConds, newConditions, emptyRange := ExtractEqAndInCondition(sctx, conditions, cols, lengths)
+	accessConds, filterConds, newConditions, emptyRange := ExtractEqAndInCondition(d.sctx, conditions, d.cols, d.lengths)
 	if emptyRange {
 		return res, nil
 	}
@@ -195,9 +194,9 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 	eqOrInCount := len(accessConds)
 	res.EqCondCount = eqCount
 	res.EqOrInCount = eqOrInCount
-	if eqOrInCount == len(cols) {
+	if eqOrInCount == len(d.cols) {
 		filterConds = append(filterConds, newConditions...)
-		ranges, err = d.buildCNFIndexRange(sctx.GetSessionVars().StmtCtx, cols, tpSlice, lengths, eqOrInCount, accessConds)
+		ranges, err = d.buildCNFIndexRange(tpSlice, eqOrInCount, accessConds)
 		if err != nil {
 			return res, err
 		}
@@ -207,12 +206,12 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 		return res, nil
 	}
 	checker := &conditionChecker{
-		colUniqueID:   cols[eqOrInCount].UniqueID,
-		length:        lengths[eqOrInCount],
-		shouldReserve: lengths[eqOrInCount] != types.UnspecifiedLength,
+		colUniqueID:   d.cols[eqOrInCount].UniqueID,
+		length:        d.lengths[eqOrInCount],
+		shouldReserve: d.lengths[eqOrInCount] != types.UnspecifiedLength,
 	}
 	if considerDNF {
-		accesses, filters := detachColumnCNFConditions(sctx, newConditions, checker)
+		accesses, filters := detachColumnCNFConditions(d.sctx, newConditions, checker)
 		accessConds = append(accessConds, accesses...)
 		filterConds = append(filterConds, filters...)
 	} else {
@@ -224,7 +223,7 @@ func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 			accessConds = append(accessConds, cond)
 		}
 	}
-	ranges, err = d.buildCNFIndexRange(sctx.GetSessionVars().StmtCtx, cols, tpSlice, lengths, eqOrInCount, accessConds)
+	ranges, err = d.buildCNFIndexRange(tpSlice, eqOrInCount, accessConds)
 	res.Ranges = ranges
 	res.AccessConds = accessConds
 	res.RemainedConds = filterConds
@@ -293,13 +292,12 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 
 // detachDNFCondAndBuildRangeForIndex will detach the index filters from table filters when it's a DNF.
 // We will detach the conditions of every DNF items, then compose them to a DNF.
-func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expression.ScalarFunction,
-	cols []*expression.Column, newTpSlice []*types.FieldType, lengths []int) ([]*Range, []expression.Expression, bool, error) {
-	sc := sctx.GetSessionVars().StmtCtx
+func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression.ScalarFunction, newTpSlice []*types.FieldType) ([]*Range, []expression.Expression, bool, error) {
+	sc := d.sctx.GetSessionVars().StmtCtx
 	firstColumnChecker := &conditionChecker{
-		colUniqueID:   cols[0].UniqueID,
-		shouldReserve: lengths[0] != types.UnspecifiedLength,
-		length:        lengths[0],
+		colUniqueID:   d.cols[0].UniqueID,
+		shouldReserve: d.lengths[0] != types.UnspecifiedLength,
+		length:        d.lengths[0],
 	}
 	rb := builder{sc: sc}
 	dnfItems := expression.FlattenDNFConditions(condition)
@@ -310,7 +308,7 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 		if sf, ok := item.(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicAnd {
 			cnfItems := expression.FlattenCNFConditions(sf)
 			var accesses, filters []expression.Expression
-			res, err := d.detachCNFCondAndBuildRangeForIndex(sctx, cnfItems, cols, newTpSlice, lengths, true)
+			res, err := d.detachCNFCondAndBuildRangeForIndex(cnfItems, newTpSlice, true)
 			if err != nil {
 				return nil, nil, false, nil
 			}
@@ -324,11 +322,11 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 				hasResidual = true
 			}
 			totalRanges = append(totalRanges, ranges...)
-			newAccessItems = append(newAccessItems, expression.ComposeCNFCondition(sctx, accesses...))
+			newAccessItems = append(newAccessItems, expression.ComposeCNFCondition(d.sctx, accesses...))
 		} else if firstColumnChecker.check(item) {
 			if firstColumnChecker.shouldReserve {
 				hasResidual = true
-				firstColumnChecker.shouldReserve = lengths[0] != types.UnspecifiedLength
+				firstColumnChecker.shouldReserve = d.lengths[0] != types.UnspecifiedLength
 			}
 			points := rb.build(item)
 			ranges, err := points2Ranges(sc, points, newTpSlice[0])
@@ -347,7 +345,7 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Conte
 		return nil, nil, false, errors.Trace(err)
 	}
 
-	return totalRanges, []expression.Expression{expression.ComposeDNFCondition(sctx, newAccessItems...)}, hasResidual, nil
+	return totalRanges, []expression.Expression{expression.ComposeDNFCondition(d.sctx, newAccessItems...)}, hasResidual, nil
 }
 
 // DetachRangeResult wraps up results when detaching conditions and builing ranges.
@@ -371,24 +369,32 @@ type DetachRangeResult struct {
 func DetachCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int) (*DetachRangeResult, error) {
 	d := &rangeDetacher{
+		sctx:             sctx,
+		allConds:         conditions,
+		cols:             cols,
+		lengths:          lengths,
 		mergeConsecutive: true,
 	}
-	return d.detachCondAndBuildRangeForCols(sctx, conditions, cols, lengths)
+	return d.detachCondAndBuildRangeForCols()
 }
 
 type rangeDetacher struct {
+	sctx             sessionctx.Context
+	allConds         []expression.Expression
+	cols             []*expression.Column
+	lengths          []int
 	mergeConsecutive bool
 }
 
-func (d *rangeDetacher) detachCondAndBuildRangeForCols(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column, lengths []int) (*DetachRangeResult, error) {
+func (d *rangeDetacher) detachCondAndBuildRangeForCols() (*DetachRangeResult, error) {
 	res := &DetachRangeResult{}
-	newTpSlice := make([]*types.FieldType, 0, len(cols))
-	for _, col := range cols {
+	newTpSlice := make([]*types.FieldType, 0, len(d.cols))
+	for _, col := range d.cols {
 		newTpSlice = append(newTpSlice, newFieldType(col.RetType))
 	}
-	if len(conditions) == 1 {
-		if sf, ok := conditions[0].(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicOr {
-			ranges, accesses, hasResidual, err := d.detachDNFCondAndBuildRangeForIndex(sctx, sf, cols, newTpSlice, lengths)
+	if len(d.allConds) == 1 {
+		if sf, ok := d.allConds[0].(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicOr {
+			ranges, accesses, hasResidual, err := d.detachDNFCondAndBuildRangeForIndex(sf, newTpSlice)
 			if err != nil {
 				return res, errors.Trace(err)
 			}
@@ -397,13 +403,13 @@ func (d *rangeDetacher) detachCondAndBuildRangeForCols(sctx sessionctx.Context, 
 			res.IsDNFCond = true
 			// If this DNF have something cannot be to calculate range, then all this DNF should be pushed as filter condition.
 			if hasResidual {
-				res.RemainedConds = conditions
+				res.RemainedConds = d.allConds
 				return res, nil
 			}
 			return res, nil
 		}
 	}
-	return d.detachCNFCondAndBuildRangeForIndex(sctx, conditions, cols, newTpSlice, lengths, true)
+	return d.detachCNFCondAndBuildRangeForIndex(d.allConds, newTpSlice, true)
 }
 
 // DetachSimpleCondAndBuildRangeForIndex will detach the index filters from table filters.
@@ -414,8 +420,14 @@ func DetachSimpleCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions [
 	for _, col := range cols {
 		newTpSlice = append(newTpSlice, newFieldType(col.RetType))
 	}
-	d := &rangeDetacher{mergeConsecutive: true}
-	res, err := d.detachCNFCondAndBuildRangeForIndex(sctx, conditions, cols, newTpSlice, lengths, false)
+	d := &rangeDetacher{
+		sctx:             sctx,
+		allConds:         conditions,
+		cols:             cols,
+		lengths:          lengths,
+		mergeConsecutive: true,
+	}
+	res, err := d.detachCNFCondAndBuildRangeForIndex(conditions, newTpSlice, false)
 	return res.Ranges, res.AccessConds, err
 }
 

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -270,7 +270,7 @@ func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.Stat
 				ran.HighExclude = false
 			}
 		}
-		ranges, err = UnionRanges(sc, ranges)
+		ranges, err = UnionRanges(sc, ranges, true)
 		if err != nil {
 			return nil, err
 		}
@@ -292,7 +292,7 @@ func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContex
 }
 
 // buildCNFIndexRange builds the range for index where the top layer is CNF.
-func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, newTp []*types.FieldType, lengths []int,
+func (d *rangeDetacher) buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, newTp []*types.FieldType, lengths []int,
 	eqAndInCount int, accessCondition []expression.Expression) ([]*Range, error) {
 	rb := builder{sc: sc}
 	var (
@@ -337,7 +337,7 @@ func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column,
 	// Take prefix index into consideration.
 	if hasPrefix(lengths) {
 		if fixPrefixColRange(ranges, lengths, newTp) {
-			ranges, err = UnionRanges(sc, ranges)
+			ranges, err = UnionRanges(sc, ranges, d.mergeConsecutive)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -357,7 +357,7 @@ type sortRange struct {
 // For two intervals [a, b], [c, d], we have guaranteed that a <= c. If b >= c. Then two intervals are overlapped.
 // And this two can be merged as [a, max(b, d)].
 // Otherwise they aren't overlapped.
-func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range) ([]*Range, error) {
+func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range, mergeConsecutive bool) ([]*Range, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -385,7 +385,8 @@ func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range) ([]*Range, error
 	ranges = ranges[:0]
 	lastRange := objects[0]
 	for i := 1; i < len(objects); i++ {
-		if bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0 {
+		if (mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0) ||
+			(!mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) > 0) {
 			if bytes.Compare(lastRange.encodedEnd, objects[i].encodedEnd) < 0 {
 				lastRange.encodedEnd = objects[i].encodedEnd
 				lastRange.originalValue.HighVal = objects[i].originalValue.HighVal

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -292,14 +292,15 @@ func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContex
 }
 
 // buildCNFIndexRange builds the range for index where the top layer is CNF.
-func (d *rangeDetacher) buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, newTp []*types.FieldType, lengths []int,
+func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 	eqAndInCount int, accessCondition []expression.Expression) ([]*Range, error) {
+	sc := d.sctx.GetSessionVars().StmtCtx
 	rb := builder{sc: sc}
 	var (
 		ranges []*Range
 		err    error
 	)
-	for _, col := range cols {
+	for _, col := range d.cols {
 		newTp = append(newTp, newFieldType(col.RetType))
 	}
 	for i := 0; i < eqAndInCount; i++ {
@@ -335,8 +336,8 @@ func (d *rangeDetacher) buildCNFIndexRange(sc *stmtctx.StatementContext, cols []
 	}
 
 	// Take prefix index into consideration.
-	if hasPrefix(lengths) {
-		if fixPrefixColRange(ranges, lengths, newTp) {
+	if hasPrefix(d.lengths) {
+		if fixPrefixColRange(ranges, d.lengths, newTp) {
 			ranges, err = UnionRanges(sc, ranges, d.mergeConsecutive)
 			if err != nil {
 				return nil, errors.Trace(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

this is a pure refactor PR without change anything

ref #https://github.com/pingcap/tidb/pull/18574

we want reuse detach range logic in partition pruning but it's hard to tweak detach behaviors

e.g. don't merge two consecutive point into one https://github.com/pingcap/tidb/pull/18574/files/d96de7d9db2d19b3edc505b39d275ff4d5dc42c6#diff-9980094f65cdcbb9cd1aaaf4d9d59e35R563

### What is changed and how it works?

What's Changed, How it Works:

extract a `rangeDetacher` and open door to pass info though field instead of params

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

no code refactor, doesn't want to change any logic

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19486)
<!-- Reviewable:end -->
