### PR TITLE
DDL: createtable not support empty name index 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ path_to_add := $(addsuffix /bin,$(subst :,/bin:,$(GOPATH))):$(PWD)/tools/bin
 export PATH := $(path_to_add):$(PATH)
 
 GO              := GO111MODULE=on go
-GOBUILD         := $(GO) build $(BUILD_FLAG) -tags codes -gcflags "-N -l"
+GOBUILD         := $(GO) build $(BUILD_FLAG) -tags codes
 GOBUILDCOVERAGE := GOPATH=$(GOPATH) cd tidb-server; $(GO) test -coverpkg="../..." -c .
 GOTEST          := $(GO) test -p $(P)
 OVERALLS        := GO111MODULE=on overalls
@@ -147,8 +147,10 @@ testSuite:
 	@echo "testSuite"
 	./tools/check/check_testSuite.sh
 
-clean: failpoint-disable
+clean:
 	$(GO) clean -i ./...
+	rm -rf *.out
+	rm -rf parser
 
 # Split tests for CI to run `make test` in parallel.
 test: test_part_1 test_part_2
@@ -158,7 +160,7 @@ test_part_1: checklist explaintest
 
 test_part_2: checkdep gotest gogenerate
 
-explaintest: server_check
+explaintest: server
 	@cd cmd/explaintest && ./run-tests.sh -s ../../bin/tidb-server
 
 ddltest:

--- a/Makefile
+++ b/Makefile
@@ -147,10 +147,8 @@ testSuite:
 	@echo "testSuite"
 	./tools/check/check_testSuite.sh
 
-clean:
+clean: failpoint-disable
 	$(GO) clean -i ./...
-	rm -rf *.out
-	rm -rf parser
 
 # Split tests for CI to run `make test` in parallel.
 test: test_part_1 test_part_2
@@ -160,7 +158,7 @@ test_part_1: checklist explaintest
 
 test_part_2: checkdep gotest gogenerate
 
