### PR TITLE
types: modify JSON object key length in BinaryJSON

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -232,7 +232,7 @@ func (s *testSuite1) TestAnalyzeTooLongColumns(c *C) {
 	tableInfo := table.Meta()
 	tbl := s.dom.StatsHandle().GetTableStats(tableInfo)
 	c.Assert(tbl.Columns[1].Len(), Equals, 0)
-	c.Assert(tbl.Columns[1].TotColSize, Equals, int64(65559))
+	c.Assert(tbl.Columns[1].TotColSize, Equals, int64(65561))
 }
 
 func (s *testFastAnalyze) TestAnalyzeFastSample(c *C) {

--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -212,7 +212,7 @@ func (bj BinaryJSON) arrayGetElem(idx int) BinaryJSON {
 
 func (bj BinaryJSON) objectGetKey(i int) []byte {
 	keyOff := int(endian.Uint32(bj.Value[headerSize+i*keyEntrySize:]))
-	keyLen := int(endian.Uint16(bj.Value[headerSize+i*keyEntrySize+keyLenOff:]))
+	keyLen := int(endian.Uint32(bj.Value[headerSize+i*keyEntrySize+keyLenOff:]))
 	return bj.Value[keyOff : keyOff+keyLen]
 }
 
@@ -622,9 +622,9 @@ func appendBinaryObject(buf []byte, x map[string]interface{}) ([]byte, error) {
 	for i, field := range fields {
 		keyEntryOff := keyEntryBegin + i*keyEntrySize
 		keyOff := len(buf) - docOff
-		keyLen := uint32(len(field.key))
+		keyLen := len(field.key)
 		endian.PutUint32(buf[keyEntryOff:], uint32(keyOff))
-		endian.PutUint16(buf[keyEntryOff+keyLenOff:], uint16(keyLen))
+		endian.PutUint32(buf[keyEntryOff+keyLenOff:], uint32(keyLen))
 		buf = append(buf, field.key...)
 	}
 	for i, field := range fields {

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -329,7 +329,7 @@ func buildBinaryObject(keys [][]byte, elems []BinaryJSON) BinaryJSON {
 	endian.PutUint32(buf[dataSizeOff:], uint32(totalSize))
 	for i, key := range keys {
 		endian.PutUint32(buf[headerSize+i*keyEntrySize:], uint32(len(buf)))
-		endian.PutUint16(buf[headerSize+i*keyEntrySize+keyLenOff:], uint16(len(key)))
+		endian.PutUint32(buf[headerSize+i*keyEntrySize+keyLenOff:], uint32(len(key)))
 		buf = append(buf, key...)
 	}
 	entryStart := headerSize + len(elems)*keyEntrySize
@@ -599,7 +599,7 @@ func (bm *binaryModifier) rebuildTo(buf []byte) ([]byte, TypeCode) {
 		if elemCount > 0 {
 			firstKeyOff := int(endian.Uint32(bj.Value[headerSize:]))
 			lastKeyOff := int(endian.Uint32(bj.Value[headerSize+(elemCount-1)*keyEntrySize:]))
-			lastKeyLen := int(endian.Uint16(bj.Value[headerSize+(elemCount-1)*keyEntrySize+keyLenOff:]))
+			lastKeyLen := int(endian.Uint32(bj.Value[headerSize+(elemCount-1)*keyEntrySize+keyLenOff:]))
 			buf = append(buf, bj.Value[firstKeyOff:lastKeyOff+lastKeyLen]...)
 		}
 	}

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/hack"
 )
 
 var _ = Suite(&testJSONSuite{})
@@ -405,6 +406,18 @@ func (s *testJSONSuite) TestGetKeys(c *C) {
 	c.Assert(parsedBJ.GetKeys().String(), Equals, "[]")
 	parsedBJ = mustParseBinaryFromString(c, "{}")
 	c.Assert(parsedBJ.GetKeys().String(), Equals, "[]")
+
+	buf := make([]byte, 65537)
+	for i := range buf {
+		buf[i] = 'a'
+	}
+	str := string(hack.String(buf))
+	parsedBJ = mustParseBinaryFromString(c, "{\""+str[:65535]+"\": 1}")
+	c.Assert(len(parsedBJ.GetKeys().String()), Equals, 65539)
+	parsedBJ = mustParseBinaryFromString(c, "{\""+str[:65536]+"\": 2}")
+	c.Assert(len(parsedBJ.GetKeys().String()), Equals, 65540)
+	parsedBJ = mustParseBinaryFromString(c, "{\""+str[:65537]+"\": 3}")
+	c.Assert(len(parsedBJ.GetKeys().String()), Equals, 65541)
 }
 
 func (s *testJSONSuite) TestBinaryJSONDepth(c *C) {

--- a/types/json/constants.go
+++ b/types/json/constants.go
@@ -166,7 +166,7 @@ var (
 const (
 	headerSize   = 8 // element size + data size.
 	dataSizeOff  = 4
-	keyEntrySize = 6 // keyOff +  keyLen
+	keyEntrySize = 8 // keyOff +  keyLen
 	keyLenOff    = 4
 	valTypeSize  = 1
 	valEntrySize = 5

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -201,7 +201,7 @@ func (s *testChunkSuite) TestAppend(c *check.C) {
 	c.Assert(dst.columns[2].nullCount(), check.Equals, 6)
 	c.Assert(string(dst.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(dst.columns[2].offsets), check.Equals, 13)
-	c.Assert(len(dst.columns[2].data), check.Equals, 150)
+	c.Assert(len(dst.columns[2].data), check.Equals, 162)
 	c.Assert(len(dst.columns[2].elemBuf), check.Equals, 0)
 	for i := 0; i < 12; i += 2 {
 		jsonElem := dst.GetRow(i).GetJSON(2)
@@ -254,7 +254,7 @@ func (s *testChunkSuite) TestTruncateTo(c *check.C) {
 	c.Assert(src.columns[2].nullCount(), check.Equals, 6)
 	c.Assert(string(src.columns[0].nullBitmap), check.Equals, string([]byte{0x55, 0x05}))
 	c.Assert(len(src.columns[2].offsets), check.Equals, 13)
-	c.Assert(len(src.columns[2].data), check.Equals, 150)
+	c.Assert(len(src.columns[2].data), check.Equals, 162)
 	c.Assert(len(src.columns[2].elemBuf), check.Equals, 0)
 	for i := 0; i < 12; i += 2 {
 		row := src.GetRow(i)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #9995 <!-- REMOVE this line if no issue to close -->

Problem Summary: Key length stored in binary json object is `uint16`, will overflow when key length >= 65536.

### What is changed and how it works?

- Modify `keyEntrySize` from `6` (4 for keyOffset and 2 for keyLen) to `8` (4 for keyOffset and 4 for keyLen).
- Modify the reads and writes of `BinaryJSON` for json object (Change `Uint16/PutUint16` to `Uint32/PutUint32`).

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Modify json object key length in BinaryJSON. <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
