### PR TITLE
ddl: compare expression in check partition definition according to column type

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -406,6 +406,18 @@ create table log_message_1 (
 			ast.ErrPartitionsMustBeDefined,
 		},
 		{
+			"create table t(a datetime) partition by range columns (a) (partition p1 values less than ('2000-02-01'), partition p2 values less than ('20000102'));",
+			ddl.ErrRangeNotIncreasing,
+		},
+		{
+			"create table t(a time) partition by range columns (a) (partition p1 values less than ('202020'), partition p2 values less than ('20:20:10'));",
+			ddl.ErrRangeNotIncreasing,
+		},
+		{
+			"create table t(a time) partition by range columns (a) (partition p1 values less than ('202090'));",
+			ddl.ErrWrongTypeColumnValue,
+		},
+		{
 			"create table t (id int) partition by range columns (id) (partition p0 values less than (1, 2));",
 			ast.ErrPartitionColumnList,
 		},

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2062,7 +2062,7 @@ func checkColumnsPartitionType(tbInfo *model.TableInfo) error {
 		// See https://dev.mysql.com/doc/mysql-partitioning-excerpt/5.7/en/partitioning-columns.html
 		switch colInfo.FieldType.Tp {
 		case mysql.TypeTiny, mysql.TypeShort, mysql.TypeInt24, mysql.TypeLong, mysql.TypeLonglong:
-		case mysql.TypeDate, mysql.TypeDatetime:
+		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeDuration:
 		case mysql.TypeVarchar, mysql.TypeString:
 		default:
 			return ErrNotAllowedTypeInPartition.GenWithStackByArgs(col.O)
@@ -2135,11 +2135,11 @@ func checkTwoRangeColumns(ctx sessionctx.Context, curr, prev *model.PartitionDef
 }
 
 func parseAndEvalBoolExpr(ctx sessionctx.Context, l, r string, colInfo *model.ColumnInfo, tbInfo *model.TableInfo) (bool, error) {
-	lexpr, err := expression.ParseSimpleExprWithTableInfo(ctx, l, tbInfo)
+	lexpr, err := expression.ParseSimpleExprCastWithTableInfo(ctx, l, tbInfo, &colInfo.FieldType)
 	if err != nil {
 		return false, err
 	}
-	rexpr, err := expression.ParseSimpleExprWithTableInfo(ctx, r, tbInfo)
+	rexpr, err := expression.ParseSimpleExprCastWithTableInfo(ctx, r, tbInfo, &colInfo.FieldType)
 	if err != nil {
 		return false, err
 	}
@@ -5300,7 +5300,7 @@ func checkColumnsTypeAndValuesMatch(ctx sessionctx.Context, meta *model.TableInf
 		// Check val.ConvertTo(colType) doesn't work, so we need this case by case check.
 		vkind := val.Kind()
 		switch colType.Tp {
-		case mysql.TypeDate, mysql.TypeDatetime:
+		case mysql.TypeDate, mysql.TypeDatetime, mysql.TypeDuration:
 			switch vkind {
 			case types.KindString, types.KindBytes:
 				if _, err := val.ConvertTo(ctx.GetSessionVars().StmtCtx, colType); err != nil {

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -732,7 +732,7 @@ func (s *testIntegrationSerialSuite) TestPartitionPruningWithDateType(c *C) {
 	tk.MustExec("create table t(a datetime) partition by range columns (a) (partition p1 values less than ('20000101'), partition p2 values less than ('2000-10-01'));")
 	tk.MustExec("insert into t values ('20000201'), ('19000101');")
 
-	//
+	// cannot get the statistical information immediately
 	// tk.MustQuery(`SELECT PARTITION_NAME,TABLE_ROWS FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_NAME = 't';`).Check(testkit.Rows("p1 1", "p2 1"))
 	str := tk.MustQuery(`desc select * from t where a < '2000-01-01';`).Rows()[0][3].(string)
 	c.Assert(strings.Contains(str, "partition:p1"), IsTrue)

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -724,6 +724,20 @@ func (s *testIntegrationSuite) TestPartitionPruningForInExpr(c *C) {
 	}
 }
 
+func (s *testIntegrationSerialSuite) TestPartitionPruningWithDateType(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a datetime) partition by range columns (a) (partition p1 values less than ('20000101'), partition p2 values less than ('2000-10-01'));")
+	tk.MustExec("insert into t values ('20000201'), ('19000101');")
+
+	//
+	// tk.MustQuery(`SELECT PARTITION_NAME,TABLE_ROWS FROM INFORMATION_SCHEMA.PARTITIONS WHERE TABLE_NAME = 't';`).Check(testkit.Rows("p1 1", "p2 1"))
+	str := tk.MustQuery(`desc select * from t where a < '2000-01-01';`).Rows()[0][3].(string)
+	c.Assert(strings.Contains(str, "partition:p1"), IsTrue)
+}
+
 func (s *testIntegrationSuite) TestPartitionPruningForEQ(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/planner/core/partition_pruning_test.go
+++ b/planner/core/partition_pruning_test.go
@@ -368,11 +368,11 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2Date(c *C) {
 		"a",
 	)
 	lessThanDataInt := []string{
-		"'1999-06-01'",
+		"'19990601'",
 		"'2000-05-01'",
-		"'2008-04-01'",
+		"'20080401'",
 		"'2010-03-01'",
-		"'2016-02-01'",
+		"'20160201'",
 		"'2020-01-01'"}
 	lessThan := make([]expression.Expression, len(lessThanDataInt))
 	for i, str := range lessThanDataInt {
@@ -387,16 +387,16 @@ func (s *testPartitionPruningSuite) TestPartitionRangePrunner2Date(c *C) {
 		result partitionRangeOR
 	}{
 		{"a < '1943-02-12'", partitionRangeOR{{0, 1}}},
-		{"a >= '1969-02-13'", partitionRangeOR{{0, 6}}},
+		{"a >= '19690213'", partitionRangeOR{{0, 6}}},
 		{"a > '2003-03-13'", partitionRangeOR{{2, 6}}},
 		{"a < '2006-02-03'", partitionRangeOR{{0, 3}}},
-		{"a = '2007-07-07'", partitionRangeOR{{2, 3}}},
+		{"a = '20070707'", partitionRangeOR{{2, 3}}},
 		{"a > '1949-10-10'", partitionRangeOR{{0, 6}}},
-		{"a > '2016-02-01' and a < '2000-01-03'", partitionRangeOR{}},
-		{"a < '1969-11-12' or a >= '2019-09-18'", partitionRangeOR{{0, 1}, {5, 6}}},
+		{"a > '2016-02-01' and a < '20000103'", partitionRangeOR{}},
+		{"a < '19691112' or a >= '2019-09-18'", partitionRangeOR{{0, 1}, {5, 6}}},
 		{"a is null", partitionRangeOR{{0, 1}}},
 		{"'2003-02-27' >= a", partitionRangeOR{{0, 3}}},
-		{"'2014-10-24' < a", partitionRangeOR{{4, 6}}},
+		{"'20141024' < a", partitionRangeOR{{4, 6}}},
 		{"'2003-03-30' > a", partitionRangeOR{{0, 3}}},
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21227
close https://github.com/pingcap/tidb/issues/21225

Problem Summary:

it is a patch of https://github.com/pingcap/tidb/pull/20937, we cannot compare datetime, date, time type column as string type

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix a bug that checks partition definition according to column type<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
