### PR TITLE
planner, expression: make non-lookup condition prune ahead and cache partition-by expression

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1563,10 +1563,10 @@ func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) (*mo
 		tblInfo.TiFlashReplica = &replica
 	}
 	if referTblInfo.Partition != nil {
-		pi := *referTblInfo.Partition
+		pi := referTblInfo.Partition.Clone()
 		pi.Definitions = make([]model.PartitionDefinition, len(referTblInfo.Partition.Definitions))
 		copy(pi.Definitions, referTblInfo.Partition.Definitions)
-		tblInfo.Partition = &pi
+		tblInfo.Partition = pi
 	}
 	return &tblInfo, nil
 }
@@ -2844,9 +2844,9 @@ func (d *ddl) AddTablePartitions(ctx sessionctx.Context, ident ast.Ident, spec *
 	// partInfo contains only the new added partition, we have to combine it with the
 	// old partitions to check all partitions is strictly increasing.
 	clonedMeta := meta.Clone()
-	tmp := *partInfo
+	tmp := partInfo.Clone()
 	tmp.Definitions = append(pi.Definitions, tmp.Definitions...)
-	clonedMeta.Partition = &tmp
+	clonedMeta.Partition = tmp
 	switch pi.Type {
 	case model.PartitionTypeRange:
 		err = checkPartitionByRange(ctx, clonedMeta, nil)

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1007,13 +1007,13 @@ func hasGlobalIndex(tblInfo *model.TableInfo) bool {
 func getTableInfoWithDroppingPartitions(t *model.TableInfo) *model.TableInfo {
 	p := t.Partition
 	nt := t.Clone()
-	np := *p
+	np := p.Clone()
 	npd := make([]model.PartitionDefinition, 0, len(p.Definitions)+len(p.DroppingDefinitions))
 	npd = append(npd, p.Definitions...)
 	npd = append(npd, p.DroppingDefinitions...)
 	np.Definitions = npd
 	np.DroppingDefinitions = nil
-	nt.Partition = &np
+	nt.Partition = np
 	return nt
 }
 

--- a/executor/brie.go
+++ b/executor/brie.go
@@ -424,9 +424,9 @@ func (gs *tidbGlueSession) CreateTable(ctx context.Context, dbName model.CIStr, 
 	// Clone() does not clone partitions yet :(
 	table = table.Clone()
 	if table.Partition != nil {
-		newPartition := *table.Partition
+		newPartition := table.Partition.Clone()
 		newPartition.Definitions = append([]model.PartitionDefinition{}, table.Partition.Definitions...)
-		table.Partition = &newPartition
+		table.Partition = newPartition
 	}
 
 	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore, true)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2446,7 +2446,7 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndex
 			b.err = err
 			return e
 		}
-		if partInfo != nil {
+		if partInfo != nil && len(partInfo.PartitionNames) > 0 {
 			e.innerMergeCtx.readerBuilder.preponePartitions, err = partitionPruning(
 				b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
 			if err != nil {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2446,7 +2446,7 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndex
 			b.err = err
 			return e
 		}
-		if tbl.Meta().GetPartitionInfo() != nil {
+		if partInfo != nil {
 			e.innerMergeCtx.readerBuilder.preponePartitions, err = partitionPruning(
 				b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
 			if err != nil {

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -73,13 +73,13 @@ partition p2 values less than (10))`)
 	tk.MustExec("drop table if exists t1, t2, t3")
 	tk.MustExec(`create table t1(k1 int, k2 int, v int, key(k1, k2)) partition by hash(k2) partitions 4`)
 	tk.MustExec(`create table t2(k1 int, k2 int, v int)`)
-	tk.MustExec(`create table t3(k1 int, k2 int, v int, key(k1, k2)) partition by hash(k2) partitions 4`)
+	tk.MustExec(`create table t3(k1 int primary key, k2 int, v int) partition by hash(k1) partitions 4`)
 	tk.MustExec(`insert into t1(k1, k2, v) values(1, 1, 11), (2, 2, 22), (3, 3, 33)`)
 	tk.MustExec(`insert into t2(k1, k2, v) values(2, 2, 222), (3, 3, 333), (4, 4, 444)`)
 	tk.MustExec(`insert into t3(k1, k2, v) values(1, 1, 11), (2, 2, 22), (3, 3, 33)`)
-	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t3) */ count(t3.v) from t3, t2 where t3.k1 = t2.k1 and t3.k2 = 2`).Check(testkit.Rows("1")) // inner as tableReader
-	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t1) */ count(t1.v) from t1, t2 where t1.k1 = t2.k1 and t1.k2 = 2`).Check(testkit.Rows("1")) // inner as indexLookupReader
-	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t1) */ count(1) from t1, t2 where t1.k1 = t2.k1 and t1.k2 = 2`).Check(testkit.Rows("1"))    // inner as indexReader
+	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t3) */ count(t3.k1) from t3, t2 where t3.k1 = t2.k1 and t3.k1 in (1, 3, 4, 5)`).Check(testkit.Rows("1")) // probe-side as tableReader
+	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t1) */ count(t1.v) from t1, t2 where t1.k1 = t2.k1 and t1.k2 = 2`).Check(testkit.Rows("1"))              // probe-side as indexLookupReader
+	tk.MustQuery(`select /*+ TIDB_INLJ(t2,t1) */ count(1) from t1, t2 where t1.k1 = t2.k1 and t1.k2 = 2`).Check(testkit.Rows("1"))                 // probe-side as indexReader
 	tk.MustQuery(`select /*+ INL_MERGE_JOIN(t1, t3) */ t1.k1, t3.k1 from t3, t1 where t1.k1 = t3.k1 and t1.k2 =2 and t3.k2 = 2`).Check(testkit.Rows("2 2"))
 }
 

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -108,6 +108,20 @@ func ParseSimpleExprsWithNames(ctx sessionctx.Context, exprStr string, schema *S
 	return exprs, nil
 }
 
+// RewriteExprsWithNames rewrite AST to Expression.
+// The expression string must only reference the column in the given NameSlice.
+func RewriteExprsWithNames(ctx sessionctx.Context, fields []ast.ExprNode, schema *Schema, names types.NameSlice) ([]Expression, error) {
+	exprs := make([]Expression, 0, len(fields))
+	for _, field := range fields {
+		expr, err := RewriteSimpleExprWithNames(ctx, field, schema, names)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+	return exprs, nil
+}
+
 // RewriteSimpleExprWithNames rewrites simple ast.ExprNode to expression.Expression.
 func RewriteSimpleExprWithNames(ctx sessionctx.Context, expr ast.ExprNode, schema *Schema, names []*types.FieldName) (Expression, error) {
 	e, err := RewriteAstExpr(ctx, expr, schema, names)

--- a/expression/util.go
+++ b/expression/util.go
@@ -161,6 +161,18 @@ func extractColumns(result []*Column, expr Expression, filter func(*Column) bool
 	return result
 }
 
+// ResetTableColIDToUniqueID reset plan unique id as table column id.
+func ResetTableColIDToUniqueID(expr Expression) {
+	switch v := expr.(type) {
+	case *Column:
+		v.UniqueID = v.ID
+	case *ScalarFunction:
+		for _, arg := range v.GetArgs() {
+			ResetTableColIDToUniqueID(arg)
+		}
+	}
+}
+
 // ExtractColumnSet extracts the different values of `UniqueId` for columns in expressions.
 func ExtractColumnSet(exprs []Expression) *intsets.Sparse {
 	set := &intsets.Sparse{}

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20201023092649-e6d6090277c9
 	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
-	github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534
+	github.com/pingcap/parser v0.0.0-20201026063818-dbde75d82578
 	github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/pingcap/tipb v0.0.0-20201026044621-45e60c77588f

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20201023092649-e6d6090277c9
 	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
-	github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77
+	github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534
 	github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/pingcap/tipb v0.0.0-20201026044621-45e60c77588f

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffx
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534 h1:6HENc/cKFTQOfihHNM6b0qQSRp+CkOpfwTOI6SIDs38=
-github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
+github.com/pingcap/parser v0.0.0-20201026063818-dbde75d82578 h1:33kaDZHy7vcBC3NpCYVk6wZ4Wc7LHeq04dCnYdMFjtA=
+github.com/pingcap/parser v0.0.0-20201026063818-dbde75d82578/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a h1:i2RElJ2aykSqZKeY+3SK18NHhajil8cQdG77wHe+P1Y=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffx
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77 h1:2x5QE9ikrymuf78VsLoaJlY9EhH1SLzoKJJ3+E84zTg=
-github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
+github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534 h1:6HENc/cKFTQOfihHNM6b0qQSRp+CkOpfwTOI6SIDs38=
+github.com/pingcap/parser v0.0.0-20201026041831-e10be3e50534/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a h1:i2RElJ2aykSqZKeY+3SK18NHhajil8cQdG77wHe+P1Y=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=


### PR DESCRIPTION
Signed-off-by: lysu <sulifx@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

need merge parser pr: https://github.com/pingcap/parser/pull/1054 firstly

fixes #20511

Problem Summary:

multi join worker (i.e. IndexJoin or IndexMergeJoin) goroutines will concurrently access inner table and current impl reuse the same parser instance to parse `by-expression` in partition table's definition and lead to race condition.

for those two executor(IndexJoin and IndexMergeJoin), `by-expression` in table definition should only be parse at once and it can avoid race condition for this simple issue.

### What is changed and how it works?

What's Changed, How it Works:

this PR change multi things:

1. make non-lookup condition ahead

for example:

```
create table t1 (c1 int, c2 int) partition by (c1) hash 3;
select * from t1 join t2 on t1.c2 = t2.c2 where t1.c = 1;
```

` t1.c = 1` only need be pruned at once, no matter how many rows need be handled in join `t1.c2 = t2.c2`

but if it's

```
create table t1 (c1 int, c2 int) partition by (c2) hash 3;
select * from t1 join t2 on t1.c2 = t2.c2;
```
it need prune for each row, but `GetPartitionByRow` no need parser, it's goroutine-safe.

>  you maybe have question about:
>
>  create table t1 (c1 int, c2 int) partition by (c1, c2) range (...);
>  select * from t1 join t2 on t1.c2 = t2.c2 and t1.c1 = 2;
> 
>  we may support it after support #20068

so after this PR, non-lookup condition will be prune ahead during build IndexJoinExecutor or  IndexMergeJoinExecutor, instead of inser executor everytime in inner worker goroutines.

2.  avoid duplicate parse / rewrite cost for by-expression

by-expresion (`partition by (c2)` in `create table t1 (c1 int, c2 int) partition by (c2) hash 3`) should be parse and rewrite at once and reuse, but we meet maybe bugs in previous like #17353

but it seems we can not reuse due to unique-id not match problem, in new implements

- range prune: all rely on colID, so it doesn't have problem
- hash prune: now rely on RangeDetacher that need unique id

it PR try to build a "sandbox"(by copy and assign) that `col.uniqueId  == col.id`, in side it, we can use RangeDetacher in col.id mode(it's too hard to change rangeDetacher to support both, so this PR try to do it outside)

so after this PR we can save reuse by-expression's expression(avoid parse and build plan nodes), but need clone cost to condition expression.

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (run tpcc in 4.4 k8s`kubectl -n suli get tidbcluster robitest`)

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/20435)
<!-- Reviewable:end -->
