### PR TITLE
planner: make pushdown limit use its child schema

### DIFF
--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -183,9 +183,9 @@ a+1
 desc select c from t where a+1=3;
 id	estRows	task	access object	operator info
 Projection_4	10.00	root		test.t.c
-└─IndexLookUp_10	10.00	root		
-  ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexLookUp_11	10.00	root		
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select c from t where a+1=3;
 c
 3
@@ -208,9 +208,9 @@ b+a
 desc select e from t where b+a=3;
 id	estRows	task	access object	operator info
 Projection_4	10.00	root		test.t.e
-└─IndexLookUp_10	10.00	root		
-  ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexLookUp_11	10.00	root		
+  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select e from t where b+a=3;
 e
 3
@@ -276,8 +276,8 @@ a	b	c	e
 5	-1	6	4
 desc select a+1 from t order by a+1;
 id	estRows	task	access object	operator info
-IndexReader_13	10000.00	root		index:IndexFullScan_12
-└─IndexFullScan_12	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
+IndexReader_14	10000.00	root		index:IndexFullScan_13
+└─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
 select a+1 from t order by a+1;
 a+1
 0
@@ -289,8 +289,8 @@ a+1
 6
 desc select b+a from t order by b+a;
 id	estRows	task	access object	operator info
-IndexReader_13	10000.00	root		index:IndexFullScan_12
-└─IndexFullScan_12	10000.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	keep order:true, stats:pseudo
+IndexReader_14	10000.00	root		index:IndexFullScan_13
+└─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	keep order:true, stats:pseudo
 select b+a from t order by b+a;
 b+a
 -3

--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -183,9 +183,9 @@ a+1
 desc select c from t where a+1=3;
 id	estRows	task	access object	operator info
 Projection_4	10.00	root		test.t.c
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexLookUp_10	10.00	root		
+  ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select c from t where a+1=3;
 c
 3
@@ -208,9 +208,9 @@ b+a
 desc select e from t where b+a=3;
 id	estRows	task	access object	operator info
 Projection_4	10.00	root		test.t.e
-└─IndexLookUp_11	10.00	root		
-  ├─IndexRangeScan_9(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
-  └─TableRowIDScan_10(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+└─IndexLookUp_10	10.00	root		
+  ├─IndexRangeScan_8(Build)	10.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	range:[3,3], keep order:false, stats:pseudo
+  └─TableRowIDScan_9(Probe)	10.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 select e from t where b+a=3;
 e
 3
@@ -276,8 +276,8 @@ a	b	c	e
 5	-1	6	4
 desc select a+1 from t order by a+1;
 id	estRows	task	access object	operator info
-IndexReader_14	10000.00	root		index:IndexFullScan_13
-└─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
+IndexReader_13	10000.00	root		index:IndexFullScan_12
+└─IndexFullScan_12	10000.00	cop[tikv]	table:t, index:expr_idx_c(`a` + 1)	keep order:true, stats:pseudo
 select a+1 from t order by a+1;
 a+1
 0
@@ -289,8 +289,8 @@ a+1
 6
 desc select b+a from t order by b+a;
 id	estRows	task	access object	operator info
-IndexReader_14	10000.00	root		index:IndexFullScan_13
-└─IndexFullScan_13	10000.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	keep order:true, stats:pseudo
+IndexReader_13	10000.00	root		index:IndexFullScan_12
+└─IndexFullScan_12	10000.00	cop[tikv]	table:t, index:expr_idx_e(`b` + `a`)	keep order:true, stats:pseudo
 select b+a from t order by b+a;
 b+a
 -3

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6041,6 +6041,16 @@ func (s *testIntegrationSerialSuite) TestCacheConstEval(c *C) {
 	tk.MustExec("admin reload expr_pushdown_blacklist")
 }
 
+
+func (s *testSuite) TestVirtualGeneratedColumnAndLimit(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int, b int as (a + 1));")
+	tk.MustExec("insert into t(a) values (1);")
+	tk.MustQuery("select /*+ LIMIT_TO_COP() */ b from t limit 1;").Check(testkit.Rows("2"))
+	tk.MustQuery("select /*+ LIMIT_TO_COP() */ b from t limit 1 order by b;").Check(testkit.Rows("2"))
+}
+
 func (s *testIntegrationSerialSuite) TestCollationBasic(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	collate.SetNewCollationEnabledForTest(true)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6041,14 +6041,13 @@ func (s *testIntegrationSerialSuite) TestCacheConstEval(c *C) {
 	tk.MustExec("admin reload expr_pushdown_blacklist")
 }
 
-
 func (s *testSuite) TestVirtualGeneratedColumnAndLimit(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (a int, b int as (a + 1));")
 	tk.MustExec("insert into t(a) values (1);")
 	tk.MustQuery("select /*+ LIMIT_TO_COP() */ b from t limit 1;").Check(testkit.Rows("2"))
-	tk.MustQuery("select /*+ LIMIT_TO_COP() */ b from t limit 1 order by b;").Check(testkit.Rows("2"))
+	tk.MustQuery("select /*+ LIMIT_TO_COP() */ b from t order by b limit 1;").Check(testkit.Rows("2"))
 }
 
 func (s *testIntegrationSerialSuite) TestCollationBasic(c *C) {

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
+cloud.google.com/go v0.50.0 h1:0E3eE8MX426vUOs7aHfI7aN1BrIzzzf4ccKCSfSjGmc=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -835,6 +835,8 @@ func (p *PhysicalLimit) attach2Task(tasks ...task) task {
 			stats := deriveLimitStats(childProfile, float64(newCount))
 			pushedDownLimit := PhysicalLimit{Count: newCount}.Init(p.ctx, stats, p.blockOffset)
 			cop = attachPlan2Task(pushedDownLimit, cop).(*copTask)
+			// Don't use clone() so that Limit and its children share the same schema. Otherwise the virtual generated column may not be resolved right.
+			pushedDownLimit.SetSchema(pushedDownLimit.children[0].Schema())
 		}
 		t = finishCopTask(p.ctx, cop)
 		sunk = p.sinkIntoIndexLookUp(t)


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20801 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

make pushdown limit use its child schema.
Then if we update the physicalTableScan's schema, then the tableReader's schema is updated as well.


### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects



### Release note <!-- bugfixes or new feature need a release note -->

- No release note
