### PR TITLE
planner: push down projection for tiflash

### DIFF
--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -191,6 +191,8 @@ func updateExecutorTableID(ctx context.Context, exec *tipb.Executor, partitionID
 		child = nil
 	case tipb.ExecType_TypeJoin:
 		child = exec.Join.Children[1-exec.Join.InnerIdx]
+	case tipb.ExecType_TypeProjection:
+		child = exec.Projection.Child
 	default:
 		return errors.Trace(fmt.Errorf("unknown new tipb protocol %d", exec.Tp))
 	}

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/pingcap/parser v0.0.0-20201222091346-02c8ff27d0bc
 	github.com/pingcap/sysutil v0.0.0-20201130064824-f0c8aa6a6966
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
-	github.com/pingcap/tipb v0.0.0-20201209065231-aa39b1b86217
+	github.com/pingcap/tipb v0.0.0-20201229060814-148bc717ce4c
 	github.com/prometheus/client_golang v1.5.1
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -671,8 +671,8 @@ github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible 
 github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible/go.mod h1:XGdcy9+yqlDSEMTpOXnwf3hiTeqrV6MN/u1se9N8yIM=
 github.com/pingcap/tipb v0.0.0-20190428032612-535e1abaa330/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tipb v0.0.0-20200417094153-7316d94df1ee/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
