### PR TITLE
expression: Improve compatibility of string literal comparisons

### DIFF
--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -956,7 +956,20 @@ func (b *builtinStrcmpSig) evalInt(row chunk.Row) (int64, bool, error) {
 		isNull      bool
 		err         error
 	)
-
+	for _, args := range b.getArgs() {
+		switch args.(type) {
+		case *Constant:
+			b := args.(*Constant).Value.GetBytes()
+			for i := len(b) - 1; i >= 0; i-- {
+				if b[i] == 0 {
+					b = append(b[:i], b[i+1:]...)
+				}
+			}
+			if b != nil {
+				args.(*Constant).Value.SetBytes(b)
+			}
+		}
+	}
 	left, isNull, err = b.args[0].EvalString(b.ctx, row)
 	if isNull || err != nil {
 		return 0, isNull, err

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -2828,6 +2828,13 @@ func (s *testIntegrationSuite2) TestBuiltin(c *C) {
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery("select strcmp('abc', 'abc')")
 	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery("select strcmp('a\\0', 'a');")
+	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery("select strcmp('a\\0\\1\\0', 'a\\0\\1')")
+	result.Check(testkit.Rows("0"))
+	result = tk.MustQuery("select strcmp('a\\0', 'a\\1')")
+	result.Check(testkit.Rows("-1"))
+
 	result = tk.MustQuery("select substr(null, 1, 2)")
 	result.Check(testkit.Rows("<nil>"))
 	result = tk.MustQuery("select substr('123', null, 2)")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #3775 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
```
mysql> select STRCMP('a\0', 'a'), STRCMP('a\1\0', 'a\0\1');
+--------------------+--------------------------+
| STRCMP('a\0', 'a') | STRCMP('a\1\0', 'a\0\1') |
+--------------------+--------------------------+
|                  0 |                        0 |
+--------------------+--------------------------+
```
Return zero in the mysql8.

How it Works:
remove 0 in the byte array

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
