### PR TITLE
session: use ExecuteInternal to execute the bootstrap SQLs

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1421,7 +1421,7 @@ func doDMLWorks(s Session) {
 }
 
 func mustExecute(s Session, sql string) {
-	_, err := s.Execute(context.Background(), sql)
+	_, err := s.ExecuteInternal(context.Background(), sql)
 	if err != nil {
 		debug.PrintStack()
 		logutil.BgLogger().Fatal("mustExecute error", zap.Error(err))


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21978

### What is changed and how it works?

Use `ExecuteInternal` to execute the bootstrap SQLs instead of `Execute` to force using the global transaction scope to commit during the bootstrap phase.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
