### PR TITLE
Revert "expression: fix unexpected field lengths of cast functions"

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -1778,10 +1778,6 @@ func BuildCastFunction(ctx sessionctx.Context, expr Expression, tp *types.FieldT
 		return expr
 	}
 
-	if tp.Flen == types.UnspecifiedLength {
-		tp.Flen = expr.GetType().Flen
-	}
-
 	var fc functionClass
 	switch tp.EvalType() {
 	case types.ETInt:

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -181,9 +181,9 @@ func (s *testInferTypeSuite) createTestCase4Constants() []typeInferTestCase {
 
 func (s *testInferTypeSuite) createTestCase4Cast() []typeInferTestCase {
 	return []typeInferTestCase{
-		{"CAST(c_int_d AS BINARY)", mysql.TypeVarString, charset.CharsetBin, mysql.BinaryFlag, 11, -1},
+		{"CAST(c_int_d AS BINARY)", mysql.TypeVarString, charset.CharsetBin, mysql.BinaryFlag, -1, -1}, // TODO: Flen should be 11.
 		{"CAST(c_int_d AS BINARY(5))", mysql.TypeString, charset.CharsetBin, mysql.BinaryFlag, 5, -1},
-		{"CAST(c_int_d AS CHAR)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 11, -1},
+		{"CAST(c_int_d AS CHAR)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, -1, -1}, // TODO: Flen should be 11.
 		{"CAST(c_int_d AS CHAR(5))", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 5, -1},
 		{"CAST(c_int_d AS DATE)", mysql.TypeDate, charset.CharsetBin, mysql.BinaryFlag, 10, 0},
 		{"CAST(c_int_d AS DATETIME)", mysql.TypeDatetime, charset.CharsetBin, mysql.BinaryFlag, 19, 0},


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: revert https://github.com/pingcap/tidb/pull/19020

it causes mysql-test all failure in the virtual col, it need pass all test before it can merge

```
FATA[0006] run test [gcol_supported_sql_funcs] err: sql:select * from t1;: failed to run query 
"select * from t1;" 
 around line 1063, 
we need(49):
select * from t1;
a	b
1	1
11	11
drop table t1;
se
but got(49):
select * from t1;
a	b
1	1
11	11
 
tidb-server(PID: 97552) stopped
```

Problem Summary: fix unstable CI caused by #19020

### What is changed and how it works?
### Check List <!--REMOVE the items that are not applicable-->

revert 

Tests <!-- At least one of them must be included. -->

- Unit test
### Release note <!-- bugfixes or new feature need a release note -->

- No release note

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19606)
<!-- Reviewable:end -->
