### PR TITLE
expression: adjust int constant when compare with year type

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7022,4 +7022,9 @@ func (s *testSuite) TestIssue20305(c *C) {
 	tk.MustExec("create table t2 (a year(4))")
 	tk.MustExec("insert into t2 values(69)")
 	tk.MustQuery("select * from t2 where a <= 69").Check(testkit.Rows("2069"))
+	// the following test is a regression test that matches MySQL's behavior.
+	tk.MustExec("drop table if exists t3")
+	tk.MustExec("CREATE TABLE `t3` (`y` year DEFAULT NULL, `a` int DEFAULT NULL)")
+	tk.MustExec("INSERT INTO `t3` VALUES (2069, 70), (2010, 11), (2155, 2156), (2069, 69)")
+	tk.MustQuery("SELECT * FROM `t3` where y <= a").Check(testkit.Rows("2155 2156"))
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7013,5 +7013,13 @@ func (s *testSuite) TestIssue20975SelectForUpdateBatchPointGetWithPartitionTable
 	tk1.MustExec("select * from t1 where id in (1, 11) for update")
 	tk2.MustExec("drop table t2")
 	tk1.MustExec("commit")
+}
 
+func (s *testSuite) TestIssue20305(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t2 (a year(4))")
+	tk.MustExec("insert into t2 values(69)")
+	tk.MustQuery("select * from t2 where a <= 69").Check(testkit.Rows("2069"))
 }

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -14,7 +14,6 @@
 package expression
 
 import (
-	"fmt"
 	"math"
 
 	"github.com/pingcap/parser/ast"
@@ -1427,12 +1426,6 @@ func (c *compareFunctionClass) refineArgsByUnsignedFlag(ctx sessionctx.Context, 
 
 // getFunction sets compare built-in function signatures for various types.
 func (c *compareFunctionClass) getFunction(ctx sessionctx.Context, rawArgs []Expression) (sig builtinFunc, err error) {
-	arg1Col, isArg1Col := rawArgs[0].(*Column)
-	fmt.Println(arg1Col.OrigName)
-	if isArg1Col && arg1Col.OrigName == "test.t2.a" {
-		fmt.Printf("mysql fuck you!")
-	}
-
 	if err = c.verifyArgs(rawArgs); err != nil {
 		return nil, err
 	}

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1328,7 +1328,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	}
 	// int constant [cmp] year type
 	if arg0IsCon && arg0IsInt && arg1Type.Tp == mysql.TypeYear {
-		adjusted, failed := types.AdjustYear(arg0.Value.GetInt64(), true)
+		adjusted, failed := types.AdjustYear(arg0.Value.GetInt64(), false)
 		if failed == nil {
 			arg0.Value.SetInt64(adjusted)
 			finalArg0 = arg0
@@ -1336,7 +1336,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	}
 	// year type [cmp] int constant
 	if arg1IsCon && arg1IsInt && arg0Type.Tp == mysql.TypeYear {
-		adjusted, failed := types.AdjustYear(arg1.Value.GetInt64(), true)
+		adjusted, failed := types.AdjustYear(arg1.Value.GetInt64(), false)
 		if failed == nil {
 			arg1.Value.SetInt64(adjusted)
 			finalArg1 = arg1

--- a/types/time.go
+++ b/types/time.go
@@ -1224,8 +1224,8 @@ func adjustYear(y int) int {
 }
 
 // AdjustYear is used for adjusting year and checking its validation.
-func AdjustYear(y int64, shouldAdjust bool) (int64, error) {
-	if y == 0 && !shouldAdjust {
+func AdjustYear(y int64, adjustZero bool) (int64, error) {
+	if y == 0 && !adjustZero {
 		return y, nil
 	}
 	y = int64(adjustYear(int(y)))

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1343,6 +1343,7 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 	testKit.MustExec("INSERT INTO t VALUES (1), (70), (99), (0), ('0')")
 	testKit.MustQuery("SELECT * FROM t WHERE a < 15698").Check(testkit.Rows("0", "1970", "1999", "2000", "2001"))
 	testKit.MustQuery("SELECT * FROM t WHERE a <= 0").Check(testkit.Rows("0"))
+	testKit.MustQuery("SELECT * FROM t WHERE a <= 1").Check(testkit.Rows("0", "1970", "1999", "2000", "2001"))
 	testKit.MustQuery("SELECT * FROM t WHERE a < 2000").Check(testkit.Rows("0", "1970", "1999"))
 	testKit.MustQuery("SELECT * FROM t WHERE a > -1").Check(testkit.Rows("0", "1970", "1999", "2000", "2001"))
 

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1371,7 +1371,7 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     `a not in (1, 2, 70)`,
-			accessConds: "[not(in(test.t.a, 1, 2, 70))]",  // this is in accordance with MySQL, MySQL won't interpret 70 here as 1970
+			accessConds: "[not(in(test.t.a, 1, 2, 70))]", // this is in accordance with MySQL, MySQL won't interpret 70 here as 1970
 			filterConds: "[]",
 			resultStr:   `[(NULL,1970) (1970,2001) (2002,+inf]]`,
 		},

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1425,7 +1425,7 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		},
 		{
 			exprStr:     "a >= 70 and a <= 69",
-			accessConds: "[ge(test.t.a, 1970) le(test.t.a, 1969)]",
+			accessConds: "[ge(test.t.a, 1970) le(test.t.a, 2069)]",
 			filterConds: "[]",
 			resultStr:   "[[1970,2069]]",
 		},

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1371,14 +1371,14 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     `a not in (1, 2, 70)`,
-			accessConds: "[not(in(test.t.a, 1, 2, 70))]",
+			accessConds: "[not(in(test.t.a, 1, 2, 70))]",  // this is in accordance with MySQL, MySQL won't interpret 70 here as 1970
 			filterConds: "[]",
 			resultStr:   `[(NULL,1970) (1970,2001) (2002,+inf]]`,
 		},
 		{
 			indexPos:    0,
 			exprStr:     `a not in (99)`,
-			accessConds: "[ne(test.t.a, 99)]",
+			accessConds: "[ne(test.t.a, 1999)]", // this is in accordance with MySQL
 			filterConds: "[]",
 			resultStr:   `[[-inf,1999) (1999,+inf]]`,
 		},
@@ -1406,7 +1406,7 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		{
 			indexPos:    0,
 			exprStr:     `a != 1`,
-			accessConds: "[ne(test.t.a, 1)]",
+			accessConds: "[ne(test.t.a, 2001)]",
 			filterConds: "[]",
 			resultStr:   `[[-inf,2001) (2001,+inf]]`,
 		},
@@ -1419,13 +1419,13 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		},
 		{
 			exprStr:     "a < 99 or a > 01",
-			accessConds: "[or(lt(test.t.a, 99), gt(test.t.a, 1))]",
+			accessConds: "[or(lt(test.t.a, 1999), gt(test.t.a, 2001))]",
 			filterConds: "[]",
 			resultStr:   "[[-inf,1999) (2001,+inf]]",
 		},
 		{
 			exprStr:     "a >= 70 and a <= 69",
-			accessConds: "[ge(test.t.a, 70) le(test.t.a, 69)]",
+			accessConds: "[ge(test.t.a, 1970) le(test.t.a, 1969)]",
 			filterConds: "[]",
 			resultStr:   "[[1970,2069]]",
 		},

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1377,6 +1377,13 @@ func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 		},
 		{
 			indexPos:    0,
+			exprStr:     `a = 1 or a = 2 or a = 70`,
+			accessConds: "[or(eq(test.t.a, 2001), or(eq(test.t.a, 2002), eq(test.t.a, 1970)))]", // this is in accordance with MySQL, MySQL won't interpret 70 here as 1970
+			filterConds: "[]",
+			resultStr:   `[[1970,1970] [2001,2002]]`,
+		},
+		{
+			indexPos:    0,
 			exprStr:     `a not in (99)`,
 			accessConds: "[ne(test.t.a, 1999)]", // this is in accordance with MySQL
 			filterConds: "[]",


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20305 <!-- REMOVE this line if no issue to close -->

Problem Summary: when we compare int with year type, and the int could be interpret as year, it should be adjusted.

Note, this change does not work when int is stored as a column, because MySQL does not support this as well.

```
CREATE TABLE `t3` (`y` year DEFAULT NULL, `a` int DEFAULT NULL);
INSERT INTO `t3` VALUES (2069, 70), (2010, 11), (2155, 2156), (2069, 69);
SELECT * FROM `t3` where y <= a;
```

MySQL produces

```
mysql> SELECT * FROM `t3` where y <= a;
+------+------+
| y    | a    |
+------+------+
| 2155 | 2156 |
+------+------+
```

### What is changed and how it works?

What's Changed: add adjust in args refinement.

### Related changes

- Need to cherry-pick to the release branch 4.0, 3.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
