### PR TITLE
domain: refine log for info syncer and topology syncer

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -465,9 +465,10 @@ func (do *Domain) infoSyncerKeeper() {
 		case <-do.info.Done():
 			logutil.BgLogger().Info("server info syncer need to restart")
 			if err := do.info.Restart(context.Background()); err != nil {
-				logutil.BgLogger().Error("server restart failed", zap.Error(err))
+				logutil.BgLogger().Error("server info syncer restart failed", zap.Error(err))
+			} else {
+				logutil.BgLogger().Info("server info syncer restarted")
 			}
-			logutil.BgLogger().Info("server info syncer restarted")
 		case <-do.exit:
 			return
 		}
@@ -493,9 +494,10 @@ func (do *Domain) topologySyncerKeeper() {
 		case <-do.info.TopologyDone():
 			logutil.BgLogger().Info("server topology syncer need to restart")
 			if err := do.info.RestartTopology(context.Background()); err != nil {
-				logutil.BgLogger().Error("server restart failed", zap.Error(err))
+				logutil.BgLogger().Error("server topology syncer restart failed", zap.Error(err))
+			} else {
+				logutil.BgLogger().Info("server topology syncer restarted")
 			}
-			logutil.BgLogger().Info("server topology syncer restarted")
 		case <-do.exit:
 			return
 		}


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
![image](https://user-images.githubusercontent.com/4352397/93172540-a4601180-f75d-11ea-943f-4e8fc76d929a.png)
The logs for these syncers are confused.

```
server topology syncer need to restart
server restart failed
server topology syncer restarted
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
Make it clear.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
