### PR TITLE
*: add runtime stats for split region statement

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1531,7 +1531,7 @@ func (e *ShowExec) fetchShowTableRegions() error {
 	if splitHelper == nil {
 		return nil
 	}
-	if splitHelper.GetRuntimeStats() != nil {
+	if e.runtimeStats != nil && splitHelper.GetRuntimeStats() != nil {
 		e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, splitHelper.GetRuntimeStats())
 	}
 

--- a/planner/core/initialize.go
+++ b/planner/core/initialize.go
@@ -483,6 +483,12 @@ func (p PointGetPlan) Init(ctx sessionctx.Context, stats *property.StatsInfo, of
 	return &p
 }
 
+// Init initializes LogicalTableDual.
+func (p SplitRegion) Init(ctx sessionctx.Context, offset int) *SplitRegion {
+	p.basePlan = newBasePlan(ctx, plancodec.TypeSplitRegion, offset)
+	return &p
+}
+
 // InitBasePlan only assigns type and context.
 func (p *PhysicalExchangerBase) InitBasePlan(ctx sessionctx.Context, tp string) {
 	p.basePlan = newBasePlan(ctx, tp, 0)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2735,11 +2735,11 @@ func (b *PlanBuilder) buildSplitIndexRegion(node *ast.SplitRegionStmt) (Plan, er
 	mockTablePlan.SetSchema(schema)
 	mockTablePlan.names = names
 
-	p := &SplitRegion{
+	p := SplitRegion{
 		TableInfo:      tblInfo,
 		PartitionNames: node.PartitionNames,
 		IndexInfo:      indexInfo,
-	}
+	}.Init(b.ctx, b.getSelectOffset())
 	p.names = names
 	p.setSchemaAndNames(buildSplitRegionsSchema())
 	// Split index regions by user specified value lists.
@@ -2850,10 +2850,10 @@ func (b *PlanBuilder) buildSplitTableRegion(node *ast.SplitRegionStmt) (Plan, er
 	mockTablePlan.SetSchema(schema)
 	mockTablePlan.names = names
 
-	p := &SplitRegion{
+	p := SplitRegion{
 		TableInfo:      tblInfo,
 		PartitionNames: node.PartitionNames,
-	}
+	}.Init(b.ctx, b.getSelectOffset())
 	p.setSchemaAndNames(buildSplitRegionsSchema())
 	if len(node.SplitOpt.ValueLists) > 0 {
 		values := make([][]types.Datum, 0, len(node.SplitOpt.ValueLists))

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -66,7 +66,7 @@ func (t backoffType) metric() prometheus.Observer {
 		return tikvBackoffHistogramLockFast
 	case BoPDRPC:
 		return tikvBackoffHistogramPD
-	case BoRegionMiss, boWaitScatterRegion:
+	case BoRegionMiss, boWaitScatterRegion, boScatterRegion:
 		return tikvBackoffHistogramRegionMiss
 	case boServerBusy:
 		return tikvBackoffHistogramServerBusy
@@ -137,6 +137,7 @@ const (
 	boTxnNotFound
 	boStaleCmd
 	boMaxTsNotSynced
+	boScatterRegion
 	boWaitScatterRegion
 )
 
@@ -164,7 +165,7 @@ func (t backoffType) createFn(vars *kv.Variables) func(context.Context, int) int
 		return NewBackoffFn(2, 1000, NoJitter)
 	case boMaxTsNotSynced:
 		return NewBackoffFn(2, 500, NoJitter)
-	case boWaitScatterRegion:
+	case boWaitScatterRegion, boScatterRegion:
 		// change base time to 2ms, because it may recover soon.
 		return NewBackoffFn(2, 100, NoJitter)
 	}
@@ -191,6 +192,8 @@ func (t backoffType) String() string {
 		return "txnNotFound"
 	case boMaxTsNotSynced:
 		return "maxTsNotSynced"
+	case boScatterRegion:
+		return "ScatterRegion"
 	case boWaitScatterRegion:
 		return "waitScatterRegion"
 	}
@@ -205,7 +208,7 @@ func (t backoffType) TError() error {
 		return ErrResolveLockTimeout
 	case BoPDRPC:
 		return ErrPDServerTimeout
-	case BoRegionMiss, boWaitScatterRegion:
+	case BoRegionMiss, boWaitScatterRegion, boScatterRegion:
 		return ErrRegionUnavailable
 	case boServerBusy:
 		return ErrTiKVServerBusy

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -193,7 +193,7 @@ func (t backoffType) String() string {
 	case boMaxTsNotSynced:
 		return "maxTsNotSynced"
 	case boScatterRegion:
-		return "ScatterRegion"
+		return "scatterRegion"
 	case boWaitScatterRegion:
 		return "waitScatterRegion"
 	}

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -88,6 +88,10 @@ type RPCRuntimeStats struct {
 	Consume int64
 }
 
+func (r *RegionRequestRuntimeStats) record(cmd tikvrpc.CmdType, d time.Duration) {
+	recordRegionRequestRuntimeStats(r.Stats, cmd, d)
+}
+
 // String implements fmt.Stringer interface.
 func (r *RegionRequestRuntimeStats) String() string {
 	var buf bytes.Buffer
@@ -208,6 +212,15 @@ func NewRegionRequestSender(regionCache *RegionCache, client Client) *RegionRequ
 	return &RegionRequestSender{
 		regionCache: regionCache,
 		client:      client,
+	}
+}
+
+// NewRegionRequestSender creates a new sender with runtime stats
+func NewRegionRequestSenderWithStats(regionCache *RegionCache, client Client, stats map[tikvrpc.CmdType]*RPCRuntimeStats) *RegionRequestSender {
+	return &RegionRequestSender{
+		regionCache:               regionCache,
+		client:                    client,
+		RegionRequestRuntimeStats: RegionRequestRuntimeStats{stats},
 	}
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -215,15 +215,6 @@ func NewRegionRequestSender(regionCache *RegionCache, client Client) *RegionRequ
 	}
 }
 
-// NewRegionRequestSender creates a new sender with runtime stats
-func NewRegionRequestSenderWithStats(regionCache *RegionCache, client Client, stats map[tikvrpc.CmdType]*RPCRuntimeStats) *RegionRequestSender {
-	return &RegionRequestSender{
-		regionCache:               regionCache,
-		client:                    client,
-		RegionRequestRuntimeStats: RegionRequestRuntimeStats{stats},
-	}
-}
-
 // SendReq sends a request to tikv server.
 func (s *RegionRequestSender) SendReq(bo *Backoffer, req *tikvrpc.Request, regionID RegionVerID, timeout time.Duration) (*tikvrpc.Response, error) {
 	resp, _, err := s.SendReqCtx(bo, req, regionID, timeout, kv.TiKV)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -683,22 +683,22 @@ type SnapshotRuntimeStats struct {
 	backoffTimes   map[backoffType]int
 }
 
-func (s *SnapshotRuntimeStats) recordBackoffInfo(bo *Backoffer) {
-	if s.backoffSleepMS == nil {
-		s.backoffSleepMS = bo.backoffSleepMS
-		s.backoffTimes = bo.backoffTimes
+func (rs *SnapshotRuntimeStats) recordBackoffInfo(bo *Backoffer) {
+	if rs.backoffSleepMS == nil {
+		rs.backoffSleepMS = bo.backoffSleepMS
+		rs.backoffTimes = bo.backoffTimes
 		return
 	}
 	for k, v := range bo.backoffSleepMS {
-		s.backoffSleepMS[k] += v
+		rs.backoffSleepMS[k] += v
 	}
 	for k, v := range bo.backoffTimes {
-		s.backoffTimes[k] += v
+		rs.backoffTimes[k] += v
 	}
 }
 
 func (rs *SnapshotRuntimeStats) mergeRegionRequestStats(stats map[tikvrpc.CmdType]*RPCRuntimeStats) {
-	if rs == nil || len(stats) == 0 {
+	if len(stats) == 0 {
 		return
 	}
 	if rs.rpcStats.Stats == nil {

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -36,6 +36,14 @@ import (
 
 const splitBatchRegionLimit = 16
 
+type SplitRegionHelper struct {
+	*tikvStore
+}
+
+type SplitRegionRuntimeStats struct {
+	*SnapshotRuntimeStats
+}
+
 func equalRegionStartKey(key, regionStartKey []byte) bool {
 	return bytes.Equal(key, regionStartKey)
 }

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -296,8 +296,7 @@ func (s *SplitRegionHelper) scatterRegion(bo *Backoffer, regionID uint64, tableI
 		if err == nil {
 			break
 		}
-		fmt.Printf("pd rpc error: %v  --\n\n", err.Error())
-		err = bo.Backoff(boWaitScatterRegion, errors.New(err.Error()))
+		err = bo.Backoff(boScatterRegion, errors.New(err.Error()))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/store/tikv/tikvrpc/tikvrpc.go
+++ b/store/tikv/tikvrpc/tikvrpc.go
@@ -81,6 +81,9 @@ const (
 	CmdDebugGetRegionProperties CmdType = 2048 + iota
 
 	CmdEmpty CmdType = 3072 + iota
+
+	CmdPDGetOperator CmdType = 4096 + iota
+	CmdPDScatterRegions
 )
 
 func (t CmdType) String() string {
@@ -161,6 +164,10 @@ func (t CmdType) String() string {
 		return "DebugGetRegionProperties"
 	case CmdTxnHeartBeat:
 		return "TxnHeartBeat"
+	case CmdPDGetOperator:
+		return "PDGetOperator"
+	case CmdPDScatterRegions:
+		return "PDScatterRegions"
 	}
 	return "Unknown"
 }

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -523,14 +523,16 @@ const (
 	TpSelectResultRuntimeStats
 	// TpInsertRuntimeStat is the tp for InsertRuntimeStat
 	TpInsertRuntimeStat
-	// TpIndexLookUpRunTimeStats is the tp for TpIndexLookUpRunTimeStats
+	// TpIndexLookUpRunTimeStats is the tp for IndexLookUpRunTimeStats
 	TpIndexLookUpRunTimeStats
-	// TpSlowQueryRuntimeStat is the tp for TpSlowQueryRuntimeStat
+	// TpSlowQueryRuntimeStat is the tp for SlowQueryRuntimeStat
 	TpSlowQueryRuntimeStat
 	// TpHashAggRuntimeStat is the tp for HashAggRuntimeStat
 	TpHashAggRuntimeStat
-	// TpIndexMergeRunTimeStats is the tp for TpIndexMergeRunTimeStats
+	// TpIndexMergeRunTimeStats is the tp for IndexMergeRunTimeStats
 	TpIndexMergeRunTimeStats
+	// TpSplitRuntimeStat is the tp for SplitRuntimeStat
+	TpSplitRuntimeStat
 )
 
 // RuntimeStats is used to express the executor runtime information.

--- a/util/plancodec/id.go
+++ b/util/plancodec/id.go
@@ -110,6 +110,8 @@ const (
 	TypeDataSource = "DataSource"
 	// TypeLoadData is the type of LoadData.
 	TypeLoadData = "LoadData"
+	// TypeSplitRegion is the type of SplitRegion.
+	TypeSplitRegion = "SplitRegion"
 )
 
 // plan id.
@@ -156,6 +158,7 @@ const (
 	typeClusterMemTableReader int = 39
 	typeDataSourceID          int = 40
 	typeLoadDataID            int = 41
+	typeSplitRegionID         int = 42
 )
 
 // TypeStringToPhysicalID converts the plan type string to plan id.
@@ -243,6 +246,8 @@ func TypeStringToPhysicalID(tp string) int {
 		return typeDataSourceID
 	case TypeLoadData:
 		return typeLoadDataID
+	case TypeSplitRegion:
+		return typeSplitRegionID
 	}
 	// Should never reach here.
 	return 0
@@ -331,6 +336,8 @@ func PhysicalIDToTypeString(id int) string {
 		return TypeClusterMemTableReader
 	case typeLoadDataID:
 		return TypeLoadData
+	case typeSplitRegionID:
+		return TypeSplitRegion
 	}
 
 	// Should never reach here.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

As title said, here is an example:

```sql
>select query,plan from slow_query where query like "split table%" order by time desc limit 1\G;
***************************[ 1. row ]***************************
query | split table t between (0) and (5000000) regions 50;
plan  |         id              task    estRows operator info   actRows execution info                                                                                                                                                                                                                                                                                                                                                  memory  disk
        SplitRegion_2   root    0       N/A             1       time:1.09s, loops:2, split_and_scatter: 37.9ms, wait_scatter_finish: 1.05s, split_keys: 50, split_regions: 40, PDScatterRegions:{num_rpc:81, total_time:80.8ms},SplitRegion:{num_rpc:40, total_time:131.3ms},PDGetOperator:{num_rpc:55, total_time:11ms},regionMiss_backoff:{num:35, total_time:70ms},waitScatterRegion_backoff:{num:15, total_time:1.03s}      N/A     N/A

```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- N/A