### PR TITLE
planner: `DELETE` cannot delete data in some cases when the database name is capitalized

### DIFF
--- a/executor/delete_test.go
+++ b/executor/delete_test.go
@@ -102,3 +102,23 @@ func (s *testSuite8) TestDeleteLockKey(c *C) {
 	}
 	wg.Wait()
 }
+
+func (s *testSuite8) TestIssue21200(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop database if exists TEST1")
+	tk.MustExec("create database TEST1")
+	tk.MustExec("use TEST1")
+	tk.MustExec("create table t(a int)")
+	tk.MustExec("create table t1(a int)")
+	tk.MustExec("insert into t values(1)")
+	tk.MustExec("insert into t1 values(1)")
+	tk.MustExec("delete a from t a where exists (select 1 from t1 where t1.a=a.a)")
+	tk.MustQuery("select * from t").Check(testkit.Rows())
+
+	tk.MustExec("insert into t values(1), (2)")
+	tk.MustExec("insert into t1 values(2)")
+	tk.MustExec("prepare stmt from 'delete a from t a where exists (select 1 from t1 where a.a=t1.a and t1.a=?)'")
+	tk.MustExec("set @a=1")
+	tk.MustExec("execute stmt using @a")
+	tk.MustQuery("select * from t").Check(testkit.Rows("2"))
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4072,12 +4072,12 @@ func (b *PlanBuilder) buildDelete(ctx context.Context, delete *ast.DeleteStmt) (
 		for _, tn := range delete.Tables.Tables {
 			foundMatch := false
 			for _, v := range tableList {
-				dbName := v.Schema.L
-				if dbName == "" {
-					dbName = b.ctx.GetSessionVars().CurrentDB
+				dbName := v.Schema
+				if dbName.L == "" {
+					dbName = model.NewCIStr(b.ctx.GetSessionVars().CurrentDB)
 				}
-				if (tn.Schema.L == "" || tn.Schema.L == dbName) && tn.Name.L == v.Name.L {
-					tn.Schema.L = dbName
+				if (tn.Schema.L == "" || tn.Schema.L == dbName.L) && tn.Name.L == v.Name.L {
+					tn.Schema = dbName
 					tn.DBInfo = v.DBInfo
 					tn.TableInfo = v.TableInfo
 					foundMatch = true


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21200  <!-- REMOVE this line if no issue to close -->

Problem Summary:

The `CurrentDB` in session vars is stored the original string representation. (i.e. if we create the database name as `tEsT1`, the `CurrentDB` would be `tEsT1`.

However, in the codes that we changed in the pr, we treat the `CurrentDB` as its lower representation. This leads to wrong string comparison result. So `DELETE` might not delete the data correctly.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Wrap `CIStr` upon the `CurrentDB`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note

- `DELETE` may not delete data correctly when the database name is not in pure lower representation.
