### PR TITLE
executor: fix IndexHashJoin hang in finishJoinWorkers

### DIFF
--- a/executor/index_lookup_hash_join.go
+++ b/executor/index_lookup_hash_join.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/ranger"
-	"github.com/sirupsen/logrus"
 )
 
 // numResChkHold indicates the number of resource chunks that an inner worker
@@ -271,7 +270,6 @@ func (e *IndexNestedLoopHashJoin) runInOrder(ctx context.Context, req *chunk.Chu
 				continue
 			}
 			if result.err != nil {
-				logrus.Warning("result.err !=nil ", result.err.Error())
 				return result.err
 			}
 		case <-ctx.Done():


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20779  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Check keepOuterOrder in finishJoinWorker, and put the error back to the correct channel.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a bug in IndexHashJoin. If a query uses the IndexHashJoin, and hangs forever but no abnormal information is logged. And we can see from the goroutine stack that it is blocked in IndexHashJoin::finishJoinWorker. It probably fixed by this plugin.
