### PR TITLE
planner: make TestPreferRangeScan stable

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1972,37 +1972,6 @@ func (s *testIntegrationSuite) TestUpdateSetDefault(c *C) {
 		"[planner:3105]The value specified for generated column 'z' in table 'tt' is not allowed.")
 }
 
-func (s *testIntegrationSerialSuite) TestPreferRangeScan(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists test;")
-	tk.MustExec("create table test(`id` int(10) NOT NULL AUTO_INCREMENT,`name` varchar(50) NOT NULL DEFAULT 'tidb',`age` int(11) NOT NULL,`addr` varchar(50) DEFAULT 'The ocean of stars',PRIMARY KEY (`id`),KEY `idx_age` (`age`))")
-	tk.MustExec("insert into test(age) values(5);")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
-	tk.MustExec("analyze table test;")
-	tk.MustExec("set session tidb_opt_prefer_range_scan=0")
-	tk.MustQuery("explain select * from test where age=5").Check(testkit.Rows(
-		"TableReader_7 2048.00 root  data:Selection_6",
-		"└─Selection_6 2048.00 cop[tikv]  eq(test.test.age, 5)",
-		"  └─TableFullScan_5 2048.00 cop[tikv] table:test keep order:false"))
-
-	tk.MustExec("set session tidb_opt_prefer_range_scan=1")
-	tk.MustQuery("explain select * from test where age=5").Check(testkit.Rows(
-		"IndexLookUp_7 2048.00 root  ",
-		"├─IndexRangeScan_5(Build) 2048.00 cop[tikv] table:test, index:idx_age(age) range:[5,5], keep order:false",
-		"└─TableRowIDScan_6(Probe) 2048.00 cop[tikv] table:test keep order:false"))
-}
-
 func (s *testIntegrationSuite) TestCorrelatedColumnAggFuncPushDown(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test;")

--- a/planner/core/testdata/plan_normalized_suite_in.json
+++ b/planner/core/testdata/plan_normalized_suite_in.json
@@ -33,6 +33,13 @@
 		]
 	},
 	{
+		"name": "TestPreferRangeScan",
+		"cases": [
+			"select * from test where age=5;",
+			"select * from test where age=5;"
+		]
+	},
+	{
 		"name": "TestNormalizedPlanForDiffStore",
 		"cases": [
 			"explain select /*+ read_from_storage(tiflash[t1]) */ * from t1",

--- a/planner/core/testdata/plan_normalized_suite_out.json
+++ b/planner/core/testdata/plan_normalized_suite_out.json
@@ -235,6 +235,27 @@
     ]
   },
   {
+    "Name": "TestPreferRangeScan",
+    "Cases": [
+      {
+        "SQL": "select * from test where age=5;",
+        "Plan": [
+          " TableReader   root ",
+          " └─Selection   cop  eq(test.test.age, ?)",
+          "   └─TableScan cop  table:test, range:[?,?], keep order:false"
+        ]
+      },
+      {
+        "SQL": "select * from test where age=5;",
+        "Plan": [
+          " IndexLookUp root ",
+          " ├─IndexScan cop  table:test, index:idx_age(age), range:[?,?], keep order:false",
+          " └─TableScan cop  table:test, keep order:false"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestNormalizedPlanForDiffStore",
     "Cases": [
       {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Fix:
```
[2020-12-09T08:13:27.200Z] FAIL: integration_test.go:1964: testIntegrationSerialSuite.TestPreferRangeScan
[2020-12-09T08:13:27.200Z] 
[2020-12-09T08:13:27.200Z] integration_test.go:1983:
[2020-12-09T08:13:27.200Z]     tk.MustQuery("explain select * from test where age=5").Check(testkit.Rows(
[2020-12-09T08:13:27.200Z]         "TableReader_7 2048.00 root  data:Selection_6",
[2020-12-09T08:13:27.200Z]         "└─Selection_6 2048.00 cop[tikv]  eq(test.test.age, 5)",
[2020-12-09T08:13:27.200Z]         "  └─TableFullScan_5 2048.00 cop[tikv] table:test keep order:false"))
[2020-12-09T08:13:27.200Z] /home/jenkins/agent/workspace/tidb_ghpr_unit_test/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:63:
[2020-12-09T08:13:27.200Z]     res.c.Assert(resBuff.String(), check.Equals, needBuff.String(), res.comment)
[2020-12-09T08:13:27.200Z] ... obtained string = "" +
[2020-12-09T08:13:27.200Z] ...     "[TableReader_7 1441.12 root  data:Selection_6]\n" +
[2020-12-09T08:13:27.200Z] ...     "[└─Selection_6 1441.12 cop[tikv]  eq(test.test.age, 5)]\n" +
[2020-12-09T08:13:27.200Z] ...     "[  └─TableFullScan_5 1454.00 cop[tikv] table:test keep order:false]\n"
[2020-12-09T08:13:27.200Z] ... expected string = "" +
[2020-12-09T08:13:27.200Z] ...     "[TableReader_7 2048.00 root  data:Selection_6]\n" +
[2020-12-09T08:13:27.200Z] ...     "[└─Selection_6 2048.00 cop[tikv]  eq(test.test.age, 5)]\n" +
[2020-12-09T08:13:27.200Z] ...     "[  └─TableFullScan_5 2048.00 cop[tikv] table:test keep order:false]\n"
[2020-12-09T08:13:27.200Z] ... sql:explain select * from test where age=5, args:[]
```

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

N/A

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.