### PR TITLE
kv: release memory cache if it is too large

### DIFF
--- a/kv/cachedb.go
+++ b/kv/cachedb.go
@@ -41,13 +41,13 @@ func (c *cachedb) Set(tableID int64, key Key, value []byte) error {
 		table = newMemDB()
 		c.memTables[tableID] = table
 	}
-
 	err := table.Set(key, value)
-	if err != nil {
-		return err
+	if ErrTxnTooLarge.Equal(err) {
+		// If it reaches the upper limit, refresh a new memory buffer.
+		c.memTables[tableID] = newMemDB()
+		return nil
 	}
-
-	return nil
+	return err
 }
 
 // Get gets value from memory
@@ -58,9 +58,7 @@ func (c *cachedb) Get(ctx context.Context, tableID int64, key Key) []byte {
 		if val, err := table.Get(ctx, key); err == nil {
 			return val
 		}
-		return nil
 	}
-
 	return nil
 }
 

--- a/kv/cachedb.go
+++ b/kv/cachedb.go
@@ -42,7 +42,7 @@ func (c *cachedb) Set(tableID int64, key Key, value []byte) error {
 		c.memTables[tableID] = table
 	}
 	err := table.Set(key, value)
-	if ErrTxnTooLarge.Equal(err) {
+	if err != nil && ErrTxnTooLarge.Equal(err) {
 		// If it reaches the upper limit, refresh a new memory buffer.
 		c.memTables[tableID] = newMemDB()
 		return nil


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

When keeping on set data in memory cache, it will reach the upper limit of membuffer.

```
[2020/11/12 14:34:46.000 +08:00] [INFO] [conn.go:801] ["command dispatched failed"] [conn=4910396939415061305] [connInfo="id:4910396939415061305, addr:172.16.5.31:44610 status:10, collation:latin1_swedish_ci, user:root"] [command=Execute] [status="inTxn:0, autocommit:1"] [sql="SELECT c FROM sbtest1 WHERE id=? [arguments: 716572]"] [txn_mode=PESSIMISTIC] [err="[kv:8004]Transaction is too large, size: 104858064\ngithub.com/pingcap/errors.AddStack\n\t/home/yusp/work/goprojects/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20201029093017-5a7df2af2ac7/errors.go:174\ngithub.com/pingcap/errors.(*Error).GenWithStackByArgs\n\t/home/yusp/work/goprojects/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20201029093017-5a7df2af2ac7/normalize.go:156\ngithub.com/pingcap/tidb/kv.(*memdb).set\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/kv/memdb.go:394\ngithub.com/pingcap/tidb/kv.(*memdb).Set\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/kv/memdb.go:314\ngithub.com/pingcap/tidb/kv.(*cachedb).Set\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/kv/cachedb.go:45\ngithub.com/pingcap/tidb/executor.(*PointGetExecutor).get\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/point_get.go:360\ngithub.com/pingcap/tidb/executor.(*PointGetExecutor).getAndLock\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/point_get.go:281\ngithub.com/pingcap/tidb/executor.(*PointGetExecutor).Next\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/point_get.go:236\ngithub.com/pingcap/tidb/executor.Next\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/executor.go:268\ngithub.com/pingcap/tidb/executor.(*recordSet).Next\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/executor/adapter.go:128\ngithub.com/pingcap/tidb/server.(*tidbResultSet).Next\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/driver_tidb.go:284\ngithub.com/pingcap/tidb/server.(*clientConn).writeChunks\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/conn.go:1706\ngithub.com/pingcap/tidb/server.(*clientConn).writeResultset\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/conn.go:1666\ngithub.com/pingcap/tidb/server.(*clientConn).handleStmtExecute\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/conn_stmt.go:213\ngithub.com/pingcap/tidb/server.(*clientConn).dispatch\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/conn.go:1026\ngithub.com/pingcap/tidb/server.(*clientConn).Run\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/conn.go:784\ngithub.com/pingcap/tidb/server.(*Server).onConn\n\t/home/yusp/work/goprojects/src/github.com/pingcap/tidb/server/server.go:459\nruntime.goexit\n\t/home/yusp/go/src/runtime/asm_amd64.s:1374\nSELECT c FROM sbtest1 WHERE id=? [arguments: 716572]"]
```
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Release the cached table when it is too large.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

* lock sysbench tables.
* run sysbench point select for a long time on large tables, it will not return the above error.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
