### PR TITLE
planner: prune duplicate expr in sort

### DIFF
--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -553,6 +553,31 @@ func (s *testPlanSuite) TestColumnPruning(c *C) {
 	}
 }
 
+func (s *testPlanSuite) TestSortByItemsPruning(c *C) {
+	defer testleak.AfterTest(c)()
+	var (
+		input  []string
+		output [][]string
+	)
+	s.testData.GetTestCases(c, &input, &output)
+	s.testData.OnRecord(func() {
+		output = make([][]string, len(input))
+	})
+
+	ctx := context.Background()
+	for i, tt := range input {
+		comment := Commentf("for %s", tt)
+		stmt, err := s.ParseOneStmt(tt, "", "")
+		c.Assert(err, IsNil, comment)
+
+		p, _, err := BuildLogicalPlan(ctx, s.ctx, stmt, s.is)
+		c.Assert(err, IsNil)
+		lp, err := logicalOptimize(ctx, flagEliminateProjection|flagPredicatePushDown|flagPrunColumns|flagPrunColumnsAgain, p.(LogicalPlan))
+		c.Assert(err, IsNil)
+		s.checkOrderByItems(lp, c, &output[i], comment)
+	}
+}
+
 func (s *testPlanSuite) TestProjectionEliminator(c *C) {
 	defer testleak.AfterTest(c)()
 	tests := []struct {
@@ -617,6 +642,27 @@ func (s *testPlanSuite) checkDataSourceCols(p LogicalPlan, c *C, ans map[int][]s
 	}
 	for _, child := range p.Children() {
 		s.checkDataSourceCols(child, c, ans, comment)
+	}
+}
+
+func (s *testPlanSuite) checkOrderByItems(p LogicalPlan, c *C, colList *[]string, comment CommentInterface) {
+	switch p := p.(type) {
+	case *LogicalSort:
+		s.testData.OnRecord(func() {
+			*colList = make([]string, len(p.ByItems))
+		})
+		for i, col := range p.ByItems {
+			s.testData.OnRecord(func() {
+				(*colList)[i] = col.String()
+			})
+			s := col.String()
+			c.Assert(s, Equals, (*colList)[i], comment)
+		}
+	}
+	children := p.Children()
+	c.Assert(len(children), LessEqual, 1, Commentf("For %v Expected <= 1 Child", comment))
+	for _, child := range children {
+		s.checkOrderByItems(child, c, colList, comment)
 	}
 }
 

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -137,9 +137,15 @@ func (la *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) 
 
 func pruneByItems(old []*util.ByItems) (new []*util.ByItems, parentUsedCols []*expression.Column) {
 	new = make([]*util.ByItems, 0, len(old))
+	seen := make(map[string]expression.Expression, len(old))
 	for _, byItem := range old {
+		hash := string(byItem.Expr.HashCode(nil))
+		possibleDupe, hashMatch := seen[hash]
+		seen[hash] = byItem.Expr
 		cols := expression.ExtractColumns(byItem.Expr)
-		if len(cols) == 0 {
+		if hashMatch && possibleDupe.Equal(nil, byItem.Expr) {
+			// do nothing, should be filtered
+		} else if len(cols) == 0 {
 			if !expression.IsRuntimeConstExpr(byItem.Expr) {
 				new = append(new, byItem)
 			}

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -137,13 +137,13 @@ func (la *LogicalAggregation) PruneColumns(parentUsedCols []*expression.Column) 
 
 func pruneByItems(old []*util.ByItems) (new []*util.ByItems, parentUsedCols []*expression.Column) {
 	new = make([]*util.ByItems, 0, len(old))
-	seen := make(map[string]expression.Expression, len(old))
+	seen := make(map[string]struct{}, len(old))
 	for _, byItem := range old {
 		hash := string(byItem.Expr.HashCode(nil))
-		possibleDupe, hashMatch := seen[hash]
-		seen[hash] = byItem.Expr
+		_, hashMatch := seen[hash]
+		seen[hash] = struct{}{}
 		cols := expression.ExtractColumns(byItem.Expr)
-		if hashMatch && possibleDupe.Equal(nil, byItem.Expr) {
+		if hashMatch {
 			// do nothing, should be filtered
 		} else if len(cols) == 0 {
 			if !expression.IsRuntimeConstExpr(byItem.Expr) {

--- a/planner/core/testdata/plan_suite_unexported_in.json
+++ b/planner/core/testdata/plan_suite_unexported_in.json
@@ -406,7 +406,8 @@
     "name": "TestSortByItemsPruning",
     "cases": [
       "select * from t where a > 1 order by a asc, a asc limit 10",
-      "select * from t where a > 1 order by a asc, b asc, a asc, c asc limit 10"
+      "select * from t where a > 1 order by a asc, b asc, a asc, c asc limit 10",
+      "select * from t where a > 1 order by pow(a, 2) asc, b asc, pow(a, 2) asc, c asc limit 10"
     ]
   },
   {

--- a/planner/core/testdata/plan_suite_unexported_in.json
+++ b/planner/core/testdata/plan_suite_unexported_in.json
@@ -403,6 +403,13 @@
     ]
   },
   {
+    "name": "TestSortByItemsPruning",
+    "cases": [
+      "select * from t where a > 1 order by a asc, a asc limit 10",
+      "select * from t where a > 1 order by a asc, b asc, a asc, c asc limit 10"
+    ]
+  },
+  {
     "name": "TestDeriveNotNullConds",
     "cases": [
       "select * from t t1 inner join t t2 on t1.e = t2.e",

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -740,6 +740,19 @@
     ]
   },
   {
+    "Name": "TestSortByItemsPruning",
+    "Cases": [
+      [
+        "test.t.a"
+      ],
+      [
+        "test.t.a",
+        "test.t.b",
+        "test.t.c"
+      ]
+    ]
+  },
+  {
     "Name": "TestDeriveNotNullConds",
     "Cases": [
       {

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -749,6 +749,11 @@
         "test.t.a",
         "test.t.b",
         "test.t.c"
+      ],
+      [
+        "pow(cast(test.t.a, double BINARY), 2)",
+        "test.t.b",
+        "test.t.c"
       ]
     ]
   },


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20322

Problem Summary: Duplicated ORDER BY condition causes bad execution plan

### What is changed and how it works?

What's Changed: Duplicated expressions are pruned from the logical plan during the preprocessing phase

How it Works: Iterate through the ByItems in the sort plan in order and prune columns that have already been seen. Any duplicates found are always noop sort steps.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Duplicate order by conditions are eliminated
