### PR TITLE
executor: fix unstable TestCoprocessorOOMAction

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6478,7 +6478,7 @@ func (s *testSerialSuite) TestCoprocessorOOMAction(c *C) {
 	for _, testcase := range testcases {
 		c.Log(testcase.name)
 		// larger than one copResponse, smaller than 2 copResponse
-		quota := 201
+		quota := 199
 		se, err := session.CreateSession4Test(s.store)
 		c.Check(err, IsNil)
 		tk.Se = se

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6477,7 +6477,8 @@ func (s *testSerialSuite) TestCoprocessorOOMAction(c *C) {
 	// assert oom action
 	for _, testcase := range testcases {
 		c.Log(testcase.name)
-		quota := 255
+		// larger than one copResponse, smaller than 2 copResponse
+		quota := 201
 		se, err := session.CreateSession4Test(s.store)
 		c.Check(err, IsNil)
 		tk.Se = se

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -608,7 +608,13 @@ func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan *copRes
 		select {
 		case resp, ok = <-respCh:
 			if it.memTracker != nil && resp != nil {
-				it.memTracker.Consume(-resp.MemSize())
+				consumed := resp.MemSize()
+				failpoint.Inject("testRateLimitActionMockConsume", func(val failpoint.Value) {
+					if val.(bool) {
+						consumed = 100
+					}
+				})
+				it.memTracker.Consume(-consumed)
 			}
 			return
 		case <-it.finishCh:
@@ -642,7 +648,13 @@ func (sender *copIteratorTaskSender) sendToTaskCh(t *copTask) (exit bool) {
 
 func (worker *copIteratorWorker) sendToRespCh(resp *copResponse, respCh chan<- *copResponse, checkOOM bool) (exit bool) {
 	if worker.memTracker != nil && checkOOM {
-		worker.memTracker.Consume(resp.MemSize())
+		consumed := resp.MemSize()
+		failpoint.Inject("testRateLimitActionMockConsume", func(val failpoint.Value) {
+			if val.(bool) {
+				consumed = 100
+			}
+		})
+		worker.memTracker.Consume(consumed)
 	}
 	select {
 	case respCh <- resp:

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -672,6 +672,13 @@ func (it *copIterator) Next(ctx context.Context) (kv.ResultSubset, error) {
 		ok     bool
 		closed bool
 	)
+	// wait unit at least 2 copResponse received.
+	failpoint.Inject("testRateLimitActionMockConsume", func(val failpoint.Value) {
+		if val.(bool) {
+			for it.memTracker.MaxConsumed() < 200 {
+			}
+		}
+	})
 
 	// If data order matters, response should be returned in the same order as copTask slice.
 	// Otherwise all responses are returned from a single channel.

--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -570,8 +570,8 @@ func (it *copIterator) open(ctx context.Context) {
 		sendRate: it.sendRate,
 	}
 	taskSender.respChan = it.respChan
-	go taskSender.run()
 	it.actionOnExceed.setEnabled(true)
+	go taskSender.run()
 }
 
 func (sender *copIteratorTaskSender) run() {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19677 <!-- REMOVE this line if no issue to close -->

For asserting OOMAction in `TestCoprocessorOOMAction`, the testcase for the non keep-order is unstable as the `quota` might be not enough to support the whole query processing.

What's Changed:
Mock the consume data to make `TestCoprocessorOOMAction` stable.

How it Works:

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

* No release note
