### PR TITLE
server: add buffer to channel to safely avoid goroutine leak

### DIFF
--- a/server/sql_info_fetcher.go
+++ b/server/sql_info_fetcher.go
@@ -189,7 +189,7 @@ func (sh *sqlInfoFetcher) zipInfoForSQL(w http.ResponseWriter, r *http.Request) 
 		// Otherwise we catch a profile and run `EXPLAIN ANALYZE` result.
 		ctx, cancelFunc := context.WithCancel(reqCtx)
 		timer := time.NewTimer(time.Second * time.Duration(timeout))
-		resultChan := make(chan *explainAnalyzeResult)
+		resultChan := make(chan *explainAnalyzeResult, 1)
 		go sh.getExplainAnalyze(ctx, sql, resultChan)
 		errChan := make(chan error)
 		var buf bytes.Buffer


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: 
No issue

Problem Summary: 
Channel `resultChan` has a send operation at the end of a created goroutine at line 262 or 273, and a receive operation in select at line 198. A bug will be triggered if the select chooses `case <-timer.C` at line 217. Because the receive is not chosen by the select, the send operation at line 262 or 273 will be blocked forever.

https://github.com/pingcap/tidb/blob/bc41e47360e87a56771ada8767ccc4fd9fcf64cb/server/sql_info_fetcher.go#L192-L198

https://github.com/pingcap/tidb/blob/bc41e47360e87a56771ada8767ccc4fd9fcf64cb/server/sql_info_fetcher.go#L259-L274

### What is changed and how it works?

What's Changed:
`resultChan` now has 1 buffer.

How it Works:
Since it has 1 buffer, the send operation in the created goroutine will not block. This doesn't change the semantics of the created goroutine because send is the last operation.
The receive operation in the select at line 217 is also not influenced, because it will still wait for the send operation to fill the buffer. So the semantics of parent goroutine are also not changed.


### Check List <!--REMOVE the items that are not applicable-->


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
