### PR TITLE
expression: Add arguments check where the function is implemented

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -527,6 +527,12 @@ func (b *builtinCastIntAsDecimalSig) evalDecimal(row chunk.Row) (res *types.MyDe
 	} else {
 		res = types.NewDecFromUint(uint64(val))
 	}
+	if b.tp.Flen > mysql.MaxDecimalWidth {
+		return res, isNull, types.ErrTooBigPrecision.GenWithStackByArgs(b.tp.Flen, string(res.ToString()), mysql.MaxDecimalWidth)
+	}
+	if b.tp.Decimal > mysql.MaxDecimalScale {
+		return res, isNull, types.ErrTooBigScale.GenWithStackByArgs(b.tp.Flen, string(res.ToString()), mysql.MaxDecimalScale)
+	}
 	res, err = types.ProduceDecWithSpecifiedTp(res, b.tp, b.ctx.GetSessionVars().StmtCtx)
 	return res, isNull, err
 }

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -422,7 +422,6 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		//c.Assert(res.ToString(), DeepEquals, t.after.ToString())
 	}
 
-
 	durationColumn.RetType.Decimal = 1
 	castToDecCases2 := []struct {
 		before  *Column

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -419,7 +419,6 @@ func (s *testEvaluatorSuite) TestCastFuncSig(c *C) {
 		_, isNull, err := sig.evalDecimal(t.row.ToRow())
 		c.Assert(isNull, Equals, false)
 		c.Assert(err, NotNil)
-		//c.Assert(res.ToString(), DeepEquals, t.after.ToString())
 	}
 
 	durationColumn.RetType.Decimal = 1

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7302,3 +7302,17 @@ func (s *testIntegrationSuite) TestIssue17476(c *C) {
 	tk.MustQuery(`SELECT count(*) FROM (table_float JOIN table_int_float_varchar AS tmp3 ON (tmp3.col_varchar_6 AND NULL) IS NULL);`).Check(testkit.Rows("154"))
 	tk.MustQuery(`SELECT * FROM (table_int_float_varchar AS tmp3) WHERE (col_varchar_6 AND NULL) IS NULL AND col_int_6=0;`).Check(testkit.Rows("13 0 -0.1 <nil>"))
 }
+
+func (s *testIntegrationSuite) TestIssue11193(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustGetErrCode("select CONVERT( 2, DECIMAL(62,60) )", mysql.ErrTooBigScale)
+	tk.MustGetErrMsg("select CONVERT( 2, DECIMAL(62,60) )", "Too big scale 60 specified for column '2'. Maximum is 30")
+	tk.MustGetErrCode("select CONVERT( 2, DECIMAL(66,29) )", mysql.ErrTooBigPrecision)
+	tk.MustGetErrMsg("select CONVERT( 2, DECIMAL(66,29) )", "Too-big precision 66 specified for '2'. Maximum is 65")
+
+	tk.MustExec("select CONVERT( 2, DECIMAL(62,20) )")
+	tk.MustQuery("select CONVERT( 2, DECIMAL(62,20) )").Check(testkit.Rows("2.00000000000000000000"))
+
+	tk.MustExec("select CONVERT( 2, DECIMAL(30,29) )")
+	tk.MustQuery("select CONVERT( 2, DECIMAL(30,29) )").Check(testkit.Rows("2.00000000000000000000000000000"))
+}

--- a/types/datum.go
+++ b/types/datum.go
@@ -1288,12 +1288,6 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *stmtctx.Statem
 		if flen < decimal {
 			return nil, ErrMBiggerThanD.GenWithStackByArgs("")
 		}
-		if flen > mysql.MaxDecimalWidth {
-			return nil, ErrTooBigPrecision.GenWithStackByArgs(flen, string(dec.ToString()), mysql.MaxDecimalWidth)
-		}
-		if decimal > mysql.MaxDecimalScale {
-			return nil, ErrTooBigScale.GenWithStackByArgs(decimal, string(dec.ToString()), mysql.MaxDecimalScale)
-		}
 		prec, frac := dec.PrecisionAndFrac()
 		if !dec.IsZero() && prec-frac > flen-decimal {
 			dec = NewMaxOrMinDec(dec.IsNegative(), flen, decimal)

--- a/types/datum.go
+++ b/types/datum.go
@@ -1288,6 +1288,12 @@ func ProduceDecWithSpecifiedTp(dec *MyDecimal, tp *FieldType, sc *stmtctx.Statem
 		if flen < decimal {
 			return nil, ErrMBiggerThanD.GenWithStackByArgs("")
 		}
+		if flen > mysql.MaxDecimalWidth {
+			return nil, ErrTooBigPrecision.GenWithStackByArgs(flen, string(dec.ToString()), mysql.MaxDecimalWidth)
+		}
+		if decimal > mysql.MaxDecimalScale {
+			return nil, ErrTooBigScale.GenWithStackByArgs(decimal, string(dec.ToString()), mysql.MaxDecimalScale)
+		}
 		prec, frac := dec.PrecisionAndFrac()
 		if !dec.IsZero() && prec-frac > flen-decimal {
 			dec = NewMaxOrMinDec(dec.IsNegative(), flen, decimal)


### PR DESCRIPTION
### What problem does this PR solve?
Problem Summary: decimal's  arguments missing check 

Issue Number:   close  #11193 

### What is changed and how it works?

- Add arguments check where the function is implemented

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
 ```
mysql> select version();
+------------------+
| version()        |
+------------------+
| 5.7.25-TiDB-None |
+------------------+
1 row in set (0.01 sec)

mysql> select CONVERT( 2, DECIMAL(62,60) ) ;
ERROR 1425 (42000): Too big scale 60 specified for column '2'. Maximum is 30.
mysql> select CONVERT( 2, DECIMAL(66,29) ) ;
ERROR 1426 (42000): Too big precision 66 specified for column '2'. Maximum is 65.
```

### Release note

- check the range of the DECIMAL's arguments