### PR TITLE
planner: bypass the DNF restriction if index merge hint is specified

### DIFF
--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -312,10 +312,12 @@ func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo, selfSchema *
 	sessionAndStmtPermission := (ds.ctx.GetSessionVars().GetEnableIndexMerge() || len(ds.indexMergeHints) > 0) && !ds.ctx.GetSessionVars().StmtCtx.NoIndexMergeHint
 	// If there is an index path, we current do not consider `IndexMergePath`.
 	needConsiderIndexMerge := true
-	for i := 1; i < len(ds.possibleAccessPaths); i++ {
-		if len(ds.possibleAccessPaths[i].AccessConds) != 0 {
-			needConsiderIndexMerge = false
-			break
+	if len(ds.indexMergeHints) == 0 {
+		for i := 1; i < len(ds.possibleAccessPaths); i++ {
+			if len(ds.possibleAccessPaths[i].AccessConds) != 0 {
+				needConsiderIndexMerge = false
+				break
+			}
 		}
 	}
 	if isPossibleIdxMerge && sessionAndStmtPermission && needConsiderIndexMerge && isReadOnlyTxn {

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -72,6 +72,13 @@
     ]
   },
   {
+    "name": "TestIndexMergeHint4CNF",
+    "cases": [
+      "explain select * from t where b = 1 and (a = 1 or c = 1)",
+      "explain select /*+ USE_INDEX_MERGE(t, a, c) */ * from t where b = 1 and (a = 1 or c = 1)"
+    ]
+  },
+  {
     "name": "TestSubqueryWithTopN",
     "cases": [
       "desc select t1.b from t t1 where t1.b in (select t2.a from t t2 order by t1.a+t2.a limit 1)",

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -292,6 +292,30 @@
     ]
   },
   {
+    "Name": "TestIndexMergeHint4CNF",
+    "Cases": [
+      {
+        "SQL": "explain select * from t where b = 1 and (a = 1 or c = 1)",
+        "Plan": [
+          "IndexLookUp_11 0.02 root  ",
+          "├─IndexRangeScan_8(Build) 10.00 cop[tikv] table:t, index:b(b) range:[1,1], keep order:false, stats:pseudo",
+          "└─Selection_10(Probe) 0.02 cop[tikv]  or(eq(test.t.a, 1), eq(test.t.c, 1))",
+          "  └─TableRowIDScan_9 10.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select /*+ USE_INDEX_MERGE(t, a, c) */ * from t where b = 1 and (a = 1 or c = 1)",
+        "Plan": [
+          "IndexMerge_9 0.02 root  ",
+          "├─IndexRangeScan_5(Build) 10.00 cop[tikv] table:t, index:a(a) range:[1,1], keep order:false, stats:pseudo",
+          "├─IndexRangeScan_6(Build) 10.00 cop[tikv] table:t, index:c(c) range:[1,1], keep order:false, stats:pseudo",
+          "└─Selection_8(Probe) 0.02 cop[tikv]  eq(test.t.b, 1)",
+          "  └─TableRowIDScan_7 19.99 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestSubqueryWithTopN",
     "Cases": [
       {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/20728

Problem Summary:

When index merge hint is specified, choose IndexMerge plan even if the filter is in CNF.

### What is changed and how it works?

What's Changed:

Bypass the DNF check if index merge hint is specified.

How it Works:

The remained partial CNF filter is kept in TableFilters.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No