### PR TITLE
tikv: set undetermined error when async commit prewrite rpc fails

### DIFF
--- a/store/mockstore/unistore/rpc.go
+++ b/store/mockstore/unistore/rpc.go
@@ -102,6 +102,12 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		r := req.Prewrite()
 		c.cluster.handleDelay(r.StartVersion, r.Context.RegionId)
 		resp.Resp, err = c.usSvr.KvPrewrite(ctx, r)
+
+		failpoint.Inject("rpcPrewriteTimeout", func(val failpoint.Value) {
+			if val.(bool) {
+				failpoint.Return(nil, undeterminedErr)
+			}
+		})
 	case tikvrpc.CmdPessimisticLock:
 		r := req.PessimisticLock()
 		c.cluster.handleDelay(r.StartVersion, r.Context.RegionId)

--- a/store/tikv/async_commit_fail_test.go
+++ b/store/tikv/async_commit_fail_test.go
@@ -1,0 +1,83 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"bytes"
+	"context"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/store/mockstore/cluster"
+	"github.com/pingcap/tidb/store/mockstore/unistore"
+)
+
+type testAsyncCommitFailSuite struct {
+	OneByOneSuite
+	cluster cluster.Cluster
+	store   *tikvStore
+}
+
+var _ = SerialSuites(&testAsyncCommitFailSuite{})
+
+func (s *testAsyncCommitFailSuite) SetUpTest(c *C) {
+	client, pdClient, cluster, err := unistore.New("")
+	c.Assert(err, IsNil)
+	unistore.BootstrapWithSingleStore(cluster)
+	s.cluster = cluster
+	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
+	c.Assert(err, IsNil)
+
+	s.store = store.(*tikvStore)
+}
+
+// TestFailCommitPrimaryRpcErrors tests rpc errors are handled properly when
+// committing primary region task.
+func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
+	defer config.RestoreFunc()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.EnableAsyncCommit = true
+	})
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/noRetryOnRpcError", "return(true)"), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout", `return(true)`), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout"), IsNil)
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/noRetryOnRpcError"), IsNil)
+	}()
+	// The rpc error will be wrapped to ErrResultUndetermined.
+	t1, err := s.store.Begin()
+	c.Assert(err, IsNil)
+	err = t1.Set([]byte("a"), []byte("a1"))
+	c.Assert(err, IsNil)
+	ctx := context.WithValue(context.Background(), sessionctx.ConnID, uint64(1))
+	err = t1.Commit(ctx)
+	c.Assert(err, NotNil)
+	c.Assert(terror.ErrorEqual(err, terror.ErrResultUndetermined), IsTrue, Commentf("%s", errors.ErrorStack(err)))
+
+	// We don't need to call "Rollback" after "Commit" fails.
+	err = t1.Rollback()
+	c.Assert(err, Equals, kv.ErrInvalidTxn)
+
+	// Create a new transaction to check. The previous transaction should actually commit.
+	t2, err := s.store.Begin()
+	c.Assert(err, IsNil)
+	res, err := t2.Get(context.Background(), []byte("a"))
+	c.Assert(err, IsNil)
+	c.Assert(bytes.Equal(res, []byte("a1")), IsTrue)
+}

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/mockstore/cluster"
-	"github.com/pingcap/tidb/store/mockstore/mocktikv"
+	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
 
@@ -39,10 +39,10 @@ type testAsyncCommitSuite struct {
 var _ = Suite(&testAsyncCommitSuite{})
 
 func (s *testAsyncCommitSuite) SetUpTest(c *C) {
-	client, clstr, pdClient, err := mocktikv.NewTiKVAndPDClient("")
+	client, pdClient, cluster, err := unistore.New("")
 	c.Assert(err, IsNil)
-	mocktikv.BootstrapWithSingleStore(clstr)
-	s.cluster = clstr
+	unistore.BootstrapWithSingleStore(cluster)
+	s.cluster = cluster
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 
@@ -120,10 +120,10 @@ func (s *testAsyncCommitSuite) mustGetLock(c *C, key []byte) *Lock {
 }
 
 func (s *testAsyncCommitSuite) TestCheckSecondaries(c *C) {
+	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.TiKVClient.EnableAsyncCommit = true
 	})
-	defer config.RestoreFunc()()
 
 	s.putAlphabets(c)
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -427,6 +427,11 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, rpcCtx *RPCContext,
 		}
 
 		s.rpcError = err
+		failpoint.Inject("noRetryOnRpcError", func(val failpoint.Value) {
+			if val.(bool) {
+				failpoint.Return(nil, false, err)
+			}
+		})
 		if e := s.onSendFail(bo, rpcCtx, err); e != nil {
 			return nil, false, errors.Trace(e)
 		}


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

When async commit is used, if prewrite fails at RPC level, we cannot know whether this transaction would succeed. We cannot suppose this transactions fails because it is possible that all prewrites succeed but we just don't receive the responses.

### What is changed and how it works?

This PR sets undetermined error when async commit is used and the prewrite response is not received. And on undetermined error, we don't cleanup the locks.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

* Part of the async commit feature.