### PR TITLE
metric: add metric for pessimistic lock keys

### DIFF
--- a/metrics/session.go
+++ b/metrics/session.go
@@ -142,4 +142,5 @@ const (
 	LblAddress     = "address"
 	LblBatchGet    = "batch_get"
 	LblGet         = "get"
+	LblLockKeys    = "lock_keys"
 )

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -45,6 +45,7 @@ var (
 	tikvTxnCmdHistogramWithRollback = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblRollback)
 	tikvTxnCmdHistogramWithBatchGet = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblBatchGet)
 	tikvTxnCmdHistogramWithGet      = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblGet)
+	tikvTxnCmdHistogramWithLockKeys = metrics.TiKVTxnCmdHistogram.WithLabelValues(metrics.LblLockKeys)
 )
 
 // SchemaAmender is used by pessimistic transactions to amend commit mutations for schema change during 2pc.
@@ -368,6 +369,7 @@ func (txn *tikvTxn) LockKeys(ctx context.Context, lockCtx *kv.LockCtx, keysInput
 	txn.mu.Lock()
 	defer txn.mu.Unlock()
 	defer func() {
+		tikvTxnCmdHistogramWithLockKeys.Observe(time.Since(startTime).Seconds())
 		if err == nil {
 			if lockCtx.PessimisticLockWaited != nil {
 				if atomic.LoadInt32(lockCtx.PessimisticLockWaited) > 0 {


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

As the title said. relate issue: https://github.com/pingcap/tidb/issues/18942

Here is an example of metric profile:

before

![image](https://user-images.githubusercontent.com/26020263/95647801-d407fc80-0b04-11eb-9694-dc6567576aaf.png)

You must be weird, why `commit` statement cost so much time in `tidb_execution`?


This PR:

![image](https://user-images.githubusercontent.com/26020263/95647793-c2265980-0b04-11eb-9bca-c43d9e8a4ef9.png)

Now, you will be more clear, because there are some time cost in `lock keys`, `tidb_execution` cost is very low. 


### What is changed and how it works?

Add metrics.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No.

### Release note <!-- bugfixes or new feature need a release note -->

- No.