### PR TITLE
transaction: lock row key in delete operation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -496,6 +496,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.3+incompatible h1:0JVooMPsT7A7HqEYdydp/OfjSOYSjhXV7w1hkKj/NPQ=

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -193,7 +193,7 @@ func (s *testMainSuite) TestKeysNeedLock(c *C) {
 		need bool
 	}{
 		{rowKey, rowVal, true},
-		{rowKey, deleteVal, false},
+		{rowKey, deleteVal, true},
 		{indexKey, nonUniqueVal, false},
 		{indexKey, nonUniqueUntouched, false},
 		{indexKey, uniqueValue, true},

--- a/session/txn.go
+++ b/session/txn.go
@@ -292,7 +292,7 @@ func keyNeedToLock(k, v []byte, flags kv.KeyFlags) bool {
 	// do not lock row key for delete operation,
 	// lock primary key and unique index only.
 	if len(v) == 0 {
-		return flags.HasNeedLocked()
+		return flags.HasNeedLocked() || k[10] == 'r'
 	}
 
 	if tablecodec.IsUntouchedIndexKValue(k, v) {

--- a/session/txn.go
+++ b/session/txn.go
@@ -289,10 +289,9 @@ func keyNeedToLock(k, v []byte, flags kv.KeyFlags) bool {
 		return true
 	}
 
-	// do not lock row key for delete operation,
-	// lock primary key and unique index only.
+	// lock row key, primary key and unique index for delete operation,
 	if len(v) == 0 {
-		return flags.HasNeedLocked() || k[10] == 'r'
+		return flags.HasNeedLocked() || tablecodec.IsRecordKey(k)
 	}
 
 	if tablecodec.IsUntouchedIndexKValue(k, v) {


### PR DESCRIPTION
Signed-off-by: you06 <you1474600@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

#19220 remove the row key in delete operation, this PR restore it and adds some test cases.

Problem Summary:

Not lock row key may cause some unexpected failures.

### What is changed and how it works?

What's Changed:

Need lock function is changed.

How it Works:

Lock all row keys for delete operations.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
