### PR TITLE
bindinfo: enforce default_db to lower case for SQL bind operations

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -943,6 +943,92 @@ func (s *testSuite) TestCaptureDBCaseSensitivity(c *C) {
 	c.Assert(rows[0][8], Equals, "manual")
 }
 
+func (s *testSuite) TestBaselineDBLowerCase(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	s.cleanBindingEnv(tk)
+	stmtsummary.StmtSummaryByDigestMap.Clear()
+	tk.MustExec("drop database if exists SPM")
+	tk.MustExec("create database SPM")
+	tk.MustExec("use SPM")
+	tk.MustExec("create table t(a int, b int)")
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk.MustExec("update t set a = a + 1")
+	tk.MustExec("update t set a = a + 1")
+	tk.MustExec("admin capture bindings")
+	rows := tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "update t set a = a + ?")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustExec("drop global binding for update t set a = a + 1")
+	rows = tk.MustQuery("show global bindings").Rows()
+	// DROP GLOBAL BINGING should remove the binding even if we are in SPM database.
+	c.Assert(len(rows), Equals, 0)
+
+	tk.MustExec("create global binding for select * from t using select * from t")
+	rows = tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustExec("drop global binding for select * from t")
+	rows = tk.MustQuery("show global bindings").Rows()
+	// DROP GLOBAL BINGING should remove the binding even if we are in SPM database.
+	c.Assert(len(rows), Equals, 0)
+
+	tk.MustExec("create session binding for select * from t using select * from t")
+	rows = tk.MustQuery("show session bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustExec("drop session binding for select * from t")
+	rows = tk.MustQuery("show session bindings").Rows()
+	// DROP SESSION BINGING should remove the binding even if we are in SPM database.
+	c.Assert(len(rows), Equals, 0)
+
+	s.cleanBindingEnv(tk)
+	// Simulate existing bindings with upper case default_db.
+	tk.MustExec("insert into mysql.bind_info values('select * from t', 'select * from t', 'SPM', 'using', '2000-01-01 09:00:00', '2000-01-01 09:00:00', '', '','" +
+		bindinfo.Manual + "')")
+	tk.MustQuery("select original_sql, default_db from mysql.bind_info where original_sql = 'select * from t'").Check(testkit.Rows(
+		"select * from t SPM",
+	))
+	tk.MustExec("admin reload bindings")
+	rows = tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustExec("drop global binding for select * from t")
+	rows = tk.MustQuery("show global bindings").Rows()
+	// DROP GLOBAL BINGING should remove the binding even if we are in SPM database.
+	c.Assert(len(rows), Equals, 0)
+
+	s.cleanBindingEnv(tk)
+	// Simulate existing bindings with upper case default_db.
+	tk.MustExec("insert into mysql.bind_info values('select * from t', 'select * from t', 'SPM', 'using', '2000-01-01 09:00:00', '2000-01-01 09:00:00', '', '','" +
+		bindinfo.Manual + "')")
+	tk.MustQuery("select original_sql, default_db from mysql.bind_info where original_sql = 'select * from t'").Check(testkit.Rows(
+		"select * from t SPM",
+	))
+	tk.MustExec("admin reload bindings")
+	rows = tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustExec("create global binding for select * from t using select * from t")
+	rows = tk.MustQuery("show global bindings").Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "select * from t")
+	// default_db should have lower case.
+	c.Assert(rows[0][2], Equals, "spm")
+	tk.MustQuery("select original_sql, default_db, status from mysql.bind_info where original_sql = 'select * from t'").Check(testkit.Rows(
+		"select * from t spm using",
+	))
+}
+
 func (s *testSuite) TestCaptureBaselinesDefaultDB(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	s.cleanBindingEnv(tk)

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -14,6 +14,7 @@
 package bindinfo
 
 import (
+	"strings"
 	"time"
 
 	"github.com/pingcap/parser"
@@ -51,6 +52,7 @@ func (h *SessionHandle) CreateBindRecord(sctx sessionctx.Context, record *BindRe
 	if err != nil {
 		return err
 	}
+	record.Db = strings.ToLower(record.Db)
 	now := types.NewTime(types.FromGoTime(time.Now().In(sctx.GetSessionVars().StmtCtx.TimeZone)), mysql.TypeTimestamp, 3)
 	for i := range record.Bindings {
 		record.Bindings[i].CreateTime = now
@@ -64,6 +66,7 @@ func (h *SessionHandle) CreateBindRecord(sctx sessionctx.Context, record *BindRe
 
 // DropBindRecord drops a BindRecord in the cache.
 func (h *SessionHandle) DropBindRecord(originalSQL, db string, binding *Binding) error {
+	db = strings.ToLower(db)
 	oldRecord := h.GetBindRecord(originalSQL, db)
 	var newRecord *BindRecord
 	record := &BindRecord{OriginalSQL: originalSQL, Db: db}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21841

Problem Summary:

DROP BINDING does not take effect when default_db does not match from case sensitivity perspective.

### What is changed and how it works?


What's Changed:

- unify all the `default_db` to lower case for all SQL bind operations;
- for existing bindings, add `LOWER()` function in SQL to handle them;

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- enforce default_db to lower case for SQL bind operations