### PR TITLE
ddl: support column type change from string to other types

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -672,6 +672,15 @@ func needChangeColumnData(oldCol, newCol *model.ColumnInfo) bool {
 		return true
 	}
 
+	switch oldCol.Tp {
+	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeEnum, mysql.TypeSet:
+		switch newCol.Tp {
+		case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
+		default:
+			return true
+		}
+	}
+
 	if newCol.Flen > 0 && newCol.Flen < oldCol.Flen || toUnsigned != originUnsigned {
 		return true
 	}

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -652,7 +652,7 @@ func needChangeColumnData(oldCol, newCol *model.ColumnInfo) bool {
 		return newCol.Flen > 0 && newCol.Flen < oldCol.Flen || toUnsigned != originUnsigned
 	}
 
-	// deal with same type
+	// Deal with the same type.
 	if oldCol.Tp == newCol.Tp {
 		switch oldCol.Tp {
 		case mysql.TypeNewDecimal:
@@ -666,7 +666,7 @@ func needChangeColumnData(oldCol, newCol *model.ColumnInfo) bool {
 		return needTruncationOrToggleSign()
 	}
 
-	// deal with different type
+	// Deal with the different type.
 	switch oldCol.Tp {
 	case mysql.TypeVarchar, mysql.TypeString, mysql.TypeVarString, mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 		switch newCol.Tp {

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -39,6 +39,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	decoder "github.com/pingcap/tidb/util/rowDecoder"
@@ -999,7 +1000,8 @@ func (w *worker) doModifyColumnTypeWithData(
 // needRollbackData indicates whether it needs to rollback data when specific error occurs.
 func needRollbackData(err error) bool {
 	return kv.ErrKeyExists.Equal(err) || errCancelledDDLJob.Equal(err) || errCantDecodeRecord.Equal(err) ||
-		types.ErrOverflow.Equal(err) || types.ErrDataTooLong.Equal(err) || types.ErrTruncated.Equal(err)
+		types.ErrOverflow.Equal(err) || types.ErrDataTooLong.Equal(err) || types.ErrTruncated.Equal(err) ||
+		json.ErrInvalidJSONText.Equal(err) || types.ErrBadNumber.Equal(err)
 }
 
 // BuildElements is exported for testing.

--- a/ddl/db_change_test.go
+++ b/ddl/db_change_test.go
@@ -484,7 +484,7 @@ func (s *testStateChangeSuite) TestAppendEnum(c *C) {
 	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: the number of enum column's elements is less than the original: 2, and tidb_enable_change_column_type is false")
 	failAlterTableSQL2 := "alter table t change c2 c2 int default 0"
 	_, err = s.se.Execute(context.Background(), failAlterTableSQL2)
-	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: cannot modify enum type column's to type int(11)")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: type int(11) not match origin enum('N','Y'), and tidb_enable_change_column_type is false")
 	alterTableSQL := "alter table t change c2 c2 enum('N','Y','A') DEFAULT 'A'"
 	_, err = s.se.Execute(context.Background(), alterTableSQL)
 	c.Assert(err, IsNil)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -957,7 +957,7 @@ func (s *testIntegrationSuite5) TestModifyColumnOption(c *C) {
 	_, err = tk.Exec("alter table t1 change a a int(11) unsigned")
 	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: can't change unsigned integer to signed or vice versa, and tidb_enable_change_column_type is false")
 	_, err = tk.Exec("alter table t2 change b b int(11) unsigned")
-	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: type int(11) not match origin char(1)")
+	c.Assert(err.Error(), Equals, "[ddl:8200]Unsupported modify column: type int(11) not match origin char(1), and tidb_enable_change_column_type is false")
 }
 
 func (s *testIntegrationSuite4) TestIndexOnMultipleGeneratedColumn(c *C) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3361,10 +3361,11 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 			mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 			skipSignCheck = true
 			skipLenCheck = true
-		case mysql.TypeEnum, mysql.TypeSet:
-			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
-		default:
+		case mysql.TypeBit:
+			// todo: currently string data type cast to bit are not compatible with mysql, should fix here after compatible
 			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+		default:
+			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		}
 	case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 		switch to.Tp {
@@ -3400,9 +3401,11 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 			mysql.TypeBlob, mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob:
 			msg := fmt.Sprintf("cannot modify %s type column's to type %s", typeVar, to.String())
 			return msg, errUnsupportedModifyColumn.GenWithStackByArgs(msg)
+		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeDuration:
+			// todo: currently enum/set cast to date and time are not support yet(expect year), should fix here after supported
+			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		default:
-			msg := fmt.Sprintf("cannot modify %s type column's to type %s", typeVar, to.String())
-			return "", errUnsupportedModifyColumn.GenWithStackByArgs(msg)
+			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		}
 	case mysql.TypeNewDecimal:
 		if origin.Tp != to.Tp {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3362,7 +3362,7 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 			skipSignCheck = true
 			skipLenCheck = true
 		case mysql.TypeBit:
-			// todo: currently string data type cast to bit are not compatible with mysql, should fix here after compatible
+			// TODO: Currently string data type cast to bit are not compatible with mysql, should fix here after compatible.
 			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		default:
 			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
@@ -3402,7 +3402,7 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 			msg := fmt.Sprintf("cannot modify %s type column's to type %s", typeVar, to.String())
 			return msg, errUnsupportedModifyColumn.GenWithStackByArgs(msg)
 		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeDuration:
-			// todo: currently enum/set cast to date and time are not support yet(expect year), should fix here after supported
+			// TODO: Currently enum/set cast to date and time are not support yet(expect year), should fix here after supported.
 			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		default:
 			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19971

Problem Summary:
DDL modify column, change type from different types, see more detail at: https://github.com/pingcap/tidb/issues/19939

### What is changed and how it works?
What's Changed:
Support ddl column type change from string to other types.

According [MySQL data types](https://dev.mysql.com/doc/refman/8.0/en/string-types.html), string types include char/varchar/binary/varbinary/blob/text/enum/set, most of them can directly cast to other types(see correlated integration test at column_type_change_test.go).

However, there are two type cannot cast yet:
- enum/set to date time type: still no cast logic at current revision, enum/set to date time not supported
- string to bit: the behavior not compatible with MySQL

Above two cases should fix at individual PRs (will create issues later)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- ddl: support column type change from string to other types
