### PR TITLE
util: fix wrong calculation to get memory usage.

### DIFF
--- a/util/memory/meminfo.go
+++ b/util/memory/meminfo.go
@@ -14,6 +14,7 @@
 package memory
 
 import (
+	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"
@@ -36,7 +37,7 @@ func MemTotalNormal() (uint64, error) {
 // MemUsedNormal returns the total used amount of RAM on this system in non-container environment.
 func MemUsedNormal() (uint64, error) {
 	v, err := mem.VirtualMemory()
-	return v.Total - (v.Free + v.Buffers + v.Cached), err
+	return v.Used, err
 }
 
 const (

--- a/util/memory/meminfo.go
+++ b/util/memory/meminfo.go
@@ -14,7 +14,6 @@
 package memory
 
 import (
-	"fmt"
 	"io/ioutil"
 	"strconv"
 	"strings"


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: 
On MacOs, the calculation ignore inactive memory. It will make memory-alarm trigger unexpected.


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Use `mem.Used` directly.
On MacOs,  it should consider inactive memory.
```
ret.Available = ret.Free + ret.Inactive
ret.Used = ret.Total - ret.Available
```
On Linux, I read the source code. `ret.Used = ret.Total - ret.Free - ret.Buffers - ret.Cached`. So the result is same with old.

How it Works:

### Related changes

Need cherry-pick to 3.0,4.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
