### PR TITLE
planner: support stable result mode

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -444,6 +444,16 @@ func (s *testSuite5) TestSetVar(c *C) {
 
 	_, err = tk.Exec("set tidb_enable_parallel_apply=-1")
 	c.Assert(terror.ErrorEqual(err, variable.ErrWrongValueForVar), IsTrue)
+
+	// test for tidb_enable_stable_result_mode
+	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set global tidb_enable_stable_result_mode = 1`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
+	tk.MustExec(`set global tidb_enable_stable_result_mode = 0`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set tidb_enable_stable_result_mode=1`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/planner/core/rule_stabilize_results.go
+++ b/planner/core/rule_stabilize_results.go
@@ -1,0 +1,117 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/planner/util"
+)
+
+/*
+	resultsStabilizer stabilizes query results by modifying Sort in the plan or inject new Sort into the plan.
+
+	First, all operators are divided into 2 types:
+	1. input-order keepers: Selection, Projection, Limit;
+	2. all other operators.
+
+	The basic idea of this rule is that:
+	1. iterate the plan from the root, and ignore all input-order keepers;
+	2. when meeting the first non-input-order keeper,
+		2.1. if it's a Sort, complete it by appending its output columns into its order-by list,
+		2.2. otherwise inject a new Sort upon this operator.
+*/
+type resultsStabilizer struct {
+}
+
+func (rs *resultsStabilizer) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
+	stable := rs.completeSort(lp)
+	if !stable {
+		lp = rs.injectSort(lp)
+	}
+	return lp, nil
+}
+
+func (rs *resultsStabilizer) completeSort(lp LogicalPlan) bool {
+	if rs.isInputOrderKeeper(lp) {
+		return rs.completeSort(lp.Children()[0])
+	} else if sort, ok := lp.(*LogicalSort); ok {
+		cols := sort.Schema().Columns // sort results by all output columns
+		if handleCol := rs.extractHandleCol(sort.Children()[0]); handleCol != nil {
+			cols = []*expression.Column{handleCol} // sort results by the handle column if we can get it
+		}
+		for _, col := range cols {
+			exist := false
+			for _, byItem := range sort.ByItems {
+				if col.Equal(nil, byItem.Expr) {
+					exist = true
+					break
+				}
+			}
+			if !exist {
+				sort.ByItems = append(sort.ByItems, &util.ByItems{Expr: col})
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (rs *resultsStabilizer) injectSort(lp LogicalPlan) LogicalPlan {
+	if rs.isInputOrderKeeper(lp) {
+		lp.SetChildren(rs.injectSort(lp.Children()[0]))
+		return lp
+	}
+
+	byItems := make([]*util.ByItems, 0, len(lp.Schema().Columns))
+	cols := lp.Schema().Columns
+	if handleCol := rs.extractHandleCol(lp); handleCol != nil {
+		cols = []*expression.Column{handleCol}
+	}
+	for _, col := range cols {
+		byItems = append(byItems, &util.ByItems{Expr: col})
+	}
+	sort := LogicalSort{
+		ByItems: byItems,
+	}.Init(lp.SCtx(), lp.SelectBlockOffset())
+	sort.SetChildren(lp)
+	return sort
+}
+
+func (rs *resultsStabilizer) isInputOrderKeeper(lp LogicalPlan) bool {
+	switch lp.(type) {
+	case *LogicalSelection, *LogicalProjection, *LogicalLimit:
+		return true
+	}
+	return false
+}
+
+// extractHandleCols does the best effort to get the handle column.
+func (rs *resultsStabilizer) extractHandleCol(lp LogicalPlan) *expression.Column {
+	switch x := lp.(type) {
+	case *LogicalSelection, *LogicalLimit:
+		return rs.extractHandleCol(lp.Children()[0])
+	case *DataSource:
+		handleCol := x.getPKIsHandleCol()
+		if handleCol != nil {
+			return handleCol
+		}
+	}
+	return nil
+}
+
+func (rs *resultsStabilizer) name() string {
+	return "stabilize_results"
+}

--- a/planner/core/rule_stabilize_results.go
+++ b/planner/core/rule_stabilize_results.go
@@ -21,17 +21,23 @@ import (
 )
 
 /*
-	resultsStabilizer stabilizes query results by modifying Sort in the plan or inject new Sort into the plan.
+	resultsStabilizer stabilizes query results.
+	Results of some queries are not stable, for example:
+		create table t (a int);
+		insert into t values (1), (2);
+		select a from t;
+	In the case above, the result can be `1 2` or `2 1`, which is not stable.
+	This rule stabilizes query results by modifying Sort in the plan or inject new Sort into the plan
 
 	First, all operators are divided into 2 types:
 	1. input-order keepers: Selection, Projection, Limit;
 	2. all other operators.
 
-	The basic idea of this rule is that:
+	The basic idea of this rule is:
 	1. iterate the plan from the root, and ignore all input-order keepers;
 	2. when meeting the first non-input-order keeper,
 		2.1. if it's a Sort, complete it by appending its output columns into its order-by list,
-		2.2. otherwise inject a new Sort upon this operator.
+		2.2. otherwise, inject a new Sort upon this operator.
 */
 type resultsStabilizer struct {
 }

--- a/planner/core/rule_stabilize_results_test.go
+++ b/planner/core/rule_stabilize_results_test.go
@@ -35,7 +35,7 @@ func (s *testRuleStabilizeRestuls) SetUpTest(c *C) {
 	s.store, s.dom, err = newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 
-	s.testData, err = testutil.LoadTestSuiteData("testdata", "plan_normalized_suite")
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "stable_result_mode_suite")
 	c.Assert(err, IsNil)
 }
 
@@ -47,87 +47,11 @@ func (s *testRuleStabilizeRestuls) TestStableResultMode(c *C) {
 
 	var input []string
 	var output []struct {
-		SQL  string
 		Plan []string
 	}
 	s.testData.GetTestCases(c, &input, &output)
-}
-
-func (s *testRuleStabilizeRestuls) TestEnableStableResultMode(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
-	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
-
-	tk.MustQuery("explain select * from t use index(primary)").Check(testkit.Rows(
-		"TableReader_10 10000.00 root  data:TableFullScan_9",
-		"└─TableFullScan_9 10000.00 cop[tikv] table:t keep order:true, stats:pseudo")) // keep order: true
-
-	tk.MustQuery("explain select b from t use index(b)").Check(testkit.Rows(
-		"IndexReader_10 10000.00 root  index:IndexFullScan_9",
-		"└─IndexFullScan_9 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo")) // keep order: true
-
-	tk.MustQuery("explain select a, b from t use index(b)").Check(testkit.Rows(
-		"Sort_5 10000.00 root  test.t.a", // since PK is needed, order results by it
-		"└─IndexReader_8 10000.00 root  index:IndexFullScan_7",
-		"  └─IndexFullScan_7 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo"))
-
-	tk.MustQuery("explain select b, c from t use index(b)").Check(testkit.Rows(
-		"Sort_5 10000.00 root  test.t.b, test.t.c", // order by both columns to make results stable
-		"└─IndexLookUp_9 10000.00 root  ",
-		"  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
-		"  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	tk.MustQuery("explain select b, c from t use index(primary)").Check(testkit.Rows(
-		"Sort_5 10000.00 root  test.t.b, test.t.c", // since PK is pruned, order results by b, c
-		"└─TableReader_8 10000.00 root  data:TableFullScan_7",
-		"  └─TableFullScan_7 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	// test agg
-	tk.MustQuery("explain select min(b), max(c) from t use index(primary) group by d").Check(testkit.Rows(
-		"Sort_6 8000.00 root  Column#5, Column#6", // order by min(b), max(c)
-		"└─HashAgg_12 8000.00 root  group by:test.t.d, funcs:min(Column#7)->Column#5, funcs:max(Column#8)->Column#6",
-		"  └─TableReader_13 8000.00 root  data:HashAgg_8",
-		"    └─HashAgg_8 8000.00 cop[tikv]  group by:test.t.d, funcs:min(test.t.b)->Column#7, funcs:max(test.t.c)->Column#8",
-		"      └─TableFullScan_11 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	tk.MustQuery("explain select min(b), max(c) from t use index(primary) group by a").Check(testkit.Rows(
-		"Sort_7 10000.00 root  Column#5, Column#6", // order by min(b), max(c)
-		"└─Projection_9 10000.00 root  cast(test.t.b, int(11))->Column#5, cast(test.t.c, int(11))->Column#6",
-		"  └─TableReader_11 10000.00 root  data:TableFullScan_10", // agg is eliminated since a is PK
-		"    └─TableFullScan_10 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	// test limit
-	tk.MustQuery("explain select * from t use index(b) limit 10").Check(testkit.Rows(
-		"TopN_8 10.00 root  test.t.a, offset:0, count:10", // order by PK
-		"└─IndexLookUp_16 10.00 root  ",
-		"  ├─TopN_15(Build) 10.00 cop[tikv]  test.t.a, offset:0, count:10",
-		"  │ └─IndexFullScan_13 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
-		"  └─TableRowIDScan_14(Probe) 10.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	tk.MustQuery("explain select * from t use index(primary) limit 10").Check(testkit.Rows(
-		"Limit_10 10.00 root  offset:0, count:10",
-		"└─TableReader_20 10.00 root  data:Limit_19",
-		"  └─Limit_19 10.00 cop[tikv]  offset:0, count:10",
-		"    └─TableFullScan_18 10.00 cop[tikv] table:t keep order:true, stats:pseudo")) // keep order: true
-
-	// test order
-	tk.MustQuery("explain select b from t use index(b) order by b").Check(testkit.Rows(
-		"IndexReader_11 10000.00 root  index:IndexFullScan_10",
-		"└─IndexFullScan_10 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo")) // keep order: true
-
-	tk.MustQuery("explain select b, c, d from t use index(b) order by b").Check(testkit.Rows(
-		"Sort_4 10000.00 root  test.t.b, test.t.c, test.t.d", // order by all columns to keep stable
-		"└─IndexLookUp_9 10000.00 root  ",
-		"  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
-		"  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-
-	// test join
-	tk.MustQuery("explain select t1.a, t2.a from t t1, t t2 where t1.a=t2.a").Check(testkit.Rows(
-		"Sort_9 12500.00 root  test.t.a, test.t.a",
-		"└─HashJoin_30 12500.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
-		"  ├─IndexReader_43(Build) 10000.00 root  index:IndexFullScan_42",
-		"  │ └─IndexFullScan_42 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
-		"  └─IndexReader_39(Probe) 10000.00 root  index:IndexFullScan_38",
-		"    └─IndexFullScan_38 10000.00 cop[tikv] table:t1, index:b(b) keep order:false, stats:pseudo"))
+	c.Assert(len(input), Equals, len(output))
+	for i := range input {
+		tk.MustQuery("explain " + input[i]).Check(testkit.Rows(output[i].Plan...))
+	}
 }

--- a/planner/core/rule_stabilize_results_test.go
+++ b/planner/core/rule_stabilize_results_test.go
@@ -1,0 +1,113 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+var _ = Suite(&testRuleStabilizeRestuls{})
+
+type testRuleStabilizeRestuls struct {
+	store kv.Storage
+	dom   *domain.Domain
+}
+
+func (s *testRuleStabilizeRestuls) SetUpTest(c *C) {
+	var err error
+	s.store, s.dom, err = newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+}
+
+func (s *testRuleStabilizeRestuls) TestEnableStableResultMode(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
+
+	tk.MustQuery("explain select * from t use index(primary)").Check(testkit.Rows(
+		"TableReader_10 10000.00 root  data:TableFullScan_9",
+		"└─TableFullScan_9 10000.00 cop[tikv] table:t keep order:true, stats:pseudo")) // keep order: true
+
+	tk.MustQuery("explain select b from t use index(b)").Check(testkit.Rows(
+		"IndexReader_10 10000.00 root  index:IndexFullScan_9",
+		"└─IndexFullScan_9 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo")) // keep order: true
+
+	tk.MustQuery("explain select a, b from t use index(b)").Check(testkit.Rows(
+		"Sort_5 10000.00 root  test.t.a", // since PK is needed, order results by it
+		"└─IndexReader_8 10000.00 root  index:IndexFullScan_7",
+		"  └─IndexFullScan_7 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain select b, c from t use index(b)").Check(testkit.Rows(
+		"Sort_5 10000.00 root  test.t.b, test.t.c", // order by both columns to make results stable
+		"└─IndexLookUp_9 10000.00 root  ",
+		"  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+		"  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain select b, c from t use index(primary)").Check(testkit.Rows(
+		"Sort_5 10000.00 root  test.t.b, test.t.c", // since PK is pruned, order results by b, c
+		"└─TableReader_8 10000.00 root  data:TableFullScan_7",
+		"  └─TableFullScan_7 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	// test agg
+	tk.MustQuery("explain select min(b), max(c) from t use index(primary) group by d").Check(testkit.Rows(
+		"Sort_6 8000.00 root  Column#5, Column#6", // order by min(b), max(c)
+		"└─HashAgg_12 8000.00 root  group by:test.t.d, funcs:min(Column#7)->Column#5, funcs:max(Column#8)->Column#6",
+		"  └─TableReader_13 8000.00 root  data:HashAgg_8",
+		"    └─HashAgg_8 8000.00 cop[tikv]  group by:test.t.d, funcs:min(test.t.b)->Column#7, funcs:max(test.t.c)->Column#8",
+		"      └─TableFullScan_11 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain select min(b), max(c) from t use index(primary) group by a").Check(testkit.Rows(
+		"Sort_7 10000.00 root  Column#5, Column#6", // order by min(b), max(c)
+		"└─Projection_9 10000.00 root  cast(test.t.b, int(11))->Column#5, cast(test.t.c, int(11))->Column#6",
+		"  └─TableReader_11 10000.00 root  data:TableFullScan_10", // agg is eliminated since a is PK
+		"    └─TableFullScan_10 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	// test limit
+	tk.MustQuery("explain select * from t use index(b) limit 10").Check(testkit.Rows(
+		"TopN_8 10.00 root  test.t.a, offset:0, count:10", // order by PK
+		"└─IndexLookUp_16 10.00 root  ",
+		"  ├─TopN_15(Build) 10.00 cop[tikv]  test.t.a, offset:0, count:10",
+		"  │ └─IndexFullScan_13 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+		"  └─TableRowIDScan_14(Probe) 10.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain select * from t use index(primary) limit 10").Check(testkit.Rows(
+		"Limit_10 10.00 root  offset:0, count:10",
+		"└─TableReader_20 10.00 root  data:Limit_19",
+		"  └─Limit_19 10.00 cop[tikv]  offset:0, count:10",
+		"    └─TableFullScan_18 10.00 cop[tikv] table:t keep order:true, stats:pseudo")) // keep order: true
+
+	// test order
+	tk.MustQuery("explain select b from t use index(b) order by b").Check(testkit.Rows(
+		"IndexReader_11 10000.00 root  index:IndexFullScan_10",
+		"└─IndexFullScan_10 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo")) // keep order: true
+
+	tk.MustQuery("explain select b, c, d from t use index(b) order by b").Check(testkit.Rows(
+		"Sort_4 10000.00 root  test.t.b, test.t.c, test.t.d", // order by all columns to keep stable
+		"└─IndexLookUp_9 10000.00 root  ",
+		"  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+		"  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	// test join
+	tk.MustQuery("explain select t1.a, t2.a from t t1, t t2 where t1.a=t2.a").Check(testkit.Rows(
+		"Sort_9 12500.00 root  test.t.a, test.t.a",
+		"└─HashJoin_30 12500.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
+		"  ├─IndexReader_43(Build) 10000.00 root  index:IndexFullScan_42",
+		"  │ └─IndexFullScan_42 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+		"  └─IndexReader_39(Probe) 10000.00 root  index:IndexFullScan_38",
+		"    └─IndexFullScan_38 10000.00 cop[tikv] table:t1, index:b(b) keep order:false, stats:pseudo"))
+}

--- a/planner/core/testdata/stable_result_mode_suite_in.json
+++ b/planner/core/testdata/stable_result_mode_suite_in.json
@@ -1,0 +1,19 @@
+[
+  {
+    "name": "TestStableResultMode",
+    "cases": [
+      "select * from t use index(primary)",
+      "select b from t use index(b)",
+      "select a, b from t use index(b)",
+      "select b, c from t use index(b)",
+      "select b, c from t use index(primary)",
+      "select min(b), max(c) from t use index(primary) group by d",
+      "select min(b), max(c) from t use index(primary) group by a",
+      "select * from t use index(b) limit 10",
+      "select * from t use index(primary) limit 10",
+      "select b from t use index(b) order by b",
+      "select b, c, d from t use index(b) order by b",
+      "select t1.a, t2.a from t t1, t t2 where t1.a=t2.a"
+    ]
+  }
+]

--- a/planner/core/testdata/stable_result_mode_suite_out.json
+++ b/planner/core/testdata/stable_result_mode_suite_out.json
@@ -1,0 +1,99 @@
+[
+  {
+    "name": "TestStableResultMode",
+    "cases": [
+      {
+        "Plan": [
+          "TableReader_10 10000.00 root  data:TableFullScan_9",
+          "└─TableFullScan_9 10000.00 cop[tikv] table:t keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "IndexReader_10 10000.00 root  index:IndexFullScan_9",
+          "└─IndexFullScan_9 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.a",
+          "└─IndexReader_8 10000.00 root  index:IndexFullScan_7",
+          "  └─IndexFullScan_7 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.b, test.t.c",
+          "└─IndexLookUp_9 10000.00 root  ",
+          "  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.b, test.t.c",
+          "└─TableReader_8 10000.00 root  data:TableFullScan_7",
+          "  └─TableFullScan_7 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_6 8000.00 root  Column#5, Column#6",
+          "└─HashAgg_12 8000.00 root  group by:test.t.d, funcs:min(Column#7)->Column#5, funcs:max(Column#8)->Column#6",
+          "  └─TableReader_13 8000.00 root  data:HashAgg_8",
+          "    └─HashAgg_8 8000.00 cop[tikv]  group by:test.t.d, funcs:min(test.t.b)->Column#7, funcs:max(test.t.c)->Column#8",
+          "      └─TableFullScan_11 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_7 10000.00 root  Column#5, Column#6",
+          "└─Projection_9 10000.00 root  cast(test.t.b, int(11))->Column#5, cast(test.t.c, int(11))->Column#6",
+          "  └─TableReader_11 10000.00 root  data:TableFullScan_10",
+          "    └─TableFullScan_10 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "TopN_8 10.00 root  test.t.a, offset:0, count:10",
+          "└─IndexLookUp_16 10.00 root  ",
+          "  ├─TopN_15(Build) 10.00 cop[tikv]  test.t.a, offset:0, count:10",
+          "  │ └─IndexFullScan_13 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_14(Probe) 10.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Limit_10 10.00 root  offset:0, count:10",
+          "└─TableReader_20 10.00 root  data:Limit_19",
+          "  └─Limit_19 10.00 cop[tikv]  offset:0, count:10",
+          "    └─TableFullScan_18 10.00 cop[tikv] table:t keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "IndexReader_11 10000.00 root  index:IndexFullScan_10",
+          "└─IndexFullScan_10 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_4 10000.00 root  test.t.b, test.t.c, test.t.d",
+          "└─IndexLookUp_9 10000.00 root  ",
+          "  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 12500.00 root  test.t.a, test.t.a",
+          "└─HashJoin_30 12500.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
+          "  ├─IndexReader_43(Build) 10000.00 root  index:IndexFullScan_42",
+          "  │ └─IndexFullScan_42 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─IndexReader_39(Probe) 10000.00 root  index:IndexFullScan_38",
+          "    └─IndexFullScan_38 10000.00 cop[tikv] table:t1, index:b(b) keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/session/session.go
+++ b/session/session.go
@@ -2170,6 +2170,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBShardAllocateStep,
 	variable.TiDBEnableChangeColumnType,
 	variable.TiDBEnableAmendPessimisticTxn,
+	variable.TiDBEnableStableResultMode,
 }
 
 var (

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -731,6 +731,9 @@ type SessionVars struct {
 
 	// PartitionPruneMode indicates how and when to prune partitions.
 	PartitionPruneMode atomic2.String
+
+	// EnableStableResultMode if stabilize query results.
+	EnableStableResultMode bool
 }
 
 // UseDynamicPartitionPrune indicates whether use new dynamic partition prune.
@@ -1523,6 +1526,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.EnableChangeColumnType = TiDBOptOn(val)
 	case TiDBEnableAmendPessimisticTxn:
 		s.EnableAmendPessimisticTxn = TiDBOptOn(val)
+	case TiDBEnableStableResultMode:
+		s.EnableStableResultMode = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -797,6 +797,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBShardAllocateStep, Value: strconv.Itoa(DefTiDBShardAllocateStep), Type: TypeInt, MinValue: 1, MaxValue: uint64(math.MaxInt64), AutoConvertOutOfRange: true},
 	{Scope: ScopeGlobal, Name: TiDBEnableTelemetry, Value: BoolToOnOff(DefTiDBEnableTelemetry), Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableAmendPessimisticTxn, Value: BoolToOnOff(DefTiDBEnableAmendPessimisticTxn), Type: TypeBool},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableStableResultMode, Value: BoolToIntStr(DefTiDBEnableStableResultMode), Type: TypeBool},
 
 	// for compatibility purpose, we should leave them alone.
 	// TODO: Follow the Terminology Updates of MySQL after their changes arrived.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -453,6 +453,9 @@ const (
 
 	// TiDBEnableAmendPessimisticTxn indicates if amend pessimistic transactions is enabled.
 	TiDBEnableAmendPessimisticTxn = "tidb_enable_amend_pessimistic_txn"
+
+	// TiDBEnableStableResultMode indicates if stabilize query results.
+	TiDBEnableStableResultMode = "tidb_enable_stable_result_mode"
 )
 
 // Default TiDB system variable values.
@@ -561,6 +564,7 @@ const (
 	DefTiDBEnableParallelApply         = false
 	DefTiDBEnableAmendPessimisticTxn   = true
 	DefTiDBPartitionPruneMode          = "static-only"
+	DefTiDBEnableStableResultMode      = false
 )
 
 // Process global variables.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: support stable result mode in the planner

### What is changed and how it works?
Results of some queries are not stable, for example:
```
create table t (a int);
insert into t values (1), (2);
select a from t;
```
In the case above, the result can be `1 2` or `2 1`, which is not stable.
This PR introduces a new switch that can make the results of these queries stable.

This feature is implemented as **a logical optimization rule**, which stabilizes results by modifying `Sort` in plans or inject new `Sort` into plans.
First, all operators are divided into 2 types:
1. input-order keepers: Selection, Projection, Limit;
2. all other operators.

**The basic idea of this rule is**:
1. iterate the plan from the root, and ignore all input-order keepers;
2. when meeting the first non-input-order keeper,
	2.1. if it's a Sort, complete it by appending its output columns into its order-by list,
	2.2. otherwise, inject a new Sort upon this operator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: support stable result mode
