### PR TITLE
executor: implement meldata for rank funcs to track memUsage

### DIFF
--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -237,7 +237,7 @@ func distinctUpdateMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) 
 func rowMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (memDeltas []int64, err error) {
 	memDeltas = make([]int64, 0)
 	for i := 0; i < srcChk.NumRows(); i++ {
-		memDelta := int64(unsafe.Sizeof(chunk.Row{}))
+		memDelta := aggfuncs.DefRowSize
 		memDeltas = append(memDeltas, memDelta)
 	}
 	return memDeltas, nil

--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -236,13 +236,7 @@ func distinctUpdateMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) 
 
 func rowMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (memDeltas []int64, err error) {
 	memDeltas = make([]int64, 0)
-	fmt.Printf("num rows %d\n", srcChk.NumRows())
 	for i := 0; i < srcChk.NumRows(); i++ {
-		row := srcChk.GetRow(i)
-		if row.IsNull(0) {
-			memDeltas = append(memDeltas, int64(0))
-			continue
-		}
 		memDelta := int64(unsafe.Sizeof(chunk.Row{}))
 		memDeltas = append(memDeltas, memDelta)
 	}

--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -235,7 +235,7 @@ func distinctUpdateMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) 
 }
 
 func rowMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (memDeltas []int64, err error) {
-	memDeltas = make([]int64, 0, 0)
+	memDeltas = make([]int64, 0)
 	fmt.Printf("num rows %d\n", srcChk.NumRows())
 	for i := 0; i < srcChk.NumRows(); i++ {
 		row := srcChk.GetRow(i)

--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -234,6 +234,21 @@ func distinctUpdateMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) 
 	return memDeltas, nil
 }
 
+func rowMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (memDeltas []int64, err error) {
+	memDeltas = make([]int64, 0, 0)
+	fmt.Printf("num rows %d\n", srcChk.NumRows())
+	for i := 0; i < srcChk.NumRows(); i++ {
+		row := srcChk.GetRow(i)
+		if row.IsNull(0) {
+			memDeltas = append(memDeltas, int64(0))
+			continue
+		}
+		memDelta := int64(unsafe.Sizeof(chunk.Row{}))
+		memDeltas = append(memDeltas, memDelta)
+	}
+	return memDeltas, nil
+}
+
 type aggMemTest struct {
 	aggTest            aggTest
 	allocMemDelta      int64

--- a/executor/aggfuncs/aggfunc_test.go
+++ b/executor/aggfuncs/aggfunc_test.go
@@ -592,7 +592,8 @@ func (s *testSuite) testAggMemFunc(c *C, p aggMemTest) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 	i := 0
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		memDelta, _ := finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+		memDelta, err := finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
+		c.Assert(err, IsNil)
 		c.Assert(memDelta, Equals, updateMemDeltas[i])
 		i++
 	}

--- a/executor/aggfuncs/aggfuncs.go
+++ b/executor/aggfuncs/aggfuncs.go
@@ -110,6 +110,8 @@ const (
 	DefFloat64Size = int64(unsafe.Sizeof(float64(0)))
 	// DefTimeSize is the size of time
 	DefTimeSize = int64(16)
+	// DefRowSize is the size of row
+	DefRowSize = int64(unsafe.Sizeof(chunk.Row{}))
 )
 
 // PartialResult represents data structure to store the partial result for the

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -53,8 +53,12 @@ func (r *rank) ResetPartialResult(pr PartialResult) {
 
 func (r *rank) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4Rank)(pr)
