### PR TITLE
ddl: check partition name unique when create hash type partition table

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -695,6 +695,10 @@ func (s *testIntegrationSuite1) TestCreateTableWithListColumnsPartition(c *C) {
 			"create table t (a int, b datetime) partition by list columns (a,b) (partition p0 values in ((1)));",
 			ast.ErrPartitionColumnList,
 		},
+		{
+			"create table t(b int) partition by hash ( b ) partitions 3 (partition p1, partition p2, partition p2);",
+			ddl.ErrSameNamePartition,
+		},
 	}
 	for i, t := range cases {
 		_, err := tk.Exec(t.sql)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1944,6 +1944,9 @@ func buildViewInfo(ctx sessionctx.Context, s *ast.CreateViewStmt) (*model.ViewIn
 
 func checkPartitionByHash(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
 	pi := tbInfo.Partition
+	if err := checkPartitionNameUnique(pi); err != nil {
+		return err
+	}
 	if err := checkAddPartitionTooManyPartitions(pi.Num); err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21131

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix a bug that hash type partition does not check partition name is unique <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
