### PR TITLE
test: fix globalkilltest

### DIFF
--- a/tests/globalkilltest/global_kill_test.go
+++ b/tests/globalkilltest/global_kill_test.go
@@ -117,8 +117,8 @@ func (s *TestGlobalKillSuite) startTiDBWithoutPD(port int, statusPort int) (cmd 
 		fmt.Sprintf("--path=%s/mocktikv", *tmpPath),
 		fmt.Sprintf("-P=%d", port),
 		fmt.Sprintf("--status=%d", statusPort),
-		fmt.Sprintf("--log-file=%s/tidb%d.log", *tmpPath, port))
-	fmt.Sprintf("--config=%s", "./config.toml")
+		fmt.Sprintf("--log-file=%s/tidb%d.log", *tmpPath, port),
+		fmt.Sprintf("--config=%s", "./config.toml"))
 	log.Infof("starting tidb: %v", cmd)
 	err = cmd.Start()
 	if err != nil {
@@ -135,8 +135,8 @@ func (s *TestGlobalKillSuite) startTiDBWithPD(port int, statusPort int, pdPath s
 		fmt.Sprintf("--path=%s", pdPath),
 		fmt.Sprintf("-P=%d", port),
 		fmt.Sprintf("--status=%d", statusPort),
-		fmt.Sprintf("--log-file=%s/tidb%d.log", *tmpPath, port))
-	fmt.Sprintf("--config=%s", "./config.toml")
+		fmt.Sprintf("--log-file=%s/tidb%d.log", *tmpPath, port),
+		fmt.Sprintf("--config=%s", "./config.toml"))
 	log.Infof("starting tidb: %v", cmd)
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21986 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Fix `globalkilltest` error.

### What is changed and how it works?

What's Changed:
Fix `TiDB` command execution.

How it Works:
Fix `TiDB` command execution.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
No.

