### PR TITLE
unistore: collect ExecutorExecutionSummary and return by DAGResponse

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -262,7 +262,7 @@ func (s *testSuite2) checkActRowsNotEmpty(c *C, tk *testkit.TestKit, sql string)
 
 func checkActRows(c *C, tk *testkit.TestKit, sql string, expected []string) {
 	actRowsCol := 2
-	rows := tk.MustQuery("explain analyze "+sql).Rows()
+	rows := tk.MustQuery("explain analyze " + sql).Rows()
 	c.Assert(len(rows), Equals, len(expected))
 	for id, row := range rows {
 		strs := make([]string, len(row))
@@ -275,7 +275,7 @@ func checkActRows(c *C, tk *testkit.TestKit, sql string, expected []string) {
 	}
 }
 
-func (s *testSuite1) TestCheckActRowsWithUnistore (c *C) {
+func (s *testSuite1) TestCheckActRowsWithUnistore(c *C) {
 	// testSuite1 use default mockstore which is unistore
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("drop table if exists t_unistore_act_rows")
@@ -284,42 +284,42 @@ func (s *testSuite1) TestCheckActRowsWithUnistore (c *C) {
 	tk.MustExec("analyze table t_unistore_act_rows")
 
 	type testStruct struct {
-		sql string
+		sql      string
 		expected []string
 	}
 
-	tests := []testStruct {
+	tests := []testStruct{
 		{
-			sql: "select * from t_unistore_act_rows",
-			expected: []string {"4", "4"},
+			sql:      "select * from t_unistore_act_rows",
+			expected: []string{"4", "4"},
 		},
 		{
-			sql: "select * from t_unistore_act_rows where a > 1",
-			expected: []string {"2", "2"},
+			sql:      "select * from t_unistore_act_rows where a > 1",
+			expected: []string{"2", "2"},
 		},
 		{
-			sql: "select * from t_unistore_act_rows where a > 1 and b > 0",
-			expected: []string {"1", "1", "2"},
+			sql:      "select * from t_unistore_act_rows where a > 1 and b > 0",
+			expected: []string{"1", "1", "2"},
 		},
 		{
-			sql: "select b from t_unistore_act_rows",
-			expected: []string {"4", "4"},
+			sql:      "select b from t_unistore_act_rows",
+			expected: []string{"4", "4"},
 		},
 		{
-			sql: "select * from t_unistore_act_rows where b > 0",
-			expected: []string {"1", "1", "4"},
+			sql:      "select * from t_unistore_act_rows where b > 0",
+			expected: []string{"1", "1", "4"},
 		},
 		{
-			sql: "select count(*) from t_unistore_act_rows",
-			expected: []string {"1", "1", "1", "4"},
+			sql:      "select count(*) from t_unistore_act_rows",
+			expected: []string{"1", "1", "1", "4"},
 		},
 		{
-			sql: "select count(*) from t_unistore_act_rows group by a",
-			expected: []string {"2", "2", "2", "4"},
+			sql:      "select count(*) from t_unistore_act_rows group by a",
+			expected: []string{"2", "2", "2", "4"},
 		},
 		{
-			sql: "select count(*) from t_unistore_act_rows group by b",
-			expected: []string {"2", "2", "2", "4"},
+			sql:      "select count(*) from t_unistore_act_rows group by b",
+			expected: []string{"2", "2", "2", "4"},
 		},
 	}
 

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -259,3 +259,71 @@ func (s *testSuite2) checkActRowsNotEmpty(c *C, tk *testkit.TestKit, sql string)
 		c.Assert(strs[actRowsCol], Not(Equals), "")
 	}
 }
+
+func checkActRows(c *C, tk *testkit.TestKit, sql string, expected []string) {
+	actRowsCol := 2
+	rows := tk.MustQuery("explain analyze "+sql).Rows()
+	c.Assert(len(rows), Equals, len(expected))
+	for id, row := range rows {
+		strs := make([]string, len(row))
+		for i, c := range row {
+			strs[i] = c.(string)
+		}
+
+		fmt.Println(row)
+		c.Assert(strs[actRowsCol], Equals, expected[id])
+	}
+}
+
+func (s *testSuite1) TestCheckActRowsWithUnistore (c *C) {
+	// testSuite1 use default mockstore which is unistore
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t_unistore_act_rows")
+	tk.MustExec("create table t_unistore_act_rows(a int, b int, index(a, b))")
+	tk.MustExec("insert into t_unistore_act_rows values (1, 0), (1, 0), (2, 0), (2, 1)")
+	tk.MustExec("analyze table t_unistore_act_rows")
+
+	type testStruct struct {
+		sql string
+		expected []string
+	}
+
+	tests := []testStruct {
+		{
+			sql: "select * from t_unistore_act_rows",
+			expected: []string {"4", "4"},
+		},
+		{
+			sql: "select * from t_unistore_act_rows where a > 1",
+			expected: []string {"2", "2"},
+		},
+		{
+			sql: "select * from t_unistore_act_rows where a > 1 and b > 0",
+			expected: []string {"1", "1", "2"},
+		},
+		{
+			sql: "select b from t_unistore_act_rows",
+			expected: []string {"4", "4"},
+		},
+		{
+			sql: "select * from t_unistore_act_rows where b > 0",
+			expected: []string {"1", "1", "4"},
+		},
+		{
+			sql: "select count(*) from t_unistore_act_rows",
+			expected: []string {"1", "1", "1", "4"},
+		},
+		{
+			sql: "select count(*) from t_unistore_act_rows group by a",
+			expected: []string {"2", "2", "2", "4"},
+		},
+		{
+			sql: "select count(*) from t_unistore_act_rows group by b",
+			expected: []string {"2", "2", "2", "4"},
+		},
+	}
+
+	for _, test := range tests {
+		checkActRows(c, tk, test.sql, test.expected)
+	}
+}

--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -270,7 +270,6 @@ func checkActRows(c *C, tk *testkit.TestKit, sql string, expected []string) {
 			strs[i] = c.(string)
 		}
 
-		fmt.Println(row)
 		c.Assert(strs[actRowsCol], Equals, expected[id])
 	}
 }

--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -110,8 +110,8 @@ func (s *testSerialSuite) TestExplainFor(c *C) {
 		}
 	}
 	c.Assert(buf.String(), Matches, ""+
-		"TableReader_5 10000.00 0 root  time:.*, loops:1, cop_task:.*num: 1, max:.*, proc_keys: 0, rpc_num: 1, rpc_time: .* data:TableFullScan_4 N/A N/A\n"+
-		"└─TableFullScan_4 10000.00 0 cop.* table:t1 time:.*, loops:0 keep order:false, stats:pseudo N/A N/A")
+		"TableReader_5 10000.00 0 root  time:.*, loops:1, cop_task: {num:.*, max:.*, proc_keys: 0, rpc_num: 1, rpc_time:.*, copr_cache_hit_ratio: 0.00} data:TableFullScan_4 N/A N/A\n"+
+		"└─TableFullScan_4 10000.00 0 cop.* table:t1 time:.*, loops:0, tikv_task:{time:.*, loops:0} keep order:false, stats:pseudo N/A N/A")
 	err := tkUser.ExecToErr(fmt.Sprintf("explain for connection %d", tkRootProcess.ID))
 	c.Check(core.ErrAccessDenied.Equal(err), IsTrue)
 	err = tkUser.ExecToErr("explain for connection 42")

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -324,7 +324,7 @@ func (e *execDetail) buildSummary() *tipb.ExecutorExecutionSummary {
 	return &tipb.ExecutorExecutionSummary{
 		TimeProcessedNs: &costNs,
 		NumProducedRows: &rows,
-		NumIterations:  &numIter,
+		NumIterations:   &numIter,
 	}
 }
 
