### PR TITLE
planner/core: skip TestEncodePlanPerformance to accelerate CI

### DIFF
--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -466,6 +466,7 @@ func (s *testPlanNormalize) TestDecodePlanPerformance(c *C) {
 }
 
 func (s *testPlanNormalize) TestEncodePlanPerformance(c *C) {
+	c.Skip("this test use a lot memory and run for too long")
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists th")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Make CI faster.

Problem Summary:

This test is too slow and eats up the whole resource on my laptop when running

PASS: plan_test.go:437: testPlanNormalize.TestDecodePlanPerformance	**8.244s**

```
PASS: errors_test.go:26: testErrorSuite.TestError	0.000s
PASS: cache_test.go:39: testCacheSuite.TestCacheKey	0.001s
PASS: find_best_task_test.go:147: testFindBestTaskSuite.TestCostOverflow	0.001s
PASS: rule_join_reorder_dp_test.go:202: testJoinReorderDPSuite.TestDPReorderAllCartesian	0.001s
PASS: find_best_task_test.go:162: testFindBestTaskSuite.TestEnforcedProperty	0.000s
PASS: find_best_task_test.go:196: testFindBestTaskSuite.TestHintCannotFitProperty	0.000s
PASS: planbuilder_test.go:189: testPlanBuilderSuite.TestDeepClone	0.002s
PASS: expression_test.go:68: testExpressionSuite.TestBetween	0.003s
PASS: rule_inject_extra_projection_test.go:31: testInjectProjSuite.TestWrapCastForAggFuncs	0.004s
PASS: planbuilder_test.go:144: testPlanBuilderSuite.TestDisableFold	0.002s
PASS: planbuilder_test.go:85: testPlanBuilderSuite.TestGetPathByIndexName	0.000s
PASS: rule_join_reorder_dp_test.go:174: testJoinReorderDPSuite.TestDPReorderTPCHQ5	0.002s
PASS: expression_test.go:79: testExpressionSuite.TestCaseWhen	0.001s
PASS: expression_test.go:117: testExpressionSuite.TestCast	0.002s
PASS: logical_plan_test.go:893: testPlanSuite.TestAggPrune	0.009s
PASS: logical_plan_test.go:607: testPlanSuite.TestAllocID	0.000s
PASS: planbuilder_test.go:216: testPlanBuilderSuite.TestPhysicalPlanClone	0.013s
PASS: expression_test.go:223: testExpressionSuite.TestCompareRow	0.002s
PASS: planbuilder_test.go:116: testPlanBuilderSuite.TestRewriterPool	0.000s
PASS: indexmerge_test.go:84: testIndexMergeSuite.TestIndexMergePathGeneration	0.017s
PASS: planbuilder_test.go:50: testPlanBuilderSuite.TestShow	0.001s
PASS: logical_plan_test.go:216: testPlanSuite.TestAntiSemiJoinConstFalse	0.002s
PASS: expression_test.go:200: testExpressionSuite.TestIsNull	0.001s
PASS: expression_test.go:266: testExpressionSuite.TestIsTruth	0.001s
PASS: expression_test.go:153: testExpressionSuite.TestPatternIn	0.003s
PASS: logical_plan_test.go:531: testPlanSuite.TestColumnPruning	0.006s
PASS: logical_plan_test.go:1616: testPlanSuite.TestConflictedJoinTypeHints	0.001s
PASS: logical_plan_test.go:245: testPlanSuite.TestDeriveNotNullConds	0.004s
PASS: logical_plan_test.go:349: testPlanSuite.TestDupRandJoinCondsPushDown	0.001s
PASS: logical_plan_test.go:507: testPlanSuite.TestEagerAggregation	0.008s
PASS: logical_plan_test.go:1547: testPlanSuite.TestFastPlanContextTables	0.001s
PASS: logical_plan_test.go:300: testPlanSuite.TestGroupByWhenNotExistCols	0.001s
PASS: logical_plan_test.go:95: testPlanSuite.TestJoinPredicatePushDown	0.007s
PASS: logical_plan_test.go:484: testPlanSuite.TestJoinReOrder	0.009s
PASS: logical_plan_test.go:1245: testPlanSuite.TestNameResolver	0.004s
PASS: logical_plan_test.go:1296: testPlanSuite.TestOuterJoinEliminator	0.005s
PASS: logical_plan_test.go:133: testPlanSuite.TestOuterWherePredicatePushDown	0.002s
PASS: logical_plan_test.go:459: testPlanSuite.TestPlanBuilder	0.010s
PASS: logical_plan_test.go:75: testPlanSuite.TestPredicatePushDown	0.012s
PASS: logical_plan_test.go:581: testPlanSuite.TestProjectionEliminator	0.001s
PASS: logical_plan_test.go:1320: testPlanSuite.TestSelectView	0.001s
PASS: logical_plan_test.go:179: testPlanSuite.TestSimplifyOuterJoin	0.002s
PASS: logical_plan_test.go:1636: testPlanSuite.TestSimplyOuterJoinWithOnlyOuterExpr	0.001s
PASS: logical_plan_test.go:1457: testPlanSuite.TestSkylinePruning	0.003s
PASS: logical_plan_test.go:556: testPlanSuite.TestSortByItemsPruning	0.001s
PASS: logical_plan_test.go:434: testPlanSuite.TestSubquery	0.006s
PASS: logical_plan_test.go:369: testPlanSuite.TestTablePartition	0.004s
PASS: logical_plan_test.go:1221: testPlanSuite.TestTopNPushDown	0.008s
PASS: logical_plan_test.go:1185: testPlanSuite.TestUnion	0.002s
PASS: logical_plan_test.go:867: testPlanSuite.TestUniqueKeyInfo	0.002s
PASS: logical_plan_test.go:1590: testPlanSuite.TestUpdateEQCond	0.001s
PASS: logical_plan_test.go:656: testPlanSuite.TestValidate	0.004s
PASS: logical_plan_test.go:917: testPlanSuite.TestVisitInfo	0.004s
PASS: logical_plan_test.go:1352: testPlanSuite.TestWindowFunction	0.036s
PASS: logical_plan_test.go:1365: testPlanSuite.TestWindowParallelFunction	0.023s
PASS: memtable_predicate_extractor_test.go:82: extractorSuite.TestClusterConfigTableExtractor	0.002s
PASS: expression_rewriter_test.go:48: testExpressionRewriterSuite.TestBinaryOpFunction	0.228s
PASS: memtable_predicate_extractor_test.go:254: extractorSuite.TestClusterLogTableExtractor	0.004s
PASS: physical_plan_test.go:413: testPlanSuite.TestAggEliminator	0.224s
PASS: memtable_predicate_extractor_test.go:774: extractorSuite.TestInspectionResultTableExtractor	0.010s
PASS: memtable_predicate_extractor_test.go:1012: extractorSuite.TestInspectionRuleTableExtractor	0.002s
PASS: memtable_predicate_extractor_test.go:913: extractorSuite.TestInspectionSummaryTableExtractor	0.002s
PASS: memtable_predicate_extractor_test.go:553: extractorSuite.TestMetricTableExtractor	0.001s
PASS: memtable_predicate_extractor_test.go:676: extractorSuite.TestMetricsSummaryTableExtractor	0.002s
PASS: cacheable_checker_test.go:32: testCacheableSuite.TestCacheable	0.255s
PASS: preprocess_test.go:282: testValidatorSuite.TestForeignKey	0.031s
PASS: prepare_test.go:827: testPrepareSuite.TestInvisibleIndex	0.258s
PASS: integration_test.go:1528: testIntegrationSuite.TestAccessPathOnClusterIndex	0.077s
PASS: stats_test.go:140: testStatsSuite.TestCardinalityGroupCols	0.305s
PASS: physical_plan_test.go:856: testPlanSuite.TestAggToCopHint	0.153s
PASS: expression_rewriter_test.go:253: testExpressionRewriterSuite.TestCheckFullGroupBy	0.171s
PASS: preprocess_test.go:72: testValidatorSuite.TestValidator	0.006s
PASS: prepare_test.go:370: testPrepareSuite.TestPrepareForGroupByItems	0.156s
PASS: cbo_test.go:327: testAnalyzeSuite.TestAnalyze	0.441s
PASS: stats_test.go:48: testStatsSuite.TestGroupNDVs	0.198s
PASS: physical_plan_test.go:778: testPlanSuite.TestAggregationHints	0.130s
PASS: prepare_test.go:796: testPrepareSuite.TestPrepareForGroupByMultiItems	0.141s
PASS: expression_rewriter_test.go:150: testExpressionRewriterSuite.TestCompareSubquery	0.185s
PASS: cbo_test.go:109: testAnalyzeSuite.TestCBOWithoutAnalyze	0.143s
PASS: integration_test.go:224: testIntegrationSuite.TestAntiJoinConstProp	0.169s
PASS: physical_plan_test.go:338: testPlanSuite.TestDAGPlanBuilderAgg	0.153s
PASS: prepare_test.go:345: testPrepareSuite.TestPrepareWithWindowFunction	0.154s
PASS: integration_test.go:992: testIntegrationSuite.TestApproxCountDistinctInPartitionTable	0.006s
PASS: cbo_test.go:509: testAnalyzeSuite.TestCorrelatedEstimation	0.172s
PASS: expression_rewriter_test.go:65: testExpressionRewriterSuite.TestDefaultFunction	0.186s
PASS: physical_plan_test.go:225: testPlanSuite.TestDAGPlanBuilderBasePhysicalPlan	0.128s
PASS: integration_test.go:1013: testIntegrationSuite.TestApproxPercentile	0.011s
PASS: expression_rewriter_test.go:30: testExpressionRewriterSuite.TestIfNullEliminateColName	0.131s
PASS: cbo_test.go:292: testAnalyzeSuite.TestEmptyTable	0.149s
PASS: physical_plan_test.go:111: testPlanSuite.TestDAGPlanBuilderJoin	0.155s
PASS: integration_test.go:141: testIntegrationSuite.TestBitColErrorMessage	0.018s
PASS: expression_rewriter_test.go:329: testExpressionRewriterSuite.TestIssue17652	0.137s
PASS: cbo_test.go:195: testAnalyzeSuite.TestEstimation	0.171s
PASS: physical_plan_test.go:76: testPlanSuite.TestDAGPlanBuilderSimpleCase	0.170s
PASS: integration_test.go:1555: testIntegrationSuite.TestClusterIndexUniqueDoubleRead	0.014s
PASS: expression_rewriter_test.go:288: testExpressionRewriterSuite.TestIssue20007	0.303s
PASS: physical_plan_test.go:1343: testPlanSuite.TestDAGPlanBuilderSplitAvg	0.467s
PASS: cbo_test.go:79: testAnalyzeSuite.TestExplainAnalyze	0.899s
PASS: integration_test.go:1725: testIntegrationSuite.TestDeleteUsingJoin	0.108s
PASS: expression_rewriter_test.go:311: testExpressionRewriterSuite.TestIssue9869	0.711s
PASS: physical_plan_test.go:150: testPlanSuite.TestDAGPlanBuilderSubquery	0.394s
PASS: integration_test.go:1614: testIntegrationSuite.TestDistinctScalarFunctionPushDown	0.007s
PASS: cbo_test.go:537: testAnalyzeSuite.TestInconsistentEstimation	0.262s
PASS: expression_rewriter_test.go:270: testExpressionRewriterSuite.TestPatternLikeToExpression	0.200s
PASS: physical_plan_test.go:264: testPlanSuite.TestDAGPlanBuilderUnion	0.186s
PASS: integration_test.go:765: testIntegrationSuite.TestErrNoDB	0.018s
PASS: physical_plan_test.go:298: testPlanSuite.TestDAGPlanBuilderUnionScan	0.157s
PASS: integration_test.go:1173: testIntegrationSuite.TestFloorUnixTimestampPruning	0.014s
PASS: cbo_test.go:902: testAnalyzeSuite.TestIndexEqualUnknown	0.335s
PASS: physical_plan_test.go:1455: testPlanSuite.TestDAGPlanBuilderWindow	0.141s
PASS: integration_test.go:1096: testIntegrationSuite.TestFullGroupByOrderBy	0.005s
PASS: physical_plan_test.go:1469: testPlanSuite.TestDAGPlanBuilderWindowParallel	0.225s
PASS: integration_test.go:1507: testIntegrationSuite.TestHintParserWarnings	0.005s
PASS: physical_plan_test.go:191: testPlanSuite.TestDAGPlanTopN	0.189s
PASS: cbo_test.go:239: testAnalyzeSuite.TestIndexRead	0.512s
PASS: integration_test.go:1050: testIntegrationSuite.TestHintWithRequiredProperty	0.008s
PASS: physical_plan_test.go:562: testPlanSuite.TestDoSubquery	0.316s
PASS: cbo_test.go:709: testAnalyzeSuite.TestIssue9562	0.320s
PASS: integration_test.go:1107: testIntegrationSuite.TestHintWithoutTableWarning	0.017s
PASS: physical_plan_test.go:448: testPlanSuite.TestEliminateMaxOneRow	0.149s
PASS: cbo_test.go:744: testAnalyzeSuite.TestIssue9805	0.138s
PASS: integration_test.go:799: testIntegrationSuite.TestINLJHintSmallTable	0.052s
PASS: physical_plan_test.go:836: testPlanSuite.TestExplainJoinHints	0.127s
PASS: integration_test.go:946: testIntegrationSuite.TestIndexHintWarning	0.015s
PASS: physical_plan_test.go:1071: testPlanSuite.TestGroupConcatOrderby	0.161s
PASS: cbo_test.go:778: testAnalyzeSuite.TestLimitCrossEstimation	0.426s
PASS: physical_plan_test.go:1116: testPlanSuite.TestHintAlias	0.161s
PASS: integration_test.go:1221: testIntegrationSuite.TestIndexJoinInnerIndexNDV	0.090s
PASS: physical_plan_test.go:1554: testPlanSuite.TestHintFromDiffDatabase	0.154s
PASS: integration_test.go:1568: testIntegrationSuite.TestIndexJoinOnClusteredIndex	0.061s
PASS: cbo_test.go:932: testAnalyzeSuite.TestLimitIndexEstimation	0.289s
PASS: physical_plan_test.go:689: testPlanSuite.TestHintScope	0.143s
PASS: integration_test.go:893: testIntegrationSuite.TestIndexJoinTableRange	0.011s
PASS: physical_plan_test.go:1163: testPlanSuite.TestIndexHint	0.170s
PASS: integration_test.go:811: testIntegrationSuite.TestIndexJoinUniqueCompositeIndex	0.104s
PASS: physical_plan_test.go:1413: testPlanSuite.TestIndexJoinHint	0.198s
PASS: cbo_test.go:818: testAnalyzeSuite.TestLowSelIndexGreedySearch	0.467s
PASS: integration_test.go:838: testIntegrationSuite.TestIndexMerge	0.006s
PASS: physical_plan_test.go:520: testPlanSuite.TestIndexJoinUnionScan	0.273s
PASS: cbo_test.go:475: testAnalyzeSuite.TestNullCount	0.340s
PASS: integration_test.go:860: testIntegrationSuite.TestInvisibleIndex	0.029s
PASS: physical_plan_test.go:593: testPlanSuite.TestIndexLookupCartesianJoin	0.250s
PASS: cbo_test.go:398: testAnalyzeSuite.TestOutdatedAnalyze	0.218s
PASS: integration_test.go:181: testIntegrationSuite.TestIsFromUnixtimeNullRejective	0.009s
PASS: physical_plan_test.go:1211: testPlanSuite.TestIndexMergeHint	0.470s
PASS: cbo_test.go:435: testAnalyzeSuite.TestPreparedNullParam	0.367s
PASS: integration_test.go:1865: testIntegrationSuite.TestIssue10448	0.004s
PASS: physical_plan_test.go:1298: testPlanSuite.TestInlineProjection	0.208s
PASS: cbo_test.go:141: testAnalyzeSuite.TestStraightJoin	0.210s
PASS: integration_test.go:978: testIntegrationSuite.TestIssue15546	0.016s
PASS: physical_plan_test.go:726: testPlanSuite.TestJoinHints	0.129s
PASS: cbo_test.go:167: testAnalyzeSuite.TestTableDual	0.140s
PASS: physical_plan_test.go:917: testPlanSuite.TestLimitToCopHint	0.132s
PASS: integration_test.go:1084: testIntegrationSuite.TestIssue15813	0.023s
PASS: cbo_test.go:865: testAnalyzeSuite.TestTiFlashCostModel	0.152s
PASS: physical_plan_test.go:1521: testPlanSuite.TestNominalSort	0.178s
PASS: cbo_test.go:850: testAnalyzeSuite.TestUpdateProjEliminate	0.116s
PASS: integration_test.go:1147: testIntegrationSuite.TestIssue15846	0.065s
PASS: physical_plan_test.go:1602: testPlanSuite.TestNthPlanHintWithExplain	0.129s
PASS: integration_test.go:1139: testIntegrationSuite.TestIssue15858	0.005s
PASS: physical_plan_test.go:983: testPlanSuite.TestPushdownDistinctDisable	0.164s
PASS: integration_test.go:1194: testIntegrationSuite.TestIssue16290And16292	0.009s
PASS: physical_plan_test.go:965: testPlanSuite.TestPushdownDistinctEnable	0.144s
PASS: integration_test.go:1517: testIntegrationSuite.TestIssue16935	0.008s
PASS: physical_plan_test.go:1002: testPlanSuite.TestPushdownDistinctEnableAggPushDownDisable	0.135s
PASS: integration_test.go:1039: testIntegrationSuite.TestIssue17813	0.007s
PASS: physical_plan_test.go:1260: testPlanSuite.TestQueryBlockHint	0.121s
PASS: integration_test.go:1708: testIntegrationSuite.TestIssue19926	0.018s
PASS: physical_plan_test.go:378: testPlanSuite.TestRefine	0.125s
PASS: physical_plan_test.go:497: testPlanSuite.TestRequestTypeSupportedOff	0.114s
PASS: integration_test.go:205: testIntegrationSuite.TestJoinNotNullFlag	0.167s
PASS: physical_plan_test.go:617: testPlanSuite.TestSemiJoinToInner	0.150s
PASS: integration_test.go:775: testIntegrationSuite.TestMaxMinEliminate	0.009s
PASS: physical_plan_test.go:648: testPlanSuite.TestUnmatchedTableInHint	0.168s
PASS: integration_test.go:1349: testIntegrationSuite.TestOptimizeHintOnPartitionTable	0.014s
PASS: integration_test.go:1694: testIntegrationSuite.TestPartialBatchPointGet	0.007s
PASS: integration_test.go:1669: testIntegrationSuite.TestPartitionExplain	0.011s
PASS: plan_test.go:437: testPlanNormalize.TestDecodePlanPerformance	8.244s
PASS: plan_test.go:136: testPlanNormalize.TestEncodeDecodePlan	0.024s
PASS: integration_test.go:741: testIntegrationSuite.TestPartitionPruningForEQ	0.005s
PASS: integration_test.go:704: testIntegrationSuite.TestPartitionPruningForInExpr	0.012s
```

### What is changed and how it works?


What's Changed:

Skip a unit test

How it Works:

The test is a performance test, should not be there


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note