### PR TITLE
tikv: rewrite 2pc executor to use lazy iterators

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -43,10 +43,10 @@ type testPessimisticSuite struct {
 }
 
 func (s *testPessimisticSuite) SetUpSuite(c *C) {
+	tikv.PrewriteMaxBackoff = 500
 	s.testSessionSuiteBase.SetUpSuite(c)
 	// Set it to 300ms for testing lock resolve.
 	atomic.StoreUint64(&tikv.ManagedLockTTL, 300)
-	tikv.PrewriteMaxBackoff = 500
 }
 
 func (s *testPessimisticSuite) TearDownSuite(c *C) {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -47,7 +47,7 @@ import (
 )
 
 type twoPhaseCommitAction interface {
-	handleSingleBatch(*twoPhaseCommitter, *Backoffer, batchMutations) error
+	handleSingleBatch(*twoPhaseCommitter, *Backoffer, *batchMutations) (bool, error)
 	tiKVTxnRegionsNumHistogram() prometheus.Observer
 	String() string
 }
@@ -72,19 +72,19 @@ func metricsTag(action string) string {
 
 // twoPhaseCommitter executes a two-phase commit protocol.
 type twoPhaseCommitter struct {
-	store               *tikvStore
-	txn                 *tikvTxn
-	startTS             uint64
-	mutations           CommitterMutations
-	lockTTL             uint64
-	commitTS            uint64
-	priority            pb.CommandPri
-	connID              uint64 // connID is used for log.
-	cleanWg             sync.WaitGroup
-	detail              unsafe.Pointer
-	txnSize             int
-	hasNoNeedCommitKeys bool
+	store    *tikvStore
+	txn      *tikvTxn
+	startTS  uint64
+	lockTTL  uint64
+	commitTS uint64
+	priority pb.CommandPri
+	connID   uint64 // connID is used for log.
+	cleanWg  sync.WaitGroup
+	detail   unsafe.Pointer
+	txnSize  int
 
+	cntKeys          int
+	sizeKeys         int
 	prewriteOnlyKeys int
 	ignoredKeys      int
 
@@ -188,14 +188,21 @@ func (c *CommitterMutations) MergeMutations(mutations CommitterMutations) {
 	c.isPessimisticLock = append(c.isPessimisticLock, mutations.isPessimisticLock...)
 }
 
+func (c *CommitterMutations) reset() {
+	c.ops = c.ops[:0]
+	c.keys = c.keys[:0]
+	c.values = c.values[:0]
+	c.isPessimisticLock = c.isPessimisticLock[:0]
+}
+
 // newTwoPhaseCommitter creates a twoPhaseCommitter.
 func newTwoPhaseCommitter(txn *tikvTxn, connID uint64) (*twoPhaseCommitter, error) {
 	return &twoPhaseCommitter{
-		store:         txn.store,
-		txn:           txn,
-		startTS:       txn.StartTS(),
-		connID:        connID,
-		regionTxnSize: map[uint64]int{},
+		store:   txn.store,
+		txn:     txn,
+		startTS: txn.StartTS(),
+		connID:  connID,
+		detail:  unsafe.Pointer(new(execdetails.CommitDetails)),
 		ttlManager: ttlManager{
 			ch: make(chan struct{}),
 		},
@@ -332,128 +339,23 @@ func (c *twoPhaseCommitter) genKeyExistsError(name string, value string, err err
 	return kv.ErrKeyExists.FastGenByArgs(value, name)
 }
 
-func (c *twoPhaseCommitter) initKeysAndMutations() error {
-	var size, putCnt, delCnt, lockCnt, checkCnt int
-
-	txn := c.txn
-	memBuf := txn.GetMemBuffer()
-	sizeHint := txn.us.GetMemBuffer().Len()
-	mutations := NewCommiterMutations(sizeHint)
-	c.isPessimistic = txn.IsPessimistic()
-
-	var err error
-	for it := memBuf.IterWithFlags(nil, nil); it.Valid(); err = it.Next() {
-		_ = err
-		key := it.Key()
-		flags := it.Flags()
-		var value []byte
-		var op pb.Op
-
-		if !it.HasValue() {
-			if !flags.HasLocked() {
-				continue
-			}
-			op = pb.Op_Lock
-			lockCnt++
-		} else {
-			value = it.Value()
-			if len(value) > 0 {
-				if tablecodec.IsUntouchedIndexKValue(key, value) {
-					continue
-				}
-				op = pb.Op_Put
-				if flags.HasPresumeKeyNotExists() {
-					op = pb.Op_Insert
-				}
-				putCnt++
-			} else {
-				if !txn.IsPessimistic() && flags.HasPresumeKeyNotExists() {
-					// delete-your-writes keys in optimistic txn need check not exists in prewrite-phase
-					// due to `Op_CheckNotExists` doesn't prewrite lock, so mark those keys should not be used in commit-phase.
-					op = pb.Op_CheckNotExists
-					checkCnt++
-					memBuf.UpdateFlags(key, kv.SetPrewriteOnly)
-				} else {
-					// normal delete keys in optimistic txn can be delete without not exists checking
-					// delete-your-writes keys in pessimistic txn can ensure must be no exists so can directly delete them
-					op = pb.Op_Del
-					delCnt++
-				}
-			}
-		}
-
-		var isPessimistic bool
-		if flags.HasLocked() {
-			isPessimistic = c.isPessimistic
-		}
-		mutations.Push(op, key, value, isPessimistic)
-		size += len(key) + len(value)
-
-		if len(c.primaryKey) == 0 && op != pb.Op_CheckNotExists {
-			c.primaryKey = key
-		}
-	}
-
-	if mutations.len() == 0 {
-		return nil
-	}
-	c.txnSize = size
-
-	if size > int(kv.TxnTotalSizeLimit) {
-		return kv.ErrTxnTooLarge.GenWithStackByArgs(size)
-	}
-	const logEntryCount = 10000
-	const logSize = 4 * 1024 * 1024 // 4MB
-	if mutations.len() > logEntryCount || size > logSize {
-		tableID := tablecodec.DecodeTableID(mutations.keys[0])
-		logutil.BgLogger().Info("[BIG_TXN]",
-			zap.Uint64("con", c.connID),
-			zap.Int64("table ID", tableID),
-			zap.Int("size", size),
-			zap.Int("keys", mutations.len()),
-			zap.Int("puts", putCnt),
-			zap.Int("dels", delCnt),
-			zap.Int("locks", lockCnt),
-			zap.Int("checks", checkCnt),
-			zap.Uint64("txnStartTS", txn.startTS))
-	}
-
-	// Sanity check for startTS.
-	if txn.StartTS() == math.MaxUint64 {
-		err = errors.Errorf("try to commit with invalid txnStartTS: %d", txn.StartTS())
-		logutil.BgLogger().Error("commit failed",
-			zap.Uint64("conn", c.connID),
-			zap.Error(err))
-		return errors.Trace(err)
-	}
-
-	commitDetail := &execdetails.CommitDetails{WriteSize: size, WriteKeys: mutations.len()}
-	metrics.TiKVTxnWriteKVCountHistogram.Observe(float64(commitDetail.WriteKeys))
-	metrics.TiKVTxnWriteSizeHistogram.Observe(float64(commitDetail.WriteSize))
-	c.hasNoNeedCommitKeys = checkCnt > 0
-	c.mutations = mutations
-	c.lockTTL = txnLockTTL(txn.startTime, size)
-	c.priority = getTxnPriority(txn)
-	c.syncLog = getTxnSyncLog(txn)
-	c.setDetail(commitDetail)
-	return nil
-}
-
 func (c *twoPhaseCommitter) primary() []byte {
-	if len(c.primaryKey) == 0 {
-		return c.mutations.keys[0]
-	}
 	return c.primaryKey
 }
 
 // asyncSecondaries returns all keys that must be checked in the recovery phase of an async commit.
 func (c *twoPhaseCommitter) asyncSecondaries() [][]byte {
-	secondaries := make([][]byte, 0, len(c.mutations.keys))
-	for i, k := range c.mutations.keys {
-		if bytes.Equal(k, c.primary()) || c.mutations.ops[i] == pb.Op_CheckNotExists {
+	secondaries := make([][]byte, 0, c.txn.Len())
+	it := committerTxnMutations{c, true}.Iter(nil, nil)
+	for {
+		m := it.Next()
+		if m.key == nil {
+			break
+		}
+		if bytes.Equal(m.key, c.primary()) || m.op == pb.Op_CheckNotExists {
 			continue
 		}
-		secondaries = append(secondaries, k)
+		secondaries = append(secondaries, m.key)
 	}
 	return secondaries
 }
@@ -487,188 +389,11 @@ func txnLockTTL(startTime time.Time, txnSize int) uint64 {
 var preSplitDetectThreshold uint32 = 100000
 var preSplitSizeThreshold uint32 = 32 << 20
 
-// doActionOnMutations groups keys into primary batch and secondary batches, if primary batch exists in the key,
-// it does action on primary batch first, then on secondary batches. If action is commit, secondary batches
-// is done in background goroutine.
-func (c *twoPhaseCommitter) doActionOnMutations(bo *Backoffer, action twoPhaseCommitAction, mutations CommitterMutations) error {
-	if mutations.len() == 0 {
-		return nil
-	}
-	groups, err := c.groupMutations(bo, mutations)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
-	return c.doActionOnGroupMutations(bo, action, groups)
-}
-
-// groupMutations groups mutations by region, then checks for any large groups and in that case pre-splits the region.
-func (c *twoPhaseCommitter) groupMutations(bo *Backoffer, mutations CommitterMutations) ([]groupedMutations, error) {
-	groups, err := c.store.regionCache.GroupSortedMutationsByRegion(bo, mutations)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-
-	// Pre-split regions to avoid too much write workload into a single region.
-	// In the large transaction case, this operation is important to avoid TiKV 'server is busy' error.
-	var didPreSplit bool
-	preSplitDetectThresholdVal := atomic.LoadUint32(&preSplitDetectThreshold)
-	for _, group := range groups {
-		if uint32(group.mutations.len()) >= preSplitDetectThresholdVal {
-			logutil.BgLogger().Info("2PC detect large amount of mutations on a single region",
-				zap.Uint64("region", group.region.GetID()),
-				zap.Int("mutations count", group.mutations.len()))
-			// Use context.Background, this time should not add up to Backoffer.
-			if c.store.preSplitRegion(context.Background(), group) {
-				didPreSplit = true
-			}
-		}
-	}
-	// Reload region cache again.
-	if didPreSplit {
-		groups, err = c.store.regionCache.GroupSortedMutationsByRegion(bo, mutations)
-		if err != nil {
-			return nil, errors.Trace(err)
-		}
-	}
-
-	return groups, nil
-}
-
-// doActionOnGroupedMutations splits groups into batches (there is one group per region, and potentially many batches per group, but all mutations
-// in a batch will belong to the same region).
-func (c *twoPhaseCommitter) doActionOnGroupMutations(bo *Backoffer, action twoPhaseCommitAction, groups []groupedMutations) error {
-	action.tiKVTxnRegionsNumHistogram().Observe(float64(len(groups)))
-
-	var sizeFunc = c.keySize
-
-	switch act := action.(type) {
-	case actionPrewrite:
-		// Do not update regionTxnSize on retries. They are not used when building a PrewriteRequest.
-		if len(bo.errors) == 0 {
-			for _, group := range groups {
-				c.regionTxnSize[group.region.id] = group.mutations.len()
-			}
-		}
-		sizeFunc = c.keyValueSize
-		atomic.AddInt32(&c.getDetail().PrewriteRegionNum, int32(len(groups)))
-	case actionPessimisticLock:
-		if act.LockCtx.Stats != nil {
-			act.LockCtx.Stats.RegionNum = int32(len(groups))
-		}
-	}
-
-	batchBuilder := newBatched(c.primary())
-	for _, group := range groups {
-		batchBuilder.appendBatchMutationsBySize(group.region, group.mutations, sizeFunc, txnCommitBatchSize)
-	}
-	firstIsPrimary := batchBuilder.setPrimary()
-
-	actionCommit, actionIsCommit := action.(actionCommit)
-	_, actionIsCleanup := action.(actionCleanup)
-	_, actionIsPessimiticLock := action.(actionPessimisticLock)
-
-	var err error
-	failpoint.Inject("skipKeyReturnOK", func(val failpoint.Value) {
-		valStr, ok := val.(string)
-		if ok && c.connID > 0 {
-			if firstIsPrimary && actionIsPessimiticLock {
-				logutil.Logger(bo.ctx).Warn("pessimisticLock failpoint", zap.String("valStr", valStr))
-				switch valStr {
-				case "pessimisticLockSkipPrimary":
-					err = c.doActionOnBatches(bo, action, batchBuilder.allBatches())
-					failpoint.Return(err)
-				case "pessimisticLockSkipSecondary":
-					err = c.doActionOnBatches(bo, action, batchBuilder.primaryBatch())
-					failpoint.Return(err)
-				}
-			}
-		}
-	})
-	failpoint.Inject("pessimisticRollbackDoNth", func() {
-		_, actionIsPessimisticRollback := action.(actionPessimisticRollback)
-		if actionIsPessimisticRollback && c.connID > 0 {
-			logutil.Logger(bo.ctx).Warn("pessimisticRollbackDoNth failpoint")
-			failpoint.Return(nil)
-		}
-	})
-
-	if firstIsPrimary &&
-		((actionIsCommit && !c.isAsyncCommit()) || actionIsCleanup || actionIsPessimiticLock) {
-		// primary should be committed(not async commit)/cleanup/pessimistically locked first
-		err = c.doActionOnBatches(bo, action, batchBuilder.primaryBatch())
-		if err != nil {
-			return errors.Trace(err)
-		}
-		if actionIsCommit && c.testingKnobs.bkAfterCommitPrimary != nil && c.testingKnobs.acAfterCommitPrimary != nil {
-			c.testingKnobs.acAfterCommitPrimary <- struct{}{}
-			<-c.testingKnobs.bkAfterCommitPrimary
-		}
-		batchBuilder.forgetPrimary()
-	}
-	// Already spawned a goroutine for async commit transaction.
-	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
-		secondaryBo := NewBackofferWithVars(context.Background(), int(atomic.LoadUint64(&CommitMaxBackoff)), c.txn.vars)
-		go func() {
-			e := c.doActionOnBatches(secondaryBo, action, batchBuilder.allBatches())
-			if e != nil {
-				logutil.BgLogger().Debug("2PC async doActionOnBatches",
-					zap.Uint64("conn", c.connID),
-					zap.Stringer("action type", action),
-					zap.Error(e))
-				tikvSecondaryLockCleanupFailureCounterCommit.Inc()
-			}
-		}()
-	} else {
-		err = c.doActionOnBatches(bo, action, batchBuilder.allBatches())
-	}
-	return errors.Trace(err)
-}
-
-// doActionOnBatches does action to batches in parallel.
-func (c *twoPhaseCommitter) doActionOnBatches(bo *Backoffer, action twoPhaseCommitAction, batches []batchMutations) error {
-	if len(batches) == 0 {
-		return nil
-	}
-
-	noNeedFork := len(batches) == 1
-	if !noNeedFork {
-		if ac, ok := action.(actionCommit); ok && ac.retry {
-			noNeedFork = true
-		}
-	}
-	if noNeedFork {
-		for _, b := range batches {
-			e := action.handleSingleBatch(c, bo, b)
-			if e != nil {
-				logutil.BgLogger().Debug("2PC doActionOnBatches failed",
-					zap.Uint64("conn", c.connID),
-					zap.Stringer("action type", action),
-					zap.Error(e),
-					zap.Uint64("txnStartTS", c.startTS))
-				return errors.Trace(e)
-			}
-		}
-		return nil
-	}
-	rateLim := len(batches)
-	// Set rateLim here for the large transaction.
-	// If the rate limit is too high, tikv will report service is busy.
-	// If the rate limit is too low, we can't full utilize the tikv's throughput.
-	// TODO: Find a self-adaptive way to control the rate limit here.
-	if rateLim > config.GetGlobalConfig().Performance.CommitterConcurrency {
-		rateLim = config.GetGlobalConfig().Performance.CommitterConcurrency
-	}
-	batchExecutor := newBatchExecutor(rateLim, c, action, bo)
-	err := batchExecutor.process(batches)
-	return errors.Trace(err)
-}
-
 func (c *twoPhaseCommitter) keyValueSize(key, value []byte) int {
 	return len(key) + len(value)
 }
 
-func (c *twoPhaseCommitter) keySize(key, value []byte) int {
+func (c *twoPhaseCommitter) keySize(key, _ []byte) int {
 	return len(key)
 }
 
@@ -803,19 +528,10 @@ func (c *twoPhaseCommitter) checkAsyncCommit() bool {
 	asyncCommitCfg := config.GetGlobalConfig().TiKVClient.AsyncCommit
 	// TODO the keys limit need more tests, this value makes the unit test pass by now.
 	// Async commit is not compatible with Binlog because of the non unique timestamp issue.
-	if c.connID > 0 && asyncCommitCfg.Enable &&
-		uint(len(c.mutations.keys)) <= asyncCommitCfg.KeysLimit &&
-		!c.shouldWriteBinlog() {
-		totalKeySize := uint64(0)
-		for _, key := range c.mutations.keys {
-			totalKeySize += uint64(len(key))
-			if totalKeySize > asyncCommitCfg.TotalKeySizeLimit {
-				return false
-			}
-		}
-		return true
-	}
-	return false
+	return c.connID > 0 && asyncCommitCfg.Enable &&
+		uint(c.cntKeys) <= asyncCommitCfg.KeysLimit &&
+		!c.shouldWriteBinlog() &&
+		uint64(c.sizeKeys) <= asyncCommitCfg.TotalKeySizeLimit
 }
 
 func (c *twoPhaseCommitter) isAsyncCommit() bool {
@@ -832,9 +548,10 @@ func (c *twoPhaseCommitter) setAsyncCommit(val bool) {
 
 func (c *twoPhaseCommitter) cleanup(ctx context.Context) {
 	c.cleanWg.Add(1)
+	c.txn.GetMemBuffer().DiscardValues()
 	go func() {
 		cleanupKeysCtx := context.WithValue(context.Background(), txnStartKey, ctx.Value(txnStartKey))
-		err := c.cleanupMutations(NewBackofferWithVars(cleanupKeysCtx, cleanupMaxBackoff, c.txn.vars), c.mutations)
+		err := c.cleanupTxnMutations(NewBackofferWithVars(cleanupKeysCtx, cleanupMaxBackoff, c.txn.vars))
 		if err != nil {
 			tikvSecondaryLockCleanupFailureCounterRollback.Inc()
 			logutil.Logger(ctx).Info("2PC cleanup failed",
@@ -892,7 +609,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 	binlogChan := c.prewriteBinlog(ctx)
 	prewriteBo := NewBackofferWithVars(ctx, PrewriteMaxBackoff, c.txn.vars)
 	start := time.Now()
-	err = c.prewriteMutations(prewriteBo, c.mutations)
+	err = c.prewriteTxnMutations(prewriteBo)
 
 	if err != nil {
 		// TODO: Now we return an undetermined error as long as one of the prewrite
@@ -933,9 +650,6 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			zap.Uint64("txnStartTS", c.startTS))
 		return errors.Trace(err)
 	}
-
-	// strip check_not_exists keys that no need to commit.
-	c.stripNoNeedCommitKeys()
 
 	var commitTS uint64
 	if c.isAsyncCommit() {
@@ -996,6 +710,8 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 		failpoint.Inject("beforeCommit", func() {})
 	}
 
+	c.txn.GetMemBuffer().DiscardValues()
+
 	if c.isAsyncCommit() {
 		// For async commit protocol, the commit is considered success here.
 		c.txn.commitTS = c.commitTS
@@ -1007,7 +723,7 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			})
 			defer c.ttlManager.close()
 			commitBo := NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), c.txn.vars)
-			err := c.commitMutations(commitBo, c.mutations)
+			err := c.commitTxnMutations(commitBo)
 			if err != nil {
 				logutil.Logger(ctx).Warn("2PC async commit failed", zap.Uint64("connID", c.connID),
 					zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS), zap.Error(err))
@@ -1019,12 +735,10 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 }
 
 func (c *twoPhaseCommitter) commitTxn(ctx context.Context, commitDetail *execdetails.CommitDetails) error {
-	c.mutations.values = nil
-	c.txn.GetMemBuffer().DiscardValues()
 	start := time.Now()
 
 	commitBo := NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), c.txn.vars)
-	err := c.commitMutations(commitBo, c.mutations)
+	err := c.commitTxnMutations(commitBo)
 	commitDetail.CommitTime = time.Since(start)
 	if commitBo.totalSleep > 0 {
 		atomic.AddInt64(&commitDetail.CommitBackoffTime, int64(commitBo.totalSleep)*int64(time.Millisecond))
@@ -1053,33 +767,6 @@ func (c *twoPhaseCommitter) commitTxn(ctx context.Context, commitDetail *execdet
 	return nil
 }
 
-func (c *twoPhaseCommitter) stripNoNeedCommitKeys() {
-	if !c.hasNoNeedCommitKeys {
-		return
-	}
-	m := &c.mutations
-	var newIdx int
-	for oldIdx := range m.keys {
-		key := m.keys[oldIdx]
-		flags, err := c.txn.GetMemBuffer().GetFlags(key)
-		if err == nil && flags.HasPrewriteOnly() {
-			continue
-		}
-		m.keys[newIdx] = key
-		if m.ops != nil {
-			m.ops[newIdx] = m.ops[oldIdx]
-		}
-		if m.values != nil {
-			m.values[newIdx] = m.values[oldIdx]
-		}
-		if m.isPessimisticLock != nil {
-			m.isPessimisticLock[newIdx] = m.isPessimisticLock[oldIdx]
-		}
-		newIdx++
-	}
-	c.mutations = m.subRange(0, newIdx)
-}
-
 // SchemaVer is the infoSchema which will return the schema version.
 type SchemaVer interface {
 	// SchemaMetaVersion returns the meta schema version.
@@ -1101,14 +788,23 @@ type RelatedSchemaChange struct {
 }
 
 func (c *twoPhaseCommitter) tryAmendTxn(ctx context.Context, startInfoSchema SchemaVer, change *RelatedSchemaChange) (bool, error) {
-	addMutations, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, c.mutations)
+	mutations := NewCommiterMutations(c.txn.Len())
+	it := committerTxnMutations{c, true}.Iter(nil, nil)
+	for {
+		m := it.Next()
+		if m.key == nil {
+			break
+		}
+		mutations.Push(m.op, m.key, m.value, m.isPessimisticLock)
+	}
+	addMutations, err := c.txn.schemaAmender.AmendTxn(ctx, startInfoSchema, change, mutations)
 	if err != nil {
 		return false, err
 	}
 	// Prewrite new mutations.
 	if addMutations != nil && len(addMutations.keys) > 0 {
 		prewriteBo := NewBackofferWithVars(ctx, PrewriteMaxBackoff, c.txn.vars)
-		err = c.prewriteMutations(prewriteBo, *addMutations)
+		err = c.prewriteMutations(prewriteBo, staticMutations{*addMutations})
 		if err != nil {
 			logutil.Logger(ctx).Warn("amend prewrite has failed", zap.Error(err), zap.Uint64("txnStartTS", c.startTS))
 			return false, err
@@ -1248,188 +944,6 @@ type batchMutations struct {
 	region    RegionVerID
 	mutations CommitterMutations
 	isPrimary bool
-}
-type batched struct {
-	batches    []batchMutations
-	primaryIdx int
-	primaryKey []byte
-}
-
-func newBatched(primaryKey []byte) *batched {
-	return &batched{
-		primaryIdx: -1,
-		primaryKey: primaryKey,
-	}
-}
-
-// appendBatchMutationsBySize appends mutations to b. It may split the keys to make
-// sure each batch's size does not exceed the limit.
-func (b *batched) appendBatchMutationsBySize(region RegionVerID, mutations CommitterMutations, sizeFn func(k, v []byte) int, limit int) {
-	var start, end int
-	for start = 0; start < mutations.len(); start = end {
-		var size int
-		for end = start; end < mutations.len() && size < limit; end++ {
-			var k, v []byte
-			k = mutations.keys[end]
-			if end < len(mutations.values) {
-				v = mutations.values[end]
-			}
-			size += sizeFn(k, v)
-			if b.primaryIdx < 0 && bytes.Equal(k, b.primaryKey) {
-				b.primaryIdx = len(b.batches)
-			}
-		}
-		b.batches = append(b.batches, batchMutations{
-			region:    region,
-			mutations: mutations.subRange(start, end),
-		})
-	}
-}
-
-func (b *batched) setPrimary() bool {
-	// If the batches include the primary key, put it to the first
-	if b.primaryIdx >= 0 {
-		if len(b.batches) > 0 {
-			b.batches[b.primaryIdx].isPrimary = true
-			b.batches[0], b.batches[b.primaryIdx] = b.batches[b.primaryIdx], b.batches[0]
-			b.primaryIdx = 0
-		}
-		return true
-	}
-
-	return false
-}
-
-func (b *batched) allBatches() []batchMutations {
-	return b.batches
-}
-
-// primaryBatch returns the batch containing the primary key.
-// Precondition: `b.setPrimary() == true`
-func (b *batched) primaryBatch() []batchMutations {
-	return b.batches[:1]
-}
-
-func (b *batched) forgetPrimary() {
-	if len(b.batches) == 0 {
-		return
-	}
-	b.batches = b.batches[1:]
-}
-
-// batchExecutor is txn controller providing rate control like utils
-type batchExecutor struct {
-	rateLim           int                  // concurrent worker numbers
-	rateLimiter       *rateLimit           // rate limiter for concurrency control, maybe more strategies
-	committer         *twoPhaseCommitter   // here maybe more different type committer in the future
-	action            twoPhaseCommitAction // the work action type
-	backoffer         *Backoffer           // Backoffer
-	tokenWaitDuration time.Duration        // get token wait time
-}
-
-// newBatchExecutor create processor to handle concurrent batch works(prewrite/commit etc)
-func newBatchExecutor(rateLimit int, committer *twoPhaseCommitter,
-	action twoPhaseCommitAction, backoffer *Backoffer) *batchExecutor {
-	return &batchExecutor{rateLimit, nil, committer,
-		action, backoffer, 1 * time.Millisecond}
-}
-
-// initUtils do initialize batchExecutor related policies like rateLimit util
-func (batchExe *batchExecutor) initUtils() error {
-	// init rateLimiter by injected rate limit number
-	batchExe.rateLimiter = newRateLimit(batchExe.rateLim)
-	return nil
-}
-
-// startWork concurrently do the work for each batch considering rate limit
-func (batchExe *batchExecutor) startWorker(exitCh chan struct{}, ch chan error, batches []batchMutations) {
-	for idx, batch1 := range batches {
-		waitStart := time.Now()
-		if exit := batchExe.rateLimiter.getToken(exitCh); !exit {
-			batchExe.tokenWaitDuration += time.Since(waitStart)
-			batch := batch1
-			go func() {
-				defer batchExe.rateLimiter.putToken()
-				var singleBatchBackoffer *Backoffer
-				if _, ok := batchExe.action.(actionCommit); ok {
-					// Because the secondary batches of the commit actions are implemented to be
-					// committed asynchronously in background goroutines, we should not
-					// fork a child context and call cancel() while the foreground goroutine exits.
-					// Otherwise the background goroutines will be canceled execeptionally.
-					// Here we makes a new clone of the original backoffer for this goroutine
-					// exclusively to avoid the data race when using the same backoffer
-					// in concurrent goroutines.
-					singleBatchBackoffer = batchExe.backoffer.Clone()
-				} else {
-					var singleBatchCancel context.CancelFunc
-					singleBatchBackoffer, singleBatchCancel = batchExe.backoffer.Fork()
-					defer singleBatchCancel()
-				}
-				beforeSleep := singleBatchBackoffer.totalSleep
-				ch <- batchExe.action.handleSingleBatch(batchExe.committer, singleBatchBackoffer, batch)
-				commitDetail := batchExe.committer.getDetail()
-				if commitDetail != nil { // lock operations of pessimistic-txn will let commitDetail be nil
-					if delta := singleBatchBackoffer.totalSleep - beforeSleep; delta > 0 {
-						atomic.AddInt64(&commitDetail.CommitBackoffTime, int64(singleBatchBackoffer.totalSleep-beforeSleep)*int64(time.Millisecond))
-						commitDetail.Mu.Lock()
-						commitDetail.Mu.BackoffTypes = append(commitDetail.Mu.BackoffTypes, singleBatchBackoffer.types...)
-						commitDetail.Mu.Unlock()
-					}
-				}
-			}()
-		} else {
-			logutil.Logger(batchExe.backoffer.ctx).Info("break startWorker",
-				zap.Stringer("action", batchExe.action), zap.Int("batch size", len(batches)),
-				zap.Int("index", idx))
-			break
-		}
-	}
-}
-
-// process will start worker routine and collect results
-func (batchExe *batchExecutor) process(batches []batchMutations) error {
-	var err error
-	err = batchExe.initUtils()
-	if err != nil {
-		logutil.Logger(batchExe.backoffer.ctx).Error("batchExecutor initUtils failed", zap.Error(err))
-		return err
-	}
-
-	// For prewrite, stop sending other requests after receiving first error.
-	backoffer := batchExe.backoffer
-	var cancel context.CancelFunc
-	if _, ok := batchExe.action.(actionPrewrite); ok {
-		backoffer, cancel = batchExe.backoffer.Fork()
-		defer cancel()
-	}
-	// concurrently do the work for each batch.
-	ch := make(chan error, len(batches))
-	exitCh := make(chan struct{})
-	go batchExe.startWorker(exitCh, ch, batches)
-	// check results
-	for i := 0; i < len(batches); i++ {
-		if e := <-ch; e != nil {
-			logutil.Logger(backoffer.ctx).Debug("2PC doActionOnBatch failed",
-				zap.Uint64("conn", batchExe.committer.connID),
-				zap.Stringer("action type", batchExe.action),
-				zap.Error(e),
-				zap.Uint64("txnStartTS", batchExe.committer.startTS))
-			// Cancel other requests and return the first error.
-			if cancel != nil {
-				logutil.Logger(backoffer.ctx).Debug("2PC doActionOnBatch to cancel other actions",
-					zap.Uint64("conn", batchExe.committer.connID),
-					zap.Stringer("action type", batchExe.action),
-					zap.Uint64("txnStartTS", batchExe.committer.startTS))
-				cancel()
-			}
-			if err == nil {
-				err = e
-			}
-		}
-	}
-	close(exitCh)
-	metrics.TiKVTokenWaitDuration.Observe(batchExe.tokenWaitDuration.Seconds())
-	return err
 }
 
 func getTxnPriority(txn *tikvTxn) pb.CommandPri {

--- a/store/tikv/2pc_exec.go
+++ b/store/tikv/2pc_exec.go
@@ -1,0 +1,394 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv
+
+import (
+	"bytes"
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/logutil"
+	"go.uber.org/zap"
+)
+
+type execJob struct {
+	batch  *batchMutations
+	bo     *Backoffer
+	cancel context.CancelFunc
+}
+
+type execController struct {
+	sync.WaitGroup
+	committer  *twoPhaseCommitter
+	action     twoPhaseCommitAction
+	filter     func([]byte) bool
+	mutations  mutations
+	numRegions int
+
+	bo     *Backoffer
+	cancel context.CancelFunc
+
+	errCh       chan error
+	jobCh       chan *execJob
+	workerLimit int
+	workerCnt   int32
+	stop        int32
+}
+
+func (c *twoPhaseCommitter) newExecController(mutations mutations, action twoPhaseCommitAction) *execController {
+	return &execController{
+		committer: c,
+		action:    action,
+		mutations: mutations,
+
+		errCh:       make(chan error, 1),
+		jobCh:       make(chan *execJob),
+		workerLimit: config.GetGlobalConfig().Performance.CommitterConcurrency,
+	}
+}
+
+func (c *execController) run(bo *Backoffer) error {
+	failpoint.Inject("pessimisticRollbackDoNth", func() {
+		_, actionIsPessimisticRollback := c.action.(actionPessimisticRollback)
+		if actionIsPessimisticRollback && c.committer.connID > 0 {
+			logutil.Logger(c.bo.ctx).Warn("pessimisticRollbackDoNth failpoint")
+			failpoint.Return(nil)
+		}
+	})
+
+	_, actionIsPrewrite := c.action.(actionPrewrite)
+	_, actionIsCommit := c.action.(actionCommit)
+	_, actionIsCleanup := c.action.(actionCleanup)
+	_, actionIsPessimisticLock := c.action.(actionPessimisticLock)
+	if actionIsPessimisticLock {
+		defer func() {
+			if stats := c.action.(actionPessimisticLock).Stats; stats != nil {
+				stats.RegionNum = int32(c.numRegions)
+			}
+		}()
+	}
+
+	var skipPrimary, skipSecondary bool
+	failpoint.Inject("skipKeyReturnOK", func(val failpoint.Value) {
+		valStr, ok := val.(string)
+		if ok && c.committer.connID > 0 {
+			if c.containsPrimaryKey() && actionIsPessimisticLock {
+				logutil.Logger(c.bo.ctx).Warn("pessimisticLock failpoint", zap.String("valStr", valStr))
+				switch valStr {
+				case "pessimisticLockSkipPrimary":
+					skipPrimary = true
+				case "pessimisticLockSkipSecondary":
+					skipSecondary = true
+				}
+			}
+		}
+	})
+
+	var cancel context.CancelFunc
+	c.bo, cancel = bo.Fork()
+	if actionIsPrewrite {
+		c.cancel = cancel
+	}
+
+	writePrimaryFirst := (actionIsCommit && !c.committer.isAsyncCommit()) || actionIsCleanup || actionIsPessimisticLock
+	if c.containsPrimaryKey() && writePrimaryFirst && !skipPrimary {
+		c.numRegions++
+		keys, err := c.handlePrimaryMutation(actionIsCommit)
+		if err != nil || keys == c.mutations.Len() {
+			return errors.Trace(err)
+		}
+	}
+
+	if skipSecondary {
+		return nil
+	}
+
+	// Already spawned a goroutine for async commit transaction.
+	if actionIsCommit && !c.committer.isAsyncCommit() {
+		c.bo, cancel = NewBackofferWithVars(context.Background(), int(atomic.LoadUint64(&CommitMaxBackoff)), c.committer.txn.vars).Fork()
+		go func() {
+			err := c.handleMutations()
+			cancel()
+			if err != nil {
+				logutil.BgLogger().Debug("2PC async doActionOnBatches",
+					zap.Uint64("conn", c.committer.connID),
+					zap.Stringer("action type", c.action),
+					zap.Error(err))
+				tikvSecondaryLockCleanupFailureCounterCommit.Inc()
+			}
+		}()
+		return nil
+	}
+
+	err := c.handleMutations()
+	cancel()
+	return errors.Trace(err)
+}
+
+func (c *execController) handlePrimaryMutation(actionIsCommit bool) (int, error) {
+	var batch *batchMutations
+	for {
+		collector, err := c.getCollector(c.bo, c.committer.primaryKey, nil)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		batch, err = collector.Collect()
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+
+		retry, err := c.action.handleSingleBatch(c.committer, c.bo, batch)
+		if err == nil && !retry {
+			break
+		}
+		if !retry {
+			return 0, errors.Trace(err)
+		}
+		if err != nil {
+			err = c.bo.Backoff(BoRegionMiss, err)
+			if err != nil {
+				return 0, errors.Trace(err)
+			}
+		}
+	}
+
+	knobs := &c.committer.testingKnobs
+	if actionIsCommit && knobs.bkAfterCommitPrimary != nil && knobs.acAfterCommitPrimary != nil {
+		knobs.acAfterCommitPrimary <- struct{}{}
+		<-knobs.bkAfterCommitPrimary
+	}
+
+	start, end := batch.mutations.keys[0], batch.mutations.keys[batch.mutations.len()-1]
+	c.filter = func(key []byte) bool {
+		return bytes.Compare(key, start) < 0 || bytes.Compare(key, end) > 0
+	}
+	return batch.mutations.len(), nil
+}
+
+func (c *execController) handleMutations() (err error) {
+	collector, err := c.getCollector(c.bo, nil, nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	var prev RegionVerID
+	for {
+		var batch *batchMutations
+		batch, err = collector.Collect()
+
+		if err != nil {
+			c.handleError(err)
+			break
+		}
+		if batch == nil {
+			break
+		}
+		if batch.region != prev {
+			prev = batch.region
+			c.numRegions++
+		}
+
+		if collector.Finished() {
+			bo, cancel := c.bo.Fork()
+			c.handleSingleBatch(&execJob{batch, bo, cancel})
+			break
+		}
+
+		if err = c.dispatchBatch(c.bo, batch); err != nil {
+			break
+		}
+	}
+	c.Wait()
+	if err == nil {
+		select {
+		case err = <-c.errCh:
+		default:
+		}
+	}
+	close(c.jobCh)
+
+	return errors.Trace(err)
+}
+
+func (c *execController) containsPrimaryKey() bool {
+	it := c.mutations.Iter(c.committer.primaryKey, nil)
+	m := it.Next()
+	return bytes.Equal(m.key, c.committer.primaryKey)
+}
+
+func (c *execController) getCollector(bo *Backoffer, start, end []byte) (*mutationBatchCollector, error) {
+	_, actionIsPrewrite := c.action.(actionPrewrite)
+	it := c.mutations.Iter(start, end)
+	if c.filter != nil {
+		it.WithFilter(c.filter)
+	}
+
+	return c.committer.newBatchCollector(bo, it, txnCommitBatchSize, actionIsPrewrite)
+}
+
+func (c *execController) dispatchBatch(bo *Backoffer, batch *batchMutations) error {
+	fbo, cancel := bo.Fork()
+	job := &execJob{batch, fbo, cancel}
+	c.Add(1)
+
+	select {
+	case c.jobCh <- job:
+		return nil
+	default:
+		c.tryAddWorker()
+	}
+
+	if c.cancel == nil {
+		c.jobCh <- job
+		return nil
+	}
+
+	// We can cancel dispatcher by return error.
+	select {
+	case c.jobCh <- job:
+		return nil
+	case err := <-c.errCh:
+		c.Done()
+		return err
+	}
+}
+
+func (c *execController) workerLoop() {
+	for job := range c.jobCh {
+		if !c.terminated() {
+			c.handleSingleBatch(job)
+		}
+		c.Done()
+	}
+}
+
+func (c *execController) handleSingleBatch(job *execJob) {
+	retry, err := c.action.handleSingleBatch(c.committer, job.bo, job.batch)
+	if !retry {
+		c.handleError(err)
+		job.cancel()
+		return
+	}
+	c.handleRegionError(err, job)
+}
+
+func (c *execController) handleRegionError(retryErr error, retryJob *execJob) {
+	c.Add(1)
+	// TODO: To avoid a spike of goroutines count,
+	// we need an heap to track all retry jobs, and poll them in the main dispatcher.
+	go func() {
+		defer c.Done()
+		if retryErr != nil {
+			beforeSleep := retryJob.bo.totalSleep
+			err := retryJob.bo.Backoff(BoRegionMiss, retryErr)
+			c.updateSingleBatchDetail(retryJob.bo, beforeSleep)
+			if err != nil {
+				c.handleError(err)
+				return
+			}
+		}
+
+		keys := retryJob.batch.mutations.keys
+		collector, err := c.getCollector(retryJob.bo, keys[0], kv.Key(keys[len(keys)-1]).Next())
+		if err != nil {
+			c.handleError(err)
+			return
+		}
+
+		for {
+			batch, err := collector.Collect()
+			if err != nil {
+				c.handleError(err)
+				return
+			}
+
+			if batch == nil {
+				return
+			}
+
+			if err := c.dispatchBatch(retryJob.bo, batch); err != nil {
+				logutil.Logger(c.bo.ctx).Debug("2pc retry on region error failed", zap.Error(err))
+				return
+			}
+		}
+	}()
+}
+
+func (c *execController) tryAddWorker() {
+	limit := int32(c.workerLimit)
+	for {
+		cnt := atomic.LoadInt32(&c.workerCnt)
+		if cnt >= limit {
+			return
+		}
+		if atomic.CompareAndSwapInt32(&c.workerCnt, cnt, cnt+1) {
+			go c.workerLoop()
+			return
+		}
+	}
+}
+
+func (c *execController) handleError(err error) {
+	if err == nil {
+		return
+	}
+
+	logutil.BgLogger().Debug("2PC doActionOnBatch failed",
+		zap.Uint64("conn", c.committer.connID),
+		zap.Stringer("action type", c.action),
+		zap.Error(err),
+		zap.Uint64("txnStartTS", c.committer.startTS))
+
+	if c.cancel != nil {
+		old := atomic.SwapInt32(&c.stop, 1)
+		if old == 0 {
+			logutil.BgLogger().Debug("2PC doActionOnBatch to cancel other actions",
+				zap.Uint64("conn", c.committer.connID),
+				zap.Stringer("action type", c.action),
+				zap.Uint64("txnStartTS", c.committer.startTS))
+			c.cancel()
+		}
+	}
+
+	select {
+	case c.errCh <- err:
+	default:
+	}
+}
+
+func (c *execController) terminated() bool {
+	return atomic.LoadInt32(&c.stop) == 1
+}
+
+func (c *execController) updateSingleBatchDetail(bo *Backoffer, beforeSleep int) {
+	detail := c.committer.getDetail()
+	if detail == nil {
+		// lock operations of pessimistic-txn will let commitDetail be nil
+		return
+	}
+	delta := bo.totalSleep - beforeSleep
+	if delta <= 0 {
+		return
+	}
+	atomic.AddInt64(&detail.CommitBackoffTime, int64(delta)*int64(time.Millisecond))
+	detail.Mu.Lock()
+	detail.Mu.BackoffTypes = append(detail.Mu.BackoffTypes, bo.types...)
+	detail.Mu.Unlock()
+}

--- a/store/tikv/2pc_fail_test.go
+++ b/store/tikv/2pc_fail_test.go
@@ -141,6 +141,6 @@ func (s *testCommitterSuite) TestFailPrewriteRegionError(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := context.Background()
-	err = committer.prewriteMutations(NewBackofferWithVars(ctx, 1000, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, 1000, nil))
 	c.Assert(err, NotNil)
 }

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -143,7 +143,7 @@ func (s *testCommitterSuite) TestDeleteYourWritesTTL(c *C) {
 		c.Assert(err, IsNil)
 		committer, err := newTwoPhaseCommitterWithInit(txn, 0)
 		c.Assert(err, IsNil)
-		err = committer.prewriteMutations(bo, committer.mutations)
+		err = committer.prewriteMutations(bo, staticMutations{committer.mutationsOfKeys(nil)})
 		c.Assert(err, IsNil)
 		state := atomic.LoadUint32((*uint32)(&committer.ttlManager.state))
 		c.Check(state, Equals, uint32(stateRunning))
@@ -159,7 +159,7 @@ func (s *testCommitterSuite) TestDeleteYourWritesTTL(c *C) {
 		c.Assert(err, IsNil)
 		committer, err := newTwoPhaseCommitterWithInit(txn, 0)
 		c.Assert(err, IsNil)
-		err = committer.prewriteMutations(bo, committer.mutations)
+		err = committer.prewriteMutations(bo, staticMutations{committer.mutationsOfKeys(nil)})
 		c.Assert(err, IsNil)
 		state := atomic.LoadUint32((*uint32)(&committer.ttlManager.state))
 		c.Check(state, Equals, uint32(stateRunning))
@@ -205,7 +205,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := newTwoPhaseCommitterWithInit(txn1, 0)
 	c.Assert(err, IsNil)
-	err = committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 
 	txn2 := s.begin(c)
@@ -213,7 +213,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("a0"))
 
-	err = committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	if err != nil {
 		// Retry.
 		txn1 = s.begin(c)
@@ -223,12 +223,12 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 		c.Assert(err, IsNil)
 		committer, err = newTwoPhaseCommitterWithInit(txn1, 0)
 		c.Assert(err, IsNil)
-		err = committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), committer.mutations)
+		err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 		c.Assert(err, IsNil)
 	}
 	committer.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 	c.Assert(err, IsNil)
-	err = committer.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), CommitterMutations{keys: [][]byte{[]byte("a")}})
+	err = committer.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), staticMutations{CommitterMutations{keys: [][]byte{[]byte("a")}}})
 	c.Assert(err, IsNil)
 
 	txn3 := s.begin(c)
@@ -249,7 +249,7 @@ func (s *testCommitterSuite) TestContextCancel(c *C) {
 	bo := NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil)
 	backoffer, cancel := bo.Fork()
 	cancel() // cancel the context
-	err = committer.prewriteMutations(backoffer, committer.mutations)
+	err = committer.prewriteTxnMutations(backoffer)
 	c.Assert(errors.Cause(err), Equals, context.Canceled)
 }
 
@@ -275,7 +275,7 @@ func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := newTwoPhaseCommitterWithInit(txn1, 0)
 	c.Assert(err, IsNil)
-	err = committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 	// txn3 writes "c"
 	err = txn3.Set([]byte("c"), []byte("c3"))
@@ -398,7 +398,7 @@ func newTwoPhaseCommitterWithInit(txn *tikvTxn, connID uint64) (*twoPhaseCommitt
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err = c.initKeysAndMutations(); err != nil {
+	if err = c.initCommitterStates(context.Background()); err != nil {
 		return nil, errors.Trace(err)
 	}
 	return c, nil
@@ -411,9 +411,9 @@ func (s *testCommitterSuite) TestCommitBeforePrewrite(c *C) {
 	committer, err := newTwoPhaseCommitterWithInit(txn, 0)
 	c.Assert(err, IsNil)
 	ctx := context.Background()
-	err = committer.cleanupMutations(NewBackofferWithVars(ctx, cleanupMaxBackoff, nil), committer.mutations)
+	err = committer.cleanupTxnMutations(NewBackofferWithVars(ctx, cleanupMaxBackoff, nil))
 	c.Assert(err, IsNil)
-	err = committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	c.Assert(err, NotNil)
 	errMsgMustContain(c, err, "already rolled back")
 }
@@ -455,7 +455,7 @@ func (s *testCommitterSuite) TestPrewritePrimaryKeyFailed(c *C) {
 	ctx := context.Background()
 	committer, err := newTwoPhaseCommitterWithInit(txn2, 0)
 	c.Assert(err, IsNil)
-	err = committer.cleanupMutations(NewBackofferWithVars(ctx, cleanupMaxBackoff, nil), committer.mutations)
+	err = committer.cleanupTxnMutations(NewBackofferWithVars(ctx, cleanupMaxBackoff, nil))
 	c.Assert(err, IsNil)
 
 	// check the data after rollback twice.
@@ -526,7 +526,7 @@ func (s *testCommitterSuite) TestPrewriteTxnSize(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := context.Background()
-	err = committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 
 	// Check the written locks in the first region (50 keys)
@@ -549,13 +549,13 @@ func (s *testCommitterSuite) TestRejectCommitTS(c *C) {
 	committer, err := newTwoPhaseCommitterWithInit(txn, 1)
 	c.Assert(err, IsNil)
 	bo := NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
-	loc, err := s.store.regionCache.LocateKey(bo, []byte("x"))
+	batch, err := committer.collectPrewriteMutationsBatch(bo)
 	c.Assert(err, IsNil)
 	mutations := []*kvrpcpb.Mutation{
 		{
-			Op:    committer.mutations.ops[0],
-			Key:   committer.mutations.keys[0],
-			Value: committer.mutations.values[0],
+			Op:    batch.mutations.ops[0],
+			Key:   batch.mutations.keys[0],
+			Value: batch.mutations.values[0],
 		},
 	}
 	prewrite := &kvrpcpb.PrewriteRequest{
@@ -566,14 +566,14 @@ func (s *testCommitterSuite) TestRejectCommitTS(c *C) {
 		MinCommitTs:  committer.startTS + 100, // Set minCommitTS
 	}
 	req := tikvrpc.NewRequest(tikvrpc.CmdPrewrite, prewrite)
-	_, err = s.store.SendReq(bo, req, loc.Region, readTimeoutShort)
+	_, err = s.store.SendReq(bo, req, batch.region, readTimeoutShort)
 	c.Assert(err, IsNil)
 
 	// Make commitTS less than minCommitTS.
 	committer.commitTS = committer.startTS + 1
 	// Ensure that the new commit ts is greater than minCommitTS when retry
 	time.Sleep(3 * time.Millisecond)
-	err = committer.commitMutations(bo, committer.mutations)
+	err = committer.commitTxnMutations(bo)
 	c.Assert(err, IsNil)
 
 	// Use startTS+2 to read the data and get nothing.
@@ -601,9 +601,8 @@ func (s *testCommitterSuite) TestPessimisticPrewriteRequest(c *C) {
 	committer, err := newTwoPhaseCommitterWithInit(txn, 0)
 	c.Assert(err, IsNil)
 	committer.forUpdateTS = 100
-	var batch batchMutations
-	batch.mutations = committer.mutations.subRange(0, 1)
-	batch.region = RegionVerID{1, 1, 1}
+	batch, err := committer.collectPrewriteMutationsBatch(NewBackofferWithVars(context.Background(), getMaxBackoff, nil))
+	c.Assert(err, IsNil)
 	req := committer.buildPrewriteRequest(batch, 1)
 	c.Assert(len(req.Prewrite().IsPessimisticLock), Greater, 0)
 	c.Assert(req.Prewrite().ForUpdateTs, Equals, uint64(100))
@@ -877,11 +876,10 @@ func (s *testCommitterSuite) getLockInfo(c *C, key []byte) *kvrpcpb.LockInfo {
 	committer, err := newTwoPhaseCommitterWithInit(txn, 1)
 	c.Assert(err, IsNil)
 	bo := NewBackofferWithVars(context.Background(), getMaxBackoff, nil)
-	loc, err := s.store.regionCache.LocateKey(bo, key)
+	batch, err := committer.collectPrewriteMutationsBatch(bo)
 	c.Assert(err, IsNil)
-	batch := batchMutations{region: loc.Region, mutations: committer.mutations.subRange(0, 1)}
 	req := committer.buildPrewriteRequest(batch, 1)
-	resp, err := s.store.SendReq(bo, req, loc.Region, readTimeoutShort)
+	resp, err := s.store.SendReq(bo, req, batch.region, readTimeoutShort)
 	c.Assert(err, IsNil)
 	c.Assert(resp.Resp, NotNil)
 	keyErrs := (resp.Resp.(*kvrpcpb.PrewriteResponse)).Errors
@@ -915,7 +913,7 @@ func (s *testCommitterSuite) TestPkNotFound(c *C) {
 	// while the secondary lock operation succeeded
 	bo := NewBackofferWithVars(context.Background(), pessimisticLockMaxBackoff, nil)
 	txn1.committer.ttlManager.close()
-	err = txn1.committer.pessimisticRollbackMutations(bo, CommitterMutations{keys: [][]byte{k1}})
+	err = txn1.committer.pessimisticRollbackKeys(bo, [][]byte{k1})
 	c.Assert(err, IsNil)
 
 	// Txn2 tries to lock the secondary key k2, dead loop if the left secondary lock by txn1 not resolved
@@ -990,10 +988,21 @@ func (s *testCommitterSuite) TestPessimisticLockPrimary(c *C) {
 
 func (c *twoPhaseCommitter) mutationsOfKeys(keys [][]byte) CommitterMutations {
 	var res CommitterMutations
-	for i := range c.mutations.keys {
+	it := committerTxnMutations{c, true}.Iter(nil, nil)
+	for {
+		m := it.Next()
+
+		if m.key == nil {
+			break
+		}
+
+		if len(keys) == 0 {
+			res.Push(m.op, m.key, m.value, m.isPessimisticLock)
+		}
+
 		for _, key := range keys {
-			if bytes.Equal(c.mutations.keys[i], key) {
-				res.Push(c.mutations.ops[i], c.mutations.keys[i], c.mutations.values[i], c.mutations.isPessimisticLock[i])
+			if bytes.Equal(m.key, key) {
+				res.Push(m.op, m.key, m.value, m.isPessimisticLock)
 				break
 			}
 		}
@@ -1057,7 +1066,7 @@ func (s *testCommitterSuite) TestCommitDeadLock(c *C) {
 // TestPushPessimisticLock tests that push forward the minCommiTS of pessimistic locks.
 func (s *testCommitterSuite) TestPushPessimisticLock(c *C) {
 	// k1 is the primary key.
-	k1, k2 := kv.Key("a"), kv.Key("b")
+	k1, k2 := kv.Key("a1"), kv.Key("a2")
 	ctx := context.Background()
 
 	txn1 := s.begin(c)
@@ -1067,12 +1076,14 @@ func (s *testCommitterSuite) TestPushPessimisticLock(c *C) {
 	c.Assert(err, IsNil)
 
 	txn1.Set(k2, []byte("v2"))
-	err = txn1.committer.initKeysAndMutations()
+	err = txn1.committer.initCommitterStates(context.Background())
 	c.Assert(err, IsNil)
+
 	// Strip the prewrite of the primary key.
-	txn1.committer.mutations = txn1.committer.mutations.subRange(1, 2)
+	mutations := txn1.committer.mutationsOfKeys(nil)
+	mutations = mutations.subRange(1, 2)
 	c.Assert(err, IsNil)
-	err = txn1.committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), txn1.committer.mutations)
+	err = txn1.committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), staticMutations{mutations})
 	c.Assert(err, IsNil)
 	// The primary lock is a pessimistic lock and the secondary lock is a optimistic lock.
 	lock1 := s.getLockInfo(c, k1)
@@ -1121,9 +1132,9 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 	for i := 0; i < bigTxnThreshold; i++ {
 		txn1.Set(secondaryLockkeys[i], []byte(fmt.Sprintf("v%d", i)))
 	}
-	err = txn1.committer.initKeysAndMutations()
+	err = txn1.committer.initCommitterStates(context.Background())
 	c.Assert(err, IsNil)
-	err = txn1.committer.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), txn1.committer.mutations)
+	err = txn1.committer.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 	// lock the pessimistic keys
 	err = txn1.LockKeys(context.Background(), lockCtx, pessimisticLockKey)
@@ -1139,7 +1150,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 	// stop txn ttl manager and remove primary key, make the other keys left behind
 	bo := NewBackofferWithVars(context.Background(), pessimisticLockMaxBackoff, nil)
 	txn1.committer.ttlManager.close()
-	err = txn1.committer.pessimisticRollbackMutations(bo, CommitterMutations{keys: [][]byte{pk}})
+	err = txn1.committer.pessimisticRollbackKeys(bo, [][]byte{pk})
 	c.Assert(err, IsNil)
 
 	// try to resolve the left optimistic locks, use clean whole region
@@ -1339,4 +1350,13 @@ func allKeysNoDups(req *kvrpcpb.PrewriteRequest) bool {
 		}
 	}
 	return true
+}
+
+func (c *twoPhaseCommitter) collectPrewriteMutationsBatch(bo *Backoffer) (*batchMutations, error) {
+	it := committerTxnMutations{c, true}.Iter(nil, nil)
+	collector, err := c.newBatchCollector(bo, it, txnCommitBatchSize, true)
+	if err != nil {
+		return nil, err
+	}
+	return collector.Collect()
 }

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -91,13 +91,13 @@ func (s *testAsyncCommitSuite) lockKeys(c *C, keys, values [][]byte, primaryKey,
 	tpc.primaryKey = primaryKey
 
 	ctx := context.Background()
-	err = tpc.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), tpc.mutations)
+	err = tpc.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 
 	if commitPrimary {
 		tpc.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 		c.Assert(err, IsNil)
-		err = tpc.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), tpc.mutationsOfKeys([][]byte{primaryKey}))
+		err = tpc.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), staticMutations{tpc.mutationsOfKeys([][]byte{primaryKey})})
 		c.Assert(err, IsNil)
 	}
 	return txn.startTS, tpc.commitTS

--- a/store/tikv/cleanup.go
+++ b/store/tikv/cleanup.go
@@ -23,7 +23,8 @@ import (
 	"go.uber.org/zap"
 )
 
-type actionCleanup struct{}
+type actionCleanup struct {
+}
 
 var _ twoPhaseCommitAction = actionCleanup{}
 var tiKVTxnRegionsNumHistogramCleanup = metrics.TiKVTxnRegionsNumHistogram.WithLabelValues(metricsTag("cleanup"))
@@ -36,37 +37,37 @@ func (actionCleanup) tiKVTxnRegionsNumHistogram() prometheus.Observer {
 	return tiKVTxnRegionsNumHistogramCleanup
 }
 
-func (actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch batchMutations) error {
+func (actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch *batchMutations) (bool, error) {
 	req := tikvrpc.NewRequest(tikvrpc.CmdBatchRollback, &pb.BatchRollbackRequest{
 		Keys:         batch.mutations.keys,
 		StartVersion: c.startTS,
 	}, pb.Context{Priority: c.priority, SyncLog: c.syncLog})
 	resp, err := c.store.SendReq(bo, req, batch.region, readTimeoutShort)
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	regionErr, err := resp.GetRegionError()
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-		if err != nil {
-			return errors.Trace(err)
-		}
-		err = c.cleanupMutations(bo, batch.mutations)
-		return errors.Trace(err)
+		return true, errors.Trace(errors.New(regionErr.String()))
 	}
 	if keyErr := resp.Resp.(*pb.BatchRollbackResponse).GetError(); keyErr != nil {
 		err = errors.Errorf("conn %d 2PC cleanup failed: %s", c.connID, keyErr)
 		logutil.BgLogger().Debug("2PC failed cleanup key",
 			zap.Error(err),
 			zap.Uint64("txnStartTS", c.startTS))
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
-	return nil
+	return false, nil
 }
 
-func (c *twoPhaseCommitter) cleanupMutations(bo *Backoffer, mutations CommitterMutations) error {
-	return c.doActionOnMutations(bo, actionCleanup{}, mutations)
+func (c *twoPhaseCommitter) cleanupMutations(bo *Backoffer, mutations mutations) error {
+	exec := c.newExecController(mutations, actionCleanup{})
+	return exec.run(bo)
+}
+
+func (c *twoPhaseCommitter) cleanupTxnMutations(bo *Backoffer) error {
+	return c.cleanupMutations(bo, committerTxnMutations{c, false})
 }

--- a/store/tikv/commit.go
+++ b/store/tikv/commit.go
@@ -26,7 +26,9 @@ import (
 	"go.uber.org/zap"
 )
 
-type actionCommit struct{ retry bool }
+type actionCommit struct {
+	retry bool
+}
 
 var _ twoPhaseCommitAction = actionCommit{}
 
@@ -41,7 +43,7 @@ func (actionCommit) tiKVTxnRegionsNumHistogram() prometheus.Observer {
 	return tiKVTxnRegionsNumHistogramCommit
 }
 
-func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch batchMutations) error {
+func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch *batchMutations) (bool, error) {
 	req := tikvrpc.NewRequest(tikvrpc.CmdCommit, &pb.CommitRequest{
 		StartVersion:  c.startTS,
 		Keys:          batch.mutations.keys,
@@ -61,23 +63,17 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 	}
 
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	regionErr, err := resp.GetRegionError()
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-		if err != nil {
-			return errors.Trace(err)
-		}
-		// re-split keys and commit again.
-		err = c.doActionOnMutations(bo, actionCommit{retry: true}, batch.mutations)
-		return errors.Trace(err)
+		return true, errors.Trace(errors.New(regionErr.String()))
 	}
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return false, errors.Trace(ErrBodyMissing)
 	}
 	commitResp := resp.Resp.(*pb.CommitResponse)
 	// Here we can make sure tikv has processed the commit primary key request. So
@@ -96,7 +92,7 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 			if rejected.MinCommitTs-rejected.AttemptedCommitTs > 943718400000 {
 				err := errors.Errorf("2PC MinCommitTS is too large, we got MinCommitTS: %d, and AttemptedCommitTS: %d",
 					rejected.MinCommitTs, rejected.AttemptedCommitTs)
-				return errors.Trace(err)
+				return false, errors.Trace(err)
 			}
 
 			// Update commit ts and retry.
@@ -105,13 +101,13 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 				logutil.Logger(bo.ctx).Warn("2PC get commitTS failed",
 					zap.Error(err),
 					zap.Uint64("txnStartTS", c.startTS))
-				return errors.Trace(err)
+				return false, errors.Trace(err)
 			}
 
 			c.mu.Lock()
 			c.commitTS = commitTS
 			c.mu.Unlock()
-			return c.commitMutations(bo, batch.mutations)
+			return true, nil
 		}
 
 		c.mu.RLock()
@@ -132,13 +128,13 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 				zap.Uint64("txnStartTS", c.startTS),
 				zap.Uint64("commitTS", c.commitTS),
 				zap.Strings("keys", hexBatchKeys(batch.mutations.keys)))
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		// The transaction maybe rolled back by concurrent transactions.
 		logutil.Logger(bo.ctx).Debug("2PC failed commit primary key",
 			zap.Error(err),
 			zap.Uint64("txnStartTS", c.startTS))
-		return err
+		return false, err
 	}
 
 	c.mu.Lock()
@@ -146,15 +142,20 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 	// Group that contains primary key is always the first.
 	// We mark transaction's status committed when we receive the first success response.
 	c.mu.committed = true
-	return nil
+	return false, nil
 }
 
-func (c *twoPhaseCommitter) commitMutations(bo *Backoffer, mutations CommitterMutations) error {
+func (c *twoPhaseCommitter) commitMutations(bo *Backoffer, mutations mutations) error {
 	if span := opentracing.SpanFromContext(bo.ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.commitMutations", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
 		bo.ctx = opentracing.ContextWithSpan(bo.ctx, span1)
 	}
 
-	return c.doActionOnMutations(bo, actionCommit{}, mutations)
+	exec := c.newExecController(mutations, actionCommit{})
+	return exec.run(bo)
+}
+
+func (c *twoPhaseCommitter) commitTxnMutations(bo *Backoffer) error {
+	return c.commitMutations(bo, committerTxnMutations{c, false})
 }

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -68,13 +68,14 @@ func (s *testLockSuite) lockKey(c *C, key, value, primaryKey, primaryValue []byt
 	tpc.primaryKey = primaryKey
 
 	ctx := context.Background()
-	err = tpc.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), tpc.mutations)
+	err = tpc.prewriteTxnMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil))
+
 	c.Assert(err, IsNil)
 
 	if commitPrimary {
 		tpc.commitTS, err = s.store.oracle.GetTimestamp(ctx)
 		c.Assert(err, IsNil)
-		err = tpc.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), tpc.mutationsOfKeys([][]byte{primaryKey}))
+		err = tpc.commitMutations(NewBackofferWithVars(ctx, int(atomic.LoadUint64(&CommitMaxBackoff)), nil), staticMutations{tpc.mutationsOfKeys([][]byte{primaryKey})})
 		c.Assert(err, IsNil)
 	}
 	return txn.startTS, tpc.commitTS
@@ -328,14 +329,17 @@ func (s *testLockSuite) TestCheckTxnStatusNoWait(c *C) {
 	c.Assert(err, IsNil)
 	txn.Set(kv.Key("key"), []byte("value"))
 	txn.Set(kv.Key("second"), []byte("xxx"))
-	committer, err := newTwoPhaseCommitterWithInit(txn.(*tikvTxn), 0)
+	committer, err := newTwoPhaseCommitter(txn.(*tikvTxn), 0)
+	c.Assert(err, IsNil)
+	err = committer.initCommitterStates(context.Background())
 	c.Assert(err, IsNil)
 	// Increase lock TTL to make CI more stable.
 	committer.lockTTL = txnLockTTL(txn.(*tikvTxn).startTime, 200*1024*1024)
 
 	// Only prewrite the secondary key to simulate a concurrent prewrite case:
 	// prewrite secondary regions success and prewrite the primary region is pending.
-	err = committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), committer.mutationsOfKeys([][]byte{[]byte("second")}))
+	ms := staticMutations{committer.mutationsOfKeys([][]byte{[]byte("second")})}
+	err = committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), ms)
 	c.Assert(err, IsNil)
 
 	oracle := s.store.GetOracle()
@@ -352,7 +356,8 @@ func (s *testLockSuite) TestCheckTxnStatusNoWait(c *C) {
 
 	errCh := make(chan error)
 	go func() {
-		errCh <- committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), committer.mutationsOfKeys([][]byte{[]byte("key")}))
+		ms := staticMutations{committer.mutationsOfKeys([][]byte{[]byte("key")})}
+		errCh <- committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), ms)
 	}()
 
 	lock := &Lock{
@@ -366,7 +371,7 @@ func (s *testLockSuite) TestCheckTxnStatusNoWait(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(status.ttl, Greater, uint64(0))
 	c.Assert(<-errCh, IsNil)
-	c.Assert(committer.cleanupMutations(bo, committer.mutations), IsNil)
+	c.Assert(committer.cleanupTxnMutations(bo), IsNil)
 
 	// Call getTxnStatusFromLock to cover TxnNotFound and retry timeout.
 	startTS, err := oracle.GetTimestamp(context.Background())
@@ -395,7 +400,7 @@ func (s *testLockSuite) prewriteTxnWithTTL(c *C, txn *tikvTxn, ttl uint64) {
 		elapsed := time.Since(txn.startTime) / time.Millisecond
 		committer.lockTTL = uint64(elapsed) + ttl
 	}
-	err = committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 }
 
@@ -481,7 +486,7 @@ func (s *testLockSuite) TestBatchResolveLocks(c *C) {
 	c.Assert(err, IsNil)
 	committer.setAsyncCommit(true)
 	committer.lockTTL = 20000
-	err = committer.prewriteMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil), committer.mutations)
+	err = committer.prewriteTxnMutations(NewBackofferWithVars(context.Background(), PrewriteMaxBackoff, nil))
 	c.Assert(err, IsNil)
 
 	var locks []*Lock

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -55,7 +55,7 @@ func (actionPessimisticRollback) tiKVTxnRegionsNumHistogram() prometheus.Observe
 	return tiKVTxnRegionsNumHistogramPessimisticRollback
 }
 
