### PR TITLE
planner: propagate NDV of column groups across plan nodes (#17854)

### DIFF
--- a/expression/column.go
+++ b/expression/column.go
@@ -15,6 +15,7 @@ package expression
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -602,4 +603,14 @@ func (col *Column) Coercibility() Coercibility {
 	}
 	col.SetCoercibility(deriveCoercibilityForColumn(col))
 	return col.collationInfo.Coercibility()
+}
+
+// SortColumns sort columns based on UniqueID.
+func SortColumns(cols []*Column) []*Column {
+	sorted := make([]*Column, len(cols))
+	copy(sorted, cols)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].UniqueID < sorted[j].UniqueID
+	})
+	return sorted
 }

--- a/expression/schema.go
+++ b/expression/schema.go
@@ -161,6 +161,23 @@ func (s *Schema) ColumnsByIndices(offsets []int) []*Column {
 	return cols
 }
 
+// ExtractColGroups checks if column groups are from current schema, and returns
+// offsets of those satisfied column groups.
+func (s *Schema) ExtractColGroups(colGroups [][]*Column) ([][]int, []int) {
+	if len(colGroups) == 0 {
+		return nil, nil
+	}
+	extracted := make([][]int, 0, len(colGroups))
+	offsets := make([]int, 0, len(colGroups))
+	for i, g := range colGroups {
+		if j := s.ColumnsIndices(g); j != nil {
+			extracted = append(extracted, j)
+			offsets = append(offsets, i)
+		}
+	}
+	return extracted, offsets
+}
+
 // MergeSchema will merge two schema into one schema. We shouldn't need to consider unique keys.
 // That will be processed in build_key_info.go.
 func MergeSchema(lSchema, rSchema *Schema) *Schema {

--- a/planner/cascades/optimize.go
+++ b/planner/cascades/optimize.go
@@ -234,7 +234,7 @@ func (opt *Optimizer) fillGroupStats(g *memo.Group) (err error) {
 		childSchema[i] = childGroup.Prop.Schema
 	}
 	planNode := expr.ExprNode
-	g.Prop.Stats, err = planNode.DeriveStats(childStats, g.Prop.Schema, childSchema)
+	g.Prop.Stats, err = planNode.DeriveStats(childStats, g.Prop.Schema, childSchema, nil)
 	return err
 }
 

--- a/planner/core/indexmerge_test.go
+++ b/planner/core/indexmerge_test.go
@@ -116,7 +116,7 @@ func (s *testIndexMergeSuite) TestIndexMergePathGeneration(c *C) {
 		}
 		ds.ctx.GetSessionVars().SetEnableIndexMerge(true)
 		idxMergeStartIndex := len(ds.possibleAccessPaths)
