### PR TITLE
executor: skip TestMemCount test case to make race test more stable

### DIFF
--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
+	"github.com/pingcap/tidb/util/israce"
 )
 
 func genApproxDistinctMergePartialResult(begin, end uint64) string {
@@ -102,6 +103,9 @@ func (s *testSuite) TestCount(c *C) {
 }
 
 func (s *testSuite) TestMemCount(c *C) {
+	if israce.RaceEnabled {
+		c.Skip("skip race test")
+	}
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncCount, mysql.TypeLonglong, 5,
 			aggfuncs.DefPartialResult4CountDistinctIntSize, distinctUpdateMemDeltaGens, true, 0, 5),


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

https://github.com/pingcap/tidb/pull/18901 add a test that will block a long time under go's race check

and it makes all PR fail

![image](https://user-images.githubusercontent.com/528332/91541506-0abbf600-e94f-11ea-8145-f08cbd7f4191.png)

### What is changed and how it works?

What's Changed, How it Works:

skip it when race open

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19578)
<!-- Reviewable:end -->
