### PR TITLE
executor: make TestSelectIntoOutfileTypes stable

### DIFF
--- a/executor/select_into_test.go
+++ b/executor/select_into_test.go
@@ -52,7 +52,7 @@ func (s *testSuite1) TestSelectIntoFileExists(c *C) {
 
 func (s *testSuite1) TestSelectIntoOutfileTypes(c *C) {
 	tmpDir := os.TempDir()
-	outfile := filepath.Join(tmpDir, "select-into-outfile.data")
+	outfile := filepath.Join(tmpDir, fmt.Sprintf("select-into-outfile-%d-%d.data", os.Getpid(), time.Now().Unix()))
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

fix CI like https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/48034/pipeline

```
[2020-09-02T09:36:16.848Z] FAIL: select_into_test.go:53: testSuite1.TestSelectIntoOutfileTypes
[2020-09-02T09:36:16.848Z] 
[2020-09-02T09:36:16.848Z] select_into_test.go:62:
[2020-09-02T09:36:16.848Z]     tk.MustExec(fmt.Sprintf("SELECT * FROM t INTO OUTFILE %q", outfile))
[2020-09-02T09:36:16.848Z] /home/jenkins/agent/workspace/tidb_ghpr_check_2/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:207:
[2020-09-02T09:36:16.848Z]     tk.c.Assert(err, check.IsNil, check.Commentf("sql:%s, %v, error stack %v", sql, args, errors.ErrorStack(err)))
[2020-09-02T09:36:16.848Z] ... value *errors.withStack = open /tmp/select-into-outfile.data: file exists ("open /tmp/select-into-outfile.data: file exists")
[2020-09-02T09:36:16.848Z] ... sql:SELECT * FROM t INTO OUTFILE "/tmp/select-into-outfile.data", [], error stack open /tmp/select-into-outfile.data: file exists
[2020-09-02T09:36:16.848Z] github.com/pingcap/errors.AddStack
[2020-09-02T09:36:16.848Z] 	/home/jenkins/agent/workspace/tidb_ghpr_check_2/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20200729012136-4e113ddee29e/errors.go:174
[2020-09-02T09:36:16.848Z] github.com/pingcap/errors.Trace
[2020-09-02T09:36:16.848Z] 	/home/jenkins/agent/workspace/tidb_ghpr_check_2/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20200729012136-4e113ddee29e/juju_adaptor.go:15
[2020-09-02T09:36:16.848Z] github.com/pingcap/tidb/executor.(*SelectIntoExec).Open
```

### What is changed and how it works?

What's Changed, How it Works:

generate tmp unique file name

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/19719)
<!-- Reviewable:end -->
