### PR TITLE
oracle: support txnScope for GetStaleTimestamp

### DIFF
--- a/store/mockoracle/oracle.go
+++ b/store/mockoracle/oracle.go
@@ -72,7 +72,7 @@ func (o *MockOracle) GetTimestamp(ctx context.Context, _ *oracle.Option) (uint64
 }
 
 // GetStaleTimestamp implements oracle.Oracle interface.
-func (o *MockOracle) GetStaleTimestamp(ctx context.Context, prevSecond uint64) (ts uint64, err error) {
+func (o *MockOracle) GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (ts uint64, err error) {
 	physical := oracle.GetPhysical(time.Now().Add(-time.Second * time.Duration(prevSecond)))
 	ts = oracle.ComposeTS(physical, 0)
 	return ts, nil

--- a/store/tikv/oracle/oracle.go
+++ b/store/tikv/oracle/oracle.go
@@ -33,7 +33,7 @@ type Oracle interface {
 	GetTimestampAsync(ctx context.Context, opt *Option) Future
 	GetLowResolutionTimestamp(ctx context.Context, opt *Option) (uint64, error)
 	GetLowResolutionTimestampAsync(ctx context.Context, opt *Option) Future
-	GetStaleTimestamp(ctx context.Context, prevSecond uint64) (uint64, error)
+	GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (uint64, error)
 	IsExpired(lockTimestamp, TTL uint64, opt *Option) bool
 	UntilExpired(lockTimeStamp, TTL uint64, opt *Option) int64
 	Close()

--- a/store/tikv/oracle/oracles/export_test.go
+++ b/store/tikv/oracle/oracles/export_test.go
@@ -60,6 +60,6 @@ func SetEmptyPDOracleLastTs(oc oracle.Oracle, ts uint64) {
 func SetEmptyPDOracleLastArrivalTs(oc oracle.Oracle, ts uint64) {
 	switch o := oc.(type) {
 	case *pdOracle:
-		o.setLastArrivalTS(ts)
+		o.setLastArrivalTS(ts, oracle.GlobalTxnScope)
 	}
 }

--- a/store/tikv/oracle/oracles/export_test.go
+++ b/store/tikv/oracle/oracles/export_test.go
@@ -54,10 +54,11 @@ func SetEmptyPDOracleLastTs(oc oracle.Oracle, ts uint64) {
 		lastTSPointer := lastTSInterface.(*uint64)
 		atomic.StoreUint64(lastTSPointer, ts)
 	}
+	setEmptyPDOracleLastArrivalTs(oc, ts)
 }
 
-// SetEmptyPDOracleLastTs exports PD oracle's global last ts to test.
-func SetEmptyPDOracleLastArrivalTs(oc oracle.Oracle, ts uint64) {
+// setEmptyPDOracleLastArrivalTs exports PD oracle's global last ts to test.
+func setEmptyPDOracleLastArrivalTs(oc oracle.Oracle, ts uint64) {
 	switch o := oc.(type) {
 	case *pdOracle:
 		o.setLastArrivalTS(ts, oracle.GlobalTxnScope)

--- a/store/tikv/oracle/oracles/local.go
+++ b/store/tikv/oracle/oracles/local.go
@@ -79,7 +79,7 @@ func (l *localOracle) GetLowResolutionTimestampAsync(ctx context.Context, opt *o
 }
 
 // GetStaleTimestamp return physical
-func (l *localOracle) GetStaleTimestamp(ctx context.Context, prevSecond uint64) (ts uint64, err error) {
+func (l *localOracle) GetStaleTimestamp(ctx context.Context, txnScope string, prevSecond uint64) (ts uint64, err error) {
 	physical := oracle.GetPhysical(time.Now().Add(-time.Second * time.Duration(prevSecond)))
 	ts = oracle.ComposeTS(physical, 0)
 	return ts, nil

--- a/store/tikv/oracle/oracles/pd.go
+++ b/store/tikv/oracle/oracles/pd.go
@@ -35,7 +35,8 @@ const slowDist = 30 * time.Millisecond
 type pdOracle struct {
 	c pd.Client
 	// txn_scope (string) -> lastTSPointer (*uint64)
-	lastTSMap        sync.Map
+	lastTSMap sync.Map
+	// txn_scope (string) -> lastArrivalTSPointer (*uint64)
 	lastArrivalTSMap sync.Map
 	quit             chan struct{}
 }

--- a/store/tikv/oracle/oracles/pd_test.go
+++ b/store/tikv/oracle/oracles/pd_test.go
@@ -43,7 +43,6 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 	o := oracles.NewEmptyPDOracle()
 	start := time.Now()
 	oracles.SetEmptyPDOracleLastTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
-	oracles.SetEmptyPDOracleLastArrivalTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
 	ts, err := o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, 10)
 	if err != nil {
 		t.Errorf("%v\n", err)
@@ -62,7 +61,6 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 	for i := uint64(3); i < 1e9; i += i/100 + 1 {
 		start = time.Now()
 		oracles.SetEmptyPDOracleLastTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
-		oracles.SetEmptyPDOracleLastArrivalTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
 		ts, err = o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, i)
 		if err != nil {
 			t.Errorf("%v\n", err)

--- a/store/tikv/oracle/oracles/pd_test.go
+++ b/store/tikv/oracle/oracles/pd_test.go
@@ -44,7 +44,7 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 	start := time.Now()
 	oracles.SetEmptyPDOracleLastTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
 	oracles.SetEmptyPDOracleLastArrivalTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
-	ts, err := o.GetStaleTimestamp(context.Background(), 10)
+	ts, err := o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, 10)
 	if err != nil {
 		t.Errorf("%v\n", err)
 	}
@@ -54,7 +54,7 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 		t.Errorf("stable TS have accuracy err, expect: %d +-2, obtain: %d", 10, duration)
 	}
 
-	_, err = o.GetStaleTimestamp(context.Background(), 1e12)
+	_, err = o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, 1e12)
 	if err == nil {
 		t.Errorf("expect exceed err but get nil")
 	}
@@ -63,7 +63,7 @@ func TestPdOracle_GetStaleTimestamp(t *testing.T) {
 		start = time.Now()
 		oracles.SetEmptyPDOracleLastTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
 		oracles.SetEmptyPDOracleLastArrivalTs(o, oracle.ComposeTS(oracle.GetPhysical(start), 0))
-		ts, err = o.GetStaleTimestamp(context.Background(), i)
+		ts, err = o.GetStaleTimestamp(context.Background(), oracle.GlobalTxnScope, i)
 		if err != nil {
 			t.Errorf("%v\n", err)
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: ref https://github.com/pingcap/tidb/issues/21717

Problem Summary:

`GetStaleTimestamp` only support `global` currentlly, this request make it support txnScope.

### Release note <!-- bugfixes or new feature need a release note -->

* No release note
