### PR TITLE
kv: distinguish memdb.Len and memdb.Count

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -238,6 +238,8 @@ type MemBuffer interface {
 	Size() int
 	// Len returns the number of entries in the DB.
 	Len() int
+	// Count returns the number of keys in the DB.
+	Count() int
 	// Dirty returns whether the root staging buffer is updated.
 	Dirty() bool
 }

--- a/kv/memdb_arena.go
+++ b/kv/memdb_arena.go
@@ -310,6 +310,8 @@ func (l *memdbVlog) revertToCheckpoint(db *memdb, cp *memdbCheckpoint) {
 		db.size -= int(hdr.valueLen)
 		// oldValue.isNull() == true means this is a newly added value.
 		if hdr.oldValue.isNull() {
+			db.len--
+
 			// If there are no flags associated with this key, we need to delete this node.
 			keptFlags := node.getKeyFlags() & persistentFlags
 			if keptFlags == 0 {

--- a/kv/memdb_test.go
+++ b/kv/memdb_test.go
@@ -51,6 +51,7 @@ func (db *memdb) DeleteKey(key []byte) {
 	}
 	db.size -= len(db.vlog.getValue(x.vptr))
 	db.deleteNode(x)
+	db.len--
 }
 
 func (s *testMemDBSuite) TestGetSet(c *C) {
@@ -471,11 +472,14 @@ func (s *testMemDBSuite) TestFlags(c *C) {
 		var buf [4]byte
 		binary.BigEndian.PutUint32(buf[:], i)
 		if i%2 == 0 {
-			db.SetWithFlags(buf[:], buf[:], SetPresumeKeyNotExists, SetKeyLocked)
+			db.UpdateFlags(buf[:], SetKeyLocked)
 		} else {
 			db.SetWithFlags(buf[:], buf[:], SetPresumeKeyNotExists)
 		}
 	}
+	c.Assert(db.Len(), Equals, 5000)
+	c.Assert(db.Count(), Equals, 10000)
+
 	db.Cleanup(h)
 
 	for i := uint32(0); i < cnt; i++ {
@@ -493,7 +497,8 @@ func (s *testMemDBSuite) TestFlags(c *C) {
 		}
 	}
 
-	c.Assert(db.Len(), Equals, 5000)
+	c.Assert(db.Len(), Equals, 0)
+	c.Assert(db.Count(), Equals, 5000)
 	c.Assert(db.Size(), Equals, 20000)
 
 	it1, _ := db.Iter(nil, nil)

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -457,7 +457,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 
 	txn := c.txn
 	memBuf := txn.GetMemBuffer()
-	sizeHint := txn.us.GetMemBuffer().Len()
+	sizeHint := txn.us.GetMemBuffer().Count()
 	c.mutations = newMemBufferMutations(sizeHint, memBuf)
 	c.isPessimistic = txn.IsPessimistic()
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21722

Problem Summary:
Due to we have merged the `locked` map into memdb as `KeyLocked` flag, the `memdb.Len` will take these flags only keys into account. This behavior will break the assumption of the `memdb.Len` should return the number of values in it. In #21722 this breaking change results in a false positive on that assertion.

### What is changed and how it works?
Using separate counters to track the number of keys and values. `memdb.Len` only tracks the number of values which is the same as the old memdb, and introduces `memdb.Count` to report the total number of keys which is useful in some scenarios.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
  - `TestFlags` is updated to cover #21722.
- Manual test
  - Run queries in #21722, to ensure there is no problem.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
