### PR TITLE
txn: support amend transaction with add unique index

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4787,7 +4787,6 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 			false,
 			model.StateNone},
 		// Test unique index
-		/* TODO unique index is not supported now.
 		{[]string{"insert into t1 values(3, 30, 300)",
 			"insert into t1 values(4, 40, 400)",
 			"insert into t2 values(11, 11, 11)",
@@ -4831,7 +4830,6 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 				{"1 10 100", "2 20 200"}},
 			true,
 			model.StateWriteOnly},
-		*/
 	}
 	tk.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Part of new feature [project](https://github.com/pingcap/tidb/projects/50), implement it in release-4.0 branch.

### What is changed and how it works?


What's Changed:

1. Fix one problem that the newly generated amend mutations are not added into the `twoPhaseCommitter` mutations fields, and these mutations(or secondar keys) are just prewrited but not commited in the commit phase.

2. Add check for newly generated keys for amend unique index, also set the `Op_type` to `Op_Insert` to check existency for these generated amend keys. 
The newly generated unique index keys need to be **pessimistically locked first** to check existency, but current implementation does not have a pessimistic retry mechanism in `2PC` code, so if there is conflict write before amend like "insert unique key with same value and then delete", the amend could also fail. The amend pessimistic lock and prewrite process are just like normal path except that there is no pessimistic write conflict retry.

How it Works:
Check new mutation uniqueness with new unique index for pessimistic transaction amend, generate amend mutations and do commit them.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Support amend transaction for add unique index.
