### PR TITLE
Revert "expression: fix a bug that DML using caseWhen may cause schema change"

### DIFF
--- a/expression/aggregation/base_func.go
+++ b/expression/aggregation/base_func.go
@@ -414,14 +414,17 @@ func (a *baseFuncDesc) WrapCastForAggArgs(ctx sessionctx.Context) {
 		// function.
 		// Note: If the `Tp` of argument is the same as the `Tp` of the
 		// aggregation function, it will not wrap cast function on it
-		// internally.
-		switch x := a.Args[i].(type) {
-		case *expression.Column:
-			x.RetType = a.RetTp
-		case *expression.ScalarFunction:
-			x.RetType = a.RetTp
-		case *expression.CorrelatedColumn:
-			x.RetType = a.RetTp
+		// internally. The reason of the special handling for `Column` is
+		// that the `RetType` of `Column` refers to the `infoschema`, so we
+		// need to set a new variable for it to avoid modifying the
+		// definition in `infoschema`.
+		if col, ok := a.Args[i].(*expression.Column); ok {
+			col.RetType = types.NewFieldType(col.RetType.Tp)
 		}
+		// originTp is used when the the `Tp` of column is TypeFloat32 while
+		// the type of the aggregation function is TypeFloat64.
+		originTp := a.Args[i].GetType().Tp
+		*(a.Args[i].GetType()) = *(a.RetTp)
+		a.Args[i].GetType().Tp = originTp
 	}
 }

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -122,7 +122,7 @@ func caseWhenHandler(expr *ScalarFunction) (Expression, bool) {
 					foldedExpr.GetType().Decimal = expr.GetType().Decimal
 					return foldedExpr, isDeferredConst
 				}
-				return foldedExpr, isDeferredConst
+				return BuildCastFunction(expr.GetCtx(), foldedExpr, foldedExpr.GetType()), isDeferredConst
 			}
 		} else {
 			// for no-const, here should return directly, because the following branches are unknown to be run or not

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -139,19 +139,6 @@ func (s *testIntegrationSuite) Test19654(c *C) {
 	tk.MustQuery("select /*+ inl_join(t2)*/ * from t1, t2 where t1.b=t2.b;").Check(testkit.Rows("a a"))
 }
 
-func (s *testIntegrationSuite) Test19387(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("USE test;")
-
-	tk.MustExec("drop table if exists t;")
-	tk.MustExec("create table t(a decimal(16, 2));")
-	tk.MustExec("select sum(case when 1 then a end) from t group by a;")
-	res := tk.MustQuery("show create table t")
-	c.Assert(len(res.Rows()), Equals, 1)
-	str := res.Rows()[0][1].(string)
-	c.Assert(strings.Contains(str, "decimal(16,2)"), IsTrue)
-}
-
 func (s *testIntegrationSuite) TestFuncREPEAT(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	defer s.cleanEnv(c)
@@ -3686,7 +3673,6 @@ func (s *testIntegrationSuite) TestAggregationBuiltin(c *C) {
 	defer s.cleanEnv(c)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a decimal(7, 6))")
 	tk.MustExec("insert into t values(1.123456), (1.123456)")
 	result := tk.MustQuery("select avg(a) from t")


### PR DESCRIPTION
Reverts pingcap/tidb#19857

Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19387 <!-- REMOVE this line if no issue to close -->

Problem Summary:

1. `BuildCastFunction(expr.GetCtx(), foldedExpr, foldedExpr.GetType())` in `constant_fold.go` in wrong and needless.
`foldedExpr.GetType()` should be `expr.GetType()`.
2. In WrapCastForAggArgs, we change the pointer to fieldType. It's very dangerous.

### What is changed and how it works?

1. Remove `BuildCastFunction(expr.GetCtx(), foldedExpr, foldedExpr.GetType())`.
2. Use a safe way to change FieldType.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note