### PR TITLE
planner: the issue that incorrect result is returned for indeterministic function when executing a prepared point-get update.

### DIFF
--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -532,19 +532,19 @@ func (s *seqTestSuite) TestPreparedUpdate(c *C) {
 		if flag {
 			counter.Write(pb)
 			hit := pb.GetCounter().GetValue()
-			c.Check(hit, Equals, float64(2))
+			c.Check(hit, Equals, float64(0))
 		}
 		tk.MustExec(`set @a=2,@b=200; execute stmt_update using @b,@a;`)
 		if flag {
 			counter.Write(pb)
 			hit := pb.GetCounter().GetValue()
-			c.Check(hit, Equals, float64(3))
+			c.Check(hit, Equals, float64(1))
 		}
 		tk.MustExec(`set @a=3,@b=300; execute stmt_update using @b,@a;`)
 		if flag {
 			counter.Write(pb)
 			hit := pb.GetCounter().GetValue()
-			c.Check(hit, Equals, float64(4))
+			c.Check(hit, Equals, float64(2))
 		}
 
 		result := tk.MustQuery("select id, c1 from prepare_test where id = ?", 1)
@@ -554,6 +554,30 @@ func (s *seqTestSuite) TestPreparedUpdate(c *C) {
 		result = tk.MustQuery("select id, c1 from prepare_test where id = ?", 3)
 		result.Check(testkit.Rows("3 303"))
 	}
+}
+
+func (s *seqTestSuite) TestIssue21884(c *C) {
+	orgEnable := plannercore.PreparedPlanCacheEnabled()
+	defer func() {
+		plannercore.SetPreparedPlanCache(orgEnable)
+	}()
+	plannercore.SetPreparedPlanCache(false)
+
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists prepare_test")
+	tk.MustExec("create table prepare_test(a bigint primary key, status bigint, last_update_time datetime)")
+	tk.MustExec("insert into prepare_test values (100, 0, '2020-12-18 20:00:00')")
+	tk.MustExec("prepare stmt from 'update prepare_test set status = ?, last_update_time = now() where a = 100'")
+	tk.MustExec("set @status = 1")
+	tk.MustExec("execute stmt using @status")
+	updateTime := tk.MustQuery("select last_update_time from prepare_test").Rows()[0][0]
+	// Sleep 1 second to make sure `last_update_time` is updated.
+	time.Sleep(1 * time.Second)
+	tk.MustExec("execute stmt using @status")
+	newUpdateTime := tk.MustQuery("select last_update_time from prepare_test").Rows()[0][0]
+	c.Assert(updateTime == newUpdateTime, IsFalse)
 }
 
 func (s *seqTestSuite) TestPreparedDelete(c *C) {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -418,15 +418,17 @@ func (e *Execute) tryCachePointPlan(ctx context.Context, sctx sessionctx.Context
 			return err
 		}
 	case *Update:
-		ok, err = IsPointUpdateByAutoCommit(sctx, p)
-		if err != nil {
-			return err
-		}
-		if ok {
-			// make constant expression store paramMarker
-			sctx.GetSessionVars().StmtCtx.PointExec = true
-			p, names, err = OptimizeAstNode(ctx, sctx, prepared.Stmt, is)
-		}
+		// Temporarily turn off the cache for UPDATE to solve #21884.
+
+		//ok, err = IsPointUpdateByAutoCommit(sctx, p)
+		//if err != nil {
+		//	return err
+		//}
+		//if ok {
+		//	// make constant expression store paramMarker
+		//	sctx.GetSessionVars().StmtCtx.PointExec = true
+		//	p, names, err = OptimizeAstNode(ctx, sctx, prepared.Stmt, is)
+		//}
 	}
 	if ok {
 		// just cache point plan now


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: #21884

Problem Summary:
In #12243, the evaluated value of the parameters of the prepared statement is improperly cached in `tryCachePointPlan`, which caused the bug reported in #21884 :

https://github.com/pingcap/tidb/blob/91bbcb8ab1a7354a4e3ddd1a41d38a8b510ea284/planner/core/common_plans.go#L405

### What is changed and how it works?

How it Works:
Commented the related caching codes in `tryCachePointPlan` as a short-term solution, the fix will be refined in the future.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that incorrect result is returned for indeterministic function when executing a prepared point-get update with "prepared plan cache" is disabled.