- Need to cherry-pick to the release branch
No.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```sh
➜  globalkilltest git:(master) ./run-tests.sh
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
./run-tests.sh: line 57: PD: unbound variable
./run-tests.sh: line 60: TIKV: unbound variable
./run-tests.sh: line 60: kill: (26352) - No such process
2020/12/24 00:36:12.390 global_kill_test.go:109: [info] pd connected
2020/12/24 00:36:12.391 global_kill_test.go:185: [info] start PD proxy: :3379 --> 127.0.0.1:2379
2020/12/24 00:36:12.391 global_kill_test.go:140: [info] starting tidb: bin/globalkilltest_tidb-server --store=tikv -L=info --path=127.0.0.1:3379 -P=5001 --status=8001 --log-file=/tmp/tidb_globalkilltest/tidb5001.log --config=./config.toml
2020/12/24 00:36:12.898 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 0 err dial tcp 127.0.0.1:5001: connect: connection refused
2020/12/24 00:36:13.149 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 1 err dial tcp 127.0.0.1:5001: connect: connection refused
2020/12/24 00:36:13.650 global_kill_test.go:216: [info] connect to server 127.0.0.1:5001 ok
2020/12/24 00:36:13.651 global_kill_test.go:140: [info] starting tidb: bin/globalkilltest_tidb-server --store=tikv -L=info --path=127.0.0.1:3379 -P=5002 --status=8002 --log-file=/tmp/tidb_globalkilltest/tidb5002.log --config=./config.toml
2020/12/24 00:36:14.153 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5002 failed, retry count 0 err dial tcp 127.0.0.1:5002: connect: connection refused
2020/12/24 00:36:14.407 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5002 failed, retry count 1 err dial tcp 127.0.0.1:5002: connect: connection refused
2020/12/24 00:36:14.908 global_kill_test.go:216: [info] connect to server 127.0.0.1:5002 ok
2020/12/24 00:36:14.909 global_kill_test.go:263: [info] exec: SELECT SLEEP(15);
2020/12/24 00:36:15.409 global_kill_test.go:455: [info] shutdown PD proxy to simulate lost connection to PD.
2020/12/24 00:36:15.410 global_kill_test.go:462: [info] sleep 8s to wait for TiDB had detected lost connection
[mysql] 2020/12/24 00:36:22 packets.go:36: unexpected EOF
2020/12/24 00:36:23.410 global_kill_test.go:468: [info] sleepRoutine err: invalid connection
2020/12/24 00:36:23.410 global_kill_test.go:474: [info] check connection after lost connection to PD.
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
2020/12/24 00:36:23.412 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 0 err driver: bad connection
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:23 packets.go:36: unexpected EOF
2020/12/24 00:36:23.668 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 1 err driver: bad connection
[mysql] 2020/12/24 00:36:24 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:24 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:24 packets.go:36: unexpected EOF
2020/12/24 00:36:24.171 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 2 err driver: bad connection
[mysql] 2020/12/24 00:36:25 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:25 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:25 packets.go:36: unexpected EOF
2020/12/24 00:36:25.175 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 3 err driver: bad connection
[mysql] 2020/12/24 00:36:27 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:27 packets.go:36: unexpected EOF
[mysql] 2020/12/24 00:36:27 packets.go:36: unexpected EOF
2020/12/24 00:36:27.179 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 4 err driver: bad connection
2020/12/24 00:36:31.184 global_kill_test.go:211: [error] connect to server addr 127.0.0.1:5001 failed driver: bad connection, take time 7.773797264s
2020/12/24 00:36:31.184 global_kill_test.go:476: [info] connectTiDB err: driver: bad connection
2020/12/24 00:36:31.185 global_kill_test.go:481: [info] restart pdProxy
2020/12/24 00:36:31.185 global_kill_test.go:185: [info] start PD proxy: :3379 --> 127.0.0.1:2379
2020/12/24 00:36:31.185 global_kill_test.go:489: [info] sleep 4s to wait for TiDB had detected lost connection restored
2020/12/24 00:36:35.195 global_kill_test.go:216: [info] connect to server 127.0.0.1:5001 ok
2020/12/24 00:36:35.199 global_kill_test.go:216: [info] connect to server 127.0.0.1:5002 ok
2020/12/24 00:36:35.199 global_kill_test.go:292: [info] connID1: 0x37e5200000000023
2020/12/24 00:36:35.199 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x37e5200000000023]
2020/12/24 00:36:35.701 global_kill_test.go:305: [info] connID2: 0x37e5200000000025
2020/12/24 00:36:35.701 global_kill_test.go:307: [info] exec: KILL QUERY 4027660626124865571(0x37e5200000000023) [on 0x37e5200000000025]
2020/12/24 00:36:35.710 global_kill_test.go:277: [info] sleepRoutine takes 510.842526ms
2020/12/24 00:36:35.710 global_kill_test.go:292: [info] connID1: 0x37e5200000000025
2020/12/24 00:36:35.711 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x37e5200000000025]
2020/12/24 00:36:36.215 global_kill_test.go:305: [info] connID2: 0x4505040000000005
2020/12/24 00:36:36.215 global_kill_test.go:307: [info] exec: KILL QUERY 4027660626124865573(0x37e5200000000025) [on 0x4505040000000005]
2020/12/24 00:36:36.252 global_kill_test.go:277: [info] sleepRoutine takes 541.149341ms
[mysql] 2020/12/24 00:36:36 packets.go:122: closing bad idle connection: EOF
2020/12/24 00:36:39.140 global_kill_test.go:157: [info] service "tidb2" stopped gracefully
2020/12/24 00:36:42.226 global_kill_test.go:157: [info] service "tidb1" stopped gracefully
PASS: global_kill_test.go:412: TestGlobalKillSuite.TestLostConnection	29.835s
2020/12/24 00:36:42.226 global_kill_test.go:140: [info] starting tidb: bin/globalkilltest_tidb-server --store=tikv -L=info --path=127.0.0.1:2379 -P=5001 --status=8001 --log-file=/tmp/tidb_globalkilltest/tidb5001.log --config=./config.toml
2020/12/24 00:36:42.739 global_kill_test.go:216: [info] connect to server 127.0.0.1:5001 ok
2020/12/24 00:36:42.741 global_kill_test.go:216: [info] connect to server 127.0.0.1:5001 ok
2020/12/24 00:36:42.741 global_kill_test.go:140: [info] starting tidb: bin/globalkilltest_tidb-server --store=tikv -L=info --path=127.0.0.1:2379 -P=5002 --status=8002 --log-file=/tmp/tidb_globalkilltest/tidb5002.log --config=./config.toml
2020/12/24 00:36:43.246 global_kill_test.go:216: [info] connect to server 127.0.0.1:5002 ok
2020/12/24 00:36:43.246 global_kill_test.go:231: [info] run mysql cli: /usr/local/bin/mysql -h127.0.0.1 -P5001 -uroot -e SELECT SLEEP(2);
2020/12/24 00:36:45.268 global_kill_test.go:243: [info] mysql cli takes: 2.021966874s
2020/12/24 00:36:45.269 global_kill_test.go:292: [info] connID1: 0x17d840000000003
2020/12/24 00:36:45.269 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x17d840000000003]
2020/12/24 00:36:45.772 global_kill_test.go:305: [info] connID2: 0x17d840000000005
2020/12/24 00:36:45.772 global_kill_test.go:307: [info] exec: KILL QUERY 107387101661626371(0x17d840000000003) [on 0x17d840000000005]
2020/12/24 00:36:45.782 global_kill_test.go:277: [info] sleepRoutine takes 512.596738ms
2020/12/24 00:36:45.782 global_kill_test.go:292: [info] connID1: 0x17d840000000003
2020/12/24 00:36:45.782 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x17d840000000003]
2020/12/24 00:36:46.287 global_kill_test.go:305: [info] connID2: 0x1e38380000000003
2020/12/24 00:36:46.287 global_kill_test.go:307: [info] exec: KILL QUERY 107387101661626371(0x17d840000000003) [on 0x1e38380000000003]
2020/12/24 00:36:46.295 global_kill_test.go:277: [info] sleepRoutine takes 512.936345ms
2020/12/24 00:36:49.206 global_kill_test.go:157: [info] service "tidb2" stopped gracefully
2020/12/24 00:36:52.062 global_kill_test.go:157: [info] service "tidb1" stopped gracefully
PASS: global_kill_test.go:367: TestGlobalKillSuite.TestMultipleTiDB	9.835s
2020/12/24 00:36:52.062 global_kill_test.go:140: [info] starting tidb: bin/globalkilltest_tidb-server --store=tikv -L=info --path=127.0.0.1:2379 -P=5001 --status=8001 --log-file=/tmp/tidb_globalkilltest/tidb5001.log --config=./config.toml
2020/12/24 00:36:52.569 global_kill_test.go:204: [warning] ping addr 127.0.0.1:5001 failed, retry count 0 err dial tcp 127.0.0.1:5001: connect: connection refused
2020/12/24 00:36:52.825 global_kill_test.go:216: [info] connect to server 127.0.0.1:5001 ok
2020/12/24 00:36:52.825 global_kill_test.go:231: [info] run mysql cli: /usr/local/bin/mysql -h127.0.0.1 -P5001 -uroot -e SELECT SLEEP(2);
2020/12/24 00:36:54.848 global_kill_test.go:243: [info] mysql cli takes: 2.022428493s
2020/12/24 00:36:54.848 global_kill_test.go:292: [info] connID1: 0x296f8e0000000003
2020/12/24 00:36:54.849 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x296f8e0000000003]
2020/12/24 00:36:55.357 global_kill_test.go:305: [info] connID2: 0x296f8e0000000009
2020/12/24 00:36:55.357 global_kill_test.go:307: [info] exec: KILL QUERY 2985761208621072387(0x296f8e0000000003) [on 0x296f8e0000000009]
2020/12/24 00:36:55.361 global_kill_test.go:277: [info] sleepRoutine takes 512.140116ms
2020/12/24 00:36:58.199 global_kill_test.go:157: [info] service "tidb" stopped gracefully
PASS: global_kill_test.go:341: TestGlobalKillSuite.TestOneTiDB	6.137s
2020/12/24 00:36:58.199 global_kill_test.go:122: [info] starting tidb: bin/globalkilltest_tidb-server --store=mocktikv -L=info --path=/tmp/tidb_globalkilltest/mocktikv -P=5000 --status=8000 --log-file=/tmp/tidb_globalkilltest/tidb5000.log --config=./config.toml
2020/12/24 00:36:58.710 global_kill_test.go:216: [info] connect to server 127.0.0.1:5000 ok
2020/12/24 00:36:58.710 global_kill_test.go:231: [info] run mysql cli: /usr/local/bin/mysql -h127.0.0.1 -P5000 -uroot -e SELECT SLEEP(2);
2020/12/24 00:37:00.733 global_kill_test.go:243: [info] mysql cli takes: 2.023225728s
2020/12/24 00:37:00.734 global_kill_test.go:292: [info] connID1: 0x20000000003
2020/12/24 00:37:00.734 global_kill_test.go:261: [info] exec: SELECT SLEEP(2); [on 0x20000000003]
2020/12/24 00:37:01.242 global_kill_test.go:305: [info] connID2: 0x20000000009
2020/12/24 00:37:01.242 global_kill_test.go:307: [info] exec: KILL QUERY 2199023255555(0x20000000003) [on 0x20000000009]
2020/12/24 00:37:01.245 global_kill_test.go:277: [info] sleepRoutine takes 510.628939ms
2020/12/24 00:37:01.249 global_kill_test.go:157: [info] service "tidb" stopped gracefully
PASS: global_kill_test.go:317: TestGlobalKillSuite.TestWithoutPD	3.050s
OK: 4 passed
PASS
ok  	github.com/pingcap/tests/globalkilltest	49.279s
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
killall: unknown signal r; valid signals:
HUP INT QUIT ILL TRAP ABRT EMT FPE KILL BUS SEGV SYS PIPE ALRM TERM URG STOP 
TSTP CONT CHLD TTIN TTOU IO XCPU XFSZ VTALRM PROF WINCH INFO USR1 USR2 
globalkilltest end
./run-tests.sh: line 96: kill: (26359) - No such process
➜  globalkilltest git:(master) git status
```


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
