### PR TITLE
ddl: update rule cache incrementally/pass arguments by ctxvars

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -883,17 +883,20 @@ func updateSchemaVersion(t *meta.Meta, job *model.Job) (int64, error) {
 		diff.AffectedOpts = affects
 	case model.ActionDropTablePartition:
 		// affects are used to update placement rule cache
-		oldIDs := job.CtxVars[0].([]int64)
 		diff.TableID = job.TableID
-		affects := make([]*model.AffectedOption, len(oldIDs))
-		for i := 0; i < len(oldIDs); i++ {
-			affects[i] = &model.AffectedOption{
-				SchemaID:   job.SchemaID,
-				TableID:    oldIDs[i],
-				OldTableID: oldIDs[i],
+		if len(job.CtxVars) > 0 {
+			if oldIDs, ok := job.CtxVars[0].([]int64); ok {
+				affects := make([]*model.AffectedOption, len(oldIDs))
+				for i := 0; i < len(oldIDs); i++ {
+					affects[i] = &model.AffectedOption{
+						SchemaID:   job.SchemaID,
+						TableID:    oldIDs[i],
+						OldTableID: oldIDs[i],
+					}
+				}
+				diff.AffectedOpts = affects
 			}
 		}
-		diff.AffectedOpts = affects
 	case model.ActionAlterTableAlterPartition:
 		diff.TableID = job.CtxVars[0].(int64)
 	default:

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -869,6 +869,7 @@ func updateSchemaVersion(t *meta.Meta, job *model.Job) (int64, error) {
 		}
 		diff.AffectedOpts = affects
 	case model.ActionTruncateTablePartition:
+		newIDs := job.Args[len(job.Args)-1].([]int64)
 		var oldIDs []int64
 		err = job.DecodeArgs(&oldIDs)
 		if err != nil {
@@ -879,11 +880,29 @@ func updateSchemaVersion(t *meta.Meta, job *model.Job) (int64, error) {
 		for i := 0; i < len(oldIDs); i++ {
 			affects[i] = &model.AffectedOption{
 				SchemaID:   job.SchemaID,
+				TableID:    newIDs[i],
+				OldTableID: oldIDs[i],
+			}
+		}
+		diff.AffectedOpts = affects
+	case model.ActionDropTablePartition:
+		// affects are used to update placement rule cache
+		oldIDs := job.Args[len(job.Args)-1].([]int64)
+		diff.TableID = job.TableID
+		affects := make([]*model.AffectedOption, len(oldIDs))
+		for i := 0; i < len(oldIDs); i++ {
+			affects[i] = &model.AffectedOption{
+				SchemaID:   job.SchemaID,
 				TableID:    oldIDs[i],
 				OldTableID: oldIDs[i],
 			}
 		}
 		diff.AffectedOpts = affects
+	case model.ActionAlterTableAlterPartition:
+		err = job.DecodeArgs(&diff.TableID)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
 	default:
 		diff.TableID = job.TableID
 	}

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1209,8 +1209,8 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 		for i, oldID := range oldIDs {
 			oldBundle, ok := d.infoHandle.Get().BundleByName(placement.GroupID(oldID))
 			if ok && !oldBundle.IsEmpty() {
-				bundles = append(bundles, buildPlacementDropBundle(oldID))
-				bundles = append(bundles, buildPlacementTruncateBundle(oldBundle, newIDs[i]))
+				bundles = append(bundles, placement.BuildPlacementDropBundle(oldID))
+				bundles = append(bundles, placement.BuildPlacementTruncateBundle(oldBundle, newIDs[i]))
 			}
 		}
 

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1134,7 +1134,7 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 		}
 		tblInfo.Partition.DroppingDefinitions = nil
 		// used by ApplyDiff in updateSchemaVersion
-		job.Args = append(job.Args, physicalTableIDs)
+		job.CtxVars = []interface{}{physicalTableIDs}
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1133,6 +1133,8 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 			w.reorgCtx.cleanNotifyReorgCancel()
 		}
 		tblInfo.Partition.DroppingDefinitions = nil
+		// used by ApplyDiff in updateSchemaVersion
+		job.Args = append(job.Args, physicalTableIDs)
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -1164,6 +1166,7 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 	}
 
 	newPartitions := make([]model.PartitionDefinition, 0, len(oldIDs))
+	newIDs := make([]int64, 0, len(oldIDs))
 	for _, oldID := range oldIDs {
 		for i := 0; i < len(pi.Definitions); i++ {
 			def := &pi.Definitions[i]
@@ -1175,6 +1178,7 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 				def.ID = pid
 				// Shallow copy only use the def.ID in event handle.
 				newPartitions = append(newPartitions, *def)
+				newIDs = append(newIDs, pid)
 				break
 			}
 		}
@@ -1205,8 +1209,8 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 		for i, oldID := range oldIDs {
 			oldBundle, ok := d.infoHandle.Get().BundleByName(placement.GroupID(oldID))
 			if ok && !oldBundle.IsEmpty() {
-				bundles = append(bundles, placement.BuildPlacementDropBundle(oldID))
-				bundles = append(bundles, placement.BuildPlacementTruncateBundle(oldBundle, newPartitions[i].ID))
+				bundles = append(bundles, buildPlacementDropBundle(oldID))
+				bundles = append(bundles, buildPlacementTruncateBundle(oldBundle, newIDs[i]))
 			}
 		}
 
@@ -1217,6 +1221,8 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 		}
 	}
 
