### PR TITLE
types: fix enum cannot be set to 0

### DIFF
--- a/types/enum.go
+++ b/types/enum.go
@@ -47,6 +47,10 @@ func (e Enum) ToNumber() float64 {
 
 // ParseEnumName creates a Enum with item name.
 func ParseEnumName(elems []string, name string, collation string) (Enum, error) {
+	if len(name) == 0 {
+		return Enum{Name: name, Value: 0}, nil
+	}
+
 	ctor := collate.GetCollator(collation)
 	for i, n := range elems {
 		if ctor.Compare(n, name) == 0 {
@@ -64,8 +68,12 @@ func ParseEnumName(elems []string, name string, collation string) (Enum, error) 
 
 // ParseEnumValue creates a Enum with special number.
 func ParseEnumValue(elems []string, number uint64) (Enum, error) {
-	if number == 0 || number > uint64(len(elems)) {
+	if number > uint64(len(elems)) {
 		return Enum{}, errors.Errorf("number %d overflow enum boundary [1, %d]", number, len(elems))
+	}
+
+	if number == 0 {
+		return Enum{Name: "", Value: number}, nil
 	}
 
 	return Enum{Name: elems[number-1], Value: number}, nil

--- a/types/enum_test.go
+++ b/types/enum_test.go
@@ -35,8 +35,9 @@ func (s *testEnumSuite) TestEnum(c *C) {
 		Expected int
 	}{
 		{[]string{"a", "b"}, "a", 1},
-		{[]string{"a"}, "b", 0},
+		{[]string{"a"}, "b", -1},
 		{[]string{"a"}, "1", 1},
+		{[]string{"a"}, "", 0},
 	}
 	citbl := []struct {
 		Elems    []string
@@ -45,14 +46,15 @@ func (s *testEnumSuite) TestEnum(c *C) {
 	}{
 		{[]string{"a", "b"}, "A     ", 1},
 		{[]string{"a"}, "A", 1},
-		{[]string{"a"}, "b", 0},
+		{[]string{"a"}, "b", -1},
 		{[]string{"啊"}, "啊", 1},
 		{[]string{"a"}, "1", 1},
+		{[]string{"a"}, "", 0},
 	}
 
 	for _, t := range tbl {
 		e, err := ParseEnumName(t.Elems, t.Name, mysql.DefaultCollationName)
-		if t.Expected == 0 {
+		if t.Expected == -1 {
 			c.Assert(err, NotNil)
 			c.Assert(e.ToNumber(), Equals, float64(0))
 			c.Assert(e.String(), Equals, "")
@@ -60,12 +62,16 @@ func (s *testEnumSuite) TestEnum(c *C) {
 		}
 
 		c.Assert(err, IsNil)
-		c.Assert(e.String(), Equals, t.Elems[t.Expected-1])
-		c.Assert(e.ToNumber(), Equals, float64(t.Expected))
+		if e.ToNumber() == 0 {
+			c.Assert(e.String(), Equals, "")
+		} else {
+			c.Assert(e.String(), Equals, t.Elems[t.Expected-1])
+			c.Assert(e.ToNumber(), Equals, float64(t.Expected))
+		}
 	}
 	for _, t := range citbl {
 		e, err := ParseEnumName(t.Elems, t.Name, "utf8_general_ci")
-		if t.Expected == 0 {
+		if t.Expected == -1 {
 			c.Assert(err, NotNil)
 			c.Assert(e.ToNumber(), Equals, float64(0))
 			c.Assert(e.String(), Equals, "")
@@ -73,8 +79,12 @@ func (s *testEnumSuite) TestEnum(c *C) {
 		}
 
 		c.Assert(err, IsNil)
-		c.Assert(e.String(), Equals, t.Elems[t.Expected-1])
-		c.Assert(e.ToNumber(), Equals, float64(t.Expected))
+		if e.ToNumber() == 0 {
+			c.Assert(e.String(), Equals, "")
+		} else {
+			c.Assert(e.String(), Equals, t.Elems[t.Expected-1])
+			c.Assert(e.ToNumber(), Equals, float64(t.Expected))
+		}
 	}
 
 	tblNumber := []struct {
@@ -84,11 +94,12 @@ func (s *testEnumSuite) TestEnum(c *C) {
 	}{
 		{[]string{"a"}, 1, 1},
 		{[]string{"a"}, 0, 0},
+		{[]string{"a"}, 2, -1},
 	}
 
 	for _, t := range tblNumber {
 		e, err := ParseEnumValue(t.Elems, t.Number)
-		if t.Expected == 0 {
+		if t.Expected == -1 {
 			c.Assert(err, NotNil)
 			continue
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Insert or update an enum column, set the value to 0.

```
mysql> create table t1(e1 enum("a"));
Query OK, 0 rows affected (0.01 sec)

mysql> insert into t1(e1) values("0");
ERROR 1366 (HY000): Incorrect enum value: '0' for column 'e1' at row 1

mysql> insert into t1(e1) values("1");
Query OK, 1 row affected (0.00 sec)

mysql> update t1 set t1.e1 = "0" where t1.e1 = "a";
ERROR 1292 (22007): Truncated incorrect enum('a') value: '0'
```

### What is changed and how it works?

What's Changed:

ParseEnumName can parse empty string.
ParseEnumValue can parse 0.

How it Works:

### Related changes

### Check List

Tests

- Unit test
- Integration test

Side effects

### Release note

No release note
