### PR TITLE
ddl: support column type change from JSON type to other types

### DIFF
--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -1167,3 +1167,377 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromDateTimeTypeToOthers
 	tk.MustExec("alter table t modify y json")
 	tk.MustQuery("select * from t").Check(testkit.Rows("\"2020-10-30\" \"19:38:25.001\" \"2020-10-30 08:21:33.455555\" \"2020-10-30 08:21:33.455555\" 2020"))
 }
+
+func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromJsonToOthers(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	// Enable column change variable.
+	tk.Se.GetSessionVars().EnableChangeColumnType = true
+
+	// Set time zone to UTC.
+	originalTz := tk.Se.GetSessionVars().TimeZone
+	tk.Se.GetSessionVars().TimeZone = time.UTC
+	defer func() {
+		tk.Se.GetSessionVars().EnableChangeColumnType = false
+		tk.Se.GetSessionVars().TimeZone = originalTz
+	}()
+
+	// Init string date type table.
+	reset := func(tk *testkit.TestKit) {
+		tk.MustExec("drop table if exists t")
+		tk.MustExec(`
+			create table t (
+				obj json,
+				arr json,
+				nil json,
+				t json,
+				f json,
+				i json,
+				ui json,
+				f64 json,
+				str json
+			)
+		`)
+	}
+
+	// To numeric data types.
+	// tinyint
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj tinyint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '[-1, 0, 1]' for column 'arr' at row 1".
+	tk.MustExec("alter table t modify arr tinyint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'null' for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil tinyint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'true' for column 't' at row 1".
+	tk.MustExec("alter table t modify t tinyint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'false' for column 'f' at row 1".
+	tk.MustExec("alter table t modify f tinyint")
+	tk.MustExec("alter table t modify i tinyint")
+	tk.MustExec("alter table t modify ui tinyint")
+	tk.MustGetErrCode("alter table t modify f64 tinyint", mysql.ErrDataOutOfRange)
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '"json string"' for column 'str' at row 1".
+	tk.MustGetErrCode("alter table t modify str tinyint", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 -22 22 323232323.32323235 \"json string\""))
+
+	// int
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj int")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '[-1, 0, 1]' for column 'arr' at row 1".
+	tk.MustExec("alter table t modify arr int")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'null' for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil int")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'true' for column 't' at row 1".
+	tk.MustExec("alter table t modify t int")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'false' for column 'f' at row 1".
+	tk.MustExec("alter table t modify f int")
+	tk.MustExec("alter table t modify i int")
+	tk.MustExec("alter table t modify ui int")
+	tk.MustExec("alter table t modify f64 int")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '"json string"' for column 'str' at row 1".
+	tk.MustGetErrCode("alter table t modify str int", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 -22 22 323232323 \"json string\""))
+
+	// bigint
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj bigint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '[-1, 0, 1]' for column 'arr' at row 1".
+	tk.MustExec("alter table t modify arr bigint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'null' for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil bigint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'true' for column 't' at row 1".
+	tk.MustExec("alter table t modify t bigint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'false' for column 'f' at row 1".
+	tk.MustExec("alter table t modify f bigint")
+	tk.MustExec("alter table t modify i bigint")
+	tk.MustExec("alter table t modify ui bigint")
+	tk.MustExec("alter table t modify f64 bigint")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '"json string"' for column 'str' at row 1".
+	tk.MustGetErrCode("alter table t modify str bigint", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 -22 22 323232323 \"json string\""))
+
+	// unsigned bigint
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj bigint unsigned")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '[-1, 0, 1]' for column 'arr' at row 1".
+	tk.MustExec("alter table t modify arr bigint unsigned")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'null' for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil bigint unsigned")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'true' for column 't' at row 1".
+	tk.MustExec("alter table t modify t bigint unsigned")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'false' for column 'f' at row 1".
+	tk.MustExec("alter table t modify f bigint unsigned")
+	// MySQL will get "ERROR 1264 (22003) Out of range value for column 'i' at row 1".
+	tk.MustExec("alter table t modify i bigint unsigned")
+	tk.MustExec("alter table t modify ui bigint unsigned")
+	tk.MustExec("alter table t modify f64 bigint unsigned")
+	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '"json string"' for column 'str' at row 1".
+	tk.MustGetErrCode("alter table t modify str bigint unsigned", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 18446744073709551594 22 323232323 \"json string\""))
+
+	// bit
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustGetErrCode("alter table t modify obj bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify arr bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify nil bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify t bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify i bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify ui bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify str bit", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// decimal
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 3156 (22001) Invalid JSON value for CAST to DECIMAL from column obj at row 1".
+	tk.MustExec("alter table t modify obj decimal(20, 10)")
+	// MySQL will get "ERROR 3156 (22001) Invalid JSON value for CAST to DECIMAL from column arr at row 1".
+	tk.MustExec("alter table t modify arr decimal(20, 10)")
+	// MySQL will get "ERROR 3156 (22001) Invalid JSON value for CAST to DECIMAL from column nil at row 1".
+	tk.MustExec("alter table t modify nil decimal(20, 10)")
+	tk.MustExec("alter table t modify t decimal(20, 10)")
+	tk.MustExec("alter table t modify f decimal(20, 10)")
+	tk.MustExec("alter table t modify i decimal(20, 10)")
+	tk.MustExec("alter table t modify ui decimal(20, 10)")
+	tk.MustExec("alter table t modify f64 decimal(20, 10)")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect DECIMAL value: '0' for column '' at row -1".
+	tk.MustGetErrCode("alter table t modify str decimal(20, 10)", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0.0000000000 0.0000000000 0.0000000000 1.0000000000 0.0000000000 -22.0000000000 22.0000000000 323232323.3232323500 \"json string\""))
+
+	// double
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj double")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 'arr' at row 1".
+	tk.MustExec("alter table t modify arr double")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil double")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 't' at row 1".
+	tk.MustExec("alter table t modify t double")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 'f' at row 1".
+	tk.MustExec("alter table t modify f double")
+	tk.MustExec("alter table t modify i double")
+	tk.MustExec("alter table t modify ui double")
+	tk.MustExec("alter table t modify f64 double")
+	// MySQL will get "ERROR 1265 (01000): Data truncated for column 'str' at row 1".
+	tk.MustGetErrCode("alter table t modify str double", mysql.ErrTruncatedWrongValue)
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 -22 22 323232323.32323235 \"json string\""))
+
+	// To string data types.
+	// char
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj char(20)")
+	tk.MustExec("alter table t modify arr char(20)")
+	tk.MustExec("alter table t modify nil char(20)")
+	tk.MustExec("alter table t modify t char(20)")
+	tk.MustExec("alter table t modify f char(20)")
+	tk.MustExec("alter table t modify i char(20)")
+	tk.MustExec("alter table t modify ui char(20)")
+	tk.MustExec("alter table t modify f64 char(20)")
+	tk.MustExec("alter table t modify str char(20)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// varchar
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj varchar(20)")
+	tk.MustExec("alter table t modify arr varchar(20)")
+	tk.MustExec("alter table t modify nil varchar(20)")
+	tk.MustExec("alter table t modify t varchar(20)")
+	tk.MustExec("alter table t modify f varchar(20)")
+	tk.MustExec("alter table t modify i varchar(20)")
+	tk.MustExec("alter table t modify ui varchar(20)")
+	tk.MustExec("alter table t modify f64 varchar(20)")
+	tk.MustExec("alter table t modify str varchar(20)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// binary
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj binary(20)")
+	tk.MustExec("alter table t modify arr binary(20)")
+	tk.MustExec("alter table t modify nil binary(20)")
+	tk.MustExec("alter table t modify t binary(20)")
+	tk.MustExec("alter table t modify f binary(20)")
+	tk.MustExec("alter table t modify i binary(20)")
+	tk.MustExec("alter table t modify ui binary(20)")
+	tk.MustExec("alter table t modify f64 binary(20)")
+	tk.MustExec("alter table t modify str binary(20)")
+	tk.MustQuery("select * from t").Check(testkit.Rows(
+		"{\"obj\": 100}\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"[-1, 0, 1]\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"null\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"true\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"false\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"-22\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"22\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 " +
+			"323232323.32323235\x00\x00 " +
+			"\"json string\"\x00\x00\x00\x00\x00\x00\x00"))
+	// varbinary
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj varbinary(20)")
+	tk.MustExec("alter table t modify arr varbinary(20)")
+	tk.MustExec("alter table t modify nil varbinary(20)")
+	tk.MustExec("alter table t modify t varbinary(20)")
+	tk.MustExec("alter table t modify f varbinary(20)")
+	tk.MustExec("alter table t modify i varbinary(20)")
+	tk.MustExec("alter table t modify ui varbinary(20)")
+	tk.MustExec("alter table t modify f64 varbinary(20)")
+	tk.MustExec("alter table t modify str varbinary(20)")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// blob
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj blob")
+	tk.MustExec("alter table t modify arr blob")
+	tk.MustExec("alter table t modify nil blob")
+	tk.MustExec("alter table t modify t blob")
+	tk.MustExec("alter table t modify f blob")
+	tk.MustExec("alter table t modify i blob")
+	tk.MustExec("alter table t modify ui blob")
+	tk.MustExec("alter table t modify f64 blob")
+	tk.MustExec("alter table t modify str blob")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// text
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustExec("alter table t modify obj text")
+	tk.MustExec("alter table t modify arr text")
+	tk.MustExec("alter table t modify nil text")
+	tk.MustExec("alter table t modify t text")
+	tk.MustExec("alter table t modify f text")
+	tk.MustExec("alter table t modify i text")
+	tk.MustExec("alter table t modify ui text")
+	tk.MustExec("alter table t modify f64 text")
+	tk.MustExec("alter table t modify str text")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// enum
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustGetErrCode("alter table t modify obj enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify arr enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify nil enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify t enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify i enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify ui enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify str enum('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// set
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')")
+	tk.MustGetErrCode("alter table t modify obj set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify arr set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify nil set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify t set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify i set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify ui set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify f64 set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustGetErrCode("alter table t modify str set('{\"obj\": 100}', '[-1]', 'null', 'true', 'false', '-22', '22', '323232323.3232323232', '\"json string\"')", mysql.ErrUnsupportedDDLOperation)
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1] null true false -22 22 323232323.32323235 \"json string\""))
+
+	// To date and time data types.
+	// datetime
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '\"2020-08-26 17:35:01.123456\"')")
+	tk.MustGetErrCode("alter table t modify obj datetime", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify arr datetime", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify nil datetime", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify t datetime", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify f datetime", mysql.ErrTruncatedWrongValue)
+	tk.MustExec("alter table t modify i datetime")
+	tk.MustExec("alter table t modify ui datetime")
+	tk.MustExec("alter table t modify f64 datetime")
+	// MySQL will get "ERROR 1292 (22007): Incorrect datetime value: '"2020-08-26 17:35:01.123456"' for column 'str' at row 1".
+	tk.MustExec("alter table t modify str datetime")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false 2020-08-26 17:35:01 2020-11-23 00:00:00 2020-08-26 17:35:01 2020-08-26 17:35:01"))
+
+	// time
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '200805', '1111', '200805.11', '\"19:35:41\"')")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect time value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustGetErrCode("alter table t modify obj time", mysql.ErrTruncatedWrongValue)
+	// MySQL will get "ERROR 1366 (HY000): Incorrect time value: '[-1, 0, 1]' for column 'arr' at row 11".
+	tk.MustGetErrCode("alter table t modify arr time", mysql.ErrTruncatedWrongValue)
+	// MySQL will get "ERROR 1366 (HY000): Incorrect time value: 'null' for column 'nil' at row 1".
+	tk.MustGetErrCode("alter table t modify nil time", mysql.ErrTruncatedWrongValue)
+	// MySQL will get "ERROR 1366 (HY000): Incorrect time value: 'true' for column 't' at row 1".
+	tk.MustGetErrCode("alter table t modify t time", mysql.ErrTruncatedWrongValue)
+	// MySQL will get "ERROR 1366 (HY000): Incorrect time value: 'true' for column 't' at row 1".
+	tk.MustGetErrCode("alter table t modify f time", mysql.ErrTruncatedWrongValue)
+	tk.MustExec("alter table t modify i time")
+	tk.MustExec("alter table t modify ui time")
+	tk.MustExec("alter table t modify f64 time")
+	// MySQL will get "ERROR 1292 (22007): Incorrect time value: '"19:35:41"' for column 'str' at row 1".
+	tk.MustExec("alter table t modify str time")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false 20:08:05 00:11:11 20:08:05 19:35:41"))
+
+	// date
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '\"2020-08-26 17:35:01.123456\"')")
+	tk.MustGetErrCode("alter table t modify obj date", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify arr date", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify nil date", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify t date", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify f date", mysql.ErrTruncatedWrongValue)
+	tk.MustExec("alter table t modify i date")
+	tk.MustExec("alter table t modify ui date")
+	tk.MustExec("alter table t modify f64 date")
+	// MySQL will get "ERROR 1292 (22007): Incorrect date value: '"2020-08-26 17:35:01.123456"' for column 'str' at row 1".
+	tk.MustExec("alter table t modify str date")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false 2020-08-26 2020-11-23 2020-08-26 2020-08-26"))
+
+	// timestamp
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '20200826173501', '20201123', '20200826173501.123456', '\"2020-08-26 17:35:01.123456\"')")
+	tk.MustGetErrCode("alter table t modify obj timestamp", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify arr timestamp", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify nil timestamp", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify t timestamp", mysql.ErrTruncatedWrongValue)
+	tk.MustGetErrCode("alter table t modify f timestamp", mysql.ErrTruncatedWrongValue)
+	tk.MustExec("alter table t modify i timestamp")
+	tk.MustExec("alter table t modify ui timestamp")
+	tk.MustExec("alter table t modify f64 timestamp")
+	// MySQL will get "ERROR 1292 (22007): Incorrect timestamptime value: '"2020-08-26 17:35:01.123456"' for column 'str' at row 1".
+	tk.MustExec("alter table t modify str timestamp")
+	tk.MustQuery("select * from t").Check(testkit.Rows("{\"obj\": 100} [-1, 0, 1] null true false 2020-08-26 17:35:01 2020-11-23 00:00:00 2020-08-26 17:35:01 2020-08-26 17:35:01"))
+
+	// year
+	reset(tk)
+	tk.MustExec("insert into t values ('{\"obj\": 100}', '[-1, 0, 1]', 'null', 'true', 'false', '2020', '91', '9', '\"2020\"')")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: '{"obj": 100}' for column 'obj' at row 1".
+	tk.MustExec("alter table t modify obj year")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: '[-1, 0, 1]' for column 'arr' at row 11".
+	tk.MustExec("alter table t modify arr year")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: 'null' for column 'nil' at row 1".
+	tk.MustExec("alter table t modify nil year")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: 'true' for column 't' at row 1".
+	tk.MustExec("alter table t modify t year")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: 'false' for column 'f' at row 1".
+	tk.MustExec("alter table t modify f year")
+	tk.MustExec("alter table t modify i year")
+	tk.MustExec("alter table t modify ui year")
+	tk.MustExec("alter table t modify f64 year")
+	// MySQL will get "ERROR 1366 (HY000): Incorrect integer value: '"2020"' for column 'str' at row 1".
+	tk.MustExec("alter table t modify str year")
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 2001 0 2020 1991 2009 2020"))
+}

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -1275,12 +1275,12 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromJsonToOthers(c *C) {
 	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: 'false' for column 'f' at row 1".
 	tk.MustExec("alter table t modify f bigint unsigned")
 	// MySQL will get "ERROR 1264 (22003) Out of range value for column 'i' at row 1".
-	tk.MustExec("alter table t modify i bigint unsigned")
+	tk.MustGetErrCode("alter table t modify i bigint unsigned", mysql.ErrDataOutOfRange)
 	tk.MustExec("alter table t modify ui bigint unsigned")
 	tk.MustExec("alter table t modify f64 bigint unsigned")
 	// MySQL will get "ERROR 1366 (HY000) Incorrect integer value: '"json string"' for column 'str' at row 1".
 	tk.MustGetErrCode("alter table t modify str bigint unsigned", mysql.ErrTruncatedWrongValue)
-	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 18446744073709551594 22 323232323 \"json string\""))
+	tk.MustQuery("select * from t").Check(testkit.Rows("0 0 0 1 0 -22 22 323232323 \"json string\""))
 
 	// bit
 	reset(tk)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4744,7 +4744,7 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		tk.Se.GetSessionVars().TimeZone = originalTz
 	}()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	timeToDate1 := now.Format("2006-01-02")
 	timeToDate2 := now.AddDate(0, 0, 30).Format("2006-01-02")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -4735,32 +4735,33 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 	enableChangeColumnType := tk.Se.GetSessionVars().EnableChangeColumnType
 	tk.Se.GetSessionVars().EnableChangeColumnType = true
 
