### PR TITLE
ddl: add index in parallel(#19386)

### DIFF
--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -230,7 +230,7 @@ func (w *backfillWorker) run(d *ddlCtx, bf backfiller) {
 // splitTableRanges uses PD region's key ranges to split the backfilling table key range space,
 // to speed up backfilling data in table with disperse handle.
 // The `t` should be a non-partitioned table or a partition.
-func splitTableRanges(t table.PhysicalTable, store kv.Storage, startHandle, endHandle kv.Handle) ([]kv.KeyRange, error) {
+func SplitTableRanges(t table.PhysicalTable, store kv.Storage, startHandle, endHandle kv.Handle) ([]kv.KeyRange, error) {
 	startRecordKey := t.RecordKey(startHandle)
 	endRecordKey := t.RecordKey(endHandle)
 
@@ -461,7 +461,7 @@ func (w *worker) writePhysicalTableRecord(t table.PhysicalTable, bfWorkerType ba
 	}()
 
 	for {
-		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startHandle, endHandle)
+		kvRanges, err := SplitTableRanges(t, reorgInfo.d.store, startHandle, endHandle)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"context"
-	"github.com/pingcap/tidb/meta"
 	"math"
 	"strconv"
 	"sync/atomic"
@@ -27,6 +26,7 @@ import (
 	ddlutil "github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -231,7 +231,7 @@ func (w *backfillWorker) run(d *ddlCtx, bf backfiller) {
 // splitTableRanges uses PD region's key ranges to split the backfilling table key range space,
 // to speed up backfilling data in table with disperse handle.
 // The `t` should be a non-partitioned table or a partition.
-func SplitTableRanges(t table.PhysicalTable, store kv.Storage, startHandle, endHandle kv.Handle) ([]kv.KeyRange, error) {
+func splitTableRanges(t table.PhysicalTable, store kv.Storage, startHandle, endHandle kv.Handle) ([]kv.KeyRange, error) {
 	startRecordKey := t.RecordKey(startHandle)
 	endRecordKey := t.RecordKey(endHandle)
 
@@ -491,7 +491,7 @@ func (w *worker) writePhysicalTableRecord(t table.PhysicalTable, bfWorkerType ba
 	}()
 
 	for {
-		kvRanges, err := SplitTableRanges(t, reorgInfo.d.store, startHandle, endHandle)
+		kvRanges, err := splitTableRanges(t, reorgInfo.d.store, startHandle, endHandle)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -323,29 +323,32 @@ func (w *worker) handleReorgTasks(reorgInfo *reorgInfo, totalAddedCount *int64, 
 	return nil
 }
 
-func (w *worker) handleSubReorgTasks(subTaskReorgInfo *subTaskReorgInfo, totalAddedCount *int64, workers []*backfillWorker, batchTasks []*reorgBackfillTask) error {
+func (w *worker) handleSubReorgTasks(subTaskReorgInfo *subTaskReorgInfo, addedCount *int64, workers []*backfillWorker, batchTasks []*reorgBackfillTask) error {
 	for i, task := range batchTasks {
 		workers[i].taskCh <- task
 	}
 	startHandle := batchTasks[0].startHandle
 	taskCnt := len(batchTasks)
 	startTime := time.Now()
-	nextHandle, taskAddedCount, err := w.waitTaskResults(workers, taskCnt, totalAddedCount, startHandle)
+	nextHandle, taskAddedCount, err := w.waitTaskResults(workers, taskCnt, addedCount, startHandle)
 	elapsedTime := time.Since(startTime)
 	if err != nil {
 		// Update the reorg handle that has been processed.
 		err1 := kv.RunInNewTxn(subTaskReorgInfo.d.store, true, func(txn kv.Transaction) error {
 			t := newMetaWithQueueTp(txn, subTaskTypeStr)
-			return errors.Trace(t.UpdateDDLSubTaskReorgInfo(subTaskReorgInfo.jobID, subTaskReorgInfo.taskID, subTaskReorgInfo.StartHandle, subTaskReorgInfo.EndHandle, subTaskReorgInfo.PhysicalTableID, subTaskReorgInfo.Runner, Failed))
+			return errors.Trace(t.UpdateDDLSubTaskReorgInfo(subTaskReorgInfo.jobID, subTaskReorgInfo.taskID, subTaskReorgInfo.StartHandle, subTaskReorgInfo.EndHandle, subTaskReorgInfo.PhysicalTableID, subTaskReorgInfo.Runner, Failed, taskAddedCount))
 		})
 		metrics.BatchAddIdxHistogram.WithLabelValues(metrics.LblError).Observe(elapsedTime.Seconds())
 		logutil.BgLogger().Warn("[ddl] backfill worker handle sub tasks failed",
-			zap.Int64("totalAddedCount", *totalAddedCount), zap.String("startHandle", toString(startHandle)),
+			zap.Int64("taskAddedCount", taskAddedCount), zap.String("startHandle", toString(startHandle)),
 			zap.String("nextHandle", toString(nextHandle)), zap.Int64("batchAddedCount", taskAddedCount),
 			zap.String("taskFailedError", err.Error()), zap.String("takeTime", elapsedTime.String()),
 			zap.NamedError("updateHandleError", err1))
 		return errors.Trace(err)
 	}
+
+	logutil.BgLogger().Info("[ddl] backfill worker handle batch tasks successful", zap.Int64("taskAddedCount", *addedCount), zap.String("startHandle", toString(startHandle)),
+		zap.String("nextHandle", toString(nextHandle)), zap.Int64("batchAddedCount", taskAddedCount), zap.String("takeTime", elapsedTime.String()))
 	return nil
 }
 

--- a/ddl/backfilling.go
+++ b/ddl/backfilling.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+	"github.com/pingcap/tidb/meta"
 	"math"
 	"strconv"
 	"sync/atomic"
@@ -335,8 +336,8 @@ func (w *worker) handleSubReorgTasks(subTaskReorgInfo *subTaskReorgInfo, addedCo
 	if err != nil {
 		// Update the reorg handle that has been processed.
 		err1 := kv.RunInNewTxn(subTaskReorgInfo.d.store, true, func(txn kv.Transaction) error {
-			t := newMetaWithQueueTp(txn, subTaskTypeStr)
-			return errors.Trace(t.UpdateDDLSubTaskReorgInfo(subTaskReorgInfo.jobID, subTaskReorgInfo.taskID, subTaskReorgInfo.StartHandle, subTaskReorgInfo.EndHandle, subTaskReorgInfo.PhysicalTableID, subTaskReorgInfo.Runner, Failed, taskAddedCount))
+			t := newMetaWithQueueTp(txn, meta.SubTaskTypeStr)
+			return errors.Trace(t.UpdateDDLSubTaskReorgInfo(subTaskReorgInfo.JobID, subTaskReorgInfo.TaskID, subTaskReorgInfo.StartHandle, subTaskReorgInfo.EndHandle, subTaskReorgInfo.PhysicalTableID, subTaskReorgInfo.Runner, meta.Failed, taskAddedCount))
 		})
 		metrics.BatchAddIdxHistogram.WithLabelValues(metrics.LblError).Observe(elapsedTime.Seconds())
 		logutil.BgLogger().Warn("[ddl] backfill worker handle sub tasks failed",

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -335,11 +335,12 @@ func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 			return errors.Trace(err)
 		}
 
-		d.workers = make(map[workerType]*worker, 2)
+		d.workers = make(map[workerType]*worker, 3)
 		d.sessPool = newSessionPool(ctxPool)
 		d.delRangeMgr = d.newDeleteRangeManager(ctxPool == nil)
 		d.workers[generalWorker] = newWorker(d.ctx, generalWorker, d.sessPool, d.delRangeMgr)
 		d.workers[addIdxWorker] = newWorker(d.ctx, addIdxWorker, d.sessPool, d.delRangeMgr)
+		d.workers[subTaskWorker] = newWorker(d.ctx, subTaskWorker, d.sessPool, d.delRangeMgr)
 		for _, worker := range d.workers {
 			worker.wg.Add(1)
 			w := worker

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -16,7 +16,6 @@ package ddl
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/table"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -34,6 +33,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/table"
 	tidbutil "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/logutil"

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -241,7 +241,7 @@ func (d *ddlCtx) addBatchTaskToQueue(subTasks []*meta.SubTask, t *meta.Meta) (er
 		if err != nil {
 			return errors.Trace(err)
 		}
-		logutil.BgLogger().Info("[ddl] add DDL subTasks", zap.Int("batch count", len(subTasks)))
+		logutil.BgLogger().Info("[ddl] add batch DDL subTasks", zap.Int("batch count", len(subTasks)))
 	}
 	return errors.Trace(err)
 }

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -758,6 +758,9 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 							totalAddedCount = totalAddedCount + subTaskProcessedCount
 							job.SetRowCount(totalAddedCount)
 							err = t.SetReorgSubTaskStatus(job.ID, taskID, meta.Reorganized)
+							if err != nil {
+								return errors.Trace(err)
+							}
 							logutil.Logger(w.logCtx).Info("[ddl] DDL subTask success", zap.String("job", job.String()),
 								zap.String("subTaskId", strconv.FormatInt(taskID, 10)),
 								zap.String("processedCount", strconv.FormatInt(subTaskProcessedCount, 10)),
@@ -766,7 +769,13 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 							break
 						case meta.Failed:
 							err = t.SetReorgSubTaskStatus(job.ID, taskID, meta.Unclaimed)
+							if err != nil {
+								return errors.Trace(err)
+							}
 							err = t.SetReorgSubTaskRunner(job.ID, taskID, meta.RunnerEmptyStr)
+							if err != nil {
+								return errors.Trace(err)
+							}
 							logutil.Logger(w.logCtx).Info("[ddl] DDL subTask failed", zap.String("job", job.String()),
 								zap.String("subTaskId", strconv.FormatInt(taskID, 10)),
 								zap.String("processedCount", strconv.FormatInt(subTaskProcessedCount, 10)),

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -733,13 +733,13 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 					isLinear := false
 					err = kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
 						t := meta.NewMeta(txn)
-						physicalId, err := t.GetReorgSubTaskPhysicalTableId(job.ID, taskID)
+						physicalID, err := t.GetReorgSubTaskPhysicalTableID(job.ID, taskID)
 						if err != nil {
 							return errors.Trace(err)
 						}
 						var currentTable table.PhysicalTable
 						if tbl, ok := tbl.(table.PartitionedTable); ok {
-							currentTable = tbl.GetPartition(physicalId)
+							currentTable = tbl.GetPartition(physicalID)
 						} else {
 							currentTable = tbl.(table.PhysicalTable)
 						}
@@ -797,7 +797,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 								if err != nil {
 									return errors.Trace(err)
 								}
-								err = t.UpdateDDLReorgHandle(job, startHandle, endHandle, physicalId)
+								err = t.UpdateDDLReorgHandle(job, startHandle, endHandle, physicalID)
 								if err != nil {
 									return errors.Trace(err)
 								}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -812,6 +812,9 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 								}
 								//update DDL Job modify row count
 								err = t.UpdateDDLJob(0, job, false)
+								if err != nil {
+									return errors.Trace(err)
+								}
 							}
 						}
 						return errors.Trace(err)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -500,7 +500,7 @@ func (w *worker) tryToClaimSubTaskFromTheQueue(ticker *time.Ticker, handleSubTas
 					if err != nil {
 						return errors.Trace(err)
 					}
-					err = t.SetReorgSubTaskStartTime(currentTask.JobID, currentTask.TaskID, time.Now().Unix())
+					err = t.SetReorgSubTaskStartTime(currentTask.JobID, currentTask.TaskID, model.TSConvert2Time(txn.StartTS()).Unix())
 					if err != nil {
 						return errors.Trace(err)
 					}
@@ -746,7 +746,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 						startHandle, _, _, runner, status, subTaskProcessedCount, startTime, err := t.GetDDLSubTaskReorgInfo(job.ID, taskID, currentTable.Meta().IsCommonHandle)
 						costTime := time.Now().Unix() - startTime
 						switch status {
-						case meta.Recorganized:
+						case meta.Reorganized:
 							lastLinearTaskID = taskID
 							reorganizeTaskNum++
 							break
@@ -757,7 +757,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 							lastLinearTaskID = taskID
 							totalAddedCount = totalAddedCount + subTaskProcessedCount
 							job.SetRowCount(totalAddedCount)
-							err = t.SetReorgSubTaskStatus(job.ID, taskID, meta.Recorganized)
+							err = t.SetReorgSubTaskStatus(job.ID, taskID, meta.Reorganized)
 							logutil.Logger(w.logCtx).Info("[ddl] DDL subTask success", zap.String("job", job.String()),
 								zap.String("subTaskId", strconv.FormatInt(taskID, 10)),
 								zap.String("processedCount", strconv.FormatInt(subTaskProcessedCount, 10)),

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -729,7 +729,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 			case <-ticker.C:
 				reorganizeTaskNum := int64(0)
 				lastLinearTaskID := int64(0)
-				for taskID := int64(0); taskID < subTaskNum; taskID++ {
+				for taskID := int64(1); taskID <= subTaskNum; taskID++ {
 					isLinear := false
 					err = kv.RunInNewTxn(d.store, true, func(txn kv.Transaction) error {
 						t := meta.NewMeta(txn)
@@ -744,7 +744,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 							currentTable = tbl.(table.PhysicalTable)
 						}
 						startHandle, _, _, runner, status, subTaskProcessedCount, startTime, err := t.GetDDLSubTaskReorgInfo(job.ID, taskID, currentTable.Meta().IsCommonHandle)
-						costTime := -startTime
+						costTime := model.TSConvert2Time(txn.StartTS()).Unix() - startTime
 						switch status {
 						case meta.Reorganized:
 							lastLinearTaskID = taskID

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -744,7 +744,7 @@ func (w *worker) handelParentJob(d *ddlCtx, job *model.Job, tableInfo *model.Tab
 							currentTable = tbl.(table.PhysicalTable)
 						}
 						startHandle, _, _, runner, status, subTaskProcessedCount, startTime, err := t.GetDDLSubTaskReorgInfo(job.ID, taskID, currentTable.Meta().IsCommonHandle)
-						costTime := time.Now().Unix() - startTime
+						costTime := -startTime
 						switch status {
 						case meta.Reorganized:
 							lastLinearTaskID = taskID

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -378,6 +378,31 @@ func updateHiddenColumns(tblInfo *model.TableInfo, idxInfo *model.IndexInfo, sta
 	}
 }
 
+func (w *worker) onCreateIndexSubTask(d *ddlCtx, t *meta.Meta, subTask *SubTask) (err error) {
+	var (
+		indexInfo      model.IndexInfo
+		startHandle    kv.Handle
+		endHandle      kv.Handle
+		isCommonHandle bool
+		status         SubTaskStatus
+		runner         string
+		physicalID     int64
+	)
+	err = subTask.DecodeArgs(&indexInfo, &isCommonHandle)
+
+	startHandle, endHandle, physicalID, runner, status, err = t.GetDDLSubTaskReorgInfo(subTask.jobID, subTask.taskID, isCommonHandle)
+
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if runner == "" && status == Unclaimed {
+		t.UpdateDDLSubTaskReorgInfo(subTask.jobID, subTask.taskID, startHandle, endHandle, physicalID, runner, Running)
+	}
+
+	return
+}
+
 func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK bool) (ver int64, err error) {
 	// Handle the rolling back job.
 	if job.IsRollingback() {
@@ -554,26 +579,32 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 		// (only the owner can execute the parent job)
 		// 1. It will get all the subTasks from the subTaskQueue, then check the 'runner' status
 		// which represents the TIDB instance that is executing the subTask,
-		// (if it's down, update the runner to nil and set status to unclaimed)
-		// 2. Check the subTask's status one by one, reset the failed subTask' runner and status to nil and unclaimed.
+		// (if it's down, update the runner to nil and set status to Unclaimed)
+		// 2. Check the subTask's status one by one, reset the failed subTask' runner and status to nil and Unclaimed.
 
-		// 	All the TIDB instance in the cluster will read the subTaskQueue on time, get at most one unclaimed task and execute each time.
+		// 	All the TIDB instance in the cluster will read the subTaskQueue on time, get at most one Unclaimed task and execute each time.
 		//  If owner find all the subTasks in queue witch have same jobId were done, it will finish the job.
-		if GetTableTotalCount(w, tblInfo) > limit {
+
+		var parentJob parentJob
+		err = job.DecodeArgs(&parentJob.subTaskNum)
+		if err == nil {
+			ver, err = w.handleParentJob(d, t, job)
+		} else if getTableTotalCount(w, tblInfo) > limit {
 			reorgInfos, getReorgErr := getParentJobReorgInfo(d, t, job, tbl)
 			if getReorgErr != nil {
 				return ver, errors.Trace(getReorgErr)
 			}
-			w.dispatchAddIndexSubTasks(d, tbl, indexInfo, reorgInfos)
+			err = w.dispatchAddIndexSubTasks(d, tbl, indexInfo, reorgInfos, t)
+		} else {
+			err = w.runReorgJob(t, reorgInfo, tbl.Meta(), d.lease, func() (addIndexErr error) {
+				defer util.Recover(metrics.LabelDDL, "onCreateIndex",
+					func() {
+						addIndexErr = errCancelledDDLJob.GenWithStack("add table `%v` index `%v` panic", tblInfo.Name, indexInfo.Name)
+					}, false)
+				return w.addTableIndex(tbl, indexInfo, reorgInfo)
+			})
 		}
 
-		err = w.runReorgJob(t, reorgInfo, tbl.Meta(), d.lease, func() (addIndexErr error) {
-			defer util.Recover(metrics.LabelDDL, "onCreateIndex",
-				func() {
-					addIndexErr = errCancelledDDLJob.GenWithStack("add table `%v` index `%v` panic", tblInfo.Name, indexInfo.Name)
-				}, false)
-			return w.addTableIndex(tbl, indexInfo, reorgInfo)
-		})
 		if err != nil {
 			if errWaitReorgTimeout.Equal(err) {
 				// if timeout, we should return, check for the owner and re-wait job done.
@@ -1108,15 +1139,15 @@ type addIndexSubTaskRange struct {
 }
 
 type parentJob struct {
-	isParent bool `json:"is_parent"`
+	subTaskNum int64 `json:"sub_task_num"`
 }
 
-func (w *worker) dispatchAddIndexSubTasks(d *ddlCtx, t table.Table, idx *model.IndexInfo, reorgInfos []reorgInfo) error {
+func (w *worker) dispatchAddIndexSubTasks(d *ddlCtx, t table.Table, idx *model.IndexInfo, reorgInfos []reorgInfo, m *meta.Meta) (err error) {
 	var (
-		job                   *model.Job
-		err                   error
-		addIndexSubTaskRanges []addIndexSubTaskRange
-		subTasks              []*SubTask
+		job         *model.Job
+		subTasks    []*SubTask
+		startHandle kv.Handle
+		endHandle   kv.Handle
 	)
 	job = reorgInfos[0].Job
 	if tbl, ok := t.(table.PartitionedTable); ok {
@@ -1126,8 +1157,17 @@ func (w *worker) dispatchAddIndexSubTasks(d *ddlCtx, t table.Table, idx *model.I
 				return errors.Trace(err)
 			}
 			for _, kvRange := range kvRanges {
-				item := addIndexSubTaskRange{kvRange, reorgInfo.PhysicalTableID}
-				addIndexSubTaskRanges = append(addIndexSubTaskRanges, item)
+				startHandle, endHandle, err = decodeHandleRange(kvRange)
+				tid := int64(len(subTasks))
+				subTask := SubTask{
+					taskID:   tid,
+					jobID:    job.ID,
+					TaskType: addIndexSubTaskType,
+				}
+				addSubTask := addIndexSubTask{idx, tbl.Meta().IsCommonHandle}
+				subTask.Args = append(subTask.Args, addSubTask.IndexInfo)
+				subTasks = append(subTasks, &subTask)
+				m.UpdateDDLSubTaskReorgInfo(job.ID, tid, startHandle, endHandle, reorgInfo.PhysicalTableID, "", Unclaimed)
 			}
 		}
 	} else {
@@ -1136,34 +1176,34 @@ func (w *worker) dispatchAddIndexSubTasks(d *ddlCtx, t table.Table, idx *model.I
 			return errors.Trace(err)
 		}
 		for _, kvRange := range kvRanges {
-			item := addIndexSubTaskRange{kvRange, reorgInfos[0].PhysicalTableID}
-			addIndexSubTaskRanges = append(addIndexSubTaskRanges, item)
+			startHandle, endHandle, err = decodeHandleRange(kvRange)
+			tid := int64(len(subTasks))
+			subTask := SubTask{
+				taskID:   tid,
+				jobID:    job.ID,
+				TaskType: addIndexSubTaskType,
+			}
+			addSubTask := addIndexSubTask{idx, tbl.Meta().IsCommonHandle}
+			subTask.Args = append(subTask.Args, addSubTask.IndexInfo)
+			subTasks = append(subTasks, &subTask)
+			m.UpdateDDLSubTaskReorgInfo(job.ID, tid, startHandle, endHandle, reorgInfos[0].PhysicalTableID, "", Unclaimed)
 		}
 	}
-
-	sessCtx := newContext(reorgInfos[0].d.store)
-	servers, err := infoschema.GetTiDBServerInfo(sessCtx)
 	if err != nil {
 		return errors.Trace(err)
 	}
-	minRangeSizeForEachTask := len(addIndexSubTaskRanges) / len(servers)
-	decodeColMap, err := makeupDecodeColMap(sessCtx, t)
+	parentJob := parentJob{int64(len(subTasks))}
+	job.Args = append(job.Args, parentJob.subTaskNum)
 
-	for i := 0; i < len(addIndexSubTaskRanges)-minRangeSizeForEachTask; i = i + minRangeSizeForEachTask {
-		subTask := SubTask{
-			Job:      reorgInfos[0].Job,
-			TaskType: addIndexSubTaskType,
-			runner:   nil,
-			Status:   unclaimed,
-		}
-		addSubTask := addIndexSubTask{idx, addIndexSubTaskRanges[i : i+minRangeSizeForEachTask], decodeColMap}
-		subTask.Args = append(subTask.Args, addSubTask.IndexInfo, addSubTask.decodeColMap, addSubTask.AddIndexSubTaskRanges)
-		subTasks = append(subTasks, &subTask)
+	err = d.addBatchTaskToQueue(subTasks)
+	if err != nil {
+		return errors.Trace(err)
 	}
-	parentJob := parentJob{true}
-	job.Args = append(job.Args, parentJob.isParent)
-	//TODO mark the job as parent job with add json agrs isParent to true
-	err = d.AddBatchTaskToQueue(subTasks)
+	err = m.UpdateDDLJob(0, job, true)
+
+	if err != nil {
+		//TODO delete subTasks from subTask queue, when update ddl job faild
+	}
 	return errors.Trace(err)
 }
 

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -547,6 +547,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 			return ver, errors.Trace(err)
 		}
 
+		//TODO set a proper value later
 		var limit int64 = 1000000
 
 		//TODO Check the job is the parent job first, if it is, it will only do the following two things:

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -541,6 +541,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 		}
 
 		reorgInfo, err := getReorgInfo(d, t, job, tbl)
+
 		if err != nil || reorgInfo.first {
 			// If we run reorg firstly, we should update the job snapshot version
 			// and then run the reorg next time.

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1237,6 +1237,9 @@ func splitTableToKVRanges(physicalTable table.PhysicalTable, d *ddlCtx, job *mod
 func convertFromKvRangeToAddIndexSubTasks(kvRanges []kv.KeyRange, physicalTable table.PhysicalTable, job *model.Job, t *meta.Meta, idx *model.IndexInfo, tbleInfo *model.TableInfo, allSubTasks []*meta.SubTask) (subTasks []*meta.SubTask, err error) {
 	for _, kvRange := range kvRanges {
 		startHandle, endHandle, err := decodeHandleRange(kvRange)
+		if err != nil {
+			return allSubTasks, errors.Trace(err)
+		}
 		taskID := int64(len(allSubTasks) + 1)
 		subTask := meta.SubTask{
 			TaskID:   taskID,

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -394,7 +394,7 @@ func (w *worker) onCreateIndexSubTask(d *ddlCtx, t *meta.Meta, subTask *meta.Sub
 	if err != nil {
 		return errors.Trace(err)
 	}
-	physicalTableID, err := t.GetReorgSubTaskPhysicalTableId(subTask.JobID, subTask.TaskID)
+	physicalTableID, err := t.GetReorgSubTaskPhysicalTableID(subTask.JobID, subTask.TaskID)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -1181,8 +1181,8 @@ func (w *worker) dispatchAddIndexSubTasks(d *ddlCtx, tbl table.Table, tblInfo *m
 	err = kv.RunInNewTxn(d.store, false, func(txn kv.Transaction) error {
 		t := meta.NewMeta(txn, meta.SubTaskListKey)
 		if tbl, ok := tbl.(table.PartitionedTable); ok {
-			for _, partitionId := range getPartitionIDs(tbl.Meta()) {
-				currentTable := tbl.GetPartition(partitionId)
+			for _, partitionID := range getPartitionIDs(tbl.Meta()) {
+				currentTable := tbl.GetPartition(partitionID)
 				kvRanges, err := splitTableToKVRanges(currentTable, d, job)
 				if err != nil {
 					return errors.Trace(err)

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -678,7 +678,7 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 
 func getParentJobSubTaskNum(job *model.Job) (ver int64, err error) {
 	var parentJob meta.ParentJob
-	err = job.DecodeArgs(&parentJob)
+	err = job.DecodeArgs(&parentJob.SubTaskNum)
 	return parentJob.SubTaskNum, errors.Trace(err)
 }
 

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -15,7 +15,6 @@ package ddl
 
 import (
 	"context"
-	"github.com/pingcap/tidb/sessionctx/variable"
 	"math"
 	"strings"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -237,7 +237,7 @@ func (w *worker) isReorgRunnable(d *ddlCtx) error {
 	}
 
 	if !d.isOwner() {
-		if w.typeStr() == subTaskTypeStr {
+		if w.typeStr() == meta.SubTaskTypeStr {
 			return nil
 		}
 		// If it's not the owner, we will try later, so here just returns an error.
@@ -264,14 +264,14 @@ type reorgInfo struct {
 }
 
 type subTaskReorgInfo struct {
-	*SubTask
+	*meta.SubTask
 	StartHandle kv.Handle
 	// EndHandle is the last handle of the adding indices table.
 	EndHandle       kv.Handle
 	d               *ddlCtx
 	PhysicalTableID int64
 
-	Status SubTaskStatus
+	Status meta.SubTaskStatus
 
 	Runner string
 }

--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -274,6 +274,8 @@ type subTaskReorgInfo struct {
 	Status meta.SubTaskStatus
 
 	Runner string
+
+	StartTime int64
 }
 
 func (r *reorgInfo) String() string {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -579,12 +579,8 @@ func (m *Meta) enQueueDDLSubTask(key []byte, task *ddl.SubTask) error {
 	return errors.Trace(err)
 }
 
-func (m *Meta) EnQueueDDLSubTask(task *ddl.SubTask, jobListKeys ...JobListKeyType) error {
-	listKey := m.jobListKey
-	if len(jobListKeys) != 0 {
-		listKey = jobListKeys[0]
-	}
-	return m.enQueueDDLSubTask(listKey, task)
+func (m *Meta) EnQueueDDLSubTask(task *ddl.SubTask) error {
+	return m.enQueueDDLSubTask(SubTaskListKey, task)
 }
 
 func (m *Meta) enQueueDDLJob(key []byte, job *model.Job) error {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -577,7 +577,7 @@ func (m *Meta) enQueueDDLSubTask(key []byte, task *SubTask) error {
 	return errors.Trace(err)
 }
 
-// add one subTask to subTask queue
+//EnQueueDDLSubTask: add one subTask to subTask queue
 func (m *Meta) EnQueueDDLSubTask(task *SubTask) error {
 	return m.enQueueDDLSubTask(SubTaskListKey, task)
 }
@@ -622,7 +622,7 @@ func (m *Meta) deQueueDDLJob(key []byte) (*model.Job, error) {
 	return job, errors.Trace(err)
 }
 
-// get a subTask from subTaskQueue
+//DeQueueDDLSubTask get a subTask from subTaskQueue
 func (m *Meta) DeQueueDDLSubTask() (*SubTask, error) {
 	return m.dequeueDDLSubTask(m.jobListKey)
 }
@@ -663,7 +663,7 @@ func (m *Meta) getDDLJob(key []byte, index int64) (*model.Job, error) {
 	return job, errors.Trace(err)
 }
 
-// get a SubTask from SubTaskQueue by index
+//GetDDLSubTaskByIdx get a SubTask from SubTaskQueue by index
 func (m *Meta) GetDDLSubTaskByIdx(index int64, jobListKeys ...JobListKeyType) (subTask *SubTask, err error) {
 	listKey := m.jobListKey
 	if len(jobListKeys) != 0 {
@@ -756,7 +756,7 @@ func (m *Meta) GetAllDDLJobsInQueue(jobListKeys ...JobListKeyType) ([]*model.Job
 	return jobs, nil
 }
 
-// get all subTasks by from subTaskQueue
+//GetAllDDLSubTaskInQueue: get all subTasks by from subTaskQueue
 func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTask, error) {
 	listKey := m.jobListKey
 	if len(jobListKeys) != 0 {
@@ -821,9 +821,9 @@ func (m *Meta) reorgSubTaskRunner(jobID int64, subTaskID int64) []byte {
 	return b
 }
 
-func (m *Meta) reorgSubTaskStatus(jobId int64, subTaskID int64) []byte {
+func (m *Meta) reorgSubTaskStatus(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 13)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
 	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_stat"...)
 	return b
@@ -1019,7 +1019,7 @@ func (m *Meta) UpdateDDLReorgHandle(job *model.Job, startHandle, endHandle kv.Ha
 	return errors.Trace(err)
 }
 
-// update the Reorg info of a subTask
+//UpdateDDLSubTaskReorgInfo
 func (m *Meta) UpdateDDLSubTaskReorgInfo(jobID int64, subTaskID int64, startHandle, endHandle kv.Handle, physicalTableID int64, runner string, status SubTaskStatus, count int64) error {
 	err := SetReorgSubTaskFiledHandle(m.txn, m.reorgSubTaskStartHandle(jobID, subTaskID), startHandle)
 	if err != nil {
@@ -1048,13 +1048,13 @@ func (m *Meta) UpdateDDLSubTaskReorgInfo(jobID int64, subTaskID int64, startHand
 	return errors.Trace(err)
 }
 
-// set the uuid to SubTask reorgInfo, if the SubTask is claimed
+//SetReorgSubTaskRunner set the uuid to SubTask reorgInfo, if the SubTask is claimed
 func (m *Meta) SetReorgSubTaskRunner(jobID int64, subTaskID int64, runner string) (err error) {
 	err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobID, subTaskID), []byte(runner))
 	return errors.Trace(err)
 }
 
-// set the startTime to SubTask reorgInfo, if the SubTask is claimed
+//SetReorgSubTaskStartTime set the startTime to SubTask reorgInfo, if the SubTask is claimed
 func (m *Meta) SetReorgSubTaskStartTime(jobID int64, subTaskID int64, startTime int64) (err error) {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, uint64(startTime))
@@ -1062,7 +1062,7 @@ func (m *Meta) SetReorgSubTaskStartTime(jobID int64, subTaskID int64, startTime 
 	return errors.Trace(err)
 }
 
-// set the status to SubTask reorgInfo
+//SetReorgSubTaskStatus set the status to SubTask reorgInfo
 func (m *Meta) SetReorgSubTaskStatus(jobID int64, subTaskID int64, status SubTaskStatus) (err error) {
 	switch status {
 	case Running:
@@ -1081,7 +1081,7 @@ func (m *Meta) SetReorgSubTaskStatus(jobID int64, subTaskID int64, status SubTas
 	return errors.Trace(err)
 }
 
-// set the rowCount to SubTask reorgInfo
+//SetReorgSubTaskRowCount set the rowCount to SubTask reorgInfo
 func (m *Meta) SetReorgSubTaskRowCount(jobID int64, subTaskID int64, count int64) (err error) {
 	err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskRowCount(jobID, subTaskID), []byte(strconv.FormatInt(count, 10)))
 	return errors.Trace(err)
@@ -1129,7 +1129,7 @@ func (m *Meta) RemoveDDLReorgHandle(job *model.Job) error {
 	return nil
 }
 
-// RemoveDDL removes the SubTask reorganization related handles.
+//RemoveDDLSubTaskReorgHandle RemoveDDL removes the SubTask reorganization related handles.
 func (m *Meta) RemoveDDLSubTaskReorgHandle(jobID int64, subTaskID int64) error {
 	err := m.txn.HDel(mDDLSubTaskReorgKey, m.reorgSubTaskStartHandle(jobID, subTaskID))
 	if err != nil {
@@ -1156,6 +1156,7 @@ func (m *Meta) RemoveDDLSubTaskReorgHandle(jobID int64, subTaskID int64) error {
 	return nil
 }
 
+//GetDDLSubTaskReorgInfo get the reorgInfo of a SubTask
 func (m *Meta) GetDDLSubTaskReorgInfo(jobID int64, subTaskID int64, isCommonHandle bool) (startHandle, endHandle kv.Handle, physicalTableID int64, runner string, status SubTaskStatus, count int64, startTime int64, err error) {
 	startHandle, err = getReorgSubTaskFieldHandle(m.txn, m.reorgSubTaskStartHandle(jobID, subTaskID), isCommonHandle)
 	if err != nil {
@@ -1242,13 +1243,13 @@ func getReorgSubTaskFieldHandle(t *structure.TxStructure, reorgSubTaskField []by
 	return kv.IntHandle(n), nil
 }
 
-// get runner uuid
-func (m *Meta) GetReorgSubTaskRunner(jobId int64, taskID int64) (runner string, err error) {
-	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobId, taskID))
+//GetReorgSubTaskRunner: get the runner's ddl uuid
+func (m *Meta) GetReorgSubTaskRunner(jobID int64, taskID int64) (runner string, err error) {
+	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobID, taskID))
 	return string(bs[:]), errors.Trace(err)
 }
 
-// get the processed row count of subTask
+//GetRorgSubTaskRowCount get the processed row count of subTask
 func (m *Meta) GetRorgSubTaskRowCount(jobID int64, taskID int64) (rowCount int64, err error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRowCount(jobID, taskID))
 	if err != nil {
@@ -1261,7 +1262,7 @@ func (m *Meta) GetRorgSubTaskRowCount(jobID int64, taskID int64) (rowCount int64
 	return count, errors.Trace(err)
 }
 
-// get the start time of the runner claiming subtask
+//GetReorgSubTaskStartTime get the start time of the runner claiming subtask
 func (m *Meta) GetReorgSubTaskStartTime(jobID int64, taskID int64) (int64, error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStartTime(jobID, taskID))
 	if err != nil {
@@ -1274,9 +1275,9 @@ func (m *Meta) GetReorgSubTaskStartTime(jobID int64, taskID int64) (int64, error
 	return startTime, errors.Trace(err)
 }
 
-// get the status of the runner claiming subtask
-func (m *Meta) GetReorgSubTaskStatus(jobId int64, taskID int64) (status SubTaskStatus, err error) {
-	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobId, taskID))
+//GetReorgSubTaskStatus get the status of the runner claiming subtask
+func (m *Meta) GetReorgSubTaskStatus(jobID int64, taskID int64) (status SubTaskStatus, err error) {
+	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, taskID))
 	var n int64
 	n, err = strconv.ParseInt(string(bs), 10, 64)
 	switch n {
@@ -1295,13 +1296,13 @@ func (m *Meta) GetReorgSubTaskStatus(jobId int64, taskID int64) (status SubTaskS
 	}
 }
 
-// get the subTask physicalTable ID from ReorgInfo.
+//GetReorgSubTaskPhysicalTableID get the subTask physicalTable ID from ReorgInfo.
 func (m *Meta) GetReorgSubTaskPhysicalTableID(jobID int64, subTaskID int64) (physcialID int64, err error) {
 	physicalTableID, err := m.txn.HGetInt64(mDDLSubTaskReorgKey, m.reorgSubTaskPhysicalTableID(jobID, subTaskID))
 	return physicalTableID, errors.Trace(err)
 }
 
-// Check if the subTask is claimed
+//IsUnClaimedSubTask Check if the subTask is claimed
 func (m *Meta) IsUnClaimedSubTask(jobID int64, subTaskID int64) (isClaimed bool, err error) {
 	runner, err := m.GetReorgSubTaskRunner(jobID, subTaskID)
 	if err != nil {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1071,7 +1071,7 @@ func (m *Meta) SetReorgSubTaskStatus(jobID int64, subTaskID int64, status SubTas
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(2, 10)))
 	case Success:
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(3, 10)))
-	case Recorganized:
+	case Reorganized:
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(4, 10)))
 	case UNKOWN:
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(10, 10)))
@@ -1281,7 +1281,7 @@ func (m *Meta) GetReorgSubTaskStatus(jobId int64, taskID int64) (status SubTaskS
 	case 3:
 		return Success, errors.Trace(err)
 	case 4:
-		return Recorganized, errors.Trace(err)
+		return Reorganized, errors.Trace(err)
 	default:
 		return UNKOWN, errors.Trace(err)
 	}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -607,7 +607,7 @@ func (m *Meta) dequeueDDLSubTask(key []byte) (*SubTask, error) {
 	}
 
 	subTask := &SubTask{}
-	err = subTask.decode(value)
+	err = subTask.Decode(value)
 	return subTask, errors.Trace(err)
 }
 
@@ -640,7 +640,7 @@ func (m *Meta) getDDLSubTask(key []byte, index int64) (*SubTask, error) {
 
 	subTask := &SubTask{}
 
-	err = subTask.decode(value)
+	err = subTask.Decode(value)
 	return subTask, errors.Trace(err)
 }
 
@@ -771,7 +771,7 @@ func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTas
 	subTasks := make([]*SubTask, 0, len(values))
 	for _, val := range values {
 		subTask := &SubTask{}
-		err = subTask.decode(val)
+		err = subTask.Decode(val)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -68,13 +68,6 @@ var (
 	mBootstrapKey     = []byte("BootstrapKey")
 	mSchemaDiffPrefix = "Diff"
 )
-
-const (
-	RunnerEmptyStr = ""
-
-	RunnerErrStr = " "
-)
-
 var (
 	// ErrDBExists is the error for db exists.
 	ErrDBExists = terror.ClassMeta.New(mysql.ErrDBCreateExists, mysql.MySQLErrName[mysql.ErrDBCreateExists])
@@ -572,17 +565,19 @@ var (
 	// AddIndexJobListKey only keeps the action of adding index.
 	AddIndexJobListKey JobListKeyType = mDDLJobAddIdxList
 
+	// SubTaskListKey keeps all actions of DDL SubTasks
 	SubTaskListKey JobListKeyType = mDDLSubTaskKey
 )
 
 func (m *Meta) enQueueDDLSubTask(key []byte, task *SubTask) error {
-	b, err := task.Encode(true)
+	b, err := task.encode(true)
 	if err == nil {
 		err = m.txn.RPush(key, b)
 	}
 	return errors.Trace(err)
 }
 
+// add one subTask to subTask queue
 func (m *Meta) EnQueueDDLSubTask(task *SubTask) error {
 	return m.enQueueDDLSubTask(SubTaskListKey, task)
 }
@@ -612,7 +607,7 @@ func (m *Meta) dequeueDDLSubTask(key []byte) (*SubTask, error) {
 	}
 
 	subTask := &SubTask{}
-	err = subTask.Decode(value)
+	err = subTask.decode(value)
 	return subTask, errors.Trace(err)
 }
 
@@ -627,6 +622,7 @@ func (m *Meta) deQueueDDLJob(key []byte) (*model.Job, error) {
 	return job, errors.Trace(err)
 }
 
+// get a subTask from subTaskQueue
 func (m *Meta) DeQueueDDLSubTask() (*SubTask, error) {
 	return m.dequeueDDLSubTask(m.jobListKey)
 }
@@ -644,7 +640,7 @@ func (m *Meta) getDDLSubTask(key []byte, index int64) (*SubTask, error) {
 
 	subTask := &SubTask{}
 
-	err = subTask.Decode(value)
+	err = subTask.decode(value)
 	return subTask, errors.Trace(err)
 }
 
@@ -667,6 +663,7 @@ func (m *Meta) getDDLJob(key []byte, index int64) (*model.Job, error) {
 	return job, errors.Trace(err)
 }
 
+// get a SubTask from SubTaskQueue by index
 func (m *Meta) GetDDLSubTaskByIdx(index int64, jobListKeys ...JobListKeyType) (subTask *SubTask, err error) {
 	listKey := m.jobListKey
 	if len(jobListKeys) != 0 {
@@ -759,6 +756,7 @@ func (m *Meta) GetAllDDLJobsInQueue(jobListKeys ...JobListKeyType) ([]*model.Job
 	return jobs, nil
 }
 
+// get all subTasks by from subTaskQueue
 func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTask, error) {
 	listKey := m.jobListKey
 	if len(jobListKeys) != 0 {
@@ -773,7 +771,7 @@ func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTas
 	subTasks := make([]*SubTask, 0, len(values))
 	for _, val := range values {
 		subTask := &SubTask{}
-		err = subTask.Decode(val)
+		err = subTask.decode(val)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -783,50 +781,50 @@ func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTas
 	return subTasks, nil
 }
 
-func (m *Meta) reorgSubTaskStartHandle(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskStartHandle(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 14)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_start"...)
 	return b
 }
 
-func (m *Meta) reorgSubTaskEndHandle(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskEndHandle(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 12)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_end"...)
 	return b
 }
 
-func (m *Meta) reorgSubTaskPhysicalTableID(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskPhysicalTableID(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 12)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_pid"...)
 	return b
 }
 
-func (m *Meta) reorgSubTaskStartTime(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskStartTime(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 12)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_time"...)
 	return b
 }
 
-func (m *Meta) reorgSubTaskRunner(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskRunner(jobID int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 15)
-	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(jobID))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_runner"...)
 	return b
 }
 
-func (m *Meta) reorgSubTaskStatus(jobId int64, subTaskId int64) []byte {
+func (m *Meta) reorgSubTaskStatus(jobId int64, subTaskID int64) []byte {
 	b := make([]byte, 8, 13)
 	binary.BigEndian.PutUint64(b, uint64(jobId))
-	binary.BigEndian.PutUint64(b, uint64(subTaskId))
+	binary.BigEndian.PutUint64(b, uint64(subTaskID))
 	b = append(b, "_stat"...)
 	return b
 }
@@ -1021,6 +1019,7 @@ func (m *Meta) UpdateDDLReorgHandle(job *model.Job, startHandle, endHandle kv.Ha
 	return errors.Trace(err)
 }
 
+// update the Reorg info of a subTask
 func (m *Meta) UpdateDDLSubTaskReorgInfo(jobID int64, subTaskID int64, startHandle, endHandle kv.Handle, physicalTableID int64, runner string, status SubTaskStatus, count int64) error {
 	err := SetReorgSubTaskFiledHandle(m.txn, m.reorgSubTaskStartHandle(jobID, subTaskID), startHandle)
 	if err != nil {
@@ -1049,11 +1048,13 @@ func (m *Meta) UpdateDDLSubTaskReorgInfo(jobID int64, subTaskID int64, startHand
 	return errors.Trace(err)
 }
 
+// set the uuid to SubTask reorgInfo, if the SubTask is claimed
 func (m *Meta) SetReorgSubTaskRunner(jobID int64, subTaskID int64, runner string) (err error) {
 	err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobID, subTaskID), []byte(runner))
 	return errors.Trace(err)
 }
 
+// set the startTime to SubTask reorgInfo, if the SubTask is claimed
 func (m *Meta) SetReorgSubTaskStartTime(jobID int64, subTaskID int64, startTime int64) (err error) {
 	b := make([]byte, 8)
 	binary.BigEndian.PutUint64(b, uint64(startTime))
@@ -1061,6 +1062,7 @@ func (m *Meta) SetReorgSubTaskStartTime(jobID int64, subTaskID int64, startTime 
 	return errors.Trace(err)
 }
 
+// set the status to SubTask reorgInfo
 func (m *Meta) SetReorgSubTaskStatus(jobID int64, subTaskID int64, status SubTaskStatus) (err error) {
 	switch status {
 	case Running:
@@ -1073,12 +1075,13 @@ func (m *Meta) SetReorgSubTaskStatus(jobID int64, subTaskID int64, status SubTas
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(3, 10)))
 	case Reorganized:
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(4, 10)))
-	case UNKOWN:
+	case UNKNOWN:
 		err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobID, subTaskID), []byte(strconv.FormatInt(10, 10)))
 	}
 	return errors.Trace(err)
 }
 
+// set the rowCount to SubTask reorgInfo
 func (m *Meta) SetReorgSubTaskRowCount(jobID int64, subTaskID int64, count int64) (err error) {
 	err = m.txn.HSet(mDDLSubTaskReorgKey, m.reorgSubTaskRowCount(jobID, subTaskID), []byte(strconv.FormatInt(count, 10)))
 	return errors.Trace(err)
@@ -1097,6 +1100,7 @@ func setReorgJobFieldHandle(t *structure.TxStructure, reorgJobField []byte, hand
 	return t.HSet(mDDLJobReorgKey, reorgJobField, handleEncodedBytes)
 }
 
+// SetReorgSubTaskFiledHandle set the subTask reorganization related handlel
 func SetReorgSubTaskFiledHandle(t *structure.TxStructure, reorgSubTaskField []byte, handle kv.Handle) error {
 	if handle == nil {
 		return nil
@@ -1155,32 +1159,32 @@ func (m *Meta) RemoveDDLSubTaskReorgHandle(jobID int64, subTaskID int64) error {
 func (m *Meta) GetDDLSubTaskReorgInfo(jobID int64, subTaskID int64, isCommonHandle bool) (startHandle, endHandle kv.Handle, physicalTableID int64, runner string, status SubTaskStatus, count int64, startTime int64, err error) {
 	startHandle, err = getReorgSubTaskFieldHandle(m.txn, m.reorgSubTaskStartHandle(jobID, subTaskID), isCommonHandle)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
 	endHandle, err = getReorgSubTaskFieldHandle(m.txn, m.reorgSubTaskEndHandle(jobID, subTaskID), isCommonHandle)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
-	physicalTableID, err = m.GetReorgSubTaskPhysicalTableId(jobID, subTaskID)
+	physicalTableID, err = m.GetReorgSubTaskPhysicalTableID(jobID, subTaskID)
 	if err != nil {
 		err = errors.Trace(err)
 		return
 	}
 	runner, err = m.GetReorgSubTaskRunner(jobID, subTaskID)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
 	status, err = m.GetReorgSubTaskStatus(jobID, subTaskID)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
 	count, err = m.GetRorgSubTaskRowCount(jobID, subTaskID)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
 	startTime, err = m.GetReorgSubTaskStartTime(jobID, subTaskID)
 	if err != nil {
-		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
+		return nil, nil, 0, RunnerEmptyStr, UNKNOWN, 0, 0, errors.Trace(err)
 	}
 	return startHandle, endHandle, physicalTableID, runner, status, count, startTime, errors.Trace(err)
 }
@@ -1238,11 +1242,13 @@ func getReorgSubTaskFieldHandle(t *structure.TxStructure, reorgSubTaskField []by
 	return kv.IntHandle(n), nil
 }
 
+// get runner uuid
 func (m *Meta) GetReorgSubTaskRunner(jobId int64, taskID int64) (runner string, err error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobId, taskID))
 	return string(bs[:]), errors.Trace(err)
 }
 
+// get the processed row count of subTask
 func (m *Meta) GetRorgSubTaskRowCount(jobID int64, taskID int64) (rowCount int64, err error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRowCount(jobID, taskID))
 	if err != nil {
@@ -1255,6 +1261,7 @@ func (m *Meta) GetRorgSubTaskRowCount(jobID int64, taskID int64) (rowCount int64
 	return count, errors.Trace(err)
 }
 
+// get the start time of the runner claiming subtask
 func (m *Meta) GetReorgSubTaskStartTime(jobID int64, taskID int64) (int64, error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStartTime(jobID, taskID))
 	if err != nil {
@@ -1267,6 +1274,7 @@ func (m *Meta) GetReorgSubTaskStartTime(jobID int64, taskID int64) (int64, error
 	return startTime, errors.Trace(err)
 }
 
+// get the status of the runner claiming subtask
 func (m *Meta) GetReorgSubTaskStatus(jobId int64, taskID int64) (status SubTaskStatus, err error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStatus(jobId, taskID))
 	var n int64
@@ -1283,15 +1291,17 @@ func (m *Meta) GetReorgSubTaskStatus(jobId int64, taskID int64) (status SubTaskS
 	case 4:
 		return Reorganized, errors.Trace(err)
 	default:
-		return UNKOWN, errors.Trace(err)
+		return UNKNOWN, errors.Trace(err)
 	}
 }
 
-func (m *Meta) GetReorgSubTaskPhysicalTableId(jobID int64, subTaskID int64) (physcialId int64, err error) {
+// get the subTask physicalTable ID from ReorgInfo.
+func (m *Meta) GetReorgSubTaskPhysicalTableID(jobID int64, subTaskID int64) (physcialID int64, err error) {
 	physicalTableID, err := m.txn.HGetInt64(mDDLSubTaskReorgKey, m.reorgSubTaskPhysicalTableID(jobID, subTaskID))
 	return physicalTableID, errors.Trace(err)
 }
 
+// Check if the subTask is claimed
 func (m *Meta) IsUnClaimedSubTask(jobID int64, subTaskID int64) (isClaimed bool, err error) {
 	runner, err := m.GetReorgSubTaskRunner(jobID, subTaskID)
 	if err != nil {
@@ -1303,9 +1313,8 @@ func (m *Meta) IsUnClaimedSubTask(jobID int64, subTaskID int64) (isClaimed bool,
 	}
 	if runner == RunnerEmptyStr && status == Unclaimed {
 		return true, nil
-	} else {
-		return false, nil
 	}
+	return false, nil
 }
 
 func getReorgJobFieldHandle(t *structure.TxStructure, reorgJobField []byte, isCommonHandle bool) (kv.Handle, error) {

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -577,7 +577,7 @@ func (m *Meta) enQueueDDLSubTask(key []byte, task *SubTask) error {
 	return errors.Trace(err)
 }
 
-//EnQueueDDLSubTask: add one subTask to subTask queue
+//EnQueueDDLSubTask add one subTask to subTask queue
 func (m *Meta) EnQueueDDLSubTask(task *SubTask) error {
 	return m.enQueueDDLSubTask(SubTaskListKey, task)
 }
@@ -756,7 +756,7 @@ func (m *Meta) GetAllDDLJobsInQueue(jobListKeys ...JobListKeyType) ([]*model.Job
 	return jobs, nil
 }
 
-//GetAllDDLSubTaskInQueue: get all subTasks by from subTaskQueue
+//GetAllDDLSubTaskInQueue get all subTasks by from subTaskQueue
 func (m *Meta) GetAllDDLSubTaskInQueue(jobListKeys ...JobListKeyType) ([]*SubTask, error) {
 	listKey := m.jobListKey
 	if len(jobListKeys) != 0 {
@@ -1019,7 +1019,7 @@ func (m *Meta) UpdateDDLReorgHandle(job *model.Job, startHandle, endHandle kv.Ha
 	return errors.Trace(err)
 }
 
-//UpdateDDLSubTaskReorgInfo
+//UpdateDDLSubTaskReorgInfo update the reorg info of a subTask
 func (m *Meta) UpdateDDLSubTaskReorgInfo(jobID int64, subTaskID int64, startHandle, endHandle kv.Handle, physicalTableID int64, runner string, status SubTaskStatus, count int64) error {
 	err := SetReorgSubTaskFiledHandle(m.txn, m.reorgSubTaskStartHandle(jobID, subTaskID), startHandle)
 	if err != nil {
@@ -1243,7 +1243,7 @@ func getReorgSubTaskFieldHandle(t *structure.TxStructure, reorgSubTaskField []by
 	return kv.IntHandle(n), nil
 }
 
-//GetReorgSubTaskRunner: get the runner's ddl uuid
+//GetReorgSubTaskRunner get the runner's ddl uuid
 func (m *Meta) GetReorgSubTaskRunner(jobID int64, taskID int64) (runner string, err error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskRunner(jobID, taskID))
 	return string(bs[:]), errors.Trace(err)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -1178,7 +1178,7 @@ func (m *Meta) GetDDLSubTaskReorgInfo(jobID int64, subTaskID int64, isCommonHand
 	if err != nil {
 		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
 	}
-	startTime, err = m.GetRorgSubTaskStartTime(jobID, subTaskID)
+	startTime, err = m.GetReorgSubTaskStartTime(jobID, subTaskID)
 	if err != nil {
 		return nil, nil, 0, RunnerErrStr, UNKOWN, 0, 0, errors.Trace(err)
 	}
@@ -1255,7 +1255,7 @@ func (m *Meta) GetRorgSubTaskRowCount(jobID int64, taskID int64) (rowCount int64
 	return count, errors.Trace(err)
 }
 
-func (m *Meta) GetRorgSubTaskStartTime(jobID int64, taskID int64) (int64, error) {
+func (m *Meta) GetReorgSubTaskStartTime(jobID int64, taskID int64) (int64, error) {
 	bs, err := m.txn.HGet(mDDLSubTaskReorgKey, m.reorgSubTaskStartTime(jobID, taskID))
 	if err != nil {
 		return 0, errors.Trace(err)

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -1,3 +1,16 @@
+// Copyright 2015 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package meta
 
 import (
@@ -7,20 +20,20 @@ import (
 	"github.com/pingcap/parser/model"
 )
 
-//SubTaskType: the ActionType of SubTask
+//SubTaskType the ActionType of a SubTask
 type SubTaskType byte
 
-//SubTaskStatus: status of  SubTask execution
+//SubTaskStatus status of SubTask execution
 type SubTaskStatus byte
 
 const (
-	//AddIndexSubTaskType: subTaskActionType of addIndex
+	//AddIndexSubTaskType subTaskActionType of addIndex
 	AddIndexSubTaskType SubTaskType = 1
 
-	//RunnerEmptyStr: When the subTask status is not executed or empty
+	//RunnerEmptyStr When the subTask status is not executed or empty
 	RunnerEmptyStr = ""
 
-	//SubTaskTypeStr: SubTask worker type str
+	//SubTaskTypeStr SubTask worker type str
 	SubTaskTypeStr = "subTask"
 )
 

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -2,6 +2,7 @@ package meta
 
 import (
 	"encoding/json"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 )

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -17,13 +17,17 @@ const (
 )
 
 const (
-	Running      SubTaskStatus = 0
-	Unclaimed    SubTaskStatus = 1
-	Failed       SubTaskStatus = 2
-	Success      SubTaskStatus = 3
-	Recorganized SubTaskStatus = 4
-	UNKOWN       SubTaskStatus = 10
+	Running     SubTaskStatus = 0
+	Unclaimed   SubTaskStatus = 1
+	Failed      SubTaskStatus = 2
+	Success     SubTaskStatus = 3
+	Reorganized SubTaskStatus = 4
+	UNKOWN      SubTaskStatus = 10
 )
+
+type ParentJob struct {
+	SubTaskNum int64 `json:"sub_task_num"`
+}
 
 type SubTask struct {
 	JobID    int64           `json:"jobId"`

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -1,0 +1,79 @@
+package meta
+
+import (
+	"encoding/json"
+	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/model"
+)
+
+type SubTaskType byte
+
+type SubTaskStatus byte
+
+const (
+	AddIndexSubTaskType SubTaskType = 1
+
+	SubTaskTypeStr = "subTask"
+)
+
+const (
+	Running      SubTaskStatus = 0
+	Unclaimed    SubTaskStatus = 1
+	Failed       SubTaskStatus = 2
+	Success      SubTaskStatus = 3
+	Recorganized SubTaskStatus = 4
+	UNKOWN       SubTaskStatus = 10
+)
+
+type SubTask struct {
+	JobID    int64           `json:"jobId"`
+	TaskID   int64           `json:"taskID"`
+	TaskType SubTaskType     `json:"taskType"`
+	RawArgs  json.RawMessage `json:"raw_args"`
+	Args     []interface{}   `json:"-"`
+	StartTS  uint64          `json:"start_ts"`
+}
+
+type AddIndexSubTask struct {
+	TableInfo *model.TableInfo `json:"tbl_info"`
+	IndexInfo *model.IndexInfo `json:"index_info"`
+	SchemaID  int64            `json:"schema_id"`
+}
+
+func (task *SubTask) Decode(b []byte) error {
+	err := json.Unmarshal(b, task)
+	return errors.Trace(err)
+}
+
+func (task *SubTask) Encode(updateRawArgs bool) ([]byte, error) {
+	var err error
+	if updateRawArgs {
+		task.RawArgs, err = json.Marshal(task.Args)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
+	}
+	var b []byte
+	b, err = json.Marshal(task)
+	return b, errors.Trace(err)
+}
+
+func (task *SubTask) DecodeArgs(args ...interface{}) error {
+	var rawArgs []json.RawMessage
+	if err := json.Unmarshal(task.RawArgs, &rawArgs); err != nil {
+		return errors.Trace(err)
+	}
+
+	sz := len(rawArgs)
+	if sz > len(args) {
+		sz = len(args)
+	}
+
+	for i := 0; i < sz; i++ {
+		if err := json.Unmarshal(rawArgs[i], args[i]); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	task.Args = args[:sz]
+	return nil
+}

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -7,29 +7,38 @@ import (
 	"github.com/pingcap/parser/model"
 )
 
+// ActionType of SubTask
 type SubTaskType byte
 
 type SubTaskStatus byte
 
 const (
+	// addIndexSubTaskType
 	AddIndexSubTaskType SubTaskType = 1
 
+	//When the subTask status is not executed or empty
+	RunnerEmptyStr = ""
+
+	//SubTask worker type
 	SubTaskTypeStr = "subTask"
 )
 
+// the status of execution SubTask
 const (
 	Running     SubTaskStatus = 0
 	Unclaimed   SubTaskStatus = 1
 	Failed      SubTaskStatus = 2
 	Success     SubTaskStatus = 3
 	Reorganized SubTaskStatus = 4
-	UNKOWN      SubTaskStatus = 10
+	UNKNOWN     SubTaskStatus = 10
 )
 
+// extra attribute for the job that has been split
 type ParentJob struct {
 	SubTaskNum int64 `json:"sub_task_num"`
 }
 
+//  the definition of the  SubTask
 type SubTask struct {
 	JobID    int64           `json:"jobId"`
 	TaskID   int64           `json:"taskID"`
@@ -39,18 +48,19 @@ type SubTask struct {
 	StartTS  uint64          `json:"start_ts"`
 }
 
+//  the definition of the addIndex subTask
 type AddIndexSubTask struct {
 	TableInfo *model.TableInfo `json:"tbl_info"`
 	IndexInfo *model.IndexInfo `json:"index_info"`
 	SchemaID  int64            `json:"schema_id"`
 }
 
-func (task *SubTask) Decode(b []byte) error {
+func (task *SubTask) decode(b []byte) error {
 	err := json.Unmarshal(b, task)
 	return errors.Trace(err)
 }
 
-func (task *SubTask) Encode(updateRawArgs bool) ([]byte, error) {
+func (task *SubTask) encode(updateRawArgs bool) ([]byte, error) {
 	var err error
 	if updateRawArgs {
 		task.RawArgs, err = json.Marshal(task.Args)
@@ -63,7 +73,7 @@ func (task *SubTask) Encode(updateRawArgs bool) ([]byte, error) {
 	return b, errors.Trace(err)
 }
 
-func (task *SubTask) DecodeArgs(args ...interface{}) error {
+func (task *SubTask) decodeArgs(args ...interface{}) error {
 	var rawArgs []json.RawMessage
 	if err := json.Unmarshal(task.RawArgs, &rawArgs); err != nil {
 		return errors.Trace(err)

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -7,23 +7,24 @@ import (
 	"github.com/pingcap/parser/model"
 )
 
-// ActionType of SubTask
+//SubTaskType: the ActionType of SubTask
 type SubTaskType byte
 
+//SubTaskStatus: status of  SubTask execution
 type SubTaskStatus byte
 
 const (
-	// addIndexSubTaskType
+	//AddIndexSubTaskType: subTaskActionType of addIndex
 	AddIndexSubTaskType SubTaskType = 1
 
-	//When the subTask status is not executed or empty
+	//RunnerEmptyStr: When the subTask status is not executed or empty
 	RunnerEmptyStr = ""
 
-	//SubTask worker type
+	//SubTaskTypeStr: SubTask worker type str
 	SubTaskTypeStr = "subTask"
 )
 
-// the status of execution SubTask
+// the status of  SubTask execution
 const (
 	Running     SubTaskStatus = 0
 	Unclaimed   SubTaskStatus = 1
@@ -33,12 +34,12 @@ const (
 	UNKNOWN     SubTaskStatus = 10
 )
 
-// extra attribute for the job that has been split
+//ParentJob extra attribute for the job that has been split
 type ParentJob struct {
 	SubTaskNum int64 `json:"sub_task_num"`
 }
 
-//  the definition of the  SubTask
+//SubTask  the definition of the  SubTask
 type SubTask struct {
 	JobID    int64           `json:"jobId"`
 	TaskID   int64           `json:"taskID"`
@@ -48,13 +49,14 @@ type SubTask struct {
 	StartTS  uint64          `json:"start_ts"`
 }
 
-//  the definition of the addIndex subTask
+//AddIndexSubTask  the definition of the addIndex subTask
 type AddIndexSubTask struct {
 	TableInfo *model.TableInfo `json:"tbl_info"`
 	IndexInfo *model.IndexInfo `json:"index_info"`
 	SchemaID  int64            `json:"schema_id"`
 }
 
+//Decode decode subTask by value
 func (task *SubTask) Decode(b []byte) error {
 	err := json.Unmarshal(b, task)
 	return errors.Trace(err)
@@ -73,7 +75,7 @@ func (task *SubTask) encode(updateRawArgs bool) ([]byte, error) {
 	return b, errors.Trace(err)
 }
 
-// decode specific json args for a SubTask
+//DecodeArgs decode specific json args for a SubTask
 func (task *SubTask) DecodeArgs(args ...interface{}) error {
 	var rawArgs []json.RawMessage
 	if err := json.Unmarshal(task.RawArgs, &rawArgs); err != nil {

--- a/meta/subTask.go
+++ b/meta/subTask.go
@@ -55,7 +55,7 @@ type AddIndexSubTask struct {
 	SchemaID  int64            `json:"schema_id"`
 }
 
-func (task *SubTask) decode(b []byte) error {
+func (task *SubTask) Decode(b []byte) error {
 	err := json.Unmarshal(b, task)
 	return errors.Trace(err)
 }
@@ -73,7 +73,8 @@ func (task *SubTask) encode(updateRawArgs bool) ([]byte, error) {
 	return b, errors.Trace(err)
 }
 
-func (task *SubTask) decodeArgs(args ...interface{}) error {
+// decode specific json args for a SubTask
+func (task *SubTask) DecodeArgs(args ...interface{}) error {
 	var rawArgs []json.RawMessage
 	if err := json.Unmarshal(task.RawArgs, &rawArgs); err != nil {
 		return errors.Trace(err)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #19386

Problem Summary:
Currently, the Add Index operation in the DDL executed by TiDB is executed on a single TiDB instance, which may cause cost too much time when the table being operated on is huge. This improvement is to distribute Index data backfilling work to multiple TiDB instances when the table is huge.

### What is changed and how it works?

#### What's Changed:

We have newly defined SubTask and SubTaskQueue, as well as recording the Reorg information of SubTask execution, and execute subtasks by reading SubTaskQueue and SubTaskReorgInfo among multiple TiDBs. Currently, we only add a new subtask that is addIndexSubTask。

TiDB Owner instance will determine whether the job needs to be splited and create SubTask.

```go
type SubTask struct {
	JobID    int64             `json:"jobId"`
	TaskID   int64             ` json:"taskId"`
	TaskType SubTaskType        `json:"taskType"`
	RawArgs  json.RawMessage    `json:"raw_args"`
	Args     []interface{}      `json:"-"`
    
    // start time of creating subTask
	StartTS  uint64            `json:"start_ts"`
    }
```

TiDB Owner instance will determine whether the job needs to be split and create SubTask. Once the subtask is created, the job will have an additional attribute called SubTaskNum, which represents the number of splits of the current job.

```go
type AddIndexSubTask struct {
	TableInfo *model.TableInfo  `json:"tbl_info"`
	IndexInfo *model.IndexInfo  `json:"index_info"`
	SchemaID  int64            `json:"schema_id"`
}
```

Therefore, every time a job is about to be executed, you can check whether there is a SubTaskNum attribute to know whether the job has been split.

```go
type ParentJob struct {
	SubTaskNum int64 `json:"sub_task_num"`
}
```


After the ParentJob is split, TiDB owner instace will dispatchSubTasks. In this operation, the ReorgInfo of all subtasks will be initialized and recorded for the first time.
```go
type subTaskReorgInfo struct {
	*meta.SubTask
	StartHandle kv.Handle
	// EndHandle is the last handle of the adding indices table.
	EndHandle       kv.Handle
	d               *ddlCtx
	PhysicalTableID int64

	Status meta.SubTaskStatus

	Runner string
	
    // start time of claiming subTask
	StartTime int64
}
```

#### How it Works:

For all non-Owner TiDB instances, they try to claim a fixed number of subtasks from the SubTaskQueue at regular intervals. Once the claim is successful, they begin to execute. The maximum number of subtasks that a single TiDB instance can execute at the same time is fixed. Once the number claimed reaches this number, it will no longer be claimed.

For TiDB owner Instance, it will check the execution of all SubTasks of the current job at regular intervals. If there is a SubTask execution failure, it will record the information of the failed TiDB Instace and reset its status so that other TiDB Instances can continue to claim the task. If the execution of a subtask times out, it will also log and reset its status. In this way, it is ensured that the entire job is not blocked for too long because of the failure of a certain subtask.

### Related changes


### Check List 

Tests 

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note

- add index in parallel.
