### PR TITLE
planner: avoid TABLE and VALUES statement panic by returning unsupported statement error

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -8109,3 +8109,17 @@ func (s *testIntegrationSerialSuite) TestIssue20876(c *C) {
 	tk.MustExec("analyze table t")
 	tk.MustQuery("select * from t where a='#';").Check(testkit.Rows("# C 10"))
 }
+
+func (s *testIntegrationSuite) TestIssue21486(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	var err error
+	tk.MustExec("use test")
+	_, err = tk.Exec("values row(1)")
+	c.Assert(err, NotNil)
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("insert into t values (1), (2), (3)")
+	_, err = tk.Exec("table t")
+	c.Assert(err, NotNil)
+}

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -76,6 +76,10 @@ func IsReadOnly(node ast.Node, vars *variable.SessionVars) bool {
 // Optimize does optimization and creates a Plan.
 // The node must be prepared first.
 func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (plannercore.Plan, types.NameSlice, error) {
+	if sel, isSelect := node.(*ast.SelectStmt); isSelect && (sel.Kind == ast.SelectStmtKindTable || sel.Kind == ast.SelectStmtKindValues) {
+		return nil, nil, errors.Errorf("%s statement is not yet supported", sel.Kind.String())
+	}
+
 	sessVars := sctx.GetSessionVars()
 
 	// Because for write stmt, TiFlash has a different results when lock the data in point get plan. We ban the TiFlash


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #21486 

Problem Summary: 

The [TABLE](https://dev.mysql.com/doc/refman/8.0/en/table.html) and [VALUES](https://dev.mysql.com/doc/refman/8.0/en/values.html) statements would cause panic since they are not yet supported.

### What is changed and how it works?

What's Changed:

When compiling an ast.StmtNode to a physical plan, return unsupported statement error if the node is a TABLE statement or a VALUES statement.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- avoid TABLE and VALUES statement panic <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
