### PR TITLE
executor: fix the display of large unsigned handle when show table regions

### DIFF
--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -16,6 +16,7 @@ package executor_test
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
@@ -1008,6 +1009,28 @@ func (s *testAutoRandomSuite) TestAutoRandomBase(c *C) {
 			"  UNIQUE KEY `b` (`b`)\n"+
 			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=5100 /*T![auto_rand_base] AUTO_RANDOM_BASE=6001 */",
 	))
+}
+
+func (s *testSerialSuite) TestAutoRandomWithLargeSignedShowTableRegions(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("create database if not exists auto_random_db;")
+	defer tk.MustExec("drop database if exists auto_random_db;")
+	tk.MustExec("use auto_random_db;")
+	tk.MustExec("drop table if exists t;")
+
+
+	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
+	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
+	tk.MustExec("create table t (a bigint unsigned auto_random primary key);")
+	tk.MustExec("set @@global.tidb_scatter_region=1;")
+	// 18446744073709541615 is MaxUint64 - 10000.
+	// 18446744073709551615 is the MaxUint64.
+	tk.MustQuery("split table t between (18446744073709541615) and (18446744073709551615) regions 2;").
+		Check(testkit.Rows("1 1"))
+	startKey := tk.MustQuery("show table t regions;").Rows()[1][1].(string)
+	idx := strings.Index(startKey, "_r_")
+	c.Assert(idx == -1, IsFalse)
+	c.Assert(startKey[idx+3] == '-', IsFalse, Commentf("actual key: %s", startKey))
 }
 
 func (s *testSuite5) TestShowEscape(c *C) {

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -1018,7 +1018,6 @@ func (s *testSerialSuite) TestAutoRandomWithLargeSignedShowTableRegions(c *C) {
 	tk.MustExec("use auto_random_db;")
 	tk.MustExec("drop table if exists t;")
 
-
 	testutil.ConfigTestUtils.SetupAutoRandomTestConfig()
 	defer testutil.ConfigTestUtils.RestoreAutoRandomTestConfig()
 	tk.MustExec("create table t (a bigint unsigned auto_random primary key);")


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #21025 <!-- REMOVE this line if no issue to close -->

Problem Summary: In the decode stage of `show table regions`, the handles is always decoded to signed integers. This may cause it returns a negative number on a table with unsigned integer column as the primary key. 

### What is changed and how it works?

What's Changed: Consider the column unsigned flag to decode it correctly.

How it Works: Omitted.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the incorrect display of large unsigned handle when `show table regions`.
