### PR TITLE
test: add conditions check for TestDefaultValForAnalyze

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -720,6 +720,8 @@ func (s *testSuite1) TestDefaultValForAnalyze(c *C) {
 	for i := 1; i < 4; i++ {
 		tk.MustExec("insert into t values (?)", i)
 	}
+	tk.MustQuery("select @@tidb_enable_fast_analyze").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@session.tidb_enable_fast_analyze").Check(testkit.Rows("0"))
 	tk.MustExec("analyze table t with 0 topn;")
 	tk.MustQuery("explain select * from t where a = 1").Check(testkit.Rows("IndexReader_6 512.00 root  index:IndexRangeScan_5",
 		"└─IndexRangeScan_5 512.00 cop[tikv] table:t, index:a(a) range:[1,1], keep order:false"))


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: #20574 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Check `tidb_enable_fast_analyze` for TestDefaultValForAnalyze.

Suspect this is the root cause.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- No release note.
