### PR TITLE
ddl: fix invalid partition value should return error when create partition table #20277

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -476,6 +476,12 @@ create table log_message_1 (
 				"PARTITION p1 VALUES LESS THAN (20190906));",
 			ddl.ErrWrongTypeColumnValue,
 		},
+		{
+			"create table t (col datetime not null default '2000-01-01')" +
+				"partition by range columns (col) (" +
+				"PARTITION p0 VALUES LESS THAN ('abc'));",
+			ddl.ErrWrongTypeColumnValue,
+		},
 	}
 	for i, t := range cases {
 		_, err := tk.Exec(t.sql)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5283,6 +5283,10 @@ func checkColumnsTypeAndValuesMatch(ctx sessionctx.Context, meta *model.TableInf
 		case mysql.TypeDate, mysql.TypeDatetime:
 			switch val.Kind() {
 			case types.KindString, types.KindBytes:
+				_, err = types.ParseTime(ctx.GetSessionVars().StmtCtx, val.GetString(), colType.Tp, types.DefaultFsp)
+				if err != nil {
+					return ErrWrongTypeColumnValue.GenWithStackByArgs()
+				}
 			default:
 				return ErrWrongTypeColumnValue.GenWithStackByArgs()
 			}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #20277

Problem Summary:

### What is changed and how it works?

What's Changed:
check whether the partition string value is mysql.TypeDate, mysql.TypeDatetime

How it Works:
check whether the partition string value is mysql.TypeDate, mysql.TypeDatetime

### Related changes

### Check List

Tests

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
No
    - Consumes more MEM
No
- Breaking backward compatibility
No
### Release note 

- fix invalid partition value should return error when create partition table #20277