-explaintest: server
+explaintest: server_check
 	@cd cmd/explaintest && ./run-tests.sh -s ../../bin/tidb-server
 
 ddltest:

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2621,6 +2621,14 @@ func (s *testSerialDBSuite) TestCreateTable(c *C) {
 	tk.MustGetErrCode(failSQL, errno.ErrTableOptionInsertMethodUnsupported)
 	tk.MustExec("drop table x;")
 	tk.MustExec("drop table y;")
+
+	// For issue #18149
+	tk.MustExec("use test")
+	failSQL = "CREATE TABLE t(a INT, KEY ``(a));"
+	tk.MustGetErrCode(failSQL, errno.ErrWrongNameForIndex)
+	_, err = tk.Exec("CREATE TABLE t(a INT, KEY ``(a));")
+	c.Assert(err.Error(), Equals, "[ddl:1280]Incorrect index name ''")
+
 }
 
 func (s *testSerialDBSuite) TestRepairTable(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1933,9 +1933,9 @@ func checkPartitionByHash(ctx sessionctx.Context, tbInfo *model.TableInfo, s *as
 
 // checkPartitionByRange checks validity of a "BY RANGE" partition.
 func checkPartitionByRange(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
-	if _, _err_ := failpoint.Eval(_curpkg_("CheckPartitionByRangeErr")); _err_ == nil {
+	failpoint.Inject("CheckPartitionByRangeErr", func() {
 		panic("Out Of Memory Quota!")
-	}
+	})
 	pi := tbInfo.Partition
 	if err := checkPartitionNameUnique(pi); err != nil {
 		return err

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1129,8 +1129,8 @@ func checkDuplicateConstraint(namesMap map[string]bool, name string, foreign boo
 	namesMap[nameLower] = true
 	return nil
 }
-func checkEmptyIndexInfo(name string, ifEmptyIndex bool) error {
-	if name == "" && ifEmptyIndex == true {
+func checkEmptyIndexInfo(name string, isEmptyIndex bool) error {
+	if isEmptyIndex && name == "" {
 		return ErrWrongNameForIndex.GenWithStackByArgs(name)
 	}
 	return nil
@@ -1187,7 +1187,7 @@ func checkConstraintNames(constraints []*ast.Constraint) error {
 
 	// Set empty constraint names.
 	for _, constr := range constraints {
-		err := checkEmptyIndexInfo(constr.Name, constr.IfEmptyIndex)
+		err := checkEmptyIndexInfo(constr.Name, constr.IsEmptyIndex)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1129,7 +1129,12 @@ func checkDuplicateConstraint(namesMap map[string]bool, name string, foreign boo
 	namesMap[nameLower] = true
 	return nil
 }
-
+func checkEmptyIndexInfo(name string, ifEmptyIndex bool) error {
+	if name == "" && ifEmptyIndex == true {
+		return ErrWrongNameForIndex.GenWithStackByArgs(name)
+	}
+	return nil
+}
 func setEmptyConstraintName(namesMap map[string]bool, constr *ast.Constraint, foreign bool) {
 	if constr.Name == "" && len(constr.Keys) > 0 {
 		var colName string
@@ -1182,6 +1187,10 @@ func checkConstraintNames(constraints []*ast.Constraint) error {
 
 	// Set empty constraint names.
 	for _, constr := range constraints {
+		err := checkEmptyIndexInfo(constr.Name, constr.IfEmptyIndex)
+		if err != nil {
+			return errors.Trace(err)
+		}
 		if constr.Tp == ast.ConstraintForeignKey {
 			setEmptyConstraintName(fkNames, constr, true)
 		} else {
@@ -1924,9 +1933,9 @@ func checkPartitionByHash(ctx sessionctx.Context, tbInfo *model.TableInfo, s *as
 
 // checkPartitionByRange checks validity of a "BY RANGE" partition.
 func checkPartitionByRange(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
-	failpoint.Inject("CheckPartitionByRangeErr", func() {
+	if _, _err_ := failpoint.Eval(_curpkg_("CheckPartitionByRangeErr")); _err_ == nil {
 		panic("Out Of Memory Quota!")
-	})
+	}
 	pi := tbInfo.Partition
 	if err := checkPartitionNameUnique(pi); err != nil {
 		return err

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -491,7 +491,7 @@ func (p *preprocessor) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 				p.err = err
 				return
 			}
-			err = checkEmptyIndexInfo(constraint.Name,constraint.IfEmptyIndex)
+			err = checkEmptyIndexInfo(constraint.Name,constraint.IsEmptyIndex)
 			if err != nil {
 				p.err = err
 				return
@@ -773,8 +773,8 @@ func checkIndexInfo(indexName string, IndexPartSpecifications []*ast.IndexPartSp
 }
 
 // checkEmptyIndexInfo checks  empty index name
-func checkEmptyIndexInfo(name string, ifEmptyIndex bool) error {
-	if name == "" && ifEmptyIndex == true {
+func checkEmptyIndexInfo(name string, isEmptyIndex bool) error {
+	if isEmptyIndex && name == "" {
 		return ddl.ErrWrongNameForIndex.GenWithStackByArgs(name)
 	}
 	return nil

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -491,6 +491,11 @@ func (p *preprocessor) checkCreateTableGrammar(stmt *ast.CreateTableStmt) {
 				p.err = err
 				return
 			}
+			err = checkEmptyIndexInfo(constraint.Name,constraint.IfEmptyIndex)
+			if err != nil {
+				p.err = err
+				return
+			}
 		case ast.ConstraintPrimaryKey:
 			if countPrimaryKey > 0 {
 				p.err = infoschema.ErrMultiplePriKey
@@ -765,6 +770,14 @@ func checkIndexInfo(indexName string, IndexPartSpecifications []*ast.IndexPartSp
 		return infoschema.ErrTooManyKeyParts.GenWithStackByArgs(mysql.MaxKeyParts)
 	}
 	return checkDuplicateColumnName(IndexPartSpecifications)
+}
+
+// checkEmptyIndexInfo checks  empty index name
+func checkEmptyIndexInfo(name string, ifEmptyIndex bool) error {
+	if name == "" && ifEmptyIndex == true {
+		return ddl.ErrWrongNameForIndex.GenWithStackByArgs(name)
+	}
+	return nil
 }
 
 // checkUnsupportedTableOptions checks if there exists unsupported table options

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -255,6 +255,12 @@ func (s *testValidatorSuite) TestValidator(c *C) {
 		{"CREATE TABLE origin (a int primary key auto_increment, b int);", false, nil},
 		{"CREATE TABLE origin (a int unique auto_increment, b int);", false, nil},
 		{"CREATE TABLE origin (a int key auto_increment, b int);", false, nil},
+
+		// issue 18149
+		{"CREATE TABLE t (a int, index ``(a));", true, errors.New("[ddl:1280]Incorrect index name ''")},
+		{"CREATE TABLE t (a int, key ``(a));", true, errors.New("[ddl:1280]Incorrect index name ''")},
+		{"CREATE TABLE t (a int, index(a));", false, nil},
+		{"CREATE TABLE t (a int,key(a));", false, nil},
 	}
 
 	_, err := s.se.Execute(context.Background(), "use test")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #18149 
create table  not support  create empty name index

after parser PR: pingcap/parser/pull/1059
then update go.mod.

Problem Summary:

### What is changed and how it works?


change token IndexName from ident to item type
use a NullIndexName struct to represent a empty index to distinguish from a anonymous index


### Related changes
- pingcap/parser


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
go test -check.f TestValidator 
go test -check.f TestCreateTable

- Manual test (add detailed scripts or steps below)
In TiDB
~~~
mysql> CREATE TABLE t(x INT, KEY ``(x));
ERROR 1280 (42000): Incorrect index name '
~~~
In MySQL:
~~~
mysql> CREATE TABLE t1(x INT, KEY ``(x));
ERROR 1280 (42000): Incorrect index name ''
~~~
It has the same action with MySQL

Side effects



### Release note 

Fix not support empty index when createtableding tables ,but  anonymous index  also support 