-	p.rows = append(p.rows, rowsInGroup...)
-	memDelta += int64(len(rowsInGroup)) * DefRowSize
+	for _, row := range rowsInGroup {
+		p.rows = append(p.rows, row)
+		if !row.IsNull(0) {
+			memDelta += DefRowSize
+		}
+	}
 	return memDelta, nil
 }
 

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -24,8 +24,6 @@ import (
 const (
 	//DefPartialResult4RankSize is the size of partialResult4Rank
 	DefPartialResult4RankSize = int64(unsafe.Sizeof(partialResult4Rank{}))
-	//DefRowSize is the size of row
-	DefRowSize = int64(unsafe.Sizeof(chunk.Row{}))
 )
 
 type rank struct {

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	DefPartialResult4RankSize = int64(unsafe.Sizeof(partialResult4Rank{}))
-	DefRowSize = int64(unsafe.Sizeof(chunk.Row{}))
+	DefRowSize                = int64(unsafe.Sizeof(chunk.Row{}))
 )
 
 type rank struct {

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -22,8 +22,10 @@ import (
 )
 
 const (
+	//DefPartialResult4RankSize is the size of partialResult4Rank
 	DefPartialResult4RankSize = int64(unsafe.Sizeof(partialResult4Rank{}))
-	DefRowSize                = int64(unsafe.Sizeof(chunk.Row{}))
+	//DefRowSize is the size of row
+	DefRowSize = int64(unsafe.Sizeof(chunk.Row{}))
 )
 
 type rank struct {

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -53,12 +53,8 @@ func (r *rank) ResetPartialResult(pr PartialResult) {
 
 func (r *rank) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4Rank)(pr)
-	for _, row := range rowsInGroup {
-		p.rows = append(p.rows, row)
-		if !row.IsNull(0) {
-			memDelta += DefRowSize
-		}
-	}
+	p.rows = append(p.rows, rowsInGroup...)
+	memDelta += int64(len(rowsInGroup)) * DefRowSize
 	return memDelta, nil
 }
 

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -143,8 +143,8 @@ func buildWindowTester(funcName string, tp byte, constantArg uint64, orderByCols
 	return pt
 }
 
-func buildWindowMemTester(funcName string, tp byte, constantArg uint64, numRows int, orderByCols int, allocMemDelta int64, updateMemDeltaGens updateMemDeltaGens, results ...interface{}) windowMemTest {
-	windowTest := buildWindowTester(funcName, tp, constantArg, orderByCols, numRows, results...)
+func buildWindowMemTester(funcName string, tp byte, constantArg uint64, numRows int, orderByCols int, allocMemDelta int64, updateMemDeltaGens updateMemDeltaGens) windowMemTest {
+	windowTest := buildWindowTester(funcName, tp, constantArg, orderByCols, numRows, nil)
 	pt := windowMemTest{
 		windowTest:         windowTest,
 		allocMemDelta:      allocMemDelta,
@@ -197,11 +197,11 @@ func (s *testSuite) TestWindowFunctions(c *C) {
 func (s *testSuite) TestMemRank(c *C) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 1, 1,
-			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens, 1),
+			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 3, 0,
-			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens, 1, 1, 1),
+			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 4, 1,
-			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens, 1, 2, 3, 4),
+			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
 	}
 	for _, test := range tests {
 		s.testWindowAggMemFunc(c, test)

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -96,8 +96,8 @@ func (s *testSuite) testWindowAggMemFunc(c *C, p windowMemTest) {
 	iter := chunk.NewIterator4Chunk(srcChk)
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		memDelta, err = finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
-		c.Assert(memDelta, Equals, updateMemDeltas[i])
 		c.Assert(err, IsNil)
+		c.Assert(memDelta, Equals, updateMemDeltas[i])
 	}
 }
 

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -144,7 +144,7 @@ func buildWindowTester(funcName string, tp byte, constantArg uint64, orderByCols
 }
 
 func buildWindowMemTester(funcName string, tp byte, constantArg uint64, numRows int, orderByCols int, allocMemDelta int64, updateMemDeltaGens updateMemDeltaGens) windowMemTest {
-	windowTest := buildWindowTester(funcName, tp, constantArg, orderByCols, numRows, nil)
+	windowTest := buildWindowTester(funcName, tp, constantArg, orderByCols, numRows)
 	pt := windowMemTest{
 		windowTest:         windowTest,
 		allocMemDelta:      allocMemDelta,

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -88,6 +88,7 @@ func (s *testSuite) testWindowAggMemFunc(c *C, p windowMemTest) {
 	c.Assert(err, IsNil)
 	finalFunc := aggfuncs.BuildWindowFunctions(s.ctx, desc, 0, p.windowTest.orderByCols)
 	finalPr, memDelta := finalFunc.AllocPartialResult()
+	c.Assert(memDelta, Equals, p.allocMemDelta)
 
 	updateMemDeltas, err := p.updateMemDeltaGens(srcChk, p.windowTest.dataType)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #19743  
Problem Summary:
Implement memDelta for sum functions to trace the memory usage of rankFunc
### What is changed and how it works?

What's Changed:
Define the struct size for the following type, and implement memory track for avg Rank
`partialResult4Rank`
`row`

### Check List 
Tests <!-- At least one of them must be included. -->

- unit test


### Release note <!-- bugfixes or new feature need a release note -->
- trace the memory usage of rank AggFunc in HashAggExec
