### PR TITLE
ddl: stable placement cache test

### DIFF
--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -294,26 +294,26 @@ func (s *testDBSuite1) TestPlacementPolicyCache(c *C) {
 		partDefs := tb.Meta().GetPartitionInfo().Definitions
 
 		rows := []string{}
-		for _, v := range partDefs {
+		for k, v := range partDefs {
 			ptID := placement.GroupID(v.ID)
 			bundles[ptID] = &placement.Bundle{
 				ID:    ptID,
-				Rules: []*placement.Rule{{ID: "default"}},
+				Rules: []*placement.Rule{{Count: k}},
 			}
-			rows = append(rows, fmt.Sprintf("%s 0 default test t1 %s <nil>  0 ", ptID, v.Name.L))
+			rows = append(rows, fmt.Sprintf("%s 0  test t1 %s <nil>  %d ", ptID, v.Name.L, k))
 		}
 		return rows
 	}
 
 	// test drop
 	rows := initTable()
-	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows(rows...))
+	tk.MustQuery("select * from information_schema.placement_policy order by REPLICAS").Check(testkit.Rows(rows...))
 	tk.MustExec("drop table t1")
 	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows())
 
 	// test truncate
 	rows = initTable()
-	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows(rows...))
+	tk.MustQuery("select * from information_schema.placement_policy order by REPLICAS").Check(testkit.Rows(rows...))
 	tk.MustExec("truncate table t1")
 	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows())
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Thx @wjhuang2016 for the report of the bug: https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/58320/pipeline.
Fix #20777

It is caused by the iteration of map(for storing placement rules). So the result obtained by sql is not necessarily ordered, i.e. the result is different in row-order. This test generate special incremental integer for field `REPLICAS` to sort.

This PR close #20777

### Check List <!--REMOVE the items that are not applicable-->

Tests 

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
