### PR TITLE
server: make dump binary time more compatible with MySQL

### DIFF
--- a/server/util.go
+++ b/server/util.go
@@ -199,12 +199,24 @@ func dumpBinaryDateTime(data []byte, t types.Time) []byte {
 	switch t.Type() {
 	case mysql.TypeTimestamp, mysql.TypeDatetime:
 		if t.IsZero() {
+			// All zero.
 			data = append(data, 0)
-		} else {
+		} else if t.Microsecond() != 0 {
+			// Has micro seconds.
 			data = append(data, 11)
 			data = dumpUint16(data, uint16(year))
 			data = append(data, byte(mon), byte(day), byte(t.Hour()), byte(t.Minute()), byte(t.Second()))
 			data = dumpUint32(data, uint32(t.Microsecond()))
+		} else if t.Hour() != 0 || t.Minute() != 0 || t.Second() != 0 {
+			// Has HH:MM:SS
+			data = append(data, 7)
+			data = dumpUint16(data, uint16(year))
+			data = append(data, byte(mon), byte(day), byte(t.Hour()), byte(t.Minute()), byte(t.Second()))
+		} else {
+			// Only YY:MM:DD
+			data = append(data, 4)
+			data = dumpUint16(data, uint16(year))
+			data = append(data, byte(mon), byte(day))
 		}
 	case mysql.TypeDate:
 		if t.IsZero() {

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -85,7 +85,7 @@ func (s *testUtilSuite) TestDumpBinaryTime(c *C) {
 	c.Assert(err, IsNil)
 	d = dumpBinaryDateTime(nil, t)
 	// 201 & 7 composed to uint16 1993 (litter-endian)
-	c.Assert(d, DeepEquals, []byte{11, 201, 7, 7, 13, 1, 1, 1, 0, 0, 0, 0})
+	c.Assert(d, DeepEquals, []byte{7, 201, 7, 7, 13, 1, 1, 1})
 
 	t, err = types.ParseDate(nil, "0000-00-00")
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
Dumping binary time is not compatible with MySQL with short values, e.g. 2020-11-19. MySQL will only dump 4 bytes.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Adjust the length with the time value.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
https://github.com/pingcap/tidb-test/pull/1106

### Release note <!-- bugfixes or new feature need a release note -->

- Make dump binary time more compatible with MySQL