@@ -371,7 +371,7 @@ type scanCtx struct {
 
 	newCollationRd  *rowcodec.BytesDecoder
 	newCollationIds map[int64]int
-	execDetail		 *execDetail
+	execDetail      *execDetail
 }
 
 type idxScanCtx struct {
@@ -379,11 +379,11 @@ type idxScanCtx struct {
 	columnLen        int
 	colInfos         []rowcodec.ColInfo
 	primaryColumnIds []int64
-	execDetail		 *execDetail
+	execDetail       *execDetail
 }
 
 type aggCtx struct {
-	col *tipb.ColumnInfo
+	col        *tipb.ColumnInfo
 	execDetail *execDetail
 }
 
@@ -396,7 +396,7 @@ type topNCtx struct {
 	heap         *topNHeap
 	orderByExprs []expression.Expression
 	sortRow      *sortRow
-	execDetail		 *execDetail
+	execDetail   *execDetail
 }
 
 func (e *closureExecutor) execute() ([]tipb.Chunk, error) {

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"time"
 
 	"github.com/juju/errors"
 	"github.com/ngaut/unistore/tikv/dbreader"
@@ -84,6 +85,7 @@ func buildClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closure
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		ce.selectionCtx.execDetail = new(execDetail)
 		ce.processor = &selectionProcessor{closureExecutor: ce}
 	}
 	lastExecutor := executors[len(executors)-1]
@@ -158,6 +160,7 @@ func newClosureExecutor(dagCtx *dagContext, dagReq *tipb.DAGRequest) (*closureEx
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+		e.scanCtx.execDetail = new(execDetail)
 	}
 	return e, nil
 }
