### PR TITLE
executor: return the result immediately when combining LIMIT row_count with DISTINCT

### DIFF
--- a/executor/aggfuncs/aggfuncs.go
+++ b/executor/aggfuncs/aggfuncs.go
@@ -203,3 +203,7 @@ type SlidingWindowAggFunc interface {
 	// completely.
 	Slide(sctx sessionctx.Context, rows []chunk.Row, lastStart, lastEnd uint64, shiftStart, shiftEnd uint64, pr PartialResult) error
 }
+
+type FinishedRows interface {
+	HasFinishedFirstRow(pr PartialResult) bool
+}

--- a/executor/aggfuncs/func_first_row.go
+++ b/executor/aggfuncs/func_first_row.go
@@ -52,6 +52,8 @@ type basePartialResult4FirstRow struct {
 	// gotFirstRow indicates whether the first row has been got,
 	// if so, we would avoid evaluating the values of the remained rows.
 	gotFirstRow bool
+	// finishedRows indicates the number of rows has been got.
+	finishedRows int
 }
 
 type partialResult4FirstRowInt struct {
@@ -129,6 +131,7 @@ func (e *firstRow4Int) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Int) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowInt)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -160,6 +163,11 @@ func (e *firstRow4Int) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Parti
 	return nil
 }
 
+func (e *firstRow4Int) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowInt)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Float32 struct {
 	baseAggFunc
 }
@@ -175,6 +183,7 @@ func (e *firstRow4Float32) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Float32) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowFloat32)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -206,6 +215,11 @@ func (e *firstRow4Float32) AppendFinalResult2Chunk(sctx sessionctx.Context, pr P
 	return nil
 }
 
+func (e *firstRow4Float32) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowFloat32)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Float64 struct {
 	baseAggFunc
 }
@@ -221,6 +235,7 @@ func (e *firstRow4Float64) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Float64) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowFloat64)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -252,6 +267,11 @@ func (e *firstRow4Float64) AppendFinalResult2Chunk(sctx sessionctx.Context, pr P
 	return nil
 }
 
+func (e *firstRow4Float64) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowFloat64)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4String struct {
 	baseAggFunc
 }
@@ -267,6 +287,7 @@ func (e *firstRow4String) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4String) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowString)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -299,6 +320,11 @@ func (e *firstRow4String) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Pa
 	return nil
 }
 
+func (e *firstRow4String) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowString)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Time struct {
 	baseAggFunc
 }
@@ -314,6 +340,7 @@ func (e *firstRow4Time) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Time) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowTime)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -345,6 +372,11 @@ func (e *firstRow4Time) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Part
 	return nil
 }
 
+func (e *firstRow4Time) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowTime)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Duration struct {
 	baseAggFunc
 }
@@ -360,6 +392,7 @@ func (e *firstRow4Duration) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Duration) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowDuration)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -391,6 +424,11 @@ func (e *firstRow4Duration) AppendFinalResult2Chunk(sctx sessionctx.Context, pr 
 	return nil
 }
 
+func (e *firstRow4Duration) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowDuration)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4JSON struct {
 	baseAggFunc
 }
@@ -406,6 +444,7 @@ func (e *firstRow4JSON) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4JSON) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowJSON)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -437,6 +476,11 @@ func (e *firstRow4JSON) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Part
 	return nil
 }
 
+func (e *firstRow4JSON) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowJSON)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Decimal struct {
 	baseAggFunc
 }
@@ -452,6 +496,7 @@ func (e *firstRow4Decimal) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Decimal) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowDecimal)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -490,6 +535,11 @@ func (*firstRow4Decimal) MergePartialResult(sctx sessionctx.Context, src, dst Pa
 	return memDelta, nil
 }
 
+func (e *firstRow4Decimal) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowDecimal)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Enum struct {
 	baseAggFunc
 }
@@ -505,6 +555,7 @@ func (e *firstRow4Enum) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Enum) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowEnum)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -538,6 +589,11 @@ func (e *firstRow4Enum) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Part
 	return nil
 }
 
+func (e *firstRow4Enum) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowEnum)(pr)
+	return p.finishedRows == 1
+}
+
 type firstRow4Set struct {
 	baseAggFunc
 }
@@ -553,6 +609,7 @@ func (e *firstRow4Set) ResetPartialResult(pr PartialResult) {
 
 func (e *firstRow4Set) UpdatePartialResult(sctx sessionctx.Context, rowsInGroup []chunk.Row, pr PartialResult) (memDelta int64, err error) {
 	p := (*partialResult4FirstRowSet)(pr)
+	p.finishedRows++
 	if p.gotFirstRow {
 		return memDelta, nil
 	}
@@ -584,4 +641,9 @@ func (e *firstRow4Set) AppendFinalResult2Chunk(sctx sessionctx.Context, pr Parti
 	}
 	chk.AppendSet(e.ordinal, p.val)
 	return nil
+}
+
+func (e *firstRow4Set) HasFinishedFirstRow(pr PartialResult) bool {
+	p := (*partialResult4FirstRowSet)(pr)
+	return p.finishedRows == 1
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #15284  

Problem Summary:

### What is changed and how it works?

What's Changed:
return the result immediately when combining LIMIT row_count with DISTINCT
How it Works:
use a variable to record the number of rows has been got and return immediately when it meets the required rows.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note