-github.com/pingcap/tipb v0.0.0-20201209065231-aa39b1b86217 h1:Ophn4Ud/QHp1BH0FJOzbAVBW9Mw8BlX0gtWkK7ubDy0=
-github.com/pingcap/tipb v0.0.0-20201209065231-aa39b1b86217/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
+github.com/pingcap/tipb v0.0.0-20201229060814-148bc717ce4c h1:kvrdp2hY+asgSvVXCj4eebA9DH4SSouRVQUZpa1Se/Y=
+github.com/pingcap/tipb v0.0.0-20201229060814-148bc717ce4c/go.mod h1:RtkHW8WbcNxj8lsbzjaILci01CtYnYbIkQhjyZWrWVI=
 github.com/pingcap/tiup v1.2.3 h1:8OCQF7sHhT6VqE8pZU1JTSogPA90OFuWWM/B746x0YY=
 github.com/pingcap/tiup v1.2.3/go.mod h1:q8WzflNHjE1U49k2qstTL0clx2pKh8pkOzUFV4RTvQo=
 github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4/go.mod h1:4OwLy04Bl9Ef3GJJCoec+30X3LQs/0/m4HFRt/2LUSA=

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1918,10 +1918,10 @@ func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty
 	ret := make([]PhysicalPlan, 0, len(allTaskTypes))
 	for _, tp := range allTaskTypes {
 		newProp, ok := p.TryToGetChildProp(prop)
-		newProp.TaskTp = tp
 		if !ok {
 			break
 		}
+		newProp.TaskTp = tp
 		proj := PhysicalProjection{
 			Exprs:                p.Exprs,
 			CalculateNoDelay:     p.CalculateNoDelay,

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2250,7 +2250,7 @@ func (la *LogicalAggregation) getHashAggs(prop *property.PhysicalProperty) []Phy
 	if prop.IsFlashProp() {
 		taskTypes = []property.TaskType{prop.TaskTp}
 	}
-	if !la.canPushToCop() {
+	if !la.canPushToCop() && !la.ctx.GetSessionVars().AllowMPPExecution && !la.ctx.GetSessionVars().AllowBCJ {
 		taskTypes = []property.TaskType{property.RootTaskType}
 	}
 	for _, taskTp := range taskTypes {

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2088,15 +2088,15 @@ func (p *baseLogicalPlan) exhaustPhysicalPlans(_ *property.PhysicalProperty) ([]
 	panic("baseLogicalPlan.exhaustPhysicalPlans() should never be called.")
 }
 func (p *baseLogicalPlan) canChildPushDown() bool {
-	_, ok := p.children[0].(*DataSource)
-	// TiFlash support pushing down more operators
-	if !ok && (p.SCtx().GetSessionVars().AllowBCJ || p.SCtx().GetSessionVars().AllowMPPExecution) {
-		_, ok = p.children[0].(*LogicalProjection)
-		if !ok {
-			_, ok = p.children[0].(*LogicalJoin)
-		}
+	switch p.children[0].(type) {
+	case *DataSource:
+		return true
+	case *LogicalJoin, *LogicalProjection:
+		// TiFlash support pushing down more operators
+		return p.SCtx().GetSessionVars().AllowBCJ || p.SCtx().GetSessionVars().AllowMPPExecution
+	default:
+		return false
 	}
-	return ok
 }
 
 func (la *LogicalAggregation) canPushToCop() bool {

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1913,7 +1913,7 @@ func (p *LogicalProjection) TryToGetChildProp(prop *property.PhysicalProperty) (
 func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([]PhysicalPlan, bool) {
 	newProp, ok := p.TryToGetChildProp(prop)
 	if !ok {
-		return nil, false
+		return nil, true
 	}
 	proj := PhysicalProjection{
 		Exprs:                p.Exprs,

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1931,9 +1931,6 @@ func (lt *LogicalTopN) canPushToCop() bool {
 
 	// TODO: develop this function after supporting push several tasks to coprecessor and supporting Projection to coprocessor.
 	_, ok := lt.children[0].(*DataSource)
-	if lt.SCtx().GetSessionVars().AllowBCJ {
-		ok = true
-	}
 	return ok
 }
 
@@ -2330,10 +2327,6 @@ func (p *LogicalLimit) canPushToCop() bool {
 
 	// TODO: develop this function after supporting push several tasks to coprecessor and supporting Projection to coprocessor.
 	_, ok := p.children[0].(*DataSource)
-	// allow push down projection for tiflash
-	if p.SCtx().GetSessionVars().AllowBCJ {
-		ok = true
-	}
 	return ok
 }
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1915,11 +1915,6 @@ func (p *LogicalProjection) TryToGetChildProp(prop *property.PhysicalProperty) (
 
 func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty) ([]PhysicalPlan, bool) {
 	allTaskTypes := prop.GetAllPossibleChildTaskTypes()
-	// TODO: only for TiFlash now, support push down projection in TiKV later
-	_, tikv := p.SCtx().GetSessionVars().GetIsolationReadEngines()[kv.TiKV]
-	if tikv {
-		allTaskTypes = []property.TaskType{prop.TaskTp}
-	}
 	ret := make([]PhysicalPlan, 0, len(allTaskTypes))
 	for _, tp := range allTaskTypes {
 		newProp, ok := p.TryToGetChildProp(prop)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -267,9 +267,8 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 			bestTask = curTask
 			break
 		}
-
 		// Get the most efficient one.
-		if curTask.cost() < bestTask.cost() || (bestTask.invalid() && !curTask.invalid()) {
+		if curTask.normalizedCost() < bestTask.normalizedCost() || (bestTask.invalid() && !curTask.invalid()) {
 			bestTask = curTask
 		}
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -268,7 +268,7 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 			break
 		}
 		// Get the most efficient one.
-		if curTask.normalizedCost() < bestTask.normalizedCost() || (bestTask.invalid() && !curTask.invalid()) {
+		if curTask.cost() < bestTask.cost() || (bestTask.invalid() && !curTask.invalid()) {
 			bestTask = curTask
 		}
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -248,14 +248,6 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 			curTask = curTask.convertToRootTask(p.ctx)
 		}
 
-		// convert to root task as needed to satisfy property
-		if prop.TaskTp == property.RootTaskType {
-			_, ok := curTask.(*rootTask)
-			if !ok {
-				curTask = finishCopTask(p.ctx, curTask)
-			}
-		}
-
 		// Enforce curTask property
 		if addEnforcer {
 			curTask = enforceProperty(prop, curTask, p.basePlan.ctx)

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -247,6 +247,13 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 		if _, ok := curTask.(*mppTask); ok && prop.TaskTp == property.RootTaskType {
 			curTask = curTask.convertToRootTask(p.ctx)
 		}
+		// convert to root task as needed to satisfy property
+		if prop.TaskTp == property.RootTaskType {
+			_, ok := curTask.(*rootTask)
+			if prop.IsFlashProp() || !ok {
+				curTask = finishCopTask(p.ctx, curTask)
+			}
+		}
 
 		// Enforce curTask property
 		if addEnforcer {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -247,10 +247,11 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 		if _, ok := curTask.(*mppTask); ok && prop.TaskTp == property.RootTaskType {
 			curTask = curTask.convertToRootTask(p.ctx)
 		}
+
 		// convert to root task as needed to satisfy property
 		if prop.TaskTp == property.RootTaskType {
 			_, ok := curTask.(*rootTask)
-			if prop.IsFlashProp() || !ok {
+			if !ok {
 				curTask = finishCopTask(p.ctx, curTask)
 			}
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -244,16 +244,9 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 		// Combine best child tasks with parent physical plan.
 		curTask := pp.attach2Task(childTasks...)
 
-		if _, ok := curTask.(*mppTask); ok && prop.TaskTp == property.RootTaskType {
-			curTask = curTask.convertToRootTask(p.ctx)
-		}
-
 		// An optimal task could not satisfy the property, so it should be converted here.
-		if prop.TaskTp == property.RootTaskType {
-			_, ok := curTask.(*rootTask)
-			if !ok {
-				curTask = finishCopTask(p.ctx, curTask)
-			}
+		if _, ok := curTask.(*rootTask); !ok && prop.TaskTp == property.RootTaskType {
+			curTask = curTask.convertToRootTask(p.ctx)
 		}
 
 		// Enforce curTask property

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -248,6 +248,14 @@ func (p *baseLogicalPlan) enumeratePhysicalPlans4Task(physicalPlans []PhysicalPl
 			curTask = curTask.convertToRootTask(p.ctx)
 		}
 
+		// An optimal task could not satisfy the property, so it should be converted here.
+		if prop.TaskTp == property.RootTaskType {
+			_, ok := curTask.(*rootTask)
+			if !ok {
+				curTask = finishCopTask(p.ctx, curTask)
+			}
+		}
+
 		// Enforce curTask property
 		if addEnforcer {
 			curTask = enforceProperty(prop, curTask, p.basePlan.ctx)

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2465,3 +2465,42 @@ func (s *testIntegrationSerialSuite) TestPushDownProjectionForTiFlash(c *C) {
 		res.Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func (s *testIntegrationSerialSuite) TestPushDownProjectionForMPP(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (id int, value decimal(6,3))")
+	tk.MustExec("analyze table t")
+
+	// Create virtual tiflash replica info.
+	dom := domain.GetDomain(tk.Se)
+	is := dom.InfoSchema()
+	db, exists := is.SchemaByName(model.NewCIStr("test"))
+	c.Assert(exists, IsTrue)
+	for _, tblInfo := range db.Tables {
+		if tblInfo.Name.L == "t" {
+			tblInfo.TiFlashReplica = &model.TiFlashReplicaInfo{
+				Count:     1,
+				Available: true,
+			}
+		}
+	}
+
+	tk.MustExec("set @@tidb_allow_mpp=1; set @@tidb_opt_broadcast_join=0;")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		res := tk.MustQuery(tt)
+		res.Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2427,7 +2427,7 @@ func (s *testIntegrationSuite) TestIssue22071(c *C) {
 	tk.MustQuery("select n in (1,n) from (select a in (1,2) as n from t) g;").Check(testkit.Rows("1", "1", "1"))
 }
 
-func (s *testIntegrationSerialSuite) TestPushDownProjection(c *C) {
+func (s *testIntegrationSerialSuite) TestPushDownProjectionForTiFlash(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
@@ -2447,11 +2447,15 @@ func (s *testIntegrationSerialSuite) TestPushDownProjection(c *C) {
 		}
 	}
 
-	tk.MustExec("set @@session.tidb_isolation_read_engines = 'tiflash'")
-	result := tk.MustQuery("desc select a+1 from t")
-	c.Assert(result.Rows()[1][0], Equals, "└─Projection_3")
+	result := tk.MustQuery("desc select /*+ hash_agg()*/count(b) from  (select a + 1 as b from t)A;")
+	// Projection -> TableReader
+	c.Assert(result.Rows()[1][0], Equals, "└─Projection_7")
+	c.Assert(result.Rows()[2][0], Equals, "  └─TableReader_11")
 
-	tk.MustExec("set @@session.tidb_isolation_read_engines = 'tikv'")
-	result = tk.MustQuery("desc select a+1 from t")
-	c.Assert(result.Rows()[0][0], Equals, "Projection_3")
+	tk.MustExec("set @@tidb_opt_broadcast_join=1;")
+	result = tk.MustQuery("desc select /*+ hash_agg()*/count(b) from  (select a + 1 as b from t)A;")
+	// TableReader -> HashAgg -> Projection, Projection is pushed down under TableReader
+	c.Assert(result.Rows()[1][0], Equals, "└─TableReader_13")
+	c.Assert(result.Rows()[2][0], Equals, "  └─HashAgg_8")
+	c.Assert(result.Rows()[3][0], Equals, "    └─Projection_10")
 }

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2451,11 +2451,21 @@ func (s *testIntegrationSerialSuite) TestPushDownProjectionForTiFlash(c *C) {
 	// Projection -> TableReader
 	c.Assert(result.Rows()[1][0], Equals, "└─Projection_7")
 	c.Assert(result.Rows()[2][0], Equals, "  └─TableReader_11")
+	// Projection -> TableReader
+	result = tk.MustQuery("desc select * from t join (select a-2 as b from t) A on A.b=t.a;")
+	c.Assert(result.Rows()[0][0], Equals, "HashJoin_17")
+	c.Assert(result.Rows()[1][0], Equals, "├─Projection_19(Build)")
+	c.Assert(result.Rows()[2][0], Equals, "│ └─TableReader_25")
 
 	tk.MustExec("set @@tidb_opt_broadcast_join=1;")
 	result = tk.MustQuery("desc select /*+ hash_agg()*/count(b) from  (select a + 1 as b from t)A;")
-	// TableReader -> HashAgg -> Projection, Projection is pushed down under TableReader
+	// Projection is pushed down under TableReader
 	c.Assert(result.Rows()[1][0], Equals, "└─TableReader_13")
 	c.Assert(result.Rows()[2][0], Equals, "  └─HashAgg_8")
 	c.Assert(result.Rows()[3][0], Equals, "    └─Projection_10")
+	// Projection is pushed down under TableReader
+	result = tk.MustQuery("desc select * from t join (select a-2 as b from t) A on A.b=t.a;")
+	c.Assert(result.Rows()[0][0], Equals, "TableReader_30")
+	c.Assert(result.Rows()[1][0], Equals, "└─BroadcastJoin_9")
+	c.Assert(result.Rows()[2][0], Equals, "  ├─Projection_27(Build)")
 }

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -129,6 +129,8 @@ func (p *PhysicalProjection) ToPB(ctx sessionctx.Context, storeType kv.StoreType
 			return nil, errors.Trace(err)
 		}
 		executorID = p.ExplainID().String()
+	} else {
+		return nil, errors.Errorf("The projection can only be pushed down to TiFlash now, not %s.", storeType.Name())
 	}
 	return &tipb.Executor{Tp: tipb.ExecType_TypeProjection, Projection: projExec, ExecutorId: &executorID}, nil
 }

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+	"github.com/pingcap/tidb/kv"
 
 	"github.com/pingcap/tidb/expression"
 )
@@ -84,7 +85,7 @@ func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 
 	// eliminate projection in a coprocessor task
 	tableReader, isTableReader := p.(*PhysicalTableReader)
-	if isTableReader {
+	if isTableReader && tableReader.StoreType == kv.TiFlash {
 		tableReader.tablePlan = eliminatePhysicalProjection(tableReader.tablePlan)
 		tableReader.TablePlans = flattenPushDownPlan(tableReader.tablePlan)
 		return p

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -15,9 +15,9 @@ package core
 
 import (
 	"context"
-	"github.com/pingcap/tidb/kv"
 
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/kv"
 )
 
 // canProjectionBeEliminatedLoose checks whether a projection can be eliminated,

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -82,6 +82,14 @@ func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 		p.Children()[i] = doPhysicalProjectionElimination(child)
 	}
 
+	// eliminate projection in a coprocessor task
+	tableReader, isTableReader := p.(*PhysicalTableReader)
+	if isTableReader {
+		tableReader.tablePlan = eliminatePhysicalProjection(tableReader.tablePlan)
+		tableReader.TablePlans = flattenPushDownPlan(tableReader.tablePlan)
+		return p
+	}
+
 	proj, isProj := p.(*PhysicalProjection)
 	if !isProj || !canProjectionBeEliminatedStrict(proj) {
 		return p

--- a/planner/core/rule_inject_extra_projection.go
+++ b/planner/core/rule_inject_extra_projection.go
@@ -16,7 +16,6 @@ package core
 import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx"
 )
@@ -57,12 +56,6 @@ func (pe *projInjector) inject(plan PhysicalPlan) PhysicalPlan {
 		plan = InjectProjBelowSort(p, p.ByItems)
 	case *NominalSort:
 		plan = TurnNominalSortIntoProj(p, p.OnlyColumn, p.ByItems)
-	case *PhysicalTableReader:
-		tableReader, isTableReader := plan.(*PhysicalTableReader)
-		if isTableReader && tableReader.StoreType == kv.TiFlash {
-			tableReader.tablePlan = pe.inject(tableReader.tablePlan)
-			tableReader.TablePlans = flattenPushDownPlan(tableReader.tablePlan)
-		}
 	}
 	return plan
 }

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1001,7 +1001,7 @@ func (p *PhysicalTopN) getPushedDownTopN(childPlan PhysicalPlan) *PhysicalTopN {
 	topN := PhysicalTopN{
 		ByItems: newByItems,
 		Count:   newCount,
-	}.Init(p.ctx, stats, p.blockOffset, p.GetChildReqProps(0))
+	}.Init(p.ctx, stats, p.blockOffset)
 	topN.SetChildren(childPlan)
 	return topN
 }

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -45,7 +45,6 @@ type task interface {
 	count() float64
 	addCost(cost float64)
 	cost() float64
-	normalizedCost() float64
 	copy() task
 	plan() PhysicalPlan
 	invalid() bool
@@ -104,10 +103,6 @@ func (t *copTask) addCost(cst float64) {
 
 func (t *copTask) cost() float64 {
 	return t.cst
-}
-
-func (t *copTask) normalizedCost() float64 {
-	return t.cst / 15
 }
 
 func (t *copTask) copy() task {
@@ -854,10 +849,6 @@ func (t *rootTask) cost() float64 {
 	return t.cst
 }
 
-func (t *rootTask) normalizedCost() float64 {
-	return t.cst
-}
-
 func (t *rootTask) plan() PhysicalPlan {
 	return t.p
 }
@@ -1594,10 +1585,6 @@ func (t *mppTask) addCost(cst float64) {
 
 func (t *mppTask) cost() float64 {
 	return t.cst
-}
-
-func (t *mppTask) normalizedCost() float64 {
-	return t.cst / 20
 }
 
 func (t *mppTask) copy() task {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1045,10 +1045,6 @@ func (p *PhysicalProjection) attach2Task(tasks ...task) task {
 	if cop, ok := tasks[0].(*copTask); ok {
 		if len(cop.rootTaskConds) == 0 {
 			cop = attachPlan2Task(p, cop).(*copTask)
-			projConcurrency := p.ctx.GetSessionVars().DistSQLScanConcurrency()
-			if projConcurrency <= 0 {
-				projConcurrency = 1
-			}
 			cop.addCost(p.GetCost(tasks[0].count()))
 			return cop
 		}

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1001,7 +1001,7 @@ func (p *PhysicalTopN) getPushedDownTopN(childPlan PhysicalPlan) *PhysicalTopN {
 	topN := PhysicalTopN{
 		ByItems: newByItems,
 		Count:   newCount,
-	}.Init(p.ctx, stats, p.blockOffset)
+	}.Init(p.ctx, stats, p.blockOffset, p.GetChildReqProps(0))
 	topN.SetChildren(childPlan)
 	return topN
 }

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -45,6 +45,7 @@ type task interface {
 	count() float64
 	addCost(cost float64)
 	cost() float64
+	normalizedCost() float64
 	copy() task
 	plan() PhysicalPlan
 	invalid() bool
@@ -103,6 +104,10 @@ func (t *copTask) addCost(cst float64) {
 
 func (t *copTask) cost() float64 {
 	return t.cst
+}
+
+func (t *copTask) normalizedCost() float64 {
+	return t.cst / 15
 }
 
 func (t *copTask) copy() task {
@@ -849,6 +854,10 @@ func (t *rootTask) cost() float64 {
 	return t.cst
 }
 
+func (t *rootTask) normalizedCost() float64 {
+	return t.cst
+}
+
 func (t *rootTask) plan() PhysicalPlan {
 	return t.p
 }
@@ -1585,6 +1594,10 @@ func (t *mppTask) addCost(cst float64) {
 
 func (t *mppTask) cost() float64 {
 	return t.cst
+}
+
+func (t *mppTask) normalizedCost() float64 {
+	return t.cst / 20
 }
 
 func (t *mppTask) copy() task {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1049,7 +1049,7 @@ func (p *PhysicalProjection) attach2Task(tasks ...task) task {
 			if projConcurrency <= 0 {
 				projConcurrency = 1
 			}
-			cop.addCost(p.GetCost(tasks[0].count() / float64(projConcurrency)))
+			cop.addCost(p.GetCost(tasks[0].count()))
 			return cop
 		}
 	}

--- a/planner/core/testdata/integration_serial_suite_in.json
+++ b/planner/core/testdata/integration_serial_suite_in.json
@@ -135,9 +135,34 @@
       "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
       "desc select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A",
       "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ count(*) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
       "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
       "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
-      "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b"
+      "desc select * from t left join (select id-2 as b from t) A on A.b=t.id",
+      "desc select * from t right join (select id-2 as b from t) A on A.b=t.id",
+      "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+      "desc select A.id from t as A where exists (select 1 from t where t.id=A.id)",
+      "desc select A.id from t as A where not exists  (select 1 from t where t.id=A.id)"
+    ]
+  },
+  {
+    "name": "TestPushDownProjectionForMPP",
+    "cases": [
+      "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A",
+      "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ count(*) from  (select id + 1 as b from t)A",
+      "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+      "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+      "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
+      "desc select * from t left join (select id-2 as b from t) A on A.b=t.id",
+      "desc select * from t right join (select id-2 as b from t) A on A.b=t.id",
+      "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+      "desc select id from t as A where exists (select 1 from t where t.id=A.id)",
+      "desc select id from t as A where not exists (select 1 from t where t.id=A.id)"
     ]
   }
 ]

--- a/planner/core/testdata/integration_serial_suite_in.json
+++ b/planner/core/testdata/integration_serial_suite_in.json
@@ -128,5 +128,16 @@
       "explain select /*+ inl_hash_join(s) */ * from t join s on t.a=s.a and t.b = s.a",
       "explain select /*+ inl_hash_join(s) */ * from t join s on t.a=s.a and t.a = s.b"
     ]
+  },
+  {
+    "name": "TestPushDownProjectionForTiFlash",
+    "cases": [
+      "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
+      "desc select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A",
+      "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+      "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+      "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
+      "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -1292,6 +1292,34 @@
         ]
       },
       {
+        "SQL": "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:count(Column#4)->Column#5",
+          "└─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "  └─TableReader_18 10000.00 root  data:TableFullScan_17",
+          "    └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ stream_agg()*/ count(*) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_17 1.00 root  funcs:count(Column#6)->Column#5",
+          "└─TableReader_18 1.00 root  data:StreamAgg_10",
+          "  └─StreamAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#6",
+          "    └─TableFullScan_16 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─Projection_25 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
+          "  └─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "    └─TableReader_18 10000.00 root  data:TableFullScan_17",
+          "      └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
         "Plan": [
           "TableReader_19 10000.00 root  data:HashJoin_9",
@@ -1317,6 +1345,28 @@
         ]
       },
       {
+        "SQL": "desc select * from t left join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_14 10000.00 root  data:HashJoin_7",
+          "└─HashJoin_7 10000.00 cop[tiflash]  left outer join, equal:[eq(test.t.id, Column#7)]",
+          "  ├─Projection_11(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "  │ └─Selection_13 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "  │   └─TableFullScan_12 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─TableFullScan_10(Probe) 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from t right join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_14 12487.50 root  data:HashJoin_7",
+          "└─HashJoin_7 12487.50 cop[tiflash]  right outer join, equal:[eq(test.t.id, Column#7)]",
+          "  ├─Selection_11(Build) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "  │ └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─Projection_12(Probe) 10000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "    └─TableFullScan_13 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
         "Plan": [
           "Projection_8 10000.00 root  Column#8, Column#4",
@@ -1328,6 +1378,185 @@
           "    └─Projection_16(Probe) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#8",
           "      └─Selection_18 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
           "        └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select A.id from t as A where exists (select 1 from t where t.id=A.id)",
+        "Plan": [
+          "TableReader_15 7992.00 root  data:HashJoin_9",
+          "└─HashJoin_9 7992.00 cop[tiflash]  semi join, equal:[eq(test.t.id, test.t.id)]",
+          "  ├─Selection_14(Build) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "  │ └─TableFullScan_13 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─Selection_12(Probe) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "    └─TableFullScan_11 10000.00 cop[tiflash] table:A keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select A.id from t as A where not exists  (select 1 from t where t.id=A.id)",
+        "Plan": [
+          "TableReader_13 8000.00 root  data:HashJoin_9",
+          "└─HashJoin_9 8000.00 cop[tiflash]  anti semi join, equal:[eq(test.t.id, test.t.id)]",
+          "  ├─TableFullScan_12(Build) 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─TableFullScan_11(Probe) 10000.00 cop[tiflash] table:A keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestPushDownProjectionForMPP",
+    "Cases": [
+      {
+        "SQL": "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:count(Column#7)->Column#5",
+          "└─TableReader_14 1.00 root  data:ExchangeSender_13",
+          "  └─ExchangeSender_13 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_8 1.00 cop[tiflash]  funcs:count(Column#4)->Column#7",
+          "      └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "        └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_15 1.00 root  funcs:count(Column#7)->Column#5",
+          "└─TableReader_17 1.00 root  data:ExchangeSender_16",
+          "  └─ExchangeSender_16 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#7",
+          "      └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─TableReader_14 1.00 root  data:ExchangeSender_13",
+          "  └─ExchangeSender_13 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_8 1.00 cop[tiflash]  funcs:sum(Column#4)->Column#7",
+          "      └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "        └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:count(Column#4)->Column#5",
+          "└─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "  └─TableReader_18 10000.00 root  data:TableFullScan_17",
+          "    └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ stream_agg()*/ count(*) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_17 1.00 root  funcs:count(Column#6)->Column#5",
+          "└─TableReader_18 1.00 root  data:StreamAgg_10",
+          "  └─StreamAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#6",
+          "    └─TableFullScan_16 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─Projection_25 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
+          "  └─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "    └─TableReader_18 10000.00 root  data:TableFullScan_17",
+          "      └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+        "Plan": [
+          "TableReader_22 10000.00 root  data:ExchangeSender_21",
+          "└─ExchangeSender_21 10000.00 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_9 10000.00 cop[tiflash]  inner join, equal:[eq(Column#4, Column#8)]",
+          "    ├─Projection_12(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
+          "    │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "    │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─Projection_18(Probe) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#8",
+          "      └─Selection_20 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "        └─TableFullScan_19 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_20 10000.00 root  data:ExchangeSender_19",
+          "└─ExchangeSender_19 10000.00 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_8 10000.00 cop[tiflash]  inner join, equal:[eq(test.t.id, Column#7)]",
+          "    ├─Projection_13(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "    │ └─Selection_16 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "    │   └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─Selection_12(Probe) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "      └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from t left join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_18 10000.00 root  data:ExchangeSender_17",
+          "└─ExchangeSender_17 10000.00 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_7 10000.00 cop[tiflash]  left outer join, equal:[eq(test.t.id, Column#7)]",
+          "    ├─Projection_11(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "    │ └─Selection_14 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "    │   └─TableFullScan_13 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─TableFullScan_10(Probe) 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from t right join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_17 12487.50 root  data:ExchangeSender_16",
+          "└─ExchangeSender_16 12487.50 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_7 12487.50 cop[tiflash]  right outer join, equal:[eq(test.t.id, Column#7)]",
+          "    ├─ExchangeReceiver_13(Build) 9990.00 cop[tiflash]  ",
+          "    │ └─ExchangeSender_12 9990.00 cop[tiflash]  ExchangeType: Broadcast",
+          "    │   └─Selection_11 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "    │     └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─Projection_14(Probe) 10000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+        "Plan": [
+          "Projection_8 10000.00 root  Column#8, Column#4",
+          "└─TableReader_22 10000.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 10000.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_9 10000.00 cop[tiflash]  inner join, equal:[eq(Column#4, Column#8)]",
+          "      ├─Projection_12(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
+          "      │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "      │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "      └─Projection_18(Probe) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#8",
+          "        └─Selection_20 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "          └─TableFullScan_19 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select id from t as A where exists (select 1 from t where t.id=A.id)",
+        "Plan": [
+          "TableReader_18 7992.00 root  data:ExchangeSender_17",
+          "└─ExchangeSender_17 7992.00 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_9 7992.00 cop[tiflash]  semi join, equal:[eq(test.t.id, test.t.id)]",
+          "    ├─ExchangeReceiver_16(Build) 9990.00 cop[tiflash]  ",
+          "    │ └─ExchangeSender_15 9990.00 cop[tiflash]  ExchangeType: Broadcast",
+          "    │   └─Selection_14 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "    │     └─TableFullScan_13 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─Selection_12(Probe) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "      └─TableFullScan_11 10000.00 cop[tiflash] table:A keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select id from t as A where not exists (select 1 from t where t.id=A.id)",
+        "Plan": [
+          "TableReader_16 8000.00 root  data:ExchangeSender_15",
+          "└─ExchangeSender_15 8000.00 cop[tiflash]  ExchangeType: PassThrough",
+          "  └─HashJoin_9 8000.00 cop[tiflash]  anti semi join, equal:[eq(test.t.id, test.t.id)]",
+          "    ├─ExchangeReceiver_14(Build) 10000.00 cop[tiflash]  ",
+          "    │ └─ExchangeSender_13 10000.00 cop[tiflash]  ExchangeType: Broadcast",
+          "    │   └─TableFullScan_12 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "    └─TableFullScan_11(Probe) 10000.00 cop[tiflash] table:A keep order:false, stats:pseudo"
         ]
       }
     ]

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -537,517 +537,183 @@
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_21 1.00 root  data:HashAgg_8",
-          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_11 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_25 1.00 root  data:HashAgg_10",
-          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_15 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_21 8.00 root  data:BroadcastJoin_11",
-          "  └─BroadcastJoin_11 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_21 8.00 root  data:HashJoin_11",
+          "  └─HashJoin_11 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "    │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_40 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_41 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─HashJoin_15 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─Selection_39(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_38 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─HashJoin_29(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_24 2.00 cop[tiflash] table:d2_t keep order:false, global read",
-          "        └─HashJoin_33(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "          ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_37(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_36 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_44 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_45 1.00 root  data:HashAgg_14",
-          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─BroadcastJoin_19 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
-          "      ├─Selection_43(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_42 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─BroadcastJoin_33(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
-          "        ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_28 2.00 cop[tiflash] table:d2_t keep order:false, global read",
-          "        └─BroadcastJoin_37(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "          ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_26 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_41(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_40 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_41 8.00 root  data:BroadcastJoin_15",
-          "  └─BroadcastJoin_15 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "└─TableReader_41 8.00 root  data:HashJoin_15",
+          "  └─HashJoin_15 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
           "    ├─Selection_40(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
           "    │ └─TableFullScan_39 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "    └─BroadcastJoin_30(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "    └─HashJoin_30(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
           "      ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
           "      │ └─TableFullScan_24 2.00 cop[tiflash] table:d2_t keep order:false, global read",
-          "      └─BroadcastJoin_34(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      └─HashJoin_34(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "        ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "        │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "        └─Selection_38(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "          └─TableFullScan_37 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t), broadcast_join_local(d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_15 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_16 1.00 root  data:HashAgg_8",
-          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_14(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_12(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_11 8.00 cop[tiflash] table:fact_t keep order:false, global read"
-=======
-          "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_20 1.00 root  data:HashAgg_10",
-          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─Selection_18(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> update tests
-=======
           "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_15 8.00 root  data:BroadcastJoin_10",
-          "  └─BroadcastJoin_10 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_15 8.00 root  data:HashJoin_10",
+          "  └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─Selection_14(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "    │ └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
           "    └─Selection_12(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_11 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t), broadcast_join_local(d2_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_26 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_27 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_24 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─HashJoin_15(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_22 2.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─HashJoin_16(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "          ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false, global read"
-=======
-          "HashAgg_30 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_31 1.00 root  data:HashAgg_14",
-          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─BroadcastJoin_18 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
-          "      ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_28 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─BroadcastJoin_19(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
-          "        ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_26 2.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─BroadcastJoin_20(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "          ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_24 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> update tests
-=======
           "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_26 8.00 root  data:BroadcastJoin_14",
-          "  └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "└─TableReader_26 8.00 root  data:HashJoin_14",
+          "  └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
           "    ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
           "    │ └─TableFullScan_24 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "    └─BroadcastJoin_15(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "    └─HashJoin_15(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
           "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
           "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d2_t keep order:false",
-          "      └─BroadcastJoin_16(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      └─HashJoin_16(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "        ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "        │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "        └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "          └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
           "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_20 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_18(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_24 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_22(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 8.00 root  data:BroadcastJoin_10",
-          "  └─BroadcastJoin_10 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "└─TableReader_20 8.00 root  data:HashJoin_10",
+          "  └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
           "    ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
           "    │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col1, 10)]",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
           "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
           "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
           "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "      ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10)",
-          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10)",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
           "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
           "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_14 1.00 root  data:HashAgg_7",
-          "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_11(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │ └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read",
-          "      └─TableFullScan_12(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
-=======
-          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_18 1.00 root  data:HashAgg_9",
-          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_15(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │ └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read",
-          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "└─TableReader_13 8.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
           "    ├─Selection_11(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "    │ └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read",
           "    └─TableFullScan_12(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─HashJoin_13 6.40 root  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "  ├─TableReader_23(Build) 2.00 root  data:Selection_22",
-          "  │ └─Selection_22 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "  │   └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false",
-          "  └─TableReader_20(Probe) 8.00 root  data:Selection_19",
-          "    └─Selection_19 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_22 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─BroadcastJoin_16 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_18 6.40 root  data:BroadcastJoin_12",
-          "  └─BroadcastJoin_12 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_18 6.40 root  data:HashJoin_12",
+          "  └─HashJoin_12 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_25 1.00 root  data:HashAgg_10",
-          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_12 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_22 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─BroadcastJoin_16 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_18 6.40 root  data:BroadcastJoin_12",
-          "  └─BroadcastJoin_12 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "└─TableReader_18 6.40 root  data:HashJoin_12",
+          "  └─HashJoin_12 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
           "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
           "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─HashJoin_13 6.40 root  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "  ├─TableReader_19(Build) 2.00 root  data:TableFullScan_18",
-          "  │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
-          "  └─TableReader_17(Probe) 8.00 root  data:TableFullScan_16",
-          "    └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_20 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─BroadcastJoin_16 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
-          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_16 6.40 root  data:BroadcastJoin_12",
-          "  └─BroadcastJoin_12 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "└─TableReader_16 6.40 root  data:HashJoin_12",
+          "  └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_21 1.00 root  data:HashAgg_10",
-          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_20 1.00 root  data:HashAgg_12",
-          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─BroadcastJoin_16 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> update tests
-=======
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_16 6.40 root  data:BroadcastJoin_12",
-          "  └─BroadcastJoin_12 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "└─TableReader_16 6.40 root  data:HashJoin_12",
+          "  └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
           "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       }
     ]
@@ -1436,8 +1102,8 @@
       {
         "SQL": "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
         "Plan": [
-          "TableReader_19 10000.00 root  data:BroadcastJoin_9",
-          "└─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:Column#4, right key:Column#8",
+          "TableReader_19 10000.00 root  data:HashJoin_9",
+          "└─HashJoin_9 10000.00 cop[tiflash]  inner join, equal:[eq(Column#4, Column#8)]",
           "  ├─Projection_13(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
           "  │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
           "  │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
@@ -1449,8 +1115,8 @@
       {
         "SQL": "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
         "Plan": [
-          "TableReader_23 10000.00 root  data:BroadcastJoin_9",
-          "└─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:test.t.id, right key:Column#7",
+          "TableReader_23 10000.00 root  data:HashJoin_9",
+          "└─HashJoin_9 10000.00 cop[tiflash]  inner join, equal:[eq(test.t.id, Column#7)]",
           "  ├─Projection_20(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
           "  │ └─Selection_22 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
           "  │   └─TableFullScan_21 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
@@ -1462,8 +1128,8 @@
         "SQL": "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
         "Plan": [
           "Projection_8 10000.00 root  Column#8, Column#4",
-          "└─TableReader_19 10000.00 root  data:BroadcastJoin_9",
-          "  └─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:Column#4, right key:Column#8",
+          "└─TableReader_19 10000.00 root  data:HashJoin_9",
+          "  └─HashJoin_9 10000.00 cop[tiflash]  inner join, equal:[eq(Column#4, Column#8)]",
           "    ├─Projection_13(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
           "    │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
           "    │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -48,6 +48,7 @@
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_35 8.00 root  data:ExchangeSender_34",
           "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -58,11 +59,24 @@
           "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
           "StreamAgg_18 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_68 8.00 root  data:ExchangeSender_67",
           "  └─ExchangeSender_67 8.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -83,11 +97,34 @@
           "          │     └─TableFullScan_25 2.00 cop[tiflash] table:d1_t keep order:false",
           "          └─Selection_30(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_29 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "StreamAgg_20 1.00 root  funcs:count(1)->Column#17",
+          "└─TableReader_72 8.00 root  data:ExchangeSender_71",
+          "  └─ExchangeSender_71 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_68 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "      ├─ExchangeReceiver_37(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_36 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_35 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │     └─TableFullScan_34 2.00 cop[tiflash] table:d3_t keep order:false",
+          "      └─HashJoin_22(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "        ├─ExchangeReceiver_33(Build) 2.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_32 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "        │   └─Selection_31 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │     └─TableFullScan_30 2.00 cop[tiflash] table:d2_t keep order:false",
+          "        └─HashJoin_23(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "          ├─ExchangeReceiver_27(Build) 2.00 cop[tiflash]  ",
+          "          │ └─ExchangeSender_26 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "          │   └─Selection_25 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │     └─TableFullScan_24 2.00 cop[tiflash] table:d1_t keep order:false",
+          "          └─Selection_29(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_28 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_35 8.00 root  data:ExchangeSender_34",
           "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -98,39 +135,52 @@
           "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_16(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_12(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_15(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_13 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
           "StreamAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_34 8.00 root  data:ExchangeSender_33",
           "  └─ExchangeSender_33 8.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -141,118 +191,130 @@
           "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_38 8.00 root  data:ExchangeSender_37",
+          "  └─ExchangeSender_37 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_34 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─ExchangeReceiver_16(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_12(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_16(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_12(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "      ├─ExchangeReceiver_15(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_13 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "StreamAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_28 8.00 root  data:ExchangeSender_27",
-          "  └─ExchangeSender_27 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_15(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_13 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_31 6.40 root  data:ExchangeSender_30",
-          "  └─ExchangeSender_30 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_28 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_38 6.40 root  data:ExchangeSender_37",
+          "  └─ExchangeSender_37 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_35 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_31 6.40 root  data:ExchangeSender_30",
-          "  └─ExchangeSender_30 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_28 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_38 6.40 root  data:ExchangeSender_37",
+          "  └─ExchangeSender_37 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_35 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_27 6.40 root  data:ExchangeSender_26",
-          "  └─ExchangeSender_26 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_34 6.40 root  data:ExchangeSender_33",
+          "  └─ExchangeSender_33 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_27 6.40 root  data:ExchangeSender_26",
-          "  └─ExchangeSender_26 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_24 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_34 6.40 root  data:ExchangeSender_33",
+          "  └─ExchangeSender_33 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_31 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -263,6 +325,7 @@
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_25 32.00 root  data:ExchangeSender_24",
           "  └─ExchangeSender_24 32.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -275,11 +338,27 @@
           "        └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
           "          └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "            └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_46 128.00 root  data:ExchangeSender_45",
           "  └─ExchangeSender_45 128.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -306,11 +385,41 @@
           "                    └─ExchangeSender_31 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
           "                      └─Selection_30 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "                        └─TableFullScan_29 16.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_44 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_46 1.00 root  data:ExchangeSender_45",
+          "  └─ExchangeSender_45 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_21 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "        ├─ExchangeReceiver_43(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_42 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
+          "        │   └─Selection_41 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "        │     └─TableFullScan_40 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─ExchangeReceiver_39(Probe) 64.00 cop[tiflash]  ",
+          "          └─ExchangeSender_38 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
+          "            └─HashJoin_22 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "              ├─ExchangeReceiver_37(Build) 4.00 cop[tiflash]  ",
+          "              │ └─ExchangeSender_36 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
+          "              │   └─Selection_35 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "              │     └─TableFullScan_34 4.00 cop[tiflash] table:d2_t keep order:false",
+          "              └─ExchangeReceiver_33(Probe) 32.00 cop[tiflash]  ",
+          "                └─ExchangeSender_32 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
+          "                  └─HashJoin_23 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "                    ├─ExchangeReceiver_27(Build) 4.00 cop[tiflash]  ",
+          "                    │ └─ExchangeSender_26 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "                    │   └─Selection_25 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "                    │     └─TableFullScan_24 4.00 cop[tiflash] table:d1_t keep order:false",
+          "                    └─ExchangeReceiver_31(Probe) 16.00 cop[tiflash]  ",
+          "                      └─ExchangeSender_30 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                        └─Selection_29 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "                          └─TableFullScan_28 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_25 32.00 root  data:ExchangeSender_24",
           "  └─ExchangeSender_24 32.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -323,11 +432,27 @@
           "        └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
           "          └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "            └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d1_k = d2_t.value and fact_t.d1_k = d3_t.value",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_44 128.00 root  data:ExchangeSender_43",
           "  └─ExchangeSender_43 128.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -350,43 +475,71 @@
           "            └─ExchangeSender_33 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
           "              └─Selection_32 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "                └─TableFullScan_31 16.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_42 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_44 1.00 root  data:ExchangeSender_43",
+          "  └─ExchangeSender_43 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_21 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
+          "        ├─ExchangeReceiver_41(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_40 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
+          "        │   └─Selection_39 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
+          "        │     └─TableFullScan_38 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─HashJoin_22(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
+          "          ├─ExchangeReceiver_37(Build) 4.00 cop[tiflash]  ",
+          "          │ └─ExchangeSender_36 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
+          "          │   └─Selection_35 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
+          "          │     └─TableFullScan_34 4.00 cop[tiflash] table:d2_t keep order:false",
+          "          └─HashJoin_24(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "            ├─ExchangeReceiver_29(Build) 4.00 cop[tiflash]  ",
+          "            │ └─ExchangeSender_28 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            │   └─Selection_27 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "            │     └─TableFullScan_26 4.00 cop[tiflash] table:d1_t keep order:false",
+          "            └─ExchangeReceiver_33(Probe) 16.00 cop[tiflash]  ",
+          "              └─ExchangeSender_32 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                └─Selection_31 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "                  └─TableFullScan_30 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_14(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_13 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_15(Build) 16.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "      │   └─Selection_13 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─ExchangeReceiver_18(Probe) 4.00 cop[tiflash]  ",
-          "        └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "          └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_9 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_24 32.00 root  data:ExchangeSender_23",
           "  └─ExchangeSender_23 32.00 cop[tiflash]  ExchangeType: PassThrough",
@@ -399,134 +552,157 @@
           "        └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
           "          └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "            └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_22 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
+          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_13 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_17(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_16 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_15 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_14 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_21(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_20 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_19 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_18 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> add normalize cost
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_14(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_13 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_14(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_13 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "      ├─ExchangeReceiver_15(Build) 16.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "      │   └─Selection_13 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─ExchangeReceiver_18(Probe) 4.00 cop[tiflash]  ",
-          "        └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "          └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 32.00 root  data:ExchangeSender_19",
-          "  └─ExchangeSender_19 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_9 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_15(Build) 16.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "      │   └─Selection_13 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_12 16.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─ExchangeReceiver_18(Probe) 4.00 cop[tiflash]  ",
-          "        └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "          └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
+          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_33 12.80 root  data:ExchangeSender_32",
-          "  └─ExchangeSender_32 12.80 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_30 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_19 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_17(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_16 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─Selection_15 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "            └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "      └─HashJoin_15 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_23(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_22 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_21 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_17 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_33 12.80 root  data:ExchangeSender_32",
-          "  └─ExchangeSender_32 12.80 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_30 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_19 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_17(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_16 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─Selection_15 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "            └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "      └─HashJoin_15 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "        ├─ExchangeReceiver_23(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_22 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_21 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_17 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_29 12.80 root  data:ExchangeSender_28",
-          "  └─ExchangeSender_28 12.80 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_26 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_16(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_22 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
+          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "      └─HashJoin_15 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─TableFullScan_19 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_18(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_17 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_29 12.80 root  data:ExchangeSender_28",
-          "  └─ExchangeSender_28 12.80 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_26 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_16(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_22 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
+          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "      └─HashJoin_15 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─TableFullScan_19 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_18(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_17 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -537,183 +713,198 @@
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_21 8.00 root  data:HashJoin_11",
-          "  └─HashJoin_11 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "    │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_24 1.00 root  data:HashAgg_10",
+          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_22(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-          "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_41 8.00 root  data:HashJoin_15",
-          "  └─HashJoin_15 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "    ├─Selection_40(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "    │ └─TableFullScan_39 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "    └─HashJoin_30(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "      ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "      │ └─TableFullScan_24 2.00 cop[tiflash] table:d2_t keep order:false, global read",
-          "      └─HashJoin_34(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "        └─Selection_38(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "          └─TableFullScan_37 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_43 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_44 1.00 root  data:HashAgg_14",
+          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "    └─HashJoin_18 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "      ├─Selection_42(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_41 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─HashJoin_32(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "        ├─Selection_28(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_27 2.00 cop[tiflash] table:d2_t keep order:false, global read",
+          "        └─HashJoin_36(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "          ├─Selection_26(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_25 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_40(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_39 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t), broadcast_join_local(d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_15 8.00 root  data:HashJoin_10",
-          "  └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─Selection_14(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "    │ └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
-          "    └─Selection_12(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_11 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "HashAgg_18 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_19 1.00 root  data:HashAgg_10",
+          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_13 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t), broadcast_join_local(d2_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-          "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_26 8.00 root  data:HashJoin_14",
-          "  └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "    ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "    │ └─TableFullScan_24 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "    └─HashJoin_15(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d2_t keep order:false",
-          "      └─HashJoin_16(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "        └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "          └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "HashAgg_29 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_30 1.00 root  data:HashAgg_14",
+          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "    └─HashJoin_17 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "      ├─Selection_28(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_27 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─HashJoin_18(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "        ├─Selection_26(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_25 2.00 cop[tiflash] table:d2_t keep order:false",
+          "        └─HashJoin_19(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "          ├─Selection_24(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_23 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_22(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_21 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_14(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_20 8.00 root  data:HashJoin_10",
-          "  └─HashJoin_10 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "    ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "    │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_22 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_13 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_14(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_13 8.00 root  data:HashJoin_9",
-          "  └─HashJoin_9 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "    ├─Selection_11(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "    │ └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read",
-          "    └─TableFullScan_12(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_14(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      │ └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read",
+          "      └─TableFullScan_15(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_18 6.40 root  data:HashJoin_12",
-          "  └─HashJoin_12 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_21 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─HashJoin_15 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_18 6.40 root  data:HashJoin_12",
-          "  └─HashJoin_12 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_21 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─HashJoin_15 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_16 6.40 root  data:HashJoin_12",
-          "  └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_18 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_19 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─HashJoin_15 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─TableFullScan_17(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_16 6.40 root  data:HashJoin_12",
-          "  └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "HashAgg_18 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_19 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─HashJoin_15 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─TableFullScan_17(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -1074,10 +1265,11 @@
       {
         "SQL": "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "HashAgg_6 1.00 root  funcs:count(Column#4)->Column#5",
-          "└─Projection_7 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "  └─TableReader_11 10000.00 root  data:TableFullScan_10",
-          "    └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_12 1.00 root  funcs:count(Column#7)->Column#5",
+          "└─TableReader_13 1.00 root  data:HashAgg_8",
+          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(Column#4)->Column#7",
+          "    └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "      └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1092,11 +1284,11 @@
       {
         "SQL": "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "HashAgg_6 1.00 root  funcs:sum(Column#7)->Column#5",
-          "└─Projection_12 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
-          "  └─Projection_7 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "    └─TableReader_11 10000.00 root  data:TableFullScan_10",
-          "      └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_12 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─TableReader_13 1.00 root  data:HashAgg_8",
+          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:sum(Column#4)->Column#7",
+          "    └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "      └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -49,16 +49,24 @@
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
 <<<<<<< HEAD
+<<<<<<< HEAD
           "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_35 8.00 root  data:ExchangeSender_34",
           "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashJoin_31 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+=======
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_40 8.00 root  data:ExchangeSender_39",
+          "  └─ExchangeSender_39 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_36 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+>>>>>>> canpushdown updated
           "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
           "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
           "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
+<<<<<<< HEAD
 =======
           "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_39 8.00 root  data:ExchangeSender_38",
@@ -71,16 +79,25 @@
           "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
 <<<<<<< HEAD
+<<<<<<< HEAD
           "StreamAgg_18 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_68 8.00 root  data:ExchangeSender_67",
           "  └─ExchangeSender_67 8.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashJoin_64 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+=======
+          "StreamAgg_21 1.00 root  funcs:count(1)->Column#17",
+          "└─TableReader_73 8.00 root  data:ExchangeSender_72",
+          "  └─ExchangeSender_72 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_69 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+>>>>>>> canpushdown updated
           "      ├─ExchangeReceiver_38(Build) 2.00 cop[tiflash]  ",
           "      │ └─ExchangeSender_37 2.00 cop[tiflash]  ExchangeType: Broadcast",
           "      │   └─Selection_36 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
@@ -97,6 +114,7 @@
           "          │     └─TableFullScan_25 2.00 cop[tiflash] table:d1_t keep order:false",
           "          └─Selection_30(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_29 8.00 cop[tiflash] table:fact_t keep order:false"
+<<<<<<< HEAD
 =======
           "StreamAgg_20 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_72 8.00 root  data:ExchangeSender_71",
@@ -119,22 +137,32 @@
           "          └─Selection_29(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_28 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
 <<<<<<< HEAD
+<<<<<<< HEAD
           "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_35 8.00 root  data:ExchangeSender_34",
           "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashJoin_31 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+=======
+          "StreamAgg_14 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_40 8.00 root  data:ExchangeSender_39",
+          "  └─ExchangeSender_39 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_36 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+>>>>>>> canpushdown updated
           "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
           "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
           "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
+<<<<<<< HEAD
 =======
           "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_39 8.00 root  data:ExchangeSender_38",
@@ -147,50 +175,60 @@
           "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_17(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_18(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
 <<<<<<< HEAD
+<<<<<<< HEAD
           "StreamAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_34 8.00 root  data:ExchangeSender_33",
           "  └─ExchangeSender_33 8.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashJoin_30 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+=======
+          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+>>>>>>> canpushdown updated
           "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
           "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
           "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
           "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+<<<<<<< HEAD
 =======
           "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_38 8.00 root  data:ExchangeSender_37",
@@ -203,118 +241,120 @@
           "      └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "      ├─ExchangeReceiver_17(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_18(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_16(Build) 8.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_15 8.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_14 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │     └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false",
-          "      └─TableFullScan_17(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_36 8.00 root  data:ExchangeSender_35",
+          "  └─ExchangeSender_35 8.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─ExchangeReceiver_17(Build) 8.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_16 8.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_15 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      │     └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false",
+          "      └─TableFullScan_18(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_38 6.40 root  data:ExchangeSender_37",
-          "  └─ExchangeSender_37 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_35 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_15 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_39 6.40 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_36 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_22(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_21 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_20 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │     └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_38 6.40 root  data:ExchangeSender_37",
-          "  └─ExchangeSender_37 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_35 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_15 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_39 6.40 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_36 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─ExchangeReceiver_22(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_21 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_20 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │     └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_34 6.40 root  data:ExchangeSender_33",
-          "  └─ExchangeSender_33 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_15 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_35 6.40 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─ExchangeReceiver_20(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_19 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#12",
-          "└─TableReader_34 6.40 root  data:ExchangeSender_33",
-          "  └─ExchangeSender_33 6.40 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "StreamAgg_15 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_35 6.40 root  data:ExchangeSender_34",
+          "  └─ExchangeSender_34 6.40 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_32 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─ExchangeReceiver_20(Build) 2.00 cop[tiflash]  ",
+          "      │ └─ExchangeSender_19 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "      │   └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -325,6 +365,7 @@
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_25 32.00 root  data:ExchangeSender_24",
@@ -353,11 +394,27 @@
           "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_15 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_46 128.00 root  data:ExchangeSender_45",
@@ -414,11 +471,41 @@
           "                        └─Selection_29 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "                          └─TableFullScan_28 16.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+          "HashAgg_45 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_47 1.00 root  data:ExchangeSender_46",
+          "  └─ExchangeSender_46 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_22 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "        ├─ExchangeReceiver_44(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_43 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
+          "        │   └─Selection_42 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "        │     └─TableFullScan_41 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─ExchangeReceiver_40(Probe) 64.00 cop[tiflash]  ",
+          "          └─ExchangeSender_39 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
+          "            └─HashJoin_23 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "              ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
+          "              │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
+          "              │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "              │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
+          "              └─ExchangeReceiver_34(Probe) 32.00 cop[tiflash]  ",
+          "                └─ExchangeSender_33 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
+          "                  └─HashJoin_24 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "                    ├─ExchangeReceiver_28(Build) 4.00 cop[tiflash]  ",
+          "                    │ └─ExchangeSender_27 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "                    │   └─Selection_26 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "                    │     └─TableFullScan_25 4.00 cop[tiflash] table:d1_t keep order:false",
+          "                    └─ExchangeReceiver_32(Probe) 16.00 cop[tiflash]  ",
+          "                      └─ExchangeSender_31 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                        └─Selection_30 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "                          └─TableFullScan_29 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_25 32.00 root  data:ExchangeSender_24",
@@ -447,11 +534,27 @@
           "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_15 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d1_k = d2_t.value and fact_t.d1_k = d3_t.value",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
           "└─TableReader_44 128.00 root  data:ExchangeSender_43",
@@ -500,45 +603,71 @@
           "                └─Selection_31 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "                  └─TableFullScan_30 16.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+          "HashAgg_43 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_45 1.00 root  data:ExchangeSender_44",
+          "  └─ExchangeSender_44 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_22 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
+          "        ├─ExchangeReceiver_42(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_41 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
+          "        │   └─Selection_40 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
+          "        │     └─TableFullScan_39 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─HashJoin_23(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
+          "          ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
+          "          │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
+          "          │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
+          "          │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
+          "          └─HashJoin_25(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "            ├─ExchangeReceiver_30(Build) 4.00 cop[tiflash]  ",
+          "            │ └─ExchangeSender_29 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            │   └─Selection_28 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "            │     └─TableFullScan_27 4.00 cop[tiflash] table:d1_t keep order:false",
+          "            └─ExchangeReceiver_34(Probe) 16.00 cop[tiflash]  ",
+          "              └─ExchangeSender_33 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                └─Selection_32 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "                  └─TableFullScan_31 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_20(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_18 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_16(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
-          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
-          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_17(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_16 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_15 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_20(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_9 1.00 root  funcs:count(1)->Column#11",
           "└─TableReader_24 32.00 root  data:ExchangeSender_23",
@@ -567,142 +696,157 @@
           "            └─Selection_19 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "              └─TableFullScan_18 16.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> add normalize cost
+=======
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> canpushdown updated
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "        ├─ExchangeReceiver_20(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_18 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_16(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_15(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_14 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_20(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_18 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_16(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
-          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
-          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "        ├─ExchangeReceiver_17(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_16 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_15 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_20(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_22 1.00 root  data:ExchangeSender_21",
-          "  └─ExchangeSender_21 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_23 1.00 root  data:ExchangeSender_22",
+          "  └─ExchangeSender_22 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_12 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "        ├─ExchangeReceiver_16(Build) 16.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_15 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "        │   └─Selection_14 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        │     └─TableFullScan_13 16.00 cop[tiflash] table:fact_t keep order:false",
-          "        └─ExchangeReceiver_19(Probe) 4.00 cop[tiflash]  ",
-          "          └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "            └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false"
+          "      └─HashJoin_13 32.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_17(Build) 16.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_16 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "        │   └─Selection_15 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        │     └─TableFullScan_14 16.00 cop[tiflash] table:fact_t keep order:false",
+          "        └─ExchangeReceiver_20(Probe) 4.00 cop[tiflash]  ",
+          "          └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
-          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_25 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_27 1.00 root  data:ExchangeSender_26",
+          "  └─ExchangeSender_26 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "      └─HashJoin_15 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─ExchangeReceiver_23(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_22 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_21 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_17 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_16 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_24(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_23 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_22 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_21 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_20(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_19 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_18 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_17 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
-          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_25 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_27 1.00 root  data:ExchangeSender_26",
+          "  └─ExchangeSender_26 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "      └─HashJoin_15 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "        ├─ExchangeReceiver_23(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_22 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_21 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "        │     └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_17 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_16 12.80 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "        ├─ExchangeReceiver_24(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_23 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_22 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_21 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_20(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_19 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_18 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_17 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_22 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
-          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_23 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "      └─HashJoin_15 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─TableFullScan_19 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_18(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_17 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_16 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "        ├─ExchangeReceiver_22(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_21 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_17 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_22 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
-          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "HashAgg_23 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
           "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "      └─HashJoin_15 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─TableFullScan_19 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_18(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_17 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─TableFullScan_16 16.00 cop[tiflash] table:fact_t keep order:false"
+          "      └─HashJoin_16 12.80 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "        ├─ExchangeReceiver_22(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_21 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─TableFullScan_20 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_19(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_18 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─TableFullScan_17 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -713,198 +857,198 @@
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_24 1.00 root  data:HashAgg_10",
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:HashAgg_10",
           "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_22(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_15 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-          "HashAgg_43 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_44 1.00 root  data:HashAgg_14",
+          "HashAgg_44 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_45 1.00 root  data:HashAgg_14",
           "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─HashJoin_18 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─Selection_42(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_41 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─HashJoin_32(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─Selection_28(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_27 2.00 cop[tiflash] table:d2_t keep order:false, global read",
-          "        └─HashJoin_36(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "          ├─Selection_26(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_25 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_40(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_39 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_19 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "      ├─Selection_43(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_42 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─HashJoin_33(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "        ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_28 2.00 cop[tiflash] table:d2_t keep order:false, global read",
+          "        └─HashJoin_37(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "          ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_26 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_41(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_40 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t), broadcast_join_local(d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_18 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_19 1.00 root  data:HashAgg_10",
+          "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_20 1.00 root  data:HashAgg_10",
           "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_13 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "    └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_18(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t), broadcast_join_local(d2_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-          "HashAgg_29 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_30 1.00 root  data:HashAgg_14",
+          "HashAgg_30 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_31 1.00 root  data:HashAgg_14",
           "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "    └─HashJoin_17 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─Selection_28(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │ └─TableFullScan_27 2.00 cop[tiflash] table:d3_t keep order:false, global read",
-          "      └─HashJoin_18(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─Selection_26(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │ └─TableFullScan_25 2.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─HashJoin_19(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "          ├─Selection_24(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │ └─TableFullScan_23 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "          └─Selection_22(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_21 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "    └─HashJoin_18 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "      ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_28 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─HashJoin_19(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "        ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_26 2.00 cop[tiflash] table:d2_t keep order:false",
+          "        └─HashJoin_20(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "          ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_24 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_13 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_14(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "    └─HashJoin_13 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_22 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_23 1.00 root  data:HashAgg_9",
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_24 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_13 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_14 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_22(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
-          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_13 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col1, 10)]",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_15(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_13(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_13 8.00 cop[tiflash]  left outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
-          "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_14(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+          "    └─HashJoin_13 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10)",
+          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
-          "HashAgg_16 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_17 1.00 root  data:HashAgg_9",
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
           "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "    └─HashJoin_12 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─Selection_14(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "      │ └─TableFullScan_13 8.00 cop[tiflash] table:fact_t keep order:false, global read",
-          "      └─TableFullScan_15(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+          "    └─HashJoin_13 8.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_15(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      │ └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read",
+          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_21 1.00 root  data:HashAgg_12",
+          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_22 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_15 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_16 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_21 1.00 root  data:HashAgg_12",
+          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_22 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_15 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_16 6.40 cop[tiflash]  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
-          "HashAgg_18 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_19 1.00 root  data:HashAgg_12",
+          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_20 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_15 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
-          "      ├─TableFullScan_17(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_16 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
+          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
-          "HashAgg_18 1.00 root  funcs:count(Column#13)->Column#12",
-          "└─TableReader_19 1.00 root  data:HashAgg_12",
+          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_20 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
-          "    └─HashJoin_15 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
-          "      ├─TableFullScan_17(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
-          "      └─TableFullScan_16(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+          "    └─HashJoin_16 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       }
     ]
@@ -1294,10 +1438,10 @@
       {
         "SQL": "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg_10 1.00 root  funcs:count(Column#4)->Column#5",
-          "└─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "  └─TableReader_18 10000.00 root  data:TableFullScan_17",
-          "    └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "StreamAgg_11 1.00 root  funcs:count(Column#4)->Column#5",
+          "└─Projection_15 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "  └─TableReader_19 10000.00 root  data:TableFullScan_18",
+          "    └─TableFullScan_18 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1312,11 +1456,11 @@
       {
         "SQL": "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg_10 1.00 root  funcs:sum(Column#7)->Column#5",
-          "└─Projection_25 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
-          "  └─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "    └─TableReader_18 10000.00 root  data:TableFullScan_17",
-          "      └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "StreamAgg_11 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─Projection_26 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
+          "  └─Projection_15 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "    └─TableReader_19 10000.00 root  data:TableFullScan_18",
+          "      └─TableFullScan_18 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1440,10 +1584,10 @@
       {
         "SQL": "desc select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg_10 1.00 root  funcs:count(Column#4)->Column#5",
-          "└─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "  └─TableReader_18 10000.00 root  data:TableFullScan_17",
-          "    └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "StreamAgg_11 1.00 root  funcs:count(Column#4)->Column#5",
+          "└─Projection_15 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "  └─TableReader_19 10000.00 root  data:TableFullScan_18",
+          "    └─TableFullScan_18 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1458,11 +1602,11 @@
       {
         "SQL": "desc select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg_10 1.00 root  funcs:sum(Column#7)->Column#5",
-          "└─Projection_25 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
-          "  └─Projection_14 10000.00 root  plus(test.t.id, 1)->Column#4",
-          "    └─TableReader_18 10000.00 root  data:TableFullScan_17",
-          "      └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "StreamAgg_11 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─Projection_26 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
+          "  └─Projection_15 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "    └─TableReader_19 10000.00 root  data:TableFullScan_18",
+          "      └─TableFullScan_18 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -20,11 +20,25 @@
       },
       {
         "SQL": "explain select * from t where b > 'a' order by convert(b, unsigned) limit 2",
-        "Plan": null
+        "Plan": [
+          "Projection_18 2.00 root  test.t.a, test.t.b",
+          "└─TopN_8 2.00 root  Column#3, offset:0, count:2",
+          "  └─Projection_19 2.00 root  test.t.a, test.t.b, cast(test.t.b, bigint(22) UNSIGNED BINARY)->Column#3",
+          "    └─TableReader_14 2.00 root  data:TopN_13",
+          "      └─TopN_13 2.00 cop[tiflash]  cast(test.t.b), offset:0, count:2",
+          "        └─Selection_12 3333.33 cop[tiflash]  gt(test.t.b, \"a\")",
+          "          └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
       },
       {
-        "SQL": "",
-        "Plan": null
+        "SQL": "explain select * from t where b > 'a' order by b limit 2",
+        "Plan": [
+          "TopN_8 2.00 root  test.t.b, offset:0, count:2",
+          "└─TableReader_17 2.00 root  data:TopN_16",
+          "  └─TopN_16 2.00 cop[tiflash]  test.t.b, offset:0, count:2",
+          "    └─Selection_15 3333.33 cop[tiflash]  gt(test.t.b, \"a\")",
+          "      └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
       }
     ]
   },
@@ -524,6 +538,7 @@
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
 <<<<<<< HEAD
+<<<<<<< HEAD
           "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_21 1.00 root  data:HashAgg_8",
           "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -542,11 +557,21 @@
           "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_21 8.00 root  data:BroadcastJoin_11",
+          "  └─BroadcastJoin_11 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "    │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_40 1.00 root  funcs:count(Column#18)->Column#17",
           "└─TableReader_41 1.00 root  data:HashAgg_12",
@@ -578,11 +603,27 @@
           "          └─Selection_41(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_40 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
+          "└─TableReader_41 8.00 root  data:BroadcastJoin_15",
+          "  └─BroadcastJoin_15 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "    ├─Selection_40(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "    │ └─TableFullScan_39 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "    └─BroadcastJoin_30(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "      ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "      │ └─TableFullScan_24 2.00 cop[tiflash] table:d2_t keep order:false, global read",
+          "      └─BroadcastJoin_34(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "        ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "        └─Selection_38(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "          └─TableFullScan_37 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t), broadcast_join_local(d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_15 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_16 1.00 root  data:HashAgg_8",
@@ -602,11 +643,21 @@
           "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false, global read"
 >>>>>>> update tests
+=======
+          "HashAgg_8 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_15 8.00 root  data:BroadcastJoin_10",
+          "  └─BroadcastJoin_10 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─Selection_14(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "    │ └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
+          "    └─Selection_12(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_11 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t), broadcast_join_local(d2_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_26 1.00 root  funcs:count(Column#18)->Column#17",
           "└─TableReader_27 1.00 root  data:HashAgg_12",
@@ -638,11 +689,27 @@
           "          └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false, global read"
 >>>>>>> update tests
+=======
+          "HashAgg_12 1.00 root  funcs:count(1)->Column#17",
+          "└─TableReader_26 8.00 root  data:BroadcastJoin_14",
+          "  └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "    ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "    │ └─TableFullScan_24 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "    └─BroadcastJoin_15(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d2_t keep order:false",
+          "      └─BroadcastJoin_16(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "        ├─Selection_21(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "        └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "          └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -660,11 +727,20 @@
           "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -682,11 +758,20 @@
           "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_20 1.00 root  data:HashAgg_7",
@@ -706,11 +791,21 @@
           "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_20 8.00 root  data:BroadcastJoin_10",
+          "  └─BroadcastJoin_10 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "    ├─Selection_19(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "    │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -728,11 +823,20 @@
           "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col1, 10)]",
+          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -750,11 +854,20 @@
           "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "    ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "    │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -772,11 +885,20 @@
           "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10)",
+          "    ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "    └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
@@ -794,11 +916,20 @@
           "      │ └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read",
           "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_7 1.00 root  funcs:count(1)->Column#11",
+          "└─TableReader_13 8.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "    ├─Selection_11(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "    │ └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read",
+          "    └─TableFullScan_12(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
           "└─HashJoin_13 6.40 root  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
@@ -818,11 +949,21 @@
           "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_18 6.40 root  data:BroadcastJoin_12",
+          "  └─BroadcastJoin_12 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
           "└─TableReader_25 1.00 root  data:HashAgg_10",
@@ -842,11 +983,21 @@
           "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_18 6.40 root  data:BroadcastJoin_12",
+          "  └─BroadcastJoin_12 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "    ├─Selection_17(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "    │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
           "└─HashJoin_13 6.40 root  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
@@ -862,11 +1013,19 @@
           "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_16 6.40 root  data:BroadcastJoin_12",
+          "  └─BroadcastJoin_12 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
+<<<<<<< HEAD
 <<<<<<< HEAD
           "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
           "└─TableReader_21 1.00 root  data:HashAgg_10",
@@ -882,6 +1041,13 @@
           "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
 >>>>>>> update tests
+=======
+          "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
+          "└─TableReader_16 6.40 root  data:BroadcastJoin_12",
+          "  └─BroadcastJoin_12 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "    ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "    └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> remove inject proj when pushing down (on tiflash)
         ]
       }
     ]
@@ -894,9 +1060,8 @@
         "Plan": [
           "StreamAgg_24 1.00 root  funcs:avg(Column#7, Column#8)->Column#4",
           "└─TableReader_25 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(Column#10)->Column#7, funcs:sum(Column#10)->Column#8",
-          "    └─Projection_32 10000.00 cop[tiflash]  cast(test.t.a, decimal(15,4) BINARY)->Column#9, Column#9",
-          "      └─TableFullScan_22 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(test.t.a)->Column#7, funcs:sum(test.t.a)->Column#8",
+          "    └─TableFullScan_22 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -905,9 +1070,8 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:avg(Column#7, Column#8)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(Column#10)->Column#7, funcs:sum(Column#10)->Column#8",
-          "    └─Projection_20 10000.00 cop[tiflash]  cast(test.t.a, decimal(15,4) BINARY)->Column#9, Column#9",
-          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(test.t.a)->Column#7, funcs:sum(test.t.a)->Column#8",
+          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -916,9 +1080,8 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
-          "    └─Projection_20 10000.00 cop[tiflash]  cast(test.t.a, decimal(32,0) BINARY)->Column#7",
-          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(test.t.a)->Column#6",
+          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -927,9 +1090,8 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
-          "    └─Projection_20 10000.00 cop[tiflash]  cast(plus(test.t.a, 1), decimal(41,0) BINARY)->Column#7",
-          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(plus(test.t.a, 1))->Column#6",
+          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -938,9 +1100,8 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
-          "    └─Projection_20 10000.00 cop[tiflash]  cast(isnull(test.t.a), decimal(22,0) BINARY)->Column#7",
-          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(isnull(test.t.a))->Column#6",
+          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -1247,11 +1408,10 @@
       {
         "SQL": "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "HashAgg_12 1.00 root  funcs:count(Column#7)->Column#5",
-          "└─TableReader_13 1.00 root  data:HashAgg_8",
-          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(Column#4)->Column#7",
-          "    └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
-          "      └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_6 1.00 root  funcs:count(Column#4)->Column#5",
+          "└─Projection_7 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "  └─TableReader_11 10000.00 root  data:TableFullScan_10",
+          "    └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1266,12 +1426,11 @@
       {
         "SQL": "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "HashAgg_12 1.00 root  funcs:sum(Column#7)->Column#5",
-          "└─TableReader_13 1.00 root  data:HashAgg_8",
-          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:sum(Column#8)->Column#7",
-          "    └─Projection_19 10000.00 cop[tiflash]  cast(Column#4, decimal(41,0) BINARY)->Column#8",
-          "      └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
-          "        └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_6 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─Projection_12 10000.00 root  cast(Column#4, decimal(41,0) BINARY)->Column#7",
+          "  └─Projection_7 10000.00 root  plus(test.t.id, 1)->Column#4",
+          "    └─TableReader_11 10000.00 root  data:TableFullScan_10",
+          "      └─TableFullScan_10 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -20,25 +20,11 @@
       },
       {
         "SQL": "explain select * from t where b > 'a' order by convert(b, unsigned) limit 2",
-        "Plan": [
-          "Projection_18 2.00 root  test.t.a, test.t.b",
-          "└─TopN_8 2.00 root  Column#3, offset:0, count:2",
-          "  └─Projection_19 2.00 root  test.t.a, test.t.b, cast(test.t.b, bigint(22) UNSIGNED BINARY)->Column#3",
-          "    └─TableReader_14 2.00 root  data:TopN_13",
-          "      └─TopN_13 2.00 cop[tiflash]  cast(test.t.b), offset:0, count:2",
-          "        └─Selection_12 3333.33 cop[tiflash]  gt(test.t.b, \"a\")",
-          "          └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
-        ]
+        "Plan": null
       },
       {
-        "SQL": "explain select * from t where b > 'a' order by b limit 2",
-        "Plan": [
-          "TopN_8 2.00 root  test.t.b, offset:0, count:2",
-          "└─TableReader_17 2.00 root  data:TopN_16",
-          "  └─TopN_16 2.00 cop[tiflash]  test.t.b, offset:0, count:2",
-          "    └─Selection_15 3333.33 cop[tiflash]  gt(test.t.b, \"a\")",
-          "      └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
-        ]
+        "SQL": "",
+        "Plan": null
       }
     ]
   },
@@ -537,6 +523,7 @@
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_20 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_21 1.00 root  data:HashAgg_8",
           "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -545,11 +532,22 @@
           "      │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─Selection_17(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:HashAgg_10",
+          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_15 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─Selection_23(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_40 1.00 root  funcs:count(Column#18)->Column#17",
           "└─TableReader_41 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#18",
@@ -564,11 +562,28 @@
           "          │ └─TableFullScan_22 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "          └─Selection_37(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_36 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_44 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_45 1.00 root  data:HashAgg_14",
+          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "    └─BroadcastJoin_19 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "      ├─Selection_43(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_42 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─BroadcastJoin_33(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "        ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_28 2.00 cop[tiflash] table:d2_t keep order:false, global read",
+          "        └─BroadcastJoin_37(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "          ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_26 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_41(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_40 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t), broadcast_join_local(d1_t) */ count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_15 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_16 1.00 root  data:HashAgg_8",
           "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -577,11 +592,22 @@
           "      │ └─TableFullScan_13 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_12(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_11 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+=======
+          "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_20 1.00 root  data:HashAgg_10",
+          "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─Selection_18(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t,d2_t,d3_t), broadcast_join_local(d2_t) */ count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_26 1.00 root  funcs:count(Column#18)->Column#17",
           "└─TableReader_27 1.00 root  data:HashAgg_12",
           "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#18",
@@ -596,11 +622,28 @@
           "          │ └─TableFullScan_20 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "          └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
           "            └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+=======
+          "HashAgg_30 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_31 1.00 root  data:HashAgg_14",
+          "  └─HashAgg_14 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "    └─BroadcastJoin_18 8.00 cop[tiflash]  inner join, left key:test.fact_t.d3_k, right key:test.d3_t.d3_k",
+          "      ├─Selection_29(Build) 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "      │ └─TableFullScan_28 2.00 cop[tiflash] table:d3_t keep order:false, global read",
+          "      └─BroadcastJoin_19(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d2_k, right key:test.d2_t.d2_k",
+          "        ├─Selection_27(Build) 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "        │ └─TableFullScan_26 2.00 cop[tiflash] table:d2_t keep order:false",
+          "        └─BroadcastJoin_20(Probe) 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "          ├─Selection_25(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "          │ └─TableFullScan_24 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "          └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "            └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -608,11 +651,21 @@
           "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -620,11 +673,21 @@
           "      ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_19 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_20 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -633,11 +696,22 @@
           "      │ └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─Selection_16(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_15 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_24 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_14 8.00 cop[tiflash]  inner join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_22(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_21 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -645,11 +719,21 @@
           "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
           "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col1, 10)]",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -657,11 +741,21 @@
           "      ├─Selection_12(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
           "      │ └─TableFullScan_11 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_10(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  left outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, left cond:[gt(test.fact_t.col2, 10)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_16(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -669,11 +763,21 @@
           "      ├─TableFullScan_12(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
           "      └─Selection_11(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10)",
+          "      ├─TableFullScan_16(Build) 2.00 cop[tiflash] table:d1_t keep order:false",
+          "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_13 1.00 root  funcs:count(Column#12)->Column#11",
           "└─TableReader_14 1.00 root  data:HashAgg_7",
           "  └─HashAgg_7 1.00 cop[tiflash]  funcs:count(1)->Column#12",
@@ -681,11 +785,21 @@
           "      ├─Selection_11(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "      │ └─TableFullScan_10 8.00 cop[tiflash] table:fact_t keep order:false, global read",
           "      └─TableFullScan_12(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+=======
+          "HashAgg_17 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_18 1.00 root  data:HashAgg_9",
+          "  └─HashAgg_9 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "    └─BroadcastJoin_13 8.00 cop[tiflash]  right outer join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, right cond:gt(test.d1_t.value, 10), other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "      ├─Selection_15(Build) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "      │ └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false, global read",
+          "      └─TableFullScan_16(Probe) 2.00 cop[tiflash] table:d1_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
           "└─HashJoin_13 6.40 root  semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "  ├─TableReader_23(Build) 2.00 root  data:Selection_22",
@@ -694,11 +808,22 @@
           "  └─TableReader_20(Probe) 8.00 root  data:Selection_19",
           "    └─Selection_19 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
           "      └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_22 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─BroadcastJoin_16 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_24 1.00 root  funcs:count(Column#13)->Column#12",
           "└─TableReader_25 1.00 root  data:HashAgg_10",
           "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#13",
@@ -707,28 +832,56 @@
           "      │ └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─Selection_15(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
           "        └─TableFullScan_14 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_21 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_22 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─BroadcastJoin_16 6.40 cop[tiflash]  semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─Selection_20(Build) 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "      │ └─TableFullScan_19 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─Selection_18(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "        └─TableFullScan_17 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k)",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_10 1.00 root  funcs:count(1)->Column#12",
           "└─HashJoin_13 6.40 root  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)]",
           "  ├─TableReader_19(Build) 2.00 root  data:TableFullScan_18",
           "  │ └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
           "  └─TableReader_17(Probe) 8.00 root  data:TableFullScan_16",
           "    └─TableFullScan_16 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_20 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─BroadcastJoin_16 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k",
+          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       },
       {
         "SQL": "explain select /*+ broadcast_join(fact_t,d1_t) */ count(*) from fact_t where not exists (select 1 from d1_t where d1_k = fact_t.d1_k and value > fact_t.col1)",
         "Plan": [
+<<<<<<< HEAD
           "HashAgg_20 1.00 root  funcs:count(Column#13)->Column#12",
           "└─TableReader_21 1.00 root  data:HashAgg_10",
           "  └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#13",
           "    └─HashJoin_12 6.40 cop[tiflash]  anti semi join, equal:[eq(test.fact_t.d1_k, test.d1_t.d1_k)], other cond:gt(test.d1_t.value, test.fact_t.col1)",
           "      ├─TableFullScan_15(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
           "      └─TableFullScan_14(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+=======
+          "HashAgg_19 1.00 root  funcs:count(Column#13)->Column#12",
+          "└─TableReader_20 1.00 root  data:HashAgg_12",
+          "  └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#13",
+          "    └─BroadcastJoin_16 6.40 cop[tiflash]  anti semi join, left key:test.fact_t.d1_k, right key:test.d1_t.d1_k, other cond:gt(test.d1_t.value, test.fact_t.col1)",
+          "      ├─TableFullScan_18(Build) 2.00 cop[tiflash] table:d1_t keep order:false, global read",
+          "      └─TableFullScan_17(Probe) 8.00 cop[tiflash] table:fact_t keep order:false"
+>>>>>>> update tests
         ]
       }
     ]
@@ -741,8 +894,9 @@
         "Plan": [
           "StreamAgg_24 1.00 root  funcs:avg(Column#7, Column#8)->Column#4",
           "└─TableReader_25 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(test.t.a)->Column#7, funcs:sum(test.t.a)->Column#8",
-          "    └─TableFullScan_22 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(Column#10)->Column#7, funcs:sum(Column#10)->Column#8",
+          "    └─Projection_32 10000.00 cop[tiflash]  cast(test.t.a, decimal(15,4) BINARY)->Column#9, Column#9",
+          "      └─TableFullScan_22 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -751,8 +905,9 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:avg(Column#7, Column#8)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(test.t.a)->Column#7, funcs:sum(test.t.a)->Column#8",
-          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:count(Column#10)->Column#7, funcs:sum(Column#10)->Column#8",
+          "    └─Projection_20 10000.00 cop[tiflash]  cast(test.t.a, decimal(15,4) BINARY)->Column#9, Column#9",
+          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -761,8 +916,9 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(test.t.a)->Column#6",
-          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
+          "    └─Projection_20 10000.00 cop[tiflash]  cast(test.t.a, decimal(32,0) BINARY)->Column#7",
+          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -771,8 +927,9 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(plus(test.t.a, 1))->Column#6",
-          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
+          "    └─Projection_20 10000.00 cop[tiflash]  cast(plus(test.t.a, 1), decimal(41,0) BINARY)->Column#7",
+          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -781,8 +938,9 @@
         "Plan": [
           "StreamAgg_16 1.00 root  funcs:sum(Column#6)->Column#4",
           "└─TableReader_17 1.00 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(isnull(test.t.a))->Column#6",
-          "    └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "  └─StreamAgg_8 1.00 cop[tiflash]  funcs:sum(Column#7)->Column#6",
+          "    └─Projection_20 10000.00 cop[tiflash]  cast(isnull(test.t.a), decimal(22,0) BINARY)->Column#7",
+          "      └─TableFullScan_15 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -1079,6 +1237,80 @@
           "  │ └─IndexRangeScan_6 1.25 cop[tikv] table:s, index:a(a) range: decided by [eq(test.s.a, test.t.a)], keep order:false, stats:pseudo",
           "  └─Selection_9(Probe) 1.25 cop[tikv]  not(isnull(test.s.b))",
           "    └─TableRowIDScan_7 1.25 cop[tikv] table:s keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestPushDownProjectionForTiFlash",
+    "Cases": [
+      {
+        "SQL": "desc select /*+ hash_agg()*/ count(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:count(Column#7)->Column#5",
+          "└─TableReader_13 1.00 root  data:HashAgg_8",
+          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:count(Column#4)->Column#7",
+          "    └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "      └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ hash_agg()*/ count(*) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:count(Column#6)->Column#5",
+          "└─TableReader_13 1.00 root  data:HashAgg_6",
+          "  └─HashAgg_6 1.00 cop[tiflash]  funcs:count(1)->Column#6",
+          "    └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select /*+ hash_agg()*/ sum(b) from  (select id + 1 as b from t)A",
+        "Plan": [
+          "HashAgg_12 1.00 root  funcs:sum(Column#7)->Column#5",
+          "└─TableReader_13 1.00 root  data:HashAgg_8",
+          "  └─HashAgg_8 1.00 cop[tiflash]  funcs:sum(Column#8)->Column#7",
+          "    └─Projection_19 10000.00 cop[tiflash]  cast(Column#4, decimal(41,0) BINARY)->Column#8",
+          "      └─Projection_10 10000.00 cop[tiflash]  plus(test.t.id, 1)->Column#4",
+          "        └─TableFullScan_11 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+        "Plan": [
+          "TableReader_19 10000.00 root  data:BroadcastJoin_9",
+          "└─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:Column#4, right key:Column#8",
+          "  ├─Projection_13(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
+          "  │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "  │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─Projection_16(Probe) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#8",
+          "    └─Selection_18 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "      └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select * from t join (select id-2 as b from t) A on A.b=t.id",
+        "Plan": [
+          "TableReader_23 10000.00 root  data:BroadcastJoin_9",
+          "└─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:test.t.id, right key:Column#7",
+          "  ├─Projection_20(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#7",
+          "  │ └─Selection_22 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "  │   └─TableFullScan_21 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "  └─Selection_19(Probe) 9990.00 cop[tiflash]  not(isnull(test.t.id))",
+          "    └─TableFullScan_18 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
+        "Plan": [
+          "Projection_8 10000.00 root  Column#8, Column#4",
+          "└─TableReader_19 10000.00 root  data:BroadcastJoin_9",
+          "  └─BroadcastJoin_9 10000.00 cop[tiflash]  inner join, left key:Column#4, right key:Column#8",
+          "    ├─Projection_13(Build) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#4",
+          "    │ └─Selection_15 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "    │   └─TableFullScan_14 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo, global read",
+          "    └─Projection_16(Probe) 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#8",
+          "      └─Selection_18 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "        └─TableFullScan_17 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       }
     ]

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -48,135 +48,59 @@
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-=======
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_40 8.00 root  data:ExchangeSender_39",
-          "  └─ExchangeSender_39 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_36 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
->>>>>>> canpushdown updated
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
-<<<<<<< HEAD
-=======
-          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
-          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
->>>>>>> canpushdown updated
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_17 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "        │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "          └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "StreamAgg_18 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_68 8.00 root  data:ExchangeSender_67",
-          "  └─ExchangeSender_67 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_64 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-=======
-          "StreamAgg_21 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_73 8.00 root  data:ExchangeSender_72",
-          "  └─ExchangeSender_72 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_69 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
->>>>>>> canpushdown updated
-          "      ├─ExchangeReceiver_38(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_37 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_36 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │     └─TableFullScan_35 2.00 cop[tiflash] table:d3_t keep order:false",
-          "      └─HashJoin_23(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─ExchangeReceiver_34(Build) 2.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_33 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "        │   └─Selection_32 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │     └─TableFullScan_31 2.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─HashJoin_24(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "          ├─ExchangeReceiver_28(Build) 2.00 cop[tiflash]  ",
-          "          │ └─ExchangeSender_27 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "          │   └─Selection_26 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │     └─TableFullScan_25 2.00 cop[tiflash] table:d1_t keep order:false",
-          "          └─Selection_30(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_29 8.00 cop[tiflash] table:fact_t keep order:false"
-<<<<<<< HEAD
-=======
-          "StreamAgg_20 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_72 8.00 root  data:ExchangeSender_71",
-          "  └─ExchangeSender_71 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_68 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─ExchangeReceiver_37(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_36 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_35 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │     └─TableFullScan_34 2.00 cop[tiflash] table:d3_t keep order:false",
-          "      └─HashJoin_22(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "        ├─ExchangeReceiver_33(Build) 2.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_32 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "        │   └─Selection_31 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "        │     └─TableFullScan_30 2.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─HashJoin_23(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "          ├─ExchangeReceiver_27(Build) 2.00 cop[tiflash]  ",
-          "          │ └─ExchangeSender_26 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "          │   └─Selection_25 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │     └─TableFullScan_24 2.00 cop[tiflash] table:d1_t keep order:false",
-          "          └─Selection_29(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "            └─TableFullScan_28 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
->>>>>>> canpushdown updated
+          "HashAgg_41 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_43 1.00 root  data:ExchangeSender_42",
+          "  └─ExchangeSender_42 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_19 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_24 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "        ├─ExchangeReceiver_40(Build) 2.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_39 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "        │   └─Selection_38 2.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "        │     └─TableFullScan_37 2.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─HashJoin_25(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "          ├─ExchangeReceiver_36(Build) 2.00 cop[tiflash]  ",
+          "          │ └─ExchangeSender_35 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "          │   └─Selection_34 2.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "          │     └─TableFullScan_33 2.00 cop[tiflash] table:d2_t keep order:false",
+          "          └─HashJoin_26(Probe) 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "            ├─ExchangeReceiver_30(Build) 2.00 cop[tiflash]  ",
+          "            │ └─ExchangeSender_29 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "            │   └─Selection_28 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "            │     └─TableFullScan_27 2.00 cop[tiflash] table:d1_t keep order:false",
+          "            └─Selection_32(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "              └─TableFullScan_31 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "StreamAgg_11 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_35 8.00 root  data:ExchangeSender_34",
-          "  └─ExchangeSender_34 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_31 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-=======
-          "StreamAgg_14 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_40 8.00 root  data:ExchangeSender_39",
-          "  └─ExchangeSender_39 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_36 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
->>>>>>> canpushdown updated
-          "      ├─ExchangeReceiver_19(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_17 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_16 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_21(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_20 8.00 cop[tiflash] table:fact_t keep order:false"
-<<<<<<< HEAD
-=======
-          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
-          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
->>>>>>> canpushdown updated
+          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
+          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_17 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_21(Build) 2.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "        │   └─Selection_19 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_18 2.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─Selection_23(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "          └─TableFullScan_22 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
@@ -210,39 +134,17 @@
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "StreamAgg_10 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_34 8.00 root  data:ExchangeSender_33",
-          "  └─ExchangeSender_33 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_30 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-=======
-          "StreamAgg_13 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_39 8.00 root  data:ExchangeSender_38",
-          "  └─ExchangeSender_38 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_35 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
->>>>>>> canpushdown updated
-          "      ├─ExchangeReceiver_18(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_16 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_15 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_20(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_19 8.00 cop[tiflash] table:fact_t keep order:false"
-<<<<<<< HEAD
-=======
-          "StreamAgg_12 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_38 8.00 root  data:ExchangeSender_37",
-          "  └─ExchangeSender_37 8.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_34 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_17(Build) 2.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_16 2.00 cop[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_15 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_14 2.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─Selection_19(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "        └─TableFullScan_18 8.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
->>>>>>> canpushdown updated
+          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
+          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_16 8.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_20(Build) 2.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_19 2.00 cop[tiflash]  ExchangeType: Broadcast",
+          "        │   └─Selection_18 2.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_17 2.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─Selection_22(Probe) 8.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "          └─TableFullScan_21 8.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
@@ -365,269 +267,97 @@
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_25 32.00 root  data:ExchangeSender_24",
-          "  └─ExchangeSender_24 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_13 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "      ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "            └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
-          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
-          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
-          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_15 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> canpushdown updated
+          "HashAgg_26 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_28 1.00 root  data:ExchangeSender_27",
+          "  └─ExchangeSender_27 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_17 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_19 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_25(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_24 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_23 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_22 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d2_k = d2_t.d2_k and fact_t.d3_k = d3_t.d3_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_46 128.00 root  data:ExchangeSender_45",
-          "  └─ExchangeSender_45 128.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_20 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "      ├─ExchangeReceiver_44(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_43 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
-          "      │   └─Selection_42 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "      │     └─TableFullScan_41 4.00 cop[tiflash] table:d3_t keep order:false",
-          "      └─ExchangeReceiver_40(Probe) 64.00 cop[tiflash]  ",
-          "        └─ExchangeSender_39 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
-          "          └─HashJoin_23 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "            ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
-          "            │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
-          "            │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "            │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
-          "            └─ExchangeReceiver_34(Probe) 32.00 cop[tiflash]  ",
-          "              └─ExchangeSender_33 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
-          "                └─HashJoin_24 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "                  ├─ExchangeReceiver_28(Build) 4.00 cop[tiflash]  ",
-          "                  │ └─ExchangeSender_27 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "                  │   └─Selection_26 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "                  │     └─TableFullScan_25 4.00 cop[tiflash] table:d1_t keep order:false",
-          "                  └─ExchangeReceiver_32(Probe) 16.00 cop[tiflash]  ",
-          "                    └─ExchangeSender_31 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "                      └─Selection_30 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "                        └─TableFullScan_29 16.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_44 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_46 1.00 root  data:ExchangeSender_45",
-          "  └─ExchangeSender_45 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "      └─HashJoin_21 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "        ├─ExchangeReceiver_43(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_42 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
-          "        │   └─Selection_41 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "        │     └─TableFullScan_40 4.00 cop[tiflash] table:d3_t keep order:false",
-          "        └─ExchangeReceiver_39(Probe) 64.00 cop[tiflash]  ",
-          "          └─ExchangeSender_38 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
-          "            └─HashJoin_22 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "              ├─ExchangeReceiver_37(Build) 4.00 cop[tiflash]  ",
-          "              │ └─ExchangeSender_36 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
-          "              │   └─Selection_35 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "              │     └─TableFullScan_34 4.00 cop[tiflash] table:d2_t keep order:false",
-          "              └─ExchangeReceiver_33(Probe) 32.00 cop[tiflash]  ",
-          "                └─ExchangeSender_32 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
-          "                  └─HashJoin_23 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "                    ├─ExchangeReceiver_27(Build) 4.00 cop[tiflash]  ",
-          "                    │ └─ExchangeSender_26 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "                    │   └─Selection_25 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "                    │     └─TableFullScan_24 4.00 cop[tiflash] table:d1_t keep order:false",
-          "                    └─ExchangeReceiver_31(Probe) 16.00 cop[tiflash]  ",
-          "                      └─ExchangeSender_30 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "                        └─Selection_29 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "                          └─TableFullScan_28 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
-          "HashAgg_45 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_47 1.00 root  data:ExchangeSender_46",
-          "  └─ExchangeSender_46 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "      └─HashJoin_22 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
-          "        ├─ExchangeReceiver_44(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_43 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
-          "        │   └─Selection_42 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
-          "        │     └─TableFullScan_41 4.00 cop[tiflash] table:d3_t keep order:false",
-          "        └─ExchangeReceiver_40(Probe) 64.00 cop[tiflash]  ",
-          "          └─ExchangeSender_39 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
-          "            └─HashJoin_23 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
-          "              ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
-          "              │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
-          "              │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
-          "              │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
-          "              └─ExchangeReceiver_34(Probe) 32.00 cop[tiflash]  ",
-          "                └─ExchangeSender_33 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
-          "                  └─HashJoin_24 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "                    ├─ExchangeReceiver_28(Build) 4.00 cop[tiflash]  ",
-          "                    │ └─ExchangeSender_27 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "                    │   └─Selection_26 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "                    │     └─TableFullScan_25 4.00 cop[tiflash] table:d1_t keep order:false",
-          "                    └─ExchangeReceiver_32(Probe) 16.00 cop[tiflash]  ",
-          "                      └─ExchangeSender_31 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "                        └─Selection_30 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
-          "                          └─TableFullScan_29 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> canpushdown updated
+          "HashAgg_47 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_49 1.00 root  data:ExchangeSender_48",
+          "  └─ExchangeSender_48 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_19 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_24 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d3_k, test.d3_t.d3_k)]",
+          "        ├─ExchangeReceiver_46(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_45 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.d3_k",
+          "        │   └─Selection_44 4.00 cop[tiflash]  not(isnull(test.d3_t.d3_k))",
+          "        │     └─TableFullScan_43 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─ExchangeReceiver_42(Probe) 64.00 cop[tiflash]  ",
+          "          └─ExchangeSender_41 64.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d3_k",
+          "            └─HashJoin_25 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d2_k, test.d2_t.d2_k)]",
+          "              ├─ExchangeReceiver_40(Build) 4.00 cop[tiflash]  ",
+          "              │ └─ExchangeSender_39 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.d2_k",
+          "              │   └─Selection_38 4.00 cop[tiflash]  not(isnull(test.d2_t.d2_k))",
+          "              │     └─TableFullScan_37 4.00 cop[tiflash] table:d2_t keep order:false",
+          "              └─ExchangeReceiver_36(Probe) 32.00 cop[tiflash]  ",
+          "                └─ExchangeSender_35 32.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d2_k",
+          "                  └─HashJoin_26 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "                    ├─ExchangeReceiver_30(Build) 4.00 cop[tiflash]  ",
+          "                    │ └─ExchangeSender_29 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "                    │   └─Selection_28 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "                    │     └─TableFullScan_27 4.00 cop[tiflash] table:d1_t keep order:false",
+          "                    └─ExchangeReceiver_34(Probe) 16.00 cop[tiflash]  ",
+          "                      └─ExchangeSender_33 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                        └─Selection_32 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k)), not(isnull(test.fact_t.d2_k)), not(isnull(test.fact_t.d3_k))",
+          "                          └─TableFullScan_31 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t where fact_t.d1_k = d1_t.d1_k",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_10 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_25 32.00 root  data:ExchangeSender_24",
-          "  └─ExchangeSender_24 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_13 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "      ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "      │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "            └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
-          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
-          "HashAgg_24 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_26 1.00 root  data:ExchangeSender_25",
-          "  └─ExchangeSender_25 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_15 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "        ├─ExchangeReceiver_19(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_18 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_17 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "        │     └─TableFullScan_16 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_23(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_22 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_21 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_20 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> canpushdown updated
+          "HashAgg_26 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_28 1.00 root  data:ExchangeSender_27",
+          "  └─ExchangeSender_27 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_12 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_17 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_21(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_20 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_19 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_18 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_25(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_24 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_23 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_22 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
         "SQL": "explain select count(*) from fact_t, d1_t, d2_t, d3_t where fact_t.d1_k = d1_t.d1_k and fact_t.d1_k = d2_t.value and fact_t.d1_k = d3_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_17 1.00 root  funcs:count(1)->Column#17",
-          "└─TableReader_44 128.00 root  data:ExchangeSender_43",
-          "  └─ExchangeSender_43 128.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_20 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
-          "      ├─ExchangeReceiver_42(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_41 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
-          "      │   └─Selection_40 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
-          "      │     └─TableFullScan_39 4.00 cop[tiflash] table:d3_t keep order:false",
-          "      └─HashJoin_23(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
-          "        ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
-          "        │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
-          "        │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
-          "        └─HashJoin_25(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "          ├─ExchangeReceiver_30(Build) 4.00 cop[tiflash]  ",
-          "          │ └─ExchangeSender_29 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "          │   └─Selection_28 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "          │     └─TableFullScan_27 4.00 cop[tiflash] table:d1_t keep order:false",
-          "          └─ExchangeReceiver_34(Probe) 16.00 cop[tiflash]  ",
-          "            └─ExchangeSender_33 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "              └─Selection_32 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "                └─TableFullScan_31 16.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_42 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_44 1.00 root  data:ExchangeSender_43",
-          "  └─ExchangeSender_43 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "      └─HashJoin_21 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
-          "        ├─ExchangeReceiver_41(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_40 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
-          "        │   └─Selection_39 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
-          "        │     └─TableFullScan_38 4.00 cop[tiflash] table:d3_t keep order:false",
-          "        └─HashJoin_22(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
-          "          ├─ExchangeReceiver_37(Build) 4.00 cop[tiflash]  ",
-          "          │ └─ExchangeSender_36 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
-          "          │   └─Selection_35 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
-          "          │     └─TableFullScan_34 4.00 cop[tiflash] table:d2_t keep order:false",
-          "          └─HashJoin_24(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "            ├─ExchangeReceiver_29(Build) 4.00 cop[tiflash]  ",
-          "            │ └─ExchangeSender_28 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "            │   └─Selection_27 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "            │     └─TableFullScan_26 4.00 cop[tiflash] table:d1_t keep order:false",
-          "            └─ExchangeReceiver_33(Probe) 16.00 cop[tiflash]  ",
-          "              └─ExchangeSender_32 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "                └─Selection_31 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "                  └─TableFullScan_30 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
-          "HashAgg_43 1.00 root  funcs:count(Column#18)->Column#17",
-          "└─TableReader_45 1.00 root  data:ExchangeSender_44",
-          "  └─ExchangeSender_44 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_18 1.00 cop[tiflash]  funcs:count(1)->Column#18",
-          "      └─HashJoin_22 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
-          "        ├─ExchangeReceiver_42(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_41 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
-          "        │   └─Selection_40 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
-          "        │     └─TableFullScan_39 4.00 cop[tiflash] table:d3_t keep order:false",
-          "        └─HashJoin_23(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
-          "          ├─ExchangeReceiver_38(Build) 4.00 cop[tiflash]  ",
-          "          │ └─ExchangeSender_37 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
-          "          │   └─Selection_36 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
-          "          │     └─TableFullScan_35 4.00 cop[tiflash] table:d2_t keep order:false",
-          "          └─HashJoin_25(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
-          "            ├─ExchangeReceiver_30(Build) 4.00 cop[tiflash]  ",
-          "            │ └─ExchangeSender_29 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "            │   └─Selection_28 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
-          "            │     └─TableFullScan_27 4.00 cop[tiflash] table:d1_t keep order:false",
-          "            └─ExchangeReceiver_34(Probe) 16.00 cop[tiflash]  ",
-          "              └─ExchangeSender_33 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "                └─Selection_32 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
-          "                  └─TableFullScan_31 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> canpushdown updated
+          "HashAgg_45 1.00 root  funcs:count(Column#18)->Column#17",
+          "└─TableReader_47 1.00 root  data:ExchangeSender_46",
+          "  └─ExchangeSender_46 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_19 1.00 cop[tiflash]  funcs:count(1)->Column#18",
+          "      └─HashJoin_24 128.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d3_t.value)]",
+          "        ├─ExchangeReceiver_44(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_43 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d3_t.value",
+          "        │   └─Selection_42 4.00 cop[tiflash]  not(isnull(test.d3_t.value))",
+          "        │     └─TableFullScan_41 4.00 cop[tiflash] table:d3_t keep order:false",
+          "        └─HashJoin_25(Probe) 64.00 cop[tiflash]  inner join, equal:[eq(test.fact_t.d1_k, test.d2_t.value)]",
+          "          ├─ExchangeReceiver_40(Build) 4.00 cop[tiflash]  ",
+          "          │ └─ExchangeSender_39 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d2_t.value",
+          "          │   └─Selection_38 4.00 cop[tiflash]  not(isnull(test.d2_t.value))",
+          "          │     └─TableFullScan_37 4.00 cop[tiflash] table:d2_t keep order:false",
+          "          └─HashJoin_27(Probe) 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "            ├─ExchangeReceiver_32(Build) 4.00 cop[tiflash]  ",
+          "            │ └─ExchangeSender_31 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "            │   └─Selection_30 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "            │     └─TableFullScan_29 4.00 cop[tiflash] table:d1_t keep order:false",
+          "            └─ExchangeReceiver_36(Probe) 16.00 cop[tiflash]  ",
+          "              └─ExchangeSender_35 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                └─Selection_34 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "                  └─TableFullScan_33 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {
@@ -667,50 +397,19 @@
       {
         "SQL": "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
         "Plan": [
-<<<<<<< HEAD
-<<<<<<< HEAD
-          "HashAgg_9 1.00 root  funcs:count(1)->Column#11",
-          "└─TableReader_24 32.00 root  data:ExchangeSender_23",
-          "  └─ExchangeSender_23 32.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_12 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "      ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "      │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "      │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "      │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "      └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
-          "        └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "          └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "            └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
-=======
-          "HashAgg_22 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_24 1.00 root  data:ExchangeSender_23",
-          "  └─ExchangeSender_23 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_13 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "        ├─ExchangeReceiver_17(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_16 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_15 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "        │     └─TableFullScan_14 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_21(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_20 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_19 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_18 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> add normalize cost
-=======
-          "HashAgg_23 1.00 root  funcs:count(Column#12)->Column#11",
-          "└─TableReader_25 1.00 root  data:ExchangeSender_24",
-          "  └─ExchangeSender_24 1.00 cop[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_10 1.00 cop[tiflash]  funcs:count(1)->Column#12",
-          "      └─HashJoin_14 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
-          "        ├─ExchangeReceiver_18(Build) 4.00 cop[tiflash]  ",
-          "        │ └─ExchangeSender_17 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
-          "        │   └─Selection_16 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
-          "        │     └─TableFullScan_15 4.00 cop[tiflash] table:d1_t keep order:false",
-          "        └─ExchangeReceiver_22(Probe) 16.00 cop[tiflash]  ",
-          "          └─ExchangeSender_21 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
-          "            └─Selection_20 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
-          "              └─TableFullScan_19 16.00 cop[tiflash] table:fact_t keep order:false"
->>>>>>> canpushdown updated
+          "HashAgg_25 1.00 root  funcs:count(Column#12)->Column#11",
+          "└─TableReader_27 1.00 root  data:ExchangeSender_26",
+          "  └─ExchangeSender_26 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_11 1.00 cop[tiflash]  funcs:count(1)->Column#12",
+          "      └─HashJoin_16 32.00 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)], other cond:gt(test.fact_t.col1, test.d1_t.value)",
+          "        ├─ExchangeReceiver_20(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_19 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_18 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k)), not(isnull(test.d1_t.value))",
+          "        │     └─TableFullScan_17 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─ExchangeReceiver_24(Probe) 16.00 cop[tiflash]  ",
+          "          └─ExchangeSender_23 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "            └─Selection_22 16.00 cop[tiflash]  not(isnull(test.fact_t.col1)), not(isnull(test.fact_t.d1_k))",
+          "              └─TableFullScan_21 16.00 cop[tiflash] table:fact_t keep order:false"
         ]
       },
       {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: push down projection for tiflash. The projection can be pushed down according to the prop from its father operator. If its father is mppTask or copTask, and its expressions can be pushed down, then the projection can be pushed down on TiFlash.

it also obeys eliminating unnecessary projections for the pushed down subtree plans.

but for the injecting projection when doing post optimization, we let it be a TODO, because new injected should keep be pushed down.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- integration test (some explain test in the test file)
- Manual test (add detailed scripts or steps below)
```
mysql> set @@tidb_allow_mpp=0; set @@tidb_opt_broadcast_join=1;

mysql> desc select /*+ hash_agg()*/ sum(a) from (select id+1 as a from t) as A ;
+--------------------------------+---------+--------------+---------------+------------------------------------------------+
| id                             | estRows | task         | access object | operator info                                  |
+--------------------------------+---------+--------------+---------------+------------------------------------------------+
| HashAgg_12                     | 1.00    | root         |               | funcs:sum(Column#7)->Column#5                  |
| └─TableReader_13               | 1.00    | root         |               | data:HashAgg_8                                 |
|   └─HashAgg_8                  | 1.00    | cop[tiflash] |               | funcs:sum(Column#8)->Column#7                  |
|     └─Projection_19            | 6.00    | cop[tiflash] |               | cast(Column#4, decimal(41,0) BINARY)->Column#8 |
|       └─Projection_10          | 6.00    | cop[tiflash] |               | plus(test.t.id, 1)->Column#4                   |
|         └─TableFullScan_11     | 6.00    | cop[tiflash] | table:t       | keep order:false, stats:pseudo                 |
+--------------------------------+---------+--------------+---------------+------------------------------------------------+
6 rows in set (0.00 sec)

mysql> set @@tidb_allow_mpp=0; set @@tidb_opt_broadcast_join=0;
Query OK, 0 rows affected (0.00 sec)

Query OK, 0 rows affected (0.00 sec)

mysql> desc select /*+ hash_agg()*/ sum(a) from (select id+1 as a from t) as A ;
+------------------------------+---------+--------------+---------------+------------------------------------------------+
| id                           | estRows | task         | access object | operator info                                  |
+------------------------------+---------+--------------+---------------+------------------------------------------------+
| HashAgg_8                    | 1.00    | root         |               | funcs:sum(Column#7)->Column#5                  |
| └─Projection_14              | 6.00    | root         |               | cast(Column#4, decimal(41,0) BINARY)->Column#7 |
|   └─Projection_9             | 6.00    | root         |               | plus(test.t.id, 1)->Column#4                   |
|     └─TableReader_13         | 6.00    | root         |               | data:TableFullScan_12                          |
|       └─TableFullScan_12     | 6.00    | cop[tiflash] | table:t       | keep order:false, stats:pseudo                 |
+------------------------------+---------+--------------+---------------+------------------------------------------------+
5 rows in set (0.00 sec)

mysql> desc t;
+-------+--------------+------+------+---------+-------+
| Field | Type         | Null | Key  | Default | Extra |
+-------+--------------+------+------+---------+-------+
| id    | int(11)      | YES  |      | NULL    |       |
| value | decimal(6,3) | YES  |      | NULL    |       |
+-------+--------------+------+------+---------+-------+
2 rows in set (0.00 sec)

mysql> desc select id+1 from t;
+-------------------------+---------+--------------+---------------+--------------------------------+
| id                      | estRows | task         | access object | operator info                  |
+-------------------------+---------+--------------+---------------+--------------------------------+
| Projection_3            | 6.00    | root         |               | plus(test.t.id, 1)->Column#4   |
| └─TableReader_7         | 6.00    | root         |               | data:TableFullScan_6           |
|   └─TableFullScan_6     | 6.00    | cop[tiflash] | table:t       | keep order:false, stats:pseudo |
+-------------------------+---------+--------------+---------------+--------------------------------+
3 rows in set (0.00 sec)



```

### Release note <!-- bugfixes or new feature need a release note -->

- support pushing down projection for TiFlash <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
