### PR TITLE
unistore: fix index-out-of-range error when unistore executes TopN

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7132,3 +7132,12 @@ func (s *testSuite) Test12178(c *C) {
 	tk.MustExec("insert into ta values (JSON_EXTRACT('{\"c\": \"1234567890123456789012345678901234567890123456789012345\"}', '$.c'))")
 	tk.MustQuery("select * from ta").Check(testkit.Rows("1234567890123456789012345678901234567890123456789012345.00"))
 }
+
+func (s *testSuite) Test15492(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int)")
+	tk.MustExec("insert into t values (2, 20), (1, 10), (3, 30)")
+	tk.MustQuery("select a + 1 as field1, a as field2 from t order by field1, field2 limit 2").Check(testkit.Rows("2 1", "3 2"))
+}

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -495,7 +495,7 @@ func buildTopNProcessor(e *closureExecutor, topN *tipb.TopN) error {
 	ctx := &topNCtx{
 		heap:         heap,
 		orderByExprs: conds,
-		sortRow:      e.newTopNSortRow(),
+		sortRow:      newTopNSortRow(len(conds)),
 		execDetail:   new(execDetail),
 	}
 
@@ -1376,7 +1376,7 @@ func (e *topNProcessor) Process(key, value []byte) (err error) {
 	if ctx.heap.tryToAddRow(ctx.sortRow) {
 		ctx.sortRow.data[0] = safeCopy(key)
 		ctx.sortRow.data[1] = safeCopy(value)
-		ctx.sortRow = e.newTopNSortRow()
+		ctx.sortRow = newTopNSortRow(len(ctx.orderByExprs))
 	}
 	if ctx.heap.err == nil {
 		gotRow = true
@@ -1384,9 +1384,9 @@ func (e *topNProcessor) Process(key, value []byte) (err error) {
 	return errors.Trace(ctx.heap.err)
 }
 
-func (e *closureExecutor) newTopNSortRow() *sortRow {
+func newTopNSortRow(numOrderByExprs int) *sortRow {
 	return &sortRow{
-		key:  make([]types.Datum, len(e.evalContext.columnInfos)),
+		key:  make([]types.Datum, numOrderByExprs),
 		data: make([][]byte, 2),
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #15492 <!-- REMOVE this line if no issue to close -->

Problem Summary:

A select sql causes "index out of range" error.

### What is changed and how it works?

What's Changed:

In unistore's `newTopNSortRow` function, length of `key` of `sortRow` should be equal to the number of `ORDER BY` expressions rather than the umber of involved columns.

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects
- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