@@ -166,6 +169,7 @@ func (e *closureExecutor) initIdxScanCtx(idxScan *tipb.IndexScan) {
 	e.idxScanCtx = new(idxScanCtx)
 	e.idxScanCtx.columnLen = len(e.columnInfos)
 	e.idxScanCtx.pkStatus = pkColNotExists
+	e.idxScanCtx.execDetail = new(execDetail)
 
 	e.idxScanCtx.primaryColumnIds = idxScan.PrimaryColumnIds
 	lastColumn := e.columnInfos[len(e.columnInfos)-1]
@@ -248,6 +252,7 @@ func tryBuildCountProcessor(e *closureExecutor, executors []*tipb.Executor) (boo
 	default:
 		e.processor = &countStarProcessor{skipVal: skipVal(true), closureExecutor: e}
 	}
+	e.aggCtx.execDetail = new(execDetail)
 	return true, nil
 }
 
@@ -261,6 +266,7 @@ func buildTopNProcessor(e *closureExecutor, topN *tipb.TopN) error {
 		heap:         heap,
 		orderByExprs: conds,
 		sortRow:      e.newTopNSortRow(),
+		execDetail:   new(execDetail),
 	}
 
 	e.topNCtx = ctx
@@ -281,6 +287,7 @@ func buildHashAggProcessor(e *closureExecutor, ctx *dagContext, agg *tipb.Aggreg
 		groupKeys:       nil,
 		aggCtxsMap:      map[string][]*aggregation.AggEvaluateContext{},
 	}
+	e.aggCtx.execDetail = new(execDetail)
 	return nil
 }
 
@@ -290,6 +297,35 @@ func buildStreamAggProcessor(e *closureExecutor, ctx *dagContext, executors []*t
 		return err
 	}
 	return buildHashAggProcessor(e, ctx, executors[len(executors)-1].Aggregation)
