### PR TITLE
infoschema: fix the bug that the metric of hot region will be same

### DIFF
--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -204,6 +204,7 @@ type HotTableIndex struct {
 func (h *Helper) FetchRegionTableIndex(metrics map[uint64]RegionMetric, allSchemas []*model.DBInfo) ([]HotTableIndex, error) {
 	hotTables := make([]HotTableIndex, 0, len(metrics))
 	for regionID, regionMetric := range metrics {
+		regionMetric := regionMetric
 		t := HotTableIndex{RegionID: regionID, RegionMetric: &regionMetric}
 		region, err := h.RegionCache.LocateRegionByID(tikv.NewBackofferWithVars(context.Background(), 500, nil), regionID)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Zheng Xiangsheng <hundundm@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

```
MySQL [(none)]> SELECT * FROM INFORMATION_SCHEMA.TIDB_HOT_REGIONS;
+----------+----------+---------------+------------------+------------+-----------+-------+----------------+--------------+------------+
| TABLE_ID | INDEX_ID | DB_NAME       | TABLE_NAME       | INDEX_NAME | REGION_ID | TYPE  | MAX_HOT_DEGREE | REGION_COUNT | FLOW_BYTES |
+----------+----------+---------------+------------------+------------+-----------+-------+----------------+--------------+------------+
|       57 |     NULL | btest         | btest10          | NULL       |  21166161 | read  |            235 |            0 |      23637 |
|       75 |     NULL | btest         | btest2           | NULL       |  21164290 | read  |            235 |            0 |      23637 |
|       64 |     NULL | btest         | btest3           | NULL       |      1622 | read  |            235 |            0 |      23637 |
|       71 |     NULL | btest         | btest8           | NULL       |  21164357 | read  |            235 |            0 |      23637 |
|       66 |     NULL | btest         | btest7           | NULL       |      1731 | read  |            235 |            0 |      23637 |
...
|       71 |     NULL | btest         | btest8           | NULL       |  21156334 | write |           1140 |            0 |     122823 |
|       84 |     NULL | btest         | btest9           | NULL       |  21166277 | write |           1140 |            0 |     122823 |
|       68 |     NULL | btest         | btest14          | NULL       |  21170223 | write |           1140 |            0 |     122823 |
|       81 |     NULL | btest         | btest11          | NULL       |  21166145 | write |           1140 |            0 |     122823 |
|       75 |     NULL | btest         | btest2           | NULL       |  21169517 | write |           1140 |            0 |     122823 |
...
+----------+----------+---------------+------------------+------------+-----------+-------+----------------+--------------+------------+
```

### What is changed and how it works?

What's Changed:

How it Works:

* fix the bug that they point to the same pointer

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
  - `SELECT * FROM INFORMATION_SCHEMA.TIDB_HOT_REGIONS;`

### Release note <!-- bugfixes or new feature need a release note -->

- fix the bug that the metric of hot region will be same
