### PR TITLE
executor: fix wrong default zero value for year type

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1487,7 +1487,7 @@ func (s *testSerialSuite) TestDuplicateEntryMessage(c *C) {
 func (s *testSerialSuite) TestIssue20768(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t1, t2")
 	tk.MustExec("create table t1(a year, primary key(a))")
 	tk.MustExec("insert ignore into t1 values(null)")
 	tk.MustExec("create table t2(a int, key(a))")

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1484,6 +1484,22 @@ func (s *testSerialSuite) TestDuplicateEntryMessage(c *C) {
 	}
 }
 
+func (s *testSerialSuite) TestIssue20768(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(a year, primary key(a))")
+	tk.MustExec("insert ignore into t1 values(null)")
+	tk.MustExec("create table t2(a int, key(a))")
+	tk.MustExec("insert into t2 values(0)")
+	tk.MustQuery("select /*+ hash_join(t1) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+	tk.MustQuery("select /*+ inl_join(t1) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+	tk.MustQuery("select /*+ inl_join(t2) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+	tk.MustQuery("select /*+ inl_hash_join(t1) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+	tk.MustQuery("select /*+ inl_merge_join(t1) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+	tk.MustQuery("select /*+ merge_join(t1) */ * from t1 join t2 on t1.a = t2.a").Check(testkit.Rows("0 0"))
+}
+
 func combination(items []string) func() []string {
 	current := 1
 	buf := make([]string, len(items))

--- a/table/column.go
+++ b/table/column.go
@@ -517,12 +517,14 @@ func getColDefaultValueFromNil(ctx sessionctx.Context, col *model.ColumnInfo) (t
 func GetZeroValue(col *model.ColumnInfo) types.Datum {
 	var d types.Datum
 	switch col.Tp {
-	case mysql.TypeTiny, mysql.TypeInt24, mysql.TypeShort, mysql.TypeLong, mysql.TypeLonglong, mysql.TypeYear:
+	case mysql.TypeTiny, mysql.TypeInt24, mysql.TypeShort, mysql.TypeLong, mysql.TypeLonglong:
 		if mysql.HasUnsignedFlag(col.Flag) {
 			d.SetUint64(0)
 		} else {
 			d.SetInt64(0)
 		}
+	case mysql.TypeYear:
+		d.SetInt64(0)
 	case mysql.TypeFloat:
 		d.SetFloat32(0)
 	case mysql.TypeDouble:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20768

### What is changed and how it works?

What's Changed: ignore unsigned flag for zero value of the year type

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- fix wrong default zero value for year type
