### PR TITLE
executor: fix unexpected 'invalid auto-id' error in pessimistic txn retry

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -657,6 +657,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 	// Rollback the statement change before retry it.
 	a.Ctx.StmtRollback()
 	a.Ctx.GetSessionVars().StmtCtx.ResetForRetry()
+	a.Ctx.GetSessionVars().RetryInfo.ResetOffset()
 
 	if err = e.Open(ctx); err != nil {
 		return nil, err

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -14,7 +14,6 @@
 package tikv
 
 import (
-	"runtime/debug"
 	"sync/atomic"
 	"time"
 
@@ -171,7 +170,6 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			} else {
 				// the lockWaitTime is set, we should return wait timeout if we are still blocked by a lock
 				if time.Since(lockWaitStartTime).Milliseconds() >= action.LockWaitTime {
-					debug.PrintStack()
 					return errors.Trace(ErrLockWaitTimeout)
 				}
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

In a high load cluster, the error `[variable:8053]Cannot get a valid auto-ID when retrying the statement` is reported frequently.

TiDB always reuse the allocated auto-ids in the retry stage by saving them to the session variable `RetryInfo`. At the beginning of retry, one should reset `RetryInfo` offset first to keep things correct.

Optimistic txn retries in the commit phase: `session.retry()`.
Pessimistic txn retries when the statement is executed: `ExecStmt.handlePessimisticDML`.

`ExecStmt.handlePessimisticDML` does not reset `RetryInfo` offset, results in the auto-ids cannot be reused. 

### What is changed and how it works?

What's Changed: make `ExecStmt.handlePessimisticDML` reset `RetryInfo` offset.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix unexpected 'invalid auto-id' error in pessimistic txn retry.
