### PR TITLE
expression: utilize the flag of column arguments to simplify expressions (#20149)

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -556,28 +556,29 @@ Projection_4	10.00	root		plus(1, test.t.nb)->Column#5
 explain select * from t ta left outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(ta.nb, 1) or ta.nb is null;
 id	estRows	task	access object	operator info
 HashJoin_7	8320.83	root		left outer join, equal:[eq(test.t.nb, test.t.nb)], left cond:[gt(test.t.a, 1)]
-├─TableReader_13(Build)	10000.00	root		data:TableFullScan_12
-│ └─TableFullScan_12	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
+├─TableReader_14(Build)	6656.67	root		data:Selection_13
+│ └─Selection_13	6656.67	cop[tikv]		or(test.t.nb, 0)
+│   └─TableFullScan_12	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 └─TableReader_11(Probe)	6656.67	root		data:Selection_10
-  └─Selection_10	6656.67	cop[tikv]		or(test.t.nb, isnull(test.t.nb))
+  └─Selection_10	6656.67	cop[tikv]		or(test.t.nb, 0)
     └─TableFullScan_9	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 explain select * from t ta right outer join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
 HashJoin_7	6656.67	root		right outer join, equal:[eq(test.t.nb, test.t.nb)]
-├─TableReader_11(Build)	3333.33	root		data:Selection_10
-│ └─Selection_10	3333.33	cop[tikv]		gt(test.t.a, 1)
+├─TableReader_11(Build)	2218.89	root		data:Selection_10
+│ └─Selection_10	2218.89	cop[tikv]		gt(test.t.a, 1), or(test.t.nb, 0)
 │   └─TableFullScan_9	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader_14(Probe)	6656.67	root		data:Selection_13
-  └─Selection_13	6656.67	cop[tikv]		or(test.t.nb, isnull(test.t.nb))
+  └─Selection_13	6656.67	cop[tikv]		or(test.t.nb, 0)
     └─TableFullScan_12	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain select * from t ta inner join t tb on ta.nb = tb.nb and ta.a > 1 where ifnull(tb.nb, 1) or tb.nb is null;
 id	estRows	task	access object	operator info
-HashJoin_9	4166.67	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
-├─TableReader_12(Build)	3333.33	root		data:Selection_11
-│ └─Selection_11	3333.33	cop[tikv]		gt(test.t.a, 1)
+HashJoin_9	2773.61	root		inner join, equal:[eq(test.t.nb, test.t.nb)]
+├─TableReader_12(Build)	2218.89	root		data:Selection_11
+│ └─Selection_11	2218.89	cop[tikv]		gt(test.t.a, 1), or(test.t.nb, 0)
 │   └─TableFullScan_10	10000.00	cop[tikv]	table:ta	keep order:false, stats:pseudo
 └─TableReader_15(Probe)	6656.67	root		data:Selection_14
-  └─Selection_14	6656.67	cop[tikv]		or(test.t.nb, isnull(test.t.nb))
+  └─Selection_14	6656.67	cop[tikv]		or(test.t.nb, 0)
     └─TableFullScan_13	10000.00	cop[tikv]	table:tb	keep order:false, stats:pseudo
 explain select ifnull(t.nc, 1) in (select count(*) from t s , t t1 where s.a = t.a and s.a = t1.a) from t;
 id	estRows	task	access object	operator info

--- a/cmd/explaintest/r/partition_pruning.result
+++ b/cmd/explaintest/r/partition_pruning.result
@@ -4000,18 +4000,18 @@ PartitionUnion_10	1000.00	root
     └─TableFullScan_20	10000.00	cop[tikv]	table:t1, partition:p4	keep order:false, stats:pseudo
 explain select * from t1 where a>=0 and a <= 0xFFFFFFFFFFFFFFFF;
 id	estRows	task	access object	operator info
-PartitionUnion_10	1000.00	root		
-├─TableReader_13	250.00	root		data:Selection_12
-│ └─Selection_12	250.00	cop[tikv]		ge(test.t1.a, 0), le(test.t1.a, 18446744073709551615)
+PartitionUnion_10	13293.33	root		
+├─TableReader_13	3323.33	root		data:Selection_12
+│ └─Selection_12	3323.33	cop[tikv]		le(test.t1.a, 18446744073709551615)
 │   └─TableFullScan_11	10000.00	cop[tikv]	table:t1, partition:p1	keep order:false, stats:pseudo
-├─TableReader_16	250.00	root		data:Selection_15
-│ └─Selection_15	250.00	cop[tikv]		ge(test.t1.a, 0), le(test.t1.a, 18446744073709551615)
+├─TableReader_16	3323.33	root		data:Selection_15
+│ └─Selection_15	3323.33	cop[tikv]		le(test.t1.a, 18446744073709551615)
 │   └─TableFullScan_14	10000.00	cop[tikv]	table:t1, partition:p2	keep order:false, stats:pseudo
-├─TableReader_19	250.00	root		data:Selection_18
-│ └─Selection_18	250.00	cop[tikv]		ge(test.t1.a, 0), le(test.t1.a, 18446744073709551615)
+├─TableReader_19	3323.33	root		data:Selection_18
+│ └─Selection_18	3323.33	cop[tikv]		le(test.t1.a, 18446744073709551615)
 │   └─TableFullScan_17	10000.00	cop[tikv]	table:t1, partition:p3	keep order:false, stats:pseudo
-└─TableReader_22	250.00	root		data:Selection_21
-  └─Selection_21	250.00	cop[tikv]		ge(test.t1.a, 0), le(test.t1.a, 18446744073709551615)
+└─TableReader_22	3323.33	root		data:Selection_21
+  └─Selection_21	3323.33	cop[tikv]		le(test.t1.a, 18446744073709551615)
     └─TableFullScan_20	10000.00	cop[tikv]	table:t1, partition:p4	keep order:false, stats:pseudo
 drop table t1;
 create table t1 (a bigint) partition by range(a+0) (

--- a/expression/flag_simplify_test.go
+++ b/expression/flag_simplify_test.go
@@ -1,0 +1,81 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package expression_test
+
+import (
+	"fmt"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
+)
+
+var _ = Suite(&testFlagSimplifySuite{})
+
+type testFlagSimplifySuite struct {
+	store    kv.Storage
+	dom      *domain.Domain
+	ctx      sessionctx.Context
+	testData testutil.TestData
+}
+
+func (s *testFlagSimplifySuite) cleanEnv(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	r := tk.MustQuery("show tables")
+	for _, tb := range r.Rows() {
+		tableName := tb[0]
+		tk.MustExec(fmt.Sprintf("drop table %v", tableName))
+	}
+}
+
+func (s *testFlagSimplifySuite) SetUpSuite(c *C) {
+	var err error
+	s.store, s.dom, err = newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	s.ctx = mock.NewContext()
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "flag_simplify")
+	c.Assert(err, IsNil)
+}
+
+func (s *testFlagSimplifySuite) TearDownSuite(c *C) {
+	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
+	s.dom.Close()
+	s.store.Close()
+}
+
+func (s *testFlagSimplifySuite) TestSimplifyExpressionByFlag(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int primary key, a bigint unsigned not null, b bigint unsigned)")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/expression/testdata/flag_simplify_in.json
+++ b/expression/testdata/flag_simplify_in.json
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "TestSimplifyExpressionByFlag",
+    "cases": [
+      "explain select * from t where a is null",
+      "explain select * from t where a is not null",
+      "explain select * from t where a > -1",
+      "explain select * from t where a <= -1",
+      "explain select * from t where a < 0",
+      "explain select * from t where a >= 0",
+      "explain select * from t where a = -1",
+      "explain select * from t where a <=> -1",
+      "explain select * from t where a != -1",
+      "explain select * from t where 0 > a",
+      "explain select * from t where 0 <= a",
+      "explain select * from t where -1 < a",
+      "explain select * from t where -1 >= a",
+      "explain select * from t where -1 = a",
+      "explain select * from t where -1 <=> a",
+      "explain select * from t where -1 != a",
+      // Tuples with null b should be filered out.
+      "explain select * from t where b >= 0",
+      "explain select * from t where b != -1",
+      // Int64 overflow corner case.
+      "explain select * from t where a = 0xFFFFFFFFFFFFFFFF"
+    ]
+  }
+]

