### PR TITLE
session: fix unit test TestUnionScanForMemBufferReader

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3433,7 +3433,8 @@ func (s *testSessionSuite3) TestSetVarHint(c *C) {
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings()[0].Err.Error(), Equals, "[planner:3126]Hint SET_VAR(group_concat_max_len=2048) is ignored as conflicting/duplicated.")
 }
 
-func (s *testSessionSuite2) TestDeprecateSlowLogMasking(c *C) {
+// TestDeprecateSlowLogMasking should be in serial suite because it changes a global variable.
+func (s *testSessionSerialSuite) TestDeprecateSlowLogMasking(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 
 	tk.MustExec("set @@global.tidb_redact_log=0")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21256 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`global.tidb_redact_log` is changed by `TestDeprecateSlowLogMasking`, maybe affect its session variable in `TestUnionScanForMemBufferReader`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

move `TestDeprecateSlowLogMasking` to serial suite.

How it Works:


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test



### Release note <!-- bugfixes or new feature need a release note -->

- No release note
