### PR TITLE
expression: fix ADD_DATE daylight saving time change

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6752,3 +6752,12 @@ func (s *testSerialSuite) TestIssue19148(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(int(tblInfo.Meta().Columns[0].Flag), Equals, 0)
 }
+
+func (s *testSuite) TestIssue19667(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (a DATETIME)")
+	tk.MustExec("INSERT INTO t VALUES('1988-04-17 01:59:59')")
+	tk.MustQuery(`SELECT DATE_ADD(a, INTERVAL 1 SECOND) FROM t`).Check(testkit.Rows("1988-04-17 02:00:00"))
+}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -2853,7 +2853,7 @@ func (du *baseDateArithmitical) add(ctx sessionctx.Context, date types.Time, int
 }
 
 func (du *baseDateArithmitical) addDate(ctx sessionctx.Context, date types.Time, year, month, day, nano int64) (types.Time, bool, error) {
-	goTime, err := date.GoTime(time.Local)
+	goTime, err := date.GoTime(time.UTC)
 	if err := handleInvalidTimeError(ctx, err); err != nil {
 		return types.ZeroTime, true, err
 	}

--- a/types/core_time.go
+++ b/types/core_time.go
@@ -251,7 +251,7 @@ func compareTime(a, b CoreTime) int {
 // When we execute select date_add('2018-01-31',interval 1 month) in mysql we got 2018-02-28
 // but in tidb we got 2018-03-03.
 // Dig it and we found it's caused by golang api time.Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time ,
-// it says October 32 converts to November 1 ,it conflits with mysql.
+// it says October 32 converts to November 1 ,it conflicts with mysql.
 // See https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_date-add
 func AddDate(year, month, day int64, ot gotime.Time) (nt gotime.Time) {
 	df := getFixDays(int(year), int(month), int(day), ot)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19667  <!-- REMOVE this line if no issue to close -->

Problem Summary: golang's time api considers daylight saving time for time arithematics, but time in UTC won't be affected. 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: change use of time.Locale to time.UTC.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
