### PR TITLE
expression: fix keepNull option for `istrue` function

### DIFF
--- a/expression/builtin_control.go
+++ b/expression/builtin_control.go
@@ -185,12 +185,12 @@ func (c *caseWhenFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 		types.SetBinChsClnFlag(fieldTp)
 	}
 	argTps := make([]types.EvalType, 0, l)
+	ctx.SetValue(isTrueKeepNullKey, struct{}{})
 	for i := 0; i < l-1; i += 2 {
-		if args[i], err = wrapWithIsTrue(ctx, true, args[i], false); err != nil {
-			return nil, err
-		}
+		args[i] = wrapWithIsTrue(ctx, args[i], false)
 		argTps = append(argTps, types.ETInt, tp)
 	}
+	ctx.SetValue(isTrueKeepNullKey, nil)
 	if l%2 == 1 {
 		argTps = append(argTps, tp)
 	}
@@ -489,10 +489,9 @@ func (c *ifFunctionClass) getFunction(ctx sessionctx.Context, args []Expression)
 	}
 	retTp := InferType4ControlFuncs(args[1], args[2])
 	evalTps := retTp.EvalType()
-	args[0], err = wrapWithIsTrue(ctx, true, args[0], false)
-	if err != nil {
-		return nil, err
-	}
+	ctx.SetValue(isTrueKeepNullKey, struct{}{})
+	args[0] = wrapWithIsTrue(ctx, args[0], false)
+	ctx.SetValue(isTrueKeepNullKey, nil)
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, evalTps, types.ETInt, evalTps, evalTps)
 	if err != nil {
 		return nil, err

--- a/expression/builtin_control.go
+++ b/expression/builtin_control.go
@@ -185,12 +185,10 @@ func (c *caseWhenFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 		types.SetBinChsClnFlag(fieldTp)
 	}
 	argTps := make([]types.EvalType, 0, l)
-	ctx.SetValue(isTrueKeepNullKey, struct{}{})
 	for i := 0; i < l-1; i += 2 {
-		args[i] = wrapWithIsTrue(ctx, args[i], false)
+		args[i] = wrapWithIsTrue(ctx, true, args[i], false)
 		argTps = append(argTps, types.ETInt, tp)
 	}
-	ctx.SetValue(isTrueKeepNullKey, nil)
 	if l%2 == 1 {
 		argTps = append(argTps, tp)
 	}
@@ -489,9 +487,7 @@ func (c *ifFunctionClass) getFunction(ctx sessionctx.Context, args []Expression)
 	}
 	retTp := InferType4ControlFuncs(args[1], args[2])
 	evalTps := retTp.EvalType()
