### PR TITLE
expression: log functions that can not be pushed to cop

### DIFF
--- a/expression/aggregation/aggregation.go
+++ b/expression/aggregation/aggregation.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tipb/go-tipb"
 )
 
@@ -204,6 +205,9 @@ func CheckAggPushDown(aggFunc *AggFuncDesc, storeType kv.StoreType) bool {
 	}
 	if ret {
 		ret = expression.IsPushDownEnabled(strings.ToLower(aggFunc.Name), storeType)
+	}
+	if !ret {
+		logutil.BgLogger().Debug("Agg function " + strings.ToLower(aggFunc.Name) + " can not pushed to cop(" + storeType.Name() + ")")
 	}
 	return ret
 }

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1154,6 +1154,7 @@ func canScalarFuncPushDown(scalarFunc *ScalarFunction, pc PbConverter, storeType
 
 	// Check whether this function can be pushed.
 	if !canFuncBePushed(scalarFunc, storeType) {
+		logutil.BgLogger().Debug("Scalar function " + scalarFunc.FuncName.L + " can not pushed to cop(" + storeType.Name() + ")")
 		return false
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Currently, when user running a query, and found the query is slower than expected because some part of the query(e.g. `Selection` or `Aggregation`) is not pushed down to coprocessor, there is no easy way to find out which function not supported by coprocessor.

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

Log functions that can not be pushed to coprocessor.
### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
