### PR TITLE
expression, executor: allow insert strings with overflowed trailing spaces

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1509,7 +1509,7 @@ func (s *testSuite9) TestIssue10402(c *C) {
 	tk.MustExec("delete from vctt")
 	tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
 	tk.MustExec("insert into vctt values ('ab\\n\\n\\n', 'ab\\n\\n\\n'), ('ab\\t\\t\\t', 'ab\\t\\t\\t'), ('ab    ', 'ab    '), ('ab\\r\\r\\r', 'ab\\r\\r\\r')")
-	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, 4)
+	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(4))
 	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\n\n ab\n\n", "ab\t\t ab\t\t", "ab   ab", "ab\r\r ab\r\r"))
 	tk.MustQuery("select length(v), length(c) from vctt").Check(testkit.Rows("4 4", "4 4", "4 2", "4 4"))
 }

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1510,6 +1510,8 @@ func (s *testSuite9) TestIssue10402(c *C) {
 	tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
 	tk.MustExec("insert into vctt values ('ab\\n\\n\\n', 'ab\\n\\n\\n'), ('ab\\t\\t\\t', 'ab\\t\\t\\t'), ('ab    ', 'ab    '), ('ab\\r\\r\\r', 'ab\\r\\r\\r')")
 	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, uint16(4))
