### PR TITLE
privilege: add privilege check for `show stats`

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -157,6 +157,30 @@ func (s *testSuite5) TestShowGrantsPrivilege(c *C) {
 	tk2.MustQuery("show grants")
 }
 
+func (s *testSuite5) TestShowStatsPrivilege(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create user show_stats")
+	tk1 := testkit.NewTestKit(c, s.store)
+	se, err := session.CreateSession4Test(s.store)
+	c.Assert(err, IsNil)
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "show_stats", Hostname: "%"}, nil, nil), IsTrue)
+	tk1.Se = se
+	eqErr := plannercore.ErrDBaccessDenied.GenWithStackByArgs("show_stats", "%", mysql.SystemDB)
+	_, err = tk1.Exec("show stats_meta")
+	c.Assert(err.Error(), Equals, eqErr.Error())
+	_, err = tk1.Exec("SHOW STATS_BUCKETS")
+	c.Assert(err.Error(), Equals, eqErr.Error())
+	_, err = tk1.Exec("SHOW STATS_HEALTHY")
+	c.Assert(err.Error(), Equals, eqErr.Error())
+	_, err = tk1.Exec("SHOW STATS_HISTOGRAMS")
+	c.Assert(err.Error(), Equals, eqErr.Error())
+	tk.MustExec("grant select on mysql.* to show_stats")
+	tk1.MustExec("show stats_meta")
+	tk1.MustExec("SHOW STATS_BUCKETS")
+	tk1.MustExec("SHOW STATS_HEALTHY")
+	tk1.MustExec("SHOW STATS_HISTOGRAMS")
+}
+
 func (s *testSuite5) TestIssue18878(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	se, err := session.CreateSession4Test(s.store)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1923,6 +1923,13 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (Plan, 
 		p.setSchemaAndNames(buildShowNextRowID())
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, show.Table.Schema.L, show.Table.Name.L, "", ErrPrivilegeCheckFail)
 		return p, nil
+	case ast.ShowStatsBuckets, ast.ShowStatsHistograms, ast.ShowStatsMeta, ast.ShowStatsHealthy:
+		user := b.ctx.GetSessionVars().User
+		var err error
+		if user != nil {
+			err = ErrDBaccessDenied.GenWithStackByArgs(user.AuthUsername, user.AuthHostname, mysql.SystemDB)
+		}
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SelectPriv, mysql.SystemDB, "", "", err)
 	}
 	schema, names := buildShowSchema(show, isView, isSequence)
 	p.SetSchema(schema)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17782  <!-- REMOVE this line if no issue to close -->

Problem Summary:
Command like `SHOW STATS_META` and `SHOW STATS_BUCKETS` didn't check privilege before. This will lead to table information leak, any user could see some table information by using `SHOW STATS`.

### What is changed and how it works?

What's Changed:
Add privilege check for `SHOW STATS` related command.

How it Works:
Only user with `SELECT` privilege on `mysql` database could execute `SHOW STATS`

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Add privilege check for `SHOW STATS_META`, `SHOW STATS_BUCKET`.
