### PR TITLE
*: add a switch for extended stats to disable the feature by default

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -465,6 +465,15 @@ func (s *testSerialSuite1) TestSetVar(c *C) {
 	tk.MustQuery(`show variables like 'tidb_general_log';`).Check(testkit.Rows("tidb_general_log OFF"))
 	c.Assert(tk.ExecToErr("set tidb_general_log = abc"), NotNil)
 	c.Assert(tk.ExecToErr("set tidb_general_log = 123"), NotNil)
+
+	tk.MustExec("SET SESSION tidb_enable_extended_stats = on")
+	tk.MustQuery("select @@session.tidb_enable_extended_stats").Check(testkit.Rows("1"))
+	tk.MustExec("SET SESSION tidb_enable_extended_stats = off")
+	tk.MustQuery("select @@session.tidb_enable_extended_stats").Check(testkit.Rows("0"))
+	tk.MustExec("SET GLOBAL tidb_enable_extended_stats = on")
+	tk.MustQuery("select @@global.tidb_enable_extended_stats").Check(testkit.Rows("1"))
+	tk.MustExec("SET GLOBAL tidb_enable_extended_stats = off")
+	tk.MustQuery("select @@global.tidb_enable_extended_stats").Check(testkit.Rows("0"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1262,6 +1262,9 @@ func asyncDelayShutdown(p *os.Process, delay time.Duration) {
 }
 
 func (e *SimpleExec) executeCreateStatistics(s *ast.CreateStatisticsStmt) (err error) {
+	if !e.ctx.GetSessionVars().EnableExtendedStats {
+		return errors.New("Extended statistics feature is not generally available now, and tidb_enable_extended_stats is OFF")
+	}
 	// Not support Cardinality and Dependency statistics type for now.
 	if s.StatsType == ast.StatsTypeCardinality || s.StatsType == ast.StatsTypeDependency {
 		return dbterror.ClassOptimizer.NewStd(mysql.ErrInternal).GenWithStack("Cardinality and Dependency statistics types are not supported")
@@ -1302,6 +1305,9 @@ func (e *SimpleExec) executeCreateStatistics(s *ast.CreateStatisticsStmt) (err e
 }
 
 func (e *SimpleExec) executeDropStatistics(s *ast.DropStatisticsStmt) error {
+	if !e.ctx.GetSessionVars().EnableExtendedStats {
+		return errors.New("Extended statistics feature is not generally available now, and tidb_enable_extended_stats is OFF")
+	}
 	db := e.ctx.GetSessionVars().CurrentDB
 	if db == "" {
 		return core.ErrNoDB
@@ -1314,6 +1320,9 @@ func (e *SimpleExec) executeDropStatistics(s *ast.DropStatisticsStmt) error {
 func (e *SimpleExec) executeAdminReloadStatistics(s *ast.AdminStmt) error {
 	if s.Tp != ast.AdminReloadStatistics {
 		return dbterror.ClassOptimizer.NewStd(mysql.ErrInternal).GenWithStack("This AdminStmt is not ADMIN RELOAD STATISTICS")
+	}
+	if !e.ctx.GetSessionVars().EnableExtendedStats {
+		return errors.New("Extended statistics feature is not generally available now, and tidb_enable_extended_stats is OFF")
 	}
 	return domain.GetDomain(e.ctx).StatsHandle().ReloadExtendedStatistics()
 }

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -763,6 +763,8 @@ func (s *testSuite3) TestExtendedStatsPrivileges(c *C) {
 	defer se.Close()
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "u1", Hostname: "%"}, nil, nil), IsTrue)
 	ctx := context.Background()
+	_, err = se.Execute(ctx, "set session tidb_enable_extended_stats = on")
+	c.Assert(err, IsNil)
 	_, err = se.Execute(ctx, "create statistics s1(correlation) on test.t(a,b)")
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[planner:1142]CREATE STATISTICS command denied to user 'u1'@'%' for table 't'")

--- a/session/session.go
+++ b/session/session.go
@@ -2274,6 +2274,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBCapturePlanBaseline,
 	variable.TiDBUsePlanBaselines,
 	variable.TiDBEvolvePlanBaselines,
+	variable.TiDBEnableExtendedStats,
 	variable.TiDBIsolationReadEngines,
 	variable.TiDBStoreLimit,
 	variable.TiDBAllowAutoRandExplicitInsert,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -666,6 +666,9 @@ type SessionVars struct {
 	// EvolvePlanBaselines indicates whether we will evolve the plan baselines.
 	EvolvePlanBaselines bool
 
+	// EnableExtendedStats indicates whether we enable the extended statistics feature.
+	EnableExtendedStats bool
+
 	// Unexported fields should be accessed and set through interfaces like GetReplicaRead() and SetReplicaRead().
 
 	// allowInSubqToJoinAndAgg can be set to false to forbid rewriting the semi join to inner join with agg.
@@ -894,6 +897,7 @@ func NewSessionVars() *SessionVars {
 		AllowRemoveAutoInc:           DefTiDBAllowRemoveAutoInc,
 		UsePlanBaselines:             DefTiDBUsePlanBaselines,
 		EvolvePlanBaselines:          DefTiDBEvolvePlanBaselines,
+		EnableExtendedStats:          false,
 		IsolationReadEngines:         make(map[kv.StoreType]struct{}),
 		LockWaitTimeout:              DefInnodbLockWaitTimeout * 1000,
 		MetricSchemaStep:             DefTiDBMetricSchemaStep,
@@ -1510,6 +1514,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.UsePlanBaselines = TiDBOptOn(val)
 	case TiDBEvolvePlanBaselines:
 		s.EvolvePlanBaselines = TiDBOptOn(val)
+	case TiDBEnableExtendedStats:
+		s.EnableExtendedStats = TiDBOptOn(val)
 	case TiDBIsolationReadEngines:
 		s.IsolationReadEngines = make(map[kv.StoreType]struct{})
 		for _, engine := range strings.Split(val, ",") {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1068,6 +1068,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBCapturePlanBaseline, Value: BoolOff, Type: TypeBool, AllowEmptyAll: true},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBUsePlanBaselines, Value: BoolToOnOff(DefTiDBUsePlanBaselines), Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEvolvePlanBaselines, Value: BoolToOnOff(DefTiDBEvolvePlanBaselines), Type: TypeBool},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableExtendedStats, Value: BoolToOnOff(false), Type: TypeBool},
 	{Scope: ScopeGlobal, Name: TiDBEvolvePlanTaskMaxTime, Value: strconv.Itoa(DefTiDBEvolvePlanTaskMaxTime), Type: TypeInt, MinValue: -1, MaxValue: math.MaxInt64},
 	{Scope: ScopeGlobal, Name: TiDBEvolvePlanTaskStartTime, Value: DefTiDBEvolvePlanTaskStartTime, Type: TypeTime},
 	{Scope: ScopeGlobal, Name: TiDBEvolvePlanTaskEndTime, Value: DefTiDBEvolvePlanTaskEndTime, Type: TypeTime},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -433,6 +433,9 @@ const (
 	// TiDBEvolvePlanBaselines indicates whether the evolution of plan baselines is enabled.
 	TiDBEvolvePlanBaselines = "tidb_evolve_plan_baselines"
 
+	// TiDBEnableExtendedStats indicates whether the extended statistics feature is enabled.
+	TiDBEnableExtendedStats = "tidb_enable_extended_stats"
+
 	// TiDBIsolationReadEngines indicates the tidb only read from the stores whose engine type is involved in IsolationReadEngines.
 	// Now, only support TiKV and TiFlash.
 	TiDBIsolationReadEngines = "tidb_isolation_read_engines"

--- a/statistics/handle/dump_test.go
+++ b/statistics/handle/dump_test.go
@@ -188,6 +188,7 @@ func (s *testStatsSuite) TestDumpPseudoColumns(c *C) {
 func (s *testStatsSuite) TestDumpExtendedStats(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set session tidb_enable_extended_stats = on")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int)")

--- a/statistics/handle/gc_test.go
+++ b/statistics/handle/gc_test.go
@@ -96,6 +96,7 @@ func (s *testStatsSuite) TestGCPartition(c *C) {
 func (s *testStatsSuite) TestGCExtendedStats(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)
+	testKit.MustExec("set session tidb_enable_extended_stats = on")
 	testKit.MustExec("use test")
 	testKit.MustExec("create table t(a int, b int, c int)")
 	testKit.MustExec("insert into t values (1,1,1),(2,2,2),(3,3,3)")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

https://github.com/pingcap/tidb/issues/18330 is not generally available now, add a switch to disable this feature by default.


### What is changed and how it works?


What's Changed:

Add a system variable `tidb_enable_extended_stats` and make it default `off`.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Add a switch for extended stats to disable the feature by default