### PR TITLE
ddl: support column type change from numeric to other types

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -717,6 +717,11 @@ func needChangeColumnData(oldCol, newCol *model.ColumnInfo) bool {
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
 			return needTruncationOrToggleSign()
 		}
+	case mysql.TypeFloat, mysql.TypeDouble:
+		switch newCol.Tp {
+		case mysql.TypeFloat, mysql.TypeDouble:
+			return needTruncationOrToggleSign()
+		}
 	}
 
 	return true
@@ -1047,7 +1052,7 @@ func (w *worker) doModifyColumnTypeWithData(
 func needRollbackData(err error) bool {
 	return kv.ErrKeyExists.Equal(err) || errCancelledDDLJob.Equal(err) || errCantDecodeRecord.Equal(err) ||
 		types.ErrOverflow.Equal(err) || types.ErrDataTooLong.Equal(err) || types.ErrTruncated.Equal(err) ||
-		json.ErrInvalidJSONText.Equal(err) || types.ErrBadNumber.Equal(err)
+		json.ErrInvalidJSONText.Equal(err) || types.ErrBadNumber.Equal(err) || types.ErrWrongValue.Equal(err)
 }
 
 // BuildElements is exported for testing.

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -1162,9 +1162,9 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 		{"decimal(2,1)", "decimal(3,2)", errUnsupportedModifyColumn.GenWithStackByArgs("decimal change from decimal(2, 1) to decimal(3, 2), and tidb_enable_change_column_type is false")},
 		{"decimal(2,1)", "decimal(2,2)", errUnsupportedModifyColumn.GenWithStackByArgs("decimal change from decimal(2, 1) to decimal(2, 2), and tidb_enable_change_column_type is false")},
 		{"decimal(2,1)", "decimal(2,1)", nil},
-		{"decimal(2,1)", "int", errUnsupportedModifyColumn.GenWithStackByArgs("type int(11) not match origin decimal(2,1)")},
-		{"decimal", "int", errUnsupportedModifyColumn.GenWithStackByArgs("type int(11) not match origin decimal(11,0)")},
-		{"decimal(2,1)", "bigint", errUnsupportedModifyColumn.GenWithStackByArgs("type bigint(20) not match origin decimal(2,1)")},
+		{"decimal(2,1)", "int", errUnsupportedModifyColumn.GenWithStackByArgs("type int(11) not match origin decimal(2,1), and tidb_enable_change_column_type is false")},
+		{"decimal", "int", errUnsupportedModifyColumn.GenWithStackByArgs("type int(11) not match origin decimal(11,0), and tidb_enable_change_column_type is false")},
+		{"decimal(2,1)", "bigint", errUnsupportedModifyColumn.GenWithStackByArgs("type bigint(20) not match origin decimal(2,1), and tidb_enable_change_column_type is false")},
 	}
 	for _, tt := range tests {
 		ftA := s.colDefStrToFieldType(c, tt.origin)

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -674,3 +674,268 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromStringToOthers(c *C)
 	tk.MustExec("insert into t(vc) values ('abc')")
 	tk.MustGetErrCode("alter table t modify vc decimal(5,3)", mysql.ErrBadNumber)
 }
