### PR TITLE
expression: Add column nullability checking before "refine args"

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -389,7 +389,7 @@ Projection_10	5.00	root		Column#11
         └─Selection_38	2.40	cop[tikv]		eq(3, test.t.a)
           └─IndexRangeScan_37	3.00	cop[tikv]	table:t1, index:idx(b)	range:[3,3], keep order:true
 drop table if exists t;
-create table t(a int unsigned);
+create table t(a int unsigned not null);
 explain select t.a = '123455' from t;
 id	estRows	task	access object	operator info
 Projection_3	10000.00	root		eq(test.t.a, 123455)->Column#3
@@ -508,7 +508,7 @@ StreamAgg_22	1.00	root		funcs:count(1)->Column#22
       │ │ └─TableDual_39	0.00	root		rows:0
       │ └─Projection_40	0.01	root		test.test01.stat_date, test.test01.show_date, test.test01.region_id
       │   └─TableReader_43	0.01	root		data:Selection_42
-      │     └─Selection_42	0.01	cop[tikv]		eq(test.test01.period, 1), ge(test.test01.stat_date, 20191202), ge(test.test01.stat_date, 20191202), gt(cast(test.test01.registration_num), 0), le(test.test01.stat_date, 20191202), le(test.test01.stat_date, 20191202)
+      │     └─Selection_42	0.01	cop[tikv]		eq(test.test01.period, 1), ge(cast(test.test01.stat_date), 2.0191202e+07), ge(test.test01.stat_date, 20191202), gt(cast(test.test01.registration_num), 0), le(cast(test.test01.stat_date), 2.0191202e+07), le(test.test01.stat_date, 20191202)
       │       └─TableFullScan_41	10000.00	cop[tikv]	table:test01	keep order:false, stats:pseudo
       └─TableReader_29(Probe)	1.00	root		data:TableRangeScan_28
         └─TableRangeScan_28	1.00	cop[tikv]	table:b	range: decided by [Column#16], keep order:true, stats:pseudo

--- a/cmd/explaintest/r/partition_pruning.result
+++ b/cmd/explaintest/r/partition_pruning.result
@@ -2261,33 +2261,33 @@ TableReader_7	10.00	root	partition:p0	data:Selection_6
   └─TableFullScan_5	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain select * from t1 where a=0xFE;
 id	estRows	task	access object	operator info
-TableReader_7	10.00	root	partition:p2	data:Selection_6
-└─Selection_6	10.00	cop[tikv]		eq(test.t1.a, 254)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		eq(cast(test.t1.a), 254)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain select * from t2 where a=0xFE;
 id	estRows	task	access object	operator info
-TableReader_7	10.00	root	partition:p2	data:Selection_6
-└─Selection_6	10.00	cop[tikv]		eq(test.t2.a, 254)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		eq(cast(test.t2.a), 254)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain select * from t1 where a > 0xFE AND a <= 0xFF;
 id	estRows	task	access object	operator info
-TableReader_7	250.00	root	partition:dual	data:Selection_6
-└─Selection_6	250.00	cop[tikv]		gt(test.t1.a, 254), le(test.t1.a, 255)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		gt(cast(test.t1.a), 254), le(cast(test.t1.a), 255)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain select * from t2 where a > 0xFE AND a <= 0xFF;
 id	estRows	task	access object	operator info
-TableReader_7	250.00	root	partition:all	data:Selection_6
-└─Selection_6	250.00	cop[tikv]		gt(test.t2.a, 254), le(test.t2.a, 255)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		gt(cast(test.t2.a), 254), le(cast(test.t2.a), 255)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain select * from t1 where a >= 0xFE AND a <= 0xFF;
 id	estRows	task	access object	operator info
-TableReader_7	250.00	root	partition:p2	data:Selection_6
-└─Selection_6	250.00	cop[tikv]		ge(test.t1.a, 254), le(test.t1.a, 255)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		ge(cast(test.t1.a), 254), le(cast(test.t1.a), 255)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain select * from t2 where a >= 0xFE AND a <= 0xFF;
 id	estRows	task	access object	operator info
-TableReader_7	250.00	root	partition:all	data:Selection_6
-└─Selection_6	250.00	cop[tikv]		ge(test.t2.a, 254), le(test.t2.a, 255)
+TableReader_7	8000.00	root	partition:all	data:Selection_6
+└─Selection_6	8000.00	cop[tikv]		ge(cast(test.t2.a), 254), le(cast(test.t2.a), 255)
   └─TableFullScan_5	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
 explain select * from t1 where a < 64 AND a >= 63;
 id	estRows	task	access object	operator info

--- a/cmd/explaintest/t/explain_easy.test
+++ b/cmd/explaintest/t/explain_easy.test
@@ -71,7 +71,7 @@ explain select t.c in (select count(*) from t s left join t t1 on s.a = t1.a whe
 explain select t.c in (select count(*) from t s right join t t1 on s.a = t1.a where 3 = t.a and t1.b = 3) from t;
 
 drop table if exists t;
-create table t(a int unsigned);
+create table t(a int unsigned not null);
 explain select t.a = '123455' from t;
 explain select t.a > '123455' from t;
 explain select t.a != '123455' from t;

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -35,7 +35,7 @@ func (s *testEvaluatorSuite) TestNewValuesFunc(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestEvaluateExprWithNull(c *C) {
-	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong).add("col1", mysql.TypeLonglong).build()
+	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong, 0).add("col1", mysql.TypeLonglong, 0).build()
 	schema := tableInfoToSchemaForTest(tblInfo)
 	col0 := schema.Columns[0]
 	col1 := schema.Columns[1]
@@ -142,15 +142,17 @@ type testTableBuilder struct {
 	tableName   string
 	columnNames []string
 	tps         []byte
+	flags       []uint
 }
 
 func newTestTableBuilder(tableName string) *testTableBuilder {
 	return &testTableBuilder{tableName: tableName}
 }
 
-func (builder *testTableBuilder) add(name string, tp byte) *testTableBuilder {
+func (builder *testTableBuilder) add(name string, tp byte, flag uint) *testTableBuilder {
 	builder.columnNames = append(builder.columnNames, name)
 	builder.tps = append(builder.tps, tp)
+	builder.flags = append(builder.flags, flag)
 	return builder
 }
 
@@ -165,6 +167,7 @@ func (builder *testTableBuilder) build() *model.TableInfo {
 		fieldType := types.NewFieldType(tp)
 		fieldType.Flen, fieldType.Decimal = mysql.GetDefaultFieldLengthAndDecimal(tp)
 		fieldType.Charset, fieldType.Collate = types.DefaultCharsetForType(tp)
+		fieldType.Flag = builder.flags[i]
 		ti.Columns = append(ti.Columns, &model.ColumnInfo{
 			ID:        int64(i + 1),
 			Name:      model.NewCIStr(colName),

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -455,7 +455,7 @@ func (s *testAnalyzeSuite) TestPreparedNullParam(c *C) {
 		testKit.MustExec("insert into t values (1), (2), (3)")
 
 		sql := "select * from t where id = ?"
-		best := "Dual"
+		best := "TableReader(Table(t)->Sel([eq(cast(test.t.id, double BINARY), <nil>)]))"
 
 		ctx := testKit.Se.(sessionctx.Context)
 		stmts, err := session.Parse(ctx, sql)

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -699,7 +699,7 @@ func (s *testIntegrationSuite) TestPartitionPruningForInExpr(c *C) {
 
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t(a int(11), b int) partition by range (a) (partition p0 values less than (4), partition p1 values less than(10), partition p2 values less than maxvalue);")
+	tk.MustExec("create table t(a int(11) not null, b int not null) partition by range (a) (partition p0 values less than (4), partition p1 values less than(10), partition p2 values less than maxvalue);")
 	tk.MustExec("insert into t values (1, 1),(10, 10),(11, 11)")
 
 	var input []string


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #16788 <!-- REMOVE this line if no issue to close -->

**This PR contains the same logic as [PR 20040](https://github.com/pingcap/tidb/pull/20040) which is a fix for [Issue 16679](https://github.com/pingcap/tidb/issues/16679)**
- The same logic can fix both issues, while the two issues are "picked" by different persons.

Problem Summary:
When comparing a nullable integer column with a float, the output is not consistent with that of MySQL.

### What is changed and how it works?

What's Changed:

Added column nullability checking
- If the column is nullable, use raw args directly;
- else, refine args

How it Works:

N/A

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility
   For some of the statements, the corresponding execution plans are changed

### Release note <!-- bugfixes or new feature need a release note -->

 <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

- No release note
