### PR TITLE
planner: generate correct query block name and offset for update / delete

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -1891,3 +1891,23 @@ func (s *testSuite) TestCapturedBindingCharset(c *C) {
 	c.Assert(rows[0][6], Equals, "")
 	c.Assert(rows[0][7], Equals, "")
 }
+
+func (s *testSuite) TestUpdateSubqueryCapture(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	s.cleanBindingEnv(tk)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int, b int, c int, key idx_b(b))")
+	tk.MustExec("create table t2(a int, b int)")
+	stmtsummary.StmtSummaryByDigestMap.Clear()
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk.MustExec("update t1 set b = 1 where b = 2 and (a in (select a from t2 where b = 1) or c in (select a from t2 where b = 1))")
+	tk.MustExec("update t1 set b = 1 where b = 2 and (a in (select a from t2 where b = 1) or c in (select a from t2 where b = 1))")
+	tk.MustExec("admin capture bindings")
+	rows := tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	bindSQL := "UPDATE /*+ use_index(@`upd_1` `test`.`t1` `idx_b`), use_index(@`sel_1` `test`.`t2` ), hash_join(@`upd_1` `test`.`t1`), use_index(@`sel_2` `test`.`t2` )*/ `t1` SET `b`=1 WHERE `b`=2 AND (`a` IN (SELECT `a` FROM `t2` WHERE `b`=1) OR `c` IN (SELECT `a` FROM `t2` WHERE `b`=1))"
+	c.Assert(rows[0][1], Equals, bindSQL)
+	tk.MustExec(bindSQL)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 0)
+}

--- a/planner/core/hints.go
+++ b/planner/core/hints.go
@@ -96,11 +96,15 @@ func getJoinHints(sctx sessionctx.Context, joinType string, parentOffset int, no
 		} else {
 			dbName, tableName = extractTableAsName(child)
 		}
-		if tableName == nil {
+		if tableName == nil || tableName.L == "" {
+			continue
+		}
+		qbName, err := utilhint.GenerateQBName(nodeType, blockOffset)
+		if err != nil {
 			continue
 		}
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(joinType),
 			Tables:   []ast.HintTable{{DBName: *dbName, TableName: *tableName}},
 		})
@@ -116,17 +120,21 @@ func genHintsFromPhysicalPlan(p PhysicalPlan, nodeType utilhint.NodeType) (res [
 	for _, child := range p.Children() {
 		res = append(res, genHintsFromPhysicalPlan(child, nodeType)...)
 	}
+	qbName, err := utilhint.GenerateQBName(nodeType, p.SelectBlockOffset())
+	if err != nil {
+		return res
+	}
 	switch pp := p.(type) {
 	case *PhysicalTableReader:
 		tbl := pp.TablePlans[0].(*PhysicalTableScan)
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintUseIndex),
 			Tables:   []ast.HintTable{{DBName: tbl.DBName, TableName: getTableName(tbl.Table.Name, tbl.TableAsName)}},
 		})
 		if tbl.StoreType == kv.TiFlash {
 			res = append(res, &ast.TableOptimizerHint{
-				QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+				QBName:   qbName,
 				HintName: model.NewCIStr(HintReadFromStorage),
 				HintData: model.NewCIStr(kv.TiFlash.Name()),
 				Tables:   []ast.HintTable{{DBName: tbl.DBName, TableName: getTableName(tbl.Table.Name, tbl.TableAsName)}},
@@ -135,7 +143,7 @@ func genHintsFromPhysicalPlan(p PhysicalPlan, nodeType utilhint.NodeType) (res [
 	case *PhysicalIndexLookUpReader:
 		index := pp.IndexPlans[0].(*PhysicalIndexScan)
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintUseIndex),
 			Tables:   []ast.HintTable{{DBName: index.DBName, TableName: getTableName(index.Table.Name, index.TableAsName)}},
 			Indexes:  []model.CIStr{index.Index.Name},
@@ -143,7 +151,7 @@ func genHintsFromPhysicalPlan(p PhysicalPlan, nodeType utilhint.NodeType) (res [
 	case *PhysicalIndexReader:
 		index := pp.IndexPlans[0].(*PhysicalIndexScan)
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintUseIndex),
 			Tables:   []ast.HintTable{{DBName: index.DBName, TableName: getTableName(index.Table.Name, index.TableAsName)}},
 			Indexes:  []model.CIStr{index.Index.Name},
@@ -163,19 +171,19 @@ func genHintsFromPhysicalPlan(p PhysicalPlan, nodeType utilhint.NodeType) (res [
 			}
 		}
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintIndexMerge),
 			Tables:   []ast.HintTable{{TableName: getTableName(tableName, tableAsName)}},
 			Indexes:  Indexs,
 		})
 	case *PhysicalHashAgg:
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintHashAgg),
 		})
 	case *PhysicalStreamAgg:
 		res = append(res, &ast.TableOptimizerHint{
-			QBName:   utilhint.GenerateQBName(nodeType, pp.blockOffset),
+			QBName:   qbName,
 			HintName: model.NewCIStr(HintStreamAgg),
 		})
 	case *PhysicalMergeJoin:

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -50,7 +50,6 @@ import (
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	util2 "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
-	utilhint "github.com/pingcap/tidb/util/hint"
 	"github.com/pingcap/tidb/util/plancodec"
 	"github.com/pingcap/tidb/util/set"
 )