+
+func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromNumericToOthers(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	// Enable column change variable.
+	tk.Se.GetSessionVars().EnableChangeColumnType = true
+
+	// Set time zone to UTC.
+	originalTz := tk.Se.GetSessionVars().TimeZone
+	tk.Se.GetSessionVars().TimeZone = time.UTC
+	defer func() {
+		tk.Se.GetSessionVars().EnableChangeColumnType = false
+		tk.Se.GetSessionVars().TimeZone = originalTz
+	}()
+
+	// Init string date type table.
+	reset := func(tk *testkit.TestKit) {
+		tk.MustExec("drop table if exists t")
+		tk.MustExec(`
+			create table t (
+				d decimal(13, 7),
+				n numeric(5, 2),
+				r real(20, 12),
+				db real(32, 11),
+				f32 float(23),
+				f64 double(46),
+				b bit(5)
+			)
+		`)
+	}
+
+	// To integer data types.
+	// tinyint
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustGetErrCode("alter table t modify d tinyint", mysql.ErrDataOutOfRange)
+	tk.MustGetErrCode("alter table t modify n tinyint", mysql.ErrDataOutOfRange)
+	tk.MustGetErrCode("alter table t modify r tinyint", mysql.ErrDataOutOfRange)
+	tk.MustGetErrCode("alter table t modify db tinyint", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify f32 tinyint")
+	tk.MustGetErrCode("alter table t modify f64 tinyint", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify b tinyint")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111 -222222222222.22223 21"))
+	// int
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d int")
+	tk.MustExec("alter table t modify n int")
+	tk.MustExec("alter table t modify r int")
+	tk.MustExec("alter table t modify db int")
+	tk.MustExec("alter table t modify f32 int")
+	tk.MustGetErrCode("alter table t modify f64 int", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify b int")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258 333 2000000 323232323 -111 -222222222222.22223 21"))
+	// bigint
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d bigint")
+	tk.MustExec("alter table t modify n bigint")
+	tk.MustExec("alter table t modify r bigint")
+	tk.MustExec("alter table t modify db bigint")
+	tk.MustExec("alter table t modify f32 bigint")
+	tk.MustExec("alter table t modify f64 bigint")
+	tk.MustExec("alter table t modify b bigint")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258 333 2000000 323232323 -111 -222222222222 21"))
+	// unsigned bigint
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	// MySQL will get "ERROR 1264 (22001): Data truncation: Out of range value for column 'd' at row 1".
+	tk.MustGetErrCode("alter table t modify d bigint unsigned", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify n bigint unsigned")
+	tk.MustExec("alter table t modify r bigint unsigned")
+	tk.MustExec("alter table t modify db bigint unsigned")
+	// MySQL will get "ERROR 1264 (22001): Data truncation: Out of range value for column 'f32' at row 1".
+	tk.MustGetErrCode("alter table t modify f32 bigint unsigned", mysql.ErrDataOutOfRange)
+	// MySQL will get "ERROR 1264 (22001): Data truncation: Out of range value for column 'f64' at row 1".
+	tk.MustGetErrCode("alter table t modify f64 bigint unsigned", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify b int")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333 2000000 323232323 -111.111115 -222222222222.22223 21"))
+
+	// To string data types.
+	// char
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d char(20)")
+	tk.MustExec("alter table t modify n char(20)")
+	tk.MustExec("alter table t modify r char(20)")
+	// MySQL will get "ERROR 1406 (22001): Data truncation: Data too long for column 'db' at row 1".
+	tk.MustExec("alter table t modify db char(20)")
+	// MySQL will get "-111.111" rather than "-111.111115" at TiDB.
+	tk.MustExec("alter table t modify f32 char(20)")
+	// MySQL will get "ERROR 1406 (22001): Data truncation: Data too long for column 'f64' at row 1".
+	tk.MustExec("alter table t modify f64 char(20)")
+	tk.MustExec("alter table t modify b char(20)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+
+	// varchar
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d varchar(30)")
+	tk.MustExec("alter table t modify n varchar(30)")
+	tk.MustExec("alter table t modify r varchar(30)")
+	tk.MustExec("alter table t modify db varchar(30)")
+	// MySQL will get "-111.111" rather than "-111.111115" at TiDB.
+	tk.MustExec("alter table t modify f32 varchar(30)")
+	// MySQL will get "ERROR 1406 (22001): Data truncation: Data too long for column 'f64' at row 1".
+	tk.MustExec("alter table t modify f64 varchar(30)")
+	tk.MustExec("alter table t modify b varchar(30)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+
+	// binary
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustGetErrCode("alter table t modify d binary(10)", mysql.ErrDataTooLong)
+	tk.MustExec("alter table t modify n binary(10)")
+	tk.MustGetErrCode("alter table t modify r binary(10)", mysql.ErrDataTooLong)
+	tk.MustGetErrCode("alter table t modify db binary(10)", mysql.ErrDataTooLong)
+	// MySQL will run with no error.
+	tk.MustGetErrCode("alter table t modify f32 binary(10)", mysql.ErrDataTooLong)
+	tk.MustGetErrCode("alter table t modify f64 binary(10)", mysql.ErrDataTooLong)
+	tk.MustExec("alter table t modify b binary(10)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33\x00\x00\x00\x00 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15\x00\x00\x00\x00\x00\x00\x00\x00\x00"))
+
+	// varbinary
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d varbinary(30)")
+	tk.MustExec("alter table t modify n varbinary(30)")
+	tk.MustExec("alter table t modify r varbinary(30)")
+	tk.MustExec("alter table t modify db varbinary(30)")
+	// MySQL will get "-111.111" rather than "-111.111115" at TiDB.
+	tk.MustExec("alter table t modify f32 varbinary(30)")
+	// MySQL will get "ERROR 1406 (22001): Data truncation: Data too long for column 'f64' at row 1".
+	tk.MustExec("alter table t modify f64 varbinary(30)")
+	tk.MustExec("alter table t modify b varbinary(30)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+
+	// blob
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d blob")
+	tk.MustExec("alter table t modify n blob")
+	tk.MustExec("alter table t modify r blob")
+	tk.MustExec("alter table t modify db blob")
+	// MySQL will get "-111.111" rather than "-111.111115" at TiDB.
+	tk.MustExec("alter table t modify f32 blob")
+	tk.MustExec("alter table t modify f64 blob")
+	tk.MustExec("alter table t modify b blob")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+
+	// text
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d text")
+	tk.MustExec("alter table t modify n text")
+	tk.MustExec("alter table t modify r text")
+	tk.MustExec("alter table t modify db text")
+	// MySQL will get "-111.111" rather than "-111.111115" at TiDB.
+	tk.MustExec("alter table t modify f32 text")
+	tk.MustExec("alter table t modify f64 text")
+	tk.MustExec("alter table t modify b text")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+
+	// enum
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.111, -222222222222.222222222222222, b'10101')")
+	tk.MustGetErrCode("alter table t modify d enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify n enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify r enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify db enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f32 enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify b enum('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111 -222222222222.22223 \x15"))
+
+	// set
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.111, -222222222222.222222222222222, b'10101')")
+	tk.MustGetErrCode("alter table t modify d set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify n set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify r set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify db set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f32 set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify b set('-258.12345', '333.33', '2000000.20000002', '323232323.3232323232', '-111.111', '-222222222222.222222222222222', b'10101')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111 -222222222222.22223 \x15"))
+
+	// To date and time data types.
+	// datetime
+	reset(tk)
+	tk.MustExec("insert into t values (200805.11, 307.333, 20200805.11111111, 20200805111307.11111111, 200805111307.11111111, 20200805111307.11111111, b'10101')")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect datetime value: '200805.1100000' for column 'd' at row 1".
+	tk.MustExec("alter table t modify d datetime")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect datetime value: '307.33' for column 'n' at row 1".
+	tk.MustExec("alter table t modify n datetime")
+	tk.MustGetErrCode("alter table t modify r datetime", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify db datetime", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f32 datetime", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 datetime", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify b datetime", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("2020-08-05 00:00:00 2000-03-07 00:00:00 20200805.11111111 20200805111307.11 200805100000 20200805111307.11 \x15"))
+	// time
+	reset(tk)
+	tk.MustExec("insert into t values (200805.11, 307.333, 20200805.11111111, 20200805111307.11111111, 200805111307.11111111, 20200805111307.11111111, b'10101')")
+	tk.MustExec("alter table t modify d time")
+	tk.MustExec("alter table t modify n time")
+	tk.MustGetErrCode("alter table t modify r time", mysql.ErrTruncatedWrongValue)
+	tk.MustExec("alter table t modify db time")
+	tk.MustExec("alter table t modify f32 time")
+	tk.MustExec("alter table t modify f64 time")
+	tk.MustGetErrCode("alter table t modify b time", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("20:08:05 00:03:07 20200805.11111111 11:13:07 10:00:00 11:13:07 \x15"))
+	// date
+	reset(tk)
+	tk.MustExec("insert into t values (200805.11, 307.333, 20200805.11111111, 20200805111307.11111111, 200805111307.11111111, 20200805111307.11111111, b'10101')")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect date value: '200805.1100000' for column 'd' at row 1".
+	tk.MustExec("alter table t modify d date")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect date value: '307.33' for column 'n' at row 1".
+	tk.MustExec("alter table t modify n date")
+	tk.MustGetErrCode("alter table t modify r date", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify db date", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f32 date", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 date", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify b date", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("2020-08-05 2000-03-07 20200805.11111111 20200805111307.11 200805100000 20200805111307.11 \x15"))
+	// timestamp
+	reset(tk)
+	tk.MustExec("insert into t values (200805.11, 307.333, 20200805.11111111, 20200805111307.11111111, 200805111307.11111111, 20200805111307.11111111, b'10101')")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect datetime value: '200805.1100000' for column 'd' at row 1".
+	tk.MustExec("alter table t modify d timestamp")
+	// MySQL will get "ERROR 1292 (22001) Data truncation: Incorrect datetime value: '307.33' for column 'n' at row 1".
+	tk.MustExec("alter table t modify n timestamp")
+	tk.MustGetErrCode("alter table t modify r timestamp", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify db timestamp", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f32 timestamp", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 timestamp", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify b timestamp", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("2020-08-05 00:00:00 2000-03-07 00:00:00 20200805.11111111 20200805111307.11 200805100000 20200805111307.11 \x15"))
+	// year
+	reset(tk)
+	tk.MustExec("insert into t values (200805.11, 307.333, 2.55555, 98.1111111, 2154.00001, 20200805111307.11111111, b'10101')")
+	tk.MustGetErrCode("alter table t modify d year", mysql.ErrDataOutOfRange)
+	tk.MustGetErrCode("alter table t modify n year", mysql.ErrDataOutOfRange)
+	// MySQL will get "ERROR 1264 (22001) Data truncation: Out of range value for column 'r' at row 1".
+	tk.MustExec("alter table t modify r year")
+	// MySQL will get "ERROR 1264 (22001) Data truncation: Out of range value for column 'db' at row 1".
+	tk.MustExec("alter table t modify db year")
+	// MySQL will get "ERROR 1264 (22001) Data truncation: Out of range value for column 'f32' at row 1".
+	tk.MustExec("alter table t modify f32 year")
+	tk.MustGetErrCode("alter table t modify f64 year", mysql.ErrDataOutOfRange)
+	tk.MustExec("alter table t modify b year")
+	tk.MustQuery("select * from t").Check(testkit.Rows("200805.1100000 307.33 2003 1998 2154 20200805111307.11 2021"))
+
+	// To json data type.
+	reset(tk)
+	tk.MustExec("insert into t values (-258.12345, 333.33, 2000000.20000002, 323232323.3232323232, -111.11111111, -222222222222.222222222222222, b'10101')")
+	tk.MustExec("alter table t modify d json")
+	tk.MustExec("alter table t modify n json")
+	tk.MustExec("alter table t modify r json")
+	tk.MustExec("alter table t modify db json")
+	tk.MustExec("alter table t modify f32 json")
+	tk.MustExec("alter table t modify f64 json")
+	tk.MustExec("alter table t modify b json")
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.12345 333.33 2000000.20000002 323232323.32323235 -111.11111450195312 -222222222222.22223 \"\\u0015\""))
+}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3400,6 +3400,26 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 			// Changing integer to other types, reorg is absolutely necessary.
 			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		}