--- a/expression/testdata/flag_simplify_out.json
+++ b/expression/testdata/flag_simplify_out.json
@@ -1,0 +1,134 @@
+[
+  {
+    "Name": "TestSimplifyExpressionByFlag",
+    "Cases": [
+      {
+        "SQL": "explain select * from t where a is null",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a is not null",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a > -1",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a <= -1",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a < 0",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a >= 0",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a = -1",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a <=> -1",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a != -1",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where 0 > a",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where 0 <= a",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where -1 < a",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where -1 >= a",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where -1 = a",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where -1 <=> a",
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where -1 != a",
+        "Plan": [
+          "TableReader_6 10000.00 root  data:TableFullScan_5",
+          "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where b >= 0",
+        "Plan": [
+          "TableReader_7 3333.33 root  data:Selection_6",
+          "└─Selection_6 3333.33 cop[tikv]  ge(test.t.b, 0)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where b != -1",
+        "Plan": [
+          "TableReader_7 3333.33 root  data:Selection_6",
+          "└─Selection_6 3333.33 cop[tikv]  ne(test.t.b, -1)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t where a = 0xFFFFFFFFFFFFFFFF",
+        "Plan": [
+          "TableReader_7 10.00 root  data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  eq(test.t.a, 18446744073709551615)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -91,7 +91,7 @@ func (s *testPointGetSuite) TestPointGetPlanCache(c *C) {
 		"└─Point_Get_1 1.00 root table:t handle:1",
 	))
 	tk.MustQuery("explain select a from t where a = -1").Check(testkit.Rows(
-		"TableDual_5 0.00 root  rows:0",
+		"TableDual_6 0.00 root  rows:0",
 	))
 	tk.MustExec(`prepare stmt0 from "select a from t where a = ?"`)
 	tk.MustExec("set @p0 = -1")

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -879,7 +879,7 @@
     "Cases": [
       {
         "SQL": "select a from t where c is not null",
-        "Best": "IndexReader(Index(t.c_d_e)[[-inf,+inf]])->Projection"
+        "Best": "IndexReader(Index(t.f)[[NULL,+inf]])"
       },
       {
         "SQL": "select a from t where c >= 4",
@@ -1225,17 +1225,17 @@
       },
       {
         "SQL": "select /*+ HASH_AGG() */ t1.a from t t1 where t1.a < any(select t2.b from t t2)",
-        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->Sel([if(isnull(test.t.a), <nil>, 1)]))->TableReader(Table(t)->HashAgg)->HashAgg->Sel([ne(Column#27, 0)])}",
+        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->Sel([1]))->TableReader(Table(t)->Sel([1])->HashAgg)->HashAgg->Sel([ne(Column#27, 0) 1])}",
         "Warning": ""
       },
       {
         "SQL": "select /*+ hash_agg() */ t1.a from t t1 where t1.a != any(select t2.b from t t2)",
-        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->Sel([if(isnull(test.t.a), <nil>, 1)]))->TableReader(Table(t))->Projection->HashAgg->Sel([ne(Column#28, 0)])}",
+        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]]->Sel([1]))->TableReader(Table(t)->Sel([1]))->HashAgg->Sel([ne(Column#28, 0) 1])}",
         "Warning": ""
       },
       {
         "SQL": "select /*+ hash_agg() */ t1.a from t t1 where t1.a = all(select t2.b from t t2)",
-        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]])->TableReader(Table(t))->Projection->HashAgg}",
+        "Best": "LeftHashJoin{IndexReader(Index(t.f)[[NULL,+inf]])->TableReader(Table(t))->HashAgg->Sel([or(and(le(Column#26, 1), if(ne(Column#27, 0), <nil>, 1)), or(eq(Column#28, 0), 0))])}",
         "Warning": ""
       },
       {


### PR DESCRIPTION
cherry-pick #20149 to release-4.0


---

### What problem does this PR solve?

Issue Number: close #17786

Problem Summary:

Not a problem. This is an enhancement to simplify expressions.

### What is changed and how it works?


What's Changed:
- fold `IsNull` function to constant true / false if the expression is marked as NotNull.
- fold expressions like unsigned_col == -1 to constant true / false if the column is marked as unsigned and not null in its flag.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Utilize the flag of column arguments to simplify expressions
