### PR TITLE
domain: fast fail TiDB when info schema out of date

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,7 @@ var (
 		"tikv":     true,
 		"unistore": true,
 	}
-	// checkTableBeforeDrop enable to execute `admin check table` before `drop table`.
+	// CheckTableBeforeDrop enable to execute `admin check table` before `drop table`.
 	CheckTableBeforeDrop = false
 	// checkBeforeDropLDFlag is a go build flag.
 	checkBeforeDropLDFlag = "None"

--- a/domain/print_prod_log.go
+++ b/domain/print_prod_log.go
@@ -1,0 +1,23 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build codes
+
+package domain
+
+import (
+	"github.com/pingcap/tidb/util/logutil"
+)
+
+func printLog() {
+	logutil.BgLogger().Fatal(ErrInfoSchemaExpired.Error())
+}

--- a/domain/print_test_log.go
+++ b/domain/print_test_log.go
@@ -1,0 +1,23 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// +build !codes
+
+package domain
+
+import (
+	"github.com/pingcap/tidb/util/logutil"
+)
+
+func printLog() {
+	logutil.BgLogger().Error(ErrInfoSchemaExpired.Error())
+}

--- a/domain/schema_checker.go
+++ b/domain/schema_checker.go
@@ -73,5 +73,6 @@ func (s *SchemaChecker) CheckBySchemaVer(txnTS uint64, startSchemaVer tikv.Schem
 
 	}
 	metrics.SchemaLeaseErrorCounter.WithLabelValues("outdated").Inc()
+	printLog()
 	return nil, ErrInfoSchemaExpired
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2031,7 +2031,7 @@ func (s *testSchemaSerialSuite) TestLoadSchemaFailed(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(ver, NotNil)
 
-	failpoint.Disable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed")
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/domain/ErrorMockReloadFailed"), IsNil)
 	time.Sleep(lease * 2)
 
 	tk.MustExec("drop table if exists t;")


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
tidb-server is no longer available when the information schema out of date appears, so quit early that the application doesn't keep sending requests to it.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Exit when information schema out of date.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Make tidb-server process exit when information is out of date.
