### PR TITLE
executor: fix fast analyze on single index

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -812,12 +812,9 @@ func (e *AnalyzeFastExec) updateCollectorSamples(sValue []byte, sKey kv.Key, sam
 	index2Cols := make([][]*model.ColumnInfo, len(e.idxsInfo))
 	for i, idxInfo := range e.idxsInfo {
 		for _, idxCol := range idxInfo.Columns {
-			for _, colInfo := range e.tblInfo.Columns {
-				if colInfo.Name == idxCol.Name {
-					index2Cols[i] = append(index2Cols[i], colInfo)
-					wantCols[colInfo.ID] = &colInfo.FieldType
-				}
-			}
+			colInfo := e.tblInfo.Columns[idxCol.Offset]
+			index2Cols[i] = append(index2Cols[i], colInfo)
+			wantCols[colInfo.ID] = &colInfo.FieldType
 		}
 	}
 

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -434,6 +434,14 @@ func (s *testSuite1) TestAnalyzeIndex(c *C) {
 	tk.MustExec("insert into t1(id, v) values(1, 2), (2, 2), (3, 2), (4, 2), (5, 1), (6, 3), (7, 4)")
 	tk.MustExec("analyze table t1 index k")
 	c.Assert(len(tk.MustQuery("show stats_buckets where table_name = 't1' and column_name = 'k' and is_index = 1").Rows()), Greater, 0)
+
+	func() {
+		defer tk.MustExec("set @@session.tidb_enable_fast_analyze=0")
+		tk.MustExec("drop stats t1")
+		tk.MustExec("set @@session.tidb_enable_fast_analyze=1")
+		tk.MustExec("analyze table t1 index k")
+		c.Assert(len(tk.MustQuery("show stats_buckets where table_name = 't1' and column_name = 'k' and is_index = 1").Rows()), Greater, 1)
+	}()
 }
 
 func (s *testSuite1) TestAnalyzeIncremental(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
tk.MustExec("create table t1 (id int, v int, primary key(id), index k(v))")
tk.MustExec("insert into t1(id, v) values(1, 2), (2, 2), (3, 2), (4, 2), (5, 1), (6, 3), (7, 4)")
tk.MustExec("drop stats t1")
tk.MustExec("set @@session.tidb_enable_fast_analyze=1")
tk.MustExec("analyze table t1 index k")
c.Assert(len(tk.MustQuery("show stats_buckets where table_name = 't1' and column_name = 'k' and is_index = 1")
```

will get undesirable 1 bucket with full 0 value:

```
show stats_buckets where table_name = 't1';
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
| Db_name | Table_name | Partition_name | Column_name | Is_index | Bucket_id | Count | Repeats | Lower_Bound | Upper_Bound |
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
| test    | t1         |                | k           |        1 |         0 |     7 |       7 | NULL        | NULL        |
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
```

Problem Summary:

current fast analyze extract index value from the decoded row values

but if we run `analyze table x index k`, it will use empty required cols to decode row values,

so we cannot extract the right index values from the empty row data.

### What is changed and how it works?

What's Changed, How it Works:

refile index columns into the decoder's `wantedCols` if col not exists in it. 

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


after this PR we can get:

```
show stats_buckets where table_name = 't1';
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
| Db_name | Table_name | Partition_name | Column_name | Is_index | Bucket_id | Count | Repeats | Lower_Bound | Upper_Bound |
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
| test    | t1         |                | k           |        1 |         0 |     1 |       1 | 1           | 1           |
| test    | t1         |                | k           |        1 |         1 |     5 |       4 | 2           | 2           |
| test    | t1         |                | k           |        1 |         2 |     6 |       1 | 3           | 3           |
| test    | t1         |                | k           |        1 |         3 |     7 |       1 | 4           | 4           |
+---------+------------+----------------+-------------+----------+-----------+-------+---------+-------------+-------------+
```

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19662)
<!-- Reviewable:end -->
