### PR TITLE
executor: support partition pruning for `IndexJoin` inner table

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2627,7 +2627,7 @@ func buildKVRangeForEachPartition(ctx sessionctx.Context, usedPartitions []table
 	for _, p := range usedPartitions {
 		if isCommonHandle {
 			rangeBuilders[p.GetPhysicalID()] = kvRangeBuilderFromFunc(func(pid int64) ([]kv.KeyRange, error) {
-				return buildKvRangesForIndexJoin(ctx, pid, -1, contentBucket[p.GetPhysicalID()], indexRanges, keyOff2IdxOff, cwc)
+				return buildKvRangesForIndexJoin(ctx, pid, -1, contentBucket[pid], indexRanges, keyOff2IdxOff, cwc)
 			})
 		} else {
 			handles := make([]kv.Handle, 0, len(contentBucket[p.GetPhysicalID()]))

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -494,6 +494,7 @@ func (iw *innerWorker) run(ctx context.Context, wg *sync.WaitGroup) {
 type indexJoinLookUpContent struct {
 	keys []types.Datum
 	row  chunk.Row
+	keyCols []int
 }
 
 func (iw *innerWorker) handleTask(ctx context.Context, task *lookUpJoinTask) error {
@@ -558,7 +559,7 @@ func (iw *innerWorker) constructLookupContent(task *lookUpJoinTask) ([]*indexJoi
 				// dLookUpKey is sorted and deduplicated at sortAndDedupLookUpContents.
 				// So we don't need to do it here.
 			}
-			lookUpContents = append(lookUpContents, &indexJoinLookUpContent{keys: dLookUpKey, row: chk.GetRow(rowIdx)})
+			lookUpContents = append(lookUpContents, &indexJoinLookUpContent{keys: dLookUpKey, row: chk.GetRow(rowIdx), keyCols:iw.keyCols})
 		}
 	}
 

--- a/executor/index_lookup_join.go
+++ b/executor/index_lookup_join.go
@@ -492,8 +492,8 @@ func (iw *innerWorker) run(ctx context.Context, wg *sync.WaitGroup) {
 }
 
 type indexJoinLookUpContent struct {
-	keys []types.Datum
-	row  chunk.Row
+	keys    []types.Datum
+	row     chunk.Row
 	keyCols []int
 }
 
@@ -559,7 +559,7 @@ func (iw *innerWorker) constructLookupContent(task *lookUpJoinTask) ([]*indexJoi
 				// dLookUpKey is sorted and deduplicated at sortAndDedupLookUpContents.
 				// So we don't need to do it here.
 			}
-			lookUpContents = append(lookUpContents, &indexJoinLookUpContent{keys: dLookUpKey, row: chk.GetRow(rowIdx), keyCols:iw.keyCols})
+			lookUpContents = append(lookUpContents, &indexJoinLookUpContent{keys: dLookUpKey, row: chk.GetRow(rowIdx), keyCols: iw.keyCols})
 		}
 	}
 

--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -22,6 +22,7 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -40,13 +41,32 @@ type nextPartition interface {
 	nextPartition(context.Context, table.PhysicalTable) (Executor, error)
 }
 
+type innerPartitionInfo struct {
+	isFullPartition  bool
+	nextRange        map[int64][]*ranger.Range
+}
+
+type innerNextPartition interface {
+	nextPartition
+	GetInnerPartitionInfo() *innerPartitionInfo
+}
+
 type nextPartitionForTableReader struct {
-	exec *TableReaderExecutor
+	*innerPartitionInfo
+	rangeBuilders map[int64]kvRangeBuilder
+	exec          *TableReaderExecutor
+}
+
+func (n nextPartitionForTableReader) GetInnerPartitionInfo() *innerPartitionInfo {
+	return n.innerPartitionInfo
 }
 
 func (n nextPartitionForTableReader) nextPartition(ctx context.Context, tbl table.PhysicalTable) (Executor, error) {
 	n.exec.table = tbl
 	n.exec.kvRanges = n.exec.kvRanges[:0]
+	if n.innerPartitionInfo != nil && !n.isFullPartition {
+		n.exec.kvRangeBuilder = n.rangeBuilders[tbl.GetPhysicalID()]
+	}
 	if err := updateDAGRequestTableID(ctx, n.exec.dagPB, tbl.Meta().ID, tbl.GetPhysicalID()); err != nil {
 		return nil, err
 	}
@@ -54,22 +74,38 @@ func (n nextPartitionForTableReader) nextPartition(ctx context.Context, tbl tabl
 }
 
 type nextPartitionForIndexLookUp struct {
+	*innerPartitionInfo
 	exec *IndexLookUpExecutor
+}
+
+func (n nextPartitionForIndexLookUp) GetInnerPartitionInfo() *innerPartitionInfo {
+	return n.innerPartitionInfo
 }
 
 func (n nextPartitionForIndexLookUp) nextPartition(ctx context.Context, tbl table.PhysicalTable) (Executor, error) {
 	n.exec.table = tbl
+	if n.innerPartitionInfo != nil && !n.isFullPartition {
+		n.exec.ranges = n.nextRange[tbl.GetPhysicalID()]
+	}
 	return n.exec, nil
 }
 
 type nextPartitionForIndexReader struct {
+	*innerPartitionInfo
 	exec *IndexReaderExecutor
+}
+
+func (n nextPartitionForIndexReader) GetInnerPartitionInfo() *innerPartitionInfo {
+	return n.innerPartitionInfo
 }
 
 func (n nextPartitionForIndexReader) nextPartition(ctx context.Context, tbl table.PhysicalTable) (Executor, error) {
 	exec := n.exec
 	exec.table = tbl
 	exec.physicalTableID = tbl.GetPhysicalID()
+	if n.innerPartitionInfo != nil && !n.isFullPartition {
+		exec.ranges = n.nextRange[tbl.GetPhysicalID()]
+	}
 	return exec, nil
 }
 

--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -42,8 +42,8 @@ type nextPartition interface {
 }
 
 type innerPartitionInfo struct {
-	isFullPartition  bool
-	nextRange        map[int64][]*ranger.Range
+	isFullPartition bool
+	nextRange       map[int64][]*ranger.Range
 }
 
 type innerNextPartition interface {

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -360,8 +360,8 @@ func generateHashPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,
 	}
 	exprs.HashCode(ctx.GetSessionVars().StmtCtx)
 	return &PartitionExpr{
-		Expr:     exprs,
-		OrigExpr: origExpr,
+		Expr:         exprs,
+		OrigExpr:     origExpr,
 		ColumnOffset: offset,
 	}, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: Although index join support partition table as inner table, it can not do partition prune according to the outer table look up keys. This pr fixes this problem.

### What is changed and how it works?

What's Changed: 

- add `ColumnOffset` in partition expression informations, which is used for re-construct keys to locate partition.
- add `buildPartitionTableForInnerExecutor` which will firstly prune partition according to query conditions and then re-construct partition locate key according to column offset and data from outer table.

How it Works:

When extract data from outer table, inner table builder will prune according to outer table data by extract partition keys and eval partition expression. If outer table data doesn't contain enough information, such as lack of partition keys, the pruning will fail.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (will be added later)
- Manual test 

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- Support partition pruning on `IndexJoin` when inner table is partition table. 




