### PR TITLE
store: add RLock when reading tikvSnapshot.mu.stats

### DIFF
--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -669,6 +669,7 @@ func prettyWriteKey(buf *bytes.Buffer, key []byte) {
 func (s *tikvSnapshot) recordBackoffInfo(bo *Backoffer) {
 	s.mu.RLock()
 	if s.mu.stats == nil || bo.totalSleep == 0 {
+		s.mu.RUnlock()
 		return
 	}
 	s.mu.RUnlock()

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -269,12 +269,14 @@ func (s *tikvSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, coll
 		minCommitTSPushed: &s.minCommitTSPushed,
 		Client:            s.store.client,
 	}
+	s.mu.RLock()
 	if s.mu.stats != nil {
 		cli.Stats = make(map[tikvrpc.CmdType]*RPCRuntimeStats)
 		defer func() {
 			s.mergeRegionRequestStats(cli.Stats)
 		}()
 	}
+	s.mu.RUnlock()
 
 	pending := batch.keys
 	for {
@@ -411,12 +413,14 @@ func (s *tikvSnapshot) get(ctx context.Context, bo *Backoffer, k kv.Key) ([]byte
 		Client:            s.store.client,
 		resolveLite:       true,
 	}
+	s.mu.RLock()
 	if s.mu.stats != nil {
 		cli.Stats = make(map[tikvrpc.CmdType]*RPCRuntimeStats)
 		defer func() {
 			s.mergeRegionRequestStats(cli.Stats)
 		}()
 	}
+	s.mu.RUnlock()
 
 	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet,
 		&pb.GetRequest{
@@ -663,9 +667,11 @@ func prettyWriteKey(buf *bytes.Buffer, key []byte) {
 }
 
 func (s *tikvSnapshot) recordBackoffInfo(bo *Backoffer) {
+	s.mu.RLock()
 	if s.mu.stats == nil || bo.totalSleep == 0 {
 		return
 	}
+	s.mu.RUnlock()
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.mu.stats == nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Fix data race:
```
[2020-12-09T09:09:22.244Z] ==================
[2020-12-09T09:09:22.244Z] WARNING: DATA RACE
[2020-12-09T09:09:22.244Z] Write at 0x00c080c823a8 by goroutine 532:
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).SetOption()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:514 +0x3be
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*BatchPointGetExec).Open()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/batch_point_get.go:109 +0x9ac
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*UnionExec).resultPuller()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:1523 +0x9b0
[2020-12-09T09:09:22.244Z] 
[2020-12-09T09:09:22.244Z] Previous read at 0x00c080c823a8 by goroutine 962:
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).batchGetSingleRegion()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:272 +0x178
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).batchGetKeysByRegions()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:243 +0xa3e
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/store/tikv.(*tikvSnapshot).BatchGet()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/store/tikv/snapshot.go:153 +0x72d
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/kv.(*BufferBatchGetter).BatchGet()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/kv/utils.go:102 +0x99e
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*BatchPointGetExec).initialize()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/batch_point_get.go:340 +0xa39
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*BatchPointGetExec).Next()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/batch_point_get.go:143 +0x819
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.Next()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:278 +0x27d
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*ProjectionExec).unParallelExecute()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/projection.go:187 +0x1db
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*ProjectionExec).Next()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/projection.go:173 +0xa9
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.Next()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:278 +0x27d
[2020-12-09T09:09:22.244Z]   github.com/pingcap/tidb/executor.(*UnionExec).resultPuller()
[2020-12-09T09:09:22.244Z]       /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/executor/executor.go:1540 +0x4e8
[2020-12-09T09:09:22.244Z] 
```

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
