### PR TITLE
*: make rollback work on user-defined variables

### DIFF
--- a/executor/set.go
+++ b/executor/set.go
@@ -91,11 +91,10 @@ func (e *SetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 				return err
 			}
 			sessionVars.UsersLock.Lock()
+			sessionVars.Users.Set(name, value)
 			if value.IsNull() {
-				delete(sessionVars.Users, name)
 				delete(sessionVars.UserVarTypes, name)
 			} else {
-				sessionVars.Users[name] = value
 				sessionVars.UserVarTypes[name] = v.Expr.GetType()
 			}
 			sessionVars.UsersLock.Unlock()

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -656,6 +656,7 @@ func (e *SimpleExec) executeRollback(s *ast.RollbackStmt) error {
 	sessVars := e.ctx.GetSessionVars()
 	logutil.BgLogger().Debug("execute rollback statement", zap.Uint64("conn", sessVars.ConnectionID))
 	sessVars.SetStatusFlag(mysql.ServerStatusInTrans, false)
+	sessVars.Users.Rollback()
 	txn, err := e.ctx.Txn(false)
 	if err != nil {
 		return err

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -766,7 +766,7 @@ func (b *builtinSetRealVarSig) evalReal(row chunk.Row) (res float64, isNull bool
 	res = datum.GetFloat64()
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.Lock()
-	sessionVars.Users[varName] = datum
+	sessionVars.Users.Set(varName, datum)
 	sessionVars.UsersLock.Unlock()
 	return res, false, nil
 }
@@ -795,7 +795,7 @@ func (b *builtinSetDecimalVarSig) evalDecimal(row chunk.Row) (*types.MyDecimal, 
 	res := datum.GetMysqlDecimal()
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.Lock()
-	sessionVars.Users[varName] = datum
+	sessionVars.Users.Set(varName, datum)
 	sessionVars.UsersLock.Unlock()
 	return res, false, nil
 }
@@ -824,7 +824,7 @@ func (b *builtinSetIntVarSig) evalInt(row chunk.Row) (int64, bool, error) {
 	res := datum.GetInt64()
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.Lock()
-	sessionVars.Users[varName] = datum
+	sessionVars.Users.Set(varName, datum)
 	sessionVars.UsersLock.Unlock()
 	return res, false, nil
 }
@@ -902,7 +902,7 @@ func (b *builtinGetStringVarSig) evalString(row chunk.Row) (string, bool, error)
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
-	if v, ok := sessionVars.Users[varName]; ok {
+	if v, ok := sessionVars.Users.Get(varName); ok {
 		return v.GetString(), false, nil
 	}
 	return "", true, nil
@@ -945,7 +945,7 @@ func (b *builtinGetIntVarSig) evalInt(row chunk.Row) (int64, bool, error) {
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
-	if v, ok := sessionVars.Users[varName]; ok {
+	if v, ok := sessionVars.Users.Get(varName); ok {
 		return v.GetInt64(), false, nil
 	}
 	return 0, true, nil
@@ -987,7 +987,7 @@ func (b *builtinGetRealVarSig) evalReal(row chunk.Row) (float64, bool, error) {
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
-	if v, ok := sessionVars.Users[varName]; ok {
+	if v, ok := sessionVars.Users.Get(varName); ok {
 		return v.GetFloat64(), false, nil
 	}
 	return 0, true, nil
@@ -1029,7 +1029,7 @@ func (b *builtinGetDecimalVarSig) evalDecimal(row chunk.Row) (*types.MyDecimal, 
 	varName = strings.ToLower(varName)
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
-	if v, ok := sessionVars.Users[varName]; ok {
+	if v, ok := sessionVars.Users.Get(varName); ok {
 		return v.GetMysqlDecimal(), false, nil
 	}
 	return nil, true, nil

--- a/expression/builtin_other_test.go
+++ b/expression/builtin_other_test.go
@@ -174,7 +174,7 @@ func (s *testEvaluatorSuite) TestSetVar(c *C) {
 		if tc.args[1] != nil {
 			key, ok := tc.args[0].(string)
 			c.Assert(ok, Equals, true)
-			sessionVar, ok := s.ctx.GetSessionVars().Users[key]
+			sessionVar, ok := s.ctx.GetSessionVars().Users.Get(key)
 			c.Assert(ok, Equals, true)
 			c.Assert(sessionVar.GetValue(), Equals, tc.res)
 		}
@@ -195,7 +195,7 @@ func (s *testEvaluatorSuite) TestGetVar(c *C) {
 		{"g", dec},
 	}
 	for _, kv := range sessionVars {
-		s.ctx.GetSessionVars().Users[kv.key] = types.NewDatum(kv.val)
+		s.ctx.GetSessionVars().Users.Set(kv.key, types.NewDatum(kv.val))
 		tp := types.NewFieldType(mysql.TypeVarString)
 		types.DefaultParamTypeForValue(kv.val, tp)
 		s.ctx.GetSessionVars().UserVarTypes[kv.key] = tp
@@ -298,7 +298,7 @@ func (s *testEvaluatorSuite) TestSetVarFromColumn(c *C) {
 	sessionVars := s.ctx.GetSessionVars()
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
-	sessionVar, ok := sessionVars.Users["a"]
+	sessionVar, ok := sessionVars.Users.Get("a")
 	c.Assert(ok, Equals, true)
 	c.Assert(sessionVar.GetString(), Equals, "a")
 }

--- a/expression/builtin_other_vec.go
+++ b/expression/builtin_other_vec.go
@@ -189,7 +189,7 @@ func (b *builtinSetStringVarSig) vecEvalString(input *chunk.Chunk, result *chunk
 		}
 		varName := strings.ToLower(buf0.GetString(i))
 		res := buf1.GetString(i)
-		sessionVars.Users[varName] = types.NewCollationStringDatum(stringutil.Copy(res), collation, collate.DefaultLen)
+		sessionVars.Users.Set(varName, types.NewCollationStringDatum(stringutil.Copy(res), collation, collate.DefaultLen))
 		result.AppendString(res)
 	}
 	return nil
@@ -229,7 +229,7 @@ func (b *builtinSetIntVarSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 		}
 		varName := strings.ToLower(buf0.GetString(i))
 		res := buf1.GetInt64(i)
-		sessionVars.Users[varName] = types.NewIntDatum(res)
+		sessionVars.Users.Set(varName, types.NewIntDatum(res))
 		i64s[i] = res
 	}
 	return nil
@@ -269,7 +269,7 @@ func (b *builtinSetRealVarSig) vecEvalReal(input *chunk.Chunk, result *chunk.Col
 		}
 		varName := strings.ToLower(buf0.GetString(i))
 		res := buf1.GetFloat64(i)
-		sessionVars.Users[varName] = types.NewFloat64Datum(res)
+		sessionVars.Users.Set(varName, types.NewFloat64Datum(res))
 		f64s[i] = res
 	}
 	return nil
@@ -309,7 +309,7 @@ func (b *builtinSetDecimalVarSig) vecEvalDecimal(input *chunk.Chunk, result *chu
 		}
 		varName := strings.ToLower(buf0.GetString(i))
 		res := buf1.GetDecimal(i)
-		sessionVars.Users[varName] = types.NewDecimalDatum(res)
+		sessionVars.Users.Set(varName, types.NewDecimalDatum(res))
 		decs[i] = *res
 	}
 	return nil
@@ -347,7 +347,7 @@ func (b *builtinGetStringVarSig) vecEvalString(input *chunk.Chunk, result *chunk
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.Users[varName]; ok {
+		if v, ok := sessionVars.Users.Get(varName); ok {
 			result.AppendString(v.GetString())
 			continue
 		}
@@ -381,7 +381,7 @@ func (b *builtinGetIntVarSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.Users[varName]; ok {
+		if v, ok := sessionVars.Users.Get(varName); ok {
 			i64s[i] = v.GetInt64()
 			continue
 		}
@@ -415,7 +415,7 @@ func (b *builtinGetRealVarSig) vecEvalReal(input *chunk.Chunk, result *chunk.Col
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.Users[varName]; ok {
+		if v, ok := sessionVars.Users.Get(varName); ok {
 			f64s[i] = v.GetFloat64()
 			continue
 		}
@@ -449,7 +449,7 @@ func (b *builtinGetDecimalVarSig) vecEvalDecimal(input *chunk.Chunk, result *chu
 			continue
 		}
 		varName := strings.ToLower(buf0.GetString(i))
-		if v, ok := sessionVars.Users[varName]; ok {
+		if v, ok := sessionVars.Users.Get(varName); ok {
 			decs[i] = *v.GetMysqlDecimal()
 			continue
 		}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1002,7 +1002,7 @@ func (b *PlanBuilder) buildPrepare(x *ast.PrepareStmt) Plan {
 		Name: x.Name,
 	}
 	if x.SQLVar != nil {
-		if v, ok := b.ctx.GetSessionVars().Users[strings.ToLower(x.SQLVar.Name)]; ok {
+		if v, ok := b.ctx.GetSessionVars().Users.Get(strings.ToLower(x.SQLVar.Name)); ok {
 			var err error
 			p.SQLText, err = v.ToString()
 			if err != nil {

--- a/session/session.go
+++ b/session/session.go
@@ -464,7 +464,6 @@ func (s *session) doCommit(ctx context.Context) error {
 	if s.GetSessionVars().EnableAmendPessimisticTxn {
 		s.txn.SetOption(kv.SchemaAmender, NewSchemaAmenderForTikvTxn(s))
 	}
-
 	return s.txn.Commit(sessionctx.SetCommitCtx(ctx, s))
 }
 
@@ -561,6 +560,7 @@ func (s *session) CommitTxn(ctx context.Context) error {
 		}
 	})
 	s.sessionVars.TxnCtx.Cleanup()
+	s.sessionVars.Users.Commit()
 	return err
 }
 

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3682,3 +3682,23 @@ func (s *testSessionSerialSuite) TestCoprocessorOOMAction(c *C) {
 		se.Close()
 	}
 }
+
+func (s *testSessionSuite3) TestUserDefinedVariableRollback(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	// Default value is NULL if not exist.
+	tk.MustQuery("select @x").Check(testkit.Rows("<nil>"))
+
+	tk.MustExec("set @x = 3")
+	tk.MustQuery("select @x").Check(testkit.Rows("3"))
+
+	// Test rollback.
+	tk.MustExec("begin")
+	tk.MustExec("set @x = 5")
+	tk.MustQuery("select @x").Check(testkit.Rows("5"))
+	tk.MustExec("rollback")
+	tk.MustQuery("select @x").Check(testkit.Rows("3"))
+
+	// Set to NULL means delete.
+	tk.MustExec("set @x = null")
+	tk.MustQuery("select @x").Check(testkit.Rows("<nil>"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Partly fix https://github.com/pingcap/tidb/issues/8393

Problem Summary:

`set @xx = yy` take effect immediately in TiDB, while in MySQL this statement can be rollbacked.

### What is changed and how it works?

What's Changed:

Make rollback work on user-defined variables.

How it Works:

Use struct `userDefinedVars` for user-defined variables.
This struct consists of a slice and a map, before commit, the modification is cached in the slice.
It has the `Commit` and `Rollback` methods to flush or drop the cached variables.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- make rollback work on user-defined variables