### PR TITLE
*: use ID instead of NAME in mysql.schema_index_usage

### DIFF
--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -63,7 +63,6 @@ func (b *executorBuilder) buildPointGet(p *plannercore.PointGetPlan) Executor {
 type PointGetExecutor struct {
 	baseExecutor
 
-	dbName       string
 	tblInfo      *model.TableInfo
 	handle       kv.Handle
 	idxInfo      *model.IndexInfo
@@ -93,7 +92,6 @@ type PointGetExecutor struct {
 // Init set fields needed for PointGetExecutor reuse, this does NOT change baseExecutor field
 func (e *PointGetExecutor) Init(p *plannercore.PointGetPlan, startTs uint64) {
 	decoder := NewRowDecoder(e.ctx, p.Schema(), p.TblInfo)
-	e.dbName = p.DBName()
 	e.tblInfo = p.TblInfo
 	e.handle = p.Handle
 	e.idxInfo = p.IndexInfo
@@ -161,7 +159,7 @@ func (e *PointGetExecutor) Close() error {
 		if e.runtimeStats != nil {
 			actRows = e.runtimeStats.GetActRows()
 		}
-		e.ctx.StoreIndexUsage(e.dbName, e.tblInfo.Name.L, e.idxInfo.Name.L, actRows)
+		e.ctx.StoreIndexUsage(e.tblInfo.ID, e.idxInfo.ID, actRows)
 	}
 	e.done = false
 	return nil

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -74,11 +74,6 @@ type nameValuePair struct {
 	param   *driver.ParamMarkerExpr
 }
 
-// DBName return the database name in PointGetPlan.
-func (p *PointGetPlan) DBName() string {
-	return p.dbName
-}
-
 // Schema implements the Plan interface.
 func (p *PointGetPlan) Schema() *expression.Schema {
 	return p.schema

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -306,13 +306,12 @@ const (
 
 	// CreateSchemaIndexUsageTable stores the index usage information.
 	CreateSchemaIndexUsageTable = `CREATE TABLE IF NOT EXISTS mysql.schema_index_usage (
-		TABLE_SCHEMA varchar(64),
-		TABLE_NAME varchar(64),
-		INDEX_NAME varchar(64),
+		TABLE_ID bigint(64),
+		INDEX_ID bigint(21),
 		QUERY_COUNT bigint(64),
 		ROWS_SELECTED bigint(64),
 		LAST_USED_AT timestamp,
-		PRIMARY KEY(TABLE_SCHEMA, TABLE_NAME, INDEX_NAME)
+		PRIMARY KEY(TABLE_ID, INDEX_ID)
 	);`
 )
 

--- a/session/session.go
+++ b/session/session.go
@@ -361,11 +361,11 @@ func (s *session) StoreQueryFeedback(feedback interface{}) {
 }
 
 // StoreIndexUsage stores index usage information in idxUsageCollector.
-func (s *session) StoreIndexUsage(dbName string, tblName string, idxName string, rowsSelected int64) {
+func (s *session) StoreIndexUsage(tblID int64, idxID int64, rowsSelected int64) {
 	if s.idxUsageCollector == nil {
 		return
 	}
-	s.idxUsageCollector.Update(dbName, tblName, idxName, &handle.IndexUsageInformation{QueryCount: 1, RowsSelected: rowsSelected})
+	s.idxUsageCollector.Update(tblID, idxID, &handle.IndexUsageInformation{QueryCount: 1, RowsSelected: rowsSelected})
 }
 
 // FieldList returns fields list of a table.

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -105,7 +105,7 @@ type Context interface {
 	// PrepareTSFuture uses to prepare timestamp by future.
 	PrepareTSFuture(ctx context.Context)
 	// StoreIndexUsage stores the index usage information.
-	StoreIndexUsage(dbName string, tblName string, idxName string, rowsSelected int64)
+	StoreIndexUsage(tblID int64, idxID int64, rowsSelected int64)
 }
 
 type basicCtxType int

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -808,7 +808,13 @@ func (s *testStatsSuite) TestIndexUsageInformation(c *C) {
 	tk.MustExec("create unique index idx_a on t_idx(a)")
 	tk.MustExec("create unique index idx_b on t_idx(b)")
 	tk.MustQuery("select a from t_idx where a=1")
-	querySQL := `select table_schema, table_name, index_name, query_count, rows_selected from mysql.schema_index_usage where table_name = "t_idx"`
+	querySQL := `select idx.table_schema, idx.table_name, idx.key_name, stats.query_count, stats.rows_selected 
+					from mysql.schema_index_usage as stats, information_schema.tidb_indexes as idx, information_schema.tables as tables
+					where tables.table_schema = idx.table_schema
+						AND tables.table_name = idx.table_name
+						AND tables.tidb_table_id = stats.table_id
+						AND idx.index_id = stats.index_id
+						AND idx.table_name = "t_idx"`
 	do := s.do
 	err := do.StatsHandle().DumpIndexUsageToKV()
 	c.Assert(err, IsNil)

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -212,7 +212,7 @@ func (c *Context) GoCtx() context.Context {
 func (c *Context) StoreQueryFeedback(_ interface{}) {}
 
 // StoreIndexUsage strores the index usage information.
-func (c *Context) StoreIndexUsage(_ string, _ string, _ string, _ int64) {}
+func (c *Context) StoreIndexUsage(_ int64, _ int64, _ int64) {}
 
 // StmtCommit implements the sessionctx.Context interface.
 func (c *Context) StmtCommit() {}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: #19209 

Problem Summary:

We used names of schema, table, index as the index ID in `MySQL.schema_index_usage`. But this design is not good enough. It makes us have to handle DDL events, such as `RENAME` and `DELETE`. It's complicated and inefficient.
So we use `TABLE_ID` and `INDEX_ID` instead of names. This will create another problem: ID is not user friendly. So we'll add a user-friendly view base on `MySQL.schema_index_usage`. This view will show the names of schema, table, and index. This view is in the design doc now and we will implement it in the later PR.


Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

- Use TABLE_ID and INDEX_ID instead of the names of schema, table, and index.
- Modify the corresponding design doc.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- No release note.