-	ctx.SetValue(isTrueKeepNullKey, struct{}{})
-	args[0] = wrapWithIsTrue(ctx, args[0], false)
-	ctx.SetValue(isTrueKeepNullKey, nil)
+	args[0] = wrapWithIsTrue(ctx, true, args[0], false)
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, evalTps, types.ETInt, evalTps, evalTps)
 	if err != nil {
 		return nil, err

--- a/expression/builtin_op.go
+++ b/expression/builtin_op.go
@@ -67,10 +67,8 @@ func (c *logicAndFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	ctx.SetValue(isTrueKeepNullKey, struct{}{})
-	args[0] = wrapWithIsTrue(ctx, args[0], false)
-	args[1] = wrapWithIsTrue(ctx, args[1], false)
-	ctx.SetValue(isTrueKeepNullKey, nil)
+	args[0] = wrapWithIsTrue(ctx, true, args[0], false)
+	args[1] = wrapWithIsTrue(ctx, true, args[1], false)
 
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt, types.ETInt)
 	if err != nil {
@@ -116,10 +114,8 @@ func (c *logicOrFunctionClass) getFunction(ctx sessionctx.Context, args []Expres
 	if err != nil {
 		return nil, err
 	}
-	ctx.SetValue(isTrueKeepNullKey, struct{}{})
-	args[0] = wrapWithIsTrue(ctx, args[0], false)
-	args[1] = wrapWithIsTrue(ctx, args[1], false)
-	ctx.SetValue(isTrueKeepNullKey, nil)
+	args[0] = wrapWithIsTrue(ctx, true, args[0], false)
+	args[1] = wrapWithIsTrue(ctx, true, args[1], false)
 
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt, types.ETInt)
 	if err != nil {
@@ -171,10 +167,8 @@ func (c *logicXorFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	if err != nil {
 		return nil, err
 	}
-	ctx.SetValue(isTrueKeepNullKey, struct{}{})
-	args[0] = wrapWithIsTrue(ctx, args[0], false)
-	args[1] = wrapWithIsTrue(ctx, args[1], false)
-	ctx.SetValue(isTrueKeepNullKey, nil)
+	args[0] = wrapWithIsTrue(ctx, true, args[0], false)
+	args[1] = wrapWithIsTrue(ctx, true, args[1], false)
 
 	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETInt, types.ETInt, types.ETInt)
 	if err != nil {

--- a/expression/builtin_op_test.go
+++ b/expression/builtin_op_test.go
@@ -486,9 +486,10 @@ func (s *testEvaluatorSuite) TestIsTrueOrFalse(c *C) {
 	sc.IgnoreTruncate = true
 
 	testCases := []struct {
-		args    []interface{}
-		isTrue  interface{}
-		isFalse interface{}
+		args     []interface{}
+		isTrue   interface{}
+		isFalse  interface{}
+		keepNull bool
 	}{
 		{
 			args:    []interface{}{-12},
@@ -540,9 +541,18 @@ func (s *testEvaluatorSuite) TestIsTrueOrFalse(c *C) {
 			isTrue:  0,
 			isFalse: 0,
 		},
+		{
+			args:     []interface{}{nil},
+			isTrue:   nil,
+			isFalse:  nil,
+			keepNull: true,
+		},
 	}
 
 	for _, tc := range testCases {
+		if tc.keepNull {
+			s.ctx.SetValue(isTrueKeepNullKey, struct{}{})
+		}
 		isTrueSig, err := funcs[ast.IsTruth].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(tc.args...)))
 		c.Assert(err, IsNil)
 		c.Assert(isTrueSig, NotNil)
@@ -550,9 +560,15 @@ func (s *testEvaluatorSuite) TestIsTrueOrFalse(c *C) {
 		isTrue, err := evalBuiltinFunc(isTrueSig, chunk.Row{})
 		c.Assert(err, IsNil)
 		c.Assert(isTrue, testutil.DatumEquals, types.NewDatum(tc.isTrue))
+		if tc.keepNull {
+			s.ctx.SetValue(isTrueKeepNullKey, nil)
+		}
 	}
 
 	for _, tc := range testCases {
+		if tc.keepNull {
+			s.ctx.SetValue(isTrueKeepNullKey, struct{}{})
+		}
 		isFalseSig, err := funcs[ast.IsFalsity].getFunction(s.ctx, s.datumsToConstants(types.MakeDatums(tc.args...)))
 		c.Assert(err, IsNil)
 		c.Assert(isFalseSig, NotNil)
@@ -560,6 +576,9 @@ func (s *testEvaluatorSuite) TestIsTrueOrFalse(c *C) {
 		isFalse, err := evalBuiltinFunc(isFalseSig, chunk.Row{})
 		c.Assert(err, IsNil)
 		c.Assert(isFalse, testutil.DatumEquals, types.NewDatum(tc.isFalse))
+		if tc.keepNull {
+			s.ctx.SetValue(isTrueKeepNullKey, nil)
+		}
 	}
 }
 

--- a/expression/function_traits.go
+++ b/expression/function_traits.go
@@ -172,3 +172,12 @@ var noopFuncs = map[string]struct{}{
 	ast.GetLock:     {},
 	ast.ReleaseLock: {},
 }
+
+// isTrueKeepNullFunctions stores functions in which "istrue" function at argument positions should keep null values
+var isTrueKeepNullFunctions = map[string]struct{}{
+	ast.LogicAnd: {},
+	ast.LogicOr:  {},
+	ast.LogicXor: {},
+	ast.Case:     {},
+	ast.If:       {},
+}

--- a/expression/util.go
+++ b/expression/util.go
@@ -431,9 +431,7 @@ func pushNotAcrossExpr(ctx sessionctx.Context, expr Expression, not bool) (_ Exp
 	if f, ok := expr.(*ScalarFunction); ok {
 		switch f.FuncName.L {
 		case ast.UnaryNot:
-			ctx.SetValue(isTrueKeepNullKey, struct{}{})
-			child := wrapWithIsTrue(ctx, f.GetArgs()[0], true)
-			ctx.SetValue(isTrueKeepNullKey, nil)
+			child := wrapWithIsTrue(ctx, true, f.GetArgs()[0], true)
 			var childExpr Expression
 			childExpr, changed = pushNotAcrossExpr(f.GetCtx(), child, !not)
 			if !changed && !not {

--- a/expression/util.go
+++ b/expression/util.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/types/parser_driver"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/logutil"
@@ -431,10 +431,9 @@ func pushNotAcrossExpr(ctx sessionctx.Context, expr Expression, not bool) (_ Exp
 	if f, ok := expr.(*ScalarFunction); ok {
 		switch f.FuncName.L {
 		case ast.UnaryNot:
-			child, err := wrapWithIsTrue(ctx, true, f.GetArgs()[0], true)
-			if err != nil {
-				return expr, false
-			}
+			ctx.SetValue(isTrueKeepNullKey, struct{}{})
+			child := wrapWithIsTrue(ctx, f.GetArgs()[0], true)
+			ctx.SetValue(isTrueKeepNullKey, nil)
 			var childExpr Expression
 			childExpr, changed = pushNotAcrossExpr(f.GetCtx(), child, !not)
 			if !changed && !not {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17720 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`isTrueOrFalseFunctionClass.keepNull` was initialized differently in expression rewriter and `EvaluateExprWithNull`, which caused `outer join` wrongly simplified to `inner join` during predicate push down optimization.

### What is changed and how it works?

What's Changed:

- Unify the initialization of `isTrueOrFalseFunctionClass` with `newFunctionImpl`.

How it Works:

- Remove the direct initialization of `ScalarFunction` in `wrapWithIsTrue`. Invoke `NewFunctionInternal` instead.
- Use `sessionctx.Context` to pass the argument `is_true_keep_null`, which affects the evaluation of `NULL` in function `istrue`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- fix the behavior of `istrue` function when `null` is involved 
<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
