### PR TITLE
util: fix chunk‘s offset size which is 8 bytes.

### DIFF
--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -128,7 +128,7 @@ func renewEmpty(chk *Chunk) *Chunk {
 	return newChk
 }
 
-// MemoryUsage returns the total memory usage of a Chunk in B.
+// MemoryUsage returns the total memory usage of a Chunk.
 // We ignore the size of Column.length and Column.nullCount
 // since they have little effect of the total memory usage.
 func (c *Chunk) MemoryUsage() (sum int64) {

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -128,7 +128,7 @@ func renewEmpty(chk *Chunk) *Chunk {
 	return newChk
 }
 
-// MemoryUsage returns the total memory usage of a Chunk.
+// MemoryUsage returns the total memory usage of a Chunk in bytes.
 // We ignore the size of Column.length and Column.nullCount
 // since they have little effect of the total memory usage.
 func (c *Chunk) MemoryUsage() (sum int64) {

--- a/util/chunk/chunk.go
+++ b/util/chunk/chunk.go
@@ -133,7 +133,7 @@ func renewEmpty(chk *Chunk) *Chunk {
 // since they have little effect of the total memory usage.
 func (c *Chunk) MemoryUsage() (sum int64) {
 	for _, col := range c.columns {
-		curColMemUsage := int64(unsafe.Sizeof(*col)) + int64(cap(col.nullBitmap)) + int64(cap(col.offsets)*4) + int64(cap(col.data)) + int64(cap(col.elemBuf))
+		curColMemUsage := int64(unsafe.Sizeof(*col)) + int64(cap(col.nullBitmap)) + int64(cap(col.offsets)*8) + int64(cap(col.data)) + int64(cap(col.elemBuf))
 		sum += curColMemUsage
 	}
 	return

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -560,7 +560,7 @@ func (s *testChunkSuite) TestChunkMemoryUsage(c *check.C) {
 	initCap := 10
 	chk := NewChunkWithCapacity(fieldTypes, initCap)
 
-	//cap(c.nullBitmap) + cap(c.offsets)*4 + cap(c.data) + cap(c.elemBuf)
+	//cap(c.nullBitmap) + cap(c.offsets)*8 + cap(c.data) + cap(c.elemBuf)
 	colUsage := make([]int, len(fieldTypes))
 	colUsage[0] = (initCap+7)>>3 + 0 + initCap*4 + 4
 	colUsage[1] = (initCap+7)>>3 + (initCap+1)*8 + initCap*8 + 0

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -563,8 +563,8 @@ func (s *testChunkSuite) TestChunkMemoryUsage(c *check.C) {
 	//cap(c.nullBitmap) + cap(c.offsets)*4 + cap(c.data) + cap(c.elemBuf)
 	colUsage := make([]int, len(fieldTypes))
 	colUsage[0] = (initCap+7)>>3 + 0 + initCap*4 + 4
-	colUsage[1] = (initCap+7)>>3 + (initCap+1)*4 + initCap*8 + 0
-	colUsage[2] = (initCap+7)>>3 + (initCap+1)*4 + initCap*8 + 0
+	colUsage[1] = (initCap+7)>>3 + (initCap+1)*8 + initCap*8 + 0
+	colUsage[2] = (initCap+7)>>3 + (initCap+1)*8 + initCap*8 + 0
 	colUsage[3] = (initCap+7)>>3 + 0 + initCap*sizeTime + sizeTime
 	colUsage[4] = (initCap+7)>>3 + 0 + initCap*8 + 8
 
@@ -596,7 +596,7 @@ func (s *testChunkSuite) TestChunkMemoryUsage(c *check.C) {
 	chk.AppendDuration(4, durationObj)
 
 	memUsage = chk.MemoryUsage()
-	colUsage[1] = (initCap+7)>>3 + (initCap+1)*4 + cap(chk.columns[1].data) + 0
+	colUsage[1] = (initCap+7)>>3 + (initCap+1)*8 + cap(chk.columns[1].data) + 0
 	expectedUsage = 0
 	for i := range colUsage {
 		expectedUsage += colUsage[i] + int(unsafe.Sizeof(*chk.columns[i]))


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: fix chunk's `offset` memusage calucation.

### What is changed and how it works?

What's Changed: 

How it Works: change `offset` size from 4bytes to 8 bytes.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- fix chunk memusage calucation.