### PR TITLE
Revert "*: record more rpc runtime information in cop runt ... (#1891…

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tipb/go-tipb"
 )
@@ -420,6 +421,11 @@ func (r *mockResultSubset) GetData() []byte { return r.data }
 
 // GetStartKey implements kv.ResultSubset interface.
 func (r *mockResultSubset) GetStartKey() kv.Key { return nil }
+
+// GetExecDetails implements kv.ResultSubset interface.
+func (r *mockResultSubset) GetExecDetails() *execdetails.ExecDetails {
+	return &execdetails.ExecDetails{}
+}
 
 // MemSize implements kv.ResultSubset interface.
 func (r *mockResultSubset) MemSize() int64 { return int64(cap(r.data)) }

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -14,11 +14,7 @@
 package distsql
 
 import (
-	"bytes"
 	"context"
-	"fmt"
-	"sort"
-	"strconv"
 	"sync/atomic"
 	"time"
 
@@ -29,8 +25,6 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
-	"github.com/pingcap/tidb/store/tikv"
-	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/codec"
@@ -88,8 +82,6 @@ type selectResult struct {
 	fetchDuration    time.Duration
 	durationReported bool
 	memTracker       *memory.Tracker
-
-	stats *selectResultRuntimeStats
 }
 
 func (r *selectResult) Fetch(ctx context.Context) {
@@ -137,18 +129,14 @@ func (r *selectResult) fetchResp(ctx context.Context) error {
 		for _, warning := range r.selectResp.Warnings {
 			sc.AppendWarning(terror.ClassTiKV.Synthesize(terror.ErrCode(warning.Code), warning.Msg))
 		}
+		resultDetail := resultSubset.GetExecDetails()
+		r.updateCopRuntimeStats(ctx, resultDetail, resultSubset.RespTime())
 		r.feedback.Update(resultSubset.GetStartKey(), r.selectResp.OutputCounts)
 		r.partialCount++
-
-		hasStats, ok := resultSubset.(CopRuntimeStats)
-		if ok {
-			copStats := hasStats.GetCopRuntimeStats()
-			if copStats != nil {
-				r.updateCopRuntimeStats(ctx, copStats, resultSubset.RespTime())
-				copStats.CopTime = duration
-				sc.MergeExecDetails(&copStats.ExecDetails, nil)
-			}
+		if resultDetail != nil {
+			resultDetail.CopTime = duration
 		}
+		sc.MergeExecDetails(resultDetail, nil)
 		if len(r.selectResp.Chunks) != 0 {
 			break
 		}
@@ -244,8 +232,8 @@ func (r *selectResult) readFromChunk(ctx context.Context, chk *chunk.Chunk) erro
 	return nil
 }
 
-func (r *selectResult) updateCopRuntimeStats(ctx context.Context, copStats *tikv.CopRuntimeStats, respTime time.Duration) {
-	callee := copStats.CalleeAddress
+func (r *selectResult) updateCopRuntimeStats(ctx context.Context, detail *execdetails.ExecDetails, respTime time.Duration) {
+	callee := detail.CalleeAddress
 	if r.rootPlanID <= 0 || r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl == nil || callee == "" {
 		return
 	}
@@ -256,19 +244,8 @@ func (r *selectResult) updateCopRuntimeStats(ctx context.Context, copStats *tikv
 
 		return
 	}
-	if r.stats == nil {
-		stmtCtx := r.ctx.GetSessionVars().StmtCtx
-		id := r.rootPlanID
-		originRuntimeStats := stmtCtx.RuntimeStatsColl.GetRootStats(id)
-		r.stats = &selectResultRuntimeStats{
-			RuntimeStats: originRuntimeStats,
-			backoffSleep: make(map[string]time.Duration),
-			rpcStat:      tikv.NewRegionRequestRuntimeStats(),
-		}
-		r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(id, r.stats)
-	}
-	r.stats.mergeCopRuntimeStats(copStats, respTime)
 
+	r.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RecordOneReaderStats(r.rootPlanID, respTime, detail)
 	for i, detail := range r.selectResp.GetExecutionSummaries() {
 		if detail != nil && detail.TimeProcessedNs != nil &&
 			detail.NumProducedRows != nil && detail.NumIterations != nil {
@@ -310,107 +287,4 @@ func (r *selectResult) Close() error {
 		r.memConsume(-int64(r.selectRespSize))
 	}
 	return r.resp.Close()
-}
-
-// CopRuntimeStats is a interface uses to check whether the result has cop runtime stats.
-type CopRuntimeStats interface {
-	// GetCopRuntimeStats gets the cop runtime stats information.
-	GetCopRuntimeStats() *tikv.CopRuntimeStats
-}
-
-type selectResultRuntimeStats struct {
-	execdetails.RuntimeStats
-	copRespTime      []time.Duration
-	procKeys         []int64
-	backoffSleep     map[string]time.Duration
-	totalProcessTime time.Duration
-	totalWaitTime    time.Duration
-	rpcStat          tikv.RegionRequestRuntimeStats
-}
-
-func (s *selectResultRuntimeStats) mergeCopRuntimeStats(copStats *tikv.CopRuntimeStats, respTime time.Duration) {
-	s.copRespTime = append(s.copRespTime, respTime)
-	s.procKeys = append(s.procKeys, copStats.ProcessedKeys)
-
-	for k, v := range copStats.BackoffSleep {
-		s.backoffSleep[k] += v
-	}
-	s.totalProcessTime += copStats.ProcessTime
-	s.totalWaitTime += copStats.WaitTime
-	s.rpcStat.Merge(copStats.RegionRequestRuntimeStats)
-}
-
-func (s *selectResultRuntimeStats) String() string {
-	buf := bytes.NewBuffer(nil)
-	if s.RuntimeStats != nil {
-		buf.WriteString(s.RuntimeStats.String())
-	}
-	if len(s.copRespTime) > 0 {
-		size := len(s.copRespTime)
-		buf.WriteString(", ")
-		if size == 1 {
-			buf.WriteString(fmt.Sprintf("cop_task: {num: 1, max:%v, proc_keys: %v", s.copRespTime[0], s.procKeys[0]))
-		} else {
-			sort.Slice(s.copRespTime, func(i, j int) bool {
-				return s.copRespTime[i] < s.copRespTime[j]
-			})
-			vMax, vMin := s.copRespTime[size-1], s.copRespTime[0]
-			vP95 := s.copRespTime[size*19/20]
-			sum := 0.0
-			for _, t := range s.copRespTime {
-				sum += float64(t)
-			}
-			vAvg := time.Duration(sum / float64(size))
-
-			sort.Slice(s.procKeys, func(i, j int) bool {
-				return s.procKeys[i] < s.procKeys[j]
-			})
-			keyMax := s.procKeys[size-1]
-			keyP95 := s.procKeys[size*19/20]
-			buf.WriteString(fmt.Sprintf("cop_task: {num: %v, max: %v, min: %v, avg: %v, p95: %v", size, vMax, vMin, vAvg, vP95))
-			if keyMax > 0 {
-				buf.WriteString(", max_proc_keys: ")
-				buf.WriteString(strconv.FormatInt(keyMax, 10))
-				buf.WriteString(", p95_proc_keys: ")
-				buf.WriteString(strconv.FormatInt(keyP95, 10))
-			}
-			if s.totalProcessTime > 0 {
-				buf.WriteString(", tot_proc: ")
-				buf.WriteString(s.totalProcessTime.String())
-				if s.totalWaitTime > 0 {
-					buf.WriteString(", tot_wait: ")
-					buf.WriteString(s.totalWaitTime.String())
-				}
-			}
-		}
-	}
-	copRPC := s.rpcStat.Stats[tikvrpc.CmdCop]
-	if copRPC != nil && copRPC.Count > 0 {
-		delete(s.rpcStat.Stats, tikvrpc.CmdCop)
-		buf.WriteString(", rpc_num: ")
-		buf.WriteString(strconv.FormatInt(copRPC.Count, 10))
-		buf.WriteString(", rpc_time: ")
-		buf.WriteString(time.Duration(copRPC.Consume).String())
-	}
-	buf.WriteString("}")
-
-	rpcStatsStr := s.rpcStat.String()
-	if len(rpcStatsStr) > 0 {
-		buf.WriteString(", ")
-		buf.WriteString(rpcStatsStr)
-	}
-
-	if len(s.backoffSleep) > 0 {
-		buf.WriteString(", backoff{")
-		idx := 0
-		for k, d := range s.backoffSleep {
-			if idx > 0 {
-				buf.WriteString(", ")
-			}
-			idx++
-			buf.WriteString(fmt.Sprintf("%s: %s", k, d.String()))
-		}
-		buf.WriteString("}")
-	}
-	return buf.String()
 }

--- a/distsql/select_result_test.go
+++ b/distsql/select_result_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tipb/go-tipb"
@@ -30,7 +29,7 @@ func (s *testSuite) TestUpdateCopRuntimeStats(c *C) {
 	sr := selectResult{ctx: ctx}
 	c.Assert(ctx.GetSessionVars().StmtCtx.RuntimeStatsColl, IsNil)
 	sr.rootPlanID = 1234
-	sr.updateCopRuntimeStats(context.Background(), &tikv.CopRuntimeStats{ExecDetails: execdetails.ExecDetails{CalleeAddress: "a"}}, 0)
+	sr.updateCopRuntimeStats(context.Background(), &execdetails.ExecDetails{CalleeAddress: "a"}, 0)
 
 	ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = execdetails.NewRuntimeStatsColl()
 	t := uint64(1)
@@ -40,12 +39,12 @@ func (s *testSuite) TestUpdateCopRuntimeStats(c *C) {
 		},
 	}
 	c.Assert(len(sr.selectResp.GetExecutionSummaries()) != len(sr.copPlanIDs), IsTrue)
-	sr.updateCopRuntimeStats(context.Background(), &tikv.CopRuntimeStats{ExecDetails: execdetails.ExecDetails{CalleeAddress: "callee"}}, 0)
+	sr.updateCopRuntimeStats(context.Background(), &execdetails.ExecDetails{CalleeAddress: "callee"}, 0)
 	c.Assert(ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.ExistsCopStats(1234), IsFalse)
 
 	sr.copPlanIDs = []int{sr.rootPlanID}
 	c.Assert(ctx.GetSessionVars().StmtCtx.RuntimeStatsColl, NotNil)
 	c.Assert(len(sr.selectResp.GetExecutionSummaries()), Equals, len(sr.copPlanIDs))
-	sr.updateCopRuntimeStats(context.Background(), &tikv.CopRuntimeStats{ExecDetails: execdetails.ExecDetails{CalleeAddress: "callee"}}, 0)
+	sr.updateCopRuntimeStats(context.Background(), &execdetails.ExecDetails{CalleeAddress: "callee"}, 0)
 	c.Assert(ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.GetCopStats(1234).String(), Equals, "time:1ns, loops:1")
 }

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -106,15 +106,11 @@ func (r *streamResult) readDataFromResponse(ctx context.Context, resp kv.Respons
 	}
 	r.feedback.Update(resultSubset.GetStartKey(), stream.OutputCounts)
 	r.partialCount++
-
-	hasStats, ok := resultSubset.(CopRuntimeStats)
-	if ok {
-		copStats := hasStats.GetCopRuntimeStats()
-		if copStats != nil {
-			copStats.CopTime = duration
-			r.ctx.GetSessionVars().StmtCtx.MergeExecDetails(&copStats.ExecDetails, nil)
-		}
+	resultDetail := resultSubset.GetExecDetails()
+	if resultDetail != nil {
+		resultDetail.CopTime = duration
 	}
+	r.ctx.GetSessionVars().StmtCtx.MergeExecDetails(resultDetail, nil)
 	return false, nil
 }
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/store/tikv/oracle"
+	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
 )
 
@@ -340,6 +341,8 @@ type ResultSubset interface {
 	GetData() []byte
 	// GetStartKey gets the start key.
 	GetStartKey() Key
+	// GetExecDetails gets the detail information.
+	GetExecDetails() *execdetails.ExecDetails
 	// MemSize returns how many bytes of memory this result use for tracing memory usage.
 	MemSize() int64
 	// RespTime returns the response time for the request.

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1030,6 +1030,12 @@ func getRuntimeInfo(ctx sessionctx.Context, p Plan) (actRows, analyzeInfo, memor
 		analyzeInfo = "time:0ns, loops:0"
 		actRows = "0"
 	}
+	switch p.(type) {
+	case *PhysicalTableReader, *PhysicalIndexReader, *PhysicalIndexLookUpReader:
+		if s := runtimeStatsColl.GetReaderStats(explainID); s != nil && len(s.String()) > 0 {
+			analyzeInfo += ", " + s.String()
+		}
+	}
 
 	memoryInfo = "N/A"
 	memTracker := ctx.GetSessionVars().StmtCtx.MemTracker.SearchTrackerWithoutLock(p.ID())

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -14,9 +14,7 @@
 package tikv
 
 import (
-	"bytes"
 	"context"
-	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -63,54 +61,14 @@ type RegionRequestSender struct {
 	storeAddr    string
 	rpcError     error
 	failStoreIDs map[uint64]struct{}
-	RegionRequestRuntimeStats
+	stats        map[tikvrpc.CmdType]*RegionRequestRuntimeStats
 }
 
 // RegionRequestRuntimeStats records the runtime stats of send region requests.
 type RegionRequestRuntimeStats struct {
-	Stats map[tikvrpc.CmdType]*RPCRuntimeStats
-}
-
-// NewRegionRequestRuntimeStats returns a new RegionRequestRuntimeStats.
-func NewRegionRequestRuntimeStats() RegionRequestRuntimeStats {
-	return RegionRequestRuntimeStats{
-		Stats: make(map[tikvrpc.CmdType]*RPCRuntimeStats),
-	}
-}
-
-// RPCRuntimeStats indicates the RPC request count and consume time.
-type RPCRuntimeStats struct {
-	Count int64
+	count int64
 	// Send region request consume time.
-	Consume int64
-}
-
-// String implements fmt.Stringer interface.
-func (r *RegionRequestRuntimeStats) String() string {
-	var buf bytes.Buffer
-	for k, v := range r.Stats {
-		if buf.Len() > 0 {
-			buf.WriteByte(',')
-		}
-		buf.WriteString(fmt.Sprintf("%s:{num_rpc:%d, total_time:%s}", k.String(), v.Count, time.Duration(v.Consume)))
-	}
-	return buf.String()
-}
-
-// Merge merges other RegionRequestRuntimeStats.
-func (r *RegionRequestRuntimeStats) Merge(rs RegionRequestRuntimeStats) {
-	for cmd, v := range rs.Stats {
-		stat, ok := r.Stats[cmd]
-		if !ok {
-			r.Stats[cmd] = &RPCRuntimeStats{
-				Count:   v.Count,
-				Consume: v.Consume,
-			}
-			continue
-		}
-		stat.Count += v.Count
-		stat.Consume += v.Consume
-	}
+	consume int64
 }
 
 // RegionBatchRequestSender sends BatchCop requests to TiFlash server by stream way.
@@ -134,9 +92,9 @@ func (ss *RegionBatchRequestSender) sendStreamReqToAddr(bo *Backoffer, ctxs []co
 	if rawHook := ctx.Value(RPCCancellerCtxKey{}); rawHook != nil {
 		ctx, cancel = rawHook.(*RPCCanceller).WithCancel(ctx)
 	}
-	if ss.Stats != nil {
+	if ss.stats != nil {
 		defer func(start time.Time) {
-			recordRegionRequestRuntimeStats(ss.Stats, req.Type, time.Since(start))
+			recordRegionRequestRuntimeStats(ss.stats, req.Type, time.Since(start))
 		}(time.Now())
 	}
 	resp, err = ss.client.SendRequest(ctx, rpcCtx.Addr, req, timout)
@@ -153,17 +111,17 @@ func (ss *RegionBatchRequestSender) sendStreamReqToAddr(bo *Backoffer, ctxs []co
 	return
 }
 
-func recordRegionRequestRuntimeStats(stats map[tikvrpc.CmdType]*RPCRuntimeStats, cmd tikvrpc.CmdType, d time.Duration) {
+func recordRegionRequestRuntimeStats(stats map[tikvrpc.CmdType]*RegionRequestRuntimeStats, cmd tikvrpc.CmdType, d time.Duration) {
 	stat, ok := stats[cmd]
 	if !ok {
-		stats[cmd] = &RPCRuntimeStats{
-			Count:   1,
-			Consume: int64(d),
+		stats[cmd] = &RegionRequestRuntimeStats{
+			count:   1,
+			consume: int64(d),
 		}
 		return
 	}
-	stat.Count++
-	stat.Consume += int64(d)
+	stat.count++
+	stat.consume += int64(d)
 }
 
 func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndRPCContext, err error) error {
@@ -386,10 +344,9 @@ func (s *RegionRequestSender) sendReqToRegion(bo *Backoffer, rpcCtx *RPCContext,
 		}
 		defer s.releaseStoreToken(rpcCtx.Store)
 	}
-
-	if s.Stats != nil {
+	if s.stats != nil {
 		defer func(start time.Time) {
-			recordRegionRequestRuntimeStats(s.Stats, req.Type, time.Since(start))
+			recordRegionRequestRuntimeStats(s.stats, req.Type, time.Since(start))
 		}(time.Now())
 	}
 	ctx := bo.ctx

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -236,9 +236,9 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 		Client:            s.store.client,
 	}
 	if s.mu.stats != nil {
-		cli.Stats = make(map[tikvrpc.CmdType]*RPCRuntimeStats)
+		cli.stats = make(map[tikvrpc.CmdType]*RegionRequestRuntimeStats)
 		defer func() {
-			s.mergeRegionRequestStats(cli.Stats)
+			s.mergeRegionRequestStats(cli.stats)
 		}()
 	}
 
@@ -364,9 +364,9 @@ func (s *tikvSnapshot) get(bo *Backoffer, k kv.Key) ([]byte, error) {
 		resolveLite:       true,
 	}
 	if s.mu.stats != nil {
-		cli.Stats = make(map[tikvrpc.CmdType]*RPCRuntimeStats)
+		cli.stats = make(map[tikvrpc.CmdType]*RegionRequestRuntimeStats)
 		defer func() {
-			s.mergeRegionRequestStats(cli.Stats)
+			s.mergeRegionRequestStats(cli.stats)
 		}()
 	}
 
@@ -591,30 +591,30 @@ func (s *tikvSnapshot) recordBackoffInfo(bo *Backoffer) {
 	}
 }
 
-func (s *tikvSnapshot) mergeRegionRequestStats(stats map[tikvrpc.CmdType]*RPCRuntimeStats) {
+func (s *tikvSnapshot) mergeRegionRequestStats(stats map[tikvrpc.CmdType]*RegionRequestRuntimeStats) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.stats == nil {
 		return
 	}
-	if s.mu.stats.rpcStats.Stats == nil {
-		s.mu.stats.rpcStats.Stats = stats
+	if s.mu.stats.rpcStats == nil {
+		s.mu.stats.rpcStats = stats
 		return
 	}
 	for k, v := range stats {
-		stat, ok := s.mu.stats.rpcStats.Stats[k]
+		stat, ok := s.mu.stats.rpcStats[k]
 		if !ok {
-			s.mu.stats.rpcStats.Stats[k] = v
+			s.mu.stats.rpcStats[k] = v
 			continue
 		}
-		stat.Count += v.Count
-		stat.Consume += v.Consume
+		stat.count += v.count
+		stat.consume += v.consume
 	}
 }
 
 // SnapshotRuntimeStats records the runtime stats of snapshot.
 type SnapshotRuntimeStats struct {
-	rpcStats       RegionRequestRuntimeStats
+	rpcStats       map[tikvrpc.CmdType]*RegionRequestRuntimeStats
 	backoffSleepMS map[backoffType]int
 	backoffTimes   map[backoffType]int
 }
@@ -622,7 +622,12 @@ type SnapshotRuntimeStats struct {
 // String implements fmt.Stringer interface.
 func (rs *SnapshotRuntimeStats) String() string {
 	var buf bytes.Buffer
-	buf.WriteString(rs.rpcStats.String())
+	for k, v := range rs.rpcStats {
+		if buf.Len() > 0 {
+			buf.WriteByte(',')
+		}
+		buf.WriteString(fmt.Sprintf("%s:{num_rpc:%d, total_time:%s}", k.String(), v.count, time.Duration(v.consume)))
+	}
 	for k, v := range rs.backoffTimes {
 		if buf.Len() > 0 {
 			buf.WriteByte(',')

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -303,13 +303,13 @@ func (s *testSnapshotSuite) TestSnapshotThreadSafe(c *C) {
 }
 
 func (s *testSnapshotSuite) TestSnapshotRuntimeStats(c *C) {
-	reqStats := NewRegionRequestRuntimeStats()
-	recordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Second)
-	recordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Millisecond)
+	reqStats := make(map[tikvrpc.CmdType]*RegionRequestRuntimeStats)
+	recordRegionRequestRuntimeStats(reqStats, tikvrpc.CmdGet, time.Second)
+	recordRegionRequestRuntimeStats(reqStats, tikvrpc.CmdGet, time.Millisecond)
 	snapshot := newTiKVSnapshot(s.store, kv.Version{Ver: 0}, 0)
 	snapshot.SetOption(kv.CollectRuntimeStats, &SnapshotRuntimeStats{})
-	snapshot.mergeRegionRequestStats(reqStats.Stats)
-	snapshot.mergeRegionRequestStats(reqStats.Stats)
+	snapshot.mergeRegionRequestStats(reqStats)
+	snapshot.mergeRegionRequestStats(reqStats)
 	bo := NewBackofferWithVars(context.Background(), 2000, nil)
 	err := bo.BackoffWithMaxSleep(boTxnLockFast, 30, errors.New("test"))
 	c.Assert(err, IsNil)

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -323,6 +323,49 @@ func (crs *CopRuntimeStats) String() string {
 		procTimes[n-1], procTimes[0], procTimes[n*4/5], procTimes[n*19/20], totalIters, totalTasks)
 }
 
+// ReaderRuntimeStats collects stats for TableReader, IndexReader and IndexLookupReader
+type ReaderRuntimeStats struct {
+	sync.Mutex
+
+	copRespTime []time.Duration
+	procKeys    []int64
+}
+
+// recordOneCopTask record once cop response time to update maxcopRespTime
+func (rrs *ReaderRuntimeStats) recordOneCopTask(t time.Duration, detail *ExecDetails) {
+	rrs.Lock()
+	defer rrs.Unlock()
+	rrs.copRespTime = append(rrs.copRespTime, t)
+	rrs.procKeys = append(rrs.procKeys, detail.ProcessedKeys)
+}
+
+func (rrs *ReaderRuntimeStats) String() string {
+	size := len(rrs.copRespTime)
+	if size == 0 {
+		return ""
+	}
+	if size == 1 {
+		return fmt.Sprintf("rpc num: 1, rpc time:%v, proc keys:%v", rrs.copRespTime[0], rrs.procKeys[0])
+	}
+	sort.Slice(rrs.copRespTime, func(i, j int) bool {
+		return rrs.copRespTime[i] < rrs.copRespTime[j]
+	})
+	vMax, vMin := rrs.copRespTime[size-1], rrs.copRespTime[0]
+	vP80, vP95 := rrs.copRespTime[size*4/5], rrs.copRespTime[size*19/20]
+	sum := 0.0
+	for _, t := range rrs.copRespTime {
+		sum += float64(t)
+	}
+	vAvg := time.Duration(sum / float64(size))
+
+	sort.Slice(rrs.procKeys, func(i, j int) bool {
+		return rrs.procKeys[i] < rrs.procKeys[j]
+	})
+	keyMax := rrs.procKeys[size-1]
+	keyP95 := rrs.procKeys[size*19/20]
+	return fmt.Sprintf("rpc num: %v, rpc max:%v, min:%v, avg:%v, p80:%v, p95:%v, proc keys max:%v, p95:%v", size, vMax, vMin, vAvg, vP80, vP95, keyMax, keyP95)
+}
+
 // RuntimeStats is used to express the executor runtime information.
 type RuntimeStats interface {
 	GetActRows() int64
@@ -363,15 +406,16 @@ func (e *BasicRuntimeStats) String() string {
 
 // RuntimeStatsColl collects executors's execution info.
 type RuntimeStatsColl struct {
-	mu        sync.Mutex
-	rootStats map[int]RuntimeStats
-	copStats  map[int]*CopRuntimeStats
+	mu          sync.Mutex
+	rootStats   map[int]RuntimeStats
+	copStats    map[int]*CopRuntimeStats
+	readerStats map[int]*ReaderRuntimeStats
 }
 
 // NewRuntimeStatsColl creates new executor collector.
 func NewRuntimeStatsColl() *RuntimeStatsColl {
 	return &RuntimeStatsColl{rootStats: make(map[int]RuntimeStats),
-		copStats: make(map[int]*CopRuntimeStats)}
+		copStats: make(map[int]*CopRuntimeStats), readerStats: make(map[int]*ReaderRuntimeStats)}
 }
 
 // RegisterStats register execStat for a executor.
@@ -426,6 +470,12 @@ func (e *RuntimeStatsColl) RecordOneCopTask(planID int, address string, summary 
 	copStats.RecordOneCopTask(address, summary)
 }
 
+// RecordOneReaderStats records a specific stats for TableReader, IndexReader and IndexLookupReader.
+func (e *RuntimeStatsColl) RecordOneReaderStats(planID int, copRespTime time.Duration, detail *ExecDetails) {
+	readerStats := e.GetReaderStats(planID)
+	readerStats.recordOneCopTask(copRespTime, detail)
+}
+
 // ExistsRootStats checks if the planID exists in the rootStats collection.
 func (e *RuntimeStatsColl) ExistsRootStats(planID int) bool {
 	e.mu.Lock()
@@ -440,6 +490,18 @@ func (e *RuntimeStatsColl) ExistsCopStats(planID int) bool {
 	defer e.mu.Unlock()
 	_, exists := e.copStats[planID]
 	return exists
+}
+
+// GetReaderStats gets the ReaderRuntimeStats specified by planID.
+func (e *RuntimeStatsColl) GetReaderStats(planID int) *ReaderRuntimeStats {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	stats, exists := e.readerStats[planID]
+	if !exists {
+		stats = &ReaderRuntimeStats{copRespTime: make([]time.Duration, 0, 20)}
+		e.readerStats[planID] = stats
+	}
+	return stats
 }
 
 // ConcurrencyInfo is used to save the concurrency information of the executor operator


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

revert https://github.com/pingcap/tidb/pull/19264 for:

```sql
fatal error: stack overflow

runtime stack:
runtime.throw(0x31bdce9, 0xe)
	/usr/local/go/src/runtime/panic.go:774 +0x72
runtime.newstack()
	/usr/local/go/src/runtime/stack.go:1046 +0x6e9
runtime.morestack()
	/usr/local/go/src/runtime/asm_amd64.s:449 +0x8f

goroutine 1174959 [running]:
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd4c0740240, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:343 +0xc33 fp=0xeb742c0468 sp=0xeb742c0460 pc=0x20e3943
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd919603860, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c0668 sp=0xeb742c0468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdf598c64e0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c0868 sp=0xeb742c0668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc953595620, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c0a68 sp=0xeb742c0868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc9cd6247e0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c0c68 sp=0xeb742c0a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd4bda851a0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c0e68 sp=0xeb742c0c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc953595e00, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1068 sp=0xeb742c0e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcce38b7980, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1268 sp=0xeb742c1068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd2b59f72c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1468 sp=0xeb742c1268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcd9864dce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1668 sp=0xeb742c1468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xca7b7a4900, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1868 sp=0xeb742c1668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcee9350360, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1a68 sp=0xeb742c1868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcc93967da0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1c68 sp=0xeb742c1a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdf331a23c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c1e68 sp=0xeb742c1c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcf07d5ae40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2068 sp=0xeb742c1e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc8b61206c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2268 sp=0xeb742c2068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcbc325bb60, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2468 sp=0xeb742c2268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc80e9bb2c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2668 sp=0xeb742c2468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcf4847d260, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2868 sp=0xeb742c2668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcadecc0d80, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2a68 sp=0xeb742c2868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd5ed6157a0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2c68 sp=0xeb742c2a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcf594a1080, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c2e68 sp=0xeb742c2c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcc00de0de0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3068 sp=0xeb742c2e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd6210b9740, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3268 sp=0xeb742c3068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc6c3d768a0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3468 sp=0xeb742c3268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdf1162c000, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3668 sp=0xeb742c3468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdf0f2e4300, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3868 sp=0xeb742c3668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdf0dd49d40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3a68 sp=0xeb742c3868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc95f45d0e0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3c68 sp=0xeb742c3a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcb216fad20, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c3e68 sp=0xeb742c3c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcb54843800, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4068 sp=0xeb742c3e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xde65e0fce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4268 sp=0xeb742c4068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd194701920, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4468 sp=0xeb742c4268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc77c4a9500, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4668 sp=0xeb742c4468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcdcfe2eea0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4868 sp=0xeb742c4668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcdac7ce960, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4a68 sp=0xeb742c4868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd1b98d18c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4c68 sp=0xeb742c4a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc862412a80, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c4e68 sp=0xeb742c4c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc862dca3c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5068 sp=0xeb742c4e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc888f86840, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5268 sp=0xeb742c5068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcdcfe2fc20, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5468 sp=0xeb742c5268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc8f5a8d8c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5668 sp=0xeb742c5468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcdc3038a20, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5868 sp=0xeb742c5668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc888f87aa0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5a68 sp=0xeb742c5868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc862dcb560, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5c68 sp=0xeb742c5a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc348d7e540, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c5e68 sp=0xeb742c5c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc862dcbb00, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6068 sp=0xeb742c5e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc7564edf20, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6268 sp=0xeb742c6068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc0af43cba0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6468 sp=0xeb742c6268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd02407c3c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6668 sp=0xeb742c6468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc7cdf28240, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6868 sp=0xeb742c6668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc7f4f3d740, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6a68 sp=0xeb742c6868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc4df189020, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6c68 sp=0xeb742c6a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc87732cfc0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c6e68 sp=0xeb742c6c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc4dff08480, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7068 sp=0xeb742c6e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc8bda7d0e0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7268 sp=0xeb742c7068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc92f081b60, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7468 sp=0xeb742c7268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc3b5a05ce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7668 sp=0xeb742c7468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc506754000, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7868 sp=0xeb742c7668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc99a6d2720, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7a68 sp=0xeb742c7868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc52ecbdec0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7c68 sp=0xeb742c7a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdc2245bce0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c7e68 sp=0xeb742c7c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdbfdba4ea0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8068 sp=0xeb742c7e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcba639b7a0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8268 sp=0xeb742c8068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcb48972420, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8468 sp=0xeb742c8268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdbfb535aa0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8668 sp=0xeb742c8468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xdbfb039200, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8868 sp=0xeb742c8668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd65ec049c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8a68 sp=0xeb742c8868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc8971180c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8c68 sp=0xeb742c8a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc83a342480, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c8e68 sp=0xeb742c8c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc83e14b800, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9068 sp=0xeb742c8e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc83bf17b00, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9268 sp=0xeb742c9068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd60a5b8cc0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9468 sp=0xeb742c9268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc8e5a66780, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9668 sp=0xeb742c9468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd60a5b9920, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9868 sp=0xeb742c9668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc138596ae0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9a68 sp=0xeb742c9868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd2b2fb6c60, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9c68 sp=0xeb742c9a68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc995edc120, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742c9e68 sp=0xeb742c9c68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc138597d40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742ca068 sp=0xeb742c9e68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc4b6177500, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742ca268 sp=0xeb742ca068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcd0b56b2c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742ca468 sp=0xeb742ca268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd1497acea0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742ca668 sp=0xeb742ca468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd177c90780, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742ca868 sp=0xeb742ca668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xceaa550360, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742caa68 sp=0xeb742ca868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc823c0fd40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cac68 sp=0xeb742caa68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xd2d654ee40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cae68 sp=0xeb742cac68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc34ef83320, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cb068 sp=0xeb742cae68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcb446a89c0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cb268 sp=0xeb742cb068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc46eb92ea0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cb468 sp=0xeb742cb268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc31ef4bd40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cb668 sp=0xeb742cb468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc744d301e0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cb868 sp=0xeb742cb668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcb588dda40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cba68 sp=0xeb742cb868 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc3e5ef9ec0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cbc68 sp=0xeb742cba68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc5f31cb560, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cbe68 sp=0xeb742cbc68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc914374fc0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cc068 sp=0xeb742cbe68 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc76eba4ea0, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cc268 sp=0xeb742cc068 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xca0f9a4e40, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cc468 sp=0xeb742cc268 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xcbd1999f80, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cc668 sp=0xeb742cc468 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc76eba5920, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cc868 sp=0xeb742cc668 pc=0x20e38dc
github.com/pingcap/tidb/distsql.(*selectResultRuntimeStats).String(0xc263e34060, 0x0, 0x0)
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/distsql/select_result.go:346 +0xbcc fp=0xeb742cca68 sp=0xeb742cc868 pc=0x20e38dc
...additional frames elided...
created by github.com/pingcap/tidb/server.(*Server).Run
	/home/jenkins/agent/workspace/tidb_v4.0.6/go/src/github.com/pingcap/tidb/server/server.go:339 +0x709
```