+	// Set time zone to UTC.
+	originalTz := tk.Se.GetSessionVars().TimeZone
+	tk.Se.GetSessionVars().TimeZone = time.UTC
 	defer func() {
 		variable.SetDDLErrorCountLimit(limit)
 		tk.Se.GetSessionVars().EnableChangeColumnType = enableChangeColumnType
+		tk.Se.GetSessionVars().TimeZone = originalTz
 	}()
 
-	//now := time.Now()
-	//now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-	//nowLoc := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	now := time.Now()
+	now = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	timeToDate1 := now.Format("2006-01-02")
+	timeToDate2 := now.AddDate(0, 0, 30).Format("2006-01-02")
 
-	//timeToDate1 := nowLoc.Format("2006-01-02")
-	//timeToDate2 := nowLoc.AddDate(0, 0, 30).Format("2006-01-02")
+	timeToDatetime1 := now.Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToDatetime2 := now.Add(20 * time.Hour).Format("2006-01-02 15:04:05")
+	timeToDatetime3 := now.Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToDatetime4 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToDatetime5 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Format("2006-01-02 15:04:05")
 
-	//timeToDatetime1 := nowLoc.Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToDatetime2 := nowLoc.Add(20 * time.Hour).Format("2006-01-02 15:04:05")
-	//timeToDatetime3 := nowLoc.Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToDatetime4 := nowLoc.AddDate(0, 0, 30).Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToDatetime5 := nowLoc.AddDate(0, 0, 30).Add(20 * time.Hour).Format("2006-01-02 15:04:05")
-
-	//timeToTimestamp1 := now.Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToTimestamp2 := now.Add(20 * time.Hour).Format("2006-01-02 15:04:05")
-	//timeToTimestamp3 := now.Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToTimestamp4 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
-	//timeToTimestamp5 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Format("2006-01-02 15:04:05")
+	timeToTimestamp1 := now.Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToTimestamp2 := now.Add(20 * time.Hour).Format("2006-01-02 15:04:05")
+	timeToTimestamp3 := now.Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToTimestamp4 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Add(12 * time.Second).Format("2006-01-02 15:04:05")
+	timeToTimestamp5 := now.AddDate(0, 0, 30).Add(20 * time.Hour).Format("2006-01-02 15:04:05")
 	currentYear := strconv.Itoa(time.Now().Year())
 