+	// used by ApplyDiff in updateSchemaVersion
+	job.Args = append(job.Args, newIDs)
 	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1405,7 +1405,6 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 		}
 	}
 
-	job.CtxVars = []interface{}{defID, ptSchemaID, ptID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1222,7 +1222,7 @@ func onTruncateTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, e
 	}
 
 	// used by ApplyDiff in updateSchemaVersion
-	job.Args = append(job.Args, newIDs)
+	job.CtxVars = []interface{}{oldIDs, newIDs}
 	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -1405,6 +1405,7 @@ func (w *worker) onExchangeTablePartition(d *ddlCtx, t *meta.Meta, job *model.Jo
 		}
 	}
 
+	job.CtxVars = []interface{}{defID, ptSchemaID, ptID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -1738,6 +1739,8 @@ func onAlterTablePartition(t *meta.Meta, job *model.Job) (int64, error) {
 		return 0, errors.Wrapf(err, "failed to notify PD the placement rules")
 	}
 
+	// used by ApplyDiff in updateSchemaVersion
+	job.CtxVars = []interface{}{partitionID}
 	ver, err := updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -135,6 +135,7 @@ func onCreateView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 			return ver, errors.Trace(err)
 		}
 	}
+	job.CtxVars = []interface{}{tbInfo, orReplace, oldTbInfoID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -493,6 +494,7 @@ func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ erro
 		}
 	})
 
+	job.CtxVars = []interface{}{newTableID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -704,6 +706,7 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		}
 	}
 
+	job.CtxVars = []interface{}{oldSchemaID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -135,7 +135,6 @@ func onCreateView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 			return ver, errors.Trace(err)
 		}
 	}
-	job.CtxVars = []interface{}{tbInfo, orReplace, oldTbInfoID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -494,7 +493,6 @@ func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ erro
 		}
 	})
 
-	job.CtxVars = []interface{}{newTableID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)
@@ -706,7 +704,6 @@ func onRenameTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		}
 	}
 
-	job.CtxVars = []interface{}{oldSchemaID}
 	ver, err = updateSchemaVersion(t, job)
 	if err != nil {
 		return ver, errors.Trace(err)

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -50,6 +50,9 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 		return tblIDs, nil
 	case model.ActionModifySchemaCharsetAndCollate:
 		return nil, b.applyModifySchemaCharsetAndCollate(m, diff)
+	case model.ActionAlterTableAlterPartition:
+		// there is no need to udpate table schema
+		return nil, b.applyPlacementUpdate(placement.GroupID(diff.TableID))
 	}
 	roDBInfo, ok := b.is.SchemaByID(diff.SchemaID)
 	if !ok {
@@ -122,8 +125,17 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 			// Reduce the impact on DML when executing partition DDL. eg.
 			// While session 1 performs the DML operation associated with partition 1,
 			// the TRUNCATE operation of session 2 on partition 2 does not cause the operation of session 1 to fail.
-			if diff.Type == model.ActionTruncateTablePartition {
+			switch diff.Type {
+			case model.ActionTruncateTablePartition:
 				tblIDs = append(tblIDs, opt.OldTableID)
+				b.applyPlacementDelete(placement.GroupID(opt.OldTableID))
+				err := b.applyPlacementUpdate(placement.GroupID(opt.TableID))
+				if err != nil {
+					return nil, errors.Trace(err)
+				}
+				continue
+			case model.ActionDropTablePartition:
+				b.applyPlacementDelete(placement.GroupID(opt.OldTableID))
 				continue
 			}
 			var err error
@@ -271,12 +283,17 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 		)
 	}
 
-	pi := tblInfo.GetPartitionInfo()
-	if pi != nil {
-		for _, partition := range pi.Definitions {
-			err = b.applyPlacementUpdate(placement.GroupID(partition.ID))
-			if err != nil {
-				return nil, err
+	switch tp {
+	case model.ActionDropTablePartition:
+	case model.ActionTruncateTablePartition:
+	default:
+		pi := tblInfo.GetPartitionInfo()
+		if pi != nil {
+			for _, partition := range pi.Definitions {
+				err = b.applyPlacementUpdate(placement.GroupID(partition.ID))
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 	}
@@ -387,6 +404,10 @@ func (b *Builder) applyDropTable(dbInfo *model.DBInfo, tableID int64, affected [
 		}
 	}
 	return affected
+}
+
+func (b *Builder) applyPlacementDelete(id string) {
+	delete(b.is.ruleBundleMap, id)
 }
 
 func (b *Builder) applyPlacementUpdate(id string) error {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: An improvement on the rule cache introduced by #20086 . Only update rules that really changed.

### Check List

Tests

- Unit test
- Integration test
- Manual test

```
use test;
create table t(id int) partition by range(id) (partition p1 values less than (10), partition p2 values less than (20));
alter table t alter partition p1 add placement policy ROLE=voter constraints='{"+zone=sh":1, "-zone=bj": 2}';
alter table t truncate partition p1;
alter table t drop partition p1;
```

Tested. The above script should execute without any error.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note