### PR TITLE
test: stabilize leak test

### DIFF
--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -58,6 +58,7 @@ func interestingGoroutines() (gs []string) {
 		"github.com/pingcap/goleveldb/leveldb/util.(*BufferPool).drain",
 		"github.com/pingcap/goleveldb/leveldb.(*DB).compactionError",
 		"github.com/pingcap/goleveldb/leveldb.(*DB).mpoolDrain",
+		"go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop",
 		"go.etcd.io/etcd/v3/pkg/logutil.(*MergeLogger).outputLoop",
 		"oracles.(*pdOracle).updateTS",
 		"tikv.(*tikvStore).runSafePointChecker",

--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -63,7 +63,8 @@ func interestingGoroutines() (gs []string) {
 		"oracles.(*pdOracle).updateTS",
 		"tikv.(*tikvStore).runSafePointChecker",
 		"tikv.(*RegionCache).asyncCheckAndResolveLoop",
-		"github.com/pingcap/badger.(*writeWorker).runMergeLSM",
+		"github.com/pingcap/badger",
+		"github.com/ngaut/unistore/tikv.(*MVCCStore).runUpdateSafePointLoop",
 	}
 	shouldIgnore := func(stack string) bool {
 		if stack == "" {


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
[2020-08-27T05:03:35.847Z] [2020/08/27 13:02:22.443 +08:00] [INFO] [db.go:626] ["Waiting for closer"]
[2020-08-27T05:03:35.847Z] 
[2020-08-27T05:03:35.847Z] ----------------------------------------------------------------------
[2020-08-27T05:03:35.847Z] FAIL: tidb_test.go:64: testMainSuite.TearDownSuite
[2020-08-27T05:03:35.847Z] 
[2020-08-27T05:03:35.847Z] tidb_test.go:70:
[2020-08-27T05:03:35.847Z]     ...
[2020-08-27T05:03:35.847Z] /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:166:
[2020-08-27T05:03:35.847Z]     c.Errorf("Test %s check-count %d appears to have leaked: %v", c.TestName(), cnt, g)
[2020-08-27T05:03:35.847Z] ... Error: Test  check-count 50 appears to have leaked: go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop(0xc0002ca8c0)
[2020-08-27T05:03:35.847Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/pkg/logutil/merge_logger.go:173 +0x3a3
[2020-08-27T05:03:35.847Z] created by go.etcd.io/etcd/pkg/logutil.NewMergeLogger
[2020-08-27T05:03:35.847Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/go.etcd.io/etcd@v0.5.0-alpha.5.0.20191023171146-3cf2f69b5738/pkg/logutil/merge_logger.go:91 +0x80
[2020-08-27T05:03:35.847Z] 
[2020-08-27T05:03:35.847Z] [2020/08/27 13:02:25.137 +08:00] [INFO] [tidb.go:70] ["new domain"] [store=efaad23a-641e-4daa-953b-bbb9e65d49e9] ["ddl lease"=20ms] ["stats lease"=-1ns]


[2020-08-26T08:09:12.672Z] ----------------------------------------------------------------------
[2020-08-26T08:09:12.672Z] FAIL: meta_test.go:306: testSuite.TestDDL
[2020-08-26T08:09:12.672Z] 
[2020-08-26T08:09:12.672Z] meta_test.go:458:
[2020-08-26T08:09:12.672Z]     ...
[2020-08-26T08:09:12.672Z] /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:166:
[2020-08-26T08:09:12.672Z]     c.Errorf("Test %s check-count %d appears to have leaked: %v", c.TestName(), cnt, g)
[2020-08-26T08:09:12.672Z] ... Error: Test testSuite.TestDDL check-count 50 appears to have leaked: github.com/pingcap/badger.Open.func4(0xc00011e018)
[2020-08-26T08:09:12.673Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/badger@v1.5.1-0.20200810065601-8c92a97807f9/db.go:341 +0x185
[2020-08-26T08:09:12.673Z] created by github.com/pingcap/badger.Open
[2020-08-26T08:09:12.673Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/badger@v1.5.1-0.20200810065601-8c92a97807f9/db.go:338 +0x100e


[2020-08-27T03:26:14.152Z] ----------------------------------------------------------------------
[2020-08-27T03:26:14.152Z] FAIL: meta_test.go:306: testSuite.TestDDL
[2020-08-27T03:26:14.152Z] 
[2020-08-27T03:26:14.152Z] meta_test.go:458:
[2020-08-27T03:26:14.153Z]     ...
[2020-08-27T03:26:14.153Z] /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testleak/leaktest.go:166:
[2020-08-27T03:26:14.153Z]     c.Errorf("Test %s check-count %d appears to have leaked: %v", c.TestName(), cnt, g)
[2020-08-27T03:26:14.153Z] ... Error: Test testSuite.TestDDL check-count 50 appears to have leaked: github.com/ngaut/unistore/tikv.(*MVCCStore).runUpdateSafePointLoop(0xc000144000)
[2020-08-27T03:26:14.153Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/ngaut/unistore@v0.0.0-20200826054345-a70ab8a1f698/tikv/mvcc.go:1445 +0x2ba
[2020-08-27T03:26:14.153Z] created by github.com/ngaut/unistore/tikv.NewMVCCStore
[2020-08-27T03:26:14.153Z] 	/home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/ngaut/unistore@v0.0.0-20200826054345-a70ab8a1f698/tikv/mvcc.go:85 +0x263
[2020-08-27T03:26:14.153Z] 
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.575 +08:00] [WARN] [2pc.go:1006] ["schemaLeaseChecker is not set for this transaction, schema check skipped"] [connID=0] [startTS=419036854110388225] [commitTS=419036854111436800]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.576 +08:00] [INFO] [db.go:565] ["Closing database"]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.600 +08:00] [INFO] [db.go:590] ["Memtable flushed"]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.600 +08:00] [INFO] [db.go:594] ["Compaction finished"]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.600 +08:00] [INFO] [db.go:616] ["BlobManager finished"]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.600 +08:00] [INFO] [db.go:620] ["ResourceManager finished"]
[2020-08-27T03:26:14.153Z] [2020/08/27 11:25:41.601 +08:00] [INFO] [db.go:626] ["Waiting for closer"]
[2020-08-27T03:26:14.153Z] 
```
### What is changed and how it works?

Ignore go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