-	// TESTED UNDER UTC+8
 	// 1. In conversion between date/time, fraction parts are taken into account
 	// Refer to doc: https://dev.mysql.com/doc/refman/5.7/en/date-and-time-type-conversion.html
 	// 2. Failed tests are commentd to pass unit-test
@@ -4788,55 +4789,52 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		{"time", `200012.498`, "year", currentYear, 0},
 
 		// time to date
-		// TODO: somewhat got one day earlier than expected
-		//{"time", `"30 20:00:12"`, "date", timeToDate2, 0},
-		//{"time", `"30 20:00"`, "date", timeToDate2, 0},
-		//{"time", `"30 20"`, "date", timeToDate2, 0},
-		//{"time", `"20:00:12"`, "date", timeToDate1, 0},
-		//{"time", `"20:00"`, "date", timeToDate1, 0},
-		//{"time", `"12"`, "date", timeToDate1, 0},
-		//{"time", `"200012"`, "date", timeToDate1, 0},
-		//{"time", `200012`, "date", timeToDate1, 0},
-		//{"time", `0012`, "date", timeToDate1, 0},
-		//{"time", `12`, "date", timeToDate1, 0},
-		//{"time", `"30 20:00:12.498"`, "date", timeToDate2, 0},
-		//{"time", `"20:00:12.498"`, "date", timeToDate1, 0},
-		//{"time", `"200012.498"`, "date", timeToDate1, 0},
-		//{"time", `200012.498`, "date", timeToDate1, 0},
+		{"time", `"30 20:00:12"`, "date", timeToDate2, 0},
+		{"time", `"30 20:00"`, "date", timeToDate2, 0},
+		{"time", `"30 20"`, "date", timeToDate2, 0},
+		{"time", `"20:00:12"`, "date", timeToDate1, 0},
+		{"time", `"20:00"`, "date", timeToDate1, 0},
+		{"time", `"12"`, "date", timeToDate1, 0},
+		{"time", `"200012"`, "date", timeToDate1, 0},
+		{"time", `200012`, "date", timeToDate1, 0},
+		{"time", `0012`, "date", timeToDate1, 0},
+		{"time", `12`, "date", timeToDate1, 0},
+		{"time", `"30 20:00:12.498"`, "date", timeToDate2, 0},
+		{"time", `"20:00:12.498"`, "date", timeToDate1, 0},
+		{"time", `"200012.498"`, "date", timeToDate1, 0},
+		{"time", `200012.498`, "date", timeToDate1, 0},
 
 		// time to datetime
