### PR TITLE
expression: add annotations to inform user to import planner/core to initalize expression.RewriteAstExpr and expression.EvalAstExpr

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -48,9 +48,13 @@ const (
 )
 
 // EvalAstExpr evaluates ast expression directly.
+// Note: initialized in planner/core
+// import expression and planner/core together to use EvalAstExpr
 var EvalAstExpr func(sctx sessionctx.Context, expr ast.ExprNode) (types.Datum, error)
 
 // RewriteAstExpr rewrites ast expression directly.
+// Note: initialized in planner/core
+// import expression and planner/core together to use EvalAstExpr
 var RewriteAstExpr func(sctx sessionctx.Context, expr ast.ExprNode, schema *Schema, names types.NameSlice) (Expression, error)
 
 // VecExpr contains all vectorized evaluation methods.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21342 <!-- REMOVE this line if no issue to close -->

Problem Summary:
When external project(like `tidb-lightning`) calls `expression.RewriteAstExpr` and `expression.EvalAstExpr`, it will cause a panic because they are not initialized. To initialize them, `planner/core` needs to be imported as well.

### What is changed and how it works?

What's Changed:
Add annotation to inform user to import planner/core to initalize expression.RewriteAstExpr and expression.EvalAstExpr

How it Works:
Just add some annotation. And there is also another PR in `tidb-lightning` to fix the panic.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- add annotation for expression.RewriteAstExpr and expression.EvalAstExpr for func var initialization
