### PR TITLE
executor: support global kill (32 bits)

### DIFF
--- a/docs/design/2020-06-01-global-kill.md
+++ b/docs/design/2020-06-01-global-kill.md
@@ -1,7 +1,7 @@
 # Global Kill
 
 - Author(s):     [pingyu](https://github.com/pingyu) (Ping Yu)
-- Last updated:  2020-11-01
+- Last updated:  2020-11-15
 - Discussion at: https://github.com/pingcap/tidb/issues/8854
 
 ## Abstract
@@ -17,12 +17,21 @@ Currently connection ids are local to TiDB instances, which means that a `KILL x
 To support "Global Kill", we need:
 1. Global connection ids, which are unique among all TiDB instances.
 2. Redirect `KILL x` to target TiDB instance, on which the connection `x` is running.
-3. Support both 32 & 64 bits `connId`. 32 bits `connId` is used on small clusters (number of TiDB instances less than 32), to be fully compatible with legacy 32 bits clients, while 64 bits `connId` is used for big clusters. Bit 0 in `connId` is a markup to distinguish between these two kinds.
+3. Support both 32 & 64 bits `connId`. 32 bits `connId` is used on small clusters (number of TiDB instances less than 2048), to be fully compatible with all clients including legacy 32 bits ones, while 64 bits `connId` is used for big clusters. Bit 0 in `connId` is a markup to distinguish between these two kinds.
 
 ## Rationale
 
 #### 1. Structure of `connId`
-##### 64 bits version
+##### 32 bits
+```
+                                      31    21 20               1    0
+                                     +--------+------------------+------+
+                                     |serverId|   local connId   |markup|
+                                     | (11b)  |       (20b)      |  =0  |
+                                     +--------+------------------+------+
+```
+
+##### 64 bits
 ```
   63 62                 41 40                                   1    0    
  +--+---------------------+--------------------------------------+------+
@@ -31,20 +40,11 @@ To support "Global Kill", we need:
  +--+---------------------+--------------------------------------+------+
 ```
 
-##### 32 bits version
-```
-                                      31    27 26                1    0
-                                     +--------+------------------+------+
-                                     |serverId|   local connId   |markup|
-                                     |  (5b)  |       (26b)      |  =0  |
-                                     +--------+------------------+------+
-```
-
 ##### Determine 32 or 64 bits
 The key factor is `serverId` (see `serverId` section for detail), which depends on number of TiDB instances in cluster.
-- Choose 32 bits version when number of TiDB instances __less or equal than 25__ _(25 = 2^5 * 0.8, where 5 is bits of `serverId` in 32 bits version)_.
-- Upgrade to 64 bits version when: 1) Fail to acquire `serverId` (because of occupied) for 32 bits version continuously __more than 6 times__ _(with a 80% (C6,25 / C6,32) probability that more than 80% `serverId` are occupied)_; 2) All `local connId` in 32 bits version are in used (see `local connId` section for detail).
-- Downgrade to 32 bits version in a gradually manner when cluster scales down from big to small, as TiDB instances keep `serverId` until next restart or lost connection to PD.
+- Choose 32 bits when number of TiDB instances __less than 2048__. Otherwise choose 64 bits.
+- When 32 bits chosen, upgrade to 64 bits when: 1) Fail to acquire `serverId` _(because of occupied)_ continuously __more than 3 times__ _(which will happen when size of cluster is increasing rapidly)_; 2) All `local connId` in 32 bits `connId` are in used (see `local connId` section for detail).
+- When 64 bits chosen, downgrade to 32 bits in a gradually manner when cluster scales down from big to small, as TiDB instances keep `serverId` until next restart or lost connection to PD.
 
 #### 2. bit 63
 Bit 63 is always __ZERO__, making `connId` in range of non-negative int64, to be more friendly to exists codes, and some languages don't have primitive type `uint64`.
@@ -55,29 +55,29 @@ Bit 63 is always __ZERO__, making `connId` in range of non-negative int64, to be
 -  `markup == 1` while __high 32 bits are zeros__, indicates that 32 bits truncation happens. See `Compatibility` section.
 
 #### 4. serverId
-- `serverId` is selected RANDOMLY by each TiDB instance on startup, and the uniqueness is guaranteed by PD (etcd). `serverId` should be larger or equal to 1, to ensure that high 32 bits of `connId` is always non-zero, and make it possible to detect truncation.
+- `serverId` is selected RANDOMLY from `serverIds pool`_(see next)_ by each TiDB instance on startup, and the uniqueness is guaranteed by PD (etcd). `serverId` should be larger or equal to 1, to ensure that high 32 bits of `connId` is always non-zero, and make it possible to detect truncation.
 
-- On failure (e.g. fail connecting to PD, or all `serverId` are unavailable), we block any new connection.
+- `serverIds pool` is:
+  - All __UNUSED__ `serverIds` within [1, 2047] acquired from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info) when 32 bits `connId` chosen.
+  - All `serverIds` within [2048, 2^22-1] when 64 bits `connId` chosen.
 
+- On failure (e.g. fail connecting to PD, or all `serverId` are unavailable when 64 bits `connId` chosen), we block any new connection.
 - `serverId` is kept by PD with a lease (defaults to 12 hours, long enough to avoid brutally killing any long-run SQL). If TiDB is disconnected to PD longer than half of the lease (defaults to 6 hours), all connections are killed, and no new connection is accepted, to avoid running with stale/incorrect `serverId`. On connection to PD restored, a new `serverId` is acquired before accepting new connection.
-
 - On single TiDB instance without PD, a `serverId` of `1` is assigned.
 
 #### 5. local connId
 `local connId` is allocated by each TiDB instance on establishing connections auto-incrementally.
 
-On busy system, integer overflow is possible, especially on 32 bits version. So it is necessary to check whether `connId` exists or not before `local connId` allocated.
-
-On busy system with long running SQL, `local connId` is possible to be used up, especially on 32 bits version. So it is necessary to check number of connections, and upgrade to 64 bits if `local connId` exhausted in 32 bits version, or return "too many connections" error in 64 bits version.
+On system being busy and/or with long running SQL, `local connId` is possible to be integer-overflow and/or used up, especially on 32 bits `connId`. So we will check `local connId` existed or not before allocation, upgrade to 64 bits if `local connId` exhausted in 32 bits `connId`, or return _"too many connections"_ error in 64 bits `connId`.
 
 #### 6. global kill
-On processing `KILL x` command, first extract `serverId` from `x`. Then if `serverId` aims to a remote TiDB instance, get the address from cluster info (see also [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info)), and redirect the command to it by "Coprocessor API" provided by the remote TiDB, along with the original user authentication.
+On processing `KILL x` command, first extract `serverId` from `x`. Then if `serverId` aims to a remote TiDB instance, get the address from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info), and redirect the command to it by "Coprocessor API" provided by the remote TiDB, along with the original user authentication.
 
 ## Compatibility
 
-- 32 bits version of `connId` is compatible to known exists clients.
+- 32 bits `connId` is compatible to well-known clients.
 
-- 64 bits version of `connId` is __incompatible__ with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connId`, while `CTRL-C` does not, because it truncates the `connId` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
+- 64 bits `connId` is __incompatible__ with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connId`, while `CTRL-C` does not, as it truncates the `connId` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
 
 - [`KILL TIDB`](https://docs.pingcap.com/tidb/v4.0/sql-statement-kill) syntax and [`compatible-kill-query`](https://docs.pingcap.com/tidb/v4.0/tidb-configuration-file#compatible-kill-query) configuration item are deprecated.
 

--- a/docs/design/2020-06-01-global-kill.md
+++ b/docs/design/2020-06-01-global-kill.md
@@ -1,7 +1,7 @@
 # Global Kill
 
 - Author(s):     [pingyu](https://github.com/pingyu) (Ping Yu)
-- Last updated:  2020-10-25
+- Last updated:  2020-11-01
 - Discussion at: https://github.com/pingcap/tidb/issues/8854
 
 ## Abstract
@@ -17,7 +17,7 @@ Currently connection ids are local to TiDB instances, which means that a `KILL x
 To support "Global Kill", we need:
 1. Global connection ids, which are unique among all TiDB instances.
 2. Redirect `KILL x` to target TiDB instance, on which the connection `x` is running.
-3. Support both 32 & 64 bits `connId`, to be compatible with legacy 32 bits clients. In this stage, we only design the 64 bits `connId`, and left a `markup` to distinguish between these two kinds.
+3. Support both 32 & 64 bits `connId`. 32 bits `connId` is used on small clusters (number of TiDB instances less than 32), to be fully compatible with legacy 32 bits clients, while 64 bits `connId` is used for big clusters. Bit 0 in `connId` is a markup to distinguish between these two kinds.
 
 ## Rationale
 
@@ -30,15 +30,21 @@ To support "Global Kill", we need:
  |=0|       (22b)         |                 (40b)                |  =1  |
  +--+---------------------+--------------------------------------+------+
 ```
+
 ##### 32 bits version
-(To be discussed in another RFC)
 ```
-                                    31                          1    0
-                                   +-----------------------------+------+
-                                   |             ???             |markup|
-                                   |             ???             |  =0  |
-                                   +-----------------------------+------+
+                                      31    27 26                1    0
+                                     +--------+------------------+------+
+                                     |serverId|   local connId   |markup|
+                                     |  (5b)  |       (26b)      |  =0  |
+                                     +--------+------------------+------+
 ```
+
+##### Determine 32 or 64 bits
+The key factor is `serverId` (see `serverId` section for detail), which depends on number of TiDB instances in cluster.
+- Choose 32 bits version when number of TiDB instances __less or equal than 25__ _(25 = 2^5 * 0.8, where 5 is bits of `serverId` in 32 bits version)_.
+- Upgrade to 64 bits version when: 1) Fail to acquire `serverId` (because of occupied) for 32 bits version continuously __more than 6 times__ _(with a 80% (C6,25 / C6,32) probability that more than 80% `serverId` are occupied)_; 2) All `local connId` in 32 bits version are in used (see `local connId` section for detail).
+- Downgrade to 32 bits version in a gradually manner when cluster scales down from big to small, as TiDB instances keep `serverId` until next restart or lost connection to PD.
 
 #### 2. bit 63
 Bit 63 is always __ZERO__, making `connId` in range of non-negative int64, to be more friendly to exists codes, and some languages don't have primitive type `uint64`.
@@ -48,26 +54,30 @@ Bit 63 is always __ZERO__, making `connId` in range of non-negative int64, to be
 -  `markup == 1` indicates that the `connID` is 64 bits long. Incompatible with legacy 32 bits clients.
 -  `markup == 1` while __high 32 bits are zeros__, indicates that 32 bits truncation happens. See `Compatibility` section.
 
-
 #### 4. serverId
-`serverId` is selected RANDOMLY by each TiDB instance on startup, and the uniqueness is guaranteed by PD(etcd). `serverId` should be larger or equal to 1, to ensure that high 32 bits of `connId` is always non-zero, and make it possible to detect truncation.
+- `serverId` is selected RANDOMLY by each TiDB instance on startup, and the uniqueness is guaranteed by PD (etcd). `serverId` should be larger or equal to 1, to ensure that high 32 bits of `connId` is always non-zero, and make it possible to detect truncation.
 
-On failure (e.g. fail connecting to PD, or all `serverId` are unavailable), we block any new connection.
+- On failure (e.g. fail connecting to PD, or all `serverId` are unavailable), we block any new connection.
 
-`serverId` is kept by PD with a lease (defaults to 12 hours, long enough to avoid brutally killing any long-run SQL). If TiDB is disconnected to PD longer than half of the lease (defaults to 6 hours), all connections are killed, and no new connection is accepted, to avoid running with stale/incorrect `serverId`. On connection to PD restored, a new `serverId` is acquired before accepting new connection.
+- `serverId` is kept by PD with a lease (defaults to 12 hours, long enough to avoid brutally killing any long-run SQL). If TiDB is disconnected to PD longer than half of the lease (defaults to 6 hours), all connections are killed, and no new connection is accepted, to avoid running with stale/incorrect `serverId`. On connection to PD restored, a new `serverId` is acquired before accepting new connection.
 
-On single TiDB instance without PD, a `serverId` of `1` is assigned.
+- On single TiDB instance without PD, a `serverId` of `1` is assigned.
 
 #### 5. local connId
-`local connId` is allocated by each TiDB instance on establishing connections incrementally.
+`local connId` is allocated by each TiDB instance on establishing connections auto-incrementally.
 
-Integer overflow is ignored at this stage, as `local connId` should be long enough.
+On busy system, integer overflow is possible, especially on 32 bits version. So it is necessary to check whether `connId` exists or not before `local connId` allocated.
+
+On busy system with long running SQL, `local connId` is possible to be used up, especially on 32 bits version. So it is necessary to check number of connections, and upgrade to 64 bits if `local connId` exhausted in 32 bits version, or return "too many connections" error in 64 bits version.
 
 #### 6. global kill
 On processing `KILL x` command, first extract `serverId` from `x`. Then if `serverId` aims to a remote TiDB instance, get the address from cluster info (see also [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info)), and redirect the command to it by "Coprocessor API" provided by the remote TiDB, along with the original user authentication.
 
 ## Compatibility
 
-- Incompatible with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connId`, while `CTRL-C` does not, because it truncates the `connId` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
+- 32 bits version of `connId` is compatible to known exists clients.
+
+- 64 bits version of `connId` is __incompatible__ with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connId`, while `CTRL-C` does not, because it truncates the `connId` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
 
 - [`KILL TIDB`](https://docs.pingcap.com/tidb/v4.0/sql-statement-kill) syntax and [`compatible-kill-query`](https://docs.pingcap.com/tidb/v4.0/tidb-configuration-file#compatible-kill-query) configuration item are deprecated.
+

--- a/docs/design/2020-06-01-global-kill.md
+++ b/docs/design/2020-06-01-global-kill.md
@@ -1,12 +1,12 @@
 # Global Kill
 
 - Author(s):     [pingyu](https://github.com/pingyu) (Ping Yu)
-- Last updated:  2021-04-26
+- Last updated:  2021-05-05
 - Discussion at: https://github.com/pingcap/tidb/issues/8854
 
 ## Abstract
 
-This document introduces the design of global connection id, and the global `KILL <connId>` based on it.
+This document introduces the design of global connection id, and the global `KILL <connID>` based on it.
 
 ## Background
 
@@ -17,16 +17,16 @@ Currently connection ids are local to TiDB instances, which means that a `KILL x
 To support "Global Kill", we need:
 1. Global connection ids, which are unique among all TiDB instances.
 2. Redirect `KILL x` to target TiDB instance, on which the connection `x` is running.
-3. Support both 32 & 64 bits `connId`. 32 bits `connId` is used on small clusters (number of TiDB instances less than 2048), to be fully compatible with all clients including legacy 32 bits ones, while 64 bits `connId` is used for big clusters. Bit 0 in `connId` is a markup to distinguish between these two kinds.
+3. Support both 32 & 64 bits `connID`. 32 bits `connID` is used on small clusters (number of TiDB instances less than 2048), to be fully compatible with all clients including legacy 32 bits ones, while 64 bits `connID` is used for big clusters. Bit 0 in `connID` is a markup to distinguish between these two kinds.
 
 ## Rationale
 
-#### 1. Structure of `connId`
+#### 1. Structure of `connID`
 ##### 32 bits
 ```
                                       31    21 20               1    0
                                      +--------+------------------+------+
-                                     |serverId|   local connId   |markup|
+                                     |serverID|   local connID   |markup|
                                      | (11b)  |       (20b)      |  =0  |
                                      +--------+------------------+------+
 ```
@@ -35,82 +35,82 @@ To support "Global Kill", we need:
 ```
   63 62                 41 40                                   1    0    
  +--+---------------------+--------------------------------------+------+
- |  |      serverId       |             local connId             |markup|
+ |  |      serverID       |             local connID             |markup|
  |=0|       (22b)         |                 (40b)                |  =1  |
  +--+---------------------+--------------------------------------+------+
 ```
 
 ##### Determine 32 or 64 bits
-The key factor is `serverId` (see `serverId` section for detail), which depends on number of TiDB instances in cluster.
+The key factor is `serverID` (see `serverID` section for detail), which depends on number of TiDB instances in cluster.
 - Choose 32 bits when number of TiDB instances __less than 2048__. Otherwise choose 64 bits.
-- When 32 bits chosen, upgrade to 64 bits when: 1) Fail to acquire `serverId` _(because of occupied)_ continuously __more than 3 times__ _(which will happen when size of cluster is increasing rapidly)_; 2) All `local connId` in 32 bits `connId` are in used (see `local connId` section for detail).
-- When 64 bits chosen, downgrade to 32 bits in a gradually manner when cluster scales down from big to small, as TiDB instances keep `serverId` until next restart or lost connection to PD.
+- When 32 bits chosen, upgrade to 64 bits when: 1) Fail to acquire `serverID` _(because of occupied)_ continuously __more than 3 times__ _(which will happen when size of cluster is increasing rapidly)_; 2) All `local connID` in 32 bits `connID` are in used (see `local connID` section for detail).
+- When 64 bits chosen, downgrade to 32 bits in a gradually manner when cluster scales down from big to small, as TiDB instances keep `serverID` until next restart or lost connection to PD.
 
