### PR TITLE
txn: fix the possible regression for retry

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6425,3 +6425,23 @@ func (s *testSuite) Test17780(c *C) {
 	// the update should not affect c0
 	tk.MustQuery("select count(*) from t0 where c0 = 0").Check(testkit.Rows("0"))
 }
+
+func (s *testSuite) TestTxnRetry(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk2 := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test;")
+	tk2.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (1)")
+	tk.MustExec("set @@tidb_disable_txn_auto_retry=0;")
+	tk.MustExec("set autocommit=0;")
+	tk.MustQuery("select * from t;").Check(testkit.Rows("1"))
+	tk.MustExec("SET SQL_SELECT_LIMIT=DEFAULT;")
+
+	tk2.MustExec("update t set a=2")
+
+	tk.MustExec("update t set a=3")
+	tk.MustExec("commit")
+	tk.MustQuery("select * from t").Check(testkit.Rows("3"))
+}

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -6444,4 +6444,12 @@ func (s *testSuite) TestTxnRetry(c *C) {
 	tk.MustExec("update t set a=3")
 	tk.MustExec("commit")
 	tk.MustQuery("select * from t").Check(testkit.Rows("3"))
+
+	// Check retry will activate the txn immediately.
+	tk.MustExec("set @var=10")
+	tk.MustExec("update t set a=@var")
+	tk2.MustExec("update t set a=2")
+	tk.MustExec("set @var=7")
+	tk.MustExec("commit")
+	tk.MustQuery("select * from t").Check(testkit.Rows("10"))
 }

--- a/session/session.go
+++ b/session/session.go
@@ -662,9 +662,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 		}
 		pessTxnConf := config.GetGlobalConfig().PessimisticTxn
 		if pessTxnConf.Enable {
-			if s.sessionVars.TxnMode == ast.Pessimistic {
-				s.sessionVars.TxnCtx.IsPessimistic = true
-			}
+			s.sessionVars.TxnCtx.IsPessimistic = true
 		}
 		s.sessionVars.RetryInfo.ResetOffset()
 		for i, sr := range nh.history {
@@ -688,7 +686,8 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 					zap.Int64("schemaVersion", schemaVersion),
 					zap.Uint("retryCnt", retryCnt),
 					zap.Int("queryNum", i),
-					zap.String("sql", sql))
+					zap.String("sql", sql),
+					zap.Bool("isPessimistic", s.GetSessionVars().TxnCtx.IsPessimistic))
 			} else {
 				logutil.Logger(ctx).Warn("retrying",
 					zap.Int64("schemaVersion", schemaVersion),
@@ -710,7 +709,8 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 		}
 		logutil.Logger(ctx).Warn("transaction association",
 			zap.Uint64("retrying txnStartTS", s.GetSessionVars().TxnCtx.StartTS),
-			zap.Uint64("original txnStartTS", orgStartTS))
+			zap.Uint64("original txnStartTS", orgStartTS),
+			zap.Bool("isPessimistic", s.GetSessionVars().TxnCtx.IsPessimistic))
 		failpoint.Inject("preCommitHook", func() {
 			hook, ok := ctx.Value("__preCommitHook").(func())
 			if ok {

--- a/session/session.go
+++ b/session/session.go
@@ -656,10 +656,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 	orgStartTS := sessVars.TxnCtx.StartTS
 	label := s.getSQLLabel()
 	for {
-		err = s.NewTxn(ctx)
-		if err != nil {
-			return err
-		}
+		s.PrepareTxnCtx(ctx)
 		s.sessionVars.RetryInfo.ResetOffset()
 		for i, sr := range nh.history {
 			st := sr.st

--- a/session/session.go
+++ b/session/session.go
@@ -660,6 +660,12 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 		if err != nil {
 			return err
 		}
+		pessTxnConf := config.GetGlobalConfig().PessimisticTxn
+		if pessTxnConf.Enable {
+			if s.sessionVars.TxnMode == ast.Pessimistic {
+				s.sessionVars.TxnCtx.IsPessimistic = true
+			}
+		}
 		s.sessionVars.RetryInfo.ResetOffset()
 		for i, sr := range nh.history {
 			st := sr.st
@@ -1507,14 +1513,6 @@ func (s *session) NewTxn(ctx context.Context) error {
 		SchemaVersion: is.SchemaMetaVersion(),
 		CreateTime:    time.Now(),
 		StartTS:       txn.StartTS(),
-	}
-	if !s.sessionVars.IsAutocommit() || s.sessionVars.RetryInfo.Retrying {
-		pessTxnConf := config.GetGlobalConfig().PessimisticTxn
-		if pessTxnConf.Enable {
-			if s.sessionVars.TxnMode == ast.Pessimistic {
-				s.sessionVars.TxnCtx.IsPessimistic = true
-			}
-		}
 	}
 	return nil
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -590,7 +590,9 @@ func (s *session) StmtCommit(memTracker *memory.Tracker) error {
 			mergeToDirtyDB(dirtyDB, op)
 		}
 	}
-	st.MergeStmtKeyExistErrs()
+	if st != nil && st.Valid() {
+		st.MergeStmtKeyExistErrs()
+	}
 	return nil
 }
 

--- a/session/txn.go
+++ b/session/txn.go
@@ -590,9 +590,7 @@ func (s *session) StmtCommit(memTracker *memory.Tracker) error {
 			mergeToDirtyDB(dirtyDB, op)
 		}
 	}
-	if st != nil && st.Valid() {
-		st.MergeStmtKeyExistErrs()
-	}
+	st.MergeStmtKeyExistErrs()
 	return nil
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
Do not activiate the `Txn` directly doing retry which does not set the pessimistic mode member properly in `txnCtx` for single stmt txn
Using pessimistic mode transaction retry.

How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

- Fix the the issue commit retry may not activiate pessimistic mode.
