### PR TITLE
*: Fix coverage test fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 	@export log_level=error; \
 	$(OVERALLS) -project=github.com/pingcap/tidb \
 			-covermode=count \
-			-ignore='.git,vendor,cmd,docs,LICENSES,tests' \
+			-ignore='.git,vendor,cmd,docs,tests,LICENSES' \
 			-concurrency=4 \
 			-- -coverpkg=./... \
 			|| { $(FAILPOINT_DISABLE); exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,9 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 	@export log_level=error; \
 	$(OVERALLS) -project=github.com/pingcap/tidb \
 			-covermode=count \
-			-ignore='.git,vendor,cmd,docs,LICENSES' \
+			-ignore='.git,vendor,cmd,docs,LICENSES,tests' \
 			-concurrency=4 \
-			-- -coverpkg=$(PACKAGES) \
+			-- -coverpkg=./... \
 			|| { $(FAILPOINT_DISABLE); exit 1; }
 else
 	@echo "Running in native mode."

--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ ifeq ("$(TRAVIS_COVERAGE)", "1")
 			-covermode=count \
 			-ignore='.git,vendor,cmd,docs,LICENSES' \
 			-concurrency=4 \
-			-- -coverpkg=./... \
+			-- -coverpkg=$(PACKAGES) \
 			|| { $(FAILPOINT_DISABLE); exit 1; }
 else
 	@echo "Running in native mode."


### PR DESCRIPTION
We should not test tests coverage like globalkilltest
```
[2020-12-03T02:50:02.332Z] 2020/12/03 10:50:02 go: directory tests/globalkilltest is outside main module
[2020-12-03T02:50:02.332Z] 2020/12/03 10:50:02 ERROR:exit status 1
[2020-12-03T02:50:04.854Z] make: *** [gotest] Error 1
```

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