-		// TODO: somewhat got one day earlier than expected
-		//{"time", `"30 20:00:12"`, "datetime", timeToDatetime4, 0},
-		//{"time", `"30 20:00"`, "datetime", timeToDatetime5, 0},
-		//{"time", `"30 20"`, "datetime", timeToDatetime5, 0},
-		//{"time", `"20:00:12"`, "datetime", timeToDatetime1, 0},
-		//{"time", `"20:00"`, "datetime", timeToDatetime2, 0},
-		//{"time", `"12"`, "datetime", timeToDatetime3, 0},
-		//{"time", `"200012"`, "datetime", timeToDatetime1, 0},
-		//{"time", `200012`, "datetime", timeToDatetime1, 0},
-		//{"time", `0012`, "datetime", timeToDatetime3, 0},
-		//{"time", `12`, "datetime", timeToDatetime3, 0},
-		//{"time", `"30 20:00:12.498"`, "datetime", timeToDatetime4, 0},
-		//{"time", `"20:00:12.498"`, "datetime", timeToDatetime1, 0},
-		//{"time", `"200012.498"`, "datetime", timeToDatetime1, 0},
-		//{"time", `200012.498`, "datetime", timeToDatetime1, 0},
+		{"time", `"30 20:00:12"`, "datetime", timeToDatetime4, 0},
+		{"time", `"30 20:00"`, "datetime", timeToDatetime5, 0},
+		{"time", `"30 20"`, "datetime", timeToDatetime5, 0},
+		{"time", `"20:00:12"`, "datetime", timeToDatetime1, 0},
+		{"time", `"20:00"`, "datetime", timeToDatetime2, 0},
+		{"time", `"12"`, "datetime", timeToDatetime3, 0},
+		{"time", `"200012"`, "datetime", timeToDatetime1, 0},
+		{"time", `200012`, "datetime", timeToDatetime1, 0},
+		{"time", `0012`, "datetime", timeToDatetime3, 0},
+		{"time", `12`, "datetime", timeToDatetime3, 0},
+		{"time", `"30 20:00:12.498"`, "datetime", timeToDatetime4, 0},
+		{"time", `"20:00:12.498"`, "datetime", timeToDatetime1, 0},
+		{"time", `"200012.498"`, "datetime", timeToDatetime1, 0},
+		{"time", `200012.498`, "datetime", timeToDatetime1, 0},
 
 		// time to timestamp
