### PR TITLE
table: fix zero date in different sqlmode

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1623,7 +1623,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
-		sc.IgnoreZeroInDate = !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
+		sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 		sc.Priority = stmt.Priority
 	case *ast.InsertStmt:
 		sc.InInsertStmt = true
@@ -1635,7 +1635,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 		sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 		sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
-		sc.IgnoreZeroInDate = !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
+		sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 		sc.Priority = stmt.Priority
 	case *ast.CreateTableStmt, *ast.AlterTableStmt:
 		// Make sure the sql_mode is strict when checking column default value.
@@ -1724,7 +1724,7 @@ func ResetUpdateStmtCtx(sc *stmtctx.StatementContext, stmt *ast.UpdateStmt, vars
 	sc.TruncateAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.DividedByZeroAsWarning = !vars.StrictSQLMode || stmt.IgnoreErr
 	sc.AllowInvalidDate = vars.SQLMode.HasAllowInvalidDatesMode()
-	sc.IgnoreZeroInDate = !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
+	sc.IgnoreZeroInDate = !vars.SQLMode.HasNoZeroInDateMode() || !vars.SQLMode.HasNoZeroDateMode() || !vars.StrictSQLMode || stmt.IgnoreErr || sc.AllowInvalidDate
 	sc.Priority = stmt.Priority
 }
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1460,6 +1460,7 @@ func (s *testSuite8) TestUpdate(c *C) {
 		"`ts` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP," +
 		"KEY `idx` (`ts`)" +
 		");")
+	tk.MustExec("set @orig_sql_mode=@@sql_mode; set @@sql_mode='';")
 	tk.MustExec("insert into tsup values(1, '0000-00-00 00:00:00');")
 	tk.MustExec("update tsup set a=5;")
 	tk.CheckLastMessage("Rows matched: 1  Changed: 1  Warnings: 0")
@@ -1468,6 +1469,7 @@ func (s *testSuite8) TestUpdate(c *C) {
 	r1.Check(r2.Rows())
 	tk.MustExec("update tsup set ts='2019-01-01';")
 	tk.MustQuery("select ts from tsup;").Check(testkit.Rows("2019-01-01 00:00:00"))
+	tk.MustExec("set @@sql_mode=@orig_sql_mode;")
 
 	// issue 5532
 	tk.MustExec("create table decimals (a decimal(20, 0) not null)")
@@ -1520,7 +1522,7 @@ func (s *testSuite8) TestUpdate(c *C) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a datetime not null, b datetime)")
 	tk.MustExec("insert into t value('1999-12-12', '1999-12-13')")
-	tk.MustExec(" set @orig_sql_mode=@@sql_mode; set @@sql_mode='';")
+	tk.MustExec("set @orig_sql_mode=@@sql_mode; set @@sql_mode='';")
 	tk.MustQuery("select * from t").Check(testkit.Rows("1999-12-12 00:00:00 1999-12-13 00:00:00"))
 	tk.MustExec("update t set a = ''")
 	tk.MustQuery("select * from t").Check(testkit.Rows("0000-00-00 00:00:00 1999-12-13 00:00:00"))

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7759,3 +7759,109 @@ func (s *testIntegrationSerialSuite) TestCollationIndexJoin(c *C) {
 	tk.MustQuery("select /*+ inl_merge_join(t2) */ t1.b, t2.b from t1 join t2 where t1.b=t2.b").Check(testkit.Rows("a A"))
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1815 Optimizer Hint /*+ INL_MERGE_JOIN(t2) */ is inapplicable"))
 }
