### PR TITLE
planner, executor: fix haven't track the memroy usage of PointGet/BatchPointGet 

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -747,6 +747,14 @@ func (a *ExecStmt) buildExecutor() (Executor, error) {
 	}
 
 	b := newExecutorBuilder(ctx, a.InfoSchema)
+
+	if pg, ok := a.Plan.(*plannercore.PointGetPlan); ok {
+		pg.TrackMem = true
+	}
+	if bpg, ok := a.Plan.(*plannercore.BatchPointGetPlan); ok {
+		bpg.TrackMem = true
+	}
+
 	e := b.build(a.Plan)
 	if b.err != nil {
 		return nil, errors.Trace(b.err)

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3849,6 +3849,11 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 	if e.lock {
 		b.hasLock = true
 	}
+
+	if plan.TrackMem {
+		e.trackMem = true
+	}
+
 	var capacity int
 	if plan.IndexInfo != nil && !isCommonHandleRead(plan.TblInfo, plan.IndexInfo) {
 		e.idxVals = plan.IndexValues

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -67,6 +67,7 @@ type PointGetPlan struct {
 	LockWaitTime       int64
 	partitionColumnPos int
 	Columns            []*model.ColumnInfo
+	TrackMem           bool
 }
 
 type nameValuePair struct {
@@ -258,6 +259,7 @@ type BatchPointGetPlan struct {
 	Lock             bool
 	LockWaitTime     int64
 	Columns          []*model.ColumnInfo
+	TrackMem         bool
 }
 
 // Clone implements PhysicalPlan interface.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
planner, executor: fix haven't track the memroy usage of PointGet/BatchPointGet

-->
planner, executor: fix haven't track the memroy usage of PointGet/BatchPointGet

### What problem does this PR solve?

Issue Number: close  #21653

Problem Summary:

### What is changed and how it works?

What's Changed:
enable memory tracker in point_get/batch_point_get

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- planner, executor: fix haven't track the memroy usage of PointGet/BatchPointGet