### PR TITLE
util/ranger: fix infinite recursion when using _tidb_rowid in DNF cond

### DIFF
--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -676,7 +676,7 @@ func (s *testStatsSuite) TestDNFCondSelectivity(c *C) {
 
 	testKit.MustExec("use test")
 	testKit.MustExec("drop table if exists t")
-	testKit.MustExec("create table t(a int primary key, b int, c int, d int)")
+	testKit.MustExec("create table t(a int, b int, c int, d int)")
 	testKit.MustExec("insert into t value(1,5,4,4),(3,4,1,8),(4,2,6,10),(6,7,2,5),(7,1,4,9),(8,9,8,3),(9,1,9,1),(10,6,6,2)")
 	testKit.MustExec("alter table t add index (b)")
 	testKit.MustExec("alter table t add index (d)")
@@ -723,4 +723,7 @@ func (s *testStatsSuite) TestDNFCondSelectivity(c *C) {
 		c.Assert(math.Abs(ratio-output[i].Selectivity) < eps, IsTrue,
 			Commentf("for %s, needed: %v, got: %v", tt, output[i].Selectivity, ratio))
 	}
+
+	// Test issue 19981
+	testKit.MustExec("select * from t where _tidb_rowid is null or _tidb_rowid > 7")
 }

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -16,6 +16,7 @@ package ranger
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -470,6 +471,12 @@ func MergeDNFItems4Col(ctx sessionctx.Context, dnfItems []expression.Expression)
 		cols := expression.ExtractColumns(dnfItem)
 		// If this condition contains multiple columns, we can't merge it.
 		if len(cols) != 1 {
+			mergedDNFItems = append(mergedDNFItems, dnfItem)
+			continue
+		}
+
+		// If this column is _tidb_rowid, we can't merge it since Selectivity() doesn't handle it, or infinite recursion will happen.
+		if cols[0].ID == model.ExtraHandleID {
 			mergedDNFItems = append(mergedDNFItems, dnfItem)
 			continue
 		}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -470,13 +470,8 @@ func MergeDNFItems4Col(ctx sessionctx.Context, dnfItems []expression.Expression)
 	for _, dnfItem := range dnfItems {
 		cols := expression.ExtractColumns(dnfItem)
 		// If this condition contains multiple columns, we can't merge it.
-		if len(cols) != 1 {
-			mergedDNFItems = append(mergedDNFItems, dnfItem)
-			continue
-		}
-
-		// If this column is _tidb_rowid, we can't merge it since Selectivity() doesn't handle it, or infinite recursion will happen.
-		if cols[0].ID == model.ExtraHandleID {
+		// If this column is _tidb_rowid, we also can't merge it since Selectivity() doesn't handle it, or infinite recursion will happen.
+		if len(cols) != 1 || cols[0].ID == model.ExtraHandleID {
 			mergedDNFItems = append(mergedDNFItems, dnfItem)
 			continue
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #19981 

Problem Summary:

Using _tidb_rowid in DNF conditions will cause `Selectivit()` become infinite recursion because `Selectivity()` doesn't handle _tidb_rowid column.

### What is changed and how it works?

add a check for _tidb_rowid column

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- no release note