-func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch batchMutations) error {
+func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch *batchMutations) (bool, error) {
 	m := &batch.mutations
 	mutations := make([]*pb.Mutation, m.len())
 	for i := range m.keys {
@@ -91,9 +91,9 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 				req.PessimisticLock().WaitTimeout = timeLeft
 			}
 		}
-		failpoint.Inject("PessimisticLockErrWriteConflict", func() error {
+		failpoint.Inject("PessimisticLockErrWriteConflict", func() {
 			time.Sleep(300 * time.Millisecond)
-			return kv.ErrWriteConflict
+			failpoint.Return(false, kv.ErrWriteConflict)
 		})
 		startTime := time.Now()
 		resp, err := c.store.SendReq(bo, req, batch.region, readTimeoutShort)
@@ -102,22 +102,17 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			atomic.AddInt64(&action.LockCtx.Stats.LockRPCCount, 1)
 		}
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
-			}
-			err = c.pessimisticLockMutations(bo, action.LockCtx, batch.mutations)
-			return errors.Trace(err)
+			return true, errors.Trace(errors.New(regionErr.String()))
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return false, errors.Trace(ErrBodyMissing)
 		}
 		lockResp := resp.Resp.(*pb.PessimisticLockResponse)
 		keyErrs := lockResp.GetErrors()
