### PR TITLE
distsql: fix cop task runtime stats redundant display

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -172,9 +172,10 @@ func (s *testSuite) TestSelectResultRuntimeStats(c *C) {
 	}
 	s2 := *s1
 	s2.RuntimeStats = s1
-	c.Assert(s2.String(), Equals, "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s}, backoff{RegionMiss: 2ms}")
+	expect := "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s}, backoff{RegionMiss: 2ms}"
+	c.Assert(s2.String(), Equals, expect)
 	// Test for idempotence.
-	c.Assert(s2.String(), Equals, "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s}, backoff{RegionMiss: 2ms}")
+	c.Assert(s2.String(), Equals, expect)
 }
 
 func (s *testSuite) createSelectStreaming(batch, totalRows int, c *C) (*streamResult, []*types.FieldType) {

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -27,9 +27,11 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -154,6 +156,25 @@ func (s *testSuite) TestSelectWithRuntimeStats(c *C) {
 	c.Assert(numAllRows, Equals, 2)
 	err := response.Close()
 	c.Assert(err, IsNil)
+}
+
+func (s *testSuite) TestSelectResultRuntimeStats(c *C) {
+	basic := &execdetails.BasicRuntimeStats{}
+	basic.Record(time.Second, 20)
+	s1 := &selectResultRuntimeStats{
+		RuntimeStats:     basic,
+		copRespTime:      []time.Duration{time.Second, time.Millisecond},
+		procKeys:         []int64{100, 200},
+		backoffSleep:     map[string]time.Duration{"RegionMiss": time.Millisecond},
+		totalProcessTime: time.Second,
+		totalWaitTime:    time.Second,
+		rpcStat:          tikv.RegionRequestRuntimeStats{},
+	}
+	s2 := *s1
+	s2.RuntimeStats = s1
+	c.Assert(s2.String(), Equals, "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s}, backoff{RegionMiss: 2ms}")
+	// Test for idempotence.
+	c.Assert(s2.String(), Equals, "time:1s, loops:1, cop_task: {num: 4, max: 1s, min: 1ms, avg: 500.5ms, p95: 1s, max_proc_keys: 200, p95_proc_keys: 200, tot_proc: 2s, tot_wait: 2s}, backoff{RegionMiss: 2ms}")
 }
 
 func (s *testSuite) createSelectStreaming(batch, totalRows int, c *C) (*streamResult, []*types.FieldType) {

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -372,7 +372,6 @@ func (s *selectResultRuntimeStats) String() string {
 			return stats.String()
 		}
 		buf.WriteString(s.RuntimeStats.String())
-
 	}
 	if len(s.copRespTime) > 0 {
 		size := len(s.copRespTime)

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -344,10 +344,35 @@ func (s *selectResultRuntimeStats) mergeCopRuntimeStats(copStats *tikv.CopRuntim
 	s.rpcStat.Merge(copStats.RegionRequestRuntimeStats)
 }
 
+func (s *selectResultRuntimeStats) merge(other *selectResultRuntimeStats) {
+	s.copRespTime = append(s.copRespTime, other.copRespTime...)
+	s.procKeys = append(s.procKeys, other.procKeys...)
+
+	for k, v := range other.backoffSleep {
+		s.backoffSleep[k] += v
+	}
+	s.totalProcessTime += other.totalProcessTime
+	s.totalWaitTime += other.totalWaitTime
+	s.rpcStat.Merge(other.rpcStat)
+}
+
 func (s *selectResultRuntimeStats) String() string {
 	buf := bytes.NewBuffer(nil)
 	if s.RuntimeStats != nil {
+		stats, ok := s.RuntimeStats.(*selectResultRuntimeStats)
+		if ok {
+			stats.merge(s)
+			// Clean for idempotence.
+			s.copRespTime = nil
+			s.procKeys = nil
+			s.backoffSleep = nil
+			s.totalWaitTime = 0
+			s.totalProcessTime = 0
+			s.rpcStat = tikv.RegionRequestRuntimeStats{}
+			return stats.String()
+		}
 		buf.WriteString(s.RuntimeStats.String())
+
 	}
 	if len(s.copRespTime) > 0 {
 		size := len(s.copRespTime)


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Close https://github.com/pingcap/tidb/issues/19673
### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- Fix cop task runtime stats redundant display.