### PR TITLE
planner: fix panic when natural join has selection and order by

### DIFF
--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -588,7 +588,7 @@ func (s *testSuiteJoin1) TestNaturalJoin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("drop table if exists t1, t2, t3")
 	tk.MustExec("create table t1 (a int, b int)")
 	tk.MustExec("create table t2 (a int, c int)")
 	tk.MustExec("create table t3 (b int, c int)")

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -605,9 +605,6 @@ func (s *testSuiteJoin1) TestNaturalJoin(c *C) {
 	tk.MustQuery("select * from t1 natural left join t2 natural left join t3 order by t3.b").Check(testkit.Rows("20 <nil> 10", "2 3 1"))
 	tk.MustQuery("select sum(t3.b) from t1 natural left join t2 natural left join t3").Check(testkit.Rows("2"))
 
-	tk.MustExec("insert t1 values (1, 2), (10, 20)")
-	tk.MustExec("insert t2 values (1, 23), (10, 22)")
-
 	tk.MustQuery("select *,rank()over(partition by t1.a order by t2.c desc) as ranking  from t1 natural left join t2 natural left join t3 order by a").Check(testkit.Rows("2 3 1 1", "20 <nil> 10 1"))
 	tk.MustQuery("select t2.a from (t1 join t2 using (a)) join t3 using (c)").Check(testkit.Rows("1"))
 	tk.MustQuery("select t2.a from t1 natural left join t2 where t2.c = 3").Check(testkit.Rows("1"))

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
+cloud.google.com/go v0.50.0 h1:0E3eE8MX426vUOs7aHfI7aN1BrIzzzf4ccKCSfSjGmc=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -586,6 +586,11 @@ func resetNotNullFlag(schema *expression.Schema, start, end int) {
 }
 
 func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (LogicalPlan, error) {
+	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
+	defer func() {
+		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
+	}()
+
 	// We will construct a "Join" node for some statements like "INSERT",
 	// "DELETE", "UPDATE", "REPLACE". For this scenario "joinNode.Right" is nil
 	// and we only build the left "ResultSetNode".
@@ -2661,9 +2666,7 @@ func (b *PlanBuilder) TableHints() *tableHintInfo {
 func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p LogicalPlan, err error) {
 	b.pushSelectOffset(sel.QueryBlockOffset)
 	b.pushTableHints(sel.TableHints, utilhint.TypeSelect, sel.QueryBlockOffset)
-	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
 	defer func() {
-		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
 		b.popSelectOffset()
 		// table hints are only visible in the current SELECT statement.
 		b.popTableHints()

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -586,10 +586,6 @@ func resetNotNullFlag(schema *expression.Schema, start, end int) {
 }
 
 func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (LogicalPlan, error) {
-	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
-	defer func() {
-		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
-	}()
 
 	// We will construct a "Join" node for some statements like "INSERT",
 	// "DELETE", "UPDATE", "REPLACE". For this scenario "joinNode.Right" is nil
@@ -2666,7 +2662,9 @@ func (b *PlanBuilder) TableHints() *tableHintInfo {
 func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p LogicalPlan, err error) {
 	b.pushSelectOffset(sel.QueryBlockOffset)
 	b.pushTableHints(sel.TableHints, utilhint.TypeSelect, sel.QueryBlockOffset)
+	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
 	defer func() {
+		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
 		b.popSelectOffset()
 		// table hints are only visible in the current SELECT statement.
 		b.popTableHints()
@@ -3536,7 +3534,9 @@ func buildColumns2Handle(
 func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (Plan, error) {
 	b.pushSelectOffset(0)
 	b.pushTableHints(update.TableHints, utilhint.TypeUpdate, 0)
+	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
 	defer func() {
+		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
 		b.popSelectOffset()
 		// table hints are only visible in the current UPDATE statement.
 		b.popTableHints()
@@ -3841,7 +3841,9 @@ func extractDefaultExpr(node ast.ExprNode) *ast.DefaultExpr {
 func (b *PlanBuilder) buildDelete(ctx context.Context, delete *ast.DeleteStmt) (Plan, error) {
 	b.pushSelectOffset(0)
 	b.pushTableHints(delete.TableHints, utilhint.TypeDelete, 0)
+	b.redundantInfos = append(b.redundantInfos, &redundantInfo{})
 	defer func() {
+		b.redundantInfos = b.redundantInfos[:len(b.redundantInfos)-1]
 		b.popSelectOffset()
 		// table hints are only visible in the current DELETE statement.
 		b.popTableHints()

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -143,11 +143,6 @@ type LogicalJoin struct {
 	// Currently, only `aggregation push down` phase will set this.
 	DefaultValues []types.Datum
 
-	// redundantSchema contains columns which are eliminated in join.
-	// For select * from a join b using (c); a.c will in output schema, and b.c will in redundantSchema.
-	redundantSchema *expression.Schema
-	redundantNames  types.NameSlice
-
 	// equalCondOutCnt indicates the estimated count of joined rows after evaluating `EqualConditions`.
 	equalCondOutCnt float64
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -405,6 +405,8 @@ type PlanBuilder struct {
 	is           infoschema.InfoSchema
 	outerSchemas []*expression.Schema
 	outerNames   [][]*types.FieldName
+	// redundantSchema,redundantNames is used for column redundant
+	redundantInfos []*redundantInfo
 	// colMapper stores the column that must be pre-resolved.
 	colMapper map[*ast.ColumnNameExpr]int
 	// visitInfo is used for privilege check.
@@ -456,6 +458,12 @@ type PlanBuilder struct {
 type handleColHelper struct {
 	id2HandleMapStack []map[int64][]HandleCols
 	stackTail         int
+}
+
+// redundantSchema,redundantNames is used for column redundant
+type redundantInfo struct {
+	redundantSchema *expression.Schema
+	redundantNames  []*types.FieldName
 }
 
 func (hch *handleColHelper) appendColToLastMap(tblID int64, handleCols HandleCols) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
planner/core
2. *: what's changed
save be coalesced Common Columns in PlanBuilder struct using stack to support column's access to sub-query  to parent-query
-->

### What problem does this PR solve?
Issue Number: close #15844 and close #20441

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
save be coalesced Common Columns in PlanBuilder struct using stack to support column's access to sub-query  to parent-query
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note
- fix panic when natural join has selection,order by,sub-query and where
<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->