### PR TITLE
executor: add benchmark for partitionRangeSplitter

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -419,11 +419,9 @@ func benchmarkAggExecWithCase(b *testing.B, casTest *aggTestCase) {
 
 func BenchmarkShuffleStreamAggRows(b *testing.B) {
 	b.ReportAllocs()
-	sortTypes := []bool{true}
-	// rows := []int{10000, 100000, 1000000, 10000000}
-	// concurrencies := []int{1, 2, 4, 8}
-	rows := []int{1000000}
-	concurrencies := []int{2}
+	sortTypes := []bool{false, true}
+	rows := []int{10000, 100000, 1000000, 10000000}
+	concurrencies := []int{1, 2, 4, 8}
 	for _, row := range rows {
 		for _, con := range concurrencies {
 			for _, sorted := range sortTypes {

--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -301,6 +301,7 @@ func buildStreamAggExecutor(ctx sessionctx.Context, srcExec Executor, schema *ex
 	sg.Init(ctx, nil, 0)
 
 	var tail core.PhysicalPlan = sg
+	// if data source is not sorted, we have to attach sort, to make the input of stream-agg sorted
 	if !dataSourceSorted {
 		byItems := make([]*util.ByItems, 0, len(sg.GroupByItems))
 		for _, col := range sg.GroupByItems {
@@ -314,13 +315,19 @@ func buildStreamAggExecutor(ctx sessionctx.Context, srcExec Executor, schema *ex
 		sg.SetChildren(src)
 	}
 
-	var plan core.PhysicalPlan
+	var (
+		plan     core.PhysicalPlan
+		splitter core.PartitionSplitterType = core.PartitionHashSplitterType
+	)
 	if concurrency > 1 {
+		if dataSourceSorted {
+			splitter = core.PartitionRangeSplitterType
+		}
 		plan = core.PhysicalShuffle{
 			Concurrency:  concurrency,
 			Tails:        []core.PhysicalPlan{tail},
 			DataSources:  []core.PhysicalPlan{src},
-			SplitterType: core.PartitionHashSplitterType,
+			SplitterType: splitter,
 			ByItemArrays: [][]expression.Expression{sg.GroupByItems},
 		}.Init(ctx, nil, 0)
 		plan.SetChildren(sg)
@@ -413,8 +420,10 @@ func benchmarkAggExecWithCase(b *testing.B, casTest *aggTestCase) {
 func BenchmarkShuffleStreamAggRows(b *testing.B) {
 	b.ReportAllocs()
 	sortTypes := []bool{true}
-	rows := []int{10000, 100000, 1000000, 10000000}
-	concurrencies := []int{1, 2, 4, 8}
+	// rows := []int{10000, 100000, 1000000, 10000000}
+	// concurrencies := []int{1, 2, 4, 8}
+	rows := []int{1000000}
+	concurrencies := []int{2}
 	for _, row := range rows {
 		for _, con := range concurrencies {
 			for _, sorted := range sortTypes {

--- a/executor/shuffle.go
+++ b/executor/shuffle.go
@@ -439,6 +439,9 @@ func buildPartitionRangeSplitter(ctx sessionctx.Context, concurrency int, byItem
 	}
 }
 
+// This method is supposed to be used for shuffle with sorted `dataSource`
+// the caller of this method should guarantee that `input` is grouped,
+// which means that rows with the same byItems should be continuous, the order does not matter.
 func (s *partitionRangeSplitter) split(ctx sessionctx.Context, input *chunk.Chunk, workerIndices []int) ([]int, error) {
 	_, err := s.groupChecker.splitIntoGroups(input)
 	if err != nil {
@@ -453,5 +456,6 @@ func (s *partitionRangeSplitter) split(ctx sessionctx.Context, input *chunk.Chun
 		}
 		s.idx = (s.idx + 1) % s.numWorkers
 	}
+
 	return workerIndices, nil
 }

--- a/executor/shuffle.go
+++ b/executor/shuffle.go
@@ -442,14 +442,22 @@ func (s *partitionRangeSplitter) split(ctx sessionctx.Context, input *chunk.Chun
 	if err != nil {
 		return workerIndices, err
 	}
+	defer func() {
+		if r := recover(); r != nil {
+			err := errors.Errorf("%v", r)
+			logutil.BgLogger().Error("shuffle panicked", zap.Error(err), zap.Stack("stack"))
+		}
+	}()
 
 	workerIndices = workerIndices[:0]
+	numRows := input.NumRows()
 	idx := -1
-	for i := 0; i < len(s.groupChecker.sameGroup); i++ {
+	for i := 0; i < numRows; i++ {
 		if !s.groupChecker.sameGroup[i] {
 			idx = (idx + 1) % s.numWorkers
 		}
 		workerIndices = append(workerIndices, idx)
 	}
+
 	return workerIndices, nil
 }

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -147,28 +147,32 @@ func optimizeByShuffle4StreamAgg(pp *PhysicalStreamAgg, ctx sessionctx.Context) 
 		return nil
 	}
 
-	var (
-		splitter         PartitionSplitterType
-		tail, dataSource PhysicalPlan
-	)
-
-	switch childExec := pp.Children()[0].(type) {
-	case *PhysicalSort:
-		splitter = PartitionHashSplitterType
-		tail, dataSource = childExec, childExec.Children()[0]
-	case *PhysicalIndexReader, *PhysicalIndexScan:
-		splitter = PartitionRangeSplitterType
-		tail, dataSource = pp, childExec
-	default:
+	sort, ok := pp.Children()[0].(*PhysicalSort)
+	if !ok {
+		// Multi-thread executing on SORTED data source is not effective enough by current implementation.
+		// TODO: Implement a better one.
 		return nil
 	}
+	tail, dataSource := sort, sort.Children()[0]
+
+	partitionBy := make([]*expression.Column, 0, len(pp.GroupByItems))
+	for _, item := range pp.GroupByItems {
+		if col, ok := item.(*expression.Column); ok {
+			partitionBy = append(partitionBy, col)
+		}
+	}
+	NDV := int(getCardinality(partitionBy, dataSource.Schema(), dataSource.statsInfo()))
+	if NDV <= 1 {
+		return nil
+	}
+	concurrency = mathutil.Min(concurrency, NDV)
 
 	reqProp := &property.PhysicalProperty{ExpectedCnt: math.MaxFloat64}
 	shuffle := PhysicalShuffle{
 		Concurrency:  concurrency,
 		Tails:        []PhysicalPlan{tail},
 		DataSources:  []PhysicalPlan{dataSource},
-		SplitterType: splitter,
+		SplitterType: PartitionHashSplitterType,
 		ByItemArrays: [][]expression.Expression{cloneExprs(pp.GroupByItems)},
 	}.Init(ctx, pp.statsInfo(), pp.SelectBlockOffset(), reqProp)
 	return shuffle

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -85,8 +85,6 @@ func optimizeByShuffle(tsk task, ctx sessionctx.Context) task {
 		return tsk
 	}
 
-	// Don't use `tsk.plan()` here, which will probably be different from `pp`.
-	// Eg., when `pp` is `NominalSort`, `tsk.plan()` would be its child.
 	switch p := tsk.plan().(type) {
 	case *PhysicalWindow:
 		if shuffle := optimizeByShuffle4Window(p, ctx); shuffle != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #20651 

Problem Summary:

This is the 4th pr to the issue `Parallelize stream aggregation executor by using shuffle executor`, add a simple benchmark to test the performance of `partitionRangeSplitter`.

The result shows that it's fast than `partitionHashSplitter` for the sorted data source, but the overall performance of shuffled stream aggregation is worse than the sequential version. 

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

* executor: add simple benchmark for stream aggregation, use range splitter as default.

Benchmarks:
| rows | no concurrency | concurrency 2 | concurrency 4 |
| ---- | ---- | ---- | ---- |
| 10000 | 4312926 ns/op | 3147944 ns/op | 2511416 ns/op |
| 100000 | 46287871 ns/op | 30565550 ns/op | 19906485 ns/op |
| 1000000 | 688690770 ns/op | 402929275 ns/op | 230093672 ns/op |
| 10000000 | 12842102225 ns/op | 7839787310 ns/op | 3884926789 ns/op |

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

* No release note
