### PR TITLE
executor, util: fix TestGlobalMemoryTrackerOnCleanUp ci error

### DIFF
--- a/executor/memory_test.go
+++ b/executor/memory_test.go
@@ -118,9 +118,7 @@ func (s *testMemoryLeak) memDiff(m1, m2 uint64) uint64 {
 }
 
 func (s *testMemoryLeak) TestGlobalMemoryTrackerOnCleanUp(c *C) {
-	originMaxConsumed := executor.GlobalMemoryUsageTracker.MaxConsumed()
-	defer executor.GlobalMemoryUsageTracker.SetMaxConsumed(originMaxConsumed)
-	executor.GlobalMemoryUsageTracker.SetMaxConsumed(0)
+	// TODO: assert the memory consume has happened in another way
 	originConsume := executor.GlobalMemoryUsageTracker.BytesConsumed()
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -140,8 +138,4 @@ func (s *testMemoryLeak) TestGlobalMemoryTrackerOnCleanUp(c *C) {
 	tk.MustExec("update t set id = 6 where id = 3")
 	afterConsume = executor.GlobalMemoryUsageTracker.BytesConsumed()
 	c.Assert(originConsume, Equals, afterConsume)
-
-	// assert consume happened
-	afterMaxConsumed := executor.GlobalMemoryUsageTracker.MaxConsumed()
-	c.Assert(afterMaxConsumed, Greater, int64(0))
 }

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -362,11 +362,6 @@ func (t *Tracker) ReplaceBytesUsed(bytes int64) {
 	t.Consume(bytes)
 }
 
-// SetMaxConsumed should only be used in unit test.
-func (t *Tracker) SetMaxConsumed(value int64) {
-	atomic.StoreInt64(&t.maxConsumed, value)
-}
-
 func (t *Tracker) getParent() *Tracker {
 	t.parMu.Lock()
 	defer t.parMu.Unlock()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19851

Problem Summary:

The current way to ensure the `Consume` in `TestGlobalMemoryTrackerOnCleanUp `is to check the maxConsumed value which is manually set into 0 before the test.
However, in the `race` test, the `maxConsumed` might be covered by other cases and cause the ci failed.

What's changed.
Remove the current way to ensure the `Consume` happened in `TestGlobalMemoryTrackerOnCleanUp` and leave a `TODO` to find a more proper way to solve this problem.



### Release note
* No release note
