### PR TITLE
variable: enlarge the default value of tidb_max_chunk_size

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -482,7 +482,7 @@ const (
 	DefBatchCommit                     = false
 	DefCurretTS                        = 0
 	DefInitChunkSize                   = 32
-	DefMaxChunkSize                    = 1024
+	DefMaxChunkSize                    = 1 << 16 // 65536
 	DefDMLBatchSize                    = 0
 	DefMaxPreparedStmtCount            = -1
 	DefWaitTimeout                     = 0


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The default `tidb_max_chunk_size` is a bit small, it is better to enlarge it to reduce some RPCs.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Change to default value to 65536.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
* `set tidb_max_chunk_size = 1024 or 65536;`
* insert many rows (> 100000) in t0;
* test the performance of `insert ignore into t1 select * from t0;`

Side effects

- Performance regression
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- Enlarge the default value of tidb_max_chunk_size for new clusters.
