### PR TITLE
optimizer: fix issue on incorrect result of natural join

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7366,3 +7366,19 @@ func (s *testIntegrationSuite) TestIssue17476(c *C) {
 	tk.MustQuery(`SELECT count(*) FROM (table_float JOIN table_int_float_varchar AS tmp3 ON (tmp3.col_varchar_6 AND NULL) IS NULL);`).Check(testkit.Rows("154"))
 	tk.MustQuery(`SELECT * FROM (table_int_float_varchar AS tmp3) WHERE (col_varchar_6 AND NULL) IS NULL AND col_int_6=0;`).Check(testkit.Rows("13 0 -0.1 <nil>"))
 }
+
+func (s *testIntegrationSuite) TestIssue17856(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t0;")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t0(c0 INT);")
+	tk.MustExec("create table t1(c0 INT);")
+	tk.MustExec("insert into t0 values(1);")
+	tk.MustExec("insert into t0 values(0);")
+	tk.MustExec("insert into t1 values(0);")
+	tk.MustExec("insert into t1 values(1);")
+	tk.MustQuery("select * from t0 natural join t1;").Check(testkit.Rows("1", "0"))
+	tk.MustExec("drop table t0;")
+	tk.MustExec("drop table t1;")
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -749,8 +749,11 @@ func (b *PlanBuilder) coalesceCommonColumns(p *LogicalJoin, leftPlan, rightPlan 
 	// Find out all the common columns and put them ahead.
 	commonLen := 0
 	for i, lName := range lNames {
+		if lName.ColName.L == "_tidb_rowid" {
+			continue
+		}
 		for j := commonLen; j < len(rNames); j++ {
-			if lName.ColName.L != rNames[j].ColName.L {
+			if rNames[j].ColName.L == "_tidb_rowid" || lName.ColName.L != rNames[j].ColName.L {
 				continue
 			}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #17856 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The natural join result is not correct due to `rowid` used in join conditions.
### What is changed and how it works?

 <!-- REMOVE this line if not applicable -->

What's Changed:
when building natural join plan, do not consider `rowid`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
### Release note <!-- bugfixes or new feature need a release note -->
fix issue #17856