+	warns := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+	c.Check(fmt.Sprintf("%v", warns), Equals, "[{Warning [types:1265]Data truncated, field len 4, data len 5} {Warning [types:1265]Data truncated, field len 4, data len 5} {Warning [types:1265]Data truncated, field len 4, data len 6} {Warning [types:1265]Data truncated, field len 4, data len 5}]")
 	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\n\n ab\n\n", "ab\t\t ab\t\t", "ab   ab", "ab\r\r ab\r\r"))
 	tk.MustQuery("select length(v), length(c) from vctt").Check(testkit.Rows("4 4", "4 4", "4 2", "4 4"))
 }

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1505,7 +1505,7 @@ func (s *testSuite9) TestIssue10402(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("create table vctt (v varchar(4), c char(4))")
 	tk.MustExec("insert into vctt values ('ab  ', 'ab   ')")
-	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab ab"))
+	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab   ab"))
 	tk.MustExec("delete from vctt")
 	tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
 	tk.MustExec("insert into vctt values ('ab\\n\\n\\n', 'ab\\n\\n\\n'), ('ab\\t\\t\\t', 'ab\\t\\t\\t'), ('ab    ', 'ab    '), ('ab\\r\\r\\r', 'ab\\r\\r\\r')")

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1510,7 +1510,7 @@ func (s *testSuite9) TestIssue10402(c *C) {
 	tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
 	tk.MustExec("insert into vctt values ('ab\\n\\n\\n', 'ab\\n\\n\\n'), ('ab\\t\\t\\t', 'ab\\t\\t\\t'), ('ab    ', 'ab    '), ('ab\\r\\r\\r', 'ab\\r\\r\\r')")
 	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, 4)
-	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\n\n ab\n\n", "ab\t\t ab\t\t", "ab ab", "ab\r\r ab\r\r"))
+	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\n\n ab\n\n", "ab\t\t ab\t\t", "ab   ab", "ab\r\r ab\r\r"))
 	tk.MustQuery("select length(v), length(c) from vctt").Check(testkit.Rows("4 4", "4 4", "4 2", "4 4"))
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1508,10 +1508,10 @@ func (s *testSuite9) TestIssue10402(c *C) {
 	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab ab"))
 	tk.MustExec("delete from vctt")
 	tk.Se.GetSessionVars().StmtCtx.SetWarnings(nil)
-	tk.MustExec("insert into vctt values ('ab\t\t\t', 'ab   ')")
-	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, 1)
-	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\t\t ab"))
-	tk.MustQuery("select length(v), length(c) from vctt").Check(testkit.Rows("4 2"))
+	tk.MustExec("insert into vctt values ('ab\\n\\n\\n', 'ab\\n\\n\\n'), ('ab\\t\\t\\t', 'ab\\t\\t\\t'), ('ab    ', 'ab    '), ('ab\\r\\r\\r', 'ab\\r\\r\\r')")
+	c.Check(tk.Se.GetSessionVars().StmtCtx.WarningCount(), Equals, 4)
+	tk.MustQuery("select * from vctt").Check(testkit.Rows("ab\n\n ab\n\n", "ab\t\t ab\t\t", "ab ab", "ab\r\r ab\r\r"))
+	tk.MustQuery("select length(v), length(c) from vctt").Check(testkit.Rows("4 4", "4 4", "4 2", "4 4"))
 }
 
 func combination(items []string) func() []string {

--- a/types/datum.go
+++ b/types/datum.go
@@ -985,12 +985,12 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementCon
 
 		if len(overflowed) != 0 {
 			trimed := strings.TrimRight(overflowed, " \t\n\r")
-			if len(trimed) != 0 {
-				err = ErrDataTooLong.GenWithStack("Data Too Long, field len %d, data len %d", flen, characterLen)
-			} else {
+			if len(trimed) == 0 && (tp.Tp == mysql.TypeVarchar || tp.Tp == mysql.TypeString) {
 				if tp.Tp == mysql.TypeVarchar {
 					sc.AppendWarning(ErrTruncated.GenWithStack("Data truncated, field len %d, data len %d", flen, characterLen))
 				}
+			} else {
+				err = ErrDataTooLong.GenWithStack("Data Too Long, field len %d, data len %d", flen, characterLen)
 			}
 		}
 

--- a/types/datum.go
+++ b/types/datum.go
@@ -952,6 +952,8 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementContext, padZero bool) (_ string, err error) {
 	flen, chs := tp.Flen, tp.Charset
 	if flen >= 0 {
+		// overflowed stores the part of the string that is out of the length contraint, it is later checked to see if the
+		// overflowed part is all whitespaces
 		var overflowed string
 		var characterLen int
 		// Flen is the rune length, not binary length, for UTF8 charset, we need to calculate the

--- a/types/datum.go
+++ b/types/datum.go
@@ -985,7 +985,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementCon
 
 		if len(overflowed) != 0 {
 			trimed := strings.TrimRight(overflowed, " \t\n\r")
-			if len(trimed) == 0 && ((tp.Tp == mysql.TypeVarchar && !IsBinaryStr(tp)) || (tp.Tp == mysql.TypeString && !IsBinaryStr(tp))) {
+			if len(trimed) == 0 && !IsBinaryStr (tp) && IsTypeChar(tp.Tp) {
 				if tp.Tp == mysql.TypeVarchar {
 					sc.AppendWarning(ErrTruncated.GenWithStack("Data truncated, field len %d, data len %d", flen, characterLen))
 				}

--- a/types/datum.go
+++ b/types/datum.go
@@ -985,7 +985,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementCon
 
 		if len(overflowed) != 0 {
 			trimed := strings.TrimRight(overflowed, " \t\n\r")
-			if len(trimed) == 0 && !IsBinaryStr (tp) && IsTypeChar(tp.Tp) {
+			if len(trimed) == 0 && !IsBinaryStr(tp) && IsTypeChar(tp.Tp) {
 				if tp.Tp == mysql.TypeVarchar {
 					sc.AppendWarning(ErrTruncated.GenWithStack("Data truncated, field len %d, data len %d", flen, characterLen))
 				}

--- a/types/datum.go
+++ b/types/datum.go
@@ -985,7 +985,7 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementCon
 
 		if len(overflowed) != 0 {
 			trimed := strings.TrimRight(overflowed, " \t\n\r")
-			if len(trimed) == 0 && (tp.Tp == mysql.TypeVarchar || tp.Tp == mysql.TypeString) {
+			if len(trimed) == 0 && ((tp.Tp == mysql.TypeVarchar && !IsBinaryStr(tp)) || (tp.Tp == mysql.TypeString && !IsBinaryStr(tp))) {
 				if tp.Tp == mysql.TypeVarchar {
 					sc.AppendWarning(ErrTruncated.GenWithStack("Data truncated, field len %d, data len %d", flen, characterLen))
 				}

--- a/types/datum.go
+++ b/types/datum.go
@@ -952,10 +952,12 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementContext, padZero bool) (_ string, err error) {
 	flen, chs := tp.Flen, tp.Charset
 	if flen >= 0 {
+		var overflowed string
+		var characterLen int
 		// Flen is the rune length, not binary length, for UTF8 charset, we need to calculate the
 		// rune count and truncate to Flen runes if it is too long.
 		if chs == charset.CharsetUTF8 || chs == charset.CharsetUTF8MB4 {
-			characterLen := utf8.RuneCountInString(s)
+			characterLen = utf8.RuneCountInString(s)
 			if characterLen > flen {
 				// 1. If len(s) is 0 and flen is 0, truncateLen will be 0, don't truncate s.
 				//    CREATE TABLE t (a char(0));
@@ -972,13 +974,27 @@ func ProduceStrWithSpecifiedTp(s string, tp *FieldType, sc *stmtctx.StatementCon
 					}
 					runeCount++
 				}
-				err = ErrDataTooLong.GenWithStack("Data Too Long, field len %d, data len %d", flen, characterLen)
+				overflowed = s[truncateLen:]
 				s = truncateStr(s, truncateLen)
 			}
 		} else if len(s) > flen {
-			err = ErrDataTooLong.GenWithStack("Data Too Long, field len %d, data len %d", flen, len(s))
+			characterLen = len(s)
+			overflowed = s[flen:]
 			s = truncateStr(s, flen)
-		} else if tp.Tp == mysql.TypeString && IsBinaryStr(tp) && len(s) < flen && padZero {
+		}
+
+		if len(overflowed) != 0 {
+			trimed := strings.TrimRight(overflowed, " \t\n\r")
+			if len(trimed) != 0 {
+				err = ErrDataTooLong.GenWithStack("Data Too Long, field len %d, data len %d", flen, characterLen)
+			} else {
+				if tp.Tp == mysql.TypeVarchar {
+					sc.AppendWarning(ErrTruncated.GenWithStack("Data truncated, field len %d, data len %d", flen, characterLen))
+				}
+			}
+		}
+
+		if tp.Tp == mysql.TypeString && IsBinaryStr(tp) && len(s) < flen && padZero {
 			padding := make([]byte, flen-len(s))
 			s = string(append([]byte(s), padding...))
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #10392 <!-- REMOVE this line if no issue to close -->

Problem Summary:

For now, TiDB will complain with error if string inserted are longer than `varchar` or `char`'s lenght constraint with trailing spaces, however, as in MySQL's doc

> For VARCHAR columns, trailing spaces in excess of the column length are truncated prior to insertion and a warning is generated, regardless of the SQL mode in use. For CHAR columns, truncation of excess trailing spaces from inserted values is performed silently regardless of the SQL mode.

https://dev.mysql.com/doc/refman/8.0/en/char.html

### What is changed and how it works?

Make overflowed trailing spaces trimed, and report warning for `varchar`.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch 4.0, 3.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
