### PR TITLE
fix read failure from system tables `tiflash_segments` and `tiflash_tables` when some tiflash node is down

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1896,6 +1896,7 @@ func (e *TiFlashSystemTableRetriever) initialize(sctx sessionctx.Context, tiflas
 					}
 					_, err = util.InternalHTTPClient().Do(req)
 					if err != nil {
+						sctx.GetSessionVars().StmtCtx.AppendWarning(err)
 						continue
 					}
 					e.instanceInfos = append(e.instanceInfos, tiflashInstanceInfo{


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/18701

Problem Summary: When some tiflash node is down, tidb will still try to fetch data from them and this makes the query failed.

### What is changed and how it works?

What's Changed: Check whether tiflash http_port is open before fetch data from them.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
follow the steps in this issue: https://github.com/pingcap/tidb/issues/18701 and make sure the result meets the expectation.

### Release note <!-- bugfixes or new feature need a release note -->

- fix read failure from system tables `tiflash_segments` and `tiflash_tables` when some tiflash node is down
