### PR TITLE
store/tikv: Add a test that checks prewrites properly set secondaries for async commit transactions

### DIFF
--- a/store/tikv/async_commit_fail_test.go
+++ b/store/tikv/async_commit_fail_test.go
@@ -16,10 +16,12 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"sort"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
@@ -80,4 +82,84 @@ func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
 	res, err := t2.Get(context.Background(), []byte("a"))
 	c.Assert(err, IsNil)
 	c.Assert(bytes.Equal(res, []byte("a1")), IsTrue)
+}
+
+func (s *testAsyncCommitSuite) TestSecondaryListInPrimaryLock(c *C) {
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.EnableAsyncCommit = true
+	})
+	defer config.RestoreFunc()()
+
+	s.putAlphabets(c)
+
+	// Split into several regions.
+	for _, splitKey := range []string{"h", "o", "u"} {
+		loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte(splitKey))
+		c.Assert(err, IsNil)
+		newRegionID := s.cluster.AllocID()
+		newPeerID := s.cluster.AllocID()
+		s.cluster.Split(loc.Region.GetID(), newRegionID, []byte(splitKey), []uint64{newPeerID}, newPeerID)
+		s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
+	}
+
+	// Ensure the region has been split
+	loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte("i"))
+	c.Assert(err, IsNil)
+	c.Assert([]byte(loc.StartKey), BytesEquals, []byte("h"))
+	c.Assert([]byte(loc.EndKey), BytesEquals, []byte("o"))
+
+	loc, err = s.store.GetRegionCache().LocateKey(s.bo, []byte("p"))
+	c.Assert(err, IsNil)
+	c.Assert([]byte(loc.StartKey), BytesEquals, []byte("o"))
+	c.Assert([]byte(loc.EndKey), BytesEquals, []byte("u"))
+
+	var connID uint64 = 0
+	test := func(keys []string, values []string) {
+		connID++
+		ctx := context.WithValue(context.Background(), sessionctx.ConnID, connID)
+
+		txn, err := s.store.Begin()
+		c.Assert(err, IsNil)
+		for i := range keys {
+			txn.Set([]byte(keys[i]), []byte(values[i]))
+		}
+
+		c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
+
+		err = txn.Commit(ctx)
+		c.Assert(err, IsNil)
+
+		tikvTxn := txn.(*tikvTxn)
+		primary := tikvTxn.committer.primary()
+		txnStatus, err := s.store.lockResolver.getTxnStatus(s.bo, txn.StartTS(), primary, 0, 0, false)
+		c.Assert(err, IsNil)
+		c.Assert(txnStatus.IsCommitted(), IsFalse)
+		c.Assert(txnStatus.action, Equals, kvrpcpb.Action_NoAction)
+		// Currently when the transaction has no secondary, the `secondaries` field of the txnStatus
+		// will be set nil. So here initialize the `expectedSecondaries` to nil too.
+		var expectedSecondaries [][]byte
+		for _, k := range keys {
+			if !bytes.Equal([]byte(k), primary) {
+				expectedSecondaries = append(expectedSecondaries, []byte(k))
+			}
+		}
+		sort.Slice(expectedSecondaries, func(i, j int) bool {
+			return bytes.Compare(expectedSecondaries[i], expectedSecondaries[j]) < 0
+		})
+
+		gotSecondaries := txnStatus.primaryLock.GetSecondaries()
+		sort.Slice(gotSecondaries, func(i, j int) bool {
+			return bytes.Compare(gotSecondaries[i], gotSecondaries[j]) < 0
+		})
+
+		c.Assert(gotSecondaries, DeepEquals, expectedSecondaries)
+
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing"), IsNil)
+	}
+
+	test([]string{"a"}, []string{"a1"})
+	test([]string{"a", "b"}, []string{"a2", "b2"})
+	test([]string{"a", "b", "d"}, []string{"a3", "b3", "d3"})
+	test([]string{"a", "b", "h", "i", "u"}, []string{"a4", "b4", "h4", "i4", "u4"})
+	test([]string{"i", "a", "z", "u", "b"}, []string{"i5", "a5", "z5", "u5", "b5"})
 }

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -29,8 +29,11 @@ import (
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
 
+type testAsyncCommitCommon struct{}
+
 type testAsyncCommitSuite struct {
 	OneByOneSuite
+	testAsyncCommitCommon
 	cluster cluster.Cluster
 	store   *tikvStore
 	bo      *Backoffer
@@ -50,14 +53,14 @@ func (s *testAsyncCommitSuite) SetUpTest(c *C) {
 	s.bo = NewBackofferWithVars(context.Background(), 5000, nil)
 }
 
-func (s *testAsyncCommitSuite) putAlphabets(c *C) {
+func (s *testAsyncCommitCommon) putAlphabets(c *C, store *tikvStore) {
 	for ch := byte('a'); ch <= byte('z'); ch++ {
-		s.putKV(c, []byte{ch}, []byte{ch})
+		s.putKV(c, store, []byte{ch}, []byte{ch})
 	}
 }
 
-func (s *testAsyncCommitSuite) putKV(c *C, key, value []byte) (uint64, uint64) {
-	txn, err := s.store.Begin()
+func (s *testAsyncCommitCommon) putKV(c *C, store *tikvStore, key, value []byte) (uint64, uint64) {
+	txn, err := store.Begin()
 	c.Assert(err, IsNil)
 	err = txn.Set(key, value)
 	c.Assert(err, IsNil)
@@ -125,7 +128,7 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries(c *C) {
 		conf.TiKVClient.EnableAsyncCommit = true
 	})
 
-	s.putAlphabets(c)
+	s.putAlphabets(c, s.store)
 
 	loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte("a"))
 	c.Assert(err, IsNil)

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -17,11 +17,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/mockstore/cluster"
@@ -264,6 +266,79 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries(c *C) {
 	c.Assert(gotCheckB, Equals, int64(1))
 	c.Assert(gotResolve, Equals, int64(1))
 	c.Assert(gotOther, Equals, int64(0))
+}
+
+func (s *testAsyncCommitSuite) TestSecondaryListInPrimaryLock(c *C) {
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.TiKVClient.EnableAsyncCommit = true
+	})
+	defer config.RestoreFunc()()
+
+	s.putAlphabets(c)
+
+	// Split into several regions.
+	for _, splitKey := range []string{"h", "o", "u"} {
+		loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte(splitKey))
+		c.Assert(err, IsNil)
+		newRegionID := s.cluster.AllocID()
+		newPeerID := s.cluster.AllocID()
+		s.cluster.Split(loc.Region.GetID(), newRegionID, []byte(splitKey), []uint64{newPeerID}, newPeerID)
+		s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
+	}
+
+	// Ensure the region has been split
+	loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte("i"))
+	c.Assert(err, IsNil)
+	c.Assert([]byte(loc.StartKey), BytesEquals, []byte("h"))
+	c.Assert([]byte(loc.EndKey), BytesEquals, []byte("o"))
+
+	loc, err = s.store.GetRegionCache().LocateKey(s.bo, []byte("p"))
+	c.Assert(err, IsNil)
+	c.Assert(loc.StartKey, BytesEquals, []byte("o"))
+	c.Assert(loc.EndKey, BytesEquals, []byte("u"))
+
+	test := func(keys []string, values []string) {
+		txn, err := s.store.Begin()
+		c.Assert(err, IsNil)
+		for i := range keys {
+			txn.Set([]byte(keys[i]), []byte(values[i]))
+		}
+
+		c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
+
+		err = txn.Commit(context.Background())
+		c.Assert(err, IsNil)
+
+		primary := txn.(*tikvTxn).committer.primary()
+		txnStatus, err := s.store.lockResolver.getTxnStatus(s.bo, txn.StartTS(), primary, 0, 0, false)
+		c.Assert(err, IsNil)
+		c.Assert(txnStatus.IsCommitted, IsFalse)
+		c.Assert(txnStatus.action, Equals, kvrpcpb.Action_NoAction)
+		expectedSecondaries := make([][]byte, 0, len(keys)-1)
+		for _, k := range keys {
+			if !bytes.Equal([]byte(k), primary) {
+				expectedSecondaries = append(expectedSecondaries, []byte(k))
+			}
+		}
+		sort.Slice(expectedSecondaries, func(i, j int) bool {
+			return bytes.Compare(expectedSecondaries[i], expectedSecondaries[j]) < 0
+		})
+
+		gotSecondaries := txnStatus.primaryLock.GetSecondaries()
+		sort.Slice(gotSecondaries, func(i, j int) bool {
+			return bytes.Compare(gotSecondaries[i], gotSecondaries[j]) < 0
+		})
+
+		c.Assert(gotSecondaries, DeepEquals, expectedSecondaries)
+
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing"), IsNil)
+	}
+
+	test([]string{"a"}, []string{"a1"})
+	test([]string{"a", "b"}, []string{"a2", "b2"})
+	test([]string{"a", "b", "d"}, []string{"a3", "b3", "d3"})
+	test([]string{"a", "b", "h", "i", "u"}, []string{"a4", "b4", "h4", "i4", "u4"})
+	test([]string{"i", "a", "z", "u", "b"}, []string{"i5", "a5", "z5", "u5", "b5"})
 }
 
 type mockResolveClient struct {

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -17,16 +17,13 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"sort"
 	"sync/atomic"
 	"time"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -267,86 +264,6 @@ func (s *testAsyncCommitSuite) TestCheckSecondaries(c *C) {
 	c.Assert(gotCheckB, Equals, int64(1))
 	c.Assert(gotResolve, Equals, int64(1))
 	c.Assert(gotOther, Equals, int64(0))
-}
-
-func (s *testAsyncCommitSuite) TestSecondaryListInPrimaryLock(c *C) {
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TiKVClient.EnableAsyncCommit = true
-	})
-	defer config.RestoreFunc()()
-
-	s.putAlphabets(c)
-
-	// Split into several regions.
-	for _, splitKey := range []string{"h", "o", "u"} {
-		loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte(splitKey))
-		c.Assert(err, IsNil)
-		newRegionID := s.cluster.AllocID()
-		newPeerID := s.cluster.AllocID()
-		s.cluster.Split(loc.Region.GetID(), newRegionID, []byte(splitKey), []uint64{newPeerID}, newPeerID)
-		s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
-	}
-
-	// Ensure the region has been split
-	loc, err := s.store.GetRegionCache().LocateKey(s.bo, []byte("i"))
-	c.Assert(err, IsNil)
-	c.Assert([]byte(loc.StartKey), BytesEquals, []byte("h"))
-	c.Assert([]byte(loc.EndKey), BytesEquals, []byte("o"))
-
-	loc, err = s.store.GetRegionCache().LocateKey(s.bo, []byte("p"))
-	c.Assert(err, IsNil)
-	c.Assert([]byte(loc.StartKey), BytesEquals, []byte("o"))
-	c.Assert([]byte(loc.EndKey), BytesEquals, []byte("u"))
-
-	var connID uint64 = 0
-	test := func(keys []string, values []string) {
-		connID++
-		ctx := context.WithValue(context.Background(), sessionctx.ConnID, connID)
-
-		txn, err := s.store.Begin()
-		c.Assert(err, IsNil)
-		for i := range keys {
-			txn.Set([]byte(keys[i]), []byte(values[i]))
-		}
-
-		c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
-
-		err = txn.Commit(ctx)
-		c.Assert(err, IsNil)
-
-		tikvTxn := txn.(*tikvTxn)
-		primary := tikvTxn.committer.primary()
-		txnStatus, err := s.store.lockResolver.getTxnStatus(s.bo, txn.StartTS(), primary, 0, 0, false)
-		c.Assert(err, IsNil)
-		c.Assert(txnStatus.IsCommitted(), IsFalse)
-		c.Assert(txnStatus.action, Equals, kvrpcpb.Action_NoAction)
-		// Currently when the transaction has no secondary, the `secondaries` field of the txnStatus
-		// will be set nil. So here initialize the `expectedSecondaries` to nil too.
-		var expectedSecondaries [][]byte
-		for _, k := range keys {
-			if !bytes.Equal([]byte(k), primary) {
-				expectedSecondaries = append(expectedSecondaries, []byte(k))
-			}
-		}
-		sort.Slice(expectedSecondaries, func(i, j int) bool {
-			return bytes.Compare(expectedSecondaries[i], expectedSecondaries[j]) < 0
-		})
-
-		gotSecondaries := txnStatus.primaryLock.GetSecondaries()
-		sort.Slice(gotSecondaries, func(i, j int) bool {
-			return bytes.Compare(gotSecondaries[i], gotSecondaries[j]) < 0
-		})
-
-		c.Assert(gotSecondaries, DeepEquals, expectedSecondaries)
-
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing"), IsNil)
-	}
-
-	test([]string{"a"}, []string{"a1"})
-	test([]string{"a", "b"}, []string{"a2", "b2"})
-	test([]string{"a", "b", "d"}, []string{"a3", "b3", "d3"})
-	test([]string{"a", "b", "h", "i", "u"}, []string{"a4", "b4", "h4", "i4", "u4"})
-	test([]string{"i", "a", "z", "u", "b"}, []string{"i5", "a5", "z5", "u5", "b5"})
 }
 
 type mockResolveClient struct {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -239,6 +239,7 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 		if err != nil {
 			return errors.Trace(err)
 		}
+		txn.committer = committer
 	}
 	defer func() {
 		// For async commit transactions, the ttl manager will be closed in the asynchronous commit goroutine.


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->


### What is changed and how it works?

What's Changed: Adds a unit test that tries to checks that `prewrite` of async commit transactions has properly set the `secondaries` field for primary lock.

This can be merged after https://github.com/pingcap/tidb/pull/20150 so that the test can be moved to `async_commit_fail_test.go`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
