### PR TITLE
config: enlarge the default value of max-txn-ttl

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -659,7 +659,7 @@ var defaultConf = Config{
 		TxnTotalSizeLimit:    DefTxnTotalSizeLimit,
 		DistinctAggPushDown:  false,
 		CommitterConcurrency: 16,
-		MaxTxnTTL:            10 * 60 * 1000, // 10min
+		MaxTxnTTL:            60 * 60 * 1000, // 1hour
 		MemProfileInterval:   "1m",
 	},
 	ProxyProtocol: ProxyProtocol{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -272,7 +272,7 @@ txn-entry-size-limit = 6291456
 committer-concurrency = 16
 
 # max lifetime of transaction ttl manager.
-max-txn-ttl = 600000
+max-txn-ttl = 3600000
 
 # the interval duration between two memory profile into global tracker
 mem-profile-interval = "1m"


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The default value of `max-txn-ttl` is a bit small, it limits the max execution time of the transactions.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Enlarge it to 1 hour.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Enlarge the default value of `max-txn-ttl` to 1 hour.
