### PR TITLE
expression: fix behavior when comparing date with string incompatible with MySQL

### DIFF
--- a/expression/errors.go
+++ b/expression/errors.go
@@ -57,7 +57,7 @@ var (
 func handleInvalidTimeError(ctx sessionctx.Context, err error) error {
 	if err == nil || !(types.ErrWrongValue.Equal(err) || types.ErrWrongValueForType.Equal(err) ||
 		types.ErrTruncatedWrongVal.Equal(err) || types.ErrInvalidWeekModeFormat.Equal(err) ||
-		types.ErrDatetimeFunctionOverflow.Equal(err)) {
+		types.ErrDatetimeFunctionOverflow.Equal(err)) || types.ErrWrongValue.Equal(err) {
 		return err
 	}
 	sc := ctx.GetSessionVars().StmtCtx

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -57,7 +57,7 @@ var (
 func handleInvalidTimeError(ctx sessionctx.Context, err error) error {
 	if err == nil || !(types.ErrWrongValue.Equal(err) || types.ErrWrongValueForType.Equal(err) ||
 		types.ErrTruncatedWrongVal.Equal(err) || types.ErrInvalidWeekModeFormat.Equal(err) ||
-		types.ErrDatetimeFunctionOverflow.Equal(err)) || types.ErrWrongValue.Equal(err) {
+		types.ErrDatetimeFunctionOverflow.Equal(err)) {
 		return err
 	}
 	sc := ctx.GetSessionVars().StmtCtx

--- a/expression/errors.go
+++ b/expression/errors.go
@@ -61,8 +61,7 @@ func handleInvalidTimeError(ctx sessionctx.Context, err error) error {
 		return err
 	}
 	sc := ctx.GetSessionVars().StmtCtx
-	err = sc.HandleTruncate(err)
-	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt) {
+	if ctx.GetSessionVars().StrictSQLMode && (sc.InInsertStmt || sc.InUpdateStmt || sc.InDeleteStmt || sc.InSelectStmt) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #21354  

Problem Summary:

### What is changed and how it works?
What's Changed:
fix behavior when comparing date with string incompatible with MySQL
How it Works:
handle `errWrongValue` as error
### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
