### PR TITLE
ddl: enlarge the limit of the number of partitions in a table

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1284,7 +1284,7 @@ func (s *testIntegrationSuite4) TestAddPartitionTooManyPartitions(c *C) {
 	for i := 1; i <= count; i++ {
 		sql1 += fmt.Sprintf("partition p%d values less than (%d),", i, i)
 	}
-	sql1 += "partition p1025 values less than (1025) );"
+	sql1 += "partition p8193 values less than (8193) );"
 	tk.MustGetErrCode(sql1, tmysql.ErrTooManyPartitions)
 
 	tk.MustExec("drop table if exists p2;")
@@ -1295,11 +1295,11 @@ func (s *testIntegrationSuite4) TestAddPartitionTooManyPartitions(c *C) {
 	for i := 1; i < count; i++ {
 		sql2 += fmt.Sprintf("partition p%d values less than (%d),", i, i)
 	}
-	sql2 += "partition p1024 values less than (1024) );"
+	sql2 += "partition p8192 values less than (8192) );"
 
 	tk.MustExec(sql2)
 	sql3 := `alter table p2 add partition (
-	partition p1025 values less than (1025)
+	partition p8193 values less than (8193)
 	);`
 	tk.MustGetErrCode(sql3, tmysql.ErrTooManyPartitions)
 }

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -59,9 +59,8 @@ const (
 	batchAddingJobs = 10
 
 	// PartitionCountLimit is limit of the number of partitions in a table.
-	// Mysql maximum number of partitions is 8192, our maximum number of partitions is 1024.
 	// Reference linking https://dev.mysql.com/doc/refman/5.7/en/partitioning-limitations.html.
-	PartitionCountLimit = 1024
+	PartitionCountLimit = 8192
 )
 
 // OnExist specifies what to do when a new object has a name collision.


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/18097

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
Enlarge it to 8192 to match the limit in MySQL 5.7.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility
The new partition table in TiDB may could not sync to MySQL 5.6.

### Release note <!-- bugfixes or new feature need a release note -->

- Enlarge the limit of the number of partitions in a table.
