### PR TITLE
expression: Cast float/double to string is not compatible with MySQL (#21416)

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -841,7 +842,7 @@ func (b *builtinCastRealAsStringSig) evalString(row chunk.Row) (res string, isNu
 		// If we strconv.FormatFloat the value with 64bits, the result is incorrect!
 		bits = 32
 	}
-	res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(val, 'f', -1, bits), b.tp, b.ctx.GetSessionVars().StmtCtx, false)
+	res, err = types.ProduceStrWithSpecifiedTp(string(hack.String(types.AppendFormatFloat(make([]byte, 20)[:0], val, types.UnspecifiedLength, bits))), b.tp, b.ctx.GetSessionVars().StmtCtx, false)
 	if err != nil {
 		return res, false, err
 	}

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -1455,10 +1455,10 @@ func (s *testEvaluatorSuite) TestCastStringAsDecimalSigWithUnsignedFlagInUnion(c
 
 // for issue https://github.com/pingcap/tidb/issues/21416
 func (s *testEvaluatorSuite) TestCastRealAsStringSig(c *C) {
-	cases := []struct{
-		in float64
+	cases := []struct {
+		in  float64
 		out string
-	} {
+	}{
 		{
 			1.01e15,
 			"1.01e15",

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/hack"
 )
 
 func (b *builtinCastIntAsDurationSig) vecEvalDuration(input *chunk.Chunk, result *chunk.Column) error {
@@ -218,7 +219,7 @@ func (b *builtinCastRealAsStringSig) vecEvalString(input *chunk.Chunk, result *c
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(strconv.FormatFloat(v, 'f', -1, bits), b.tp, sc, false)
+		res, err = types.ProduceStrWithSpecifiedTp(string(hack.String(types.AppendFormatFloat(make([]byte, 20)[:0], v, types.UnspecifiedLength, bits))), b.tp, sc, false)
 		if err != nil {
 			return err
 		}

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -417,7 +417,7 @@ func (s *testUtilSuite) TestAppendFormatFloat(c *C) {
 		},
 	}
 	for _, t := range tests {
-		c.Assert(string(appendFormatFloat(nil, t.fVal, t.prec, t.bitSize)), Equals, t.out)
+		c.Assert(string(types.AppendFormatFloat(nil, t.fVal, t.prec, t.bitSize)), Equals, t.out)
 	}
 }
 

--- a/types/helper.go
+++ b/types/helper.go
@@ -208,6 +208,7 @@ const (
 	defaultMySQLPrec = 5
 )
 
+// AppendFormatFloat convert a float point number to it's text represent, similar with my_gcvt in MySQL
 func AppendFormatFloat(in []byte, fVal float64, prec, bitSize int) []byte {
 	absVal := math.Abs(fVal)
 	if absVal > math.MaxFloat64 || math.IsNaN(absVal) {

--- a/types/helper.go
+++ b/types/helper.go
@@ -254,7 +254,11 @@ func AppendFormatFloat(in []byte, fVal float64, prec, bitSize int) []byte {
 			// minus 1 for .
 			digits--
 		}
-		exponent, _ := strconv.Atoi(string(hack.String(out[ePosInOut+1:])))
+		exponent, err := strconv.Atoi(string(hack.String(out[ePosInOut+1:])))
+		if err != nil {
+			// should never reach this, but for code check
+			exponent = 0
+		}
 		if exponent > 0 && digits > exponent+1 {
 			// if number of digits is greater than exponent+1, use 'f' format
 			out = strconv.AppendFloat(in, fVal, 'f', prec, bitSize)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21416 <!-- REMOVE this line if no issue to close -->

Problem Summary: Cast float/double to string is not compatible with MySQL

### What is changed and how it works?

What's Changed:
1. move appendFormatFloat function in server/util.go to types/helper.go and make it exportable.
2. in the AppendFormatFloat function, when the value is greater than or equal to 1e15,  but the number of digits is great than the decimal's exponent+1, use the 'f' format instead of the 'e' format.
3. use AppendFormatFloat to convert float point numbers instead of strconv.FormatFloat in cast SQL function.

How it Works:

MySQL use my_gcvt function in strings/dtoa.cc to hand convert float point number to it's text represent. In our tidb code, it's handle by appendFormatFloat function in server/util.go. But we only use it when writing float point number to text protocol. So we need to use it when cast float point numbers to string as well.
Another issue of appendFormatFloat is that when the value is greater than or equal to 1e15, it uses the 'e' format. But for my_gcvt, if the value is greater than or equal to 1e15, but the number of digits is great than the decimal's exponent+1, it uses the 'f' format instead of the 'e' format. Such as 'select 1.0123456789012345e15', we return 'e' format but MySQL return 'f' format. So we need to follow this too.

### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)
It's for vector test.
  1. create table test_float64(id double);
  2. insert into test_float64 values(1.01e15);
  3. insert into test_float64 values(1.0123456789012345e15);
  4. select cast(id as char) from test_float64;

Side effects

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note