-		_, err = lp.recursiveDeriveStats()
+		_, err = lp.recursiveDeriveStats(nil)
 		c.Assert(err, IsNil)
 		result := getIndexMergePathDigest(ds.possibleAccessPaths, idxMergeStartIndex)
 		s.testdata.OnRecord(func() {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1526,7 +1526,7 @@ func (s *testPlanSuite) TestSkylinePruning(c *C) {
 		p, err = logicalOptimize(ctx, builder.optFlag, p.(LogicalPlan))
 		c.Assert(err, IsNil, comment)
 		lp := p.(LogicalPlan)
-		_, err = lp.recursiveDeriveStats()
+		_, err = lp.recursiveDeriveStats(nil)
 		c.Assert(err, IsNil, comment)
 		var ds *DataSource
 		var byItems []*util.ByItems

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -170,7 +170,7 @@ func isLogicalRuleDisabled(r logicalOptRule) bool {
 }
 
 func physicalOptimize(logic LogicalPlan) (PhysicalPlan, float64, error) {
-	if _, err := logic.recursiveDeriveStats(); err != nil {
+	if _, err := logic.recursiveDeriveStats(nil); err != nil {
 		return nil, 0, err
 	}
 

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -167,12 +167,19 @@ type LogicalPlan interface {
 	pushDownTopN(topN *LogicalTopN) LogicalPlan
 
 	// recursiveDeriveStats derives statistic info between plans.
-	recursiveDeriveStats() (*property.StatsInfo, error)
+	recursiveDeriveStats(colGroups [][]*expression.Column) (*property.StatsInfo, error)
 
 	// DeriveStats derives statistic info for current plan node given child stats.
 	// We need selfSchema, childSchema here because it makes this method can be used in
 	// cascades planner, where LogicalPlan might not record its children or schema.
-	DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error)
+	DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error)
+
+	// ExtractColGroups extracts column groups from child operator whose DNVs are required by the current operator.
+	// For example, if current operator is LogicalAggregation of `Group By a, b`, we indicate the child operators to maintain
+	// and propagate the NDV info of column group (a, b), to improve the row count estimation of current LogicalAggregation.
+	// The parameter colGroups are column groups required by upper operators, besides from the column groups derived from
+	// current operator, we should pass down parent colGroups to child operator as many as possible.
+	ExtractColGroups(colGroups [][]*expression.Column) [][]*expression.Column
 
 	// PreparePossibleProperties is only used for join and aggregation. Like group by a,b,c, all permutation of (a,b,c) is
 	// valid, but the ordered indices in leaf plan is limited. So we can get all possible order properties by a pre-walking.

--- a/planner/core/rule_join_reorder_dp.go
+++ b/planner/core/rule_join_reorder_dp.go
@@ -38,7 +38,7 @@ type joinGroupNonEqEdge struct {
 
 func (s *joinReorderDPSolver) solve(joinGroup []LogicalPlan, eqConds []expression.Expression) (LogicalPlan, error) {
 	for _, node := range joinGroup {
-		_, err := node.recursiveDeriveStats()
+		_, err := node.recursiveDeriveStats(nil)
 		if err != nil {
 			return nil, err
 		}
@@ -245,7 +245,7 @@ func (s *joinReorderDPSolver) newJoinWithEdge(leftPlan, rightPlan LogicalPlan, e
 		}
 	}
 	join := s.newJoin(leftPlan, rightPlan, eqConds, otherConds)
-	_, err := join.recursiveDeriveStats()
+	_, err := join.recursiveDeriveStats(nil)
 	return join, err
 }
 

--- a/planner/core/rule_join_reorder_dp_test.go
+++ b/planner/core/rule_join_reorder_dp_test.go
@@ -49,7 +49,7 @@ func (mj mockLogicalJoin) init(ctx sessionctx.Context) *mockLogicalJoin {
 	return &mj
 }
 
-func (mj *mockLogicalJoin) recursiveDeriveStats() (*property.StatsInfo, error) {
+func (mj *mockLogicalJoin) recursiveDeriveStats(_ [][]*expression.Column) (*property.StatsInfo, error) {
 	if mj.stats == nil {
 		mj.stats = mj.statsMap[mj.involvedNodeSet]
 	}

--- a/planner/core/rule_join_reorder_greedy.go
+++ b/planner/core/rule_join_reorder_greedy.go
@@ -42,7 +42,7 @@ type joinReorderGreedySolver struct {
 // connect them, we make a bushy join tree to do the cartesian joins finally.
 func (s *joinReorderGreedySolver) solve(joinNodePlans []LogicalPlan) (LogicalPlan, error) {
 	for _, node := range joinNodePlans {
-		_, err := node.recursiveDeriveStats()
+		_, err := node.recursiveDeriveStats(nil)
 		if err != nil {
 			return nil, err
 		}
@@ -80,7 +80,7 @@ func (s *joinReorderGreedySolver) constructConnectedJoinTree() (*jrNode, error) 
 			if newJoin == nil {
 				continue
 			}
-			_, err := newJoin.recursiveDeriveStats()
+			_, err := newJoin.recursiveDeriveStats(nil)
 			if err != nil {
 				return nil, err
 			}

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"math"
+	"sort"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
@@ -34,7 +35,10 @@ func (p *basePhysicalPlan) StatsCount() float64 {
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalTableDual) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalTableDual) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	profile := &property.StatsInfo{
 		RowCount:    float64(p.RowCount),
 		Cardinality: make(map[int64]float64, selfSchema.Len()),
@@ -47,7 +51,10 @@ func (p *LogicalTableDual) DeriveStats(childStats []*property.StatsInfo, selfSch
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalMemTable) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalMemTable) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	statsTable := statistics.PseudoTable(p.TableInfo)
 	stats := &property.StatsInfo{
 		RowCount:     float64(statsTable.Count),
@@ -63,7 +70,10 @@ func (p *LogicalMemTable) DeriveStats(childStats []*property.StatsInfo, selfSche
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalShow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalShow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	// A fake count, just to avoid panic now.
 	p.stats = getFakeStats(selfSchema)
 	return p.stats, nil
@@ -81,31 +91,47 @@ func getFakeStats(schema *expression.Schema) *property.StatsInfo {
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalShowDDLJobs) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalShowDDLJobs) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	// A fake count, just to avoid panic now.
 	p.stats = getFakeStats(selfSchema)
 	return p.stats, nil
 }
 
-func (p *baseLogicalPlan) recursiveDeriveStats() (*property.StatsInfo, error) {
-	if p.stats != nil {
-		return p.stats, nil
-	}
+// RecursiveDeriveStats4Test is a exporter just for test.
+func RecursiveDeriveStats4Test(p LogicalPlan) (*property.StatsInfo, error) {
+	return p.recursiveDeriveStats(nil)
+}
+
+// GetStats4Test is a exporter just for test.
+func GetStats4Test(p LogicalPlan) *property.StatsInfo {
+	return p.statsInfo()
+}
+
+func (p *baseLogicalPlan) recursiveDeriveStats(colGroups [][]*expression.Column) (*property.StatsInfo, error) {
 	childStats := make([]*property.StatsInfo, len(p.children))
 	childSchema := make([]*expression.Schema, len(p.children))
+	cumColGroups := p.self.ExtractColGroups(colGroups)
 	for i, child := range p.children {
-		childProfile, err := child.recursiveDeriveStats()
+		childProfile, err := child.recursiveDeriveStats(cumColGroups)
 		if err != nil {
 			return nil, err
 		}
 		childStats[i] = childProfile
 		childSchema[i] = child.Schema()
 	}
-	return p.self.DeriveStats(childStats, p.self.Schema(), childSchema)
+	return p.self.DeriveStats(childStats, p.self.Schema(), childSchema, colGroups)
+}
+
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (p *baseLogicalPlan) ExtractColGroups(_ [][]*expression.Column) [][]*expression.Column {
+	return nil
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *baseLogicalPlan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *baseLogicalPlan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
 	if len(childStats) == 1 {
 		p.stats = childStats[0]
 		return p.stats, nil
@@ -113,6 +139,9 @@ func (p *baseLogicalPlan) DeriveStats(childStats []*property.StatsInfo, selfSche
 	if len(childStats) > 1 {
 		err := ErrInternal.GenWithStack("LogicalPlans with more than one child should implement their own DeriveStats().")
 		return nil, err
+	}
+	if p.stats != nil {
+		return p.stats, nil
 	}
 	profile := &property.StatsInfo{
 		RowCount:    float64(1),
@@ -138,8 +167,48 @@ func (ds *DataSource) getColumnNDV(colID int64) (ndv float64) {
 	return ndv
 }
 
-func (ds *DataSource) initStats() {
+func (ds *DataSource) getGroupNDVs(colGroups [][]*expression.Column) []property.GroupNDV {
+	if colGroups == nil {
+		return nil
+	}
+	tbl := ds.tableStats.HistColl
+	ndvs := make([]property.GroupNDV, 0, len(colGroups))
+	for idxID, idx := range tbl.Indices {
+		idxCols := make([]int64, len(tbl.Idx2ColumnIDs[idxID]))
+		copy(idxCols, tbl.Idx2ColumnIDs[idxID])
+		sort.Slice(idxCols, func(i, j int) bool {
+			return idxCols[i] < idxCols[j]
+		})
+		for _, g := range colGroups {
+			// We only want those exact matches.
+			if len(g) != len(idxCols) {
+				continue
+			}
+			match := true
+			for i, col := range g {
+				// Both slices are sorted according to UniqueID.
+				if col.UniqueID != idxCols[i] {
+					match = false
+					break
+				}
+			}
+			if match {
+				ndv := property.GroupNDV{
+					Cols: idxCols,
+					NDV:  float64(idx.NDV),
+				}
+				ndvs = append(ndvs, ndv)
+				break
+			}
+		}
+	}
+	return ndvs
+}
+
+func (ds *DataSource) initStats(colGroups [][]*expression.Column) {
 	if ds.tableStats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		ds.tableStats.GroupNDVs = ds.getGroupNDVs(colGroups)
 		return
 	}
 	if ds.statisticTable == nil {
@@ -158,11 +227,11 @@ func (ds *DataSource) initStats() {
 		tableStats.Cardinality[col.UniqueID] = ds.getColumnNDV(col.ID)
 	}
 	ds.tableStats = tableStats
+	ds.tableStats.GroupNDVs = ds.getGroupNDVs(colGroups)
 	ds.TblColHists = ds.statisticTable.ID2UniqueID(ds.TblCols)
 }
 
 func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs, filledPaths []*util.AccessPath) *property.StatsInfo {
-	ds.initStats()
 	selectivity, nodes, err := ds.tableStats.HistColl.Selectivity(ds.ctx, conds, filledPaths)
 	if err != nil {
 		logutil.BgLogger().Debug("something wrong happened, use the default selectivity", zap.Error(err))
@@ -176,8 +245,17 @@ func (ds *DataSource) deriveStatsByFilter(conds expression.CNFExprs, filledPaths
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
-	ds.initStats()
+func (ds *DataSource) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
+	if ds.stats != nil && len(colGroups) == 0 {
+		return ds.stats, nil
+	}
+	ds.initStats(colGroups)
+	if ds.stats != nil {
+		// Just reload the GroupNDVs.
+		selectivity := ds.stats.RowCount / ds.tableStats.RowCount
+		ds.stats = ds.tableStats.Scale(selectivity)
+		return ds.stats, nil
+	}
 	// PushDownNot here can convert query 'not (a != 1)' to 'a = 1'.
 	for i, expr := range ds.pushedDownConds {
 		ds.pushedDownConds[i] = expression.PushDownNot(ds.ctx, expr)
@@ -264,7 +342,8 @@ func (ds *DataSource) generateAndPruneIndexMergePath(needPrune bool) {
 }
 
 // DeriveStats implements LogicalPlan DeriveStats interface.
-func (ts *LogicalTableScan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (_ *property.StatsInfo, err error) {
+func (ts *LogicalTableScan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (_ *property.StatsInfo, err error) {
+	ts.Source.initStats(nil)
 	// PushDownNot here can convert query 'not (a != 1)' to 'a = 1'.
 	for i, expr := range ts.AccessConds {
 		// TODO The expressions may be shared by TableScan and several IndexScans, there would be redundant
@@ -292,7 +371,8 @@ func (ts *LogicalTableScan) DeriveStats(childStats []*property.StatsInfo, selfSc
 }
 
 // DeriveStats implements LogicalPlan DeriveStats interface.
-func (is *LogicalIndexScan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (is *LogicalIndexScan) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	is.Source.initStats(nil)
 	for i, expr := range is.AccessConds {
 		is.AccessConds[i] = expression.PushDownNot(is.ctx, expr)
 	}
@@ -469,13 +549,20 @@ func (ds *DataSource) buildIndexMergeOrPath(partialPaths []*util.AccessPath, cur
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalSelection) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalSelection) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	p.stats = childStats[0].Scale(SelectionFactor)
+	p.stats.GroupNDVs = nil
 	return p.stats, nil
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalUnionAll) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalUnionAll) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	p.stats = &property.StatsInfo{
 		Cardinality: make(map[int64]float64, selfSchema.Len()),
 	}
@@ -500,13 +587,19 @@ func deriveLimitStats(childProfile *property.StatsInfo, limitCount float64) *pro
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalLimit) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalLimit) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	p.stats = deriveLimitStats(childStats[0], float64(p.Count))
 	return p.stats, nil
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (lt *LogicalTopN) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (lt *LogicalTopN) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if lt.stats != nil {
+		return lt.stats, nil
+	}
 	lt.stats = deriveLimitStats(childStats[0], float64(lt.Count))
 	return lt.stats, nil
 }
@@ -528,9 +621,52 @@ func getCardinality(cols []*expression.Column, schema *expression.Schema, profil
 	return cardinality
 }
 
+func (p *LogicalProjection) getGroupNDVs(colGroups [][]*expression.Column, childProfile *property.StatsInfo, selfSchema *expression.Schema) []property.GroupNDV {
+	if len(colGroups) == 0 || len(childProfile.GroupNDVs) == 0 {
+		return nil
+	}
+	exprCol2ProjCol := make(map[int64]int64)
+	for i, expr := range p.Exprs {
+		exprCol, ok := expr.(*expression.Column)
+		if !ok {
+			continue
+		}
+		exprCol2ProjCol[exprCol.UniqueID] = selfSchema.Columns[i].UniqueID
+	}
+	ndvs := make([]property.GroupNDV, 0, len(childProfile.GroupNDVs))
+	for _, childGroupNDV := range childProfile.GroupNDVs {
+		projCols := make([]int64, len(childGroupNDV.Cols))
+		for i, col := range childGroupNDV.Cols {
+			projCol, ok := exprCol2ProjCol[col]
+			if !ok {
+				projCols = nil
+				break
+			}
+			projCols[i] = projCol
+		}
+		if projCols == nil {
+			continue
+		}
+		sort.Slice(projCols, func(i, j int) bool {
+			return projCols[i] < projCols[j]
+		})
+		groupNDV := property.GroupNDV{
+			Cols: projCols,
+			NDV:  childGroupNDV.NDV,
+		}
+		ndvs = append(ndvs, groupNDV)
+	}
+	return ndvs
+}
+
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalProjection) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalProjection) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
 	childProfile := childStats[0]
+	if p.stats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childProfile, selfSchema)
+		return p.stats, nil
+	}
 	p.stats = &property.StatsInfo{
 		RowCount:    childProfile.RowCount,
 		Cardinality: make(map[int64]float64, len(p.Exprs)),
@@ -539,16 +675,78 @@ func (p *LogicalProjection) DeriveStats(childStats []*property.StatsInfo, selfSc
 		cols := expression.ExtractColumns(expr)
 		p.stats.Cardinality[selfSchema.Columns[i].UniqueID] = getCardinality(cols, childSchema[0], childProfile)
 	}
+	p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childProfile, selfSchema)
 	return p.stats, nil
 }
 
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (p *LogicalProjection) ExtractColGroups(colGroups [][]*expression.Column) [][]*expression.Column {
+	if len(colGroups) == 0 {
+		return nil
+	}
+	extColGroups, _ := p.Schema().ExtractColGroups(colGroups)
+	if len(extColGroups) == 0 {
+		return nil
+	}
+	extracted := make([][]*expression.Column, 0, len(extColGroups))
+	for _, cols := range extColGroups {
+		exprs := make([]*expression.Column, len(cols))
+		allCols := true
+		for i, offset := range cols {
+			col, ok := p.Exprs[offset].(*expression.Column)
+			// TODO: for functional dependent projections like `col1 + 1` -> `col2`, we can maintain GroupNDVs actually.
+			if !ok {
+				allCols = false
+				break
+			}
+			exprs[i] = col
+		}
+		if allCols {
+			extracted = append(extracted, expression.SortColumns(exprs))
+		}
+	}
+	return extracted
+}
+
+func (la *LogicalAggregation) getGroupNDVs(colGroups [][]*expression.Column, childProfile *property.StatsInfo, selfSchema *expression.Schema, gbyCols []*expression.Column) []property.GroupNDV {
+	if len(colGroups) == 0 || len(childProfile.GroupNDVs) == 0 {
+		return nil
+	}
+	// Check if the child profile provides GroupNDV for the GROUP BY columns.
+	// Note that gbyCols may not be the exact GROUP BY columns, e.g, GROUP BY a+b,
+	// but we have no other approaches for the cardinality estimation of these cases
+	// except for using the independent assumption, unless we can use stats of expression index.
+	gbyCols = expression.SortColumns(gbyCols)
+	for _, groupNDV := range childProfile.GroupNDVs {
+		if len(gbyCols) != len(groupNDV.Cols) {
+			continue
+		}
+		match := true
+		for i, col := range groupNDV.Cols {
+			if col != gbyCols[i].UniqueID {
+				match = false
+				break
+			}
+		}
+		if match {
+			return []property.GroupNDV{groupNDV}
+		}
+	}
+	return nil
+}
+
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (la *LogicalAggregation) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (la *LogicalAggregation) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
 	childProfile := childStats[0]
 	gbyCols := make([]*expression.Column, 0, len(la.GroupByItems))
 	for _, gbyExpr := range la.GroupByItems {
 		cols := expression.ExtractColumns(gbyExpr)
 		gbyCols = append(gbyCols, cols...)
+	}
+	if la.stats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		la.stats.GroupNDVs = la.getGroupNDVs(colGroups, childProfile, selfSchema, gbyCols)
+		return la.stats, nil
 	}
 	cardinality := getCardinality(gbyCols, childSchema[0], childProfile)
 	la.stats = &property.StatsInfo{
@@ -560,7 +758,39 @@ func (la *LogicalAggregation) DeriveStats(childStats []*property.StatsInfo, self
 		la.stats.Cardinality[col.UniqueID] = cardinality
 	}
 	la.inputCount = childProfile.RowCount
+	la.stats.GroupNDVs = la.getGroupNDVs(colGroups, childProfile, selfSchema, gbyCols)
 	return la.stats, nil
+}
+
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (la *LogicalAggregation) ExtractColGroups(_ [][]*expression.Column) [][]*expression.Column {
+	// Parent colGroups would be dicarded, because aggregation would make NDV of colGroups
+	// which does not match GroupByItems invalid.
+	// Note that gbyCols may not be the exact GROUP BY columns, e.g, GROUP BY a+b,
+	// but we have no other approaches for the cardinality estimation of these cases
+	// except for using the independent assumption, unless we can use stats of expression index.
+	gbyCols := make([]*expression.Column, 0, len(la.GroupByItems))
+	for _, gbyExpr := range la.GroupByItems {
+		cols := expression.ExtractColumns(gbyExpr)
+		gbyCols = append(gbyCols, cols...)
+	}
+	if len(gbyCols) > 0 {
+		return [][]*expression.Column{expression.SortColumns(gbyCols)}
+	}
+	return nil
+}
+
+func (p *LogicalJoin) getGroupNDVs(colGroups [][]*expression.Column, childStats []*property.StatsInfo) []property.GroupNDV {
+	outerIdx := int(-1)
+	if p.JoinType == LeftOuterJoin || p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		outerIdx = 0
+	} else if p.JoinType == RightOuterJoin {
+		outerIdx = 1
+	}
+	if outerIdx >= 0 && len(colGroups) > 0 {
+		return childStats[outerIdx].GroupNDVs
+	}
+	return nil
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
@@ -570,7 +800,12 @@ func (la *LogicalAggregation) DeriveStats(childStats []*property.StatsInfo, self
 // N(s) stands for the number of rows in relation s. V(s.key) means the Cardinality of join key in s.
 // This is a quite simple strategy: We assume every bucket of relation which will participate join has the same number of rows, and apply cross join for
 // every matched bucket.
-func (p *LogicalJoin) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalJoin) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childStats)
+		return p.stats, nil
+	}
 	leftProfile, rightProfile := childStats[0], childStats[1]
 	leftJoinKeys, rightJoinKeys := p.GetJoinKeys()
 	helper := &fullJoinRowCountHelper{
@@ -602,6 +837,7 @@ func (p *LogicalJoin) DeriveStats(childStats []*property.StatsInfo, selfSchema *
 			p.stats.Cardinality[id] = c
 		}
 		p.stats.Cardinality[selfSchema.Columns[selfSchema.Len()-1].UniqueID] = 2.0
+		p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childStats)
 		return p.stats, nil
 	}
 	count := p.equalCondOutCnt
@@ -621,7 +857,34 @@ func (p *LogicalJoin) DeriveStats(childStats []*property.StatsInfo, selfSchema *
 		RowCount:    count,
 		Cardinality: cardinality,
 	}
+	p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childStats)
 	return p.stats, nil
+}
+
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (p *LogicalJoin) ExtractColGroups(colGroups [][]*expression.Column) [][]*expression.Column {
+	leftJoinKeys, rightJoinKeys := p.GetJoinKeys()
+	extracted := make([][]*expression.Column, 0, 2+len(colGroups))
+	if len(leftJoinKeys) > 1 && (p.JoinType == InnerJoin || p.JoinType == LeftOuterJoin || p.JoinType == RightOuterJoin) {
+		extracted = append(extracted, expression.SortColumns(leftJoinKeys), expression.SortColumns(rightJoinKeys))
+	}
+	var outerSchema *expression.Schema
+	if p.JoinType == LeftOuterJoin || p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		outerSchema = p.Children()[0].Schema()
+	} else if p.JoinType == RightOuterJoin {
+		outerSchema = p.Children()[1].Schema()
+	}
+	if len(colGroups) == 0 || outerSchema == nil {
+		return extracted
+	}
+	_, offsets := outerSchema.ExtractColGroups(colGroups)
+	if len(offsets) == 0 {
+		return extracted
+	}
+	for _, offset := range offsets {
+		extracted = append(extracted, colGroups[offset])
+	}
+	return extracted
 }
 
 type fullJoinRowCountHelper struct {
@@ -644,8 +907,20 @@ func (h *fullJoinRowCountHelper) estimate() float64 {
 	return count
 }
 
+func (la *LogicalApply) getGroupNDVs(colGroups [][]*expression.Column, childStats []*property.StatsInfo) []property.GroupNDV {
+	if len(colGroups) > 0 && (la.JoinType == LeftOuterSemiJoin || la.JoinType == AntiLeftOuterSemiJoin || la.JoinType == LeftOuterJoin) {
+		return childStats[0].GroupNDVs
+	}
+	return nil
+}
+
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (la *LogicalApply) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (la *LogicalApply) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
+	if la.stats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		la.stats.GroupNDVs = la.getGroupNDVs(colGroups, childStats)
+		return la.stats, nil
+	}
 	leftProfile := childStats[0]
 	la.stats = &property.StatsInfo{
 		RowCount:    leftProfile.RowCount,
@@ -661,7 +936,29 @@ func (la *LogicalApply) DeriveStats(childStats []*property.StatsInfo, selfSchema
 			la.stats.Cardinality[selfSchema.Columns[i].UniqueID] = leftProfile.RowCount
 		}
 	}
+	la.stats.GroupNDVs = la.getGroupNDVs(colGroups, childStats)
 	return la.stats, nil
+}
+
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (la *LogicalApply) ExtractColGroups(colGroups [][]*expression.Column) [][]*expression.Column {
+	var outerSchema *expression.Schema
+	// Apply doesn't have RightOuterJoin.
+	if la.JoinType == LeftOuterJoin || la.JoinType == LeftOuterSemiJoin || la.JoinType == AntiLeftOuterSemiJoin {
+		outerSchema = la.Children()[0].Schema()
+	}
+	if len(colGroups) == 0 || outerSchema == nil {
+		return nil
+	}
+	_, offsets := outerSchema.ExtractColGroups(colGroups)
+	if len(offsets) == 0 {
+		return nil
+	}
+	extracted := make([][]*expression.Column, len(offsets))
+	for i, offset := range offsets {
+		extracted[i] = colGroups[offset]
+	}
+	return extracted
 }
 
 // Exists and MaxOneRow produce at most one row, so we set the RowCount of stats one.
@@ -677,13 +974,28 @@ func getSingletonStats(schema *expression.Schema) *property.StatsInfo {
 }
 
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalMaxOneRow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalMaxOneRow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, _ [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		return p.stats, nil
+	}
 	p.stats = getSingletonStats(selfSchema)
 	return p.stats, nil
 }
 
+func (p *LogicalWindow) getGroupNDVs(colGroups [][]*expression.Column, childStats []*property.StatsInfo) []property.GroupNDV {
+	if len(colGroups) > 0 {
+		return childStats[0].GroupNDVs
+	}
+	return nil
+}
+
 // DeriveStats implement LogicalPlan DeriveStats interface.
-func (p *LogicalWindow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema) (*property.StatsInfo, error) {
+func (p *LogicalWindow) DeriveStats(childStats []*property.StatsInfo, selfSchema *expression.Schema, childSchema []*expression.Schema, colGroups [][]*expression.Column) (*property.StatsInfo, error) {
+	if p.stats != nil {
+		// Reload GroupNDVs since colGroups may have changed.
+		p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childStats)
+		return p.stats, nil
+	}
 	childProfile := childStats[0]
 	p.stats = &property.StatsInfo{
 		RowCount:    childProfile.RowCount,
@@ -697,5 +1009,23 @@ func (p *LogicalWindow) DeriveStats(childStats []*property.StatsInfo, selfSchema
 	for i := childLen; i < selfSchema.Len(); i++ {
 		p.stats.Cardinality[selfSchema.Columns[i].UniqueID] = childProfile.RowCount
 	}
+	p.stats.GroupNDVs = p.getGroupNDVs(colGroups, childStats)
 	return p.stats, nil
+}
+
+// ExtractColGroups implements LogicalPlan ExtractColGroups interface.
+func (p *LogicalWindow) ExtractColGroups(colGroups [][]*expression.Column) [][]*expression.Column {
+	if len(colGroups) == 0 {
+		return nil
+	}
+	childSchema := p.Children()[0].Schema()
+	_, offsets := childSchema.ExtractColGroups(colGroups)
+	if len(offsets) == 0 {
+		return nil
+	}
+	extracted := make([][]*expression.Column, len(offsets))
+	for i, offset := range offsets {
+		extracted[i] = colGroups[offset]
+	}
+	return extracted
 }

--- a/planner/core/stats_test.go
+++ b/planner/core/stats_test.go
@@ -1,0 +1,138 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"context"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser"
+	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/planner/property"
+	"github.com/pingcap/tidb/util/hint"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
+)
+
+var _ = Suite(&testStatsSuite{})
+
+type testStatsSuite struct {
+	*parser.Parser
+	testData testutil.TestData
+}
+
+func (s *testStatsSuite) SetUpSuite(c *C) {
+	s.Parser = parser.New()
+	s.Parser.EnableWindowFunc(true)
+
+	var err error
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "stats_suite")
+	c.Assert(err, IsNil)
+}
+
+func (s *testStatsSuite) TearDownSuite(c *C) {
+	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
+}
+
+func (s *testStatsSuite) TestGroupNDVs(c *C) {
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk := testkit.NewTestKit(c, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int not null, b int not null, key(a,b))")
+	tk.MustExec("insert into t1 values(1,1),(1,2),(2,1),(2,2),(1,1)")
+	tk.MustExec("create table t2(a int not null, b int not null, key(a,b))")
+	tk.MustExec("insert into t2 values(1,1),(1,2),(1,3),(2,1),(2,2),(2,3),(3,1),(3,2),(3,3),(1,1)")
+	tk.MustExec("analyze table t1")
+	tk.MustExec("analyze table t2")
+
+	ctx := context.Background()
+	var input []string
+	var output []struct {
+		SQL       string
+		AggInput  string
+		JoinInput string
+	}
+	is := dom.InfoSchema()
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		comment := Commentf("case:%v sql: %s", i, tt)
+		stmt, err := s.ParseOneStmt(tt, "", "")
+		c.Assert(err, IsNil, comment)
+		core.Preprocess(tk.Se, stmt, is)
+		builder := core.NewPlanBuilder(tk.Se, is, &hint.BlockHintProcessor{})
+		p, err := builder.Build(ctx, stmt)
+		c.Assert(err, IsNil, comment)
+		p, err = core.LogicalOptimize(ctx, builder.GetOptFlag(), p.(core.LogicalPlan))
+		c.Assert(err, IsNil, comment)
+		lp := p.(core.LogicalPlan)
+		_, err = core.RecursiveDeriveStats4Test(lp)
+		c.Assert(err, IsNil, comment)
+		var agg *core.LogicalAggregation
+		var join *core.LogicalJoin
+		stack := make([]core.LogicalPlan, 0, 2)
+		traversed := false
+		for !traversed {
+			switch v := lp.(type) {
+			case *core.LogicalAggregation:
+				agg = v
+				lp = lp.Children()[0]
+			case *core.LogicalJoin:
+				join = v
+				lp = v.Children()[0]
+				stack = append(stack, v.Children()[1])
+			case *core.LogicalApply:
+				lp = lp.Children()[0]
+				stack = append(stack, v.Children()[1])
+			case *core.LogicalUnionAll:
+				lp = lp.Children()[0]
+				for i := 1; i < len(v.Children()); i++ {
+					stack = append(stack, v.Children()[i])
+				}
+			case *core.DataSource:
+				if len(stack) == 0 {
+					traversed = true
+				} else {
+					lp = stack[0]
+					stack = stack[1:]
+				}
+			default:
+				lp = lp.Children()[0]
+			}
+		}
+		aggInput := ""
+		joinInput := ""
+		if agg != nil {
+			s := core.GetStats4Test(agg.Children()[0])
+			aggInput = property.ToString(s.GroupNDVs)
+		}
+		if join != nil {
+			l := core.GetStats4Test(join.Children()[0])
+			r := core.GetStats4Test(join.Children()[1])
+			joinInput = property.ToString(l.GroupNDVs) + ";" + property.ToString(r.GroupNDVs)
+		}
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].AggInput = aggInput
+			output[i].JoinInput = joinInput
+		})
+		c.Assert(aggInput, Equals, output[i].AggInput, comment)
+		c.Assert(joinInput, Equals, output[i].JoinInput, comment)
+	}
+}