@@ -3052,8 +3051,8 @@ func (b *PlanBuilder) pushHintWithoutTableWarning(hint *ast.TableOptimizerHint) 
 	b.ctx.GetSessionVars().StmtCtx.AppendWarning(ErrInternal.GenWithStack(errMsg))
 }
 
-func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType utilhint.NodeType, currentLevel int) {
-	hints = b.hintProcessor.GetCurrentStmtHints(hints, nodeType, currentLevel)
+func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, currentLevel int) {
+	hints = b.hintProcessor.GetCurrentStmtHints(hints, currentLevel)
 	var (
 		sortMergeTables, INLJTables, INLHJTables, INLMJTables, hashJoinTables, BCTables, BCJPreferLocalTables []hintTableInfo
 		indexHintList, indexMergeHintList                                                                     []indexHintInfo
@@ -3075,19 +3074,19 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType u
 
 		switch hint.HintName.L {
 		case TiDBMergeJoin, HintSMJ:
-			sortMergeTables = append(sortMergeTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			sortMergeTables = append(sortMergeTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case TiDBBroadCastJoin, HintBCJ:
-			BCTables = append(BCTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			BCTables = append(BCTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case HintBCJPreferLocal:
-			BCJPreferLocalTables = append(BCJPreferLocalTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			BCJPreferLocalTables = append(BCJPreferLocalTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case TiDBIndexNestedLoopJoin, HintINLJ:
-			INLJTables = append(INLJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			INLJTables = append(INLJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case HintINLHJ:
-			INLHJTables = append(INLHJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			INLHJTables = append(INLHJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case HintINLMJ:
-			INLMJTables = append(INLMJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			INLMJTables = append(INLMJTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case TiDBHashJoin, HintHJ:
-			hashJoinTables = append(hashJoinTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+			hashJoinTables = append(hashJoinTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 		case HintHashAgg:
 			aggHints.preferAggType |= preferHashAgg
 		case HintStreamAgg:
@@ -3127,9 +3126,9 @@ func (b *PlanBuilder) pushTableHints(hints []*ast.TableOptimizerHint, nodeType u
 		case HintReadFromStorage:
 			switch hint.HintData.(model.CIStr).L {
 			case HintTiFlash:
-				tiflashTables = append(tiflashTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+				tiflashTables = append(tiflashTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 			case HintTiKV:
-				tikvTables = append(tikvTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, nodeType, currentLevel)...)
+				tikvTables = append(tikvTables, tableNames2HintTableInfo(b.ctx, hint.HintName.L, hint.Tables, b.hintProcessor, currentLevel)...)
 			}
 		case HintIndexMerge:
 			dbName := hint.Tables[0].DBName
@@ -3241,7 +3240,7 @@ func (b *PlanBuilder) TableHints() *tableHintInfo {
 
 func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p LogicalPlan, err error) {
 	b.pushSelectOffset(sel.QueryBlockOffset)
-	b.pushTableHints(sel.TableHints, utilhint.TypeSelect, sel.QueryBlockOffset)
+	b.pushTableHints(sel.TableHints, sel.QueryBlockOffset)
 	defer func() {
 		b.popSelectOffset()
 		// table hints are only visible in the current SELECT statement.
@@ -4169,7 +4168,7 @@ func buildColumns2Handle(
 
 func (b *PlanBuilder) buildUpdate(ctx context.Context, update *ast.UpdateStmt) (Plan, error) {
 	b.pushSelectOffset(0)
-	b.pushTableHints(update.TableHints, utilhint.TypeUpdate, 0)
+	b.pushTableHints(update.TableHints, 0)
 	defer func() {
 		b.popSelectOffset()
 		// table hints are only visible in the current UPDATE statement.
@@ -4520,7 +4519,7 @@ func extractDefaultExpr(node ast.ExprNode) *ast.DefaultExpr {
 
 func (b *PlanBuilder) buildDelete(ctx context.Context, delete *ast.DeleteStmt) (Plan, error) {
 	b.pushSelectOffset(0)
-	b.pushTableHints(delete.TableHints, utilhint.TypeDelete, 0)
+	b.pushTableHints(delete.TableHints, 0)
 	defer func() {
 		b.popSelectOffset()
 		// table hints are only visible in the current DELETE statement.

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -152,7 +152,7 @@ func (tr *QueryTimeRange) Condition() string {
 	return fmt.Sprintf("where time>='%s' and time<='%s'", tr.From.Format(MetricTableTimeFormat), tr.To.Format(MetricTableTimeFormat))
 }
 
-func tableNames2HintTableInfo(ctx sessionctx.Context, hintName string, hintTables []ast.HintTable, p *hint.BlockHintProcessor, nodeType hint.NodeType, currentOffset int) []hintTableInfo {
+func tableNames2HintTableInfo(ctx sessionctx.Context, hintName string, hintTables []ast.HintTable, p *hint.BlockHintProcessor, currentOffset int) []hintTableInfo {
 	if len(hintTables) == 0 {
 		return nil
 	}
@@ -164,7 +164,7 @@ func tableNames2HintTableInfo(ctx sessionctx.Context, hintName string, hintTable
 			dbName:       hintTable.DBName,
 			tblName:      hintTable.TableName,
 			partitions:   hintTable.PartitionList,
-			selectOffset: p.GetHintOffset(hintTable.QBName, nodeType, currentOffset),
+			selectOffset: p.GetHintOffset(hintTable.QBName, currentOffset),
 		}
 		if tableInfo.dbName.L == "" {
 			tableInfo.dbName = defaultDBName

--- a/util/hint/hint_processor.go
+++ b/util/hint/hint_processor.go
@@ -262,19 +262,26 @@ func ParseHintsSet(p *parser.Parser, sql, charset, collation, db string) (*Hints
 	hs := CollectHint(stmtNodes[0])
 	processor := &BlockHintProcessor{}
 	stmtNodes[0].Accept(processor)
-	hintNodeType := nodeType4Stmt(stmtNodes[0])
+	topNodeType := nodeType4Stmt(stmtNodes[0])
 	for i, tblHints := range hs.tableHints {
 		newHints := make([]*ast.TableOptimizerHint, 0, len(tblHints))
+		curOffset := i + 1
+		if topNodeType == TypeDelete || topNodeType == TypeUpdate {
+			curOffset = curOffset - 1
+		}
 		for _, tblHint := range tblHints {
 			if tblHint.HintName.L == hintQBName {
 				continue
 			}
-			offset := processor.GetHintOffset(tblHint.QBName, hintNodeType, i+1)
-			if offset < 0 || !processor.checkTableQBName(tblHint.Tables, hintNodeType) {
+			offset := processor.GetHintOffset(tblHint.QBName, curOffset)
+			if offset < 0 || !processor.checkTableQBName(tblHint.Tables) {
 				hintStr := RestoreTableOptimizerHint(tblHint)
 				return nil, nil, nil, errors.New(fmt.Sprintf("Unknown query block name in hint %s", hintStr))
 			}
-			tblHint.QBName = GenerateQBName(hintNodeType, offset)
+			tblHint.QBName, err = GenerateQBName(topNodeType, offset)
+			if err != nil {
+				return nil, nil, nil, err
+			}
 			for i, tbl := range tblHint.Tables {
 				if tbl.DBName.String() == "" {
 					tblHint.Tables[i].DBName = model.NewCIStr(db)
@@ -401,9 +408,9 @@ func nodeType4Stmt(node ast.StmtNode) NodeType {
 	return TypeInvalid
 }
 
-// getBlockName finds the offset of query block name. It use 0 as offset for top level update or delete,
+// getBlockName finds the offset of query block name. It uses 0 as offset for top level update or delete,
 // -1 for invalid block name.
-func (p *BlockHintProcessor) getBlockOffset(blockName model.CIStr, nodeType NodeType) int {
+func (p *BlockHintProcessor) getBlockOffset(blockName model.CIStr) int {
 	if p.QbNameMap != nil {
 		level, ok := p.QbNameMap[blockName.L]
 		if ok {
@@ -411,13 +418,10 @@ func (p *BlockHintProcessor) getBlockOffset(blockName model.CIStr, nodeType Node
 		}
 	}
 	// Handle the default query block name.
-	if nodeType == TypeUpdate && blockName.L == defaultUpdateBlockName {
+	if blockName.L == defaultUpdateBlockName || blockName.L == defaultDeleteBlockName {
 		return 0
 	}
-	if nodeType == TypeDelete && blockName.L == defaultDeleteBlockName {
-		return 0
-	}
-	if nodeType == TypeSelect && strings.HasPrefix(blockName.L, defaultSelectBlockPrefix) {
+	if strings.HasPrefix(blockName.L, defaultSelectBlockPrefix) {
 		suffix := blockName.L[len(defaultSelectBlockPrefix):]
 		level, err := strconv.ParseInt(suffix, 10, 64)
 		if err != nil || level > int64(p.selectStmtOffset) {
@@ -429,16 +433,16 @@ func (p *BlockHintProcessor) getBlockOffset(blockName model.CIStr, nodeType Node
 }
 
 // GetHintOffset gets the offset of stmt that the hints take effects.
-func (p *BlockHintProcessor) GetHintOffset(qbName model.CIStr, nodeType NodeType, currentOffset int) int {
+func (p *BlockHintProcessor) GetHintOffset(qbName model.CIStr, currentOffset int) int {
 	if qbName.L != "" {
-		return p.getBlockOffset(qbName, nodeType)
+		return p.getBlockOffset(qbName)
 	}
 	return currentOffset
 }
 
-func (p *BlockHintProcessor) checkTableQBName(tables []ast.HintTable, nodeType NodeType) bool {
+func (p *BlockHintProcessor) checkTableQBName(tables []ast.HintTable) bool {
 	for _, table := range tables {
-		if table.QBName.L != "" && p.getBlockOffset(table.QBName, nodeType) < 0 {
+		if table.QBName.L != "" && p.getBlockOffset(table.QBName) < 0 {
 			return false
 		}
 	}
@@ -446,7 +450,7 @@ func (p *BlockHintProcessor) checkTableQBName(tables []ast.HintTable, nodeType N
 }
 
 // GetCurrentStmtHints extracts all hints that take effects at current stmt.
-func (p *BlockHintProcessor) GetCurrentStmtHints(hints []*ast.TableOptimizerHint, nodeType NodeType, currentOffset int) []*ast.TableOptimizerHint {
+func (p *BlockHintProcessor) GetCurrentStmtHints(hints []*ast.TableOptimizerHint, currentOffset int) []*ast.TableOptimizerHint {
 	if p.QbHints == nil {
 		p.QbHints = make(map[int][]*ast.TableOptimizerHint)
 	}
@@ -454,8 +458,8 @@ func (p *BlockHintProcessor) GetCurrentStmtHints(hints []*ast.TableOptimizerHint
 		if hint.HintName.L == hintQBName {
 			continue
 		}
-		offset := p.GetHintOffset(hint.QBName, nodeType, currentOffset)
-		if offset < 0 || !p.checkTableQBName(hint.Tables, nodeType) {
+		offset := p.GetHintOffset(hint.QBName, currentOffset)
+		if offset < 0 || !p.checkTableQBName(hint.Tables) {
 			hintStr := RestoreTableOptimizerHint(hint)
 			p.Ctx.GetSessionVars().StmtCtx.AppendWarning(errors.New(fmt.Sprintf("Hint %s is ignored due to unknown query block name", hintStr)))
 			continue
@@ -466,11 +470,15 @@ func (p *BlockHintProcessor) GetCurrentStmtHints(hints []*ast.TableOptimizerHint
 }
 
 // GenerateQBName builds QBName from offset.
-func GenerateQBName(nodeType NodeType, blockOffset int) model.CIStr {
-	if nodeType == TypeDelete && (blockOffset == 0 || blockOffset == 1) {
-		return model.NewCIStr(defaultDeleteBlockName)
-	} else if nodeType == TypeUpdate && (blockOffset == 0 || blockOffset == 1) {
-		return model.NewCIStr(defaultUpdateBlockName)
+func GenerateQBName(nodeType NodeType, blockOffset int) (model.CIStr, error) {
+	if blockOffset == 0 {
+		if nodeType == TypeDelete {
+			return model.NewCIStr(defaultDeleteBlockName), nil
+		}
+		if nodeType == TypeUpdate {
+			return model.NewCIStr(defaultUpdateBlockName), nil
+		}
+		return model.NewCIStr(""), errors.New(fmt.Sprintf("Unexpected NodeType %d when block offset is 0", nodeType))
 	}
-	return model.NewCIStr(fmt.Sprintf("%s%d", defaultSelectBlockPrefix, blockOffset))
+	return model.NewCIStr(fmt.Sprintf("%s%d", defaultSelectBlockPrefix, blockOffset)), nil
 }


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21822

Problem Summary:

Baseline capture fails for update containing subquery.

### What is changed and how it works?

What's Changed:
- Don't check `NodeType` when getting offset for a query block name, because the node type is just the outer most node type, e.g, the top node type is update, while the embedded node type is select;
- Enforce the restriction that `selectOffset` for Update / Delete must be 0, and adjust `GenerateQBName`;
- Don't generate join hint with empty table name;


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix baseline capture failure for update containing subquery