-#### 2. bit 63
-Bit 63 is always __ZERO__, making `connId` in range of non-negative int64, to be more friendly to exists codes, and some languages don't have primitive type `uint64`.
+#### 2. Bit 63
+Bit 63 is always __ZERO__, making `connID` in range of non-negative int64, to be more friendly to exists codes, and some languages don't have primitive type `uint64`.
 
-#### 3. markup
+#### 3. Markup
 -  `markup == 0` indicates that the `connID` is just 32 bits long effectively, and high 32 bits should be all zeros. Compatible with legacy 32 bits clients.
 -  `markup == 1` indicates that the `connID` is 64 bits long. Incompatible with legacy 32 bits clients.
 -  `markup == 1` while __high 32 bits are zeros__, indicates that 32 bits truncation happens. See `Compatibility` section.
 
-#### 4. serverId
-- `serverId` is selected RANDOMLY from `serverIds pool`_(see next)_ by each TiDB instance on startup, and the uniqueness is guaranteed by PD (etcd). `serverId` should be larger or equal to 1, to ensure that high 32 bits of `connId` is always non-zero, and make it possible to detect truncation.
+#### 4. ServerID
+- `serverID` is selected RANDOMLY from `serverIDs pool`_(see next)_ by each TiDB instance on startup, and the uniqueness is guaranteed by PD (etcd). `serverID` should be larger or equal to 1, to ensure that high 32 bits of `connID` is always non-zero, and make it possible to detect truncation.
 
