### PR TITLE
executor: initialize expensive query handler on domain creation

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1297,11 +1297,6 @@ func (do *Domain) ExpensiveQueryHandle() *expensivequery.Handle {
 	return do.expensiveQueryHandle
 }
 
-// InitExpensiveQueryHandle init the expensive query handler.
-func (do *Domain) InitExpensiveQueryHandle() {
-	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do.exit)
-}
-
 const privilegeKey = "/tidb/privilege"
 
 // NotifyUpdatePrivilege updates privilege key in etcd, TiDB client that watches

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -692,6 +692,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 	}
 
 	do.SchemaValidator = NewSchemaValidator(ddlLease, do)
+	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do.exit)
 	return do
 }
 

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -475,19 +475,6 @@ func (s *testBootstrapSuite) TestOldPasswordUpgrade(c *C) {
 	c.Assert(newpwd, Equals, "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E")
 }
 
-func (s *testBootstrapSuite) TestBootstrapInitExpensiveQueryHandle(c *C) {
-	defer testleak.AfterTest(c)()
-	store := newStore(c, s.dbName)
-	defer store.Close()
-	se, err := createSession(store)
-	c.Assert(err, IsNil)
-	dom := domain.GetDomain(se)
-	c.Assert(dom, NotNil)
-	defer dom.Close()
-	dom.InitExpensiveQueryHandle()
-	c.Assert(dom.ExpensiveQueryHandle(), NotNil)
-}
-
 func (s *testBootstrapSuite) TestStmtSummary(c *C) {
 	defer testleak.AfterTest(c)()
 	ctx := context.Background()

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -475,6 +475,18 @@ func (s *testBootstrapSuite) TestOldPasswordUpgrade(c *C) {
 	c.Assert(newpwd, Equals, "*0D3CED9BEC10A777AEC23CCC353A8C08A633045E")
 }
 
+func (s *testBootstrapSuite) TestBootstrapInitExpensiveQueryHandle(c *C) {
+	defer testleak.AfterTest(c)()
+	store := newStore(c, s.dbName)
+	defer store.Close()
+	se, err := createSession(store)
+	c.Assert(err, IsNil)
+	dom := domain.GetDomain(se)
+	c.Assert(dom, NotNil)
+	defer dom.Close()
+	c.Assert(dom.ExpensiveQueryHandle(), NotNil)
+}
+
 func (s *testBootstrapSuite) TestStmtSummary(c *C) {
 	defer testleak.AfterTest(c)()
 	ctx := context.Background()

--- a/session/session.go
+++ b/session/session.go
@@ -2172,7 +2172,6 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	}
 
 	dom := domain.GetDomain(se)
-	dom.InitExpensiveQueryHandle()
 
 	se2, err := createSession(store)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #18401 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
Merge the expensive query handler initialization logic into the `NewDomain` function.

How it Works:

Originally the query execution handler is not initialized, thus `LogOnQueryExceedMemQuota` is a closure that accesses nil pointer. Now initialize query execution handler on `Domain` creation, so it won't access the nil pointer during bootstrap.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
NA
- Breaking backward compatibility
NA

### Release note <!-- bugfixes or new feature need a release note -->

- Fix expensive query handler initialization during bootstrap