@@ -129,23 +124,23 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 				}
 				action.ValuesLock.Unlock()
 			}
-			return nil
+			return false, nil
 		}
 		var locks []*Lock
 		for _, keyErr := range keyErrs {
 			// Check already exists error
 			if alreadyExist := keyErr.GetAlreadyExist(); alreadyExist != nil {
 				key := alreadyExist.GetKey()
-				return c.extractKeyExistsErr(key)
+				return false, c.extractKeyExistsErr(key)
 			}
 			if deadlock := keyErr.Deadlock; deadlock != nil {
-				return &ErrDeadlock{Deadlock: deadlock}
+				return false, &ErrDeadlock{Deadlock: deadlock}
 			}
 
 			// Extract lock from key error
 			lock, err1 := extractLockFromKeyErr(keyErr)
 			if err1 != nil {
-				return errors.Trace(err1)
+				return false, errors.Trace(err1)
 			}
 			locks = append(locks, lock)
 		}
@@ -154,7 +149,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		startTime = time.Now()
 		msBeforeTxnExpired, _, err := c.store.lockResolver.ResolveLocks(bo, 0, locks)
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		if action.LockCtx.Stats != nil {
 			atomic.AddInt64(&action.LockCtx.Stats.ResolveLockTime, int64(time.Since(startTime)))
@@ -164,13 +159,13 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		// the pessimistic lock. We should return acquire fail with nowait set or timeout error if necessary.
 		if msBeforeTxnExpired > 0 {
 			if action.LockWaitTime == kv.LockNoWait {
-				return ErrLockAcquireFailAndNoWaitSet
+				return false, ErrLockAcquireFailAndNoWaitSet
 			} else if action.LockWaitTime == kv.LockAlwaysWait {
 				// do nothing but keep wait
 			} else {
 				// the lockWaitTime is set, we should return wait timeout if we are still blocked by a lock
 				if time.Since(lockWaitStartTime).Milliseconds() >= action.LockWaitTime {
-					return errors.Trace(ErrLockWaitTimeout)
+					return false, errors.Trace(ErrLockWaitTimeout)
 				}
 			}
 			if action.LockCtx.PessimisticLockWaited != nil {
@@ -186,13 +181,13 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			// actionPessimisticLock runs on each region parallelly, we have to consider that
 			// the error may be dropped.
 			if atomic.LoadUint32(action.Killed) == 1 {
-				return errors.Trace(ErrQueryInterrupted)
+				return false, errors.Trace(ErrQueryInterrupted)
 			}
 		}
 	}
 }
 
