### PR TITLE
opentracing: fix missing opentracing span issue

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -910,6 +910,7 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 		atomic.StoreUint32(&cc.ctx.GetSessionVars().Killed, 0)
 	}()
 	span := opentracing.StartSpan("server.dispatch")
+	ctx = opentracing.ContextWithSpan(ctx, span)
 
 	t := time.Now()
 	cc.lastPacket = data


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Currently when `opentracing` is enabled, only the `server.dispatch` span will be tracked, but **NONE** of its child spans found in `Jaeger`.


Problem Summary:

### What is changed and how it works?

What's Changed:

update the context with "server.dispatch" span as the root span.

How it Works:

The issue is caused by the missing `opentracing.ContextWithSpan` after "server.dispatch" span created. This PR is just added that.

Without this patch:
![image](https://user-images.githubusercontent.com/3883644/94907205-5d4e7c00-04d2-11eb-846e-5211e2ee3aad.png)


With this patch:
![image](https://user-images.githubusercontent.com/3883644/94907133-4576f800-04d2-11eb-884c-bafda64522bd.png)


### Related changes

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- fix missing opentracing span issue