-		// TODO: result seems correct expect 8hrs earlier
-		//{"time", `"30 20:00:12"`, "timestamp", timeToTimestamp4, 0},
-		//{"time", `"30 20:00"`, "timestamp", timeToTimestamp5, 0},
-		//{"time", `"30 20"`, "timestamp", timeToTimestamp5, 0},
-		//{"time", `"20:00:12"`, "timestamp", timeToTimestamp1, 0},
-		//{"time", `"20:00"`, "timestamp", timeToTimestamp2, 0},
-		//{"time", `"12"`, "timestamp", timeToTimestamp3, 0},
-		//{"time", `"200012"`, "timestamp", timeToTimestamp1, 0},
-		//{"time", `200012`, "timestamp", timeToTimestamp1, 0},
-		//{"time", `0012`, "timestamp", timeToTimestamp3, 0},
-		//{"time", `12`, "timestamp", timeToTimestamp3, 0},
-		//{"time", `"30 20:00:12.498"`, "timestamp", timeToTimestamp4, 0},
-		//{"time", `"20:00:12.498"`, "timestamp", timeToTimestamp1, 0},
-		//{"time", `"200012.498"`, "timestamp", timeToTimestamp1, 0},
-		//{"time", `200012.498`, "timestamp", timeToTimestamp1, 0},
+		{"time", `"30 20:00:12"`, "timestamp", timeToTimestamp4, 0},
+		{"time", `"30 20:00"`, "timestamp", timeToTimestamp5, 0},
+		{"time", `"30 20"`, "timestamp", timeToTimestamp5, 0},
+		{"time", `"20:00:12"`, "timestamp", timeToTimestamp1, 0},
+		{"time", `"20:00"`, "timestamp", timeToTimestamp2, 0},
+		{"time", `"12"`, "timestamp", timeToTimestamp3, 0},
+		{"time", `"200012"`, "timestamp", timeToTimestamp1, 0},
+		{"time", `200012`, "timestamp", timeToTimestamp1, 0},
+		{"time", `0012`, "timestamp", timeToTimestamp3, 0},
+		{"time", `12`, "timestamp", timeToTimestamp3, 0},
+		{"time", `"30 20:00:12.498"`, "timestamp", timeToTimestamp4, 0},
+		{"time", `"20:00:12.498"`, "timestamp", timeToTimestamp1, 0},
+		{"time", `"200012.498"`, "timestamp", timeToTimestamp1, 0},
+		{"time", `200012.498`, "timestamp", timeToTimestamp1, 0},
 
 		// date to time
 		{"date", `"2019-01-02"`, "time", "00:00:00", 0},
@@ -4855,22 +4853,20 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		{"date", `190102`, "year", "2019", 0},
 
 		// date to datetime
-		// TODO: looks like 8hrs later than expected
-		//{"date", `"2019-01-02"`, "datetime", "2019-01-02 00:00:00", 0},
-		//{"date", `"19-01-02"`, "datetime", "2019-01-02 00:00:00", 0},
-		//{"date", `"20190102"`, "datetime", "2019-01-02 00:00:00", 0},
-		//{"date", `"190102"`, "datetime", "2019-01-02 00:00:00", 0},
-		//{"date", `20190102`, "datetime", "2019-01-02 00:00:00", 0},
-		//{"date", `190102`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `"2019-01-02"`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `"19-01-02"`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `"20190102"`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `"190102"`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `20190102`, "datetime", "2019-01-02 00:00:00", 0},
+		{"date", `190102`, "datetime", "2019-01-02 00:00:00", 0},
 
 		// date to timestamp
-		// TODO: looks like 8hrs later than expected
-		//{"date", `"2019-01-02"`, "timestamp", "2019-01-02 00:00:00", 0},
-		//{"date", `"19-01-02"`, "timestamp", "2019-01-02 00:00:00", 0},
-		//{"date", `"20190102"`, "timestamp", "2019-01-02 00:00:00", 0},
-		//{"date", `"190102"`, "timestamp", "2019-01-02 00:00:00", 0},
-		//{"date", `20190102`, "timestamp", "2019-01-02 00:00:00", 0},
-		//{"date", `190102`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `"2019-01-02"`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `"19-01-02"`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `"20190102"`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `"190102"`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `20190102`, "timestamp", "2019-01-02 00:00:00", 0},
+		{"date", `190102`, "timestamp", "2019-01-02 00:00:00", 0},
 
 		// timestamp to year
 		{"timestamp", `"2006-01-02 15:04:05"`, "year", "2006", 0},
