### PR TITLE
planner/core: add 'split table using statistics' statement

### DIFF
--- a/executor/split.go
+++ b/executor/split.go
@@ -500,6 +500,11 @@ func (e *SplitTableRegionExec) getSplitTablePhysicalKeysFromValueList(physicalID
 }
 
 func (e *SplitTableRegionExec) getSplitTableKeysFromBound() ([][]byte, error) {
+	if e.num == 0 {
+		// A dummy operation.
+		e.done = true
+		return nil, nil
+	}
 	var keys [][]byte
 	pi := e.tableInfo.GetPartitionInfo()
 	if pi == nil {

--- a/go.mod
+++ b/go.mod
@@ -89,3 +89,5 @@ require (
 )
 
 go 1.13
+
+replace github.com/pingcap/parser => github.com/tiancaiamao/parser v0.0.0-20201216062414-3d43b083e82c

--- a/go.sum
+++ b/go.sum
@@ -861,6 +861,10 @@ github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7
 github.com/thda/tds v0.1.7/go.mod h1:isLIF1oZdXfkqVMJM8RyNrsjlHPlTKnPlnsBs7ngZcM=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
+github.com/tiancaiamao/parser v0.0.0-20201214031037-5711ad4cde4b h1:L2i3TdEcd6xYQ0Z8zHbFJCwE5yzrX4qmnStyWbW/pvM=
+github.com/tiancaiamao/parser v0.0.0-20201214031037-5711ad4cde4b/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
+github.com/tiancaiamao/parser v0.0.0-20201216062414-3d43b083e82c h1:C1hrKQEJOX+juW74wAMjqfs9aLT+yQDqlSS33iQe+OY=
+github.com/tiancaiamao/parser v0.0.0-20201216062414-3d43b083e82c/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

TiDB has [`split table by (value list)...` and `split table between ...`](https://docs.pingcap.com/tidb/dev/sql-statement-split-region#split-table-region) grammar.
In `split table by ...`, the user need to provide the values list which is inconvenient.
In `split table between ...` the range is evenly split which may not be applicable to some cases.

Maybe we can add another one: `split table using statistics ...` 

For example:

```
create table t1 (c1 int, c2 varchar, primary key (c1,c2));
insert into t1 (c1, c2) select m,n from t2;
```

Here the data distribution of `t1` is decided by `t2`, we can leverage the statistics from `t2` when splitting `t1`.

`split table t1 using statistics c1 = t2.m, c2 = t2.n regions 256`

Problem Summary:

### What is changed and how it works?

What's Changed:

Support `split table using statistics` statement.

How it Works:

Use the column histogram to calculate the split values list.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

### Release note <!-- bugfixes or new feature need a release note -->

- Add another `split table` grammar that allows user to split table by specifying column statistics