### PR TITLE
expression: fix unmatched column lengths errors caused by `builtinGreatestStringSig` and `builtinLeastStringSig`

### DIFF
--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -797,6 +797,7 @@ func (b *builtinGreatestStringSig) vecEvalString(input *chunk.Chunk, result *chu
 		if err := b.args[j].VecEvalString(b.ctx, input, arg); err != nil {
 			return err
 		}
+		dst.ReserveString(n)
 		for i := 0; i < n; i++ {
 			if src.IsNull(i) || arg.IsNull(i) {
 				dst.AppendNull()

--- a/expression/builtin_compare_vec.go
+++ b/expression/builtin_compare_vec.go
@@ -254,6 +254,7 @@ func (b *builtinLeastStringSig) vecEvalString(input *chunk.Chunk, result *chunk.
 	src := result
 	arg := buf1
 	dst := buf2
+	dst.ReserveString(n)
 	for j := 1; j < len(b.args); j++ {
 		if err := b.args[j].VecEvalString(b.ctx, input, arg); err != nil {
 			return err
@@ -793,11 +794,11 @@ func (b *builtinGreatestStringSig) vecEvalString(input *chunk.Chunk, result *chu
 	src := result
 	arg := buf1
 	dst := buf2
+	dst.ReserveString(n)
 	for j := 1; j < len(b.args); j++ {
 		if err := b.args[j].VecEvalString(b.ctx, input, arg); err != nil {
 			return err
 		}
-		dst.ReserveString(n)
 		for i := 0; i < n; i++ {
 			if src.IsNull(i) || arg.IsNull(i) {
 				dst.AppendNull()

--- a/util/chunk/column.go
+++ b/util/chunk/column.go
@@ -703,7 +703,7 @@ func (c *Column) MergeNulls(cols ...*Column) {
 	}
 	for _, col := range cols {
 		if c.length != col.length {
-			panic("should ensure all columns have the same length")
+			panic(fmt.Sprintf("should ensure all columns have the same length, expect %v, but got %v", c.length, col.length))
 		}
 	}
 	for _, col := range cols {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #16147 <!-- REMOVE this line if no issue to close -->

Problem Summary: expression: fix unmatched column lengths errors caused by `builtinGreatestStringSig` and `builtinLeastStringSig`

### What is changed and how it works?
Built-in functions `builtinGreatestStringSig` and `builtinLeastStringSig` allocate buffers from their own buffer pool, but they don't initialize allocated buffers before using them, which may cause some problems.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- expression: fix unmatched column lengths errors caused by `builtinGreatestStringSig` and `builtinLeastStringSig`
