### PR TITLE
*: pull prune's static phase up to logic optimize

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1553,10 +1553,10 @@ func buildTableInfoWithLike(ident ast.Ident, referTblInfo *model.TableInfo) (*mo
 		tblInfo.TiFlashReplica = &replica
 	}
 	if referTblInfo.Partition != nil {
-		pi := *referTblInfo.Partition
+		pi := referTblInfo.Partition.Clone()
 		pi.Definitions = make([]model.PartitionDefinition, len(referTblInfo.Partition.Definitions))
 		copy(pi.Definitions, referTblInfo.Partition.Definitions)
-		tblInfo.Partition = &pi
+		tblInfo.Partition = pi
 	}
 	return &tblInfo, nil
 }
@@ -2834,9 +2834,9 @@ func (d *ddl) AddTablePartitions(ctx sessionctx.Context, ident ast.Ident, spec *
 	// partInfo contains only the new added partition, we have to combine it with the
 	// old partitions to check all partitions is strictly increasing.
 	clonedMeta := meta.Clone()
-	tmp := *partInfo
+	tmp := partInfo.Clone()
 	tmp.Definitions = append(pi.Definitions, tmp.Definitions...)
-	clonedMeta.Partition = &tmp
+	clonedMeta.Partition = tmp
 	err = checkPartitionByRange(ctx, clonedMeta, nil)
 	if err != nil {
 		if ErrSameNamePartition.Equal(err) && spec.IfNotExists {

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -1007,13 +1007,13 @@ func hasGlobalIndex(tblInfo *model.TableInfo) bool {
 func getTableInfoWithDroppingPartitions(t *model.TableInfo) *model.TableInfo {
 	p := t.Partition
 	nt := t.Clone()
-	np := *p
+	np := p.Clone()
 	npd := make([]model.PartitionDefinition, 0, len(p.Definitions)+len(p.DroppingDefinitions))
 	npd = append(npd, p.Definitions...)
 	npd = append(npd, p.DroppingDefinitions...)
 	np.Definitions = npd
 	np.DroppingDefinitions = nil
-	nt.Partition = &np
+	nt.Partition = np
 	return nt
 }
 

--- a/executor/brie.go
+++ b/executor/brie.go
@@ -424,9 +424,9 @@ func (gs *tidbGlueSession) CreateTable(ctx context.Context, dbName model.CIStr, 
 	// Clone() does not clone partitions yet :(
 	table = table.Clone()
 	if table.Partition != nil {
-		newPartition := *table.Partition
+		newPartition := table.Partition.Clone()
 		newPartition.Definitions = append([]model.PartitionDefinition{}, table.Partition.Definitions...)
-		table.Partition = &newPartition
+		table.Partition = newPartition
 	}
 
 	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore, true)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2305,6 +2305,20 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 		lastColHelper: v.CompareFilters,
 	}
+	if e.ctx.GetSessionVars().UseDynamicPartitionPrune() {
+		tbl, partInfo, err := extractPartitionTable(b.is, innerPlan)
+		if err != nil {
+			b.err = err
+			return e
+		}
+		if tbl.Meta().GetPartitionInfo() != nil {
+			e.innerCtx.readerBuilder.preponePartitions, err = partitionPruning(b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
+			if err != nil {
+				b.err = err
+				return nil
+			}
+		}
+	}
 	childrenUsedSchema := markChildrenUsedCols(v.Schema(), v.Children()[0].Schema(), v.Children()[1].Schema())
 	e.joiner = newJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema)
 	outerKeyCols := make([]int, len(v.OuterJoinKeys))
@@ -2320,6 +2334,39 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 	e.joinResult = newFirstChunk(e)
 	executorCounterIndexLookUpJoin.Inc()
 	return e
+}
+
+func extractPartitionTable(is infoschema.InfoSchema, plan plannercore.Plan) (tbl table.Table, partInfo *plannercore.PartitionInfo, err error) {
+	switch v := plan.(type) {
+	case *plannercore.PhysicalTableReader:
+		tbl, _ = is.TableByID(v.GetTableScan().Table.ID)
+		partInfo = &v.PartitionInfo
+		return
+	case *plannercore.PhysicalIndexReader:
+		idx := v.IndexPlans[0].(*plannercore.PhysicalIndexScan)
+		tbl, _ = is.TableByID(idx.Table.ID)
+		partInfo = &v.PartitionInfo
+		return
+	case *plannercore.PhysicalIndexLookUpReader:
+		ts := v.TablePlans[0].(*plannercore.PhysicalTableScan)
+		tbl, _ = is.TableByID(ts.Table.ID)
+		partInfo = &v.PartitionInfo
+		return
+	case *plannercore.PhysicalUnionScan:
+		tbl, partInfo, err = extractPartitionTable(is, v.Children()[0])
+		return
+	case *plannercore.PhysicalProjection:
+		indexLookUp, _ := v.Children()[0].(*plannercore.PhysicalIndexLookUpReader)
+		ts := indexLookUp.TablePlans[0].(*plannercore.PhysicalTableScan)
+		tbl, _ = is.TableByID(ts.Table.ID)
+		partInfo = &indexLookUp.PartitionInfo
+		return
+	case *plannercore.PhysicalSelection:
+		tbl, partInfo, err = extractPartitionTable(is, v.Children()[0])
+		return
+	}
+	err = errors.New("Wrong plan type for dataReaderBuilder")
+	return
 }
 
 func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndexMergeJoin) Executor {
@@ -2391,6 +2438,21 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndex
 		indexRanges:   v.Ranges,
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 		lastColHelper: v.CompareFilters,
+	}
+	if e.ctx.GetSessionVars().UseDynamicPartitionPrune() {
+		tbl, partInfo, err := extractPartitionTable(b.is, innerPlan)
+		if err != nil {
+			b.err = err
+			return e
+		}
+		if tbl.Meta().GetPartitionInfo() != nil {
+			e.innerMergeCtx.readerBuilder.preponePartitions, err = partitionPruning(
+				b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
+			if err != nil {
+				b.err = err
+				return nil
+			}
+		}
 	}
 	childrenUsedSchema := markChildrenUsedCols(v.Schema(), v.Children()[0].Schema(), v.Children()[1].Schema())
 	joiners := make([]joiner, e.ctx.GetSessionVars().IndexLookupJoinConcurrency())
@@ -2637,16 +2699,10 @@ func keyColumnsIncludeAllPartitionColumns(keyColumns []int, pe *tables.Partition
 	return true
 }
 
-func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, schema *expression.Schema, partitionInfo *plannercore.PartitionInfo,
-	lookUpContent []*indexJoinLookUpContent) (usedPartition []table.PhysicalTable, canPrune bool, contentPos []int64, err error) {
+func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, schema *expression.Schema,
+	lookUpContent []*indexJoinLookUpContent, preponePartitions []table.PhysicalTable) (usedPartition []table.PhysicalTable, canPrune bool, contentPos []int64, err error) {
 	partitionTbl := tbl.(table.PartitionedTable)
 	locateKey := make([]types.Datum, schema.Len())
-	// TODO: condition based pruning can be do in advance.
-	condPruneResult, err := partitionPruning(ctx, partitionTbl, partitionInfo.PruningConds, partitionInfo.PartitionNames, partitionInfo.Columns, partitionInfo.ColumnNames)
-	if err != nil {
-		return nil, false, nil, err
-	}
-
 	// check whether can runtime prune.
 	type partitionExpr interface {
 		PartitionExpr() (*tables.PartitionExpr, error)
@@ -2662,7 +2718,7 @@ func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, sch
 	for _, offset := range pe.ColumnOffset {
 		if _, ok := offsetMap[offset]; !ok {
 			logutil.BgLogger().Warn("can not runtime prune in index join")
-			return condPruneResult, false, nil, nil
+			return preponePartitions, false, nil, nil
 		}
 	}
 
@@ -2683,7 +2739,7 @@ func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, sch
 	}
 
 	usedPartition = make([]table.PhysicalTable, 0, len(partitions))
-	for _, p := range condPruneResult {
+	for _, p := range preponePartitions {
 		if _, ok := partitions[p.GetPhysicalID()]; ok {
 			usedPartition = append(usedPartition, p)
 		}
@@ -3060,6 +3116,8 @@ type dataReaderBuilder struct {
 	plannercore.Plan
 	*executorBuilder
 
+	preponePartitions []table.PhysicalTable
+
 	selectResultHook // for testing
 }
 
@@ -3115,7 +3173,7 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoinInternal(ctx context.
 func (builder *dataReaderBuilder) buildUnionScanForIndexJoin(ctx context.Context, v *plannercore.PhysicalUnionScan,
 	values []*indexJoinLookUpContent, indexRanges []*ranger.Range, keyOff2IdxOff []int,
 	cwc *plannercore.ColWithCmpFuncManager, canReorderHandles bool) (Executor, error) {
-	childBuilder := &dataReaderBuilder{Plan: v.Children()[0], executorBuilder: builder.executorBuilder}
+	childBuilder := &dataReaderBuilder{Plan: v.Children()[0], executorBuilder: builder.executorBuilder, preponePartitions: builder.preponePartitions}
 	reader, err := childBuilder.buildExecutorForIndexJoin(ctx, values, indexRanges, keyOff2IdxOff, cwc, canReorderHandles)
 	if err != nil {
 		return nil, err
@@ -3144,10 +3202,8 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			}
 			return builder.buildTableReaderFromKvRanges(ctx, e, kvRanges)
 		}
-
-		tbl, _ := builder.is.TableByID(tbInfo.ID)
-		pt := tbl.(table.PartitionedTable)
-		pe, err := tbl.(interface {
+		pt := e.table.(table.PartitionedTable)
+		pe, err := e.table.(interface {
 			PartitionExpr() (*tables.PartitionExpr, error)
 		}).PartitionExpr()
 		if err != nil {
@@ -3174,13 +3230,8 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 				kvRanges = append(kvRanges, tmp...)
 			}
 		} else {
-			partitionInfo := &v.PartitionInfo
-			partitions, err := partitionPruning(e.ctx, pt, partitionInfo.PruningConds, partitionInfo.PartitionNames, partitionInfo.Columns, partitionInfo.ColumnNames)
-			if err != nil {
-				return nil, err
-			}
-			kvRanges = make([]kv.KeyRange, 0, len(partitions)*len(lookUpContents))
-			for _, p := range partitions {
+			kvRanges = make([]kv.KeyRange, 0, len(builder.preponePartitions)*len(lookUpContents))
+			for _, p := range builder.preponePartitions {
 				pid := p.GetPhysicalID()
 				tmp, err := buildKvRangesForIndexJoin(e.ctx, pid, -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 				if err != nil {
@@ -3226,12 +3277,7 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			kvRanges = append(kvRanges, tmp...)
 		}
 	} else {
-		partitionInfo := &v.PartitionInfo
-		partitions, err := partitionPruning(e.ctx, pt, partitionInfo.PruningConds, partitionInfo.PartitionNames, partitionInfo.Columns, partitionInfo.ColumnNames)
-		if err != nil {
-			return nil, err
-		}
-		for _, p := range partitions {
+		for _, p := range builder.preponePartitions {
 			pid := p.GetPhysicalID()
 			tmp := distsql.TableHandlesToKVRanges(pid, handles)
 			kvRanges = append(kvRanges, tmp...)
@@ -3355,37 +3401,44 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 		return e, err
 	}
 
-	nextPartition := nextPartitionForIndexReader{exec: e, innerPartitionInfo: &innerPartitionInfo{isFullPartition: true}}
-	tbl, _ := builder.executorBuilder.is.TableByID(tbInfo.ID)
-	usedPartition, canPrune, contentPos, err := prunePartitionForInnerExecutor(builder.executorBuilder.ctx, tbl, e.Schema(), &v.PartitionInfo, lookUpContents)
+	pt := e.table.(table.PartitionedTable)
+	pe, err := e.table.(interface {
+		PartitionExpr() (*tables.PartitionExpr, error)
+	}).PartitionExpr()
 	if err != nil {
 		return nil, err
 	}
-	if len(usedPartition) != 0 {
-		if canPrune {
-			rangeMap, err := buildIndexRangeForEachPartition(e.ctx, usedPartition, contentPos, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
+
+	var kvRanges []kv.KeyRange
+	if keyColumnsIncludeAllPartitionColumns(lookUpContents[0].keyCols, pe) {
+		locateKey := make([]types.Datum, e.Schema().Len())
+		kvRanges = make([]kv.KeyRange, 0, len(lookUpContents))
+		for _, content := range lookUpContents {
+			for i, date := range content.keys {
+				locateKey[content.keyCols[i]] = date
+			}
+			p, err := pt.GetPartitionByRow(e.ctx, locateKey)
 			if err != nil {
 				return nil, err
 			}
-			nextPartition.isFullPartition = false
-			nextPartition.nextRange = rangeMap
-		} else {
-			e.ranges, err = buildRangesForIndexJoin(e.ctx, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
+			tmp, err := buildKvRangesForIndexJoin(e.ctx, p.GetPhysicalID(), e.index.ID, []*indexJoinLookUpContent{content}, indexRanges, keyOff2IdxOff, cwc)
 			if err != nil {
 				return nil, err
 			}
+			kvRanges = append(kvRanges, tmp...)
 		}
-		partitionExec := &PartitionTableExecutor{
-			baseExecutor:  *e.base(),
-			partitions:    usedPartition,
-			nextPartition: nextPartition,
+	} else {
+		kvRanges = make([]kv.KeyRange, 0, len(builder.preponePartitions)*len(lookUpContents))
+		for _, p := range builder.preponePartitions {
+			tmp, err := buildKvRangesForIndexJoin(e.ctx, p.GetPhysicalID(), e.index.ID, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
+			if err != nil {
+				return nil, err
+			}
+			kvRanges = append(kvRanges, tmp...)
 		}
-		err = partitionExec.Open(ctx)
-		return partitionExec, err
 	}
-	ret := &TableDualExec{baseExecutor: *e.base()}
-	err = ret.Open(ctx)
-	return ret, err
+	err = e.open(ctx, kvRanges)
+	return e, err
 }
 
 func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context.Context, v *plannercore.PhysicalIndexLookUpReader,
@@ -3406,7 +3459,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 	}
 	nextPartition := nextPartitionForIndexLookUp{exec: e, innerPartitionInfo: &innerPartitionInfo{isFullPartition: true}}
 	tbl, _ := builder.executorBuilder.is.TableByID(tbInfo.ID)
-	usedPartition, canPrune, contentPos, err := prunePartitionForInnerExecutor(builder.executorBuilder.ctx, tbl, e.Schema(), &v.PartitionInfo, lookUpContents)
+	usedPartition, canPrune, contentPos, err := prunePartitionForInnerExecutor(builder.executorBuilder.ctx, tbl, e.Schema(), lookUpContents, builder.preponePartitions)
 	if err != nil {
 		return nil, err
 	}

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2305,20 +2305,6 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 		lastColHelper: v.CompareFilters,
 	}
-	if e.ctx.GetSessionVars().UseDynamicPartitionPrune() {
-		tbl, partInfo, err := extractPartitionTable(b.is, innerPlan)
-		if err != nil {
-			b.err = err
-			return e
-		}
-		if tbl.Meta().GetPartitionInfo() != nil {
-			e.innerCtx.readerBuilder.preponePartitions, err = partitionPruning(b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
-			if err != nil {
-				b.err = err
-				return nil
-			}
-		}
-	}
 	childrenUsedSchema := markChildrenUsedCols(v.Schema(), v.Children()[0].Schema(), v.Children()[1].Schema())
 	e.joiner = newJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues, v.OtherConditions, leftTypes, rightTypes, childrenUsedSchema)
 	outerKeyCols := make([]int, len(v.OuterJoinKeys))
@@ -2334,39 +2320,6 @@ func (b *executorBuilder) buildIndexLookUpJoin(v *plannercore.PhysicalIndexJoin)
 	e.joinResult = newFirstChunk(e)
 	executorCounterIndexLookUpJoin.Inc()
 	return e
-}
-
-func extractPartitionTable(is infoschema.InfoSchema, plan plannercore.Plan) (tbl table.Table, partInfo *plannercore.PartitionInfo, err error) {
-	switch v := plan.(type) {
-	case *plannercore.PhysicalTableReader:
-		tbl, _ = is.TableByID(v.GetTableScan().Table.ID)
-		partInfo = &v.PartitionInfo
-		return
-	case *plannercore.PhysicalIndexReader:
-		idx := v.IndexPlans[0].(*plannercore.PhysicalIndexScan)
-		tbl, _ = is.TableByID(idx.Table.ID)
-		partInfo = &v.PartitionInfo
-		return
-	case *plannercore.PhysicalIndexLookUpReader:
-		ts := v.TablePlans[0].(*plannercore.PhysicalTableScan)
-		tbl, _ = is.TableByID(ts.Table.ID)
-		partInfo = &v.PartitionInfo
-		return
-	case *plannercore.PhysicalUnionScan:
-		tbl, partInfo, err = extractPartitionTable(is, v.Children()[0])
-		return
-	case *plannercore.PhysicalProjection:
-		indexLookUp, _ := v.Children()[0].(*plannercore.PhysicalIndexLookUpReader)
-		ts := indexLookUp.TablePlans[0].(*plannercore.PhysicalTableScan)
-		tbl, _ = is.TableByID(ts.Table.ID)
-		partInfo = &indexLookUp.PartitionInfo
-		return
-	case *plannercore.PhysicalSelection:
-		tbl, partInfo, err = extractPartitionTable(is, v.Children()[0])
-		return
-	}
-	err = errors.New("Wrong plan type for dataReaderBuilder")
-	return
 }
 
 func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndexMergeJoin) Executor {
@@ -2438,21 +2391,6 @@ func (b *executorBuilder) buildIndexLookUpMergeJoin(v *plannercore.PhysicalIndex
 		indexRanges:   v.Ranges,
 		keyOff2IdxOff: v.KeyOff2IdxOff,
 		lastColHelper: v.CompareFilters,
-	}
-	if e.ctx.GetSessionVars().UseDynamicPartitionPrune() {
-		tbl, partInfo, err := extractPartitionTable(b.is, innerPlan)
-		if err != nil {
-			b.err = err
-			return e
-		}
-		if tbl.Meta().GetPartitionInfo() != nil {
-			e.innerMergeCtx.readerBuilder.preponePartitions, err = partitionPruning(
-				b.ctx, tbl.(table.PartitionedTable), partInfo.PruningConds, partInfo.PartitionNames, partInfo.Columns, partInfo.ColumnNames)
-			if err != nil {
-				b.err = err
-				return nil
-			}
-		}
 	}
 	childrenUsedSchema := markChildrenUsedCols(v.Schema(), v.Children()[0].Schema(), v.Children()[1].Schema())
 	joiners := make([]joiner, e.ctx.GetSessionVars().IndexLookupJoinConcurrency())
@@ -2601,7 +2539,7 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 
 	tmp, _ := b.is.TableByID(ts.Table.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, v.PartitionInfo.PruningConds, v.PartitionInfo.PartitionNames, v.PartitionInfo.Columns, v.PartitionInfo.ColumnNames)
+	partitions := getUsedPartition(tbl, v.PartitionInfo.UsedPartitions)
 	if err != nil {
 		b.err = err
 		return nil
@@ -2649,11 +2587,7 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 func buildPartitionTable(b *executorBuilder, tblInfo *model.TableInfo, partitionInfo *plannercore.PartitionInfo, e Executor, n nextPartition) (Executor, error) {
 	tmp, _ := b.is.TableByID(tblInfo.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, partitionInfo.PruningConds, partitionInfo.PartitionNames, partitionInfo.Columns, partitionInfo.ColumnNames)
-	if err != nil {
-		return nil, err
-	}
-
+	partitions := getUsedPartition(tbl, partitionInfo.UsedPartitions)
 	if len(partitions) == 0 {
 		return &TableDualExec{baseExecutor: *e.base()}, nil
 	}
@@ -2700,8 +2634,9 @@ func keyColumnsIncludeAllPartitionColumns(keyColumns []int, pe *tables.Partition
 }
 
 func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, schema *expression.Schema,
-	lookUpContent []*indexJoinLookUpContent, preponePartitions []table.PhysicalTable) (usedPartition []table.PhysicalTable, canPrune bool, contentPos []int64, err error) {
+	lookUpContent []*indexJoinLookUpContent, prePruenPartitions []int) (usedPartitions []table.PhysicalTable, canPrune bool, contentPos []int64, err error) {
 	partitionTbl := tbl.(table.PartitionedTable)
+	preponePartitions := getUsedPartition(partitionTbl, prePruenPartitions)
 	locateKey := make([]types.Datum, schema.Len())
 	// check whether can runtime prune.
 	type partitionExpr interface {
@@ -2738,13 +2673,13 @@ func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, sch
 		contentPos[idx] = p.GetPhysicalID()
 	}
 
-	usedPartition = make([]table.PhysicalTable, 0, len(partitions))
+	usedPartitions = make([]table.PhysicalTable, 0, len(partitions))
 	for _, p := range preponePartitions {
 		if _, ok := partitions[p.GetPhysicalID()]; ok {
-			usedPartition = append(usedPartition, p)
+			usedPartitions = append(usedPartitions, p)
 		}
 	}
-	return usedPartition, true, contentPos, nil
+	return usedPartitions, true, contentPos, nil
 }
 
 func buildNoRangeIndexReader(b *executorBuilder, v *plannercore.PhysicalIndexReader) (*IndexReaderExecutor, error) {
@@ -2838,11 +2773,7 @@ func (b *executorBuilder) buildIndexReader(v *plannercore.PhysicalIndexReader) E
 
 	tmp, _ := b.is.TableByID(is.Table.ID)
 	tbl := tmp.(table.PartitionedTable)
-	partitions, err := partitionPruning(b.ctx, tbl, v.PartitionInfo.PruningConds, v.PartitionInfo.PartitionNames, v.PartitionInfo.Columns, v.PartitionInfo.ColumnNames)
-	if err != nil {
-		b.err = err
-		return nil
-	}
+	partitions := getUsedPartition(tbl, v.PartitionInfo.UsedPartitions)
 	ret.partitions = partitions
 	return ret
 }
@@ -3116,8 +3047,6 @@ type dataReaderBuilder struct {
 	plannercore.Plan
 	*executorBuilder
 
-	preponePartitions []table.PhysicalTable
-
 	selectResultHook // for testing
 }
 
@@ -3173,7 +3102,7 @@ func (builder *dataReaderBuilder) buildExecutorForIndexJoinInternal(ctx context.
 func (builder *dataReaderBuilder) buildUnionScanForIndexJoin(ctx context.Context, v *plannercore.PhysicalUnionScan,
 	values []*indexJoinLookUpContent, indexRanges []*ranger.Range, keyOff2IdxOff []int,
 	cwc *plannercore.ColWithCmpFuncManager, canReorderHandles bool) (Executor, error) {
-	childBuilder := &dataReaderBuilder{Plan: v.Children()[0], executorBuilder: builder.executorBuilder, preponePartitions: builder.preponePartitions}
+	childBuilder := &dataReaderBuilder{Plan: v.Children()[0], executorBuilder: builder.executorBuilder}
 	reader, err := childBuilder.buildExecutorForIndexJoin(ctx, values, indexRanges, keyOff2IdxOff, cwc, canReorderHandles)
 	if err != nil {
 		return nil, err
@@ -3230,8 +3159,9 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 				kvRanges = append(kvRanges, tmp...)
 			}
 		} else {
-			kvRanges = make([]kv.KeyRange, 0, len(builder.preponePartitions)*len(lookUpContents))
-			for _, p := range builder.preponePartitions {
+			usedPartitions := getUsedPartition(pt, v.PartitionInfo.UsedPartitions)
+			kvRanges = make([]kv.KeyRange, 0, len(usedPartitions)*len(lookUpContents))
+			for _, p := range usedPartitions {
 				pid := p.GetPhysicalID()
 				tmp, err := buildKvRangesForIndexJoin(e.ctx, pid, -1, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 				if err != nil {
@@ -3277,7 +3207,8 @@ func (builder *dataReaderBuilder) buildTableReaderForIndexJoin(ctx context.Conte
 			kvRanges = append(kvRanges, tmp...)
 		}
 	} else {
-		for _, p := range builder.preponePartitions {
+		usedPartitions := getUsedPartition(pt, v.PartitionInfo.UsedPartitions)
+		for _, p := range usedPartitions {
 			pid := p.GetPhysicalID()
 			tmp := distsql.TableHandlesToKVRanges(pid, handles)
 			kvRanges = append(kvRanges, tmp...)
@@ -3428,8 +3359,9 @@ func (builder *dataReaderBuilder) buildIndexReaderForIndexJoin(ctx context.Conte
 			kvRanges = append(kvRanges, tmp...)
 		}
 	} else {
-		kvRanges = make([]kv.KeyRange, 0, len(builder.preponePartitions)*len(lookUpContents))
-		for _, p := range builder.preponePartitions {
+		usedPartitions := getUsedPartition(pt, v.PartitionInfo.UsedPartitions)
+		kvRanges = make([]kv.KeyRange, 0, len(usedPartitions)*len(lookUpContents))
+		for _, p := range usedPartitions {
 			tmp, err := buildKvRangesForIndexJoin(e.ctx, p.GetPhysicalID(), e.index.ID, lookUpContents, indexRanges, keyOff2IdxOff, cwc)
 			if err != nil {
 				return nil, err
@@ -3459,7 +3391,7 @@ func (builder *dataReaderBuilder) buildIndexLookUpReaderForIndexJoin(ctx context
 	}
 	nextPartition := nextPartitionForIndexLookUp{exec: e, innerPartitionInfo: &innerPartitionInfo{isFullPartition: true}}
 	tbl, _ := builder.executorBuilder.is.TableByID(tbInfo.ID)
-	usedPartition, canPrune, contentPos, err := prunePartitionForInnerExecutor(builder.executorBuilder.ctx, tbl, e.Schema(), lookUpContents, builder.preponePartitions)
+	usedPartition, canPrune, contentPos, err := prunePartitionForInnerExecutor(builder.executorBuilder.ctx, tbl, e.Schema(), lookUpContents, v.PartitionInfo.UsedPartitions)
 	if err != nil {
 		return nil, err
 	}
@@ -3900,13 +3832,7 @@ func (b *executorBuilder) buildAdminResetTelemetryID(v *plannercore.AdminResetTe
 	return &AdminResetTelemetryIDExec{baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID())}
 }
 
-func partitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds []expression.Expression, partitionNames []model.CIStr,
-	columns []*expression.Column, columnNames types.NameSlice) ([]table.PhysicalTable, error) {
-	idxArr, err := plannercore.PartitionPruning(ctx, tbl, conds, partitionNames, columns, columnNames)
-	if err != nil {
-		return nil, err
-	}
-
+func getUsedPartition(tbl table.PartitionedTable, idxArr []int) []table.PhysicalTable {
 	pi := tbl.Meta().GetPartitionInfo()
 	var ret []table.PhysicalTable
 	if fullRangePartition(idxArr) {
@@ -3923,7 +3849,7 @@ func partitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds 
 			ret = append(ret, p)
 		}
 	}
-	return ret, nil
+	return ret
 }
 
 func fullRangePartition(idxArr []int) bool {

--- a/expression/simple_rewriter.go
+++ b/expression/simple_rewriter.go
@@ -108,6 +108,20 @@ func ParseSimpleExprsWithNames(ctx sessionctx.Context, exprStr string, schema *S
 	return exprs, nil
 }
 
+// RewriteExprsWithNames rewrite AST to Expression.
+// The expression string must only reference the column in the given NameSlice.
+func RewriteExprsWithNames(ctx sessionctx.Context, fields []ast.ExprNode, schema *Schema, names types.NameSlice) ([]Expression, error) {
+	exprs := make([]Expression, 0, len(fields))
+	for _, field := range fields {
+		expr, err := RewriteSimpleExprWithNames(ctx, field, schema, names)
+		if err != nil {
+			return nil, err
+		}
+		exprs = append(exprs, expr)
+	}
+	return exprs, nil
+}
+
 // RewriteSimpleExprWithNames rewrites simple ast.ExprNode to expression.Expression.
 func RewriteSimpleExprWithNames(ctx sessionctx.Context, expr ast.ExprNode, schema *Schema, names []*types.FieldName) (Expression, error) {
 	e, err := RewriteAstExpr(ctx, expr, schema, names)

--- a/expression/util.go
+++ b/expression/util.go
@@ -161,6 +161,18 @@ func extractColumns(result []*Column, expr Expression, filter func(*Column) bool
 	return result
 }
 
+// ResetTableColIDToUniqueID reset plan unique id as table column id.
+func ResetTableColIDToUniqueID(expr Expression) {
+	switch v := expr.(type) {
+	case *Column:
+		v.UniqueID = v.ID
+	case *ScalarFunction:
+		for _, arg := range v.GetArgs() {
+			ResetTableColIDToUniqueID(arg)
+		}
+	}
+}
+
 // ExtractColumnSet extracts the different values of `UniqueId` for columns in expressions.
 func ExtractColumnSet(exprs []Expression) *intsets.Sparse {
 	set := &intsets.Sparse{}

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20200927054727-1290113160f0
 	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
-	github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77
+	github.com/pingcap/parser v0.0.0-20201022110210-2f282c073255
 	github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/pingcap/tipb v0.0.0-20200618092958-4fad48b4c8c3

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ github.com/pingcap/log v0.0.0-20200511115504-543df19646ad h1:SveG82rmu/GFxYanffx
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77 h1:2x5QE9ikrymuf78VsLoaJlY9EhH1SLzoKJJ3+E84zTg=
-github.com/pingcap/parser v0.0.0-20201021061956-783a03250c77/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
+github.com/pingcap/parser v0.0.0-20201022110210-2f282c073255 h1:RGVyKCRNhSZ207AUZr33eJe+rU7NitCCL6akR14hBEc=
+github.com/pingcap/parser v0.0.0-20201022110210-2f282c073255/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a h1:i2RElJ2aykSqZKeY+3SK18NHhajil8cQdG77wHe+P1Y=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -890,12 +890,7 @@ func (p *LogicalJoin) constructInnerTableScanTask(
 		cst:               sessVars.ScanFactor * rowSize * ts.stats.RowCount,
 		tblColHists:       ds.TblColHists,
 		keepOrder:         ts.KeepOrder,
-	}
-	copTask.partitionInfo = PartitionInfo{
-		PruningConds:   ds.allConds,
-		PartitionNames: ds.partitionNames,
-		Columns:        ds.TblCols,
-		ColumnNames:    ds.names,
+		partitionInfo:     buildPartitionInfoFromDs(ds),
 	}
 	selStats := ts.stats.Scale(selectivity)
 	ts.addPushedDownSelection(copTask, selStats)
@@ -955,16 +950,11 @@ func (p *LogicalJoin) constructInnerIndexScanTask(
 		physicalTableID:  ds.physicalTableID,
 	}.Init(ds.ctx, ds.blockOffset)
 	cop := &copTask{
-		indexPlan:   is,
-		tblColHists: ds.TblColHists,
-		tblCols:     ds.TblCols,
-		keepOrder:   is.KeepOrder,
-	}
-	cop.partitionInfo = PartitionInfo{
-		PruningConds:   ds.allConds,
-		PartitionNames: ds.partitionNames,
-		Columns:        ds.TblCols,
-		ColumnNames:    ds.names,
+		indexPlan:     is,
+		tblColHists:   ds.TblColHists,
+		tblCols:       ds.TblCols,
+		keepOrder:     is.KeepOrder,
+		partitionInfo: buildPartitionInfoFromDs(ds),
 	}
 	if !ds.isCoveringIndex(ds.schema.Columns, path.FullIdxCols, path.FullIdxColLens, is.Table) {
 		// On this way, it's double read case.

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -290,11 +290,7 @@ func (p *PhysicalTableReader) accessObject(sctx sessionctx.Context) string {
 
 func partitionAccessObject(sctx sessionctx.Context, tbl table.PartitionedTable, pi *model.PartitionInfo, partTable *PartitionInfo) string {
 	var buffer bytes.Buffer
-	idxArr, err := PartitionPruning(sctx, tbl, partTable.PruningConds, partTable.PartitionNames, partTable.Columns, partTable.ColumnNames)
-	if err != nil {
-		return "partition pruning error" + err.Error()
-	}
-
+	idxArr := partTable.UsedPartitions
 	if len(idxArr) == 0 {
 		return "partition:dual"
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -772,12 +772,7 @@ func (ds *DataSource) convertToIndexMergeScan(prop *property.PhysicalProperty, c
 	cop := &copTask{
 		indexPlanFinished: true,
 		tblColHists:       ds.TblColHists,
-	}
-	cop.partitionInfo = PartitionInfo{
-		PruningConds:   ds.allConds,
-		PartitionNames: ds.partitionNames,
-		Columns:        ds.TblCols,
-		ColumnNames:    ds.names,
+		partitionInfo:     buildPartitionInfoFromDs(ds),
 	}
 	for _, partPath := range path.PartialIndexPaths {
 		var scan PhysicalPlan
@@ -975,15 +970,10 @@ func (ds *DataSource) convertToIndexScan(prop *property.PhysicalProperty, candid
 	path := candidate.path
 	is, cost, _ := ds.getOriginalPhysicalIndexScan(prop, path, candidate.isMatchProp, candidate.isSingleScan)
 	cop := &copTask{
-		indexPlan:   is,
-		tblColHists: ds.TblColHists,
-		tblCols:     ds.TblCols,
-	}
-	cop.partitionInfo = PartitionInfo{
-		PruningConds:   ds.allConds,
-		PartitionNames: ds.partitionNames,
-		Columns:        ds.TblCols,
-		ColumnNames:    ds.names,
+		indexPlan:     is,
+		tblColHists:   ds.TblColHists,
+		tblCols:       ds.TblCols,
+		partitionInfo: buildPartitionInfoFromDs(ds),
 	}
 	if !candidate.isSingleScan {
 		// On this way, it's double read case.
@@ -1453,12 +1443,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 		indexPlanFinished: true,
 		tblColHists:       ds.TblColHists,
 		cst:               cost,
-	}
-	copTask.partitionInfo = PartitionInfo{
-		PruningConds:   ds.allConds,
-		PartitionNames: ds.partitionNames,
-		Columns:        ds.TblCols,
-		ColumnNames:    ds.names,
+		partitionInfo:     buildPartitionInfoFromDs(ds),
 	}
 	task = copTask
 	if candidate.isMatchProp {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -2901,6 +2901,8 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		// Use the new partition implementation, clean up the code here when it's full implemented.
 		if !b.ctx.GetSessionVars().UseDynamicPartitionPrune() {
 			b.optFlag = b.optFlag | flagPartitionProcessor
+		} else {
+			b.optFlag = b.optFlag | flagPartitionProcessor2
 		}
 
 		pt := tbl.(table.PartitionedTable)

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -485,7 +485,8 @@ type DataSource struct {
 	pushedDownConds []expression.Expression
 	// allConds contains all the filters on this table. For now it's maintained
 	// in predicate push down and used only in partition pruning.
-	allConds []expression.Expression
+	allConds         []expression.Expression
+	usedPartitionIDs []int
 
 	statisticTable *statistics.Table
 	tableStats     *property.StatsInfo

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -50,6 +50,7 @@ const (
 	flagPredicatePushDown
 	flagEliminateOuterJoin
 	flagPartitionProcessor
+	flagPartitionProcessor2
 	flagPushDownAgg
 	flagPushDownTopN
 	flagJoinReOrder
@@ -67,6 +68,7 @@ var optRuleList = []logicalOptRule{
 	&ppdSolver{},
 	&outerJoinEliminator{},
 	&partitionProcessor{},
+	&partitionProcessor2{},
 	&aggregationPushDownSolver{},
 	&pushDownTopNOptimizer{},
 	&joinReOrderSolver{},

--- a/planner/core/rule_partition_processor2.go
+++ b/planner/core/rule_partition_processor2.go
@@ -1,0 +1,61 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+// // Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/table"
+)
+
+// partitionProcessor2 is here because it's easier to prune partition after predicate push down.
+type partitionProcessor2 struct{}
+
+func (s *partitionProcessor2) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
+	return s.rewriteDataSource(lp)
+}
+
+func (*partitionProcessor2) name() string {
+	return "partition_processor_v2"
+}
+
+func (s *partitionProcessor2) rewriteDataSource(lp LogicalPlan) (LogicalPlan, error) {
+	switch p := lp.(type) {
+	case *DataSource:
+		return s.prune(p)
+	default:
+		children := lp.Children()
+		for i, child := range children {
+			newChild, err := s.rewriteDataSource(child)
+			if err != nil {
+				return nil, err
+			}
+			children[i] = newChild
+		}
+	}
+	return lp, nil
+}
+
+func (s *partitionProcessor2) prune(ds *DataSource) (LogicalPlan, error) {
+	pi := ds.tableInfo.GetPartitionInfo()
+	if pi == nil {
+		return ds, nil
+	}
+	tbl := ds.table.(table.PartitionedTable)
+	usedPartitionIDs, err := PartitionPruning(ds.SCtx(), tbl, ds.allConds, ds.partitionNames, ds.TblCols, ds.names)
+	if err != nil {
+		return nil, err
+	}
+	ds.usedPartitionIDs = usedPartitionIDs
+	return ds, nil
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

div prune to static and dynamic phase and make cooperate works together

- [x] pull prune's static-phase up to logic optimize
- [x] rebuild static-phase result after hit plan cache
- [ ] keep prune's dynamic phase works on build executor
- [ ] get status by the static-phase result's partition tables
- [ ] dispatch feedback by one executor multi-range to different partition's stats

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/20604)
<!-- Reviewable:end -->
