### PR TITLE
ddl: add verification for placement rule request

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -48,6 +48,7 @@ import (
 	"github.com/pingcap/tidb/util/versioninfo"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
+	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/zap"
 )
 

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -48,7 +48,6 @@ import (
 	"github.com/pingcap/tidb/util/versioninfo"
 	"go.etcd.io/etcd/clientv3"
 	"go.etcd.io/etcd/clientv3/concurrency"
-	"go.etcd.io/etcd/pkg/transport"
 	"go.uber.org/zap"
 )
 
@@ -282,7 +281,7 @@ func doRequest(ctx context.Context, addrs []string, route, method string, body i
 		if strings.HasPrefix(addr, "http") {
 			url = fmt.Sprintf("%s%s", addr, route)
 		} else {
-			url = fmt.Sprintf("%s://%s%s", util.InternalHTTPSchema(), addr, route)
+			url = fmt.Sprintf("%s://%s%s", util2.InternalHTTPSchema(), addr, route)
 		}
 
 		if ctx != nil {
@@ -297,7 +296,7 @@ func doRequest(ctx context.Context, addrs []string, route, method string, body i
 			req.Header.Set("Content-Type", "application/json")
 		}
 
-		res, err = util.InternalHTTPClient().Do(req)
+		res, err = util2.InternalHTTPClient().Do(req)
 		if err == nil {
 			bodyBytes, err := ioutil.ReadAll(res.Body)
 			if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Refer to this [test](https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/lightning_ghpr_test/detail/lightning_ghpr_test/2020/pipeline/52/). TiDB got:

```
[ERROR] [tidb.go:83] [“[ddl] init domain failed”] [error=“Get http://127.0.0.1:2379/pd/api/v1/config/placement-rule: EOF”]
```

And PD got:

```
[WARN] [config_logging.go:279] ["rejected connection"] [remote-addr=127.0.0.1:19794] [server-name=] [error="tls: first record does not look like a TLS handshake"]
``` 

So add tls verification for http request.

### Check List

Tests

- Unit test
- Integration test

### Release note

- No release note
