### PR TITLE
domain: make TestT more stable

### DIFF
--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -270,7 +270,7 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(is, NotNil)
 
 	// for updating the self schema version
-	goCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	goCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = dd.SchemaSyncer().OwnerCheckAllVersions(goCtx, is.SchemaMetaVersion())
 	cancel()
 	c.Assert(err, IsNil)
@@ -278,7 +278,7 @@ func (*testSuite) TestT(c *C) {
 	c.Assert(snapIs, NotNil)
 	c.Assert(err, IsNil)
 	// Make sure that the self schema version doesn't be changed.
-	goCtx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)
+	goCtx, cancel = context.WithTimeout(context.Background(), 100*time.Millisecond)
 	err = dd.SchemaSyncer().OwnerCheckAllVersions(goCtx, is.SchemaMetaVersion())
 	cancel()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #15533 <!-- REMOVE this line if no issue to close -->

Problem Summary:
```
[2020-09-02T09:20:25.146Z] FAIL: domain_test.go:243: testSuite.TestT
[2020-09-02T09:20:25.146Z] 
[2020-09-02T09:20:25.146Z] domain_test.go:284:
[2020-09-02T09:20:25.146Z]     c.Assert(err, IsNil)
[2020-09-02T09:20:25.146Z] ... value *errors.withStack = context deadline exceeded ("context deadline exceeded")
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Increase the context's timeout to make TestT more stable.
`goCtx, cancel = context.WithTimeout(context.Background(), 10*time.Millisecond)`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note 
