### PR TITLE
expression, types: fix unexpected result from TIME() when fsp digits > 6

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -1696,6 +1696,10 @@ func (s *testIntegrationSuite2) TestTimeBuiltin(c *C) {
 	// result = tk.MustQuery("select time('2003-12-10-10 01:02:03.000123')")
 	// result.Check(testkit.Rows("00:20:03")
 
+	// Issue 20995
+	result = tk.MustQuery("select time('0.1234567')")
+	result.Check(testkit.Rows("00:00:00.123457"))
+
 	// for hour
 	result = tk.MustQuery(`SELECT hour("12:13:14.123456"), hour("12:13:14.000010"), hour("272:59:55"), hour(020005), hour(null), hour("27aaaa2:59:55");`)
 	result.Check(testkit.Rows("12 12 272 2 <nil> <nil>"))

--- a/types/fsp.go
+++ b/types/fsp.go
@@ -39,7 +39,7 @@ func CheckFsp(fsp int) (int8, error) {
 		return DefaultFsp, nil
 	}
 	if fsp < int(MinFsp) || fsp > int(MaxFsp) {
-		return DefaultFsp, errors.Errorf("Invalid fsp %d", fsp)
+		return MaxFsp, nil
 	}
 	return int8(fsp), nil
 }

--- a/types/fsp.go
+++ b/types/fsp.go
@@ -38,7 +38,9 @@ func CheckFsp(fsp int) (int8, error) {
 	if fsp == int(UnspecifiedFsp) {
 		return DefaultFsp, nil
 	}
-	if fsp < int(MinFsp) || fsp > int(MaxFsp) {
+	if fsp < int(MinFsp) {
+		return DefaultFsp, errors.Errorf("Invalid fsp %d", fsp)
+	} else if fsp > int(MaxFsp) {
 		return MaxFsp, nil
 	}
 	return int8(fsp), nil

--- a/types/fsp_test.go
+++ b/types/fsp_test.go
@@ -43,16 +43,16 @@ func (s *FspTest) TestCheckFsp(c *C) {
 	c.Assert(err, IsNil)
 
 	obtained, err = CheckFsp(int(MaxFsp) + 1)
-	c.Assert(obtained, Equals, DefaultFsp)
-	c.Assert(err, ErrorMatches, "Invalid fsp "+strconv.Itoa(int(MaxFsp)+1))
+	c.Assert(obtained, Equals, MaxFsp)
+	c.Assert(err, IsNil)
 
 	obtained, err = CheckFsp(int(MaxFsp) + 2019)
-	c.Assert(obtained, Equals, DefaultFsp)
-	c.Assert(err, ErrorMatches, "Invalid fsp "+strconv.Itoa(int(MaxFsp)+2019))
+	c.Assert(obtained, Equals, MaxFsp)
+	c.Assert(err, IsNil)
 
 	obtained, err = CheckFsp(int(MaxFsp) + 4294967296)
-	c.Assert(obtained, Equals, DefaultFsp)
-	c.Assert(err, ErrorMatches, "Invalid fsp "+strconv.Itoa(int(MaxFsp)+4294967296))
+	c.Assert(obtained, Equals, MaxFsp)
+	c.Assert(err, IsNil)
 
 	obtained, err = CheckFsp(int(MaxFsp+MinFsp) / 2)
 	c.Assert(obtained, Equals, (MaxFsp+MinFsp)/2)

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -484,7 +484,6 @@ func (s *testTimeSuite) TestTimeFsp(c *C) {
 		Fsp   int8
 	}{
 		{"00:00:00.1", -2},
-		{"00:00:00.1", 7},
 	}
 
 	for _, test := range errTable {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #20995 

Problem Summary:

### What is changed and how it works?

What's Changed:
fix unexpected result from TIME() when fsp digits > 6
How it Works:
if fsp digits > 6, fsp digits is set to  `MaxFsp`.
### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
