### PR TITLE
txn: disable amend by default on master

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -5970,6 +5970,7 @@ func (s *testDBSuite1) TestAlterTableWithValidation(c *C) {
 func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 	// Prepare work.
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
 	tk.MustExec("drop database if exists test_db")
 	tk.MustExec("create database test_db")
 	tk.MustExec("use test_db")
@@ -6041,7 +6042,6 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 			false,
 			model.StateNone},
 		// Test unique index
-		/* TODO unique index is not supported now.
 		{[]string{"insert into t1 values(3, 30, 300)",
 			"insert into t1 values(4, 40, 400)",
 			"insert into t2 values(11, 11, 11)",
@@ -6085,7 +6085,6 @@ func (s *testSerialDBSuite) TestCommitTxnWithIndexChange(c *C) {
 				{"1 10 100", "2 20 200"}},
 			true,
 			model.StateWriteOnly},
-		*/
 	}
 	tk.MustQuery("select * from t1;").Check(testkit.Rows("1 10 100", "2 20 200"))
 

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -2034,6 +2034,9 @@ func (s *testPessimisticSuite) TestAsyncCommitWithSchemaChange(c *C) {
 	tk.MustExec("insert into tk values(1, 1, 1)")
 	tk2 := s.newAsyncCommitTestKitWithInit(c)
 	tk3 := s.newAsyncCommitTestKitWithInit(c)
+	tk.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
+	tk2.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
+	tk3.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
 
 	// The txn tk writes something but with failpoint the primary key is not committed.
 	tk.MustExec("begin pessimistic")
@@ -2099,6 +2102,9 @@ func (s *testPessimisticSuite) Test1PCWithSchemaChange(c *C) {
 	tk.MustExec("drop table if exists tk")
 	tk.MustExec("create table tk (c1 int primary key, c2 int)")
 	tk.MustExec("insert into tk values (1, 1)")
+	tk.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
+	tk2.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
+	tk3.MustExec("set tidb_enable_amend_pessimistic_txn = 1;")
 
 	tk.MustExec("begin pessimistic")
 	tk.MustExec("insert into tk values(2, 2)")

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2140,6 +2140,8 @@ func (s *testSchemaSuite) TestRetrySchemaChangeForEmptyChange(c *C) {
 	tk.MustExec("insert into t1 values (1)")
 	tk.MustExec("commit")
 
+	// TODO remove this enable after fixing table delta map.
+	tk.MustExec("set tidb_enable_amend_pessimistic_txn = 1")
 	tk.MustExec("begin pessimistic")
 	tk1.MustExec("alter table t add k int")
 	tk.MustExec("select * from t for update")

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -607,7 +607,7 @@ const (
 	DefTiDBShardAllocateStep            = math.MaxInt64
 	DefTiDBEnableTelemetry              = true
 	DefTiDBEnableParallelApply          = false
-	DefTiDBEnableAmendPessimisticTxn    = true
+	DefTiDBEnableAmendPessimisticTxn    = false
 	DefTiDBPartitionPruneMode           = "static-only"
 	DefTiDBEnableRateLimitAction        = true
 	DefTiDBEnableAsyncCommit            = false


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

Transaction amend is not a released feature on the master branch, disable it by default. And there is still more new compatibility issues to solve like https://github.com/pingcap/tidb/issues/21470.

### What is changed and how it works?

What's Changed:

How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
