### PR TITLE
executor: fix error tikv_cop_wait time in metric profile

### DIFF
--- a/executor/inspection_profile.go
+++ b/executor/inspection_profile.go
@@ -542,13 +542,13 @@ func (pb *profileBuilder) formatValueByTp(value float64) string {
 		if math.IsNaN(value) {
 			return ""
 		}
-		if value > 1 {
+		if math.Abs(value) > 1 {
 			// second unit
 			return fmt.Sprintf("%.2fs", value)
-		} else if value*1000 > 1 {
+		} else if math.Abs(value*1000) > 1 {
 			// millisecond unit
 			return fmt.Sprintf("%.2f ms", value*1000)
-		} else if value*1000*1000 > 1 {
+		} else if math.Abs(value*1000*1000) > 1 {
 			// microsecond unit
 			return fmt.Sprintf("%.2f ms", value*1000*1000)
 		}
@@ -635,8 +635,9 @@ func (pb *profileBuilder) genTiDBQueryTree() *metricNode {
 						table: "tikv_cop_request",
 						children: []*metricNode{
 							{
-								table: "tikv_cop_wait",
-								label: []string{"type"},
+								table:     "tikv_cop_wait",
+								label:     []string{"type"},
+								condition: "type != 'all'",
 							},
 							{table: "tikv_cop_handle"},
 						},


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

`tikv_cop_wait` metric has a `type` label, it has 3 values: `all`, `schedule`,`snapshot`.  And the `all total_time` = `schedule total time` + `snapshot total time`. 
```sql
METRICS_SCHEMA> select type,sum(value) from tikv_cop_wait_total_time group by type;
+----------+---------------------+
| type     | sum(value)          |
+----------+---------------------+
| all      | 6704.248505983651   |
| schedule | 6628.518727877801   |
| snapshot |   75.85378299487088 |
+----------+---------------------+
```

### What is changed and how it works?

When collecting the total time of `tikv_cop_wait`, should ignore the `all` type value.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test

**Before**

![image](https://user-images.githubusercontent.com/26020263/92431057-11f1c800-f1c9-11ea-862c-bd4253a002e8.png)

**This PR**

![image](https://user-images.githubusercontent.com/26020263/92431088-23d36b00-f1c9-11ea-9855-4880285cc983.png)


Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

-  Fix issue of tikv_cop_wait time in metric profile.