### PR TITLE
store/tikv: Fix goroutine leak in tikv client

### DIFF
--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -367,6 +367,10 @@ func (s *tikvStore) Close() error {
 	if s.coprCache != nil {
 		s.coprCache.cache.Close()
 	}
+
+	if err := s.kv.Close(); err != nil {
+		return errors.Trace(err)
+	}
 	return nil
 }
 

--- a/store/tikv/safepoint.go
+++ b/store/tikv/safepoint.go
@@ -46,6 +46,7 @@ type SafePointKV interface {
 	Put(k string, v string) error
 	Get(k string) (string, error)
 	GetWithPrefix(k string) ([]*mvccpb.KeyValue, error)
+	Close() error
 }
 
 // MockSafePointKV implements SafePointKV at mock test
@@ -88,6 +89,11 @@ func (w *MockSafePointKV) GetWithPrefix(prefix string) ([]*mvccpb.KeyValue, erro
 		}
 	}
 	return kvs, nil
+}
+
+// Close implements the Close method for SafePointKV
+func (w *MockSafePointKV) Close() error {
+	return nil
 }
 
 // EtcdSafePointKV implements SafePointKV at runtime
@@ -138,6 +144,11 @@ func (w *EtcdSafePointKV) GetWithPrefix(k string) ([]*mvccpb.KeyValue, error) {
 		return nil, errors.Trace(err)
 	}
 	return resp.Kvs, nil
+}
+
+// Close implements the Close for SafePointKV
+func (w *EtcdSafePointKV) Close() error {
+	return errors.Trace(w.cli.Close())
 }
 
 func saveSafePoint(kv SafePointKV, t uint64) error {


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20654 

Problem Summary: There's a goroutine leak found in tikv client, and it's confirmed to be caused by forgetting closing the etcd client in `EtcdSafePointKV`.

The bug doesn't harm TiDB, since the `tikvStore` longs for the whole lifetime of the TiDB process. However, it affects other projects that make use of TiKV client. For example, CDC may open and close tikv client many times.

### What is changed and how it works?

This PR fixes the goroutine leak by adding a `Close` interface to SafePointKV, and invoke it in `Close` method of `tikvStore`.

### Related changes

- Need to cherry-pick to the release branch
  - release 4.0
  - release 3.0
  The problem should also exists in release 2.x, but I'm not sure if it's necessary. Nor do I know if we still have release plan of 2.1.x.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

The code segment of the test program: 

```go
func main() {
	go func() {
		log.Println(http.ListenAndServe("localhost:6060", nil))
	}()

	_ = store.Register("tikv", tikv.Driver{})

	uri := "tikv://xxx.xxx.xxx.xxx:2379?disableGC=true"

	for {
		var times int
		fmt.Scanf("%d", &times)

		for i := 0; i < times; i++ {
			tiStore, err := store.New(uri)
			if err != nil {
				panic(err)
			}
			err = tiStore.Close()
			if err != nil {
				panic(err)
			}
		}
	}
}
```

Run and type `100` (create and close tikv client 100 times), dump the goroutines by pprof after the log stopps:

```
goroutine profile: total 606
```

After the fix and run again:

```
goroutine profile: total 5
```

Side effects

\-

### Release note <!-- bugfixes or new feature need a release note -->

- Fix an goroutine leak issue in TiKV client.