-- `serverIds pool` is:
-  - All __UNUSED__ `serverIds` within [1, 2047] acquired from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info) when 32 bits `connId` chosen.
-  - All `serverIds` within [2048, 2^22-1] when 64 bits `connId` chosen.
+- `serverIDs pool` is:
+  - All __UNUSED__ `serverIDs` within [1, 2047] acquired from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info) when 32 bits `connID` chosen.
+  - All `serverIDs` within [2048, 2^22-1] when 64 bits `connID` chosen.
 
-- On failure (e.g. fail connecting to PD, or all `serverId` are unavailable when 64 bits `connId` chosen), we block any new connection.
-- `serverId` is kept by PD with a lease (defaults to 12 hours, long enough to avoid brutally killing any long-run SQL). If TiDB is disconnected to PD longer than half of the lease (defaults to 6 hours), all connections are killed, and no new connection is accepted, to avoid running with stale/incorrect `serverId`. On connection to PD restored, a new `serverId` is acquired before accepting new connection.
-- On single TiDB instance without PD, a `serverId` of `1` is assigned.
+- On failure (e.g. fail connecting to PD, or all `serverID` are unavailable when 64 bits `connID` chosen), we block any new connection.
+- `serverID` is kept by PD with a lease (defaults to 12 hours, long enough to avoid brutally killing any long-run SQL). If TiDB is disconnected to PD longer than half of the lease (defaults to 6 hours), all connections are killed, and no new connection is accepted, to avoid running with stale/incorrect `serverID`. On connection to PD restored, a new `serverID` is acquired before accepting new connection.
+- On single TiDB instance without PD, a `serverID` of `1` is assigned.
 
