### PR TITLE
Revert "expression, types: fix decimal precision for SUM function" to make ci happy

### DIFF
--- a/executor/aggfuncs/func_sum.go
+++ b/executor/aggfuncs/func_sum.go
@@ -152,13 +152,11 @@ type sum4Decimal struct {
 
 func (e *sum4Decimal) AllocPartialResult() (pr PartialResult, memDelta int64) {
 	p := new(partialResult4SumDecimal)
-	p.val = *types.NewZeroDec(e.args[0].GetType().Flen, e.args[0].GetType().Decimal)
 	return PartialResult(p), DefPartialResult4SumDecimalSize
 }
 
 func (e *sum4Decimal) ResetPartialResult(pr PartialResult) {
 	p := (*partialResult4SumDecimal)(pr)
-	p.val = *types.NewZeroDec(e.args[0].GetType().Flen, e.args[0].GetType().Decimal)
 	p.notNullRowCount = 0
 }
 
@@ -180,6 +178,11 @@ func (e *sum4Decimal) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup [
 			return 0, err
 		}
 		if isNull {
+			continue
+		}
+		if p.notNullRowCount == 0 {
+			p.val = *input
+			p.notNullRowCount = 1
 			continue
 		}
 
@@ -306,7 +309,6 @@ type sum4DistinctDecimal struct {
 
 func (e *sum4DistinctDecimal) AllocPartialResult() (pr PartialResult, memDelta int64) {
 	p := new(partialResult4SumDistinctDecimal)
-	p.val = *types.NewZeroDec(e.args[0].GetType().Flen, e.args[0].GetType().Decimal)
 	p.isNull = true
 	p.valSet = set.NewStringSet()
 	return PartialResult(p), DefPartialResult4SumDistinctDecimalSize
@@ -314,7 +316,6 @@ func (e *sum4DistinctDecimal) AllocPartialResult() (pr PartialResult, memDelta i
 
 func (e *sum4DistinctDecimal) ResetPartialResult(pr PartialResult) {
 	p := (*partialResult4SumDistinctDecimal)(pr)
-	p.val = *types.NewZeroDec(e.args[0].GetType().Flen, e.args[0].GetType().Decimal)
 	p.isNull = true
 	p.valSet = set.NewStringSet()
 }
@@ -339,7 +340,11 @@ func (e *sum4DistinctDecimal) UpdatePartialResult(sctx sessionctx.Context, rowsI
 		}
 		p.valSet.Insert(decStr)
 		memDelta += int64(len(decStr))
-		p.isNull = false
+		if p.isNull {
+			p.val = *input
+			p.isNull = false
+			continue
+		}
 		newSum := new(types.MyDecimal)
 		if err = types.DecimalAdd(&p.val, input, newSum); err != nil {
 			return memDelta, err

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -2345,21 +2345,3 @@ func NewMaxOrMinDec(negative bool, prec, frac int) *MyDecimal {
 	terror.Log(errors.Trace(err))
 	return dec
 }
-
-// NewZeroDec returns the zero value decimal for given precision and fraction.
-func NewZeroDec(prec, frac int) *MyDecimal {
-	if prec == UnspecifiedLength {
-		return NewDecFromInt(0)
-	}
-	str := make([]byte, prec+1)
-	for i := 0; i < len(str); i++ {
-		str[i] = '0'
-	}
-	if frac != UnspecifiedLength {
-		str[prec-frac] = '.'
-	}
-	dec := new(MyDecimal)
-	err := dec.FromString(str)
-	terror.Log(errors.Trace(err))
-	return dec
-}

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -918,28 +918,6 @@ func (s *testMyDecimalSuite) TestMaxOrMin(c *C) {
 	}
 }
 
-func (s *testMyDecimalSuite) TestZero(c *C) {
-	type tcase struct {
-		prec   int
-		frac   int
-		result string
-	}
-	tests := []tcase{
-		{2, 1, "0.0"},
-		{4, 2, "0.00"},
-		{65, 2, "0.00"},
-		{65, 6, "0.000000"},
-		{1, 1, "0.0"},
-		{1, 0, "0"},
-		{2, 0, "0"},
-		{0, 0, "0"},
-	}
-	for _, tt := range tests {
-		dec := NewZeroDec(tt.prec, tt.frac)
-		c.Assert(dec.String(), Equals, tt.result)
-	}
-}
-
 func (s *testMyDecimalSuite) TestReset(c *C) {
 	var x1, y1, z1 MyDecimal
 	c.Assert(x1.FromString([]byte("38520.130741106671")), IsNil)


### PR DESCRIPTION
Revert "expression, types: fix decimal precision for SUM function" to make ci happy

https://github.com/pingcap/tidb/pull/19592

### Release note <!-- bugfixes or new feature need a release note -->

-  No release note.