### PR TITLE
executor: make TestPointGetReadLock stable

### DIFF
--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -621,6 +621,8 @@ func (s *testPointGetSuite) TestPointGetReadLock(c *C) {
 	c.Assert(ok, IsFalse)
 	tk.MustExec("unlock tables")
 
+	// Force reload schema to ensure the cache is released.
+	c.Assert(s.dom.Reload(), IsNil)
 	rows = tk.MustQuery("explain analyze select * from point where id = 1").Rows()
 	c.Assert(len(rows), Equals, 1)
 	explain = fmt.Sprintf("%v", rows[0])


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The schema reload is async, so it may not release the cache in time.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
Force reload schema after `unlock tables`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