@@ -4882,14 +4878,13 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		{"timestamp", `"2006-01-02 23:59:59.506"`, "year", "2006", 0},
 
 		// timestamp to time
-		// TODO: looks like 8hrs earlier than expected
-		//{"timestamp", `"2006-01-02 15:04:05"`, "time", "15:04:05", 0},
-		//{"timestamp", `"06-01-02 15:04:05"`, "time", "15:04:05", 0},
-		//{"timestamp", `"20060102150405"`, "time", "15:04:05", 0},
-		//{"timestamp", `"060102150405"`, "time", "15:04:05", 0},
-		//{"timestamp", `20060102150405`, "time", "15:04:05", 0},
-		//{"timestamp", `060102150405`, "time", "15:04:05", 0},
-		//{"timestamp", `"2006-01-02 23:59:59.506"`, "time", "00:00:00", 0},
+		{"timestamp", `"2006-01-02 15:04:05"`, "time", "15:04:05", 0},
+		{"timestamp", `"06-01-02 15:04:05"`, "time", "15:04:05", 0},
+		{"timestamp", `"20060102150405"`, "time", "15:04:05", 0},
+		{"timestamp", `"060102150405"`, "time", "15:04:05", 0},
+		{"timestamp", `20060102150405`, "time", "15:04:05", 0},
+		{"timestamp", `060102150405`, "time", "15:04:05", 0},
+		{"timestamp", `"2006-01-02 23:59:59.506"`, "time", "00:00:00", 0},
 
 		// timestamp to date
 		{"timestamp", `"2006-01-02 15:04:05"`, "date", "2006-01-02", 0},
@@ -4898,24 +4893,16 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		{"timestamp", `"060102150405"`, "date", "2006-01-02", 0},
 		{"timestamp", `20060102150405`, "date", "2006-01-02", 0},
 		{"timestamp", `060102150405`, "date", "2006-01-02", 0},
-		// TODO: check the following case
-		// set @@timezone="+8:00"
-		// create table t (a timestamp)
-		// insert into t (a) values('2006-01-02 23:59:59.506')
-		// select cast(a as date) from t == 2006-01-03
-		// set @@timezone="+0:00"
-		// select cast(a as date) from t == 2006-01-02
-		//{"timestamp", `"2006-01-02 23:59:59.506"`, "date", "2006-01-03", 0},
+		{"timestamp", `"2006-01-02 23:59:59.506"`, "date", "2006-01-03", 0},
 
 		// timestamp to datetime
-		// TODO: looks like 8hrs earlier than expected
-		//{"timestamp", `"2006-01-02 15:04:05"`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `"06-01-02 15:04:05"`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `"20060102150405"`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `"060102150405"`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `20060102150405`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `060102150405`, "datetime", "2006-01-02 15:04:05", 0},
-		//{"timestamp", `"2006-01-02 23:59:59.506"`, "datetime", "2006-01-03 00:00:00", 0},
+		{"timestamp", `"2006-01-02 15:04:05"`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `"06-01-02 15:04:05"`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `"20060102150405"`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `"060102150405"`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `20060102150405`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `060102150405`, "datetime", "2006-01-02 15:04:05", 0},
+		{"timestamp", `"2006-01-02 23:59:59.506"`, "datetime", "2006-01-03 00:00:00", 0},
 
 		// datetime to year
 		{"datetime", `"2006-01-02 15:04:05"`, "year", "2006", 0},
@@ -4952,30 +4939,28 @@ func (s *testDBSuite1) TestModifyColumnTime(c *C) {
 		{"datetime", `"9999-01-02 23:59:59"`, "date", "9999-01-02", 0},
 
 		// datetime to timestamp
-		// TODO: looks like 8hrs later than expected
-		//{"datetime", `"2006-01-02 15:04:05"`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `"06-01-02 15:04:05"`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `"20060102150405"`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `"060102150405"`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `20060102150405`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `060102150405`, "timestamp", "2006-01-02 15:04:05", 0},
-		//{"datetime", `"2006-01-02 23:59:59.506"`, "timestamp", "2006-01-02 23:59:59", 0},
-		//{"datetime", `"1000-01-02 23:59:59"`, "timestamp", "", errno.ErrTruncatedWrongValue},
-		//{"datetime", `"9999-01-02 23:59:59"`, "timestamp", "", errno.ErrTruncatedWrongValue},
+		{"datetime", `"2006-01-02 15:04:05"`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `"06-01-02 15:04:05"`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `"20060102150405"`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `"060102150405"`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `20060102150405`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `060102150405`, "timestamp", "2006-01-02 15:04:05", 0},
+		{"datetime", `"2006-01-02 23:59:59.506"`, "timestamp", "2006-01-03 00:00:00", 0},
+		{"datetime", `"1000-01-02 23:59:59"`, "timestamp", "1000-01-02 23:59:59", 0},
+		{"datetime", `"9999-01-02 23:59:59"`, "timestamp", "9999-01-02 23:59:59", 0},
 
 		// year to time
-		// TODO: ban conversion that maybe fail
 		// failed cases are not handled by TiDB
-		//{"year", `"2019"`, "time", "00:20:19", 0},
-		//{"year", `2019`, "time", "00:20:19", 0},
-		//{"year", `"00"`, "time", "00:20:00", 0},
-		//{"year", `"69"`, "time", "", errno.ErrTruncatedWrongValue},
-		//{"year", `"70"`, "time", "", errno.ErrTruncatedWrongValue},
-		//{"year", `"99"`, "time", "", errno.ErrTruncatedWrongValue},
-		//{"year", `00`, "time", "00:00:00", 0},
-		//{"year", `69`, "time", "", errno.ErrTruncatedWrongValue},
-		//{"year", `70`, "time", "", errno.ErrTruncatedWrongValue},
-		//{"year", `99`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `"2019"`, "time", "00:20:19", 0},
+		{"year", `2019`, "time", "00:20:19", 0},
+		{"year", `"00"`, "time", "00:20:00", 0},
+		{"year", `"69"`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `"70"`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `"99"`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `00`, "time", "00:00:00", 0},
+		{"year", `69`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `70`, "time", "", errno.ErrTruncatedWrongValue},
+		{"year", `99`, "time", "", errno.ErrTruncatedWrongValue},
 
 		// year to date
 		{"year", `"2019"`, "date", "", errno.ErrTruncatedWrongValue},

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3497,6 +3497,11 @@ func checkTypeChangeSupported(origin *types.FieldType, to *types.FieldType) bool
 		return false
 	}
 
