### PR TITLE
table: fix insert value into hash partition table which not int

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -2957,3 +2957,18 @@ func (s *testIntegrationSuite7) TestAddPartitionForTableWithWrongType(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(ddl.ErrWrongTypeColumnValue.Equal(err), IsTrue)
 }
+
+func (s *testIntegrationSuite7) TestInsertIntoPartitionTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop tables if exists t")
+	tk.MustExec(`CREATE TABLE t(
+	a bit(1) DEFAULT NULL,
+	b int(11) DEFAULT NULL
+	) PARTITION BY HASH(a)
+	PARTITIONS 3`)
+	tk.MustExec("INSERT INTO t VALUES(0, 0)")
+	tk.MustExec("INSERT INTO t VALUES(1, 1)")
+	result := tk.MustQuery("SELECT * FROM t WHERE a = 1")
+	result.Check(testkit.Rows("\x01 1"))
+}

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -2957,18 +2957,3 @@ func (s *testIntegrationSuite7) TestAddPartitionForTableWithWrongType(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(ddl.ErrWrongTypeColumnValue.Equal(err), IsTrue)
 }
-
-func (s *testIntegrationSuite7) TestInsertIntoPartitionTable(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop tables if exists t")
-	tk.MustExec(`CREATE TABLE t(
-	a bit(1) DEFAULT NULL,
-	b int(11) DEFAULT NULL
-	) PARTITION BY HASH(a)
-	PARTITIONS 3`)
-	tk.MustExec("INSERT INTO t VALUES(0, 0)")
-	tk.MustExec("INSERT INTO t VALUES(1, 1)")
-	result := tk.MustQuery("SELECT * FROM t WHERE a = 1")
-	result.Check(testkit.Rows("\x01 1"))
-}

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -734,7 +734,18 @@ func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *mode
 // TODO: supports linear hashing
 func (t *partitionedTable) locateHashPartition(ctx sessionctx.Context, pi *model.PartitionInfo, r []types.Datum) (int, error) {
 	if col, ok := t.partitionExpr.Expr.(*expression.Column); ok {
-		ret := r[col.Index].GetInt64()
+		var data types.Datum
+		switch r[col.Index].Kind() {
+		case types.KindInt64, types.KindUint64:
+			data = r[col.Index]
+		default:
+			var err error
+			data, err = r[col.Index].ConvertTo(ctx.GetSessionVars().StmtCtx, types.NewFieldType(mysql.TypeLong))
+			if err != nil {
+				return 0, err
+			}
+		}
+		ret := data.GetInt64()
 		ret = ret % int64(t.meta.Partition.Num)
 		if ret < 0 {
 			ret = -ret

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -502,3 +502,18 @@ func (ts *testSuite) TestHashPartitionAndConditionConflict(c *C) {
 
 	tk.MustQuery("select * from t2 partition (p1) where t2.a = 6;").Check(testkit.Rows())
 }
+
+func (ts *testSuite) TestHashPartitionInsertValue(c *C) {
+	tk := testkit.NewTestKit(c, ts.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop tables if exists t")
+	tk.MustExec(`CREATE TABLE t(
+	a bit(1) DEFAULT NULL,
+	b int(11) DEFAULT NULL
+	) PARTITION BY HASH(a)
+	PARTITIONS 3`)
+	tk.MustExec("INSERT INTO t VALUES(0, 0)")
+	tk.MustExec("INSERT INTO t VALUES(1, 1)")
+	result := tk.MustQuery("SELECT * FROM t WHERE a = 1")
+	result.Check(testkit.Rows("\x01 1"))
+}

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -504,7 +504,7 @@ func (ts *testSuite) TestHashPartitionAndConditionConflict(c *C) {
 }
 
 func (ts *testSuite) TestHashPartitionInsertValue(c *C) {
-	tk := testkit.NewTestKit(c, ts.store)
+	tk := testkit.NewTestKitWithInit(c, ts.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop tables if exists t")
 	tk.MustExec(`CREATE TABLE t(

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -512,6 +512,7 @@ func (ts *testSuite) TestHashPartitionInsertValue(c *C) {
 	b int(11) DEFAULT NULL
 	) PARTITION BY HASH(a)
 	PARTITIONS 3`)
+	defer tk.MustExec("drop tables if exists t4")
 	tk.MustExec("INSERT INTO t4 VALUES(0, 0)")
 	tk.MustExec("INSERT INTO t4 VALUES(1, 1)")
 	result := tk.MustQuery("SELECT * FROM t4 WHERE a = 1")

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -506,14 +506,14 @@ func (ts *testSuite) TestHashPartitionAndConditionConflict(c *C) {
 func (ts *testSuite) TestHashPartitionInsertValue(c *C) {
 	tk := testkit.NewTestKitWithInit(c, ts.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop tables if exists t")
-	tk.MustExec(`CREATE TABLE t(
+	tk.MustExec("drop tables if exists t4")
+	tk.MustExec(`CREATE TABLE t4(
 	a bit(1) DEFAULT NULL,
 	b int(11) DEFAULT NULL
 	) PARTITION BY HASH(a)
 	PARTITIONS 3`)
-	tk.MustExec("INSERT INTO t VALUES(0, 0)")
-	tk.MustExec("INSERT INTO t VALUES(1, 1)")
-	result := tk.MustQuery("SELECT * FROM t WHERE a = 1")
+	tk.MustExec("INSERT INTO t4 VALUES(0, 0)")
+	tk.MustExec("INSERT INTO t4 VALUES(1, 1)")
+	result := tk.MustQuery("SELECT * FROM t4 WHERE a = 1")
 	result.Check(testkit.Rows("\x01 1"))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #21172 

Problem Summary:

### What is changed and how it works?

What's Changed:

change the `locateHashPartition` function, when the column is not int, it will first convert int.

How it Works:

change the `locateHashPartition` function, when the column is not int, it will first convert int.


### Related changes

- Need to cherry-pick to the release branch

### Check List

Tests

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
No
    - Consumes more MEM
No
- Breaking backward compatibility
No

### Release note 

- fix insert value into hash partition table which not int