-func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch batchMutations) error {
+func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch *batchMutations) (bool, error) {
 	req := tikvrpc.NewRequest(tikvrpc.CmdPessimisticRollback, &pb.PessimisticRollbackRequest{
 		StartVersion: c.startTS,
 		ForUpdateTs:  c.forUpdateTS,
@@ -200,27 +195,57 @@ func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Bac
 	})
 	resp, err := c.store.SendReq(bo, req, batch.region, readTimeoutShort)
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	regionErr, err := resp.GetRegionError()
 	if err != nil {
-		return errors.Trace(err)
+		return false, errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
+		return true, errors.Trace(errors.New(regionErr.String()))
+	}
+	return false, nil
+}
+
+func (c *twoPhaseCommitter) tryPreSplitLockKeys(bo *Backoffer, keys [][]byte) error {
+	if uint32(len(keys)) < preSplitDetectThreshold {
+		return nil
+	}
+
+	var preSplitCal preSplitCalculator
+	it := c.mapWithRegion(bo, lockKeysMutations{keys}.Iter(nil, nil))
+	for {
+		m, err := it.Next()
 		if err != nil {
 			return errors.Trace(err)
 		}
-		err = c.pessimisticRollbackMutations(bo, batch.mutations)
-		return errors.Trace(err)
+		if m.key == nil {
+			break
+		}
+		preSplitCal.Process(m)
 	}
+	splitKeys, splitRegions := preSplitCal.Finish()
+	c.trySplitRegions(splitKeys, splitRegions)
 	return nil
 }
 
