### PR TITLE
parser: replace ast.SelectLockInShareMode with ast.SelectLockForShare

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -68,3 +68,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/cncal/parser v0.0.0-20201011071852-bddb0c51e0e1

--- a/go.sum
+++ b/go.sum
@@ -72,6 +72,8 @@ github.com/chzyer/readline v0.0.0-20171208011716-f6d7a1f6fbf3/go.mod h1:nSuG5e5P
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncal/parser v0.0.0-20201011071852-bddb0c51e0e1 h1:zQMCCWMaFtMceQdTEiXGAW8eQR9dwDoKnyj9bKgDqRw=
+github.com/cncal/parser v0.0.0-20201011071852-bddb0c51e0e1/go.mod h1:RlLfMRJwFBSiXd2lUaWdV5pSXtrpyvZM8k5bbZWsheU=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa h1:OaNxuTZr7kxeODyLWsRMC+OD03aFUH+mW6r2d+MWa5Y=
 github.com/cockroachdb/datadriven v0.0.0-20190809214429-80d97fb3cbaa/go.mod h1:zn76sxSg3SzpJ0PPJaLDCu+Bu0Lg3sKTORVIj19EIF8=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2726,7 +2726,7 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p L
 		}
 	}
 	if sel.LockInfo != nil && sel.LockInfo.LockType != ast.SelectLockNone {
-		if sel.LockInfo.LockType == ast.SelectLockInShareMode && !enableNoopFuncs {
+		if sel.LockInfo.LockType == ast.SelectLockForShare && !enableNoopFuncs {
 			err = expression.ErrFunctionsNoopImpl.GenWithStackByArgs("LOCK IN SHARE MODE")
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What is changed and how it works?

What's Changed:

As described in [mysql 8.0 manual](https://dev.mysql.com/doc/refman/8.0/en/innodb-locking-reads.html), `SELECT ... LOCK IN SHARE MODE` has been replaced by `SELECT ... FOR SHARE`. So I replace `ast.SelectLockInShareMode` with `ast.SelectLockForShare` in parser.

### Related changes

[PR in parser](https://github.com/pingcap/parser/pull/946)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->
No release note