### PR TITLE
session: make rollback work on global variables

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -102,6 +102,7 @@ func (s *testSuite5) TestSetVar(c *C) {
 	tk.MustQuery(`select @issue4302;`).Check(testkit.Rows("1"))
 
 	// Set default
+	tk.MustExec("set @@autocommit=1")
 	// {ScopeGlobal | ScopeSession, "low_priority_updates", "OFF"},
 	// For global var
 	tk.MustQuery(`select @@global.low_priority_updates;`).Check(testkit.Rows("0"))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: https://github.com/pingcap/tidb/issues/8393

Problem Summary:

`begin; set @@global.xxx = yyy`  the global variable is written immediately, even the transaction is not committed yet.

### What is changed and how it works?

What's Changed:

Use the current session to execute the write global session SQL, instead of using ExecuteRestrictedSQL

How it Works:

So the changes are in the current session's union store and will be committed until the auto-commit or an explicit "commit".

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- make rollback work on global variables