### PR TITLE
*: fix stats feedback after tableReader handle multiple ranges

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2145,7 +2145,7 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) Executor {
 			if enableFastAnalyze {
 				b.buildAnalyzeFastIndex(e, task, v.Opts)
 			} else {
-				if task.TableID.StoreAsCollectID() && len(task.TableID.CollectIDs) > 1 && !task.IndexInfo.Global && !task.IndexInfo.Unique {
+				if !task.TableID.StoreAsCollectID() && len(task.TableID.CollectIDs) > 1 && !task.IndexInfo.Global && !task.IndexInfo.Unique {
 					b.buildAnalyzeFastIndex(e, task, v.Opts)
 				} else {
 					e.tasks = append(e.tasks, b.buildAnalyzeIndexPushdown(task, v.Opts, autoAnalyze))

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -53,7 +53,7 @@ func (sr selectResultHook) SelectResult(ctx context.Context, sctx sessionctx.Con
 }
 
 type kvRangeBuilder interface {
-	buildKeyRange(pid int64) ([]kv.KeyRange, error)
+	buildKeyRange(ranges []*ranger.Range, feedback *statistics.QueryFeedback) ([]kv.KeyRange, error)
 }
 
 // TableReaderExecutor sends DAG request and reads table data from kv layer.
@@ -214,7 +214,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	var builder distsql.RequestBuilder
 	var reqBuilder *distsql.RequestBuilder
 	if e.kvRangeBuilder != nil {
-		kvRange, err := e.kvRangeBuilder.buildKeyRange(getPhysicalTableID(e.table))
+		kvRange, err := e.kvRangeBuilder.buildKeyRange(e.ranges, e.feedback)
 		if err != nil {
 			return nil, err
 		}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -721,7 +721,7 @@ type AnalyzeTableID struct {
 }
 
 // StoreAsCollectID indicates whether collect table id is same as persist table id.
-// for new partition implementation is TRUE but FALSE for old partition implementation
+// for new partition implementation is FALSE but TRUE for old partition implementation
 func (h *AnalyzeTableID) StoreAsCollectID() bool {
 	return h.PersistID == h.CollectIDs[0]
 }

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -859,12 +859,8 @@ func (s *testStatsSuite) TestCompareFeedbackForNonPartitionAndPartition(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
 	testKit.MustExec("use test")
-	m := variable.DynamicOnly
-	testKit.MustExec("set @@tidb_partition_prune_mode=`" + string(m) + "`")
-	testKit.MustExec("set global tidb_partition_prune_mode=`" + string(m) + "`")
-	s.do.GetGlobalVarsCache().Disable()
+	testKit.MustExec("set @@tidb_partition_prune_mode=`" + string(variable.DynamicOnly) + "`")
 	h := s.do.StatsHandle()
-	c.Assert(h.RefreshVars(), IsNil)
 	testKit.MustExec(`drop table if exists t1, t2`)
 	testKit.MustExec(`create table t1 (a bigint(64), b bigint(64), primary key(a), index idx(b))`)
 	testKit.MustExec(`create table t2 (a bigint(64), b bigint(64), primary key(a), index idx(b))
@@ -895,14 +891,14 @@ func (s *testStatsSuite) TestCompareFeedbackForNonPartitionAndPartition(c *C) {
 			sql:     "select * from %s where a <= 5",
 			idxCols: 0,
 		},
-		//{
-		//	sql: "select * from %s use index(idx) where b <= 5",
-		//	idxCols: 1,
-		//},
-		//{
-		//	sql: "select b from %s use index(idx) where b <= 5",
-		//	idxCols: 1,
-		//},
+		{
+			sql:     "select * from %s use index(idx) where b <= 5",
+			idxCols: 1,
+		},
+		{
+			sql:     "select b from %s use index(idx) where b <= 5",
+			idxCols: 1,
+		},
 	}
 
 	is := s.do.InfoSchema()


### PR DESCRIPTION
Signed-off-by: lysu <sulifx@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

please take look at new added test case https://github.com/pingcap/tidb/pull/20576/files#diff-523447cdeae856e7d26993187e970db2b89206853ca6e2d4d5e7a19b822d7cbbR923

- we need split kv range by histogram bound if feedback enable
- one cop resp will piggyback multi ranges's feedback info, we need the addition dispatch logic to count on partition table's stat
- previous have the bug that kv ranges in kvRequest doesn't sorted, it will make range split and feedback logic confused, this PR change "p1-1, p2-1, p1-2, p2-2" => "p1-1, p1-2, p2-1, p2-2"

### What is changed and how it works?

What's Changed, How it Works:

- split kv range by histogram boud if feedbak enable
- fix feedback handle logic when recieve cop resp 
- keep kv range sorted(maybe we can do a optimize to avoid useless kv range(e.g. table range is 1-100, range 200-201 should not send...but keep it now will simplify feedback logic - -, we can do it later))

WIP, still some problem when handle index feedback.

### Related changes

- n/a

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/20576)
<!-- Reviewable:end -->
