### PR TITLE
executor: Nested prepare stmt should not be prepared

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -134,6 +134,10 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 	stmt := stmts[0]
 
+	if _, ok := stmt.(*ast.ExecuteStmt); ok {
+		return ErrUnsupportedPs
+	}
+
 	err = ResetContextOfStmt(e.ctx, stmt)
 	if err != nil {
 		return err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8123 

Problem Summary:

Nested `prepare stmt` should not be execute success and throw `error 1295`

```
prepare stmt1 from 'select 1';
prepare stmt2 from 'execute stmt1';
```

What's Changed:

How it Works:

```
prepare stmt1 from 'select 1';
prepare stmt2 from 'execute stmt1';
ERROR 1295 (HY000): This command is not supported in the prepared statement protocol yet
```

Tests

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note 

- Raise an `error` when preparing nested `prepare stmt`.
