### PR TITLE
ddl: make use of the new rule cache api[2/3]

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5513,8 +5513,13 @@ func (d *ddl) AlterTablePartition(ctx sessionctx.Context, ident ast.Ident, spec 
 			EndKeyHex:   endKey,
 		})
 	}
-	bundle.Index = placement.RuleIndexPartition
-	bundle.Override = true
+	if len(bundle.Rules) == 0 {
+		bundle.Index = 0
+		bundle.Override = false
+	} else {
+		bundle.Index = placement.RuleIndexPartition
+		bundle.Override = true
+	}
 
 	job := &model.Job{
 		SchemaID:   schema.ID,

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -622,7 +622,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionDropTable, model.ActionDropView, model.ActionDropSequence:
 		ver, err = onDropTableOrView(t, job)
 	case model.ActionDropTablePartition:
-		ver, err = onDropTablePartition(t, job)
+		ver, err = onDropTablePartition(d, t, job)
 	case model.ActionTruncateTablePartition:
 		ver, err = onTruncateTablePartition(d, t, job)
 	case model.ActionExchangeTablePartition:

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -867,19 +867,16 @@ func getPartitionDef(tblInfo *model.TableInfo, partName string) (index int, def 
 	return index, nil, table.ErrUnknownPartition.GenWithStackByArgs(partName, tblInfo.Name.O)
 }
 
-func buildPlacementDropRules(schemaID, tableID int64, partitionIDs []int64) []*placement.RuleOp {
-	rules := make([]*placement.RuleOp, 0, len(partitionIDs))
+func buildPlacementDropRules(partitionIDs []int64) []*placement.Bundle {
+	bundles := make([]*placement.Bundle, 0, len(partitionIDs))
 	for _, partitionID := range partitionIDs {
-		rules = append(rules, &placement.RuleOp{
-			Action:           placement.RuleOpDel,
-			DeleteByIDPrefix: true,
-			Rule: &placement.Rule{
-				GroupID: placement.RuleDefaultGroupID,
-				ID:      fmt.Sprintf("%d_t%d_p%d", schemaID, tableID, partitionID),
-			},
+		bundles = append(bundles, &placement.Bundle{
+			ID:       placement.GroupID(partitionID),
+			Index:    placement.RuleIndexPartition,
+			Override: true,
 		})
 	}
-	return rules
+	return bundles
 }
 
 // onDropTablePartition deletes old partition meta.
@@ -907,8 +904,9 @@ func onDropTablePartition(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		physicalTableIDs = removePartitionInfo(tblInfo, partNames)
 	}
 
-	rules := buildPlacementDropRules(job.SchemaID, tblInfo.ID, physicalTableIDs)
-	err = infosync.UpdatePlacementRules(nil, rules)
+	bundles := buildPlacementDropRules(physicalTableIDs)
+
+	err = infosync.PutRuleBundles(nil, bundles)
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return ver, errors.Wrapf(err, "failed to notify PD the placement rules")
@@ -1536,7 +1534,7 @@ func onAlterTablePartition(t *meta.Meta, job *model.Job) (int64, error) {
 		return 0, errors.Trace(table.ErrUnknownPartition.GenWithStackByArgs("drop?", tblInfo.Name.O))
 	}
 
-	err = infosync.PutRuleBundle(nil, bundle)
+	err = infosync.PutRuleBundles(nil, []*placement.Bundle{bundle})
 	if err != nil {
 		job.State = model.JobStateCancelled
 		return 0, errors.Wrapf(err, "failed to notify PD the placement rules")

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -871,9 +871,7 @@ func buildPlacementDropRules(partitionIDs []int64) []*placement.Bundle {
 	bundles := make([]*placement.Bundle, 0, len(partitionIDs))
 	for _, partitionID := range partitionIDs {
 		bundles = append(bundles, &placement.Bundle{
-			ID:       placement.GroupID(partitionID),
-			Index:    placement.RuleIndexPartition,
-			Override: true,
+			ID: placement.GroupID(partitionID),
 		})
 	}
 	return bundles

--- a/ddl/placement/types.go
+++ b/ddl/placement/types.go
@@ -113,7 +113,6 @@ func (b *Bundle) IsEmpty() bool {
 	return len(b.Rules) == 0 && b.Index == 0 && b.Override == false
 }
 
-
 // RuleOpType indicates the operation type.
 type RuleOpType string
 

--- a/ddl/placement/types.go
+++ b/ddl/placement/types.go
@@ -108,6 +108,12 @@ func (b *Bundle) Clone() *Bundle {
 	return newBundle
 }
 
+// IsEmpty is used to check if a bundle is empty.
+func (b *Bundle) IsEmpty() bool {
+	return len(b.Rules) == 0 && b.Index == 0 && b.Override == false
+}
+
+
 // RuleOpType indicates the operation type.
 type RuleOpType string
 

--- a/ddl/placement/types.go
+++ b/ddl/placement/types.go
@@ -110,7 +110,7 @@ func (b *Bundle) Clone() *Bundle {
 
 // IsEmpty is used to check if a bundle is empty.
 func (b *Bundle) IsEmpty() bool {
-	return len(b.Rules) == 0 && b.Index == 0 && b.Override == false
+	return len(b.Rules) == 0 && b.Index == 0 && !b.Override
 }
 
 // RuleOpType indicates the operation type.

--- a/ddl/placement/types_test.go
+++ b/ddl/placement/types_test.go
@@ -28,6 +28,23 @@ var _ = Suite(&testRuleSuite{})
 
 type testBundleSuite struct{}
 
+func (t *testBundleSuite) TestEmpty(c *C) {
+	bundle := &Bundle{ID: GroupID(1)}
+	c.Assert(bundle.IsEmpty(), IsTrue)
+
+	bundle = &Bundle{ID: GroupID(1), Index: 1}
+	c.Assert(bundle.IsEmpty(), IsFalse)
+
+	bundle = &Bundle{ID: GroupID(1), Override: true}
+	c.Assert(bundle.IsEmpty(), IsFalse)
+
+	bundle = &Bundle{ID: GroupID(1), Rules: []*Rule{{ID: "434"}}}
+	c.Assert(bundle.IsEmpty(), IsFalse)
+
+	bundle = &Bundle{ID: GroupID(1), Index: 1, Override: true}
+	c.Assert(bundle.IsEmpty(), IsFalse)
+}
+
 func (t *testBundleSuite) TestClone(c *C) {
 	bundle := &Bundle{ID: GroupID(1), Rules: []*Rule{{ID: "434"}}}
 

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -253,29 +253,21 @@ func (s *testPlacementSuite) TestPlacementBuild(c *C) {
 
 func (s *testPlacementSuite) TestPlacementBuildDrop(c *C) {
 	tests := []struct {
-		input  []int64
-		output []*placement.Bundle
+		input int64
+		output *placement.Bundle
 	}{
 		{
-			input: []int64{2},
-			output: []*placement.Bundle{
-				{ID: placement.GroupID(2)},
-			},
+			input: 2,
+			output: &placement.Bundle{ID: placement.GroupID(2)},
 		},
 		{
-			input: []int64{1, 2},
-			output: []*placement.Bundle{
-				{ID: placement.GroupID(1)},
-				{ID: placement.GroupID(2)},
-			},
+			input: 1,
+			output: &placement.Bundle{ID: placement.GroupID(1)},
 		},
 	}
 	for _, t := range tests {
-		out := buildPlacementDropRules(t.input)
-		c.Assert(len(out), Equals, len(t.output))
-		for i := range t.output {
-			c.Assert(t.output[i], DeepEquals, out[i])
-		}
+		out := buildPlacementDropBundle(t.input)
+		c.Assert(t.output, DeepEquals, out)
 	}
 }
 

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -259,26 +259,14 @@ func (s *testPlacementSuite) TestPlacementBuildDrop(c *C) {
 		{
 			input: []int64{2},
 			output: []*placement.Bundle{
-				{
-					ID:       placement.GroupID(2),
-					Index:    placement.RuleIndexPartition,
-					Override: true,
-				},
+				{ID: placement.GroupID(2)},
 			},
 		},
 		{
 			input: []int64{1, 2},
 			output: []*placement.Bundle{
-				{
-					ID:       placement.GroupID(1),
-					Index:    placement.RuleIndexPartition,
-					Override: true,
-				},
-				{
-					ID:       placement.GroupID(2),
-					Index:    placement.RuleIndexPartition,
-					Override: true,
-				},
+				{ID: placement.GroupID(1)},
+				{ID: placement.GroupID(2)},
 			},
 		},
 	}

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -254,48 +254,39 @@ func (s *testPlacementSuite) TestPlacementBuild(c *C) {
 func (s *testPlacementSuite) TestPlacementBuildDrop(c *C) {
 	tests := []struct {
 		input  []int64
-		output []*placement.RuleOp
+		output []*placement.Bundle
 	}{
 		{
 			input: []int64{2},
-			output: []*placement.RuleOp{
+			output: []*placement.Bundle{
 				{
-					Action:           placement.RuleOpDel,
-					DeleteByIDPrefix: true,
-					Rule: &placement.Rule{
-						GroupID: placement.RuleDefaultGroupID,
-						ID:      "0_t0_p2",
-					},
+					ID:       placement.GroupID(2),
+					Index:    placement.RuleIndexPartition,
+					Override: true,
 				},
 			},
 		},
 		{
 			input: []int64{1, 2},
-			output: []*placement.RuleOp{
+			output: []*placement.Bundle{
 				{
-					Action:           placement.RuleOpDel,
-					DeleteByIDPrefix: true,
-					Rule: &placement.Rule{
-						GroupID: placement.RuleDefaultGroupID,
-						ID:      "0_t0_p1",
-					},
+					ID:       placement.GroupID(1),
+					Index:    placement.RuleIndexPartition,
+					Override: true,
 				},
 				{
-					Action:           placement.RuleOpDel,
-					DeleteByIDPrefix: true,
-					Rule: &placement.Rule{
-						GroupID: placement.RuleDefaultGroupID,
-						ID:      "0_t0_p2",
-					},
+					ID:       placement.GroupID(2),
+					Index:    placement.RuleIndexPartition,
+					Override: true,
 				},
 			},
 		},
 	}
 	for _, t := range tests {
-		out := buildPlacementDropRules(0, 0, t.input)
+		out := buildPlacementDropRules(t.input)
 		c.Assert(len(out), Equals, len(t.output))
 		for i := range t.output {
-			c.Assert(s.compareRuleOp(out[i], t.output[i]), IsTrue, Commentf("expect: %+v, obtained: %+v", t.output[i], out[i]))
+			c.Assert(t.output[i], DeepEquals, out[i])
 		}
 	}
 }

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -253,15 +253,15 @@ func (s *testPlacementSuite) TestPlacementBuild(c *C) {
 
 func (s *testPlacementSuite) TestPlacementBuildDrop(c *C) {
 	tests := []struct {
-		input int64
+		input  int64
 		output *placement.Bundle
 	}{
 		{
-			input: 2,
+			input:  2,
 			output: &placement.Bundle{ID: placement.GroupID(2)},
 		},
 		{
-			input: 1,
+			input:  1,
 			output: &placement.Bundle{ID: placement.GroupID(1)},
 		},
 	}

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -425,14 +425,7 @@ func GetRuleBundle(ctx context.Context, name string) (*placement.Bundle, error) 
 
 // PutRuleBundles is used to post specific rule bundles to PD.
 func PutRuleBundles(ctx context.Context, bundles []*placement.Bundle) error {
-	empty := true
-	for _, bundle := range bundles {
-		if len(bundle.Rules) != 0 || bundle.Index != 0 || bundle.Override != false {
-			empty = false
-			break
-		}
-	}
-	if empty {
+	if len(bundles) == 0 {
 		return nil
 	}
 

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -423,8 +423,8 @@ func GetRuleBundle(ctx context.Context, name string) (*placement.Bundle, error) 
 	return bundle, err
 }
 
-// PutRuleBundle is used to post one specific rule bundle to PD.
-func PutRuleBundle(ctx context.Context, bundle *placement.Bundle) error {
+// PutRuleBundles is used to post specific rule bundles to PD.
+func PutRuleBundles(ctx context.Context, bundles []*placement.Bundle) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return err
@@ -440,12 +440,12 @@ func PutRuleBundle(ctx context.Context, bundle *placement.Bundle) error {
 		return errors.Errorf("pd unavailable")
 	}
 
-	b, err := json.Marshal(bundle)
+	b, err := json.Marshal(bundles)
 	if err != nil {
 		return err
 	}
 
-	_, err = doRequest(ctx, addrs, path.Join(pdapi.Config, "placement-rule", bundle.ID), "POST", bytes.NewReader(b))
+	_, err = doRequest(ctx, addrs, path.Join(pdapi.Config, "placement-rule")+"?partial=true", "POST", bytes.NewReader(b))
 	return err
 }
 

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -425,6 +425,17 @@ func GetRuleBundle(ctx context.Context, name string) (*placement.Bundle, error) 
 
 // PutRuleBundles is used to post specific rule bundles to PD.
 func PutRuleBundles(ctx context.Context, bundles []*placement.Bundle) error {
+	empty := true
+	for _, bundle := range bundles {
+		if len(bundle.Rules) != 0 || bundle.Index != 0 || bundle.Override != false {
+			empty = false
+			break
+		}
+	}
+	if empty {
+		return nil
+	}
+
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return err


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: It is a part of the project Define Placement Rules in SQL. Placement rule cache api is introduced in #20086 . This PR makes the old `drop partition` statements using the new rule cache api. 

Truncate rules when truncate partition is to be solved in the next PR.
two

### Check List 

Tests

- Unit test
- Integration test
- Manual test

Refer to the manual test of https://github.com/pingcap/tidb/pull/19223#issuecomment-674625270.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
