### PR TITLE
executor: fix alter user statement for user() and current_user() #19345

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -770,8 +770,11 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 		if user == nil {
 			return errors.New("Session user is empty")
 		}
+		// Use AuthHostname to search the user record, set Hostname as AuthHostname.
+		userCopy := *user
+		userCopy.Hostname = userCopy.AuthHostname
 		spec := &ast.UserSpec{
-			User:    user,
+			User:    &userCopy,
 			AuthOpt: s.CurrentAuth,
 		}
 		s.Specs = []*ast.UserSpec{spec}
@@ -784,6 +787,12 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 
 	failedUsers := make([]string, 0, len(s.Specs))
 	for _, spec := range s.Specs {
+		if spec.User.CurrentUser {
+			user := e.ctx.GetSessionVars().User
+			spec.User.Username = user.Username
+			spec.User.Hostname = user.AuthHostname
+		}
+
 		exists, err := userExists(e.ctx, spec.User.Username, spec.User.Hostname)
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry pick from https://github.com/pingcap/tidb/pull/19345

### Release note
- Fix the behavior of alter user statement.