### PR TITLE
sessionctx/variable: fix a DATA RACE to make CI more stable

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1566,7 +1566,13 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 	case TiDBFoundInBinding:
 		s.FoundInBinding = TiDBOptOn(val)
 	case TiDBEnableCollectExecutionInfo:
-		config.GetGlobalConfig().EnableCollectExecutionInfo = TiDBOptOn(val)
+		oldConfig := config.GetGlobalConfig()
+		newValue := TiDBOptOn(val)
+		if oldConfig.EnableCollectExecutionInfo != newValue {
+			newConfig := *oldConfig
+			newConfig.EnableCollectExecutionInfo = newValue
+			config.StoreGlobalConfig(&newConfig)
+		}
 	case SQLSelectLimit:
 		result, err := strconv.ParseUint(val, 10, 64)
 		if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/20573

Problem Summary:

### What is changed and how it works?

The data race between here https://github.com/pingcap/tidb/blob/fb80822390c49aabf2c220d4892f3bc0c7b1c113/executor/executor.go#L1705 and here https://github.com/pingcap/tidb/blob/fb80822390c49aabf2c220d4892f3bc0c7b1c113/sessionctx/variable/session.go#L1569

Found in this test https://github.com/pingcap/tidb/blob/fb80822390c49aabf2c220d4892f3bc0c7b1c113/executor/explainfor_test.go#L81 and here is the stack:

```
[2020-11-26T09:25:00.286Z] ==================
[2020-11-26T09:25:00.286Z] WARNING: DATA RACE
[2020-11-26T09:25:00.286Z] Write at 0x00c08a9ca585 by goroutine 950:
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/sessionctx/variable.(*SessionVars).SetSystemVar()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/variable/session.go:1566 +0x49b3
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/sessionctx/variable.SetSessionSystemVar()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/sessionctx/variable/varsutil.go:225 +0x188
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/executor.(*SetExecutor).setSysVariable()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/set.go:191 +0x1a8f
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/executor.(*SetExecutor).Next()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/set.go:108 +0x302
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/executor.Next()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:277 +0x27d
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelayExecutor()
[2020-11-26T09:25:00.286Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:522 +0x38e
[2020-11-26T09:25:00.286Z]   github.com/pingcap/tidb/executor.(*ExecStmt).handleNoDelay()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:404 +0x254
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/executor.(*ExecStmt).Exec()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/adapter.go:354 +0x3f6
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.runStmt()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1312 +0x2c1
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.(*session).ExecuteStmt()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1256 +0x9ff
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).Exec()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:170 +0x2f1
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/util/testkit.(*TestKit).MustExec()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:216 +0x91
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/executor_test.(*testSerialSuite).TestExplainFor()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/explainfor_test.go:81 +0x6a5
[2020-11-26T09:25:00.287Z]   runtime.call32()
[2020-11-26T09:25:00.287Z]       /usr/local/go/src/runtime/asm_amd64.s:539 +0x3a
[2020-11-26T09:25:00.287Z]   reflect.Value.Call()
[2020-11-26T09:25:00.287Z]       /usr/local/go/src/reflect/value.go:321 +0xd3
[2020-11-26T09:25:00.287Z]   github.com/pingcap/check.(*suiteRunner).forkTest.func1()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:850 +0x9aa
[2020-11-26T09:25:00.287Z]   github.com/pingcap/check.(*suiteRunner).forkCall.func1()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/pkg/mod/github.com/pingcap/check@v0.0.0-20200212061837-5e12011dc712/check.go:739 +0x113
[2020-11-26T09:25:00.287Z] 
[2020-11-26T09:25:00.287Z] Previous read at 0x00c08a9ca585 by goroutine 164:
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/executor.ResetContextOfStmt()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:1705 +0xb66
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.(*session).ExecuteStmt()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1228 +0x1f1
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.(*session).Execute()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:1168 +0x2a1
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.execRestrictedSQL()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:882 +0x18f
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.(*session).ExecRestrictedSQLWithContext()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:821 +0x3c0
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/session.(*session).ExecRestrictedSQL()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/session/session.go:787 +0x92
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/bindinfo.(*BindHandle).Update()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/bindinfo/handle.go:137 +0x16c
[2020-11-26T09:25:00.287Z]   github.com/pingcap/tidb/domain.(*Domain).globalBindHandleWorkerLoop.func1()
[2020-11-26T09:25:00.287Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/domain/domain.go:976 +0x254
[2020-11-26T09:25:00.287Z] 
```


What's Changed:

Fix a data race

How it Works:

`config.StoreGlobalConfig(&newConfig)` is atomic, so it can get rid of the DATA RACE.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
