### PR TITLE
coprocessor: fix potential deal lock

### DIFF
--- a/store/tikv/coprocessor.go
+++ b/store/tikv/coprocessor.go
@@ -1448,7 +1448,8 @@ func (e *rateLimitAction) destroyTokenIfNeeded(returnToken func()) {
 
 	returnToken()
 	// we suspend worker when `exceeded` is true until being notified by `broadcastIfNeeded`
-	for e.cond.exceeded {
+	// If not enabled we should not let worker wait, it may cause a dead lock.
+	for e.cond.exceeded && e.isEnabled() {
 		e.cond.waitingWorkerCnt++
 		e.cond.Wait()
 		e.cond.waitingWorkerCnt--


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21177

Problem Summary:

In `rateLimitAction.destroyTokenIfNeeded` if we hit exceeded just block the `copIteratorWorker` until other goroutine call `rateLimitAction.broadcastIfNeeded`, `rateLimitAction.broadcastIfNeeded` or `rateLimitAction.close`.

But there has a corner case:
```
goroutine1                                                  goroutine2                                      goroutine3
rateLimitAction.Action:                                                                                     for e.exceeded {
  if !e.isEnabled() {                                                                                         e.cond.Wait()
    ...                                                                                                     --> context switch
  }

  e.conditionLock() 
--> context switch
                                                            rateLimitAction.close:
                                                              e.setEnable(false)
                                                              e.conditionLock()
                                                              defer e.conditionUnlock()
                                                              e.cond.exceeded = false
                                                              ...
                                                              e.cond.Broadcast() --> switch context
    e.cond.once.Do(...) //  e.cond.exceeded = true
    --> switch context
                                                                                                            // in function destroyTokenIfNeeded
                                                                                                            // returned from e.cond.Wait()
                                                                                                            // check e.exceeded is true and loop again
                                                                                                              e.cond.Wait()
                                                                                                            }

```

in this situation, the `rateLimitAction.exceeded` is `true` and `rateLimitAction.enabled` is `0`, then it will cause `copIteratorWorker` wait in `rateLimitAction.cond` forever.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- No

### Release note <!-- bugfixes or new feature need a release note -->

- No release note