### PR TITLE
*: fix invalid txn with DDL

### DIFF
--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -75,6 +75,17 @@ func (s *testSuite6) TestInTxnExecDDLFail(c *C) {
 	result.Check(testkit.Rows("1"))
 }
 
+func (s *testSuite6) TestInTxnExecDDLInvalid(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (c_int int, c_str varchar(40));")
+	tk.MustExec("insert into t values (1, 'quizzical hofstadter');")
+	tk.MustExec("begin;")
+	_ = tk.MustQuery("select c_int from t where c_str is not null for update;")
+	tk.MustExec("alter table t add index idx_4 (c_str);")
+}
+
 func (s *testSuite6) TestCreateTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/session/session.go
+++ b/session/session.go
@@ -1309,21 +1309,6 @@ func runStmt(ctx context.Context, se *session, s sqlexec.Statement) (rs sqlexec.
 	}
 	rs, err = s.Exec(ctx)
 	sessVars.TxnCtx.StatementCount++
-	if !s.IsReadOnly(sessVars) {
-		// All the history should be added here.
-		if err == nil && sessVars.TxnCtx.CouldRetry {
-			GetHistory(se).Add(s, sessVars.StmtCtx)
-		}
-
-		// Handle the stmt commit/rollback.
-		if se.txn.Valid() {
-			if err != nil {
-				se.StmtRollback()
-			} else {
-				se.StmtCommit()
-			}
-		}
-	}
 	if rs != nil {
 		return &execStmtResult{
 			RecordSet: rs,


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21722 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Select for update statement in optimistic transaction still lazy execute, so it has no chance to `StmtCommit` when executing.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Move `StmtCommit` in `finishStmt`.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix invalid txn when executing DDL after `SELECT FOR UPDATE` statement in transaction.
