### PR TITLE
privilege: fix user change after `show grants` and add user existed check for `show grants`

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/diagnosticspb"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/distsql"
@@ -663,9 +664,7 @@ func (b *executorBuilder) buildShow(v *plannercore.PhysicalShow) Executor {
 		// Note: "show grants" result are different from "show grants for current_user",
 		// The former determine privileges with roles, while the later doesn't.
 		vars := e.ctx.GetSessionVars()
-		e.User = vars.User
-		e.User.Hostname = vars.User.AuthHostname
-		e.User.Username = vars.User.AuthUsername
+		e.User = &auth.UserIdentity{Username: vars.User.AuthUsername, Hostname: vars.User.AuthHostname}
 		e.Roles = vars.ActiveRoles
 	}
 	if e.Tp == ast.ShowMasterStatus {

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,7 +16,6 @@ package executor_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/privilege/privileges"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -28,6 +27,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
 	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"

--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -1004,7 +1004,19 @@ func (p *MySQLPrivilege) showGrants(user, host string, roles []*auth.RoleIdentit
 	allRoles := p.FindAllRole(roles)
 	// Show global grants.
 	var currentPriv mysql.PrivilegeType
-	var hasGrantOptionPriv = false
+	var hasGrantOptionPriv, userExists = false, false
+	// Check whether user exists.
+	if userList, ok := p.UserMap[user]; ok {
+		for _, record := range userList {
+			if host == record.Host || record.hostMatch(host) {
+				userExists = true
+				break
+			}
+		}
+		if !userExists {
+			return gs
+		}
+	}
 	var g string
 	for _, record := range p.User {
 		if record.baseRecord.match(user, host) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18878  <!-- REMOVE this line if no issue to close -->

Problem Summary: 
- `select user()` returns different result after execute `show grants`
- `show grants` can show grants on not existed user.

### What is changed and how it works?

What's Changed:

- Do not use `auth.UserIdentity` pointer on show grants.
- Add check in `showGrants` to avoid executed on not existed user.

How it Works:

Because of `SHOW GRANTS` change the content in `auth.Identity`, when execute `SHOW GRANTS`, it will change the host of `User` in session variable. The result of `select user()` will changed.
 
### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- Fix `SHOW GRANTS` can show grants for not existed user.
