### PR TITLE
expression: fix inaccurate error info for year column out of range (#20169)

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -2968,7 +2968,7 @@ func (s *testDBSuite5) TestAddIndexForGeneratedColumn(c *C) {
 	s.tk.MustExec("insert into t values()")
 	s.tk.MustExec("ALTER TABLE t ADD COLUMN y1 year as (y + 2)")
 	_, err := s.tk.Exec("ALTER TABLE t ADD INDEX idx_y(y1)")
-	c.Assert(err.Error(), Equals, "[ddl:15]cannot decode index value, because cannot convert datum from unsigned bigint to type year.")
+	c.Assert(err.Error(), Equals, "[ddl:15]cannot decode index value, because [types:1690]DECIMAL value is out of range in '(4, 0)'")
 
 	t := s.testGetTable(c, "t")
 	for _, idx := range t.Indices() {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -208,6 +208,11 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t1(a bigint);`)
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
+
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1 (a year);`)
+	_, err = tk.Exec(`insert into t1 values(2156);`)
+	c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -208,11 +208,6 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t1(a bigint);`)
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
-
-	tk.MustExec(`drop table if exists t1;`)
-	tk.MustExec(`create table t1 (a year);`)
-	_, err = tk.Exec(`insert into t1 values(2156);`)
-	// c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -209,9 +209,9 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
 
-	tk.MustExec(`drop table if exists t;`)
-	tk.MustExec(`create table t (a year);`)
-	_, err = tk.Exec(`insert into t values(2156);`)
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1 (a year);`)
+	_, err = tk.Exec(`insert into t1 values(2156);`)
 	c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -209,9 +209,9 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
 
-	// tk.MustExec(`drop table if exists t1;`)
-	// tk.MustExec(`create table t1 (a year);`)
-	// _, err = tk.Exec(`insert into t1 values(2156);`)
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1 (a year);`)
+	_, err = tk.Exec(`insert into t1 values(2156);`)
 	// c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -209,10 +209,10 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
 
-	tk.MustExec(`drop table if exists t1;`)
-	tk.MustExec(`create table t1 (a year);`)
-	_, err = tk.Exec(`insert into t1 values(2156);`)
-	c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
+	// tk.MustExec(`drop table if exists t1;`)
+	// tk.MustExec(`create table t1 (a year);`)
+	// _, err = tk.Exec(`insert into t1 values(2156);`)
+	// c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -208,6 +208,11 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t1(a bigint);`)
 	_, err := tk.Exec(`insert into t1 values("asfasdfsajhlkhlksdaf");`)
 	c.Assert(terror.ErrorEqual(err, table.ErrTruncatedWrongValueForField), IsTrue)
+
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`create table t (a year);`)
+	_, err = tk.Exec(`insert into t values(2156);`)
+	c.Assert(err.Error(), Equals, `[types:1264]Out of range value for column 'a' at row 1`)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1459,7 +1459,7 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("drop table t")
 	tk.MustExec("CREATE TABLE `t` (	`c1` year DEFAULT NULL, `c2` year DEFAULT NULL, `c3` date DEFAULT NULL, `c4` datetime DEFAULT NULL,	KEY `idx` (`c1`,`c2`))")
 	_, err = tk.Exec("UPDATE t SET c2=16777215 WHERE c1>= -8388608 AND c1 < -9 ORDER BY c1 LIMIT 2")
-	c.Assert(err.Error(), Equals, "cannot convert datum from bigint to type year.")
+	c.Assert(err.Error(), Equals, "[types:1690]DECIMAL value is out of range in '(4, 0)'")
 
 	tk.MustExec("update (select * from t) t set c1 = 1111111")
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1459,7 +1459,8 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("drop table t")
 	tk.MustExec("CREATE TABLE `t` (	`c1` year DEFAULT NULL, `c2` year DEFAULT NULL, `c3` date DEFAULT NULL, `c4` datetime DEFAULT NULL,	KEY `idx` (`c1`,`c2`))")
 	_, err = tk.Exec("UPDATE t SET c2=16777215 WHERE c1>= -8388608 AND c1 < -9 ORDER BY c1 LIMIT 2")
-	c.Assert(err.Error(), Equals, "[types:1690]DECIMAL value is out of range in '(4, 0)'")
+	c.Assert(err.Error(), Equals, "cannot convert datum from bigint to type year.")
+	// c.Assert(err.Error(), Equals, "[types:1690]DECIMAL value is out of range in '(4, 0)'")
 
 	tk.MustExec("update (select * from t) t set c1 = 1111111")
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1459,8 +1459,7 @@ func (s *testSuite) TestUpdate(c *C) {
 	tk.MustExec("drop table t")
 	tk.MustExec("CREATE TABLE `t` (	`c1` year DEFAULT NULL, `c2` year DEFAULT NULL, `c3` date DEFAULT NULL, `c4` datetime DEFAULT NULL,	KEY `idx` (`c1`,`c2`))")
 	_, err = tk.Exec("UPDATE t SET c2=16777215 WHERE c1>= -8388608 AND c1 < -9 ORDER BY c1 LIMIT 2")
-	c.Assert(err.Error(), Equals, "cannot convert datum from bigint to type year.")
-	// c.Assert(err.Error(), Equals, "[types:1690]DECIMAL value is out of range in '(4, 0)'")
+	c.Assert(err.Error(), Equals, "[types:1690]DECIMAL value is out of range in '(4, 0)'")
 
 	tk.MustExec("update (select * from t) t set c1 = 1111111")
 

--- a/types/datum.go
+++ b/types/datum.go
@@ -1266,7 +1266,7 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	}
 	y, err = AdjustYear(y, adjust)
 	if err != nil {
-		_, err = invalidConv(d, target.Tp)
+		err = ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
 	}
 	ret.SetInt64(y)
 	return ret, err

--- a/types/datum.go
+++ b/types/datum.go
@@ -1266,7 +1266,8 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	}
 	y, err = AdjustYear(y, adjust)
 	if err != nil {
-		err = ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
+		_, err = invalidConv(d, target.Tp)
+		// err = ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
 	}
 	ret.SetInt64(y)
 	return ret, err

--- a/types/datum.go
+++ b/types/datum.go
@@ -1266,8 +1266,7 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 	}
 	y, err = AdjustYear(y, adjust)
 	if err != nil {
-		_, err = invalidConv(d, target.Tp)
-		// err = ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
+		err = ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%d, %d)", target.Flen, target.Decimal))
 	}
 	ret.SetInt64(y)
 	return ret, err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #18792

Problem Summary: Inaccurate error info for year column out of range.

### What is changed and how it works?

What's Changed:
Modified return error type as overflow.

### Related changes

- PR: #20169

### Check List

Tests

- Unit test
- Manual test
```
tidb> create table t (a year)
tidb> insert into t values(2156)
ERROR 1264 (22003): Out of range value for column 'a' at row 1
```

### Release note

- Fix inaccurate error info for year column out of range.