### PR TITLE
test: fix ci failure in TestParallelDropSchemaAndDropTable

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -762,7 +762,7 @@ func (s *testDBSuite5) TestParallelDropSchemaAndDropTable(c *C) {
 	wg.Wait()
 	c.Assert(done, IsTrue)
 	c.Assert(checkErr, NotNil)
-	// There are two possible assert result is because that:
+	// There are two possible assert result because:
 	// 1: If drop-database is finished before drop-table being put into the ddl job queue, it will return unknown table error directly in previous check .
 	// 2: If drop-table has passed the previous check and been put into the ddl job queue, then drop-database finished, it will return schema change error.
 	assertRes := checkErr.Error() == "[domain:8028]Information schema is changed during the execution of the"+

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -763,7 +763,7 @@ func (s *testDBSuite5) TestParallelDropSchemaAndDropTable(c *C) {
 	c.Assert(done, IsTrue)
 	c.Assert(checkErr, NotNil)
 	// There are two possible assert result because:
-	// 1: If drop-database is finished before drop-table being put into the ddl job queue, it will return unknown table error directly in previous check .
+	// 1: If drop-database is finished before drop-table being put into the ddl job queue, it will return "unknown table" error directly in the previous check.
 	// 2: If drop-table has passed the previous check and been put into the ddl job queue, then drop-database finished, it will return schema change error.
 	assertRes := checkErr.Error() == "[domain:8028]Information schema is changed during the execution of the"+
 		" statement(for example, table definition may be updated by other DDL ran in parallel). "+


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/17967 

Problem Summary: fix ci failure when drop table and drop table parallelly.

### What is changed and how it works?

How it Works: make assert error compatible with 2 different possible results.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- None
