### PR TITLE
planner: fix column-prune only have an effect on the first child for union all partitions

### DIFF
--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -189,10 +189,14 @@ func (p *LogicalUnionAll) PruneColumns(parentUsedCols []*expression.Column) erro
 		parentUsedCols = make([]*expression.Column, len(p.schema.Columns))
 		copy(parentUsedCols, p.schema.Columns)
 	}
-	for _, child := range p.Children() {
+	for i, child := range p.Children() {
+		originCols := child.Schema().Columns
 		err := child.PruneColumns(parentUsedCols)
 		if err != nil {
 			return err
+		}
+		if i != len(p.Children())-1 {
+			child.Schema().Columns = originCols
 		}
 	}
 

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -189,14 +189,10 @@ func (p *LogicalUnionAll) PruneColumns(parentUsedCols []*expression.Column) erro
 		parentUsedCols = make([]*expression.Column, len(p.schema.Columns))
 		copy(parentUsedCols, p.schema.Columns)
 	}
-	for i, child := range p.Children() {
-		originCols := child.Schema().Columns
+	for _, child := range p.Children() {
 		err := child.PruneColumns(parentUsedCols)
 		if err != nil {
 			return err
-		}
-		if i != len(p.Children())-1 {
-			child.Schema().Columns = originCols
 		}
 	}
 

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -877,6 +877,10 @@ func (s *partitionProcessor) makeUnionAllChildren(ds *DataSource, pi *model.Part
 			newDataSource.baseLogicalPlan = newBaseLogicalPlan(ds.SCtx(), plancodec.TypeTableScan, &newDataSource, ds.blockOffset)
 			newDataSource.isPartition = true
 			newDataSource.physicalTableID = pi.Definitions[i].ID
+			// copy ds.schema to avoid column-prune UnionAll problem
+			// https://github.com/pingcap/tidb/issues/19161
+			newDsSchema := *ds.schema
+			newDataSource.schema = &newDsSchema
 
 			// There are many expression nodes in the plan tree use the original datasource
 			// id as FromID. So we set the id of the newDataSource with the original one to


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19161

Problem Summary:

see more detail in issue's description

in current code,  it will loop prune column for echo UnionAll children:

https://github.com/pingcap/tidb/blob/658132fcf3d859204ec53c0caaf27d837a63cf00/planner/core/rule_column_pruning.go#L192

but first child be pruned will remove column from shared `ds.schema.columns`

https://github.com/pingcap/tidb/blob/e78308ed082c2b33dc763012b2fa43351a9dc884/planner/core/rule_column_pruning.go#L238

then other children no longer have a chance to prune this column due to it has been removed

https://github.com/pingcap/tidb/blob/e78308ed082c2b33dc763012b2fa43351a9dc884/planner/core/rule_column_pruning.go#L225

### What is changed and how it works?

What's Changed, How it Works:

it's too hard to make prune-column works well for shared `ds.Schema`

so this PR choose to let buildUnionPartition without shared `ds.Schema`

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

-  fix column-prune only have an effect on the first partition for union all partitions<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19536)
<!-- Reviewable:end -->
