### PR TITLE
*: separate auto_increment ID allocator from _tidb_rowid allocator

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -618,4 +618,5 @@ type RecoverInfo struct {
 	SnapshotTS    uint64
 	CurAutoIncID  int64
 	CurAutoRandID int64
+	CurRowID      int64
 }

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -655,7 +655,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 	case model.ActionTruncateTable:
 		ver, err = onTruncateTable(d, t, job)
 	case model.ActionRebaseAutoID:
-		ver, err = onRebaseRowIDType(d.store, t, job)
+		ver, err = onRebaseAutoIncrementIDType(d.store, t, job)
 	case model.ActionRebaseAutoRandomBase:
 		ver, err = onRebaseAutoRandomType(d.store, t, job)
 	case model.ActionRenameTable:

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1022,6 +1022,7 @@ const (
 	ErrTableOptionInsertMethodUnsupported = 8233
 	ErrInvalidPlacementSpec               = 8234
 	ErrDDLReorgElementNotExist            = 8235
+	ErrAutoIDAllocatorNotFound            = 8236
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout           = 9001

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -990,6 +990,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrUnknownAllocatorType:       mysql.Message("Invalid allocator type", nil),
 	ErrAutoRandReadFailed:         mysql.Message("Failed to read auto-random value from storage engine", nil),
 	ErrInvalidIncrementAndOffset:  mysql.Message("Invalid auto_increment settings: auto_increment_increment: %d, auto_increment_offset: %d, both of them must be in range [1..65535]", nil),
+	ErrAutoIDAllocatorNotFound:    mysql.Message("ID allocator for %s not found", nil),
 
 	ErrWarnOptimizerHintInvalidInteger:  mysql.Message("integer value is out of range in '%s'", nil),
 	ErrWarnOptimizerHintUnsupportedHint: mysql.Message("Optimizer hint %s is not supported by TiDB and is ignored", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -46,6 +46,11 @@ error = '''
 Failed to read auto-random value from storage engine
 '''
 
+["autoid:8236"]
+error = '''
+ID allocator for %s not found
+'''
+
 ["ddl:1025"]
 error = '''
 Error on rename of '%-.210s' to '%-.210s' (errno: %d - %s)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -334,13 +334,15 @@ func (e *ShowNextRowIDExec) Next(ctx context.Context, req *chunk.Chunk) error {
 
 		var colName, idType string
 		switch alloc.GetType() {
-		case autoid.RowIDAllocType, autoid.AutoIncrementType:
+		case autoid.RowIDAllocType:
+			colName = model.ExtraHandleName.O
+		case autoid.AutoIncrementType:
 			idType = "AUTO_INCREMENT"
-			if col := tblMeta.GetAutoIncrementColInfo(); col != nil {
-				colName = col.Name.O
-			} else {
-				colName = model.ExtraHandleName.O
+			col := tblMeta.GetAutoIncrementColInfo()
+			if col == nil {
+				return errors.Errorf("auto_increment column not found")
 			}
+			colName = col.Name.O
 		case autoid.AutoRandomType:
 			idType = "AUTO_RANDOM"
 			colName = tblMeta.GetPkName().O

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3516,15 +3516,12 @@ func (s *testSuite) TestCheckIndex(c *C) {
 	c.Assert(err, IsNil)
 	is := s.domain.InfoSchema()
 	db := model.NewCIStr("test_admin")
-	dbInfo, ok := is.SchemaByName(db)
-	c.Assert(ok, IsTrue)
 	tblName := model.NewCIStr("t")
 	tbl, err := is.TableByName(db, tblName)
 	c.Assert(err, IsNil)
 	tbInfo := tbl.Meta()
 
-	alloc := autoid.NewAllocator(s.store, dbInfo.ID, false, autoid.RowIDAllocType)
-	tb, err := tables.TableFromMeta(autoid.NewAllocators(alloc), tbInfo)
+	tb, err := tables.TableFromMeta(nil, tbInfo)
 	c.Assert(err, IsNil)
 
 	_, err = se.Execute(context.Background(), "admin check index t c")

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -281,7 +281,7 @@ func getAutoIncrementID(ctx sessionctx.Context, schema *model.DBInfo, tblInfo *m
 	if err != nil {
 		return 0, err
 	}
-	return tbl.Allocators(ctx).Get(autoid.RowIDAllocType).Base() + 1, nil
+	return tbl.Allocators(ctx).Get(autoid.AutoIncrementType).Base() + 1, nil
 }
 
 func (e *memtableRetriever) setDataFromSchemata(ctx sessionctx.Context, schemas []*model.DBInfo) {

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -690,7 +690,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		}
 		// Use the value if it's not null and not 0.
 		if recordID != 0 {
-			err = e.Table.RebaseAutoID(e.ctx, recordID, true, autoid.RowIDAllocType)
+			err = e.Table.RebaseAutoID(e.ctx, recordID, true, autoid.AutoIncrementType)
 			if err != nil {
 				return nil, err
 			}
@@ -777,7 +777,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	}
 	// Use the value if it's not null and not 0.
 	if recordID != 0 {
-		err = e.Table.RebaseAutoID(e.ctx, recordID, true, autoid.RowIDAllocType)
+		err = e.Table.RebaseAutoID(e.ctx, recordID, true, autoid.AutoIncrementType)
 		if err != nil {
 			return types.Datum{}, err
 		}

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1087,13 +1087,13 @@ func (s *testSuite3) TestAutoIDIncrementAndOffset(c *C) {
 	// AutoID allocation will take increment and offset into consideration.
 	tk.MustQuery(`select b from io`).Check(testkit.Rows("10", "12", "14"))
 	// HandleID allocation will ignore the increment and offset.
-	tk.MustQuery(`select _tidb_rowid from io`).Check(testkit.Rows("15", "16", "17"))
+	tk.MustQuery(`select _tidb_rowid from io`).Check(testkit.Rows("1", "2", "3"))
 	tk.MustExec(`delete from io`)
 
 	tk.Se.GetSessionVars().AutoIncrementIncrement = 10
 	tk.MustExec(`insert into io(b) values (null),(null),(null)`)
 	tk.MustQuery(`select b from io`).Check(testkit.Rows("20", "30", "40"))
-	tk.MustQuery(`select _tidb_rowid from io`).Check(testkit.Rows("41", "42", "43"))
+	tk.MustQuery(`select _tidb_rowid from io`).Check(testkit.Rows("4", "5", "6"))
 
 	// Test invalid value.
 	tk.Se.GetSessionVars().AutoIncrementIncrement = -1

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -799,17 +799,17 @@ func HelperTestAdminShowNextID(c *C, s *seqTestSuite, str string) {
 	tk.MustExec("create table t(id int, c int)")
 	// Start handle is 1.
 	r := tk.MustQuery(str + " t next_row_id")
-	r.Check(testkit.Rows("test t _tidb_rowid 1 AUTO_INCREMENT"))
+	r.Check(testkit.Rows("test t _tidb_rowid 1 "))
 	// Row ID is step + 1.
 	tk.MustExec("insert into t values(1, 1)")
 	r = tk.MustQuery(str + " t next_row_id")
-	r.Check(testkit.Rows("test t _tidb_rowid 11 AUTO_INCREMENT"))
+	r.Check(testkit.Rows("test t _tidb_rowid 11 "))
 	// Row ID is original + step.
 	for i := 0; i < int(step); i++ {
 		tk.MustExec("insert into t values(10000, 1)")
 	}
 	r = tk.MustQuery(str + " t next_row_id")
-	r.Check(testkit.Rows("test t _tidb_rowid 21 AUTO_INCREMENT"))
+	r.Check(testkit.Rows("test t _tidb_rowid 21 "))
 	tk.MustExec("drop table t")
 
 	// test for a table with the primary key
@@ -854,19 +854,19 @@ func HelperTestAdminShowNextID(c *C, s *seqTestSuite, str string) {
 	// Test for a sequence.
 	tk.MustExec("create sequence seq1 start 15 cache 57")
 	r = tk.MustQuery(str + " seq1 next_row_id")
-	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 AUTO_INCREMENT", "test1 seq1  15 SEQUENCE"))
+	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 ", "test1 seq1  15 SEQUENCE"))
 	r = tk.MustQuery("select nextval(seq1)")
 	r.Check(testkit.Rows("15"))
 	r = tk.MustQuery(str + " seq1 next_row_id")
-	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 AUTO_INCREMENT", "test1 seq1  72 SEQUENCE"))
+	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 ", "test1 seq1  72 SEQUENCE"))
 	r = tk.MustQuery("select nextval(seq1)")
 	r.Check(testkit.Rows("16"))
 	r = tk.MustQuery(str + " seq1 next_row_id")
-	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 AUTO_INCREMENT", "test1 seq1  72 SEQUENCE"))
+	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 ", "test1 seq1  72 SEQUENCE"))
 	r = tk.MustQuery("select setval(seq1, 96)")
 	r.Check(testkit.Rows("96"))
 	r = tk.MustQuery(str + " seq1 next_row_id")
-	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 AUTO_INCREMENT", "test1 seq1  97 SEQUENCE"))
+	r.Check(testkit.Rows("test1 seq1 _tidb_rowid 1 ", "test1 seq1  97 SEQUENCE"))
 }
 
 func (s *seqTestSuite) TestNoHistoryWhenDisableRetry(c *C) {

--- a/executor/show.go
+++ b/executor/show.go
@@ -933,7 +933,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 		fmt.Fprintf(buf, " COMPRESSION='%s'", tableInfo.Compression)
 	}
 
-	incrementAllocator := allocators.Get(autoid.RowIDAllocType)
+	incrementAllocator := allocators.Get(autoid.AutoIncrementType)
 	if hasAutoIncID && incrementAllocator != nil {
 		autoIncID, err := incrementAllocator.NextGlobalAutoID(tableInfo.ID)
 		if err != nil {

--- a/executor/write.go
+++ b/executor/write.go
@@ -105,7 +105,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 				if err != nil {
 					return false, err
 				}
-				if err = t.RebaseAutoID(sctx, recordID, true, autoid.RowIDAllocType); err != nil {
+				if err = t.RebaseAutoID(sctx, recordID, true, autoid.AutoIncrementType); err != nil {
 					return false, err
 				}
 			}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -320,8 +320,15 @@ func (b *Builder) applyCreateTable(m *meta.Meta, dbInfo *model.DBInfo, tableID i
 	} else {
 		switch tp {
 		case model.ActionRebaseAutoID, model.ActionModifyTableAutoIdCache:
-			newAlloc := autoid.NewAllocator(b.handle.store, dbInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.RowIDAllocType)
-			allocs = append(allocs, newAlloc)
+			hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
+			if hasRowID {
+				newAlloc := autoid.NewAllocator(b.handle.store, dbInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.RowIDAllocType)
+				allocs = append(allocs, newAlloc)
+			}
+			if ok, _ := HasAutoIncrementColumn(tblInfo); ok {
+				newAlloc := autoid.NewAllocator(b.handle.store, dbInfo.ID, tblInfo.IsAutoIncColUnsigned(), autoid.AutoIncrementType)
+				allocs = append(allocs, newAlloc)
+			}
 		case model.ActionRebaseAutoRandomBase:
 			newAlloc := autoid.NewAllocator(b.handle.store, dbInfo.ID, tblInfo.IsAutoRandomBitColUnsigned(), autoid.AutoRandomType)
 			allocs = append(allocs, newAlloc)

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -26,6 +26,7 @@ var (
 	ErrWrongAutoKey              = dbterror.ClassAutoid.NewStd(mysql.ErrWrongAutoKey)
 	ErrInvalidAllocatorType      = dbterror.ClassAutoid.NewStd(mysql.ErrUnknownAllocatorType)
 	ErrAutoRandReadFailed        = dbterror.ClassAutoid.NewStd(mysql.ErrAutoRandReadFailed)
+	ErrAutoIDAllocatorNotFound   = dbterror.ClassAutoid.NewStd(mysql.ErrAutoIDAllocatorNotFound)
 )
 
 const (

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -214,7 +214,7 @@ func (s *testSuite) TestMeta(c *C) {
 		ID:   3,
 		Name: model.NewCIStr("tbl3"),
 	}
-	err = t.CreateTableAndSetAutoID(1, tbInfo3, 123, 0)
+	err = t.CreateTableAndSetAutoID(1, tbInfo3, 123, 0, 0)
 	c.Assert(err, IsNil)
 	id, err := t.GetAutoTableID(1, tbInfo3.ID)
 	c.Assert(err, IsNil)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1092,16 +1092,13 @@ func (s *testSessionSuite) TestAutoIncrementID(c *C) {
 	tk.MustExec("insert into autoid values(9223372036854775808);")
 	tk.MustExec("insert into autoid values();")
 	tk.MustExec("insert into autoid values();")
-	tk.MustQuery("select * from autoid").Check(testkit.Rows("9223372036854775808", "9223372036854775810", "9223372036854775812"))
+	tk.MustQuery("select * from autoid").Check(testkit.Rows("9223372036854775808", "9223372036854775809", "9223372036854775810"))
 	// In TiDB : _tidb_rowid will also consume the autoID when the auto_increment column is not the primary key.
 	// Using the MaxUint64 and MaxInt64 as the autoID upper limit like MySQL will cause _tidb_rowid allocation fail here.
-	_, err := tk.Exec("insert into autoid values(18446744073709551614)")
+	tk.MustExec("insert into autoid values(18446744073709551614)")
+	_, err := tk.Exec("insert into autoid values()")
 	c.Assert(terror.ErrorEqual(err, autoid.ErrAutoincReadFailed), IsTrue)
-	_, err = tk.Exec("insert into autoid values()")
-	c.Assert(terror.ErrorEqual(err, autoid.ErrAutoincReadFailed), IsTrue)
-	// FixMe: MySQL works fine with the this sql.
-	_, err = tk.Exec("insert into autoid values(18446744073709551615)")
-	c.Assert(terror.ErrorEqual(err, autoid.ErrAutoincReadFailed), IsTrue)
+	tk.MustExec("insert into autoid values(18446744073709551615)")
 
 	tk.MustExec("drop table if exists autoid")
 	tk.MustExec("create table autoid(`auto_inc_id` bigint(20) UNSIGNED NOT NULL AUTO_INCREMENT,UNIQUE KEY `auto_inc_id` (`auto_inc_id`))")
@@ -1120,15 +1117,12 @@ func (s *testSessionSuite) TestAutoIncrementID(c *C) {
 	// Corner cases for signed bigint auto_increment Columns.
 	tk.MustExec("drop table if exists autoid")
 	tk.MustExec("create table autoid(`auto_inc_id` bigint(20) NOT NULL AUTO_INCREMENT,UNIQUE KEY `auto_inc_id` (`auto_inc_id`))")
-	// In TiDB : _tidb_rowid will also consume the autoID when the auto_increment column is not the primary key.
-	// Using the MaxUint64 and MaxInt64 as autoID upper limit like MySQL will cause insert fail if the values is
-	// 9223372036854775806. Because _tidb_rowid will be allocated 9223372036854775807 at same time.
-	tk.MustExec("insert into autoid values(9223372036854775805);")
-	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index()").Check(testkit.Rows("9223372036854775805 9223372036854775806"))
+	tk.MustExec("insert into autoid values(9223372036854775806);")
+	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index()").Check(testkit.Rows("9223372036854775806 1"))
 	_, err = tk.Exec("insert into autoid values();")
 	c.Assert(terror.ErrorEqual(err, autoid.ErrAutoincReadFailed), IsTrue)
-	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index()").Check(testkit.Rows("9223372036854775805 9223372036854775806"))
-	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index(auto_inc_id)").Check(testkit.Rows("9223372036854775805 9223372036854775806"))
+	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index()").Check(testkit.Rows("9223372036854775806 1"))
+	tk.MustQuery("select auto_inc_id, _tidb_rowid from autoid use index(auto_inc_id)").Check(testkit.Rows("9223372036854775806 1"))
 
 	tk.MustExec("drop table if exists autoid")
 	tk.MustExec("create table autoid(`auto_inc_id` bigint(20) NOT NULL AUTO_INCREMENT,UNIQUE KEY `auto_inc_id` (`auto_inc_id`))")

--- a/table/table.go
+++ b/table/table.go
@@ -220,7 +220,7 @@ func AllocAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.Conte
 	}
 	increment := sctx.GetSessionVars().AutoIncrementIncrement
 	offset := sctx.GetSessionVars().AutoIncrementOffset
-	_, max, err := t.Allocators(sctx).Get(autoid.RowIDAllocType).Alloc(t.Meta().ID, uint64(1), int64(increment), int64(offset))
+	_, max, err := t.Allocators(sctx).Get(autoid.AutoIncrementType).Alloc(t.Meta().ID, uint64(1), int64(increment), int64(offset))
 	if err != nil {
 		return 0, err
 	}
@@ -236,7 +236,7 @@ func AllocBatchAutoIncrementValue(ctx context.Context, t Table, sctx sessionctx.
 	}
 	increment = int64(sctx.GetSessionVars().AutoIncrementIncrement)
 	offset := int64(sctx.GetSessionVars().AutoIncrementOffset)
-	min, max, err := t.Allocators(sctx).Get(autoid.RowIDAllocType).Alloc(t.Meta().ID, uint64(N), increment, offset)
+	min, max, err := t.Allocators(sctx).Get(autoid.AutoIncrementType).Alloc(t.Meta().ID, uint64(N), increment, offset)
 	if err != nil {
 		return min, max, err
 	}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -102,10 +102,6 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(autoID, Greater, int64(0))
 
-	handle, err := tables.AllocHandle(nil, tb)
-	c.Assert(err, IsNil)
-	c.Assert(handle.IntValue(), Greater, int64(0))
-
 	ctx := ts.se
 	rid, err := tb.AddRecord(ctx, types.MakeDatums(1, "abc"))
 	c.Assert(err, IsNil)
@@ -159,10 +155,10 @@ func (ts *testSuite) TestBasic(c *C) {
 	c.Assert(err, IsNil)
 
 	table.MockTableFromMeta(tb.Meta())
-	alc := tb.Allocators(nil).Get(autoid.RowIDAllocType)
+	alc := tb.Allocators(nil).Get(autoid.AutoIncrementType)
 	c.Assert(alc, NotNil)
 
-	err = tb.RebaseAutoID(nil, 0, false, autoid.RowIDAllocType)
+	err = tb.RebaseAutoID(nil, 0, false, autoid.AutoIncrementType)
 	c.Assert(err, IsNil)
 }
 
@@ -245,10 +241,6 @@ func (ts *testSuite) TestUniqueIndexMultipleNullEntries(c *C) {
 	c.Assert(string(tb.IndexPrefix()), Not(Equals), "")
 	c.Assert(string(tb.RecordPrefix()), Not(Equals), "")
 	c.Assert(tables.FindIndexByColName(tb, "b"), NotNil)
-
-	handle, err := tables.AllocHandle(nil, tb)
-	c.Assert(err, IsNil)
-	c.Assert(handle.IntValue(), Greater, int64(0))
 
 	autoid, err := table.AllocAutoIncrementValue(context.Background(), tb, ts.se)
 	c.Assert(err, IsNil)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #982 <!-- REMOVE this line if no issue to close -->

Problem Summary: before this PR, auto_increment ID and `_tidb_rowid` share the same key-value. The problem is any action that effects `auto_increment` column also has an impact on `_tidb_rowid`. For example, 
```sql
create table t (a bigint auto_increment unique key);
insert into t values (9223372036854775805); -- MaxInt64-2
insert into t values (1);
```
```console
Query OK, 0 rows affected (0.00 sec)
Query OK, 0 rows affected (0.00 sec)
ERROR 1467 (HY000): Failed to read auto-increment value from storage engine
```
The first insert statement forces auto_increment ID rebase to `9223372036854775807`. Even if the second insert statement does not trigger auto_increment ID allocation, TiDB throws an "Failed to read" error because the `_tidb_rowid` allocator is exhausted.

### What is changed and how it works?

What's Changed:
- separate auto_increment ID allocator from _tidb_rowid allocator
- fix a lot of tests

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch ?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- **[ATTENTION] Breaking backward compatibility**

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
