### PR TITLE
*: support baseline capture for prepared statements

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -970,6 +970,36 @@ func (s *testSuite) TestCaptureBaselinesDefaultDB(c *C) {
 	c.Assert(len(tk.Se.GetSessionVars().StmtCtx.IndexNames), Equals, 0)
 }
 
+func (s *testSuite) TestCapturePreparedStmt(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	s.cleanBindingEnv(tk)
+	stmtsummary.StmtSummaryByDigestMap.Clear()
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int, c int, key idx_b(b), key idx_c(c))")
+	c.Assert(tk.MustUseIndex("select * from t where b = 1 and c > 1", "idx_b(b)"), IsTrue)
+	tk.MustExec("prepare stmt from 'select /*+ use_index(t,idx_c) */ * from t where b = ? and c > ?'")
+	tk.MustExec("set @p = 1")
+	tk.MustExec("execute stmt using @p, @p")
+	tk.MustExec("execute stmt using @p, @p")
+
+	tk.MustQuery("show global bindings").Check(testkit.Rows())
+	tk.MustExec("admin capture bindings")
+	rows := tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t where b = ? and c > ?")
+	c.Assert(rows[0][1], Equals, "SELECT /*+ use_index(@`sel_1` `test`.`t` `idx_c`)*/ * FROM `t` WHERE `b`=? AND `c`>?")
+
+	c.Assert(tk.MustUseIndex("select /*+ use_index(t,idx_b) */ * from t where b = 1 and c > 1", "idx_c(c)"), IsTrue)
+	tk.MustExec("admin flush bindings")
+	tk.MustExec("admin evolve bindings")
+	rows = tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t where b = ? and c > ?")
+	c.Assert(rows[0][1], Equals, "SELECT /*+ use_index(@`sel_1` `test`.`t` `idx_c`)*/ * FROM `t` WHERE `b`=? AND `c`>?")
+}
+
 func (s *testSuite) TestDropSingleBindings(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	s.cleanBindingEnv(tk)
@@ -1752,4 +1782,26 @@ func (s *testSuite) TestDMLIndexHintBind(c *C) {
 	tk.MustExec("delete from t where b = 1 and c > 1")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.IndexNames[0], Equals, "t:idx_c")
 	c.Assert(tk.MustUseIndex("delete from t where b = 1 and c > 1", "idx_c(c)"), IsTrue)
+}
+
+func (s *testSuite) TestCapturedBindingCharset(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	s.cleanBindingEnv(tk)
+	stmtsummary.StmtSummaryByDigestMap.Clear()
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(name varchar(25), index idx(name))")
+
+	tk.MustExec("set character_set_connection = 'ascii'")
+	tk.MustExec("update t set name = 'hello' where name <= 'abc'")
+	tk.MustExec("update t set name = 'hello' where name <= 'abc'")
+	tk.MustExec("set character_set_connection = 'utf8mb4'")
+	tk.MustExec("admin capture bindings")
+	rows := tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "update t set name = ? where name <= ?")
+	c.Assert(rows[0][1], Equals, "UPDATE /*+ use_index(@`upd_1` `test`.`t` `idx`)*/ `t` SET `name`=_ASCII'hello' WHERE `name`<=_ASCII'abc'")
+	// Charset and Collation are empty now, they are not used currently.
+	c.Assert(rows[0][6], Equals, "")
+	c.Assert(rows[0][7], Equals, "")
 }

