### PR TITLE
planner: ignore ORDER BY when there is aggregate without GROUP BY

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1963,6 +1963,12 @@ func (s *testIntegrationSuite) TestOrderByHavingNotInSelect(c *C) {
 		"[planner:3029]Expression #1 of ORDER BY contains aggregate function and applies to the result of a non-aggregated query")
 	tk.MustGetErrMsg("select v1 from ttest having count(v2)",
 		"[planner:8123]In aggregated query without GROUP BY, expression #1 of SELECT list contains nonaggregated column 'v1'; this is incompatible with sql_mode=only_full_group_by")
+
+	// ignore ORDER BY
+	tk.MustQuery("select count(v1) from ttest order by v1").Check(testkit.Rows("3"))
+	tk.MustQuery("select count(v1) from ttest order by v2").Check(testkit.Rows("3"))
+	tk.MustQuery("select count(distinct v1) from ttest order by v2").Check(testkit.Rows("2"))
+	tk.MustQuery("select count(distinct v1) from ttest order by count(v2)").Check(testkit.Rows("2"))
 }
 
 func (s *testIntegrationSuite) TestUpdateSetDefault(c *C) {
@@ -2022,6 +2028,12 @@ func (s *testIntegrationSuite) TestOrderByNotInSelectDistinct(c *C) {
 	tk.MustQuery("select distinct sum(v1) as z from ttest group by v2 order by z+1").Check(testkit.Rows("1", "4"))
 	tk.MustQuery("select distinct sum(v1)+1 from ttest group by v2 order by sum(v1)+1").Check(testkit.Rows("2", "5"))
 	tk.MustQuery("select distinct v1 as z from ttest order by v1+z").Check(testkit.Rows("1", "4"))
+
+	// ignore ORDER BY
+	tk.MustQuery("select distinct count(v1) from ttest order by v2").Check(testkit.Rows("3"))
+	tk.MustQuery("select distinct count(v1) from ttest order by v1").Check(testkit.Rows("3"))
+	tk.MustQuery("select distinct count(v1) from ttest order by count(v1)").Check(testkit.Rows("3"))
+	tk.MustQuery("select distinct count(v1) from ttest order by sum(v2)").Check(testkit.Rows("3"))
 }
 
 func (s *testIntegrationSuite) TestCorrelatedColumnAggFuncPushDown(c *C) {

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3051,7 +3051,8 @@ func (b *PlanBuilder) buildSelect(ctx context.Context, sel *ast.SelectStmt) (p L
 		}
 	}
 
-	if sel.OrderBy != nil {
+	ignoreOrderBy := hasAgg && sel.GroupBy == nil
+	if sel.OrderBy != nil && !ignoreOrderBy {
 		if b.ctx.GetSessionVars().SQLMode.HasOnlyFullGroupBy() {
 			p, err = b.buildSortWithCheck(ctx, p, sel.OrderBy.Items, orderMap, windowMapper, projExprs, oldLen, sel.Distinct)
 		} else {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -462,7 +462,7 @@ func (s *testPlanSuite) TestPlanBuilder(c *C) {
 	s.testData.GetTestCases(c, &input, &output)
 	ctx := context.Background()
 	for i, ca := range input {
-		comment := Commentf("for %s", ca)
+		comment := Commentf("case:%d, for %s", ca)
 		stmt, err := s.ParseOneStmt(ca, "", "")
 		c.Assert(err, IsNil, comment)
 
@@ -477,7 +477,7 @@ func (s *testPlanSuite) TestPlanBuilder(c *C) {
 		s.testData.OnRecord(func() {
 			output[i] = ToString(p)
 		})
-		c.Assert(ToString(p), Equals, output[i], Commentf("for %s", ca))
+		c.Assert(ToString(p), Equals, output[i], comment)
 	}
 }
 
@@ -512,7 +512,7 @@ func (s *testPlanSuite) TestEagerAggregation(c *C) {
 	ctx := context.Background()
 	s.ctx.GetSessionVars().AllowAggPushDown = true
 	for ith, tt := range input {
-		comment := Commentf("for %s", tt)
+		comment := Commentf("case:%d, for %s", ith, tt)
 		stmt, err := s.ParseOneStmt(tt, "", "")
 		c.Assert(err, IsNil, comment)
 
@@ -523,7 +523,7 @@ func (s *testPlanSuite) TestEagerAggregation(c *C) {
 		s.testData.OnRecord(func() {
 			output[ith] = ToString(p)
 		})
-		c.Assert(ToString(p), Equals, output[ith], Commentf("for %s %d", tt, ith))
+		c.Assert(ToString(p), Equals, output[ith], comment)
 	}
 	s.ctx.GetSessionVars().AllowAggPushDown = false
 }
@@ -538,7 +538,7 @@ func (s *testPlanSuite) TestColumnPruning(c *C) {
 
 	ctx := context.Background()
 	for i, tt := range input {
-		comment := Commentf("for %s", tt)
+		comment := Commentf("case:%d, for %s", i, tt)
 		stmt, err := s.ParseOneStmt(tt, "", "")
 		c.Assert(err, IsNil, comment)
 

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -3,7 +3,7 @@
     "Name": "TestEagerAggregation",
     "Cases": [
       "DataScan(t)->Aggr(sum(test.t.a),sum(plus(test.t.a, 1)),count(test.t.a))->Projection",
-      "DataScan(t)->Aggr(sum(plus(test.t.a, test.t.b)),sum(plus(test.t.a, test.t.c)),count(test.t.a))->Sel([gt(Column#13, 0)])->Projection->Sort->Projection",
+      "DataScan(t)->Aggr(sum(plus(test.t.a, test.t.b)),sum(plus(test.t.a, test.t.c)),count(test.t.a))->Sel([gt(Column#13, 0)])->Projection->Projection",
       "Join{DataScan(a)->Aggr(sum(test.t.a),firstrow(test.t.c))->DataScan(b)}(test.t.c,test.t.c)->Aggr(sum(Column#26))->Projection",
       "Join{DataScan(a)->DataScan(b)->Aggr(sum(test.t.a),firstrow(test.t.c))}(test.t.c,test.t.c)->Aggr(sum(Column#26))->Projection",
       "Join{DataScan(a)->DataScan(b)->Aggr(sum(test.t.a),firstrow(test.t.c))}(test.t.c,test.t.c)->Aggr(sum(Column#26),firstrow(test.t.a))->Projection",
@@ -193,7 +193,7 @@
       "IndexReader(Index(t.f)[[NULL,+inf]]->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Projection",
       "TableReader(Table(t))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#14 over())->Sort->Projection",
       "TableReader(Table(t))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#14 over(partition by test.t.a))->Sort->Projection",
-      "TableReader(Table(t)->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Sort->Projection",
+      "TableReader(Table(t)->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Projection",
       "Apply{IndexReader(Index(t.f)[[NULL,+inf]])->IndexReader(Index(t.f)[[NULL,+inf]]->Sel([gt(test.t.a, test.t.a)]))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#26 over())->MaxOneRow->Sel([Column#26])}->Projection",
       "[planner:3594]You cannot use the alias 'w' of an expression containing a window function in this context.'",
       "[planner:1247]Reference 'sum_a' not supported (reference to window function)",
@@ -266,7 +266,7 @@
       "IndexReader(Index(t.f)[[NULL,+inf]]->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Projection",
       "TableReader(Table(t))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#14 over())->Sort->Projection",
       "TableReader(Table(t))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#14 over(partition by test.t.a))->Sort->Projection",
-      "TableReader(Table(t)->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Sort->Projection",
+      "TableReader(Table(t)->StreamAgg)->StreamAgg->Window(sum(Column#13)->Column#15 over())->Projection",
       "Apply{IndexReader(Index(t.f)[[NULL,+inf]])->IndexReader(Index(t.f)[[NULL,+inf]]->Sel([gt(test.t.a, test.t.a)]))->Window(sum(cast(test.t.a, decimal(65,0) BINARY))->Column#26 over())->MaxOneRow->Sel([Column#26])}->Projection",
       "[planner:3594]You cannot use the alias 'w' of an expression containing a window function in this context.'",
       "[planner:1247]Reference 'sum_a' not supported (reference to window function)",
@@ -628,8 +628,7 @@
       },
       {
         "1": [
-          "test.t.a",
-          "test.t.d"
+          "test.t.a"
         ],
         "2": [
           "test.t.d"


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: MySQL will ignore ORDER BY when there is aggregate without GROUP BY.

For example,

``` mysql
create table t (a int, b int);

select count(a) from t order by b;                            # ✔︎
select count(a) from t order by a;                            # ✔︎
select distinct count(a) from t order by a;                   # ✔︎
select distinct count(a) from t order by sum(a);              # ✔︎
select count(a) from t group by b order by a;                 # ✗
select distinct count(a) from t group by b order by sum(a);   # ✗
select distinct b from t group by a order by count(a);        # ✗
```

### What is changed and how it works?

- do not check and build `Sort` if there is aggregate without GROUP BY.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Ignore ORDER BY when there is aggregate without GROUP BY. <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