--- a/planner/core/testdata/stats_suite_in.json
+++ b/planner/core/testdata/stats_suite_in.json
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "TestGroupNDVs",
+    "cases": [
+      // DataSource -> Aggregation.
+      "select count(1) from t1 group by a, b",
+      // DataSource -> Join.
+      "select * from t1, t2 where t1.a = t2.a and t1.b = t2.b",
+      // DataSource(Range) -> Aggregation.
+      "select count(1) from t1 where a > 0 group by a, b",
+      // DataSource(Selection) -> Aggregation.
+      "select count(1) from t1 where b > 0 group by a, b",
+      // DataSource -> Selection -> Aggregation. Change `cos` to another function if it can be pushed down to copr later.
+      "select count(1) from t1 where cos(a) > 0 group by a, b",
+      // DataSource -> Projection -> Aggregation.
+      "select count(c3) from (select a as c1, b as c2, a+1 as c3 from t1) as tmp group by c2, c1",
+      // DataSource -> Projection -> Aggregation.
+      "select count(c3) from (select a+b as c1, b as c2, a+1 as c3 from t1) as tmp group by c2, c1",
+      // DataSource -> Apply(LeftOuterJoin) -> Aggregation.
+      "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b > (select t2.b from t2 where t2.a = t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+      // DataSource -> Apply(InnerJoin) -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b > (select t2.b from t2 where t2.a = t1.a)) tmp group by tmp.a, tmp.b",
+      // DataSource -> Apply(LeftOuterSemiJoin) -> Aggregation.
+      "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b in (select t2.b from t2 where t2.a = t1.a limit 3)) as cmp from t1) tmp group by tmp.a, tmp.b",
+      // DataSource -> Apply(AntiLeftOuterSemiJoin) -> Aggregation.
+      "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b not in (select t2.b from t2 where t2.a = t1.a limit 3)) as cmp from t1) tmp group by tmp.a, tmp.b",
+      // DataSource -> Apply(SemiJoin) -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b in (select t2.b from t2 where t2.a = t1.a limit 3)) tmp group by tmp.a, tmp.b",
+      // DataSource -> Apply(AntiSemiJoin) -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b not in (select t2.b from t2 where t2.a = t1.a limit 3)) tmp group by tmp.a, tmp.b",
+      // DataSource -> InnerJoin -> Aggregation.
+      "select count(1) from t1, t2 where t1.a = t2.a group by t1.a, t1.b",
+      // DataSource -> LeftOuterJoin -> Aggregation.
+      "select count(1) from t1 left join t2 on t1.a = t2.a group by t1.a, t1.b",
+      // DataSource -> LeftOuterJoin -> Aggregation.
+      "select count(1) from t1 left join t2 on t1.a = t2.a group by t2.a, t2.b",
+      // DataSource -> RightOuterJoin -> Aggregation.
+      "select count(1) from t1 right join t2 on t1.a = t2.a group by t1.a, t1.b",
+      // DataSource -> RightOuterJoin -> Aggregation.
+      "select count(1) from t1 right join t2 on t1.a = t2.a group by t2.a, t2.b",
+      // DataSource -> LeftOuterSemiJoin -> Aggregation.
+      "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b in (select t2.b from t2 where t2.a > t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+      // DataSource -> AntiLeftOuterSemiJoin -> Aggregation.
+      "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b not in (select t2.b from t2 where t2.a > t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+      // DataSource -> SemiJoin -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b in (select t2.b from t2 where t2.a > t1.a)) tmp group by tmp.a, tmp.b",
+      // DataSource -> AntiSemiJoin -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b not in (select t2.b from t2 where t2.a > t1.a)) tmp group by tmp.a, tmp.b",
+      // DataSource -> Aggregation -> Join.
+      "select * from t1 left join (select t2.a as a, t2.b as b, count(1) as cnt from t2 group by t2.a, t2.b) as tmp on t1.a = tmp.a and t1.b = tmp.b",
+      // DataSource -> Limit -> Aggregation.
+      "select count(1) from (select t1.a as a, t1.b as b from t1 limit 3) tmp group by tmp.a, tmp.b",
+      // DataSource -> Window -> Aggregation.
+      "select count(tmp.a_sum) from (select t1.a as a, t1.b as b, sum(a) over() as a_sum from t1) tmp group by tmp.a, tmp.b"
+    ]
+  }
+]