+	if origin.Tp == mysql.TypeJSON && (to.Tp == mysql.TypeEnum || to.Tp == mysql.TypeSet || to.Tp == mysql.TypeBit) {
+		// TODO: Currently json cast to enum/set/bit are not support yet, should fix here after supported.
+		return false
+	}
+
 	return true
 }
 

--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -1608,7 +1608,7 @@ func (b *builtinCastJSONAsIntSig) evalInt(row chunk.Row) (res int64, isNull bool
 		return res, isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
-	res, err = types.ConvertJSONToInt(sc, val, mysql.HasUnsignedFlag(b.tp.Flag))
+	res, err = types.ConvertJSONToInt64(sc, val, mysql.HasUnsignedFlag(b.tp.Flag))
 	return
 }
 

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -1160,7 +1160,7 @@ func (b *builtinCastJSONAsIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.C
 		if result.IsNull(i) {
 			continue
 		}
-		i64s[i], err = types.ConvertJSONToInt(sc, buf.GetJSON(i), mysql.HasUnsignedFlag(b.tp.Flag))
+		i64s[i], err = types.ConvertJSONToInt64(sc, buf.GetJSON(i), mysql.HasUnsignedFlag(b.tp.Flag))
 		if err != nil {
 			return err
 		}

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -561,9 +561,7 @@ func (sc *StatementContext) GetExecDetails() execdetails.ExecDetails {
 // This is the case for `insert`, `update`, `alter table`, `create table` and `load data infile` statements, when not in strict SQL mode.
 // see https://dev.mysql.com/doc/refman/5.7/en/out-of-range-and-overflow.html
 func (sc *StatementContext) ShouldClipToZero() bool {
-	// TODO: Currently altering column of integer to unsigned integer is not supported.
-	// If it is supported one day, that case should be added here.
-	return sc.InInsertStmt || sc.InLoadDataStmt || sc.InUpdateStmt || sc.InCreateOrAlterStmt
+	return sc.InInsertStmt || sc.InLoadDataStmt || sc.InUpdateStmt || sc.InCreateOrAlterStmt || sc.IsDDLJobInQueue
 }
 
 // ShouldIgnoreOverflowError indicates whether we should ignore the error when type conversion overflows,

--- a/types/convert.go
+++ b/types/convert.go
@@ -560,8 +560,27 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 		default:
 			return 1, nil
 		}
-	case json.TypeCodeInt64, json.TypeCodeUint64:
-		return j.GetInt64(), nil
+	case json.TypeCodeInt64:
+		i := j.GetInt64()
+		if unsigned {
+			uBound := IntergerUnsignedUpperBound(tp)
+			u, err :=  ConvertIntToUint(sc, i, uBound, tp)
+			return int64(u), sc.HandleOverflow(err, err)
+		}
+
+		lBound := IntergerSignedLowerBound(tp)
+		uBound := IntergerSignedUpperBound(tp)
+		return ConvertIntToInt(i, lBound, uBound, tp)
+	case json.TypeCodeUint64:
+		u := j.GetUint64()
+		if unsigned {
+			uBound := IntergerUnsignedUpperBound(tp)
+			u, err := ConvertUintToUint(u, uBound, tp)
+			return int64(u), sc.HandleOverflow(err, err)
+		}
+
+		uBound := IntergerSignedUpperBound(tp)
+		return ConvertUintToInt(u, uBound, tp)
 	case json.TypeCodeFloat64:
 		f := j.GetFloat64()
 		if !unsigned {

--- a/types/convert.go
+++ b/types/convert.go
@@ -543,8 +543,13 @@ func StrToFloat(sc *stmtctx.StatementContext, str string, isFuncCast bool) (floa
 	return f, errors.Trace(err)
 }
 
-// ConvertJSONToInt casts JSON into int64.
-func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned bool) (int64, error) {
+// ConvertJSONToInt64 casts JSON into int64.
+func ConvertJSONToInt64(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned bool) (int64, error) {
+	return ConvertJSONToInt(sc, j, unsigned, mysql.TypeLonglong)
+}
+
+// ConvertJSONToInt casts JSON into int by type.
+func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned bool, tp byte) (int64, error) {
 	switch j.TypeCode {
 	case json.TypeCodeObject, json.TypeCodeArray:
 		return 0, nil
@@ -560,13 +565,13 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 	case json.TypeCodeFloat64:
 		f := j.GetFloat64()
 		if !unsigned {
-			lBound := IntergerSignedLowerBound(mysql.TypeLonglong)
-			uBound := IntergerSignedUpperBound(mysql.TypeLonglong)
-			u, e := ConvertFloatToInt(f, lBound, uBound, mysql.TypeLonglong)
+			lBound := IntergerSignedLowerBound(tp)
+			uBound := IntergerSignedUpperBound(tp)
+			u, e := ConvertFloatToInt(f, lBound, uBound, tp)
 			return u, sc.HandleOverflow(e, e)
 		}
-		bound := IntergerUnsignedUpperBound(mysql.TypeLonglong)
-		u, err := ConvertFloatToUint(sc, f, bound, mysql.TypeLonglong)
+		bound := IntergerUnsignedUpperBound(tp)
+		u, err := ConvertFloatToUint(sc, f, bound, tp)
 		return int64(u), sc.HandleOverflow(err, err)
 	case json.TypeCodeString:
 		str := string(hack.String(j.GetString()))

--- a/types/convert.go
+++ b/types/convert.go
@@ -564,7 +564,7 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 		i := j.GetInt64()
 		if unsigned {
 			uBound := IntergerUnsignedUpperBound(tp)
-			u, err :=  ConvertIntToUint(sc, i, uBound, tp)
+			u, err := ConvertIntToUint(sc, i, uBound, tp)
 			return int64(u), sc.HandleOverflow(err, err)
 		}
 

--- a/types/convert.go
+++ b/types/convert.go
@@ -570,7 +570,8 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 
 		lBound := IntergerSignedLowerBound(tp)
 		uBound := IntergerSignedUpperBound(tp)
-		return ConvertIntToInt(i, lBound, uBound, tp)
+		i, err := ConvertIntToInt(i, lBound, uBound, tp)
+		return i, sc.HandleOverflow(err, err)
 	case json.TypeCodeUint64:
 		u := j.GetUint64()
 		if unsigned {
@@ -580,7 +581,8 @@ func ConvertJSONToInt(sc *stmtctx.StatementContext, j json.BinaryJSON, unsigned 
 		}
 
 		uBound := IntergerSignedUpperBound(tp)
-		return ConvertUintToInt(u, uBound, tp)
+		i, err := ConvertUintToInt(u, uBound, tp)
+		return i, sc.HandleOverflow(err, err)
 	case json.TypeCodeFloat64:
 		f := j.GetFloat64()
 		if !unsigned {

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -272,6 +272,15 @@ func (s *testTypeConvertSuite) TestConvertType(c *C) {
 	v, err = Convert(ZeroDuration, ft)
 	c.Assert(err, IsNil)
 	c.Assert(v, Equals, int64(time.Now().Year()))
+	bj1, err := json.ParseBinaryFromString("99")
+	c.Assert(err, IsNil)
+	v, err = Convert(bj1, ft)
+	c.Assert(err, IsNil)
+	c.Assert(v, Equals, int64(1999))
+	bj2, err := json.ParseBinaryFromString("-1")
+	c.Assert(err, IsNil)
+	_, err = Convert(bj2, ft)
+	c.Assert(err, NotNil)
 
 	// For enum
 	ft = NewFieldType(mysql.TypeEnum)

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -982,7 +982,7 @@ func (s *testTypeConvertSuite) TestConvertJSONToInt(c *C) {
 		j, err := json.ParseBinaryFromString(tt.In)
 		c.Assert(err, IsNil)
 
-		casted, _ := ConvertJSONToInt(new(stmtctx.StatementContext), j, false)
+		casted, _ := ConvertJSONToInt64(new(stmtctx.StatementContext), j, false)
 		c.Assert(casted, Equals, tt.Out)
 	}
 }

--- a/types/datum.go
+++ b/types/datum.go
@@ -1365,6 +1365,12 @@ func (d *Datum) convertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 		y = int64(d.GetMysqlTime().Year())
 	case KindMysqlDuration:
 		y = int64(time.Now().Year())
+	case KindMysqlJSON:
+		y, err = ConvertJSONToInt64(sc, d.GetMysqlJSON(), false)
+		if err != nil {
+			ret.SetInt64(0)
+			return ret, errors.Trace(err)
+		}
 	default:
 		ret, err = d.convertToInt(sc, NewFieldType(mysql.TypeLonglong))
 		if err != nil {

--- a/types/datum.go
+++ b/types/datum.go
@@ -1065,7 +1065,7 @@ func (d *Datum) convertToUint(sc *stmtctx.StatementContext, target *FieldType) (
 		}
 	case KindMysqlJSON:
 		var i64 int64
-		i64, err = ConvertJSONToInt(sc, d.GetMysqlJSON(), true)
+		i64, err = ConvertJSONToInt(sc, d.GetMysqlJSON(), true, tp)
 		val = uint64(i64)
 	default:
 		return invalidConv(d, target.Tp)
@@ -1712,7 +1712,7 @@ func (d *Datum) toSignedInteger(sc *stmtctx.StatementContext, tp byte) (int64, e
 		fval := d.GetMysqlSet().ToNumber()
 		return ConvertFloatToInt(fval, lowerBound, upperBound, tp)
 	case KindMysqlJSON:
-		return ConvertJSONToInt(sc, d.GetMysqlJSON(), false)
+		return ConvertJSONToInt(sc, d.GetMysqlJSON(), false, tp)
 	case KindBinaryLiteral, KindMysqlBit:
 		val, err := d.GetBinaryLiteral().ToInt(sc)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/20662

Problem Summary:
DDL modify column, change type from different types, see more detail at: https://github.com/pingcap/tidb/issues/19939

### What is changed and how it works?
What's Changed:
Support ddl column type change from JSON type to other types.

This PR made some changes:
1. Tested the JSON type cast to others(see correlated integration test at column_type_change_test.go), include JSON data type: object, array, boolean(true and false), number(integer and float), null.
2. Fix commented test code at db_test.go about date time conversion.

Below case cannot supported because of the Datum.ConvertTo() contains no proper implementations about it:
- JSON to enum/set/bit

Above case should fix at individual PRs (will create issues later).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- ddl: support column type change from JSON type to other types