### PR TITLE
executor: fix incorrect results when there is an IndexLookUp under the inner side of an Apply 

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -581,6 +581,7 @@ func (e *IndexLookUpExecutor) Close() error {
 	e.finished = nil
 	e.workerStarted = false
 	e.memTracker = nil
+	e.resultCurr = nil
 	return nil
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6213,6 +6213,17 @@ func (s *testSuite) TestPrevStmtDesensitization(c *C) {
 	c.Assert(tk.Se.GetSessionVars().PrevStmt.String(), Equals, "insert into t values ( ? ) , ( ? )")
 }
 
+func (s *testSuite) TestIssue19372(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t1, t2;")
+	tk.MustExec("create table t1 (c_int int, c_str varchar(40), key(c_str));")
+	tk.MustExec("create table t2 like t1;")
+	tk.MustExec("insert into t1 values (1, 'a'), (2, 'b'), (3, 'c');")
+	tk.MustExec("insert into t2 select * from t1;")
+	tk.MustQuery("select (select t2.c_str from t2 where t2.c_str <= t1.c_str and t2.c_int in (1, 2) order by t2.c_str limit 1) x from t1 order by c_int;").Check(testkit.Rows("a", "a", "a"))
+}
+
 func (s *testSuite) TestCollectDMLRuntimeStats(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19372 <!-- REMOVE this line if no issue to close -->

Problem Summary: executor: fix incorrect results when there is an IndexLookUp under the inner side of an Apply 

### What is changed and how it works?
When an `IndexLookUp` is under the inner side of an `Apply`, it may be invoked multiple times, but in `IndexLookUp.Close()`, the field `resultCurr` is not cleared up, so in the next round of invocation, some stale rows may be returned because of [this logic](https://github.com/pingcap/tidb/blob/master/executor/distsql.go#L614).


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
### Release note <!-- bugfixes or new feature need a release note -->

- executor: fix incorrect results when there is an IndexLookUp under the inner side of an Apply 