### PR TITLE
session: fix mysql_list_fields leaking table info

### DIFF
--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -1080,6 +1080,16 @@ func (s *testPrivilegeSuite) TestUserTableConsistency(c *C) {
 	tk.MustQuery(buf.String()).Check(testkit.Rows(res.String()))
 }
 
+func (s *testPrivilegeSuite) TestFieldList(c *C) { // Issue #14237 List fields RPC
+	se := newSession(c, s.store, s.dbName)
+	mustExec(c, se, `CREATE USER 'tableaccess'@'localhost'`)
+	mustExec(c, se, `CREATE TABLE fieldlistt1 (a int)`)
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "tableaccess", Hostname: "localhost"}, nil, nil), IsTrue)
+	_, err := se.FieldList("fieldlistt1")
+	message := "SELECT command denied to user 'tableaccess'@'localhost' for table 'fieldlistt1'"
+	c.Assert(strings.Contains(err.Error(), message), IsTrue)
+}
+
 func mustExec(c *C, se session.Session, sql string) {
 	_, err := se.Execute(context.Background(), sql)
 	c.Assert(err, IsNil)

--- a/session/session.go
+++ b/session/session.go
@@ -362,6 +362,19 @@ func (s *session) FieldList(tableName string) ([]*ast.ResultField, error) {
 	is := infoschema.GetInfoSchema(s)
 	dbName := model.NewCIStr(s.GetSessionVars().CurrentDB)
 	tName := model.NewCIStr(tableName)
+	pm := privilege.GetPrivilegeManager(s)
+	if pm != nil && s.sessionVars.User != nil {
+		if !pm.RequestVerification(s.sessionVars.ActiveRoles, dbName.O, tName.O, "", mysql.AllPrivMask) {
+			user := s.sessionVars.User
+			u := user.Username
+			h := user.Hostname
+			if len(user.AuthUsername) > 0 && len(user.AuthHostname) > 0 {
+				u = user.AuthUsername
+				h = user.AuthHostname
+			}
+			return nil, plannercore.ErrTableaccessDenied.GenWithStackByArgs("SELECT", u, h, tableName)
+		}
+	}
 	table, err := is.TableByName(dbName, tName)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: Fixes #14237

Problem Summary:

The binary protocol command to list fields leaks information. This adds a check when calling the session function to list fields.

### What is changed and how it works?

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Manual test using MySQL C program:

```
/*
 example.c
 compile with:
 gcc example.c -o example  `mysql_config --cflags --libs`
*/

#include <mysql.h>
#include <stdio.h>

int main(int argc, char **argv) {

  MYSQL *conn = mysql_init(NULL);
  if (conn == NULL)  {
      fprintf(stderr, "%s\n", mysql_error(conn));
      exit(1);
  }

  /* CREATE USER newuser; GRANT SELECT ON employees.titles TO newuser; */
  if (mysql_real_connect(conn, "127.0.0.1", "newuser", "", "employees", 4000, NULL, 0) == NULL) {
//  if (mysql_real_connect(conn, "127.0.0.1", "newuser", "", "employees", 8021, NULL, 0) == NULL) {
      fprintf(stderr, "%s\n", mysql_error(conn));
      mysql_close(conn);
      exit(1);
  }  

  int i;
  MYSQL_RES *tbl_cols = mysql_list_fields(conn, "salaries", NULL);
  if (tbl_cols == NULL) {
      fprintf(stderr, "%s\n", mysql_error(conn));
      mysql_close(conn);
      exit(1);
  }

  unsigned int field_cnt = mysql_num_fields(tbl_cols);
  printf("Number of columns: %d\n", field_cnt);

  for (i=0; i < field_cnt; ++i) {
    /* col describes i-th column of the table */
    MYSQL_FIELD *col = mysql_fetch_field_direct(tbl_cols, i);
    printf ("Column %d: %s\n", i, col->name);
  }
  
  mysql_free_result(tbl_cols);

  mysql_close(conn);
  exit(0);

}
```

I call it from a shell program:
```
mysql -e 'create database employees'
mysql employees < e.sql
mysql -e "CREATE USER newuser; GRANT SELECT ON employees.titles TO newuser;";
gcc example.c -o example  `mysql_config --cflags --libs` && ./example

mysql -e "GRANT SELECT on employees.salaries TO newuser";
./example
```
The output:
```
SELECT command denied to user 'newuser'@'%' for table 'salaries' # First run
Number of columns: 4 # second run
Column 0: emp_no
Column 1: salary
Column 2: from_date
Column 3: to_date
```

Side effects

- Breaking backward compatibility (for broken apps. But this RPC is not commonly used by drivers. It is mostly legacy.)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note