### PR TITLE
ddl: add missing flags when alter table change column

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4650,6 +4650,28 @@ func (s *testSerialDBSuite) TestDDLJobErrorCount(c *C) {
 	}
 }
 
+func (s *testDBSuite5) TestChangeColumnShouldKeepFlagWhenTypeIsTimestamp(c *C) {
+	s.tk = testkit.NewTestKit(c, s.store)
+	s.tk.MustExec("use " + s.schemaName)
+	s.mustExec(c, "drop table if exists tt")
+	s.mustExec(c, "create table tt(id int auto_increment primary key, c timestamp)")
+	ctx := s.tk.Se.(sessionctx.Context)
+	is := domain.GetDomain(ctx).InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr(s.schemaName), model.NewCIStr("tt"))
+	c.Assert(err, IsNil)
+	colC := tbl.Meta().Columns[1]
+	originFlag := colC.Flag
+	c.Assert(originFlag > 0, IsTrue)
+	c.Assert(colC.Name.L, Equals, "c")
+	s.mustExec(c, "alter table tt change column c cc timestamp")
+	is = domain.GetDomain(ctx).InfoSchema()
+	tbl, err = is.TableByName(model.NewCIStr(s.schemaName), model.NewCIStr("tt"))
+	c.Assert(err, IsNil)
+	colCC := tbl.Meta().Columns[1]
+	c.Assert(colCC.Name.L, Equals, "cc")
+	c.Assert(originFlag, Equals, colCC.Flag)
+}
+
 func init() {
 	// Make sure it will only be executed once.
 	domain.SchemaOutOfDateRetryInterval = int64(50 * time.Millisecond)

--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -150,9 +150,12 @@ func (e *BatchPointGetExec) initialize(ctx context.Context) error {
 		keys := make([]kv.Key, 0, len(e.idxVals))
 		for _, idxVals := range e.idxVals {
 			physID := getPhysID(e.tblInfo, idxVals[e.partPos].GetInt64())
-			idxKey, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
+			idxKey, hasNull, err1 := encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, idxVals, physID)
 			if err1 != nil && !kv.ErrNotExist.Equal(err1) {
 				return err1
+			}
+			if hasNull {
+				continue
 			}
 			s := hack.String(idxKey)
 			if _, found := dedup[s]; found {

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -127,3 +127,14 @@ func (s *testBatchPointGetSuite) TestBatchPointGetInTxn(c *C) {
 	tk.MustQuery("select * from s where (a, b) in ((1, 1), (2, 2), (3, 3)) for update").Check(testkit.Rows("1 1 1", "3 3 10"))
 	tk.MustExec("rollback")
 }
+
+func (s *testBatchPointGetSuite) TestBatchPointGetCache(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table customers (id int primary key, token varchar(255) unique)")
+	tk.MustExec("INSERT INTO test.customers (id, token) VALUES (28, '07j')")
+	tk.MustExec("INSERT INTO test.customers (id, token) VALUES (29, '03j')")
+	tk.MustExec("BEGIN")
+	tk.MustQuery("SELECT id, token FROM test.customers WHERE id IN (28)")
+	tk.MustQuery("SELECT id, token FROM test.customers WHERE id IN (28, 29);").Check(testkit.Rows("28 07j", "29 03j"))
+}

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -535,12 +535,12 @@ func (e *hugeMemTableRetriever) setDataForColumns(ctx sessionctx.Context) error 
 		schema := e.dbs[e.dbsIdx]
 		for e.tblIdx < len(schema.Tables) {
 			table := schema.Tables[e.tblIdx]
+			e.tblIdx++
 			if checker != nil && !checker.RequestVerification(ctx.GetSessionVars().ActiveRoles, schema.Name.L, table.Name.L, "", mysql.AllPrivMask) {
 				continue
 			}
 
 			e.dataForColumnsInTable(schema, table)
-			e.tblIdx++
 			if len(e.rows) >= batch {
 				return nil
 			}

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -157,9 +157,13 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 		tblID = e.tblInfo.ID
 	}
 	if e.idxInfo != nil {
-		e.idxKey, err = encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, e.idxVals, tblID)
+		hasNull := false
+		e.idxKey, hasNull, err = encodeIndexKey(e.base(), e.tblInfo, e.idxInfo, e.idxVals, tblID)
 		if err != nil && !kv.ErrNotExist.Equal(err) {
 			return err
+		}
+		if hasNull {
+			return nil
 		}
 
 		e.handleVal, err = e.get(ctx, e.idxKey)
@@ -299,9 +303,13 @@ func (e *PointGetExecutor) get(ctx context.Context, key kv.Key) ([]byte, error) 
 	return e.snapshot.Get(ctx, key)
 }
 
-func encodeIndexKey(e *baseExecutor, tblInfo *model.TableInfo, idxInfo *model.IndexInfo, idxVals []types.Datum, tID int64) (_ []byte, err error) {
+func encodeIndexKey(e *baseExecutor, tblInfo *model.TableInfo, idxInfo *model.IndexInfo, idxVals []types.Datum, tID int64) (_ []byte, hasNull bool, err error) {
 	sc := e.ctx.GetSessionVars().StmtCtx
 	for i := range idxVals {
+		if idxVals[i].IsNull() {
+			hasNull = true
+			continue
+		}
 		colInfo := tblInfo.Columns[idxInfo.Columns[i].Offset]
 		// table.CastValue will append 0x0 if the string value's length is smaller than the BINARY column's length.
 		// So we don't use CastValue for string value for now.
@@ -313,19 +321,19 @@ func encodeIndexKey(e *baseExecutor, tblInfo *model.TableInfo, idxInfo *model.In
 		} else {
 			idxVals[i], err = table.CastValue(e.ctx, idxVals[i], colInfo, true, false)
 			if types.ErrOverflow.Equal(err) {
-				return nil, kv.ErrNotExist
+				return nil, false, kv.ErrNotExist
 			}
 		}
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 	}
 
 	encodedIdxVals, err := codec.EncodeKey(sc, nil, idxVals...)
 	if err != nil {
-		return nil, err
+		return nil, false, err
 	}
-	return tablecodec.EncodeIndexSeekKey(tID, idxInfo.ID, encodedIdxVals), nil
+	return tablecodec.EncodeIndexSeekKey(tID, idxInfo.ID, encodedIdxVals), hasNull, nil
 }
 
 func decodeRowValToChunk(e *baseExecutor, tblInfo *model.TableInfo, handle int64, rowVal []byte, chk *chunk.Chunk, rd *rowcodec.ChunkDecoder) error {

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -512,6 +512,16 @@ func (s *testPointGetSuite) TestSelectCheckVisibility(c *C) {
 	checkSelectResultError("select * from t", tikv.ErrGCTooEarly)
 }
 
+func (s *testPointGetSuite) TestNullValues(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t ( id bigint(10) primary key, f varchar(191) default null, unique key `idx_f` (`f`))")
+	tk.MustExec(`insert into t values (1, "")`)
+	rs := tk.MustQuery(`select * from t where f in (null)`).Rows()
+	c.Assert(len(rs), Equals, 0)
+}
+
 func (s *testPointGetSuite) TestReturnValues(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6588,6 +6588,24 @@ func (s *testIntegrationSuite) TestIssue17727(c *C) {
 	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
 }
 
+func (s *testIntegrationSuite) TestIssue18850(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t, t1")
+	tk.MustExec("create table t(a int, b enum('A', 'B'));")
+	tk.MustExec("create table t1(a1 int, b1 enum('B', 'A'));")
+	tk.MustExec("insert into t values (1, 'A');")
+	tk.MustExec("insert into t1 values (1, 'A');")
+	tk.MustQuery("select /*+ HASH_JOIN(t, t1) */ * from t join t1 on t.b = t1.b1;").Check(testkit.Rows("1 A 1 A"))
+
+	tk.MustExec("drop table t, t1")
+	tk.MustExec("create table t(a int, b set('A', 'B'));")
+	tk.MustExec("create table t1(a1 int, b1 set('B', 'A'));")
+	tk.MustExec("insert into t values (1, 'A');")
+	tk.MustExec("insert into t1 values (1, 'A');")
+	tk.MustQuery("select /*+ HASH_JOIN(t, t1) */ * from t join t1 on t.b = t1.b1;").Check(testkit.Rows("1 A 1 A"))
+}
+
 func (s *testIntegrationSerialSuite) TestIssue18702(c *C) {
 	collate.SetNewCollationEnabledForTest(true)
 	defer collate.SetNewCollationEnabledForTest(false)

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1124,6 +1124,18 @@ func (s *testTableSuite) TestStmtSummaryTable(c *C) {
 	}, nil, nil)
 }
 
+func (s *testTableSuite) TestIssue18845(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`CREATE USER 'user18845'@'localhost';`)
+	tk.Se.Auth(&auth.UserIdentity{
+		Username:     "user18845",
+		Hostname:     "localhost",
+		AuthUsername: "user18845",
+		AuthHostname: "localhost",
+	}, nil, nil)
+	tk.MustQuery(`select count(*) from information_schema.columns;`)
+}
+
 // Test statements_summary_history.
 func (s *testTableSuite) TestStmtSummaryHistoryTable(c *C) {
 	tk := s.newTestKitWithRoot(c)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -105,7 +105,7 @@ func (s *tikvSnapshot) BatchGet(ctx context.Context, keys []kv.Key) (map[string]
 	m := make(map[string][]byte)
 	s.mu.RLock()
 	if s.mu.cached != nil {
-		tmp := keys[:0]
+		tmp := make([]kv.Key, 0, len(keys))
 		for _, key := range keys {
 			if val, ok := s.mu.cached[string(key)]; ok {
 				if len(val) > 0 {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20720 

Problem Summary:

Alter table change column is missing some flag when generate the new column info.

### What is changed and how it works?

What's Changed:

Add missing flags back when execute alter table change column

### Related changes

- Need to cherry-pick to the release branch 4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- Fix missing flags when execute alter table change column