### PR TITLE
planner: fix incorrect results when using a prefix index with OR condition

### DIFF
--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -455,6 +455,10 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression
 		}
 	}
 
+	// Take prefix index into consideration.
+	if hasPrefix(d.lengths) {
+		fixPrefixColRange(totalRanges, d.lengths, newTpSlice)
+	}
 	totalRanges, err := UnionRanges(sc, totalRanges, d.mergeConsecutive)
 	if err != nil {
 		return nil, nil, false, errors.Trace(err)

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1309,6 +1309,42 @@ func (s *testRangerSuite) TestCompIndexMultiColDNF2(c *C) {
 	}
 }
 
+func (s *testRangerSuite) TestPrefixIndexMultiColDNF(c *C) {
+	defer testleak.AfterTest(c)()
+	dom, store, err := newDomainStoreWithBootstrap(c)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	c.Assert(err, IsNil)
+	testKit := testkit.NewTestKit(c, store)
+	testKit.MustExec("use test;")
+	testKit.MustExec("drop table if exists t2;")
+	testKit.MustExec("create table t2 (id int unsigned not null auto_increment primary key, t text, index(t(3)));")
+	testKit.MustExec("insert into t2 (t) values ('aaaa'),('a');")
+
+	var input []string
+	var output []struct {
+		SQL    string
+		Plan   []string
+		Result []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	inputLen := len(input)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(testKit.MustQuery("explain " + tt).Rows())
+			output[i].Result = s.testData.ConvertRowsToStrings(testKit.MustQuery(tt).Rows())
+		})
+		testKit.MustQuery("explain " + tt).Check(testkit.Rows(output[i].Plan...))
+		testKit.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
+		if i+1 == inputLen/2 {
+			testKit.MustExec("analyze table t2;")
+		}
+	}
+}
+
 func (s *testRangerSuite) TestIndexRangeForYear(c *C) {
 	defer testleak.AfterTest(c)()
 	dom, store, err := newDomainStoreWithBootstrap(c)

--- a/util/ranger/testdata/ranger_suite_in.json
+++ b/util/ranger/testdata/ranger_suite_in.json
@@ -58,5 +58,14 @@
       "select * from t where (a,b) in ((1,1),(2,2)) and c > 2;",
       "select * from t where ((a = 1 and b = 1) or (a = 2 and b = 2)) and c > 2;"
     ]
+  },
+  {
+    "name": "TestPrefixIndexMultiColDNF",
+    "cases": [
+      "select * from t2 where t='aaaa';",
+      "select * from t2 where t='aaaa' or t = 'a';",
+      "select * from t2 where t='aaaa';",
+      "select * from t2 where t='aaaa' or t = 'a';"
+    ]
   }
 ]

--- a/util/ranger/testdata/ranger_suite_out.json
+++ b/util/ranger/testdata/ranger_suite_out.json
@@ -334,5 +334,58 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestPrefixIndexMultiColDNF",
+    "Cases": [
+      {
+        "SQL": "select * from t2 where t='aaaa';",
+        "Plan": [
+          "IndexLookUp_11 10.00 root  ",
+          "├─IndexRangeScan_8(Build) 10.00 cop[tikv] table:t2, index:t(t) range:[\"aaa\",\"aaa\"], keep order:false, stats:pseudo",
+          "└─Selection_10(Probe) 10.00 cop[tikv]  eq(test.t2.t, \"aaaa\")",
+          "  └─TableRowIDScan_9 10.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 aaaa"
+        ]
+      },
+      {
+        "SQL": "select * from t2 where t='aaaa' or t = 'a';",
+        "Plan": [
+          "IndexLookUp_11 16.00 root  ",
+          "├─IndexRangeScan_8(Build) 20.00 cop[tikv] table:t2, index:t(t) range:[\"a\",\"a\"], [\"aaa\",\"aaa\"], keep order:false, stats:pseudo",
+          "└─Selection_10(Probe) 16.00 cop[tikv]  or(eq(test.t2.t, \"aaaa\"), eq(test.t2.t, \"a\"))",
+          "  └─TableRowIDScan_9 20.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 aaaa",
+          "2 a"
+        ]
+      },
+      {
+        "SQL": "select * from t2 where t='aaaa';",
+        "Plan": [
+          "TableReader_7 0.00 root  data:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.t2.t, \"aaaa\")",
+          "  └─TableRangeScan_5 2.00 cop[tikv] table:t2 range:[0,+inf], keep order:false"
+        ],
+        "Result": [
+          "1 aaaa"
+        ]
+      },
+      {
+        "SQL": "select * from t2 where t='aaaa' or t = 'a';",
+        "Plan": [
+          "TableReader_7 0.80 root  data:Selection_6",
+          "└─Selection_6 0.80 cop[tikv]  or(eq(test.t2.t, \"aaaa\"), eq(test.t2.t, \"a\"))",
+          "  └─TableRangeScan_5 2.00 cop[tikv] table:t2 range:[0,+inf], keep order:false"
+        ],
+        "Result": [
+          "1 aaaa",
+          "2 a"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21234 

Problem Summary:
In the previous implementation, when we use a prefix index with OR condition, it will fail to Cut Datum By PrefixLen.

### What is changed and how it works?

When we use `detachDNFCondAndBuildRangeForIndex` function, we take prefix index into consideration.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
### Release note <!-- bugfixes or new feature need a release note -->

- fix incorrect results when using a prefix index with OR condition