### PR TITLE
planner: allow a nonaggregate column not named in GROUP BY clause when this column is limited to single value

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2055,3 +2055,17 @@ func (s *testIntegrationSuite) TestConditionColPruneInPhysicalUnionScan(c *C) {
 	tk.MustQuery("select count(*) from t where c = 1 and c in (3);").
 		Check(testkit.Rows("0"))
 }
+
+// Test for issue https://github.com/pingcap/tidb/issues/18320
+func (s *testIntegrationSuite) TestNonaggregateColumnWithSingleValueInOnlyFullGroupByMode(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int, b int, c int)")
+	tk.MustExec("insert into t values (1, 2, 3), (4, 5, 6), (7, 8, 9)")
+	tk.MustQuery("select a, count(b) from t where a = 1").Check(testkit.Rows("1 1"))
+	tk.MustQuery("select a, count(b) from t where a = 10").Check(testkit.Rows("<nil> 0"))
+	tk.MustQuery("select a, c, sum(b) from t where a = 1 group by c").Check(testkit.Rows("1 3 2"))
+	tk.MustGetErrMsg("select a from t where a = 1 order by count(b)", "[planner:3029]Expression #1 of ORDER BY contains aggregate function and applies to the result of a non-aggregated query")
+	tk.MustQuery("select a from t where a = 1 having count(b) > 0").Check(testkit.Rows("1"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!-->

### What problem does this PR solve?

Issue Number: close #18320 <!-- REMOVE this line if no issue to close -->

Problem Summary:
A nonaggregate column not named in a GROUP BY clause but limited to a single value is illegal under ONLY_FULL_GROUP_BY mode.

### What is changed and how it works?

What's Changed:
```
create table t(a int,b int);
select a,count(b) from t where a=10;
```
Before this PR:
```
ERROR 8123 (HY000): In aggregated query without GROUP BY, expression of SELECT list contains nonaggregated column 'a'; this is incompatible with sql_mode=only_full_group_by
```
After this PR:
```
+------+----------+
| a    | count(b) |
+------+----------+
| NULL |        0 |
+------+----------+
1 row in set (0.00 sec)
```

How It Works?

Collect columns which are limited to single value. For every nonaggregate column not named in GROUP BY clause, check whether it is among columns which are either in GROUP BY clause or limited to single value,  or determined by those columns.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- allow a nonaggregate column not named in a GROUP BY clause when this column is limited to a single value<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
