### PR TITLE
*: optimize for encoding huge plan

### DIFF
--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -294,26 +294,26 @@ func (s *testDBSuite1) TestPlacementPolicyCache(c *C) {
 		partDefs := tb.Meta().GetPartitionInfo().Definitions
 
 		rows := []string{}
-		for _, v := range partDefs {
+		for k, v := range partDefs {
 			ptID := placement.GroupID(v.ID)
 			bundles[ptID] = &placement.Bundle{
 				ID:    ptID,
-				Rules: []*placement.Rule{{ID: "default"}},
+				Rules: []*placement.Rule{{Count: k}},
 			}
-			rows = append(rows, fmt.Sprintf("%s 0 default test t1 %s <nil>  0 ", ptID, v.Name.L))
+			rows = append(rows, fmt.Sprintf("%s 0  test t1 %s <nil>  %d ", ptID, v.Name.L, k))
 		}
 		return rows
 	}
 
 	// test drop
 	rows := initTable()
-	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows(rows...))
+	tk.MustQuery("select * from information_schema.placement_policy order by REPLICAS").Check(testkit.Rows(rows...))
 	tk.MustExec("drop table t1")
 	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows())
 
 	// test truncate
 	rows = initTable()
-	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows(rows...))
+	tk.MustQuery("select * from information_schema.placement_policy order by REPLICAS").Check(testkit.Rows(rows...))
 	tk.MustExec("truncate table t1")
 	tk.MustQuery("select * from information_schema.placement_policy").Check(testkit.Rows())
 }

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -103,9 +103,6 @@ func (e *ExplainExec) generateExplainInfo(ctx context.Context) (rows [][]string,
 	if err = e.explain.RenderResult(); err != nil {
 		return nil, err
 	}
-	if e.analyzeExec != nil {
-		e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl = nil
-	}
 	return e.explain.Rows, nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20201023092649-e6d6090277c9
 	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
-	github.com/pingcap/parser v0.0.0-20201030090627-3d18e257aed6
+	github.com/pingcap/parser v0.0.0-20201104071116-b3d18bf9e537
 	github.com/pingcap/sysutil v0.0.0-20201021075216-f93ced2829e2
 	github.com/pingcap/tidb-tools v4.0.5-0.20200820092506-34ea90c93237+incompatible
 	github.com/pingcap/tipb v0.0.0-20201026044621-45e60c77588f
@@ -99,5 +99,3 @@ require (
 )
 
 go 1.13
-
-replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5

--- a/go.mod
+++ b/go.mod
@@ -100,3 +100,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/corona10/goimagehash v1.0.2/go.mod h1:/l9umBhvcHQXVtQO1V6Gp1yD20STawk
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5 h1:YT2XVqyn6S2YHZWEGAsoV2iF8GtkjkToCKroSMiXxjQ=
+github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/golex v0.0.0-20181122101858-9c343928389c/go.mod h1:+bmmJDNmKlhWNG+gwWCkaBoTy39Fs+bzRxVBzoTQbIc=

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,7 @@ cloud.google.com/go v0.44.1/go.mod h1:iSa0KzasP4Uvy3f1mN/7PiObzGgflwredwwASm/v6A
 cloud.google.com/go v0.44.2/go.mod h1:60680Gw3Yr4ikxnPRS/oxxkBccT6SA1yMk63TGekxKY=
 cloud.google.com/go v0.45.1/go.mod h1:RpBamKRgapWJb87xiFSdk4g1CME7QZg3uwTez+TSTjc=
 cloud.google.com/go v0.46.3/go.mod h1:a6bKKbmY7er1mI7TEI4lsAkts/mkhTSZK8w33B4RAg0=
+cloud.google.com/go v0.50.0 h1:0E3eE8MX426vUOs7aHfI7aN1BrIzzzf4ccKCSfSjGmc=
 cloud.google.com/go v0.50.0/go.mod h1:r9sluTvynVuxRIOHXQEHMFffphuXHOMZMycpNR5e6To=
 cloud.google.com/go/bigquery v1.0.1/go.mod h1:i/xbL2UlR5RvWAURpBYZTtm/cXjCha9lbfbpx4poX+o=
 cloud.google.com/go/bigquery v1.3.0 h1:sAbMqjY1PEQKZBWfbu6Y6bsupJ9c4QdHnzg/VvYTLcE=
@@ -445,8 +446,6 @@ github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20201030090627-3d18e257aed6 h1:bNO9e9i741BrO/ImHelgHh+UKpHMbiYE1+pqty5YMzU=
-github.com/pingcap/parser v0.0.0-20201030090627-3d18e257aed6/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20201021075216-f93ced2829e2 h1:b2G/eqDeywtdJF3w9nIUdqMmXChsmpLvf4FzUxJ9Vmk=

--- a/go.sum
+++ b/go.sum
@@ -498,6 +498,7 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
+github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44 h1:tB9NOR21++IjLyVx3/PCPhWMwqGNCMQEH96A6dMZ/gc=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.3+incompatible h1:0JVooMPsT7A7HqEYdydp/OfjSOYSjhXV7w1hkKj/NPQ=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,6 @@ github.com/corona10/goimagehash v1.0.2/go.mod h1:/l9umBhvcHQXVtQO1V6Gp1yD20STawk
 github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
-github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5 h1:YT2XVqyn6S2YHZWEGAsoV2iF8GtkjkToCKroSMiXxjQ=
-github.com/crazycs520/parser v0.0.0-20201103121313-b282a7d2d8d5/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cznic/golex v0.0.0-20181122101858-9c343928389c/go.mod h1:+bmmJDNmKlhWNG+gwWCkaBoTy39Fs+bzRxVBzoTQbIc=
@@ -446,6 +444,8 @@ github.com/pingcap/log v0.0.0-20200117041106-d28c14d3b1cd/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
 github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
+github.com/pingcap/parser v0.0.0-20201104071116-b3d18bf9e537 h1:YfUAzfwnHWnhUJVTGB7kMquFJeslYPe2dYq6GvD5o98=
+github.com/pingcap/parser v0.0.0-20201104071116-b3d18bf9e537/go.mod h1:74+OEdwM4B/jMpBRl92ch6CSmSYkQtv2TNxIjFdT/GE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20200715082929-4c47bcac246a/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20201021075216-f93ced2829e2 h1:b2G/eqDeywtdJF3w9nIUdqMmXChsmpLvf4FzUxJ9Vmk=

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -38,11 +38,14 @@ type planEncoder struct {
 
 // EncodePlan is used to encodePlan the plan to the plan tree with compressing.
 func EncodePlan(p Plan) string {
-	pn := encoderPool.Get().(*planEncoder)
-	defer encoderPool.Put(pn)
+	if explain, ok := p.(*Explain); ok {
+		p = explain.TargetPlan
+	}
 	if p == nil || p.SCtx() == nil {
 		return ""
 	}
+	pn := encoderPool.Get().(*planEncoder)
+	defer encoderPool.Put(pn)
 	selectPlan := getSelectPlan(p)
 	if selectPlan != nil {
 		failpoint.Inject("mockPlanRowCount", func(val failpoint.Value) {

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -474,7 +474,6 @@ func (s *testPlanNormalize) TestEncodePlanPerformance(c *C) {
 	tk.MustExec("create table th (i int, a int,b int, c int, index (a)) partition by hash (a) partitions 8192;")
 	tk.MustExec("set @@tidb_slow_log_threshold=200000")
 
-	// generate SQL
 	query := "select count(*) from th t1 join th t2 join th t3 join th t4 join th t5 join th t6 join th t7 join th t8 where t1.i=t2.a and t1.i=t3.i and t3.i=t4.i and t4.i=t5.i and t5.i=t6.i and t6.i=t7.i and t7.i=t8.i"
 	tk.Se.GetSessionVars().PlanID = 0
 	tk.MustExec(query)

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -474,16 +474,17 @@ func (s *testPlanNormalize) TestEncodePlanPerformance(c *C) {
 	tk.MustExec("create table th (i int, a int,b int, c int, index (a)) partition by hash (a) partitions 8192;")
 	tk.MustExec("set @@tidb_slow_log_threshold=200000")
 
-	query := "select count(*) from th t1 join th t2 join th t3 join th t4 join th t5 join th t6 join th t7 join th t8 where t1.i=t2.a and t1.i=t3.i and t3.i=t4.i and t4.i=t5.i and t5.i=t6.i and t6.i=t7.i and t7.i=t8.i"
+	query := "select count(*) from th t1 join th t2 join th t3 join th t4 join th t5 join th t6 where t1.i=t2.a and t1.i=t3.i and t3.i=t4.i and t4.i=t5.i and t5.i=t6.i"
 	tk.Se.GetSessionVars().PlanID = 0
 	tk.MustExec(query)
 	info := tk.Se.ShowProcess()
 	c.Assert(info, NotNil)
 	p, ok := info.Plan.(core.PhysicalPlan)
 	c.Assert(ok, IsTrue)
+	tk.Se.GetSessionVars().StmtCtx.RuntimeStatsColl = nil
 	start := time.Now()
 	encodedPlanStr := core.EncodePlan(p)
-	c.Assert(time.Since(start).Seconds(), Less, 5.0)
+	c.Assert(time.Since(start).Seconds(), Less, 10.0)
 	_, err := plancodec.DecodePlan(encodedPlanStr)
 	c.Assert(err, IsNil)
 }

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -42,7 +42,7 @@ type Tracker struct {
 		sync.Mutex
 		// The children memory trackers. If the Tracker is the Global Tracker, like executor.GlobalDiskUsageTracker,
 		// we wouldn't maintain its children in order to avoiding mutex contention.
-		children []*Tracker
+		children map[int][]*Tracker
 	}
 	actionMu struct {
 		sync.Mutex
@@ -143,7 +143,10 @@ func (t *Tracker) AttachTo(parent *Tracker) {
 		oldParent.remove(t)
 	}
 	parent.mu.Lock()
-	parent.mu.children = append(parent.mu.children, t)
+	if parent.mu.children == nil {
+		parent.mu.children = make(map[int][]*Tracker)
+	}
+	parent.mu.children[t.label] = append(parent.mu.children[t.label], t)
 	parent.mu.Unlock()
 
 	t.setParent(parent)
@@ -164,10 +167,13 @@ func (t *Tracker) Detach() {
 
 func (t *Tracker) remove(oldChild *Tracker) {
 	found := false
+	label := oldChild.label
 	t.mu.Lock()
-	for i, child := range t.mu.children {
+	children := t.mu.children[label]
+	for i, child := range children {
 		if child == oldChild {
-			t.mu.children = append(t.mu.children[:i], t.mu.children[i+1:]...)
+			children = append(children[:i], children[i+1:]...)
+			t.mu.children[label] = children
 			found = true
 			break
 		}
@@ -191,15 +197,18 @@ func (t *Tracker) ReplaceChild(oldChild, newChild *Tracker) {
 	newConsumed := newChild.BytesConsumed()
 	newChild.setParent(t)
 
+	label := oldChild.label
 	t.mu.Lock()
-	for i, child := range t.mu.children {
+	children := t.mu.children[label]
+	for i, child := range children {
 		if child != oldChild {
 			continue
 		}
 
 		newConsumed -= oldChild.BytesConsumed()
 		oldChild.setParent(nil)
-		t.mu.children[i] = newChild
+		children[i] = newChild
+		t.mu.children[label] = children
 		break
 	}
 	t.mu.Unlock()
@@ -248,30 +257,14 @@ func (t *Tracker) MaxConsumed() int64 {
 	return atomic.LoadInt64(&t.maxConsumed)
 }
 
-// SearchTracker searches the specific tracker under this tracker.
-func (t *Tracker) SearchTracker(label int) *Tracker {
-	if t.label == label {
-		return t
-	}
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	for _, child := range t.mu.children {
-		if result := child.SearchTracker(label); result != nil {
-			return result
-		}
-	}
-	return nil
-}
-
 // SearchTrackerWithoutLock searches the specific tracker under this tracker without lock.
 func (t *Tracker) SearchTrackerWithoutLock(label int) *Tracker {
 	if t.label == label {
 		return t
 	}
-	for _, child := range t.mu.children {
-		if result := child.SearchTrackerWithoutLock(label); result != nil {
-			return result
-		}
+	children := t.mu.children[label]
+	if len(children) > 0 {
+		return children[0]
 	}
 	return nil
 }
@@ -291,9 +284,9 @@ func (t *Tracker) toString(indent string, buffer *bytes.Buffer) {
 	fmt.Fprintf(buffer, "%s  \"consumed\": %s\n", indent, t.BytesToString(t.BytesConsumed()))
 
 	t.mu.Lock()
-	for i := range t.mu.children {
-		if t.mu.children[i] != nil {
-			t.mu.children[i].toString(indent+"  ", buffer)
+	for _, children := range t.mu.children {
+		for _, child := range children {
+			child.toString(indent+"  ", buffer)
 		}
 	}
 	t.mu.Unlock()

--- a/util/memory/tracker_test.go
+++ b/util/memory/tracker_test.go
@@ -143,7 +143,7 @@ func (s *testSuite) TestAttachTo(c *C) {
 	c.Assert(oldParent.BytesConsumed(), Equals, int64(100))
 	c.Assert(child.getParent(), DeepEquals, oldParent)
 	c.Assert(len(oldParent.mu.children), Equals, 1)
-	c.Assert(oldParent.mu.children[0], DeepEquals, child)
+	c.Assert(oldParent.mu.children[child.label][0], DeepEquals, child)
 
 	child.AttachTo(newParent)
 	c.Assert(child.BytesConsumed(), Equals, int64(100))
@@ -151,7 +151,7 @@ func (s *testSuite) TestAttachTo(c *C) {
 	c.Assert(newParent.BytesConsumed(), Equals, int64(100))
 	c.Assert(child.getParent(), DeepEquals, newParent)
 	c.Assert(len(newParent.mu.children), Equals, 1)
-	c.Assert(newParent.mu.children[0], DeepEquals, child)
+	c.Assert(newParent.mu.children[child.label][0], DeepEquals, child)
 	c.Assert(len(oldParent.mu.children), Equals, 0)
 }
 
@@ -163,7 +163,7 @@ func (s *testSuite) TestDetach(c *C) {
 	c.Assert(child.BytesConsumed(), Equals, int64(100))
 	c.Assert(parent.BytesConsumed(), Equals, int64(100))
 	c.Assert(len(parent.mu.children), Equals, 1)
-	c.Assert(parent.mu.children[0], DeepEquals, child)
+	c.Assert(parent.mu.children[child.label][0], DeepEquals, child)
 
 	child.Detach()
 	c.Assert(child.BytesConsumed(), Equals, int64(100))
@@ -185,14 +185,14 @@ func (s *testSuite) TestReplaceChild(c *C) {
 	parent.ReplaceChild(oldChild, newChild)
 	c.Assert(parent.BytesConsumed(), Equals, int64(500))
 	c.Assert(len(parent.mu.children), Equals, 1)
-	c.Assert(parent.mu.children[0], DeepEquals, newChild)
+	c.Assert(parent.mu.children[newChild.label][0], DeepEquals, newChild)
 	c.Assert(newChild.getParent(), DeepEquals, parent)
 	c.Assert(oldChild.getParent(), IsNil)
 
 	parent.ReplaceChild(oldChild, nil)
 	c.Assert(parent.BytesConsumed(), Equals, int64(500))
 	c.Assert(len(parent.mu.children), Equals, 1)
-	c.Assert(parent.mu.children[0], DeepEquals, newChild)
+	c.Assert(parent.mu.children[newChild.label][0], DeepEquals, newChild)
 	c.Assert(newChild.getParent(), DeepEquals, parent)
 	c.Assert(oldChild.getParent(), IsNil)
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Here is a performance problem when encoding huge plan:

![image](https://user-images.githubusercontent.com/26020263/97986733-19be9900-1e15-11eb-88f7-ab049ea54360.png)

Here is a sample test case:

```sql
set @@tidb_partition_prune_mode='static-only';
create table th (i int, a int,b int, c int, index (a)) partition by hash (a) partitions 8192;
```

encode the plan of the below query:

```sql
select count(*) from th t1 join th t2 join th t3 join th t4 join th t5 join th t6 join th t7 join th t8 where t1.i=t2.a and t1.i=t3.i and t3.i=t4.i and t4.i=t5.i and t5.i=t6.i and t6.i=t7.i and t7.i=t8.i;
```

Before this PR, `EncodePlan` will cost `40.1s` on my machine.
This PR, `EncodePlan` only cost `0.95s` on my machine.

Another tiny optimization was in parser: https://github.com/pingcap/parser/pull/1072

### What is changed and how it works?

Use `map` to store the children of `memory.Tracker`.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- optimize for encoding huge plan.