### PR TITLE
executor: set StmtType correctly in SummaryStmt for failed queries

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1021,6 +1021,10 @@ func (a *ExecStmt) SummaryStmt(succ bool) {
 		return
 	}
 	stmtCtx := sessVars.StmtCtx
+	// Make sure StmtType is filled even if succ is false.
+	if stmtCtx.StmtType == "" {
+		stmtCtx.StmtType = GetStmtLabel(a.StmtNode)
+	}
 	normalizedSQL, digest := stmtCtx.SQLDigest()
 	costTime := time.Since(sessVars.StartTime) + sessVars.DurationParse
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21646

Problem Summary:

Baseline capture would fail if the first execution of a query fails.

### What is changed and how it works?

What's Changed:

Set the `StmtType` correctly even if the query fails in `SummaryStmt`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Set StmtType correctly in SummaryStmt for failed queries