### PR TITLE
kv: fix unsafe operation on value returned from memdb

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -276,7 +276,7 @@ func TableHandlesToKVRanges(tid int64, handles []kv.Handle) []kv.KeyRange {
 		if commonHandle, ok := handles[i].(*kv.CommonHandle); ok {
 			ran := kv.KeyRange{
 				StartKey: tablecodec.EncodeRowKey(tid, commonHandle.Encoded()),
-				EndKey:   tablecodec.EncodeRowKey(tid, append(commonHandle.Encoded(), 0)),
+				EndKey:   tablecodec.EncodeRowKey(tid, kv.Key(commonHandle.Encoded()).Next()),
 			}
 			krs = append(krs, ran)
 			i++

--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -192,3 +192,15 @@ func (s *testClusteredSuite) TestClusteredWithOldRowFormat(c *C) {
 	tk.MustExec("insert into t values ('b568004d-afad-11ea-8e4d-d651e3a981b7', 1, -1);")
 	tk.MustQuery("select * from t use index(primary);").Check(testkit.Rows("b568004d-afad-11ea-8e4d-d651e3a981b7 1 -1"))
 }
+
+func (s *testClusteredSuite) TestIssue20002(c *C) {
+	tk := s.newTK(c)
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t ( c_int int, c_str varchar(40), c_datetime datetime, primary key(c_str), unique key(c_datetime));")
+	tk.MustExec("insert into t values (1, 'laughing hertz', '2020-04-27 20:29:30'), (2, 'sharp yalow', '2020-04-01 05:53:36'), (3, 'pedantic hoover', '2020-03-10 11:49:00');")
+	tk.MustExec("begin;")
+	tk.MustExec("update t set c_str = 'amazing herschel' where c_int = 3;")
+	tk.MustExec("select c_int, c_str, c_datetime from t where c_datetime between '2020-01-09 22:00:28' and '2020-04-08 15:12:37';")
+	tk.MustExec("commit;")
+	tk.MustExec("admin check index t `c_datetime`;")
+}

--- a/kv/memdb_arena.go
+++ b/kv/memdb_arena.go
@@ -272,7 +272,7 @@ func (l *memdbVlog) getValue(addr memdbArenaAddr) []byte {
 		return tombstone
 	}
 	valueOff := lenOff - valueLen
-	return block[valueOff:lenOff]
+	return block[valueOff:lenOff:lenOff]
 }
 
 func (l *memdbVlog) getSnapshotValue(addr memdbArenaAddr, snap *memdbCheckpoint) ([]byte, bool) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/20002

Problem Summary:

`TableHandlesToKVRanges` modified the slice returned by `memdb`.

### What is changed and how it works?
The first change is to use `Key.Next` instead of `append(..., 0)` this is the correct way to get the next key.

To avoid similar problems in the future, set the `cap` of the returned slice, so that later `append` will allocate a new slice.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