+	case mysql.TypeFloat, mysql.TypeDouble:
+		switch to.Tp {
+		case mysql.TypeFloat, mysql.TypeDouble:
+			skipSignCheck = true
+			skipLenCheck = true
+		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeEnum, mysql.TypeSet:
+			// TODO: Currently float/double cast to date/datetime/timestamp/enum/set are all not support yet, should fix here after supported.
+			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+		default:
+			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+		}
+	case mysql.TypeBit:
+		switch to.Tp {
+		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeTimestamp, mysql.TypeDuration, mysql.TypeEnum, mysql.TypeSet:
+			// TODO: Currently bit cast to date/datetime/timestamp/time/enum/set are all not support yet, should fix here after supported.
+			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+		case mysql.TypeBit:
+		default:
+			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+		}
 	case mysql.TypeEnum, mysql.TypeSet:
 		var typeVar string
 		if origin.Tp == mysql.TypeEnum {
@@ -3432,7 +3452,11 @@ func CheckModifyTypeCompatible(origin *types.FieldType, to *types.FieldType) (al
 		}
 	case mysql.TypeNewDecimal:
 		if origin.Tp != to.Tp {
-			return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+			switch to.Tp {
+			case mysql.TypeEnum, mysql.TypeSet:
+				return "", errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
+			}
+			return unsupportedMsg, errUnsupportedModifyColumn.GenWithStackByArgs(unsupportedMsg)
 		}
 		// Floating-point and fixed-point types also can be UNSIGNED. As with integer types, this attribute prevents
 		// negative values from being stored in the column. Unlike the integer types, the upper range of column values

--- a/types/convert.go
+++ b/types/convert.go
@@ -264,7 +264,7 @@ func convertDecimalStrToUint(sc *stmtctx.StatementContext, str string, upperBoun
 
 	val, err := strconv.ParseUint(intStr, 10, 64)
 	if err != nil {
-		return val, errors.Trace(err)
+		return val, overflow(str, tp)
 	}
 	return val + round, nil
 }

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -1160,6 +1160,7 @@ func (s *testTypeConvertSuite) TestConvertDecimalStrToUint(c *C) {
 		{"18446744073709551614.55", 18446744073709551615, true},
 		{"18446744073709551615.344", 18446744073709551615, true},
 		{"18446744073709551615.544", 0, false},
+		{"-111.111", 0, false},
 	}
 	for _, ca := range cases {
 		result, err := convertDecimalStrToUint(&stmtctx.StatementContext{}, ca.input, math.MaxUint64, 0)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/19970

Problem Summary:
DDL modify column, change type from different types, see more detail at: https://github.com/pingcap/tidb/issues/19939

### What is changed and how it works?
What's Changed:
Support ddl column type change from numeric(only float/double/decimal contained) to other types.

According [MySQL data types](https://dev.mysql.com/doc/refman/8.0/en/numeric-types.html), numeric types include `tinyint/smallint/mediumint/int/bigint/decimal/numeric(decimal)/real(float)/double/float`, the column change from integer part(`tinyint/smallint/mediumint/int/bigint`) to other types were already done at #20536. 

This PR tested the rest of numeric type cast to others(see correlated integration test at column_type_change_test.go).

However, there are some cases cannot supported:
- float/double to date/datetime/timestamp/enum/set
- bit to date/datetime/timestamp/time/enum/set
- decimal to enum/set
all because of the Datum.ConvertTo() contains no proper implementations about those type casts.

Above cases should fix at individual PRs (will create issues later).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- ddl: support column type change from string to other types.
