### PR TITLE
[DNM] expression, planner: Optimize CBO to choose point get for some case

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1116,6 +1116,18 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 			} else {
 				cmpType = types.ETDatetime
 			}
+		} else if cmpType == types.ETReal && ((lhsEvalType == types.ETString && !isLHSConst && rhsEvalType == types.ETInt && isRHSConst) ||
+			(lhsEvalType == types.ETInt && isLHSConst && rhsEvalType == types.ETString && !isRHSConst)) {
+			/*
+				cmpType is ETReal and
+
+				<non-const string expression> <cmp> <const int expression>
+				or
+				<const int expression> <cmp> <non-const string expression>
+
+				Do comparison as string rather than real
+			*/
+			cmpType = types.ETString
 		}
 	}
 	return cmpType

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -44,7 +44,7 @@
       "*core.Explain",
       "*core.Explain",
       "TableReader(Table(t))->Insert",
-      "Show->Sel([eq(Column#4, 0)])->Projection",
+      "Show->Sel([eq(cast(Column#4, double BINARY), 0)])->Projection",
       "Dual->Projection",
       "Dual->Projection",
       "Dual->Projection",

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -44,7 +44,7 @@
       "*core.Explain",
       "*core.Explain",
       "TableReader(Table(t))->Insert",
-      "Show->Sel([eq(cast(Column#4, double BINARY), 0)])->Projection",
+      "Show->Sel([eq(Column#4, 0)])->Projection",
       "Dual->Projection",
       "Dual->Projection",
       "Dual->Projection",


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20756

### What is changed and how it works?

What's Changed:

If the expression match `string type columnName` eq `int constant`, and int constant is not 0, we can convert compare type from Real to String

### Related changes

- No

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- expression, planner: optimize CBO to choose point get for some case.