### PR TITLE
executor: fix hint not working in prepared statement

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -337,7 +337,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		}
 		maxExecutionTime := getMaxExecutionTime(sctx)
 		// Update processinfo, ShowProcess() will use it.
-		fmt.Println("pi.SetProcessInfo", cmd, maxExecutionTime, sql)
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
 		if a.Ctx.GetSessionVars().StmtCtx.StmtType == "" {
 			a.Ctx.GetSessionVars().StmtCtx.StmtType = GetStmtLabel(a.StmtNode)

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -337,6 +337,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		}
 		maxExecutionTime := getMaxExecutionTime(sctx)
 		// Update processinfo, ShowProcess() will use it.
+		fmt.Println("pi.SetProcessInfo", cmd, maxExecutionTime, sql)
 		pi.SetProcessInfo(sql, time.Now(), cmd, maxExecutionTime)
 		if a.Ctx.GetSessionVars().StmtCtx.StmtType == "" {
 			a.Ctx.GetSessionVars().StmtCtx.StmtType = GetStmtLabel(a.StmtNode)

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
-
 	"github.com/pingcap/tidb/domain"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -110,7 +110,7 @@ func (s *testSuite1) TestPrepareStmtAfterIsolationReadChange(c *C) {
 }
 
 type mockSessionManager2 struct {
-	se session.Session
+	se     session.Session
 	killed bool
 }
 
@@ -160,18 +160,6 @@ func (s *testSuite12) TestPreparedStmtWithHint(c *C) {
 	c.Assert(err, IsNil)
 	se.SetSessionManager(sm)
 	go dom.ExpensiveQueryHandle().SetSessionManager(sm).Run()
-	//go func() {
-	//	for i := 0; i < 100; i++ {
-	//		pi := se.ShowProcess()
-	//		fmt.Println(pi.Time, time.Since(pi.Time), pi.MaxExecutionTime)
-	//		if pi != nil && pi.MaxExecutionTime == 100 {
-	//			se.GetSessionManager().Kill(0, true)
-	//			break
-	//		} else {
-	//			time.Sleep(100 * time.Millisecond)
-	//		}
-	//	}
-	//}()
 	rs, err := se.Execute(context.Background(), "execute stmt")
 	c.Check(err, IsNil)
 	tk := testkit.NewTestKit(c, store)

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -143,6 +143,7 @@ func (s *testSuite9) TestPreparedStmtWithHint(c *C) {
 	_, err = se.Execute(context.Background(), "prepare stmt from \"select /*+ max_execution_time(100) */ sleep(10)\"")
 	c.Assert(err, IsNil)
 	se.SetSessionManager(sm)
+	go dom.ExpensiveQueryHandle().SetSessionManager(sm).Run()
 	go func() {
 		for i := 0; i < 100; i++ {
 			pi := se.ShowProcess()

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -154,6 +154,7 @@ func (s *testSuite9) TestPreparedStmtWithHint(c *C) {
 		}
 	}()
 	rs, err := se.Execute(context.Background(), "execute stmt")
+	c.Check(err, IsNil)
 	tk := testkit.NewTestKit(c, store)
 	tk.ResultSetToResult(rs[0], Commentf("%v", rs[0])).Check(testkit.Rows("1"))
 }

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -106,20 +106,9 @@ func (s *testSuite1) TestPrepareStmtAfterIsolationReadChange(c *C) {
 
 func (s *testSuite9) TestPreparedStmtWithHint(c *C) {
 	// see https://github.com/pingcap/tidb/issues/18535
-	store, dom, err := newStoreWithBootstrap()
-	c.Assert(err, IsNil)
-	tk := testkit.NewTestKit(c, store)
-	defer func() {
-		dom.Close()
-		store.Close()
-	}()
-	orgEnable := plannercore.PreparedPlanCacheEnabled()
-	defer func() {
-		plannercore.SetPreparedPlanCache(orgEnable)
-	}()
-	plannercore.SetPreparedPlanCache(true)
+	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("prepare stmt from \"select /*+ max_execution_time(10) */ sleep(1)\"")
+	tk.MustExec("prepare stmt from \"select /*+ max_execution_time(100) */ sleep(1)\"")
 	tk.MustQuery("execute stmt").Check(testkit.Rows("1")) // hint should work and interrupt the sleep execution
 }
 

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -107,7 +107,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 	tableHints := hint.ExtractTableHintsFromStmtNode(node, sctx)
 	stmtHints, warns := handleStmtHints(tableHints)
 	defer func() {
-		sessVars.StmtCtx.StmtHints = stmtHints
 		for _, warn := range warns {
 			sctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 		}

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -110,6 +110,7 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 	for _, warn := range warns {
 		sctx.GetSessionVars().StmtCtx.AppendWarning(warn)
 	}
+	warns = warns[:0]
 	bestPlan, names, _, err := optimize(ctx, sctx, node, is)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18535 <!-- REMOVE this line if no issue to close -->

Problem Summary: in `optimize`, `sessVars.StmtCtx.StmtHints` will be overwrite in a defered function at returning, but if the executed statement is a prepared statement, the hint will be eclipsed, causeing the hint being invalid.

### What is changed and how it works?

What's Changed:

How it Works:

removed the overwrite.

### Related changes

- Need to cherry-pick to the 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