-func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *kv.LockCtx, mutations CommitterMutations) error {
-	return c.doActionOnMutations(bo, actionPessimisticLock{lockCtx}, mutations)
+func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *kv.LockCtx, mutations mutations) error {
+	exec := c.newExecController(mutations, actionPessimisticLock{LockCtx: lockCtx})
+	return exec.run(bo)
 }
 
-func (c *twoPhaseCommitter) pessimisticRollbackMutations(bo *Backoffer, mutations CommitterMutations) error {
-	return c.doActionOnMutations(bo, actionPessimisticRollback{}, mutations)
+func (c *twoPhaseCommitter) pessimisticRollbackMutations(bo *Backoffer, mutations mutations) error {
+	exec := c.newExecController(mutations, actionPessimisticRollback{})
+	return exec.run(bo)
+}
+
+func (c *twoPhaseCommitter) pessimisticLockKeys(bo *Backoffer, lockCtx *kv.LockCtx, keys [][]byte) error {
+	if err := c.tryPreSplitLockKeys(bo, keys); err != nil {
+		return err
+	}
+	return c.pessimisticLockMutations(bo, lockCtx, lockKeysMutations{keys})
+}
+
+func (c *twoPhaseCommitter) pessimisticRollbackKeys(bo *Backoffer, keys [][]byte) error {
+	return c.pessimisticRollbackMutations(bo, lockKeysMutations{keys})
 }

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -30,9 +30,9 @@ import (
 	"go.uber.org/zap"
 )
 
-type actionPrewrite struct{}
+type actionPrewrite struct {
+}
 
-var _ twoPhaseCommitAction = actionPrewrite{}
 var tiKVTxnRegionsNumHistogramPrewrite = metrics.TiKVTxnRegionsNumHistogram.WithLabelValues(metricsTag("prewrite"))
 
 func (actionPrewrite) String() string {
@@ -43,7 +43,7 @@ func (actionPrewrite) tiKVTxnRegionsNumHistogram() prometheus.Observer {
 	return tiKVTxnRegionsNumHistogramPrewrite
 }
 
-func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize uint64) *tikvrpc.Request {
+func (c *twoPhaseCommitter) buildPrewriteRequest(batch *batchMutations, txnSize uint64) *tikvrpc.Request {
 	m := &batch.mutations
 	mutations := make([]*pb.Mutation, m.len())
 	for i := range m.keys {
@@ -90,11 +90,11 @@ func (c *twoPhaseCommitter) buildPrewriteRequest(batch batchMutations, txnSize u
 	return tikvrpc.NewRequest(tikvrpc.CmdPrewrite, req, pb.Context{Priority: c.priority, SyncLog: c.syncLog})
 }
 
-func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch batchMutations) error {
+func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch *batchMutations) (bool, error) {
 	txnSize := uint64(c.regionTxnSize[batch.region.id])
 	// When we retry because of a region miss, we don't know the transaction size. We set the transaction size here
 	// to MaxUint64 to avoid unexpected "resolve lock lite".
-	if len(bo.errors) > 0 {
+	if len(bo.errors) > 0 || txnSize == 0 {
 		txnSize = math.MaxUint64
 	}
 
@@ -110,22 +110,17 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		}
 
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		regionErr, err := resp.GetRegionError()
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(BoRegionMiss, errors.New(regionErr.String()))
-			if err != nil {
-				return errors.Trace(err)
-			}
-			err = c.prewriteMutations(bo, batch.mutations)
-			return errors.Trace(err)
+			return true, errors.Trace(errors.New(regionErr.String()))
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return false, errors.Trace(ErrBodyMissing)
 		}
 		prewriteResp := resp.Resp.(*pb.PrewriteResponse)
 		keyErrs := prewriteResp.GetErrors()
@@ -143,7 +138,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 				// continue committing the transaction if prewrite are all finished.
 				if prewriteResp.MinCommitTs == 0 {
 					if c.testingKnobs.noFallBack {
-						return nil
+						return false, nil
 					}
 					logutil.Logger(bo.ctx).Warn("async commit cannot proceed since the returned minCommitTS is zero, "+
 						"fallback to normal path", zap.Uint64("startTS", c.startTS))
@@ -156,20 +151,20 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 					c.mu.Unlock()
 				}
 			}
-			return nil
+			return false, nil
 		}
 		var locks []*Lock
 		for _, keyErr := range keyErrs {
 			// Check already exists error
 			if alreadyExist := keyErr.GetAlreadyExist(); alreadyExist != nil {
 				key := alreadyExist.GetKey()
-				return c.extractKeyExistsErr(key)
+				return false, c.extractKeyExistsErr(key)
 			}
 
 			// Extract lock from key error
 			lock, err1 := extractLockFromKeyErr(keyErr)
 			if err1 != nil {
-				return errors.Trace(err1)
+				return false, errors.Trace(err1)
 			}
 			logutil.BgLogger().Info("prewrite encounters lock",
 				zap.Uint64("conn", c.connID),
@@ -179,24 +174,29 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		start := time.Now()
 		msBeforeExpired, err := c.store.lockResolver.resolveLocksForWrite(bo, c.startTS, locks)
 		if err != nil {
-			return errors.Trace(err)
+			return false, errors.Trace(err)
 		}
 		atomic.AddInt64(&c.getDetail().ResolveLockTime, int64(time.Since(start)))
 		if msBeforeExpired > 0 {
 			err = bo.BackoffWithMaxSleep(BoTxnLock, int(msBeforeExpired), errors.Errorf("2PC prewrite lockedKeys: %d", len(locks)))
 			if err != nil {
-				return errors.Trace(err)
+				return false, errors.Trace(err)
 			}
 		}
 	}
 }
 
-func (c *twoPhaseCommitter) prewriteMutations(bo *Backoffer, mutations CommitterMutations) error {
+func (c *twoPhaseCommitter) prewriteMutations(bo *Backoffer, mutations mutations) error {
 	if span := opentracing.SpanFromContext(bo.ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("twoPhaseCommitter.prewriteMutations", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
 		bo.ctx = opentracing.ContextWithSpan(bo.ctx, span1)
 	}
 
-	return c.doActionOnMutations(bo, actionPrewrite{}, mutations)
+	exec := c.newExecController(mutations, actionPrewrite{})
+	return exec.run(bo)
+}
+
+func (c *twoPhaseCommitter) prewriteTxnMutations(bo *Backoffer) error {
+	return c.prewriteMutations(bo, committerTxnMutations{c, true})
 }

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -247,14 +247,13 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 			committer.ttlManager.close()
 		}
 	}()
-
 	initRegion := trace.StartRegion(ctx, "InitKeys")
-	err = committer.initKeysAndMutations()
+	err = committer.initCommitterStates(ctx)
 	initRegion.End()
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if committer.mutations.len() == 0 {
+	if len(committer.primaryKey) == 0 {
 		return nil
 	}
 
@@ -280,10 +279,19 @@ func (txn *tikvTxn) Commit(ctx context.Context) error {
 		return errors.Trace(err)
 	}
 
+	keys := make([][]byte, 0, committer.txn.Len())
+	it := committerTxnMutations{committer, true}.Iter(nil, nil)
+	for {
+		m := it.Next()
+		if m.key == nil {
+			break
+		}
+		keys = append(keys, m.key)
+	}
 	// latches enabled
 	// for transactions which need to acquire latches
 	start = time.Now()
-	lock := txn.store.txnLatches.Lock(committer.startTS, committer.mutations.keys)
+	lock := txn.store.txnLatches.Lock(committer.startTS, keys)
 	commitDetail := committer.getDetail()
 	commitDetail.LocalLatchTime = time.Since(start)
 	if commitDetail.LocalLatchTime > 0 {
@@ -333,7 +341,7 @@ func (txn *tikvTxn) rollbackPessimisticLocks() error {
 	}
 	bo := NewBackofferWithVars(context.Background(), cleanupMaxBackoff, txn.vars)
 	keys := txn.collectLockedKeys()
-	return txn.committer.pessimisticRollbackMutations(bo, CommitterMutations{keys: keys})
+	return txn.committer.pessimisticRollbackKeys(bo, keys)
 }
 
 func (txn *tikvTxn) collectLockedKeys() [][]byte {
@@ -443,7 +451,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 		// If the number of keys greater than 1, it can be on different region,
 		// concurrently execute on multiple regions may lead to deadlock.
 		txn.committer.isFirstLock = txn.lockedCnt == 0 && len(keys) == 1
-		err = txn.committer.pessimisticLockMutations(bo, lockCtx, CommitterMutations{keys: keys})
+		err = txn.committer.pessimisticLockKeys(bo, lockCtx, keys)
 		if bo.totalSleep > 0 {
 			atomic.AddInt64(&lockCtx.Stats.BackoffTime, int64(bo.totalSleep)*int64(time.Millisecond))
 			lockCtx.Stats.Mu.Lock()
@@ -532,7 +540,7 @@ func (txn *tikvTxn) asyncPessimisticRollback(ctx context.Context, keys [][]byte)
 		failpoint.Inject("AsyncRollBackSleep", func() {
 			time.Sleep(100 * time.Millisecond)
 		})
-		err := committer.pessimisticRollbackMutations(NewBackofferWithVars(ctx, pessimisticRollbackMaxBackoff, txn.vars), CommitterMutations{keys: keys})
+		err := committer.pessimisticRollbackKeys(NewBackofferWithVars(ctx, pessimisticRollbackMaxBackoff, txn.vars), keys)
 		if err != nil {
 			logutil.Logger(ctx).Warn("[kv] pessimisticRollback failed.", zap.Error(err))
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Close #19055

### What is changed and how it works?
Use new tools introduced in #20173 to reduce the memory footprint during the 2PC commit.

The core component is `execController`, which uses a `sync.WaitGroup` to track all ongoing requests. Every `execController` will start `n` workers and jobs will be dispatched to them.

The usage of `sync.WaitGroup` is
1. Before enqueueing a job, increment this counter;
2. Decremrnt this counter if a job is finished successfully;
3. If an retryable error occurs, **DO NOT** change this counter and start a new dispatcher worker;
4. Repeat step 1 and 2 for each retry job;
5. After all job is disaptched in the retry range, decrement this coutner.

To support this new controll flow, the signature of `handleSingleBatch` has been changed, it will retrun the retry decision instead of retry recursively.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Unit test


Side effects

- Performance regression
    - Consumes more CPU

### Release note

- Reduce the memory footprint of the 2PC committer.