+}
+
+type execDetail struct {
+	timeProcessed   time.Duration
+	numProducedRows int
+	numIterations   int
+}
+
+func (e *execDetail) update(begin time.Time, gotRow bool) {
+	e.timeProcessed += time.Since(begin)
+	e.numIterations++
+	if gotRow {
+		e.numProducedRows++
+	}
+}
+
+func (e *execDetail) updateOnlyRows(gotRow int) {
+	e.numProducedRows += gotRow
+}
+
+func (e *execDetail) buildSummary() *tipb.ExecutorExecutionSummary {
+	costNs := uint64(e.timeProcessed / time.Nanosecond)
+	rows := uint64(e.numProducedRows)
+	numIter := uint64(e.numIterations)
+	return &tipb.ExecutorExecutionSummary{
+		TimeProcessedNs: &costNs,
+		NumProducedRows: &rows,
+		NumIterations:  &numIter,
+	}
 }
 
 // closureExecutor is an execution engine that flatten the DAGRequest.Executors to a single closure `processor` that
@@ -335,6 +371,7 @@ type scanCtx struct {
 
 	newCollationRd  *rowcodec.BytesDecoder
 	newCollationIds map[int64]int
+	execDetail		 *execDetail
 }
 
 type idxScanCtx struct {
@@ -342,20 +379,24 @@ type idxScanCtx struct {
 	columnLen        int
 	colInfos         []rowcodec.ColInfo
 	primaryColumnIds []int64
+	execDetail		 *execDetail
 }
 
 type aggCtx struct {
 	col *tipb.ColumnInfo
+	execDetail *execDetail
 }
 
 type selectionCtx struct {
 	conditions []expression.Expression
+	execDetail *execDetail
 }
 
 type topNCtx struct {
 	heap         *topNHeap
 	orderByExprs []expression.Expression
 	sortRow      *sortRow
+	execDetail		 *execDetail
 }
 
 func (e *closureExecutor) execute() ([]tipb.Chunk, error) {
@@ -445,11 +486,20 @@ type countStarProcessor struct {
 
 // countStarProcess is used for `count(*)`.
 func (e *countStarProcessor) Process(key, value []byte) error {
+	defer func(begin time.Time) {
+		if e.idxScanCtx != nil {
+			e.idxScanCtx.execDetail.update(begin, true)
+		} else {
+			e.scanCtx.execDetail.update(begin, true)
+		}
+		e.aggCtx.execDetail.update(begin, false)
+	}(time.Now())
 	e.rowCount++
 	return nil
 }
 
 func (e *countStarProcessor) Finish() error {
+	e.aggCtx.execDetail.updateOnlyRows(1)
 	return e.countFinish()
 }
 
@@ -470,6 +520,15 @@ type countColumnProcessor struct {
 }
 
 func (e *countColumnProcessor) Process(key, value []byte) error {
+	gotRow := false
+	defer func(begin time.Time) {
+		if e.idxScanCtx != nil {
+			e.idxScanCtx.execDetail.update(begin, gotRow)
+		} else {
+			e.scanCtx.execDetail.update(begin, gotRow)
+		}
+		e.aggCtx.execDetail.update(begin, false)
+	}(time.Now())
 	if e.idxScanCtx != nil {
 		values, _, err := tablecodec.CutIndexKeyNew(key, e.idxScanCtx.columnLen)
 		if err != nil {
@@ -477,6 +536,7 @@ func (e *countColumnProcessor) Process(key, value []byte) error {
 		}
 		if values[0][0] != codec.NilFlag {
 			e.rowCount++
+			gotRow = true
 		}
 	} else {
 		// Since the handle value doesn't affect the count result, we don't need to decode the handle.
@@ -486,12 +546,14 @@ func (e *countColumnProcessor) Process(key, value []byte) error {
 		}
 		if !isNull {
 			e.rowCount++
+			gotRow = true
 		}
 	}
 	return nil
 }
 
 func (e *countColumnProcessor) Finish() error {
+	e.aggCtx.execDetail.updateOnlyRows(1)
 	return e.countFinish()
 }
 
@@ -510,10 +572,17 @@ func (e *tableScanProcessor) Process(key, value []byte) error {
 	if e.rowCount == e.limit {
 		return dbreader.ScanBreak
 	}
+	gotRow := false
+	defer func(begin time.Time) {
+		e.scanCtx.execDetail.update(begin, gotRow)
+	}(time.Now())
 	e.rowCount++
-	err := e.tableScanProcessCore(key, value)
+	err := e.tableScanProcessCore(key, value, false)
 	if e.scanCtx.chk.NumRows() == chunkMaxRows {
 		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	if err == nil {
+		gotRow = true
 	}
 	return err
 }
@@ -524,16 +593,21 @@ func (e *tableScanProcessor) Finish() error {
 
 func (e *closureExecutor) processCore(key, value []byte) error {
 	if e.idxScanCtx != nil {
-		return e.indexScanProcessCore(key, value)
+		return e.indexScanProcessCore(key, value, true)
 	}
-	return e.tableScanProcessCore(key, value)
+	return e.tableScanProcessCore(key, value, true)
 }
 
 func (e *closureExecutor) hasSelection() bool {
 	return len(e.selectionCtx.conditions) > 0
 }
 
-func (e *closureExecutor) processSelection() (gotRow bool, err error) {
+func (e *closureExecutor) processSelection(needCollectDetail bool) (gotRow bool, err error) {
+	if needCollectDetail {
+		defer func(begin time.Time) {
+			e.selectionCtx.execDetail.update(begin, gotRow)
+		}(time.Now())
+	}
 	chk := e.scanCtx.chk
 	row := chk.GetRow(chk.NumRows() - 1)
 	gotRow = true
@@ -585,7 +659,13 @@ func (e *closureExecutor) copyError(err error) error {
 	return ret
 }
 
-func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
+func (e *closureExecutor) tableScanProcessCore(key, value []byte, needCollectDetail bool) error {
+	incRow := false
+	if needCollectDetail {
+		defer func(begin time.Time) {
+			e.scanCtx.execDetail.update(begin, incRow)
+		}(time.Now())
+	}
 	handle, err := tablecodec.DecodeRowKey(key)
 	if err != nil {
 		return errors.Trace(err)
@@ -594,6 +674,7 @@ func (e *closureExecutor) tableScanProcessCore(key, value []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	incRow = true
 	return nil
 }
 
@@ -610,10 +691,17 @@ func (e *indexScanProcessor) Process(key, value []byte) error {
 	if e.rowCount == e.limit {
 		return dbreader.ScanBreak
 	}
+	gotRow := false
+	defer func(begin time.Time) {
+		e.idxScanCtx.execDetail.update(begin, gotRow)
+	}(time.Now())
 	e.rowCount++
-	err := e.indexScanProcessCore(key, value)
+	err := e.indexScanProcessCore(key, value, false)
 	if e.scanCtx.chk.NumRows() == chunkMaxRows {
 		err = e.chunkToOldChunk(e.scanCtx.chk)
+	}
+	if err == nil {
+		gotRow = true
 	}
 	return err
 }
@@ -622,7 +710,13 @@ func (e *indexScanProcessor) Finish() error {
 	return e.scanFinish()
 }
 
-func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
+func (e *closureExecutor) indexScanProcessCore(key, value []byte, needCollectDetail bool) error {
+	gotRow := false
+	if needCollectDetail {
+		defer func(begin time.Time) {
+			e.idxScanCtx.execDetail.update(begin, gotRow)
+		}(time.Now())
+	}
 	handleStatus := mapPkStatusToHandleStatus(e.idxScanCtx.pkStatus)
 	restoredCols := make([]rowcodec.ColInfo, 0, len(e.idxScanCtx.colInfos))
 	for _, c := range e.idxScanCtx.colInfos {
@@ -644,6 +738,7 @@ func (e *closureExecutor) indexScanProcessCore(key, value []byte) error {
 			}
 		}
 	}
+	gotRow = true
 	return nil
 }
 
@@ -672,6 +767,10 @@ type selectionProcessor struct {
 }
 
 func (e *selectionProcessor) Process(key, value []byte) error {
+	var gotRow bool
+	defer func(begin time.Time) {
+		e.selectionCtx.execDetail.update(begin, gotRow)
+	}(time.Now())
 	if e.rowCount == e.limit {
 		return dbreader.ScanBreak
 	}
@@ -679,7 +778,7 @@ func (e *selectionProcessor) Process(key, value []byte) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	gotRow, err := e.processSelection()
+	gotRow, err = e.processSelection(false)
 	if err != nil {
 		return err
 	}
@@ -702,11 +801,15 @@ type topNProcessor struct {
 }
 
 func (e *topNProcessor) Process(key, value []byte) (err error) {
+	gotRow := false
+	defer func(begin time.Time) {
+		e.topNCtx.execDetail.update(begin, gotRow)
+	}(time.Now())
 	if err = e.processCore(key, value); err != nil {
 		return err
 	}
 	if e.hasSelection() {
-		gotRow, err1 := e.processSelection()
+		gotRow, err1 := e.processSelection(true)
 		if err1 != nil || !gotRow {
 			return err1
 		}
@@ -727,6 +830,9 @@ func (e *topNProcessor) Process(key, value []byte) (err error) {
 		ctx.sortRow.data[0] = safeCopy(key)
 		ctx.sortRow.data[1] = safeCopy(value)
 		ctx.sortRow = e.newTopNSortRow()
+	}
+	if ctx.heap.err == nil {
+		gotRow = true
 	}
 	return errors.Trace(ctx.heap.err)
 }
@@ -768,12 +874,16 @@ type hashAggProcessor struct {
 }
 
 func (e *hashAggProcessor) Process(key, value []byte) (err error) {
+	incRow := false
+	defer func(begin time.Time) {
+		e.aggCtx.execDetail.update(begin, incRow)
+	}(time.Now())
 	err = e.processCore(key, value)
 	if err != nil {
 		return err
 	}
 	if e.hasSelection() {
-		gotRow, err1 := e.processSelection()
+		gotRow, err1 := e.processSelection(true)
 		if err1 != nil || !gotRow {
 			return err1
 		}
@@ -783,6 +893,7 @@ func (e *hashAggProcessor) Process(key, value []byte) (err error) {
 	if _, ok := e.groups[string(gk)]; !ok {
 		e.groups[string(gk)] = struct{}{}
 		e.groupKeys = append(e.groupKeys, gk)
+		incRow = true
 	}
 	// Update aggregate expressions.
 	aggCtxs := e.getContexts(gk)

--- a/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/store/mockstore/unistore/cophandler/cop_handler.go
@@ -97,7 +97,7 @@ func handleCopDAGRequest(dbReader *dbreader.DBReader, lockStore *lockstore.MemSt
 		return buildResp(nil, nil, dagReq, err, dagCtx.sc.GetWarnings(), time.Since(startTime))
 	}
 	chunks, err := closureExec.execute()
-	return buildResp(chunks, closureExec.counts, dagReq, err, dagCtx.sc.GetWarnings(), time.Since(startTime))
+	return buildResp(chunks, closureExec, dagReq, err, dagCtx.sc.GetWarnings(), time.Since(startTime))
 }
 
 func buildDAG(reader *dbreader.DBReader, lockStore *lockstore.MemStore, req *coprocessor.Request) (*dagContext, *tipb.DAGRequest, error) {
@@ -288,18 +288,49 @@ func (e *ErrLocked) Error() string {
 	return fmt.Sprintf("key is locked, key: %q, Type: %v, primary: %q, startTS: %v", e.Key, e.LockType, e.Primary, e.StartTS)
 }
 
-func buildResp(chunks []tipb.Chunk, counts []int64, dagReq *tipb.DAGRequest, err error, warnings []stmtctx.SQLWarn, dur time.Duration) *coprocessor.Response {
+func buildResp(chunks []tipb.Chunk, closureExecutor *closureExecutor, dagReq *tipb.DAGRequest, err error, warnings []stmtctx.SQLWarn, dur time.Duration) *coprocessor.Response {
 	resp := &coprocessor.Response{}
+	var counts []int64
+	if closureExecutor != nil {
+		counts = closureExecutor.counts
+	}
 	selResp := &tipb.SelectResponse{
 		Error:        toPBError(err),
 		Chunks:       chunks,
 		OutputCounts: counts,
 	}
+	executors := dagReq.Executors
 	if dagReq.CollectExecutionSummaries != nil && *dagReq.CollectExecutionSummaries {
-		execSummary := make([]*tipb.ExecutorExecutionSummary, len(dagReq.Executors))
+		execSummary := make([]*tipb.ExecutorExecutionSummary, len(executors))
 		for i := range execSummary {
-			// TODO: Add real executor execution summary information.
-			execSummary[i] = &tipb.ExecutorExecutionSummary{}
+			if closureExecutor == nil {
+				selResp.ExecutionSummaries = execSummary
+				continue
+			}
+			switch executors[i].Tp {
+			case tipb.ExecType_TypeTableScan:
+				execSummary[i] = closureExecutor.scanCtx.execDetail.buildSummary()
+				fmt.Println("[table scan]", i, *execSummary[i].NumProducedRows)
+			case tipb.ExecType_TypeIndexScan:
+				execSummary[i] = closureExecutor.idxScanCtx.execDetail.buildSummary()
+			case tipb.ExecType_TypeSelection:
+				execSummary[i] = closureExecutor.selectionCtx.execDetail.buildSummary()
+			case tipb.ExecType_TypeTopN:
+				execSummary[i] = closureExecutor.topNCtx.execDetail.buildSummary()
+			case tipb.ExecType_TypeAggregation, tipb.ExecType_TypeStreamAgg:
+				execSummary[i] = closureExecutor.aggCtx.execDetail.buildSummary()
+			case tipb.ExecType_TypeLimit:
+				costNs := uint64(0)
+				rows := uint64(closureExecutor.rowCount)
+				numIter := uint64(1)
+				execSummary[i] = &tipb.ExecutorExecutionSummary{
+					TimeProcessedNs: &costNs,
+					NumProducedRows: &rows,
+					NumIterations:   &numIter,
+				}
+			default:
+				execSummary[i] = &tipb.ExecutorExecutionSummary{}
+			}
 		}
 		selResp.ExecutionSummaries = execSummary
 	}

--- a/store/mockstore/unistore/cophandler/cop_handler.go
+++ b/store/mockstore/unistore/cophandler/cop_handler.go
@@ -310,7 +310,6 @@ func buildResp(chunks []tipb.Chunk, closureExecutor *closureExecutor, dagReq *ti
 			switch executors[i].Tp {
 			case tipb.ExecType_TypeTableScan:
 				execSummary[i] = closureExecutor.scanCtx.execDetail.buildSummary()
-				fmt.Println("[table scan]", i, *execSummary[i].NumProducedRows)
 			case tipb.ExecType_TypeIndexScan:
 				execSummary[i] = closureExecutor.idxScanCtx.execDetail.buildSummary()
 			case tipb.ExecType_TypeSelection:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: one step in #19209   <!-- REMOVE this line if no issue to close -->

Problem Summary:

Add real executor execution summary information.

### What is changed and how it works?

What's Changed:

- add `execDetail` struct
- collect `execDetail` for:
    - TableScan
    - IndexScan
    - Select
    - Agg
    - TopN
    - Limit
- add real executor execution summary in DAGResponse base on `execDetail`
- add test for `ActRows`

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
- No release note.
