### PR TITLE
WIP: mockstore: fix unistore index panic

### DIFF
--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -875,7 +875,7 @@ func (e *topNProcessor) Process(key, value []byte) (err error) {
 
 func (e *closureExecutor) newTopNSortRow() *sortRow {
 	return &sortRow{
-		key:  make([]types.Datum, len(e.evalContext.columnInfos)),
+		key:  make([]types.Datum, len(e.topNCtx.orderByExprs)),
 		data: make([][]byte, 2),
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

1. Run tidb with unistore mode;
2. Run the same SQL from issue #15492 occured `index out of range` panic

```sql
SELECT 'f' XOR ( ! `col_smallint` ) AS field1, ~ ( NOT `col_smallint` ) AS field2 FROM `table1_int_autoinc`  ORDER BY field1, field2 LIMIT 8 /* QNO 46 CON_ID 192 */ ;

(1105, 'runtime error: index out of range [1] with length 1')
```


### What is changed and how it works?


What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
