### PR TITLE
types, expression, codec: agg JSON values

### DIFF
--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -428,6 +428,36 @@ func (bj *BinaryJSON) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
+// HashValue converts certain JSON values for aggregate comparisons.
+// For example int64(3) == float64(3.0)
+func (bj BinaryJSON) HashValue(buf []byte) []byte {
+	switch bj.TypeCode {
+	case TypeCodeInt64:
+		// Convert to a FLOAT if no precision is lost.
+		// In the future, it will be better to convert to a DECIMAL value instead
+		// See: https://github.com/pingcap/tidb/issues/9988
+		if bj.GetInt64() == int64(float64(bj.GetInt64())) {
+			buf = appendBinaryFloat64(buf, float64(bj.GetInt64()))
+		} else {
+			buf = append(buf, bj.Value...)
+		}
+	case TypeCodeArray:
+		elemCount := int(endian.Uint32(bj.Value))
+		for i := 0; i < elemCount; i++ {
+			buf = bj.arrayGetElem(i).HashValue(buf)
+		}
+	case TypeCodeObject:
+		elemCount := int(endian.Uint32(bj.Value))
+		for i := 0; i < elemCount; i++ {
+			buf = append(buf, bj.objectGetKey(i)...)
+			buf = bj.objectGetVal(i).HashValue(buf)
+		}
+	default:
+		buf = append(buf, bj.Value...)
+	}
+	return buf
+}
+
 // CreateBinary creates a BinaryJSON from interface.
 func CreateBinary(in interface{}) BinaryJSON {
 	typeCode, buf, err := appendBinary(nil, in)

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -1249,9 +1249,7 @@ func HashGroupKey(sc *stmtctx.StatementContext, n int, col *chunk.Column, buf []
 				buf[i] = append(buf[i], NilFlag)
 			} else {
 				buf[i] = append(buf[i], jsonFlag)
-				j := col.GetJSON(i)
-				buf[i] = append(buf[i], j.TypeCode)
-				buf[i] = append(buf[i], j.Value...)
+				buf[i] = col.GetJSON(i).HashValue(buf[i])
 			}
 		}
 	case types.ETString:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fix https://github.com/pingcap/tidb/issues/10467

### What is changed and how it works?

MySQL can group the JSON values `3` and `3.0` together in a group by statement, versus TiDB which currently handles these separately.

This picks up the PR https://github.com/pingcap/tidb/pull/15973 , but modifies it to only convert values to float when safe to do so. I think ideally the `DECIMAL` type should be used to compare values with fixed-point math, which depends on https://github.com/pingcap/tidb/issues/9988

This means that there are some cases (which are left as comments in the integration test) which are handled correctly in MySQL, but not yet in TiDB.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

- Performance regression

(It's a little bit slower to do this of course.)

### Release note <!-- bugfixes or new feature need a release note -->

- TiDB now attemps to compare integer and float values as equal when aggregating JSON values.