### PR TITLE
executor: modify admin executors to support partitioned table with global index

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -488,11 +488,11 @@ func (e *IndexLookUpExecutor) getRetTpsByHandle() []*types.FieldType {
 	} else {
 		tps = []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	}
-	if e.index.Global {
-		tps = append(tps, types.NewFieldType(mysql.TypeLonglong))
-	}
 	if e.checkIndexValue != nil {
 		tps = e.idxColTps
+	}
+	if e.index.Global {
+		tps = append(tps, types.NewFieldType(mysql.TypeLonglong))
 	}
 	return tps
 }
@@ -798,7 +798,7 @@ func (w *indexWorker) extractTaskHandles(ctx context.Context, chk *chunk.Chunk, 
 		}
 		if w.checkIndexValue != nil {
 			if retChk == nil {
-				retChk = chunk.NewChunkWithCapacity(w.idxColTps, w.batchSize)
+				retChk = chunk.NewChunkWithCapacity(w.idxLookup.getRetTpsByHandle(), w.batchSize)
 			}
 			retChk.Append(chk, 0, chk.NumRows())
 		}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -130,7 +130,7 @@ var _ = SerialSuites(&testSerialSuite1{&baseTestSuite{}})
 var _ = SerialSuites(&testSlowQuery{&baseTestSuite{}})
 var _ = Suite(&partitionTableSuite{&baseTestSuite{}})
 var _ = SerialSuites(&tiflashTestSuite{})
-var _ = SerialSuites(&globalIndexSuite{&baseTestSuite{}})
+var _ = Suite(&globalIndexSuite{&baseTestSuite{}})
 var _ = SerialSuites(&testSerialSuite{&baseTestSuite{}})
 var _ = SerialSuites(&testCoprCache{})
 

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -181,4 +181,10 @@ partition p2 values less than (10))`)
 	tk.MustExec("alter table p add unique idx(id)")
 	tk.MustExec("insert into p values (1,3), (3,4), (5,6), (7,9)")
 	tk.MustQuery("select * from p use index (idx)").Check(testkit.Rows("1 3", "3 4", "5 6", "7 9"))
+
+	tk.MustExec("drop table if exists p")
+	tk.MustExec("create table p (id int, c int) partition by hash(c) partitions 5")
+	tk.MustExec("alter table p add unique idx(id)")
+	tk.MustExec("insert into p values (1,3), (3,4), (5,6), (7,9)")
+	tk.MustQuery("select * from p use index (idx) order by id").Check(testkit.Rows("1 3", "3 4", "5 6", "7 9"))
 }

--- a/kv/key.go
+++ b/kv/key.go
@@ -445,25 +445,3 @@ func NewPartitionHandle(pid int64, h Handle) PartitionHandle {
 		PartitionID: pid,
 	}
 }
-
-// Equal implements the Handle interface.
-func (ph PartitionHandle) Equal(h Handle) bool {
-	if ph2, ok := h.(PartitionHandle); ok {
-		return ph.PartitionID == ph2.PartitionID && ph.Handle.Equal(ph2.Handle)
-	}
-	return false
-}
-
-// Compare implements the Handle interface.
-func (ph PartitionHandle) Compare(h Handle) int {
-	if ph2, ok := h.(PartitionHandle); ok {
-		if ph.PartitionID < ph2.PartitionID {
-			return -1
-		}
-		if ph.PartitionID > ph2.PartitionID {
-			return 1
-		}
-		return ph.Handle.Compare(ph2.Handle)
-	}
-	panic("PartitonHandle compares to non-parition Handle")
-}

--- a/session/session.go
+++ b/session/session.go
@@ -858,6 +858,10 @@ func (s *session) ExecRestrictedSQLWithSnapshot(sql string) ([]chunk.Row, []*ast
 		se.sessionVars.OptimizerUseInvisibleIndexes = true
 		defer func() { se.sessionVars.OptimizerUseInvisibleIndexes = false }()
 	}
+	if s.sessionVars.UseDynamicPartitionPrune() {
+		se.sessionVars.PartitionPruneMode.Store(string(variable.DynamicOnly))
+		defer func() { se.sessionVars.PartitionPruneMode.Store(string(variable.StaticOnly)) }()
+	}
 	return execRestrictedSQL(ctx, se, sql)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

executor: support admin operators on partitioned table with global index.

### What is changed and how it works?

Proposal: [#18982](https://github.com/pingcap/tidb/pull/18982) 

What's Changed and How it's Works:
`buildCheckTable`: Modify reader schema to support global index, use dynamic partition prune.
`cleanupIndex`:  Build `partitonHandle` when index is global, modify table reader to read data in correct partition.
No change but write test cases for `buildRecoverIndex`, `buildCheckIndexRange`, `buildCheckIndexRange`.

Based on [#20350](https://github.com/pingcap/tidb/pull/20350).

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

-  N/A<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