+
+func (s *testIntegrationSuite) TestIssue19892(c *C) {
+	defer s.cleanEnv(c)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("USE test")
+	tk.MustExec("CREATE TABLE dd(a date, b datetime)")
+
+	// check NO_ZERO_DATE
+	{
+		tk.MustExec("SET sql_mode=''")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(a) values('0000-00-00')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("0000-00-00"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(b) values('2000-10-01')")
+			tk.MustExec("UPDATE dd SET b = '0000-00-00'")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+		}
+
+		tk.MustExec("SET sql_mode='NO_ZERO_DATE'")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(b) values('0000-00-00')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '0000-00-00 00:00:00'"))
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(a) values('2000-10-01')")
+			tk.MustExec("UPDATE dd SET a = '0000-00-00'")
+			// tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect date value: '0000-00-00'"))
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("0000-00-00"))
+		}
+
+		tk.MustExec("SET sql_mode='NO_ZERO_DATE,STRICT_TRANS_TABLES'")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustGetErrMsg("INSERT INTO dd(b) VALUES ('0000-00-00')", "[table:1366]Incorrect datetime value: '0000-00-00' for column 'b' at row 1")
+			tk.MustExec("INSERT IGNORE INTO dd(b) VALUES ('0000-00-00')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '0000-00-00 00:00:00'"))
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(b) values('2000-10-01')")
+			tk.MustGetErrMsg("UPDATE dd SET b = '0000-00-00'", "[types:1292]Incorrect datetime value: '0000-00-00 00:00:00'")
+			tk.MustExec("UPDATE IGNORE dd SET b = '0000-00-00'")
+			// FIXME: has two warning rows
+			// tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '0000-00-00 00:00:00'"))
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+		}
+	}
+
+	// check NO_ZERO_IN_DATE
+	{
+		tk.MustExec("SET sql_mode=''")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(a) values('2000-01-00')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("2000-01-00"))
+			tk.MustExec("INSERT INTO dd(a) values('2000-00-01')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("2000-01-00", "2000-00-01"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(b) values('2000-01-02')")
+			tk.MustExec("UPDATE dd SET b = '2000-00-02'")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows())
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("2000-00-02 00:00:00"))
+		}
+
+		tk.MustExec("SET sql_mode='NO_ZERO_IN_DATE'")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(a) values('2000-01-00')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect date value: '2000-01-00'"))
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("0000-00-00"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(a) values('2000-01-02')")
+			tk.MustExec("UPDATE dd SET a = '2000-00-02'")
+			// FIXME: has two warning rows?
+			// tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect date value: '2000-00-02'"))
+			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("0000-00-00"))
+		}
+
+		tk.MustExec("SET sql_mode='NO_ZERO_IN_DATE,STRICT_TRANS_TABLES'")
+		{
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustGetErrMsg("INSERT INTO dd(b) VALUES ('2000-01-00')", "[table:1366]Incorrect datetime value: '2000-01-00' for column 'b' at row 1")
+			tk.MustExec("INSERT IGNORE INTO dd(b) VALUES ('2000-00-01')")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '2000-00-01 00:00:00'"))
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+
+			tk.MustExec("TRUNCATE TABLE dd")
+			tk.MustExec("INSERT INTO dd(b) VALUES ('2000-01-02')")
+			tk.MustGetErrMsg("UPDATE dd SET b = '2000-01-00'", "[types:1292]Incorrect datetime value: '2000-01-00'")
+			tk.MustExec("UPDATE IGNORE dd SET b = '2000-01-00'")
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '2000-01-00 00:00:00'"))
+			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
+		}
+	}
+}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7816,7 +7816,7 @@ func (s *testIntegrationSuite) TestIssue19892(c *C) {
 		tk.MustExec("SET sql_mode='NO_ZERO_DATE,STRICT_TRANS_TABLES'")
 		{
 			tk.MustExec("TRUNCATE TABLE dd")
-			tk.MustGetErrMsg("INSERT INTO dd(c) VALUES ('0000-00-00 20:00:00')", "[table:1366]Incorrect timestamp value: '0000-00-00 20:00:00' for column 'c' at row 1")
+			tk.MustGetErrMsg("INSERT INTO dd(c) VALUES ('0000-00-00 20:00:00')", "[table:1292]Incorrect timestamp value: '0000-00-00 20:00:00' for column 'c' at row 1")
 			tk.MustExec("INSERT IGNORE INTO dd(c) VALUES ('0000-00-00 20:00:00')")
 			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect timestamp value: '0000-00-00 20:00:00'"))
 			tk.MustQuery("SELECT c FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
@@ -7895,7 +7895,7 @@ func (s *testIntegrationSuite) TestIssue19892(c *C) {
 		tk.MustExec("SET sql_mode='NO_ZERO_IN_DATE,STRICT_TRANS_TABLES'")
 		{
 			tk.MustExec("TRUNCATE TABLE dd")
-			tk.MustGetErrMsg("INSERT INTO dd(b) VALUES ('2000-01-00')", "[table:1366]Incorrect datetime value: '2000-01-00' for column 'b' at row 1")
+			tk.MustGetErrMsg("INSERT INTO dd(b) VALUES ('2000-01-00')", "[table:1292]Incorrect datetime value: '2000-01-00' for column 'b' at row 1")
 			tk.MustExec("INSERT IGNORE INTO dd(b) VALUES ('2000-00-01')")
 			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect datetime value: '2000-00-01'"))
 			tk.MustQuery("SELECT b FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
@@ -7914,7 +7914,7 @@ func (s *testIntegrationSuite) TestIssue19892(c *C) {
 			tk.MustQuery("SELECT c FROM dd").Check(testkit.Rows("0000-00-00 00:00:00"))
 
 			tk.MustExec("TRUNCATE TABLE dd")
-			tk.MustGetErrMsg("INSERT INTO dd(c) VALUES ('2000-01-00 20:00:00')", "[table:1366]Incorrect timestamp value: '2000-01-00 20:00:00' for column 'c' at row 1")
+			tk.MustGetErrMsg("INSERT INTO dd(c) VALUES ('2000-01-00 20:00:00')", "[table:1292]Incorrect timestamp value: '2000-01-00 20:00:00' for column 'c' at row 1")
 			tk.MustExec("INSERT INTO dd(c) VALUES ('2000-01-02')")
 			tk.MustGetErrMsg("UPDATE dd SET c = '2000-01-00 20:00:00'", "[types:1292]Incorrect timestamp value: '2000-01-00 20:00:00'")
 			tk.MustExec("UPDATE IGNORE dd SET b = '2000-01-00'")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -3817,7 +3817,7 @@ func (s *testIntegrationSuite) TestAggregationBuiltinJSONObjectAgg(c *C) {
 		i char(36),
 		j text(50));`)
 
-	tk.MustExec(`insert into t values(1, 'ab', 5.5, '{"id": 1}', '2020-01-10', '11:12:13', '2020-01-11', '0000-00-00 00:00:00', 'first', 'json_objectagg_test');`)
+	tk.MustExec(`insert into t values(1, 'ab', 5.5, '{"id": 1}', '2020-01-10', '11:12:13', '2020-01-11', '2020-10-18 00:00:00', 'first', 'json_objectagg_test');`)
 
 	result := tk.MustQuery("select json_objectagg(a, b) from t group by a order by a;")
 	result.Check(testkit.Rows(`{"1": "ab"}`))
@@ -3828,9 +3828,9 @@ func (s *testIntegrationSuite) TestAggregationBuiltinJSONObjectAgg(c *C) {
 	result = tk.MustQuery("select json_objectagg(f, g) from t group by f order by f;")
 	result.Check(testkit.Rows(`{"11:12:13": "2020-01-11 00:00:00"}`))
 	result = tk.MustQuery("select json_objectagg(g, h) from t group by g order by g;")
-	result.Check(testkit.Rows(`{"2020-01-11 00:00:00": "0000-00-00 00:00:00"}`))
+	result.Check(testkit.Rows(`{"2020-01-11 00:00:00": "2020-10-18 00:00:00"}`))
 	result = tk.MustQuery("select json_objectagg(h, i) from t group by h order by h;")
-	result.Check(testkit.Rows(`{"0000-00-00 00:00:00": "first"}`))
+	result.Check(testkit.Rows(`{"2020-10-18 00:00:00": "first"}`))
 	result = tk.MustQuery("select json_objectagg(i, j) from t group by i order by i;")
 	result.Check(testkit.Rows(`{"first": "json_objectagg_test"}`))
 	result = tk.MustQuery("select json_objectagg(a, null) from t group by a order by a;")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -7843,8 +7843,7 @@ func (s *testIntegrationSuite) TestIssue19892(c *C) {
 			tk.MustExec("TRUNCATE TABLE dd")
 			tk.MustExec("INSERT INTO dd(a) values('2000-01-02')")
 			tk.MustExec("UPDATE dd SET a = '2000-00-02'")
-			// FIXME: has two warning rows?
-			// tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect date value: '2000-00-02'"))
+			tk.MustQuery("SHOW WARNINGS").Check(testkit.Rows("Warning 1292 Incorrect date value: '2000-00-02'"))
 			tk.MustQuery("SELECT a FROM dd").Check(testkit.Rows("0000-00-00"))
 		}
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -367,7 +367,7 @@ func (s *testSessionSuite) TestAffectedRows(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int, c1 timestamp);")
-	tk.MustExec(`insert t values(1, 0);`)
+	tk.MustExec(`insert t(id) values(1);`)
 	tk.MustExec(`UPDATE t set id = 1 where id = 1;`)
 	c.Assert(int(tk.Se.AffectedRows()), Equals, 0)
 
@@ -1022,8 +1022,10 @@ func (s *testSessionSuite) TestPrepareZero(c *C) {
 	_, rs := tk.Exec("execute s1 using @v1")
 	c.Assert(rs, NotNil)
 	tk.MustExec("set @v2='" + types.ZeroDatetimeStr + "'")
+	tk.MustExec("set @orig_sql_mode=@@sql_mode; set @@sql_mode='';")
 	tk.MustExec("execute s1 using @v2")
 	tk.MustQuery("select v from t").Check(testkit.Rows("0000-00-00 00:00:00"))
+	tk.MustExec("set @@sql_mode=@orig_sql_mode;")
 }
 
 func (s *testSessionSuite) TestPrimaryKeyAutoIncrement(c *C) {

--- a/table/column.go
+++ b/table/column.go
@@ -217,7 +217,6 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 			sc.AppendWarning(types.ErrWrongValue.GenWithStackByArgs(zeroT, tm.String()))
 			return types.NewDatum(zeroV), nil
 		}
-		return casted, nil
 	}
 
 	if col.Charset == charset.CharsetASCII {

--- a/table/column.go
+++ b/table/column.go
@@ -158,6 +158,80 @@ func handleWrongUtf8Value(ctx sessionctx.Context, col *model.ColumnInfo, casted 
 	return truncateVal, err
 }
 
+func handleZeroDatetime(ctx sessionctx.Context, col *model.ColumnInfo, casted types.Datum, str string, tmIsInvalid bool) (types.Datum, bool, error) {
+	sc := ctx.GetSessionVars().StmtCtx
+	tm := casted.GetMysqlTime()
+	mode := ctx.GetSessionVars().SQLMode
+
+	var (
+		zeroV types.Time
+		zeroT string
+	)
+	switch col.Tp {
+	case mysql.TypeDate:
+		zeroV, zeroT = types.ZeroDate, types.DateStr
+	case mysql.TypeDatetime:
+		zeroV, zeroT = types.ZeroDatetime, types.DateTimeStr
+	case mysql.TypeTimestamp:
+		zeroV, zeroT = types.ZeroTimestamp, types.TimestampStr
+	}
+
+	// ref https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_date
+	// if NO_ZERO_DATE is not enabled, '0000-00-00' is permitted and inserts produce no warning
+	// if NO_ZERO_DATE is enabled, '0000-00-00' is permitted and inserts produce a warning
+	// If NO_ZERO_DATE mode and strict mode are enabled, '0000-00-00' is not permitted and inserts produce an error, unless IGNORE is given as well. For INSERT IGNORE and UPDATE IGNORE, '0000-00-00' is permitted and inserts produce a warning.
+	// if NO_ZERO_IN_DATE is not enabled, dates with zero parts are permitted and inserts produce no warning
+	// if NO_ZERO_IN_DATE is enabled, dates with zero parts are inserted as '0000-00-00' and produce a warning
+	// If NO_ZERO_IN_DATE mode and strict mode are enabled, dates with zero parts are not permitted and inserts produce an error, unless IGNORE is given as well. For INSERT IGNORE and UPDATE IGNORE, dates with zero parts are inserted as '0000-00-00' and produce a warning.
+
+	ignoreErr := sc.DupKeyAsWarning
+
+	// in MySQL 8.0, the Timestamp's case is different to Datetime/Date, as shown below:
+	//
+	// |              | NZD               | NZD|ST  | ELSE              | ELSE|ST  |
+	// | ------------ | ----------------- | ------- | ----------------- | -------- |
+	// | `0000-00-01` | Success + Warning | Error   | Success + Warning | Error    |
+	// | `0000-00-00` | Success + Warning | Error   | Success           | Success  |
+	//
+	// * **NZD**: NO_ZERO_DATE_MODE
+	// * **ST**: STRICT_TRANS_TABLES
+	// * **ELSE**: empty or NO_ZERO_IN_DATE_MODE
+	if tm.IsZero() && col.Tp == mysql.TypeTimestamp {
+		innerErr := types.ErrWrongValue.GenWithStackByArgs(zeroT, str)
+		if mode.HasStrictMode() && !ignoreErr && (tmIsInvalid || mode.HasNoZeroDateMode()) {
+			return types.NewDatum(zeroV), true, innerErr
+		}
+
+		if tmIsInvalid || mode.HasNoZeroDateMode() {
+			sc.AppendWarning(innerErr)
+		}
+		return types.NewDatum(zeroV), true, nil
+	} else if tm.IsZero() || tm.InvalidZero() {
+		if tm.IsZero() {
+			if !mode.HasNoZeroDateMode() {
+				return types.NewDatum(zeroV), true, nil
+			}
+		} else if tm.InvalidZero() {
+			if !mode.HasNoZeroInDateMode() {
+				return casted, true, nil
+			}
+		}
+
+		innerErr := types.ErrWrongValue.GenWithStackByArgs(zeroT, str)
+		if mode.HasStrictMode() && !ignoreErr {
+			return types.NewDatum(zeroV), true, innerErr
+		}
+
+		// TODO: as in MySQL 8.0's implement, warning message is `types.ErrWarnDataOutOfRange`,
+		// but this error message need a `rowIdx` argument, in this context, the `rowIdx` is missing.
+		// And refactor this function seems too complicated, so we set the warning message the same to error's.
+		sc.AppendWarning(innerErr)
+		return types.NewDatum(zeroV), true, nil
+	}
+
+	return casted, false, nil
+}
+
 // CastValue casts a value based on column type.
 // If forceIgnoreTruncate is true, truncated errors will be ignored.
 // If returnOverflow is true, don't handle overflow errors in this function.
@@ -181,75 +255,8 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 	} else if (sc.InInsertStmt || sc.InUpdateStmt) && !casted.IsNull() &&
 		(val.Kind() != types.KindMysqlTime || !val.GetMysqlTime().IsZero()) &&
 		(col.Tp == mysql.TypeDate || col.Tp == mysql.TypeDatetime || col.Tp == mysql.TypeTimestamp) {
-		tm := casted.GetMysqlTime()
-		mode := ctx.GetSessionVars().SQLMode
-
-		var (
-			zeroV types.Time
-			zeroT string
-		)
-		switch col.Tp {
-		case mysql.TypeDate:
-			zeroV, zeroT = types.ZeroDate, types.DateStr
-		case mysql.TypeDatetime:
-			zeroV, zeroT = types.ZeroDatetime, types.DateTimeStr
-		case mysql.TypeTimestamp:
-			zeroV, zeroT = types.ZeroTimestamp, types.TimestampStr
-		}
-
-		// ref https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_no_zero_date
-		// if NO_ZERO_DATE is not enabled, '0000-00-00' is permitted and inserts produce no warning
-		// if NO_ZERO_DATE is enabled, '0000-00-00' is permitted and inserts produce a warning
-		// If NO_ZERO_DATE mode and strict mode are enabled, '0000-00-00' is not permitted and inserts produce an error, unless IGNORE is given as well. For INSERT IGNORE and UPDATE IGNORE, '0000-00-00' is permitted and inserts produce a warning.
-		// if NO_ZERO_IN_DATE is not enabled, dates with zero parts are permitted and inserts produce no warning
-		// if NO_ZERO_IN_DATE is enabled, dates with zero parts are inserted as '0000-00-00' and produce a warning
-		// If NO_ZERO_IN_DATE mode and strict mode are enabled, dates with zero parts are not permitted and inserts produce an error, unless IGNORE is given as well. For INSERT IGNORE and UPDATE IGNORE, dates with zero parts are inserted as '0000-00-00' and produce a warning.
-
-		ignoreErr := sc.DupKeyAsWarning
-
-		// in MySQL 8.0, the Timestamp's case is different to Datetime/Date, as shown below:
-		//
-		// |              | NZD               | NZD|ST  | ELSE              | ELSE|ST  |
-		// | ------------ | ----------------- | ------- | ----------------- | -------- |
-		// | `0000-00-01` | Success + Warning | Error   | Success + Warning | Error    |
-		// | `0000-00-00` | Success + Warning | Error   | Success           | Success  |
-		//
-		// * **NZD**: NO_ZERO_DATE_MODE
-		// * **ST**: STRICT_TRANS_TABLES
-		// * **ELSE**: empty or NO_ZERO_IN_DATE_MODE
-		if tm.IsZero() && col.Tp == mysql.TypeTimestamp {
-			isInZero := types.ErrWrongValue.Equal(err)
-
-			innerErr := types.ErrWrongValue.GenWithStackByArgs(zeroT, val.GetString())
-			if mode.HasStrictMode() && !ignoreErr && (isInZero || mode.HasNoZeroDateMode()) {
-				return types.NewDatum(zeroV), innerErr
-			}
-
-			if isInZero || mode.HasNoZeroDateMode() {
-				sc.AppendWarning(innerErr)
-			}
-			return types.NewDatum(zeroV), nil
-		} else if tm.IsZero() || tm.InvalidZero() {
-			if tm.IsZero() {
-				if !mode.HasNoZeroDateMode() {
-					return types.NewDatum(zeroV), nil
-				}
-			} else if tm.InvalidZero() {
-				if !mode.HasNoZeroInDateMode() {
-					return casted, nil
-				}
-			}
-
-			innerErr := types.ErrWrongValue.GenWithStackByArgs(zeroT, val.GetString())
-			if mode.HasStrictMode() && !ignoreErr {
-				return types.NewDatum(zeroV), innerErr
-			}
-
-			// TODO: as in MySQL 8.0's implement, warning message is `types.ErrWarnDataOutOfRange`,
-			// but this error message need a `rowIdx` argument, in this context, the `rowIdx` is missing.
-			// And refactor this function seems too complicated, so we set the warning message the same to error's.
-			sc.AppendWarning(innerErr)
-			return types.NewDatum(zeroV), nil
+		if innCasted, exit, innErr := handleZeroDatetime(ctx, col, casted, val.GetString(), types.ErrWrongValue.Equal(err)); exit {
+			return innCasted, innErr
 		}
 	}
 

--- a/types/errors.go
+++ b/types/errors.go
@@ -21,9 +21,10 @@ import (
 
 // const strings for ErrWrongValue
 const (
-	DateTimeStr = "datetime"
-	DateStr     = "date"
-	TimeStr     = "time"
+	DateTimeStr  = "datetime"
+	DateStr      = "date"
+	TimeStr      = "time"
+	TimestampStr = "timestamp"
 )
 
 var (

--- a/types/errors.go
+++ b/types/errors.go
@@ -22,6 +22,7 @@ import (
 // const strings for ErrWrongValue
 const (
 	DateTimeStr = "datetime"
+	DateStr     = "date"
 	TimeStr     = "time"
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19892, #19634

Problem Summary:

### What is changed and how it works?

What's Changed:


How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- The same behavior of `NO_ZERO_DATE` and `NO_ZERO_IN_DATE` to MySQL's in INSERT/UPDATE statement <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
