### PR TITLE
executor: throw error when prepared statement is execute, deallocate or prepare

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -147,7 +147,8 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return ErrPrepareDDL
 	}
 
-	if _, ok := stmt.(*ast.LoadDataStmt); ok {
+	switch stmt.(type) {
+	case *ast.LoadDataStmt, *ast.PrepareStmt, *ast.ExecuteStmt, *ast.DeallocateStmt:
 		return ErrUnsupportedPs
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #17412

Problem Summary: 
TiDB regards sql like `prepare stmt1 from "execute stmt"` as valid.

### What is changed and how it works?

What's Changed:
When prepared statement is execute, deallocate or prepare, throw error `ERROR 1295 (HY000): This command is not supported in the prepared statement protocol yet`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- throw error when prepared statement is execute, deallocate or prepare<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
