### PR TITLE
planner: fix update generated columns error

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1573,6 +1573,7 @@ func (s *testSuite8) TestUpdate(c *C) {
 	tk.MustGetErrCode("update t2 set a=default(b), b=default(b);", mysql.ErrBadGeneratedColumn)
 	tk.MustGetErrCode("update t2 set a=default(a), c=default(c);", mysql.ErrBadGeneratedColumn)
 	tk.MustGetErrCode("update t2 set a=default(a), c=default(a);", mysql.ErrBadGeneratedColumn)
+	tk.MustGetErrCode("update t2 as tt set c = 123;", mysql.ErrBadGeneratedColumn)
 	tk.MustExec("drop table t1, t2")
 }
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4659,7 +4659,6 @@ func extractTableList(node ast.ResultSetNode, input []*ast.TableName, asName boo
 			if x.AsName.L != "" && asName {
 				newTableName := *s
 				newTableName.Name = x.AsName
-				newTableName.Schema = model.NewCIStr("")
 				input = append(input, &newTableName)
 			} else {
 				input = append(input, s)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #20598 

Problem Summary:

### What is changed and how it works?

What's Changed:

   delete the schema default value

How it Works:

   delete the schema default value, so when the function `buildUpdateLists` invoke.  `columnFullName` wiil contains schema information


### Related changes

### Check List 

Tests 

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
No
    - Consumes more MEM
No
- Breaking backward compatibility

### Release note 

- fix update generated columns error