--- a/bindinfo/cache.go
+++ b/bindinfo/cache.go
@@ -120,15 +120,19 @@ func (br *BindRecord) prepareHints(sctx sessionctx.Context) error {
 		if (bind.Hint != nil && bind.ID != "") || bind.Status == deleted {
 			continue
 		}
-		if sctx != nil {
-			_, err := getHintsForSQL(sctx, bind.BindSQL)
-			if err != nil {
-				return err
-			}
-		}
-		hintsSet, warns, err := hint.ParseHintsSet(p, bind.BindSQL, bind.Charset, bind.Collation, br.Db)
+		hintsSet, stmt, warns, err := hint.ParseHintsSet(p, bind.BindSQL, bind.Charset, bind.Collation, br.Db)
 		if err != nil {
 			return err
+		}
+		if sctx != nil {
+			paramChecker := &paramMarkerChecker{}
+			stmt.Accept(paramChecker)
+			if !paramChecker.hasParamMarker {
+				_, err = getHintsForSQL(sctx, bind.BindSQL)
+				if err != nil {
+					return err
+				}
+			}
 		}
 		hintsStr, err := hintsSet.Restore()
 		if err != nil {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -46,6 +46,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/hint"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/plancodec"
@@ -974,7 +975,7 @@ func getPlanTree(sctx sessionctx.Context, p plannercore.Plan) string {
 	if atomic.LoadUint32(&cfg.Log.RecordPlanInSlowLog) == 0 {
 		return ""
 	}
-	planTree := getEncodedPlan(sctx, p)
+	planTree, _ := getEncodedPlan(sctx, p, false, nil)
 	if len(planTree) == 0 {
 		return planTree
 	}
@@ -992,14 +993,23 @@ func getPlanDigest(sctx sessionctx.Context, p plannercore.Plan) (normalized, pla
 	return
 }
 
-// getEncodedPlan uses to get encoded plan.
-func getEncodedPlan(sctx sessionctx.Context, p plannercore.Plan) (encodedPlan string) {
+// getEncodedPlan gets the encoded plan, and generates the hint string if indicated.
+func getEncodedPlan(sctx sessionctx.Context, p plannercore.Plan, genHint bool, n ast.StmtNode) (encodedPlan, hintStr string) {
 	encodedPlan = sctx.GetSessionVars().StmtCtx.GetEncodedPlan()
+	hintStr = sctx.GetSessionVars().StmtCtx.GetPlanHint()
 	if len(encodedPlan) > 0 {
 		return
 	}
 	encodedPlan = plannercore.EncodePlan(p)
 	sctx.GetSessionVars().StmtCtx.SetEncodedPlan(encodedPlan)
+	if genHint {
+		hints := plannercore.GenHintsFromPhysicalPlan(p)
+		if n != nil {
+			hints = append(hints, hint.ExtractTableHintsFromStmtNode(n, nil)...)
+		}
+		hintStr = hint.RestoreOptimizerHints(hints)
+		sctx.GetSessionVars().StmtCtx.SetPlanHint(hintStr)
+	}
 	return
 }
 
@@ -1027,6 +1037,7 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	}
 	normalizedSQL, digest := stmtCtx.SQLDigest()
 	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
+	charset, collation := sessVars.GetCharsetInfo()
 
 	var prevSQL, prevSQLDigest string
 	if _, ok := a.StmtNode.(*ast.CommitStmt); ok {
@@ -1040,8 +1051,8 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	sessVars.SetPrevStmtDigest(digest)
 
 	// No need to encode every time, so encode lazily.
-	planGenerator := func() string {
-		return getEncodedPlan(a.Ctx, a.Plan)
+	planGenerator := func() (string, string) {
+		return getEncodedPlan(a.Ctx, a.Plan, !sessVars.InRestrictedSQL, a.StmtNode)
 	}
 	// Generating plan digest is slow, only generate it once if it's 'Point_Get'.
 	// If it's a point get, different SQLs leads to different plans, so SQL digest
@@ -1070,6 +1081,8 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 	stmtExecInfo := &stmtsummary.StmtExecInfo{
 		SchemaName:      strings.ToLower(sessVars.CurrentDB),
 		OriginalSQL:     sql,
+		Charset:         charset,
+		Collation:       collation,
 		NormalizedSQL:   normalizedSQL,
 		Digest:          digest,
 		PrevSQL:         prevSQL,

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -364,7 +364,7 @@ func handleInvalidBindRecord(ctx context.Context, sctx sessionctx.Context, level
 }
 
 func handleEvolveTasks(ctx context.Context, sctx sessionctx.Context, br *bindinfo.BindRecord, stmtNode ast.StmtNode, planHint string) {
-	bindSQL := bindinfo.GenerateBindSQL(ctx, stmtNode, planHint)
+	bindSQL := bindinfo.GenerateBindSQL(ctx, stmtNode, planHint, false)
 	if bindSQL == "" {
 		return
 	}

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -147,6 +147,7 @@ type StatementContext struct {
 	planNormalized        string
 	planDigest            string
 	encodedPlan           string
+	planHint              string
 	Tables                []TableEntry
 	PointExec             bool  // for point update cached execution, Constant expression need to set "paramMarker"
 	lockWaitStartTime     int64 // LockWaitStartTime stores the pessimistic lock wait start time
@@ -236,6 +237,16 @@ func (sc *StatementContext) GetEncodedPlan() string {
 // SetEncodedPlan sets the encoded plan, it is used to avoid repeated encode.
 func (sc *StatementContext) SetEncodedPlan(encodedPlan string) {
 	sc.encodedPlan = encodedPlan
+}
+
+// GetPlanHint gets the hint string generated from the plan.
+func (sc *StatementContext) GetPlanHint() string {
+	return sc.planHint
+}
+
+// SetPlanHint sets the hint for the plan.
+func (sc *StatementContext) SetPlanHint(hint string) {
+	sc.planHint = hint
 }
 
 // TableEntry presents table in db.

--- a/util/hint/hint_processor.go
+++ b/util/hint/hint_processor.go
@@ -251,13 +251,13 @@ func BindHint(stmt ast.StmtNode, hintsSet *HintsSet) ast.StmtNode {
 }
 
 // ParseHintsSet parses a SQL string, then collects and normalizes the HintsSet.
-func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*HintsSet, []error, error) {
+func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*HintsSet, ast.StmtNode, []error, error) {
 	stmtNodes, warns, err := p.Parse(sql, charset, collation)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 	if len(stmtNodes) != 1 {
-		return nil, nil, errors.New(fmt.Sprintf("bind_sql must be a single statement: %s", sql))
+		return nil, nil, nil, errors.New(fmt.Sprintf("bind_sql must be a single statement: %s", sql))
 	}
 	hs := CollectHint(stmtNodes[0])
 	processor := &BlockHintProcessor{}
@@ -272,7 +272,7 @@ func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*Hints
 			offset := processor.GetHintOffset(tblHint.QBName, hintNodeType, i+1)
 			if offset < 0 || !processor.checkTableQBName(tblHint.Tables, hintNodeType) {
 				hintStr := RestoreTableOptimizerHint(tblHint)
-				return nil, nil, errors.New(fmt.Sprintf("Unknown query block name in hint %s", hintStr))
+				return nil, nil, nil, errors.New(fmt.Sprintf("Unknown query block name in hint %s", hintStr))
 			}
 			tblHint.QBName = GenerateQBName(hintNodeType, offset)
 			for i, tbl := range tblHint.Tables {
@@ -284,7 +284,7 @@ func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*Hints
 		}
 		hs.tableHints[i] = newHints
 	}
-	return hs, extractHintWarns(warns), nil
+	return hs, stmtNodes[0], extractHintWarns(warns), nil
 }
 
 func extractHintWarns(warns []error) []error {

--- a/util/stmtsummary/statement_summary.go
+++ b/util/stmtsummary/statement_summary.go
@@ -104,8 +104,11 @@ type stmtSummaryByDigestElement struct {
 	endTime   int64
 	// basic
 	sampleSQL   string
+	charset     string
+	collation   string
 	prevSQL     string
 	samplePlan  string
+	planHint    string
 	indexNames  []string
 	execCount   int64
 	sumErrors   int
@@ -200,11 +203,13 @@ type stmtSummaryByDigestElement struct {
 type StmtExecInfo struct {
 	SchemaName     string
 	OriginalSQL    string
+	Charset        string
+	Collation      string
 	NormalizedSQL  string
 	Digest         string
 	PrevSQL        string
 	PrevSQLDigest  string
-	PlanGenerator  func() string
+	PlanGenerator  func() (string, string)
 	PlanDigest     string
 	PlanDigestGen  func() string
 	User           string
@@ -350,14 +355,23 @@ func (ssMap *stmtSummaryByDigestMap) ToHistoryDatum(user *auth.UserIdentity, isS
 	return rows
 }
 
+// BindableStmt is a wrapper struct for a statement that is extracted from statements_summary and can be
+// created binding on.
+type BindableStmt struct {
+	Schema    string
+	Query     string
+	PlanHint  string
+	Charset   string
+	Collation string
+}
+
 // GetMoreThanOnceBindableStmt gets users' select/update/delete SQLs that occurred more than once.
-func (ssMap *stmtSummaryByDigestMap) GetMoreThanOnceBindableStmt() ([]string, []string) {
+func (ssMap *stmtSummaryByDigestMap) GetMoreThanOnceBindableStmt() []*BindableStmt {
 	ssMap.Lock()
 	values := ssMap.summaryMap.Values()
 	ssMap.Unlock()
 
-	schemas := make([]string, 0, len(values))
-	sqls := make([]string, 0, len(values))
+	stmts := make([]*BindableStmt, 0, len(values))
 	for _, value := range values {
 		ssbd := value.(*stmtSummaryByDigest)
 		func() {
@@ -370,15 +384,26 @@ func (ssMap *stmtSummaryByDigestMap) GetMoreThanOnceBindableStmt() ([]string, []
 
 					// Empty auth users means that it is an internal queries.
 					if len(ssElement.authUsers) > 0 && (ssbd.history.Len() > 1 || ssElement.execCount > 1) {
-						schemas = append(schemas, ssbd.schemaName)
-						sqls = append(sqls, ssElement.sampleSQL)
+						stmt := &BindableStmt{
+							Schema:    ssbd.schemaName,
+							Query:     ssElement.sampleSQL,
+							PlanHint:  ssElement.planHint,
+							Charset:   ssElement.charset,
+							Collation: ssElement.collation,
+						}
+						// If it is SQL command prepare / execute, the ssElement.sampleSQL is `execute ...`, we should get the original select query.
+						// If it is binary protocol prepare / execute, ssbd.normalizedSQL should be same as ssElement.sampleSQL.
+						if ssElement.prepared {
+							stmt.Query = ssbd.normalizedSQL
+						}
+						stmts = append(stmts, stmt)
 					}
 					ssElement.Unlock()
 				}
 			}
 		}()
 	}
-	return schemas, sqls
+	return stmts
 }
 
 // SetEnabled enables or disables statement summary in global(cluster) or session(server) scope.
@@ -595,13 +620,17 @@ func (ssbd *stmtSummaryByDigest) collectHistorySummaries(historySize int) []*stm
 func newStmtSummaryByDigestElement(sei *StmtExecInfo, beginTime int64, intervalSeconds int64) *stmtSummaryByDigestElement {
 	// sampleSQL / authUsers(sampleUser) / samplePlan / prevSQL / indexNames store the values shown at the first time,
 	// because it compacts performance to update every time.
+	samplePlan, planHint := sei.PlanGenerator()
 	ssElement := &stmtSummaryByDigestElement{
 		beginTime: beginTime,
 		sampleSQL: formatSQL(sei.OriginalSQL),
+		charset:   sei.Charset,
+		collation: sei.Collation,
 		// PrevSQL is already truncated to cfg.Log.QueryLogMaxLen.
 		prevSQL: sei.PrevSQL,
 		// samplePlan needs to be decoded so it can't be truncated.
-		samplePlan:    sei.PlanGenerator(),
+		samplePlan:    samplePlan,
+		planHint:      planHint,
 		indexNames:    sei.StmtCtx.IndexNames,
 		minLatency:    sei.TotalLatency,
 		firstSeen:     sei.StartTime,

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -38,8 +38,8 @@ type testStmtSummarySuite struct {
 	ssMap *stmtSummaryByDigestMap
 }
 
-func emptyPlanGenerator() string {
-	return ""
+func emptyPlanGenerator() (string, string) {
+	return "", ""
 }
 
 func fakePlanDigestGenerator() string {
@@ -75,11 +75,12 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 		digest:     stmtExecInfo1.Digest,
 		planDigest: stmtExecInfo1.PlanDigest,
 	}
+	samplePlan, _ := stmtExecInfo1.PlanGenerator()
 	expectedSummaryElement := stmtSummaryByDigestElement{
 		beginTime:            now + 60,
 		endTime:              now + 1860,
 		sampleSQL:            stmtExecInfo1.OriginalSQL,
-		samplePlan:           stmtExecInfo1.PlanGenerator(),
+		samplePlan:           samplePlan,
 		indexNames:           stmtExecInfo1.StmtCtx.IndexNames,
 		execCount:            1,
 		sumLatency:           stmtExecInfo1.TotalLatency,
@@ -921,22 +922,19 @@ func (s *testStmtSummarySuite) TestGetMoreThanOnceBindableStmt(c *C) {
 	stmtExecInfo1.NormalizedSQL = "insert ?"
 	stmtExecInfo1.StmtCtx.StmtType = "Insert"
 	s.ssMap.AddStatement(stmtExecInfo1)
-	schemas, sqls := s.ssMap.GetMoreThanOnceBindableStmt()
-	c.Assert(len(schemas), Equals, 0)
-	c.Assert(len(sqls), Equals, 0)
+	stmts := s.ssMap.GetMoreThanOnceBindableStmt()
+	c.Assert(len(stmts), Equals, 0)
 
 	stmtExecInfo1.NormalizedSQL = "select ?"
 	stmtExecInfo1.Digest = "digest1"
 	stmtExecInfo1.StmtCtx.StmtType = "Select"
 	s.ssMap.AddStatement(stmtExecInfo1)
-	schemas, sqls = s.ssMap.GetMoreThanOnceBindableStmt()
-	c.Assert(len(schemas), Equals, 0)
-	c.Assert(len(sqls), Equals, 0)
+	stmts = s.ssMap.GetMoreThanOnceBindableStmt()
+	c.Assert(len(stmts), Equals, 0)
 
 	s.ssMap.AddStatement(stmtExecInfo1)
-	schemas, sqls = s.ssMap.GetMoreThanOnceBindableStmt()
-	c.Assert(len(schemas), Equals, 1)
-	c.Assert(len(sqls), Equals, 1)
+	stmts = s.ssMap.GetMoreThanOnceBindableStmt()
+	c.Assert(len(stmts), Equals, 1)
 }
 
 // Test `formatBackoffTypes`.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21215

Problem Summary:

Baseline capture does not support prepared statements.

### What is changed and how it works?

What's Changed:

- extract hint string from plan and store it into statements_summary in `SummaryStmt` if the query is a prepared statement;
- in baseline capture, specially handle prepared statements, i.e, use the hint string directly, instead of using `explain format='hint'` to generate hint string;
- do not use `explain format = 'hint'` to check the validation of the bind_sql if it is a prepared statement;
- do not evolve baseline for prepared statements;


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test: would be covered by UTF


Side effects

- bind_sql may appear to contain `?` now.

### Release note <!-- bugfixes or new feature need a release note -->

- support baseline capture for prepared statements