### PR TITLE
expression: incompatibility with MySQL for ADDTIME()

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -5526,6 +5526,10 @@ func (b *builtinAddStringAndStringSig) evalString(row chunk.Row) (result string,
 		return "", isNull, err
 	}
 	sc := b.ctx.GetSessionVars().StmtCtx
+	_, err = types.ParseDatetime(sc, arg1Str)
+	if err == nil {
+		return "", true, err
+	}
 	arg1, err = types.ParseDuration(sc, arg1Str, getFsp4TimeAddSub(arg1Str))
 	if err != nil {
 		if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {

--- a/expression/builtin_time_vec_generated.go
+++ b/expression/builtin_time_vec_generated.go
@@ -405,6 +405,11 @@ func (b *builtinAddStringAndStringSig) vecEvalString(input *chunk.Chunk, result 
 		// calculate
 
 		sc := b.ctx.GetSessionVars().StmtCtx
+		_, err = types.ParseDatetime(sc, arg1)
+		if err == nil {
+			result.AppendNull() // fixed: false
+			continue
+		}
 		arg1Duration, err := types.ParseDuration(sc, arg1, getFsp4TimeAddSub(arg1))
 		if err != nil {
 			if terror.ErrorEqual(err, types.ErrTruncatedWrongVal) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #19150

### What is changed and how it works?

What's Changed:

- builtinAddStringStringSig eval/vecEval return null when arg1 is Datetime type (eg: `ADDTIME(arg0, arg1)`)

How it Works:

make related builtinAddDateFuncs return null

### Related changes

Tests

- No code

Side effects

- Breaking backward compatibility

### Release note 

- Fix incompatibility with MySQL 8.0 for ADDTIME()