### PR TITLE
expression: fix unexpect invalid json text error when query with `json_extract`

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -22,6 +22,7 @@
 package expression
 
 import (
+	json2 "encoding/json"
 	"math"
 	"strconv"
 	"strings"
@@ -36,6 +37,8 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/hack"
+
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -688,7 +691,8 @@ func (b *builtinCastStringAsJSONSig) evalJSON(row chunk.Row) (res json.BinaryJSO
 	if isNull || err != nil {
 		return res, isNull, err
 	}
-	if mysql.HasParseToJSONFlag(b.tp.Flag) {
+	data := hack.Slice(val)
+	if mysql.HasParseToJSONFlag(b.tp.Flag) && json2.Valid(data) {
 		res, err = json.ParseBinaryFromString(val)
 	} else {
 		res = json.CreateBinary(val)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #11883  

Problem Summary:

### What is changed and how it works?

What's Changed:
fix unexpect invalid json text error when query with `json_extract`
How it Works:
When a string can't be casted to json, use `json.CreateBinary`
### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
