### PR TITLE
expression: make TIME function compatible with MySQL (#19158)

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2277,13 +2277,9 @@ func (b *builtinTimeSig) evalDuration(row chunk.Row) (res types.Duration, isNull
 	fsp = int(tmpFsp)
 
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ParseDurationForTime(sc, expr, int8(fsp))
+	res, isNull, err = types.ParseDurationForTime(sc, expr, int8(fsp))
 	if types.ErrTruncatedWrongVal.Equal(err) {
 		err = sc.HandleTruncate(err)
-	} else if types.ErrOverflow.Equal(err) {
-		isNull = true
-		// omit overflow error for hhmmss, there must be a better way
-		err = nil
 	}
 	return res, isNull, err
 }

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -782,6 +782,7 @@ func (s *testEvaluatorSuite) TestTime(c *C) {
 		{"01:02:03.000123", "01:02:03.000123", false, false},
 		{"01:02:03", "01:02:03", false, false},
 		{"-838:59:59.000000", "-838:59:59.000000", false, false},
+		{"60", "<nil>", true, false},
 	}
 
 	for _, t := range cases {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1643,6 +1643,9 @@ func (s *testIntegrationSuite2) TestTimeBuiltin(c *C) {
 	// result.Check(testkit.Rows("<nil>")
 	// result = tk.MustQuery("select time('2003-12-10-10 01:02:03.000123')")
 	// result.Check(testkit.Rows("00:20:03")
+	// fixed issue #19158
+	result = tk.MustQuery("select TIME(60);")
+	result.Check(testkit.Rows("<nil>"))
 
 	//for hour
 	result = tk.MustQuery(`SELECT hour("12:13:14.123456"), hour("12:13:14.000010"), hour("272:59:55"), hour(020005), hour(null), hour("27aaaa2:59:55");`)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1646,6 +1646,7 @@ func (s *testIntegrationSuite2) TestTimeBuiltin(c *C) {
 	// fixed issue #19158
 	result = tk.MustQuery("select TIME(60);")
 	result.Check(testkit.Rows("<nil>"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning|1292|Truncated incorrect time value: '60'"))
 
 	//for hour
 	result = tk.MustQuery(`SELECT hour("12:13:14.123456"), hour("12:13:14.000010"), hour("272:59:55"), hour(020005), hour(null), hour("27aaaa2:59:55");`)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19158

Problem Summary:

### What is changed and how it works?

What's Changed:
`SELECT TIME(60);` now returns NULL

How it Works:
check parsed HHMMSS, when MM > 60 || SS > 60, caller should handle this condition differently

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

- MySQL compatibility changes
