### PR TITLE
expression: fix incorrect implementation in `builtinRealIsFalseSig`

### DIFF
--- a/expression/builtin_op_vec.go
+++ b/expression/builtin_op_vec.go
@@ -474,14 +474,14 @@ func (b *builtinRealIsFalseSig) vecEvalInt(input *chunk.Chunk, result *chunk.Col
 
 	result.ResizeInt64(numRows, false)
 	i64s := result.Int64s()
-	bufI64s := buf.Int64s()
+	bufF64s := buf.Float64s()
 	for i := 0; i < numRows; i++ {
 		isNull := buf.IsNull(i)
 		if b.keepNull && isNull {
 			result.SetNull(i, true)
 			continue
 		}
-		if isNull || bufI64s[i] != 0 {
+		if isNull || bufF64s[i] != 0 {
 			i64s[i] = 0
 		} else {
 			i64s[i] = 1

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7100,6 +7100,7 @@ func (s *testIntegrationSerialSuite) TestIssue19116(c *C) {
 
 func (s *testIntegrationSerialSuite) TestIssue18674(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustQuery("select -1.0 % -1.0").Check(testkit.Rows("0.0"))
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(`pk` int primary key,`col_float_key_signed` float  ,key (`col_float_key_signed`))")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7098,6 +7098,19 @@ func (s *testIntegrationSerialSuite) TestIssue19116(c *C) {
 	tk.MustQuery("select coercibility(1=1);").Check(testkit.Rows("5"))
 }
 
+func (s *testIntegrationSerialSuite) TestIssue18674(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(`pk` int primary key,`col_float_key_signed` float  ,key (`col_float_key_signed`))")
+	tk.MustExec("insert into t1 values (0, null), (1, 0), (2, -0), (3, 1), (-1,-1)")
+	tk.MustQuery("select * from t1 where ( `col_float_key_signed` % `col_float_key_signed`) IS FALSE").Sort().Check(testkit.Rows("-1 -1", "3 1"))
+	tk.MustQuery("select  `col_float_key_signed` , `col_float_key_signed` % `col_float_key_signed` from t1").Sort().Check(testkit.Rows(
+		"-1 -0", "0 <nil>", "0 <nil>", "1 0", "<nil> <nil>"))
+	tk.MustQuery("select  `col_float_key_signed` , (`col_float_key_signed` % `col_float_key_signed`) IS FALSE from t1").Sort().Check(testkit.Rows(
+		"-1 1", "0 0", "0 0", "1 1", "<nil> 0"))
+}
+
 func (s *testIntegrationSerialSuite) TestIssue17063(c *C) {
 	collate.SetNewCollationEnabledForTest(true)
 	defer collate.SetNewCollationEnabledForTest(false)

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -2281,6 +2281,10 @@ func doDivMod(from1, from2, to, mod *MyDecimal, fracIncr int) error {
 	if idxTo != 0 {
 		copy(to.wordBuf[:], to.wordBuf[idxTo:])
 	}
+
+	if to.IsZero() {
+		to.negative = false
+	}
 	return err
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18674 <!-- REMOVE this line if no issue to close -->

Problem Summary: fix incorrect implementation in `builtinRealIsFalseSig`

### What is changed and how it works?

Fix incorrect implementation in `builtinRealIsFalseSig`.

The type of its child is `Real`, but when checking false values, it regards them as `Int` incorrectly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

-  expression: fix incorrect implementation in `builtinRealIsFalseSig`