-#### 5. local connId
-`local connId` is allocated by each TiDB instance on establishing connections:
+#### 5. Local connID
+`local connID` is allocated by each TiDB instance on establishing connections:
 
-- For 32 bits `connId`, `local connId` is possible to be integer-overflow and/or used up, especially on system being busy and/or with long running SQL. So we use a lock-free queue to maintain available `local connId`, dequeue on client connecting, and enqueue on disconnecting. When `local connId` exhausted, upgrade to 64 bits.
+- For 32 bits `connID`, `local connID` is possible to be integer-overflow and/or used up, especially on system being busy and/or with long running SQL. So we use a __lock-free queue__ to maintain available `local connID`, dequeue on client connecting, and enqueue on disconnecting. When `local connID` exhausted, upgrade to 64 bits.
 
-- For 64 bits `connId`, allocate `local connId` by auto-increment, flip to zero if integer-overflow, and check `local connId` existed or not before allocation by maintaining a map of connection ids. At last, return _"Too many connections"_ error if exhausted.
+- For 64 bits `connID`, allocate `local connID` by __auto-increment__. Besides, flip to zero if integer-overflow, and check `local connID` existed or not by [Server.clients](https://github.com/pingcap/tidb/blob/7e1533392030514440d27ba98001c374cdf8808f/server/server.go#L122) for correctness with trivial cost, as the conflict is very unlikely to happen (It needs more than 3 years to use up 2^40 `local connID` in a 1w TPS instance). At last, return _"Too many connections"_ error if exhausted.
 
-#### 6. global kill
-On processing `KILL x` command, first extract `serverId` from `x`. Then if `serverId` aims to a remote TiDB instance, get the address from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info), and redirect the command to it by "Coprocessor API" provided by the remote TiDB, along with the original user authentication.
+#### 6. Global kill
+On processing `KILL x` command, first extract `serverID` from `x`. Then if `serverID` aims to a remote TiDB instance, get the address from [`CLUSTER_INFO`](https://docs.pingcap.com/tidb/stable/information-schema-cluster-info#cluster_info), and redirect the command to it by "Coprocessor API" provided by the remote TiDB, along with the original user authentication.
 
-#### 7. summary
+#### 7. Summary
 |      | 32 bits | 64 bits |
 | ---- | ---- | ---- |
-| ServerId pool size | 2^11 | 2^22 - 2^11 |
-| ServerId allocation | Random of __Unused__ serverIds acquired from PD within pool. Retry if unavailable. Upgrade to 64 bits while failed more than 3 times | Random of __All__ serverIds within pool. Retry if unavailable |
-| Local connId pool size | 2^20 | 2^40 |
-| Local connId allocation | Using a queue to maintain and allocate available local connId. Upgrade to 64 bits while exhausted | Auto-increment within pool. Flip to zero when overflow. Return "Too many connections" if exhausted |
+| ServerID pool size | 2^11 | 2^22 - 2^11 |
+| ServerID allocation | Random of __Unused__ serverIDs acquired from PD within pool. Retry if unavailable. Upgrade to 64 bits while failed more than 3 times | Random of __All__ serverIDs within pool. Retry if unavailable |
+| Local connID pool size | 2^20 | 2^40 |
+| Local connID allocation | Using a queue to maintain and allocate available local connID. Upgrade to 64 bits while exhausted | Auto-increment within pool. Flip to zero when overflow. Return "Too many connections" if exhausted |
 
 
 
 ## Compatibility
 
-- 32 bits `connId` is compatible to well-known clients.
+- 32 bits `connID` is compatible to well-known clients.
 
-- 64 bits `connId` is __incompatible__ with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connId`, while `CTRL-C` does not, as it truncates the `connId` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
+- 64 bits `connID` is __incompatible__ with legacy 32 bits clients. (According to some quick tests by now, MySQL client v8.0.19 supports `KILL` a connection with 64 bits `connID`, while `CTRL-C` does not, as it truncates the `connID` to 32 bits). A warning is set prompting that truncation happened, but user cannot see it, because `CTRL-C` is sent by a new connection in an instant.
 
 - [`KILL TIDB`](https://docs.pingcap.com/tidb/v4.0/sql-statement-kill) syntax and [`compatible-kill-query`](https://docs.pingcap.com/tidb/v4.0/tidb-configuration-file#compatible-kill-query) configuration item are deprecated.
 
 ## Test Design
 
 ### Prerequisite
-Set `small_cluster_size_threshold` and `local_connid_pool_size` to small numbers (e.g. 4) by variable hacking, for easily switch between 32 and 64 bits `connId`.
+Set `small_cluster_size_threshold` and `local_connid_pool_size` to small numbers (e.g. 4) by variable hacking, for easily switch between 32 and 64 bits `connID`.
 
-### Scenario A. 32 bits `connId` with small cluster
+### Scenario A. 32 bits `connID` with small cluster
 1. A TiDB without PD, killed by Ctrl+C, and killed by KILL.
 2. One TiDB with PD, killed by Ctrl+C, and killed by KILL.
 3. Multiple TiDB nodes, killed {local,remote} by {Ctrl-C,KILL}.
 
-### Scenario B. Upgrade from 32 to 64 bits `connId`
+### Scenario B. Upgrade from 32 to 64 bits `connID`
 1. Upgrade caused by cluster scaled up from small to big.
-2. Upgrade caused by `local connId` used up.
+2. Upgrade caused by `local connID` used up.
 
-### Scenario C. 64 bits `connId` with big cluster
+### Scenario C. 64 bits `connID` with big cluster
 1. Multiple TiDB nodes, killed {local,remote} by {Ctrl-C,KILL}.
 
-### Scenario D. Downgrade from 64 to 32 bits `connId`
+### Scenario D. Downgrade from 64 to 32 bits `connID`
 1. Downgrade caused by cluster scaled down from big to small.
 
 ### Scenario E. Fault tolerant while disconnected with PD


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #8854  https://github.com/pingcap/tidb/issues/17732 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?
Support CTRL-C to kill a connection/query by 32 bits connection id.
#17649 has implemented global kill with 64 bits connection id. This PR will implements 32 bits connection id to improve compatibility to legacy 32 bits mysql clients.

What's Changed:
Compose a 32 bits global unique connection id. See [design doc](https://github.com/pingyu/tidb/blob/global_kill_32/docs/design/2020-06-01-global-kill.md) for detail.

How it Works:
Compose a 32 bits global unique connection id by global unique server id and local connection id, and propose related logic such as upgrade/downgrade/integer overflow.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: TBD

- Need to cherry-pick to the release branch: TBD

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test: TBD
- Integration test: TBD
- Manual test (add detailed scripts or steps below): TBD


### Release note <!-- bugfixes or new feature need a release note -->

- Support KILL <connectionID> (32 bits) across the whole cluster.