--- a/planner/core/testdata/stats_suite_out.json
+++ b/planner/core/testdata/stats_suite_out.json
@@ -1,0 +1,132 @@
+[
+  {
+    "Name": "TestGroupNDVs",
+    "Cases": [
+      {
+        "SQL": "select count(1) from t1 group by a, b",
+        "AggInput": "[{[1 2] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select * from t1, t2 where t1.a = t2.a and t1.b = t2.b",
+        "AggInput": "",
+        "JoinInput": "[{[5 6] 4}];[{[8 9] 9}]"
+      },
+      {
+        "SQL": "select count(1) from t1 where a > 0 group by a, b",
+        "AggInput": "[{[11 12] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from t1 where b > 0 group by a, b",
+        "AggInput": "[{[15 16] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from t1 where cos(a) > 0 group by a, b",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(c3) from (select a as c1, b as c2, a+1 as c3 from t1) as tmp group by c2, c1",
+        "AggInput": "[{[23 24] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(c3) from (select a+b as c1, b as c2, a+1 as c3 from t1) as tmp group by c2, c1",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b > (select t2.b from t2 where t2.a = t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[37 38] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b > (select t2.b from t2 where t2.a = t1.a)) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b in (select t2.b from t2 where t2.a = t1.a limit 3)) as cmp from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[53 54] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b not in (select t2.b from t2 where t2.a = t1.a limit 3)) as cmp from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[61 62] 4}]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b in (select t2.b from t2 where t2.a = t1.a limit 3)) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b not in (select t2.b from t2 where t2.a = t1.a limit 3)) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(1) from t1, t2 where t1.a = t2.a group by t1.a, t1.b",
+        "AggInput": "[]",
+        "JoinInput": "[];[]"
+      },
+      {
+        "SQL": "select count(1) from t1 left join t2 on t1.a = t2.a group by t1.a, t1.b",
+        "AggInput": "[{[90 91] 4}]",
+        "JoinInput": "[{[90 91] 4}];[]"
+      },
+      {
+        "SQL": "select count(1) from t1 left join t2 on t1.a = t2.a group by t2.a, t2.b",
+        "AggInput": "[]",
+        "JoinInput": "[];[]"
+      },
+      {
+        "SQL": "select count(1) from t1 right join t2 on t1.a = t2.a group by t1.a, t1.b",
+        "AggInput": "[]",
+        "JoinInput": "[];[]"
+      },
+      {
+        "SQL": "select count(1) from t1 right join t2 on t1.a = t2.a group by t2.a, t2.b",
+        "AggInput": "[{[114 115] 9}]",
+        "JoinInput": "[];[{[114 115] 9}]"
+      },
+      {
+        "SQL": "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b in (select t2.b from t2 where t2.a > t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[118 119] 4}]",
+        "JoinInput": "[{[118 119] 4}];[]"
+      },
+      {
+        "SQL": "select count(tmp.cmp) from (select t1.a as a, t1.b as b, (t1.b not in (select t2.b from t2 where t2.a > t1.a)) as cmp from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[126 127] 4}]",
+        "JoinInput": "[{[126 127] 4}];[]"
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b in (select t2.b from t2 where t2.a > t1.a)) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": "[];[]"
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 where t1.b not in (select t2.b from t2 where t2.a > t1.a)) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": "[];[]"
+      },
+      {
+        "SQL": "select * from t1 left join (select t2.a as a, t2.b as b, count(1) as cnt from t2 group by t2.a, t2.b) as tmp on t1.a = tmp.a and t1.b = tmp.b",
+        "AggInput": "[{[151 152] 9}]",
+        "JoinInput": "[{[148 149] 4}];[{[151 152] 9}]"
+      },
+      {
+        "SQL": "select count(1) from (select t1.a as a, t1.b as b from t1 limit 3) tmp group by tmp.a, tmp.b",
+        "AggInput": "[]",
+        "JoinInput": ""
+      },
+      {
+        "SQL": "select count(tmp.a_sum) from (select t1.a as a, t1.b as b, sum(a) over() as a_sum from t1) tmp group by tmp.a, tmp.b",
+        "AggInput": "[{[159 160] 4}]",
+        "JoinInput": ""
+      }
+    ]
+  }
+]


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/17854

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

First step to solve https://github.com/pingcap/tidb/issues/17185

Problem Summary:

Join size estimation is far from reality.

### What is changed and how it works?

What's Changed:

- Collect column groups which are interested by plan nodes from top-down.
- Maintain NDV of those column groups from bottom-up.

### Related changes

- Need to cherry-pick to the release branch: let's see its effect first.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- Propagate NDV of column groups across plan nodes
