### PR TITLE
planner: add special partition pruner for list columns partition (#21577)

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -56,19 +56,34 @@ partition p2 values less than (10))`)
 
 func (s *partitionTableSuite) TestPartitionIndexJoin(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("drop table if exists p, t")
-	tk.MustExec(`create table p (id int, c int, key i_id(id), key i_c(c)) partition by range (c) (
-partition p0 values less than (4),
-partition p1 values less than (7),
-partition p2 values less than (10))`)
-	tk.MustExec("create table t (id int)")
-	tk.MustExec("insert into p values (3,3), (4,4), (6,6), (9,9)")
-	tk.MustExec("insert into t values (4), (9)")
+	for i := 0; i < 3; i++ {
+		tk.MustExec("drop table if exists p, t")
+		if i == 0 {
+			// Test for range partition
+			tk.MustExec(`create table p (id int, c int, key i_id(id), key i_c(c)) partition by range (c) (
+				partition p0 values less than (4),
+				partition p1 values less than (7),
+				partition p2 values less than (10))`)
+		} else if i == 1 {
+			// Test for list partition
+			tk.MustExec(`create table p (id int, c int, key i_id(id), key i_c(c)) partition by list (c) (
+				partition p0 values in (1,2,3,4),
+				partition p1 values in (5,6,7),
+				partition p2 values in (8, 9,10))`)
+		} else {
+			// Test for hash partition
+			tk.MustExec(`create table p (id int, c int, key i_id(id), key i_c(c)) partition by hash(c) partitions 5;`)
+		}
 
-	// Build indexLookUp in index join
-	tk.MustQuery("select /*+ INL_JOIN(p) */ * from p, t where p.id = t.id").Sort().Check(testkit.Rows("4 4 4", "9 9 9"))
-	// Build index reader in index join
-	tk.MustQuery("select /*+ INL_JOIN(p) */ p.id from p, t where p.id = t.id").Check(testkit.Rows("4", "9"))
+		tk.MustExec("create table t (id int)")
+		tk.MustExec("insert into p values (3,3), (4,4), (6,6), (9,9)")
+		tk.MustExec("insert into t values (4), (9)")
+
+		// Build indexLookUp in index join
+		tk.MustQuery("select /*+ INL_JOIN(p) */ * from p, t where p.id = t.id").Sort().Check(testkit.Rows("4 4 4", "9 9 9"))
+		// Build index reader in index join
+		tk.MustQuery("select /*+ INL_JOIN(p) */ p.id from p, t where p.id = t.id").Check(testkit.Rows("4", "9"))
+	}
 }
 
 func (s *partitionTableSuite) TestPartitionUnionScanIndexJoin(c *C) {

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -224,6 +224,232 @@ func (s *partitionProcessor) processHashPartition(ds *DataSource, pi *model.Part
 	return tableDual, nil
 }
 
+// listPartitionPruner uses to prune partition for list partition.
+type listPartitionPruner struct {
+	*partitionProcessor
+	ctx             sessionctx.Context
+	pi              *model.PartitionInfo
+	partitionNames  []model.CIStr
+	colIDToUniqueID map[int64]int64
+	fullRange       map[int]struct{}
+	listPrune       *tables.ForListPruning
+}
+
+func newListPartitionPruner(ctx sessionctx.Context, tbl table.Table, partitionNames []model.CIStr,
+	s *partitionProcessor, conds []expression.Expression, pruneList *tables.ForListPruning) *listPartitionPruner {
+	colIDToUniqueID := make(map[int64]int64)
+	for _, cond := range conds {
+		condCols := expression.ExtractColumns(cond)
+		for _, c := range condCols {
+			colIDToUniqueID[c.ID] = c.UniqueID
+		}
+	}
+	fullRange := make(map[int]struct{})
+	fullRange[FullRange] = struct{}{}
+	return &listPartitionPruner{
+		partitionProcessor: s,
+		ctx:                ctx,
+		pi:                 tbl.Meta().Partition,
+		partitionNames:     partitionNames,
+		colIDToUniqueID:    colIDToUniqueID,
+		fullRange:          fullRange,
+		listPrune:          pruneList,
+	}
+}
+
+func (l *listPartitionPruner) locatePartition(cond expression.Expression) (tables.ListPartitionLocation, bool, error) {
+	switch sf := cond.(type) {
+	case *expression.Constant:
+		b, err := sf.Value.ToBool(l.ctx.GetSessionVars().StmtCtx)
+		if err == nil && b == 0 {
+			// A constant false expression.
+			return nil, false, nil
+		}
+	case *expression.ScalarFunction:
+		switch sf.FuncName.L {
+		case ast.LogicOr:
+			dnfItems := expression.FlattenDNFConditions(sf)
+			return l.locatePartitionByDNFCondition(dnfItems)
+		case ast.LogicAnd:
+			cnfItems := expression.FlattenCNFConditions(sf)
+			return l.locatePartitionByCNFCondition(cnfItems)
+		}
+		return l.locatePartitionByColumn(sf)
+	}
+	return nil, true, nil
+}
+
+func (l *listPartitionPruner) locatePartitionByCNFCondition(conds []expression.Expression) (tables.ListPartitionLocation, bool, error) {
+	if len(conds) == 0 {
+		return nil, true, nil
+	}
+	countFull := 0
+	helper := tables.NewListPartitionLocationHelper()
+	for _, cond := range conds {
+		cnfLoc, isFull, err := l.locatePartition(cond)
+		if err != nil {
+			return nil, false, err
+		}
+		if isFull {
+			countFull++
+			continue
+		}
+		if cnfLoc.IsEmpty() {
+			// No partition for intersection, just return 0 partition.
+			return nil, false, nil
+		}
+		if !helper.Intersect(cnfLoc) {
+			return nil, false, nil
+		}
+	}
+	if countFull == len(conds) {
+		return nil, true, nil
+	}
+	return helper.GetLocation(), false, nil
+}
+
+func (l *listPartitionPruner) locatePartitionByDNFCondition(conds []expression.Expression) (tables.ListPartitionLocation, bool, error) {
+	if len(conds) == 0 {
+		return nil, true, nil
+	}
+	helper := tables.NewListPartitionLocationHelper()
+	for _, cond := range conds {
+		dnfLoc, isFull, err := l.locatePartition(cond)
+		if err != nil || isFull {
+			return nil, isFull, err
+		}
+		helper.Union(dnfLoc)
+	}
+	return helper.GetLocation(), false, nil
+}
+
+// locatePartitionByColumn uses to locate partition by the one of the list columns value.
+// Such as: partition by list columns(a,b) (partition p0 values in ((1,1),(2,2)), partition p1 values in ((6,6),(7,7)));
+// and if the condition is `a=1`, then we can use `a=1` and the expression `(a in (1,2))` to locate partition `p0`.
+func (l *listPartitionPruner) locatePartitionByColumn(cond *expression.ScalarFunction) (tables.ListPartitionLocation, bool, error) {
+	condCols := expression.ExtractColumns(cond)
+	if len(condCols) != 1 {
+		return nil, true, nil
+	}
+	var colPrune *tables.ForListColumnPruning
+	for _, cp := range l.listPrune.ColPrunes {
+		if cp.ExprCol.ID == condCols[0].ID {
+			colPrune = cp
+		}
+	}
+	if colPrune == nil {
+		return nil, true, nil
+	}
+	return l.locateColumnPartitionsByCondition(cond, colPrune)
+}
+
+func (l *listPartitionPruner) locateColumnPartitionsByCondition(cond expression.Expression, colPrune *tables.ForListColumnPruning) (tables.ListPartitionLocation, bool, error) {
+	ranges, err := l.detachCondAndBuildRange([]expression.Expression{cond}, colPrune.ExprCol)
+	if err != nil {
+		return nil, false, err
+	}
+
+	sc := l.ctx.GetSessionVars().StmtCtx
+	helper := tables.NewListPartitionLocationHelper()
+	for _, r := range ranges {
+		if r.IsPointNullable(sc) {
+			if len(r.HighVal) != 1 {
+				return nil, true, nil
+			}
+			location, err := colPrune.LocatePartition(sc, r.HighVal[0])
+			if err != nil {
+				return nil, false, err
+			}
+			if len(l.partitionNames) > 0 {
+				for _, pg := range location {
+					if l.findByName(l.partitionNames, l.pi.Definitions[pg.PartIdx].Name.L) {
+						helper.UnionPartitionGroup(pg)
+					}
+				}
+			} else {
+				helper.Union(location)
+			}
+		} else {
+			return nil, true, nil
+		}
+	}
+	return helper.GetLocation(), false, nil
+}
+
+func (l *listPartitionPruner) detachCondAndBuildRange(conds []expression.Expression, exprCols ...*expression.Column) ([]*ranger.Range, error) {
+	cols := make([]*expression.Column, 0, len(exprCols))
+	colLen := make([]int, 0, len(exprCols))
+	for _, c := range exprCols {
+		c = c.Clone().(*expression.Column)
+		if uniqueID, ok := l.colIDToUniqueID[c.ID]; ok {
+			c.UniqueID = uniqueID
+		}
+		cols = append(cols, c)
+		colLen = append(colLen, types.UnspecifiedLength)
+	}
+
+	detachedResult, err := ranger.DetachCondAndBuildRangeForPartition(l.ctx, conds, cols, colLen)
+	if err != nil {
+		return nil, err
+	}
+	return detachedResult.Ranges, nil
+}
+
+func (l *listPartitionPruner) findUsedListColumnsPartitions(conds []expression.Expression) (map[int]struct{}, error) {
+	if len(conds) == 0 {
+		return l.fullRange, nil
+	}
+	location, isFull, err := l.locatePartitionByCNFCondition(conds)
+	if err != nil {
+		return nil, err
+	}
+	if isFull {
+		return l.fullRange, nil
+	}
+	used := make(map[int]struct{}, len(location))
+	for _, pg := range location {
+		used[pg.PartIdx] = struct{}{}
+	}
+	return used, nil
+}
+
+func (l *listPartitionPruner) findUsedListPartitions(conds []expression.Expression) (map[int]struct{}, error) {
+	if len(conds) == 0 {
+		return l.fullRange, nil
+	}
+	exprCols := l.listPrune.PruneExprCols
+	pruneExpr := l.listPrune.PruneExpr
+	ranges, err := l.detachCondAndBuildRange(conds, exprCols...)
+	if err != nil {
+		return nil, err
+	}
+	used := make(map[int]struct{}, len(ranges))
+	for _, r := range ranges {
+		if r.IsPointNullable(l.ctx.GetSessionVars().StmtCtx) {
+			if len(r.HighVal) != len(exprCols) && !r.HighVal[0].IsNull() {
+				// For the list partition, if the first argument is null,
+				// then the list partition expression should also be null.
+				return l.fullRange, nil
+			}
+			value, isNull, err := pruneExpr.EvalInt(l.ctx, chunk.MutRowFromDatums(r.HighVal).ToRow())
+			if err != nil {
+				return nil, err
+			}
+			partitionIdx := l.listPrune.LocatePartition(value, isNull)
+			if partitionIdx == -1 {
+				continue
+			}
+			if len(l.partitionNames) > 0 && !l.findByName(l.partitionNames, l.pi.Definitions[partitionIdx].Name.L) {
+				continue
+			}
+			used[partitionIdx] = struct{}{}
+		} else {
+			return l.fullRange, nil
+		}
+	}
+	return used, nil
+}
+
 func (s *partitionProcessor) findUsedListPartitions(ctx sessionctx.Context, tbl table.Table, partitionNames []model.CIStr,
 	conds []expression.Expression) ([]int, error) {
 	pi := tbl.Meta().Partition
@@ -232,64 +458,15 @@ func (s *partitionProcessor) findUsedListPartitions(ctx sessionctx.Context, tbl 
 		return nil, err
 	}
 
-	colIDToUniqueID := make(map[int64]int64)
-	for _, cond := range conds {
-		condCols := expression.ExtractColumns(cond)
-		for _, c := range condCols {
-			colIDToUniqueID[c.ID] = c.UniqueID
-		}
+	listPruner := newListPartitionPruner(ctx, tbl, partitionNames, s, conds, partExpr.ForListPruning)
+	var used map[int]struct{}
+	if partExpr.ForListPruning.ColPrunes == nil {
+		used, err = listPruner.findUsedListPartitions(conds)
+	} else {
+		used, err = listPruner.findUsedListColumnsPartitions(conds)
 	}
-
-	pruneList := partExpr.ForListPruning
-	cols := make([]*expression.Column, 0, len(pruneList.ExprCols))
-	colLen := make([]int, 0, len(pruneList.ExprCols))
-	for _, c := range pruneList.ExprCols {
-		c = c.Clone().(*expression.Column)
-		if uniqueID, ok := colIDToUniqueID[c.ID]; ok {
-			c.UniqueID = uniqueID
-		}
-		cols = append(cols, c)
-		colLen = append(colLen, types.UnspecifiedLength)
-	}
-
-	detachedResult, err := ranger.DetachCondAndBuildRangeForPartition(ctx, conds, cols, colLen)
 	if err != nil {
 		return nil, err
-	}
-
-	ranges := detachedResult.Ranges
-	used := make(map[int]struct{}, len(ranges))
-	for _, r := range ranges {
-		if r.IsPointNullable(ctx.GetSessionVars().StmtCtx) {
-			if !r.HighVal[0].IsNull() {
-				if len(r.HighVal) != len(cols) {
-					used[FullRange] = struct{}{}
-					break
-				}
-			}
-			found := int64(-1)
-			row := chunk.MutRowFromDatums(r.HighVal).ToRow()
-			for j, expr := range pruneList.Exprs {
-				ret, _, err := expr.EvalInt(ctx, row)
-				if err != nil {
-					return nil, err
-				}
-				if ret > 0 {
-					found = int64(j)
-					break
-				}
-			}
-			if found == -1 {
-				continue
-			}
-			if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[found].Name.L) {
-				continue
-			}
-			used[int(found)] = struct{}{}
-		} else {
-			used[FullRange] = struct{}{}
-			break
-		}
 	}
 	if _, ok := used[FullRange]; ok {
 		or := partitionRangeOR{partitionRange{0, len(pi.Definitions)}}

--- a/planner/core/testdata/partition_pruner_in.json
+++ b/planner/core/testdata/partition_pruner_in.json
@@ -86,16 +86,230 @@
   {
     "name": "TestListColumnsPartitionPruner",
     "cases": [
-      "select * from t1 where a = 1 or b = 2",
-      "select * from t1 where a = 1 and b = 2",
-      "select * from t1 where a = 1 and b = 1",
-      "select * from t1 where a in (1,2,3) or b in (4,5,6)",
-      "select * from t1 where a in (1,2,3) and b in (4,5,6)",
-      "select * from t1 where a in (1,2,3) and b in (3,4,6)",
-      "select * from t1 where ( a=1 and b=1) or (a=6 and b=6)",
-      "select * from t1 where a = 100 and b = 100",
-      "select * from t1 join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id=7",
-      "select * from t1 left join t2 on true where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id = 7"
+      {
+        "SQL": "select * from t1 order by id,a",
+        "Pruner": "t1: all"
+      },
+      {
+        "SQL": "select count(1) from t1 order by id,a",
+        "Pruner": "t1: all"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or b = 2",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select count(1) from t1 where a = 1 or b = 2",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and b = 2",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select count(1) from t1 where a = 1 and b = 2",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and b = 1",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) or b in (4,5,6)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) and b in (4,5,6)",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) and b in (3,4,6)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) and b in (1,2,3)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) or b in (1,2,3)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where ( a=1 and b=1) or (a=6 and b=6)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a = 100 and b = 100",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id=7",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select * from t1 left join t2 on true where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id = 7 order by t1.id,t1.a",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select * from t1 where a = 1",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where b = 1",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where b is null",
+        "Pruner": "t1: p1"
+      },
+      {
+        "SQL": "select * from t1 where a is null",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or b = 2",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a = 2 and b = 2) or ((a,b) in ((4,4),(5,5)))",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a is null and b = 10)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a = 10 and b is null)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a = 8 or (a = 10 and b is null)",
+        "Pruner": "t1: p1"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and false",
+        "Pruner": ""
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and true",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or false",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or true order by id,a",
+        "Pruner": "t1: all"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or b in (100,200)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (1,2)",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (1,6)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (100,200)",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) or b in (1,2) or (a=3 and b =3)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) or (a=3 and b =3)",
+        "Pruner": "t1: p0,p1"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) and (a=3 and b =3)",
+        "Pruner": ""
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and (b=6 or a=6)",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a = 100 and (b=200 or a=200)",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a+b=3)",
+        "Pruner": "t1: all"
+      },
+      {
+        "SQL": "select * from t1 where id = 1 or id=2",
+        "Pruner": "t1: all"
+      },
+      {
+        "SQL": "select * from t1 where id = 1 and a=1",
+        "Pruner": "t1: p0"
+      },
+      {
+        "SQL": "select * from t1 partition(p1) where a = 1 or b = 2",
+        "Pruner": "t1: dual"
+      },
+      {
+        "SQL": "select * from t1 join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and (t2.a = 6 and t2.b = 6)",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select * from t1 join t1 as t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and (t2.a = 6 and t2.b = 6)",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select * from t1 where t1.a in (select b from t2 where a in (1,2)) order by a",
+        "Pruner": "t1: all; t2: p0"
+      },
+      {
+        "SQL": "select * from t1 where t1.a in (select b from t1 where a in (1,2)) order by a",
+        "Pruner": "t1: all; t1: p0"
+      },
+      {
+        "SQL": "select * from t1 left join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and t2.a in (6,7,8)",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select * from t1 right join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and t2.a in (1,2,3)",
+        "Pruner": "t1: p0; t2: p0"
+      },
+      {
+        "SQL": "select * from t1 join t2 on true where t1.a=5 and t2.a in (6,7,8) and t2.b = 6",
+        "Pruner": "t1: p0; t2: p1"
+      },
+      {
+        "SQL": "select count(*) from t1 join t2 on t1.b = t2.b where t1.a in (1,2) and t2.a in (1,6) and t1.b in (1,6)",
+        "Pruner": "t1: p0; t2: p0,p1"
+      },
+      {
+        "SQL": "select /*+ INL_JOIN(t2,t1) */      count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (1,6)",
+        "Pruner": "t1: p0,p1; t2: p0"
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (6,1)",
+        "Pruner": "t1: p0,p1; t2: p0"
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (100,9,6)",
+        "Pruner": "t1: p1; t2: dual"
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (100,9,6,1)",
+        "Pruner": "t1: p0,p1; t2: p0"
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) union select * from t1 where b in (6,7,8) order by a",
+        "Pruner": "t1: p0; t1: p1"
+      }
     ]
   }
 ]

--- a/planner/core/testdata/partition_pruner_out.json
+++ b/planner/core/testdata/partition_pruner_out.json
@@ -1709,24 +1709,24 @@
           "1"
         ],
         "Plan": [
-          "StreamAgg_10 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_11 0.00 root  inner join, equal:[eq(test_partition.t1.b, test_partition.t2.b)]",
-          "  ├─TableReader_18(Build) 0.04 root partition:p0,p1 data:Selection_17",
-          "  │ └─Selection_17 0.04 cop[tikv]  in(test_partition.t2.a, 1, 6), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
-          "  │   └─TableFullScan_16 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "  └─TableReader_15(Probe) 0.04 root partition:p0 data:Selection_14",
-          "    └─Selection_14 0.04 cop[tikv]  in(test_partition.t1.a, 1, 2), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
-          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "StreamAgg_13 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_14 0.00 root  inner join, equal:[eq(test_partition.t1.b, test_partition.t2.b)]",
+          "  ├─TableReader_21(Build) 0.04 root partition:p0,p1 data:Selection_20",
+          "  │ └─Selection_20 0.04 cop[tikv]  in(test_partition.t2.a, 1, 6), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
+          "  │   └─TableFullScan_19 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_18(Probe) 0.04 root partition:p0 data:Selection_17",
+          "    └─Selection_17 0.04 cop[tikv]  in(test_partition.t1.a, 1, 2), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
+          "      └─TableFullScan_16 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "StreamAgg_10 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_23 0.10 root  inner join, equal:[eq(test_partition_1.t1.b, test_partition_1.t2.b)]",
-          "  ├─IndexReader_30(Build) 0.40 root partition:p0,p1 index:Selection_29",
-          "  │ └─Selection_29 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
-          "  │   └─IndexRangeScan_28 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [6 1,6 1], [6 6,6 6], keep order:false, stats:pseudo",
-          "  └─IndexReader_27(Probe) 0.40 root partition:p0 index:Selection_26",
-          "    └─Selection_26 0.40 cop[tikv]  not(isnull(test_partition_1.t1.b))",
-          "      └─IndexRangeScan_25 0.40 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo"
+          "StreamAgg_13 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_26 0.10 root  inner join, equal:[eq(test_partition_1.t1.b, test_partition_1.t2.b)]",
+          "  ├─IndexReader_33(Build) 0.40 root partition:p0,p1 index:Selection_32",
+          "  │ └─Selection_32 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_31 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [6 1,6 1], [6 6,6 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_30(Probe) 0.40 root partition:p0 index:Selection_29",
+          "    └─Selection_29 0.40 cop[tikv]  not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_28 0.40 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1735,24 +1735,24 @@
           "1"
         ],
         "Plan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
-          "  ├─TableReader_17(Build) 0.04 root partition:p0,p1 data:Selection_16",
-          "  │ └─Selection_16 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
-          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─TableReader_14(Probe) 0.04 root partition:p0 data:Selection_13",
-          "    └─Selection_13 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
-          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_13 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_20(Build) 0.04 root partition:p0,p1 data:Selection_19",
+          "  │ └─Selection_19 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_17(Probe) 0.04 root partition:p0 data:Selection_16",
+          "    └─Selection_16 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─IndexJoin_13 0.10 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
-          "  ├─IndexReader_24(Build) 0.40 root partition:p0 index:Selection_23",
-          "  │ └─Selection_23 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
-          "  │   └─IndexRangeScan_22 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
-          "  └─IndexReader_12(Probe) 0.32 root partition:p0,p1 index:Selection_11",
-          "    └─Selection_11 0.32 cop[tikv]  in(test_partition_1.t1.b, 1, 6), not(isnull(test_partition_1.t1.b))",
-          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexJoin_16 0.10 root  inner join, inner:IndexReader_15, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_27(Build) 0.40 root partition:p0 index:Selection_26",
+          "  │ └─Selection_26 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_25 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_15(Probe) 0.32 root partition:p0,p1 index:Selection_14",
+          "    └─Selection_14 0.32 cop[tikv]  in(test_partition_1.t1.b, 1, 6), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_13 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1761,24 +1761,24 @@
           "1"
         ],
         "Plan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
-          "  ├─TableReader_17(Build) 0.04 root partition:p0,p1 data:Selection_16",
-          "  │ └─Selection_16 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 6, 1), not(isnull(test_partition.t1.b))",
-          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─TableReader_14(Probe) 0.04 root partition:p0 data:Selection_13",
-          "    └─Selection_13 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 6, 1), not(isnull(test_partition.t2.b))",
-          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_13 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_20(Build) 0.04 root partition:p0,p1 data:Selection_19",
+          "  │ └─Selection_19 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 6, 1), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_17(Probe) 0.04 root partition:p0 data:Selection_16",
+          "    └─Selection_16 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 6, 1), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─IndexHashJoin_15 0.10 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
-          "  ├─IndexReader_24(Build) 0.40 root partition:p0 index:Selection_23",
-          "  │ └─Selection_23 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
-          "  │   └─IndexRangeScan_22 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
-          "  └─IndexReader_12(Probe) 0.32 root partition:p0,p1 index:Selection_11",
-          "    └─Selection_11 0.32 cop[tikv]  in(test_partition_1.t1.b, 6, 1), not(isnull(test_partition_1.t1.b))",
-          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_18 0.10 root  inner join, inner:IndexReader_15, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_27(Build) 0.40 root partition:p0 index:Selection_26",
+          "  │ └─Selection_26 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_25 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_15(Probe) 0.32 root partition:p0,p1 index:Selection_14",
+          "    └─Selection_14 0.32 cop[tikv]  in(test_partition_1.t1.b, 6, 1), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_13 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1787,24 +1787,24 @@
           "0"
         ],
         "Plan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
-          "  ├─TableReader_17(Build) 0.06 root partition:p1 data:Selection_16",
-          "  │ └─Selection_16 0.06 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6), not(isnull(test_partition.t1.b))",
-          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─TableReader_14(Probe) 0.06 root partition:dual data:Selection_13",
-          "    └─Selection_13 0.06 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6), not(isnull(test_partition.t2.b))",
-          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_13 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_20(Build) 0.06 root partition:p1 data:Selection_19",
+          "  │ └─Selection_19 0.06 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_17(Probe) 0.06 root partition:dual data:Selection_16",
+          "    └─Selection_16 0.06 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─IndexHashJoin_15 0.23 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
-          "  ├─IndexReader_24(Build) 0.60 root partition:dual index:Selection_23",
-          "  │ └─Selection_23 0.60 cop[tikv]  not(isnull(test_partition_1.t2.b))",
-          "  │   └─IndexRangeScan_22 0.60 cop[tikv] table:t2, index:a(a, b, id) range:[1 6,1 6], [1 9,1 9], [1 100,1 100], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
-          "  └─IndexReader_12(Probe) 0.48 root partition:p1 index:Selection_11",
-          "    └─Selection_11 0.48 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6), not(isnull(test_partition_1.t1.b))",
-          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_18 0.23 root  inner join, inner:IndexReader_15, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_27(Build) 0.60 root partition:dual index:Selection_26",
+          "  │ └─Selection_26 0.60 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_25 0.60 cop[tikv] table:t2, index:a(a, b, id) range:[1 6,1 6], [1 9,1 9], [1 100,1 100], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
+          "  └─IndexReader_15(Probe) 0.48 root partition:p1 index:Selection_14",
+          "    └─Selection_14 0.48 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_13 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1813,24 +1813,24 @@
           "1"
         ],
         "Plan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─HashJoin_10 0.01 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
-          "  ├─TableReader_17(Build) 0.08 root partition:p0,p1 data:Selection_16",
-          "  │ └─Selection_16 0.08 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6, 1), not(isnull(test_partition.t1.b))",
-          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "  └─TableReader_14(Probe) 0.08 root partition:p0 data:Selection_13",
-          "    └─Selection_13 0.08 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6, 1), not(isnull(test_partition.t2.b))",
-          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_13 0.01 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_20(Build) 0.08 root partition:p0,p1 data:Selection_19",
+          "  │ └─Selection_19 0.08 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6, 1), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_17(Probe) 0.08 root partition:p0 data:Selection_16",
+          "    └─Selection_16 0.08 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6, 1), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
-          "└─IndexHashJoin_15 0.41 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
-          "  ├─IndexReader_24(Build) 0.80 root partition:p0 index:Selection_23",
-          "  │ └─Selection_23 0.80 cop[tikv]  not(isnull(test_partition_1.t2.b))",
-          "  │   └─IndexRangeScan_22 0.80 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [1 9,1 9], [1 100,1 100], [2 1,2 1], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
-          "  └─IndexReader_12(Probe) 0.64 root partition:p0,p1 index:Selection_11",
-          "    └─Selection_11 0.64 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6, 1), not(isnull(test_partition_1.t1.b))",
-          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+          "StreamAgg_12 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_18 0.41 root  inner join, inner:IndexReader_15, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_27(Build) 0.80 root partition:p0 index:Selection_26",
+          "  │ └─Selection_26 0.80 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_25 0.80 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [1 9,1 9], [1 100,1 100], [2 1,2 1], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
+          "  └─IndexReader_15(Probe) 0.64 root partition:p0,p1 index:Selection_14",
+          "    └─Selection_14 0.64 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6, 1), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_13 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1845,24 +1845,24 @@
         ],
         "Plan": [
           "Sort_12 48.00 root  Column#10",
-          "└─HashAgg_14 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
-          "  └─Union_15 60.00 root  ",
-          "    ├─TableReader_19 30.00 root partition:p0 data:Selection_18",
-          "    │ └─Selection_18 30.00 cop[tikv]  in(test_partition.t1.a, 1, 2, 3)",
-          "    │   └─TableFullScan_17 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "    └─TableReader_23 30.00 root partition:p1 data:Selection_22",
-          "      └─Selection_22 30.00 cop[tikv]  in(test_partition.t1.b, 6, 7, 8)",
-          "        └─TableFullScan_21 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "└─HashAgg_16 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
+          "  └─Union_17 60.00 root  ",
+          "    ├─TableReader_21 30.00 root partition:p0 data:Selection_20",
+          "    │ └─Selection_20 30.00 cop[tikv]  in(test_partition.t1.a, 1, 2, 3)",
+          "    │   └─TableFullScan_19 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "    └─TableReader_25 30.00 root partition:p1 data:Selection_24",
+          "      └─Selection_24 30.00 cop[tikv]  in(test_partition.t1.b, 6, 7, 8)",
+          "        └─TableFullScan_23 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
           "Sort_12 48.00 root  Column#10",
-          "└─HashAgg_14 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
-          "  └─Union_15 60.00 root  ",
-          "    ├─IndexReader_18 30.00 root partition:p0 index:IndexRangeScan_17",
-          "    │ └─IndexRangeScan_17 30.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo",
-          "    └─IndexReader_25 30.00 root partition:p1 index:Selection_24",
-          "      └─Selection_24 30.00 cop[tikv]  in(test_partition_1.t1.b, 6, 7, 8)",
-          "        └─IndexFullScan_23 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+          "└─HashAgg_16 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
+          "  └─Union_17 60.00 root  ",
+          "    ├─IndexReader_20 30.00 root partition:p0 index:IndexRangeScan_19",
+          "    │ └─IndexRangeScan_19 30.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo",
+          "    └─IndexReader_27 30.00 root partition:p1 index:Selection_26",
+          "      └─Selection_26 30.00 cop[tikv]  in(test_partition_1.t1.b, 6, 7, 8)",
+          "        └─IndexFullScan_25 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
         ]
       }
     ]

--- a/planner/core/testdata/partition_pruner_out.json
+++ b/planner/core/testdata/partition_pruner_out.json
@@ -810,15 +810,88 @@
     "Name": "TestListColumnsPartitionPruner",
     "Cases": [
       {
+        "SQL": "select * from t1 order by id,a",
+        "Result": [
+          "<nil> 10 <nil>",
+          "1 1 1",
+          "2 2 2",
+          "3 3 3",
+          "4 4 4",
+          "5 5 5",
+          "6 6 6",
+          "7 7 7",
+          "8 8 8",
+          "9 9 9",
+          "10 10 10"
+        ],
+        "Plan": [
+          "Sort_4 10000.00 root  test_partition.t1.id, test_partition.t1.a",
+          "└─TableReader_8 10000.00 root partition:all data:TableFullScan_7",
+          "  └─TableFullScan_7 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_4 10000.00 root  test_partition_1.t1.id, test_partition_1.t1.a",
+          "└─IndexReader_10 10000.00 root partition:all index:IndexFullScan_9",
+          "  └─IndexFullScan_9 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select count(1) from t1 order by id,a",
+        "Result": [
+          "11"
+        ],
+        "Plan": [
+          "Projection_6 1.00 root  Column#5",
+          "└─Sort_7 1.00 root  test_partition.t1.id, test_partition.t1.a",
+          "  └─StreamAgg_20 1.00 root  funcs:count(Column#10)->Column#5, funcs:firstrow(Column#11)->test_partition.t1.id, funcs:firstrow(Column#12)->test_partition.t1.a",
+          "    └─TableReader_21 1.00 root partition:all data:StreamAgg_12",
+          "      └─StreamAgg_12 1.00 cop[tikv]  funcs:count(1)->Column#10, funcs:firstrow(test_partition.t1.id)->Column#11, funcs:firstrow(test_partition.t1.a)->Column#12",
+          "        └─TableFullScan_19 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Projection_6 1.00 root  Column#5",
+          "└─Sort_7 1.00 root  test_partition_1.t1.id, test_partition_1.t1.a",
+          "  └─StreamAgg_24 1.00 root  funcs:count(Column#13)->Column#5, funcs:firstrow(Column#14)->test_partition_1.t1.id, funcs:firstrow(Column#15)->test_partition_1.t1.a",
+          "    └─IndexReader_25 1.00 root partition:all index:StreamAgg_12",
+          "      └─StreamAgg_12 1.00 cop[tikv]  funcs:count(1)->Column#13, funcs:firstrow(test_partition_1.t1.id)->Column#14, funcs:firstrow(test_partition_1.t1.a)->Column#15",
+          "        └─IndexFullScan_23 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "select * from t1 where a = 1 or b = 2",
         "Result": [
           "1 1 1",
           "2 2 2"
         ],
         "Plan": [
-          "TableReader_7 19.99 root partition:all data:Selection_6",
+          "TableReader_7 19.99 root partition:p0 data:Selection_6",
           "└─Selection_6 19.99 cop[tikv]  or(eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2))",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 19.99 root partition:p0 index:Selection_9",
+          "└─Selection_9 19.99 cop[tikv]  or(eq(test_partition_1.t1.a, 1), eq(test_partition_1.t1.b, 2))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select count(1) from t1 where a = 1 or b = 2",
+        "Result": [
+          "2"
+        ],
+        "Plan": [
+          "StreamAgg_20 1.00 root  funcs:count(Column#7)->Column#5",
+          "└─TableReader_21 1.00 root partition:p0 data:StreamAgg_9",
+          "  └─StreamAgg_9 1.00 cop[tikv]  funcs:count(1)->Column#7",
+          "    └─Selection_19 19.99 cop[tikv]  or(eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2))",
+          "      └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_27 1.00 root  funcs:count(Column#10)->Column#5",
+          "└─IndexReader_28 1.00 root partition:p0 index:StreamAgg_9",
+          "  └─StreamAgg_9 1.00 cop[tikv]  funcs:count(1)->Column#10",
+          "    └─Selection_26 19.99 cop[tikv]  or(eq(test_partition_1.t1.a, 1), eq(test_partition_1.t1.b, 2))",
+          "      └─IndexFullScan_25 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
         ]
       },
       {
@@ -828,6 +901,27 @@
           "TableReader_7 0.01 root partition:dual data:Selection_6",
           "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.10 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[1 2,1 2], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select count(1) from t1 where a = 1 and b = 2",
+        "Result": [
+          "0"
+        ],
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:count(1)->Column#5",
+          "└─TableReader_17 0.01 root partition:dual data:Selection_16",
+          "  └─Selection_16 0.01 cop[tikv]  eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2)",
+          "    └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_10 1.00 root  funcs:count(1)->Column#5",
+          "└─IndexReader_15 0.10 root partition:dual index:IndexRangeScan_14",
+          "  └─IndexRangeScan_14 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[1 2,1 2], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -839,6 +933,10 @@
           "TableReader_7 0.01 root partition:p0 data:Selection_6",
           "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 1)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.10 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -852,9 +950,14 @@
           "6 6 6"
         ],
         "Plan": [
-          "TableReader_7 59.91 root partition:all data:Selection_6",
+          "TableReader_7 59.91 root partition:p0,p1 data:Selection_6",
           "└─Selection_6 59.91 cop[tikv]  or(in(test_partition.t1.a, 1, 2, 3), in(test_partition.t1.b, 4, 5, 6))",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 59.91 root partition:p0,p1 index:Selection_9",
+          "└─Selection_9 59.91 cop[tikv]  or(in(test_partition_1.t1.a, 1, 2, 3), in(test_partition_1.t1.b, 4, 5, 6))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
         ]
       },
       {
@@ -864,6 +967,10 @@
           "TableReader_7 0.09 root partition:dual data:Selection_6",
           "└─Selection_6 0.09 cop[tikv]  in(test_partition.t1.a, 1, 2, 3), in(test_partition.t1.b, 4, 5, 6)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.90 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.90 cop[tikv] table:t1, index:a(a, b, id) range:[1 4,1 4], [1 5,1 5], [1 6,1 6], [2 4,2 4], [2 5,2 5], [2 6,2 6], [3 4,3 4], [3 5,3 5], [3 6,3 6], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -875,6 +982,45 @@
           "TableReader_7 0.09 root partition:p0 data:Selection_6",
           "└─Selection_6 0.09 cop[tikv]  in(test_partition.t1.a, 1, 2, 3), in(test_partition.t1.b, 3, 4, 6)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.90 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.90 cop[tikv] table:t1, index:a(a, b, id) range:[1 3,1 3], [1 4,1 4], [1 6,1 6], [2 3,2 3], [2 4,2 4], [2 6,2 6], [3 3,3 3], [3 4,3 4], [3 6,3 6], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) and b in (1,2,3)",
+        "Result": [
+          "1 1 1",
+          "2 2 2",
+          "3 3 3"
+        ],
+        "Plan": [
+          "TableReader_7 0.09 root partition:p0 data:Selection_6",
+          "└─Selection_6 0.09 cop[tikv]  in(test_partition.t1.a, 1, 2, 3), in(test_partition.t1.b, 1, 2, 3)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.90 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.90 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], [1 2,1 2], [1 3,1 3], [2 1,2 1], [2 2,2 2], [2 3,2 3], [3 1,3 1], [3 2,3 2], [3 3,3 3], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) or b in (1,2,3)",
+        "Result": [
+          "1 1 1",
+          "2 2 2",
+          "3 3 3"
+        ],
+        "Plan": [
+          "TableReader_7 59.91 root partition:p0 data:Selection_6",
+          "└─Selection_6 59.91 cop[tikv]  or(in(test_partition.t1.a, 1, 2, 3), in(test_partition.t1.b, 1, 2, 3))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 59.91 root partition:p0 index:Selection_9",
+          "└─Selection_9 59.91 cop[tikv]  or(in(test_partition_1.t1.a, 1, 2, 3), in(test_partition_1.t1.b, 1, 2, 3))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
         ]
       },
       {
@@ -887,6 +1033,10 @@
           "TableReader_7 0.02 root partition:p0,p1 data:Selection_6",
           "└─Selection_6 0.02 cop[tikv]  or(and(eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 1)), and(eq(test_partition.t1.a, 6), eq(test_partition.t1.b, 6)))",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.20 root partition:p0,p1 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.20 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], [6 6,6 6], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -896,6 +1046,10 @@
           "TableReader_7 0.01 root partition:dual data:Selection_6",
           "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 100), eq(test_partition.t1.b, 100)",
           "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.10 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[100 100,100 100], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -907,25 +1061,808 @@
           "  ├─TableReader_12(Build) 0.00 root partition:p1 data:Selection_11",
           "  │ └─Selection_11 0.00 cop[tikv]  eq(test_partition.t2.b, 7), eq(test_partition.t2.id, 7), in(test_partition.t2.a, 6, 7, 8)",
           "  │   └─TableFullScan_10 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "  └─TableReader_15(Probe) 0.01 root partition:all data:Selection_14",
+          "  └─TableReader_15(Probe) 0.01 root partition:p0 data:Selection_14",
           "    └─Selection_14 0.01 cop[tikv]  eq(test_partition.t1.id, 7), or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 3), in(test_partition.t1.b, 3, 5)))",
           "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "HashJoin_9 0.03 root  CARTESIAN inner join",
+          "├─IndexReader_12(Build) 0.01 root partition:p0 index:Selection_11",
+          "│ └─Selection_11 0.01 cop[tikv]  eq(test_partition_1.t1.id, 7), or(eq(test_partition_1.t1.a, 1), and(eq(test_partition_1.t1.a, 3), in(test_partition_1.t1.b, 3, 5)))",
+          "│   └─IndexRangeScan_10 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─IndexReader_14(Probe) 3.00 root partition:p1 index:IndexRangeScan_13",
+          "  └─IndexRangeScan_13 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 7 7,6 7 7], [7 7 7,7 7 7], [8 7 7,8 7 7], keep order:false, stats:pseudo"
         ]
       },
       {
-        "SQL": "select * from t1 left join t2 on true where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id = 7",
+        "SQL": "select * from t1 left join t2 on true where (t1.a=1 or t1.a = 3 and t1.b in (3,5)) and t2.a in (6,7,8) and t2.b=7 and t2.id = 7 order by t1.id,t1.a",
         "Result": [
           "1 1 1 7 7 7",
           "3 3 3 7 7 7"
         ],
         "Plan": [
-          "HashJoin_7 80.16 root  CARTESIAN inner join",
-          "├─TableReader_14(Build) 8.00 root partition:p1 data:Selection_13",
-          "│ └─Selection_13 8.00 cop[tikv]  1, eq(test_partition.t2.b, 7), eq(test_partition.t2.id, 7), in(test_partition.t2.a, 6, 7, 8)",
-          "│   └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_11(Probe) 10.02 root partition:all data:Selection_10",
-          "  └─Selection_10 10.02 cop[tikv]  1, or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 3), in(test_partition.t1.b, 3, 5)))",
-          "    └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "Sort_7 80.16 root  test_partition.t1.id, test_partition.t1.a",
+          "└─HashJoin_10 80.16 root  CARTESIAN inner join",
+          "  ├─TableReader_17(Build) 8.00 root partition:p1 data:Selection_16",
+          "  │ └─Selection_16 8.00 cop[tikv]  1, eq(test_partition.t2.b, 7), eq(test_partition.t2.id, 7), in(test_partition.t2.a, 6, 7, 8)",
+          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 10.02 root partition:p0 data:Selection_13",
+          "    └─Selection_13 10.02 cop[tikv]  1, or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 3), in(test_partition.t1.b, 3, 5)))",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_7 0.05 root  test_partition_1.t1.id, test_partition_1.t1.a",
+          "└─HashJoin_11 0.05 root  CARTESIAN inner join",
+          "  ├─IndexReader_14(Build) 0.02 root partition:p0 index:Selection_13",
+          "  │ └─Selection_13 0.02 cop[tikv]  or(eq(test_partition_1.t1.a, 1), and(eq(test_partition_1.t1.a, 3), in(test_partition_1.t1.b, 3, 5)))",
+          "  │   └─IndexRangeScan_12 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "  └─IndexReader_17(Probe) 2.40 root partition:p1 index:Selection_16",
+          "    └─Selection_16 2.40 cop[tikv]  1",
+          "      └─IndexRangeScan_15 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 7 7,6 7 7], [7 7 7,7 7 7], [8 7 7,8 7 7], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 10.00 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  eq(test_partition.t1.a, 1)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.00 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where b = 1",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 10.00 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  eq(test_partition.t1.b, 1)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 10.00 root partition:p0 index:Selection_9",
+          "└─Selection_9 10.00 cop[tikv]  eq(test_partition_1.t1.b, 1)",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where b is null",
+        "Result": [
+          "<nil> 10 <nil>"
+        ],
+        "Plan": [
+          "TableReader_7 10.00 root partition:p1 data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  isnull(test_partition.t1.b)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 10.00 root partition:p1 index:Selection_9",
+          "└─Selection_9 10.00 cop[tikv]  isnull(test_partition_1.t1.b)",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a is null",
+        "Result": null,
+        "Plan": [
+          "TableReader_7 10.00 root partition:dual data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  isnull(test_partition.t1.a)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.00 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:a(a, b, id) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or b = 2",
+        "Result": [
+          "1 1 1",
+          "2 2 2"
+        ],
+        "Plan": [
+          "TableReader_7 19.99 root partition:p0 data:Selection_6",
+          "└─Selection_6 19.99 cop[tikv]  or(eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 19.99 root partition:p0 index:Selection_9",
+          "└─Selection_9 19.99 cop[tikv]  or(eq(test_partition_1.t1.a, 1), eq(test_partition_1.t1.b, 2))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a = 2 and b = 2) or ((a,b) in ((4,4),(5,5)))",
+        "Result": [
+          "1 1 1",
+          "2 2 2",
+          "4 4 4",
+          "5 5 5"
+        ],
+        "Plan": [
+          "TableReader_7 10.03 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.03 cop[tikv]  or(or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 2), eq(test_partition.t1.b, 2))), or(and(eq(test_partition.t1.a, 4), eq(test_partition.t1.b, 4)), and(eq(test_partition.t1.a, 5), eq(test_partition.t1.b, 5))))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.30 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.30 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [2 2,2 2], [4 4,4 4], [5 5,5 5], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a is null and b = 10)",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 10.01 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.01 cop[tikv]  or(eq(test_partition.t1.a, 1), and(isnull(test_partition.t1.a), eq(test_partition.t1.b, 10)))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_7 16.00 root partition:p0 index:Selection_6",
+          "└─Selection_6 16.00 cop[tikv]  or(eq(test_partition_1.t1.a, 1), and(isnull(test_partition_1.t1.a), eq(test_partition_1.t1.b, 10)))",
+          "  └─IndexRangeScan_5 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[NULL,NULL], [1,1], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a = 10 and b is null)",
+        "Result": [
+          "1 1 1",
+          "<nil> 10 <nil>"
+        ],
+        "Plan": [
+          "TableReader_7 10.01 root partition:p0,p1 data:Selection_6",
+          "└─Selection_6 10.01 cop[tikv]  or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 10), isnull(test_partition.t1.b)))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.10 root partition:p0,p1 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.10 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [10 NULL,10 NULL], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 8 or (a = 10 and b is null)",
+        "Result": [
+          "8 8 8",
+          "<nil> 10 <nil>"
+        ],
+        "Plan": [
+          "TableReader_7 10.01 root partition:p1 data:Selection_6",
+          "└─Selection_6 10.01 cop[tikv]  or(eq(test_partition.t1.a, 8), and(eq(test_partition.t1.a, 10), isnull(test_partition.t1.b)))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.10 root partition:p1 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.10 cop[tikv] table:t1, index:a(a, b, id) range:[8,8], [10 NULL,10 NULL], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and false",
+        "Result": null,
+        "Plan": [
+          "TableDual_6 0.00 root  rows:0"
+        ],
+        "IndexPlan": [
+          "TableDual_6 0.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and true",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 10.00 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  eq(test_partition.t1.a, 1)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.00 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or false",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 10.00 root partition:p0 data:Selection_6",
+          "└─Selection_6 10.00 cop[tikv]  or(eq(test_partition.t1.a, 1), 0)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 10.00 root partition:p0 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or true order by id,a",
+        "Result": [
+          "<nil> 10 <nil>",
+          "1 1 1",
+          "2 2 2",
+          "3 3 3",
+          "4 4 4",
+          "5 5 5",
+          "6 6 6",
+          "7 7 7",
+          "8 8 8",
+          "9 9 9",
+          "10 10 10"
+        ],
+        "Plan": [
+          "Sort_5 10000.00 root  test_partition.t1.id, test_partition.t1.a",
+          "└─TableReader_10 10000.00 root partition:all data:Selection_9",
+          "  └─Selection_9 10000.00 cop[tikv]  or(eq(test_partition.t1.a, 1), 1)",
+          "    └─TableFullScan_8 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_5 10000.00 root  test_partition_1.t1.id, test_partition_1.t1.a",
+          "└─IndexReader_9 10000.00 root partition:all index:IndexFullScan_8",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or b in (100,200)",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 29.98 root partition:p0 data:Selection_6",
+          "└─Selection_6 29.98 cop[tikv]  or(eq(test_partition.t1.a, 1), in(test_partition.t1.b, 100, 200))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 29.98 root partition:p0 index:Selection_9",
+          "└─Selection_9 29.98 cop[tikv]  or(eq(test_partition_1.t1.a, 1), in(test_partition_1.t1.b, 100, 200))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (1,2)",
+        "Result": [
+          "1 1 1",
+          "2 2 2"
+        ],
+        "Plan": [
+          "TableReader_7 29.98 root partition:p0 data:Selection_6",
+          "└─Selection_6 29.98 cop[tikv]  or(eq(test_partition.t1.a, 100), in(test_partition.t1.b, 1, 2))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 29.98 root partition:p0 index:Selection_9",
+          "└─Selection_9 29.98 cop[tikv]  or(eq(test_partition_1.t1.a, 100), in(test_partition_1.t1.b, 1, 2))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (1,6)",
+        "Result": [
+          "1 1 1",
+          "6 6 6"
+        ],
+        "Plan": [
+          "TableReader_7 29.98 root partition:p0,p1 data:Selection_6",
+          "└─Selection_6 29.98 cop[tikv]  or(eq(test_partition.t1.a, 100), in(test_partition.t1.b, 1, 6))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 29.98 root partition:p0,p1 index:Selection_9",
+          "└─Selection_9 29.98 cop[tikv]  or(eq(test_partition_1.t1.a, 100), in(test_partition_1.t1.b, 1, 6))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 100 or b in (100,200)",
+        "Result": null,
+        "Plan": [
+          "TableReader_7 29.98 root partition:dual data:Selection_6",
+          "└─Selection_6 29.98 cop[tikv]  or(eq(test_partition.t1.a, 100), in(test_partition.t1.b, 100, 200))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 29.98 root partition:dual index:Selection_9",
+          "└─Selection_9 29.98 cop[tikv]  or(eq(test_partition_1.t1.a, 100), in(test_partition_1.t1.b, 100, 200))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) or b in (1,2) or (a=3 and b =3)",
+        "Result": [
+          "1 1 1",
+          "2 2 2",
+          "3 3 3",
+          "6 6 6"
+        ],
+        "Plan": [
+          "TableReader_7 39.97 root partition:p0,p1 data:Selection_6",
+          "└─Selection_6 39.97 cop[tikv]  or(in(test_partition.t1.a, 1, 6), or(in(test_partition.t1.b, 1, 2), and(eq(test_partition.t1.a, 3), eq(test_partition.t1.b, 3))))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 40.06 root partition:p0,p1 index:Selection_9",
+          "└─Selection_9 40.06 cop[tikv]  or(in(test_partition_1.t1.a, 1, 6), or(in(test_partition_1.t1.b, 1, 2), and(eq(test_partition_1.t1.a, 3), eq(test_partition_1.t1.b, 3))))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6)",
+        "Result": [
+          "1 1 1",
+          "6 6 6"
+        ],
+        "Plan": [
+          "TableReader_7 20.00 root partition:p0,p1 data:Selection_6",
+          "└─Selection_6 20.00 cop[tikv]  in(test_partition.t1.a, 1, 6)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 20.00 root partition:p0,p1 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [6,6], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) or (a=3 and b =3)",
+        "Result": [
+          "1 1 1",
+          "3 3 3",
+          "6 6 6"
+        ],
+        "Plan": [
+          "TableReader_7 20.01 root partition:p0,p1 data:Selection_6",
+          "└─Selection_6 20.01 cop[tikv]  or(in(test_partition.t1.a, 1, 6), and(eq(test_partition.t1.a, 3), eq(test_partition.t1.b, 3)))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 20.10 root partition:p0,p1 index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 20.10 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3 3,3 3], [6,6], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,6) and (a=3 and b =3)",
+        "Result": null,
+        "Plan": [
+          "TableDual_5 8000.00 root  rows:0"
+        ],
+        "IndexPlan": [
+          "TableDual_5 8000.00 root  rows:0"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 and (b=6 or a=6)",
+        "Result": null,
+        "Plan": [
+          "TableReader_7 0.01 root partition:dual data:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 1), or(eq(test_partition.t1.b, 6), 0)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.10 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[1 6,1 6], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 100 and (b=200 or a=200)",
+        "Result": null,
+        "Plan": [
+          "TableReader_7 0.01 root partition:dual data:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 100), or(eq(test_partition.t1.b, 200), 0)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_6 0.10 root partition:dual index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:t1, index:a(a, b, id) range:[100 200,100 200], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a = 1 or (a+b=3)",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 8002.00 root partition:all data:Selection_6",
+          "└─Selection_6 8002.00 cop[tikv]  or(eq(test_partition.t1.a, 1), eq(plus(test_partition.t1.a, test_partition.t1.b), 3))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 8002.00 root partition:all index:Selection_9",
+          "└─Selection_9 8002.00 cop[tikv]  or(eq(test_partition_1.t1.a, 1), eq(plus(test_partition_1.t1.a, test_partition_1.t1.b), 3))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where id = 1 or id=2",
+        "Result": [
+          "1 1 1",
+          "2 2 2"
+        ],
+        "Plan": [
+          "TableReader_7 20.00 root partition:all data:Selection_6",
+          "└─Selection_6 20.00 cop[tikv]  or(eq(test_partition.t1.id, 1), eq(test_partition.t1.id, 2))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 20.00 root partition:all index:Selection_9",
+          "└─Selection_9 20.00 cop[tikv]  or(eq(test_partition_1.t1.id, 1), eq(test_partition_1.t1.id, 2))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where id = 1 and a=1",
+        "Result": [
+          "1 1 1"
+        ],
+        "Plan": [
+          "TableReader_7 0.01 root partition:p0 data:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test_partition.t1.a, 1), eq(test_partition.t1.id, 1)",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_7 0.01 root partition:p0 index:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test_partition_1.t1.id, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 partition(p1) where a = 1 or b = 2",
+        "Result": null,
+        "Plan": [
+          "TableReader_7 19.99 root partition:dual data:Selection_6",
+          "└─Selection_6 19.99 cop[tikv]  or(eq(test_partition.t1.a, 1), eq(test_partition.t1.b, 2))",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "IndexReader_10 19.99 root partition:dual index:Selection_9",
+          "└─Selection_9 19.99 cop[tikv]  or(eq(test_partition_1.t1.a, 1), eq(test_partition_1.t1.b, 2))",
+          "  └─IndexFullScan_8 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and (t2.a = 6 and t2.b = 6)",
+        "Result": null,
+        "Plan": [
+          "Projection_7 0.01 root  test_partition.t1.id, test_partition.t1.a, test_partition.t1.b, test_partition.t2.id, test_partition.t2.a, test_partition.t2.b",
+          "└─HashJoin_9 0.01 root  inner join, equal:[eq(test_partition.t2.id, test_partition.t1.id)]",
+          "  ├─TableReader_12(Build) 0.01 root partition:p1 data:Selection_11",
+          "  │ └─Selection_11 0.01 cop[tikv]  eq(test_partition.t2.a, 6), eq(test_partition.t2.b, 6), not(isnull(test_partition.t2.id))",
+          "  │   └─TableFullScan_10 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 19.98 root partition:p0 data:Selection_14",
+          "    └─Selection_14 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Projection_7 1.25 root  test_partition_1.t1.id, test_partition_1.t1.a, test_partition_1.t1.b, test_partition_1.t2.id, test_partition_1.t2.a, test_partition_1.t2.b",
+          "└─HashJoin_15 1.25 root  inner join, equal:[eq(test_partition_1.t2.id, test_partition_1.t1.id)]",
+          "  ├─IndexReader_20(Build) 1.00 root partition:p1 index:IndexRangeScan_19",
+          "  │ └─IndexRangeScan_19 1.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 6 -inf,6 6 +inf], keep order:false, stats:pseudo",
+          "  └─IndexReader_18(Probe) 19.98 root partition:p0 index:Selection_17",
+          "    └─Selection_17 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "      └─IndexRangeScan_16 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 join t1 as t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and (t2.a = 6 and t2.b = 6)",
+        "Result": null,
+        "Plan": [
+          "Projection_7 0.01 root  test_partition.t1.id, test_partition.t1.a, test_partition.t1.b, test_partition.t1.id, test_partition.t1.a, test_partition.t1.b",
+          "└─HashJoin_9 0.01 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t1.id)]",
+          "  ├─TableReader_12(Build) 0.01 root partition:p1 data:Selection_11",
+          "  │ └─Selection_11 0.01 cop[tikv]  eq(test_partition.t1.a, 6), eq(test_partition.t1.b, 6), not(isnull(test_partition.t1.id))",
+          "  │   └─TableFullScan_10 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 19.98 root partition:p0 data:Selection_14",
+          "    └─Selection_14 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Projection_7 1.25 root  test_partition_1.t1.id, test_partition_1.t1.a, test_partition_1.t1.b, test_partition_1.t1.id, test_partition_1.t1.a, test_partition_1.t1.b",
+          "└─HashJoin_15 1.25 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t1.id)]",
+          "  ├─IndexReader_20(Build) 1.00 root partition:p1 index:IndexRangeScan_19",
+          "  │ └─IndexRangeScan_19 1.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 6 -inf,6 6 +inf], keep order:false, stats:pseudo",
+          "  └─IndexReader_18(Probe) 19.98 root partition:p0 index:Selection_17",
+          "    └─Selection_17 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "      └─IndexRangeScan_16 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where t1.a in (select b from t2 where a in (1,2)) order by a",
+        "Result": [
+          "1 1 1",
+          "2 2 2"
+        ],
+        "Plan": [
+          "Sort_11 19.98 root  test_partition.t1.a",
+          "└─HashJoin_15 19.98 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.a)]",
+          "  ├─HashAgg_21(Build) 15.98 root  group by:test_partition.t2.b, funcs:firstrow(test_partition.t2.b)->test_partition.t2.b",
+          "  │ └─TableReader_22 15.98 root partition:p0 data:HashAgg_16",
+          "  │   └─HashAgg_16 15.98 cop[tikv]  group by:test_partition.t2.b, ",
+          "  │     └─Selection_20 19.98 cop[tikv]  in(test_partition.t2.a, 1, 2), not(isnull(test_partition.t2.b))",
+          "  │       └─TableFullScan_19 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_28(Probe) 9990.00 root partition:all data:Selection_27",
+          "    └─Selection_27 9990.00 cop[tikv]  not(isnull(test_partition.t1.a))",
+          "      └─TableFullScan_26 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_11 199.80 root  test_partition_1.t1.a",
+          "└─IndexJoin_17 199.80 root  inner join, inner:IndexReader_16, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.a, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.a)",
+          "  ├─HashAgg_26(Build) 159.84 root  group by:test_partition_1.t2.b, funcs:firstrow(test_partition_1.t2.b)->test_partition_1.t2.b",
+          "  │ └─IndexReader_27 159.84 root partition:p0 index:HashAgg_22",
+          "  │   └─HashAgg_22 159.84 cop[tikv]  group by:test_partition_1.t2.b, ",
+          "  │     └─IndexRangeScan_25 199.80 cop[tikv] table:t2, index:a(a, b, id) range:[1 -inf,1 +inf], [2 -inf,2 +inf], keep order:false, stats:pseudo",
+          "  └─IndexReader_16(Probe) 1.25 root partition:all index:Selection_15",
+          "    └─Selection_15 1.25 cop[tikv]  not(isnull(test_partition_1.t1.a))",
+          "      └─IndexRangeScan_14 1.25 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.a, test_partition_1.t2.b)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where t1.a in (select b from t1 where a in (1,2)) order by a",
+        "Result": [
+          "1 1 1",
+          "2 2 2"
+        ],
+        "Plan": [
+          "Sort_11 19.98 root  test_partition.t1.a",
+          "└─HashJoin_15 19.98 root  inner join, equal:[eq(test_partition.t1.b, test_partition.t1.a)]",
+          "  ├─HashAgg_21(Build) 15.98 root  group by:test_partition.t1.b, funcs:firstrow(test_partition.t1.b)->test_partition.t1.b",
+          "  │ └─TableReader_22 15.98 root partition:p0 data:HashAgg_16",
+          "  │   └─HashAgg_16 15.98 cop[tikv]  group by:test_partition.t1.b, ",
+          "  │     └─Selection_20 19.98 cop[tikv]  in(test_partition.t1.a, 1, 2), not(isnull(test_partition.t1.b))",
+          "  │       └─TableFullScan_19 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_28(Probe) 9990.00 root partition:all data:Selection_27",
+          "    └─Selection_27 9990.00 cop[tikv]  not(isnull(test_partition.t1.a))",
+          "      └─TableFullScan_26 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_11 199.80 root  test_partition_1.t1.a",
+          "└─IndexJoin_17 199.80 root  inner join, inner:IndexReader_16, outer key:test_partition_1.t1.b, inner key:test_partition_1.t1.a, equal cond:eq(test_partition_1.t1.b, test_partition_1.t1.a)",
+          "  ├─HashAgg_26(Build) 159.84 root  group by:test_partition_1.t1.b, funcs:firstrow(test_partition_1.t1.b)->test_partition_1.t1.b",
+          "  │ └─IndexReader_27 159.84 root partition:p0 index:HashAgg_22",
+          "  │   └─HashAgg_22 159.84 cop[tikv]  group by:test_partition_1.t1.b, ",
+          "  │     └─IndexRangeScan_25 199.80 cop[tikv] table:t1, index:a(a, b, id) range:[1 -inf,1 +inf], [2 -inf,2 +inf], keep order:false, stats:pseudo",
+          "  └─IndexReader_16(Probe) 1.25 root partition:all index:Selection_15",
+          "    └─Selection_15 1.25 cop[tikv]  not(isnull(test_partition_1.t1.a))",
+          "      └─IndexRangeScan_14 1.25 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.a, test_partition_1.t1.b)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 left join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and t2.a in (6,7,8)",
+        "Result": null,
+        "Plan": [
+          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
+          "├─TableReader_11(Build) 19.98 root partition:p0 data:Selection_10",
+          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─TableReader_14(Probe) 29.97 root partition:p1 data:Selection_13",
+          "  └─Selection_13 29.97 cop[tikv]  in(test_partition.t2.a, 6, 7, 8), not(isnull(test_partition.t2.id))",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
+          "├─IndexReader_11(Build) 19.98 root partition:p0 index:Selection_10",
+          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "│   └─IndexRangeScan_9 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─IndexReader_14(Probe) 29.97 root partition:p1 index:Selection_13",
+          "  └─Selection_13 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
+          "    └─IndexRangeScan_12 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[6,6], [7,7], [8,8], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 right join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and t2.a in (1,2,3)",
+        "Result": [
+          "1 1 1 1 1 1",
+          "3 3 3 3 3 3"
+        ],
+        "Plan": [
+          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
+          "├─TableReader_11(Build) 19.98 root partition:p0 data:Selection_10",
+          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─TableReader_14(Probe) 29.97 root partition:p0 data:Selection_13",
+          "  └─Selection_13 29.97 cop[tikv]  in(test_partition.t2.a, 1, 2, 3), not(isnull(test_partition.t2.id))",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
+          "├─IndexReader_11(Build) 19.98 root partition:p0 index:Selection_10",
+          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "│   └─IndexRangeScan_9 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─IndexReader_14(Probe) 29.97 root partition:p0 index:Selection_13",
+          "  └─Selection_13 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
+          "    └─IndexRangeScan_12 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 join t2 on true where t1.a=5 and t2.a in (6,7,8) and t2.b = 6",
+        "Result": [
+          "5 5 5 6 6 6"
+        ],
+        "Plan": [
+          "Projection_7 80.00 root  test_partition.t1.id, test_partition.t1.a, test_partition.t1.b, test_partition.t2.id, test_partition.t2.a, test_partition.t2.b",
+          "└─HashJoin_9 80.00 root  CARTESIAN inner join",
+          "  ├─TableReader_12(Build) 8.00 root partition:p1 data:Selection_11",
+          "  │ └─Selection_11 8.00 cop[tikv]  1, eq(test_partition.t2.b, 6), in(test_partition.t2.a, 6, 7, 8)",
+          "  │   └─TableFullScan_10 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 10.00 root partition:p0 data:Selection_14",
+          "    └─Selection_14 10.00 cop[tikv]  1, eq(test_partition.t1.a, 5)",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Projection_7 300.00 root  test_partition_1.t1.id, test_partition_1.t1.a, test_partition_1.t1.b, test_partition_1.t2.id, test_partition_1.t2.a, test_partition_1.t2.b",
+          "└─HashJoin_9 300.00 root  CARTESIAN inner join",
+          "  ├─IndexReader_11(Build) 3.00 root partition:p1 index:IndexRangeScan_10",
+          "  │ └─IndexRangeScan_10 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 6 NULL,6 6 +inf], [7 6 NULL,7 6 +inf], [8 6 NULL,8 6 +inf], keep order:false, stats:pseudo",
+          "  └─IndexReader_13(Probe) 100.00 root partition:p0 index:IndexRangeScan_12",
+          "    └─IndexRangeScan_12 100.00 cop[tikv] table:t1, index:a(a, b, id) range:[5 NULL,5 +inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select count(*) from t1 join t2 on t1.b = t2.b where t1.a in (1,2) and t2.a in (1,6) and t1.b in (1,6)",
+        "Result": [
+          "1"
+        ],
+        "Plan": [
+          "StreamAgg_10 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_11 0.00 root  inner join, equal:[eq(test_partition.t1.b, test_partition.t2.b)]",
+          "  ├─TableReader_18(Build) 0.04 root partition:p0,p1 data:Selection_17",
+          "  │ └─Selection_17 0.04 cop[tikv]  in(test_partition.t2.a, 1, 6), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
+          "  │   └─TableFullScan_16 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 0.04 root partition:p0 data:Selection_14",
+          "    └─Selection_14 0.04 cop[tikv]  in(test_partition.t1.a, 1, 2), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_10 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_23 0.10 root  inner join, equal:[eq(test_partition_1.t1.b, test_partition_1.t2.b)]",
+          "  ├─IndexReader_30(Build) 0.40 root partition:p0,p1 index:Selection_29",
+          "  │ └─Selection_29 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_28 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [6 1,6 1], [6 6,6 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_27(Probe) 0.40 root partition:p0 index:Selection_26",
+          "    └─Selection_26 0.40 cop[tikv]  not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_25 0.40 cop[tikv] table:t1, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ INL_JOIN(t2,t1) */      count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (1,6)",
+        "Result": [
+          "1"
+        ],
+        "Plan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_17(Build) 0.04 root partition:p0,p1 data:Selection_16",
+          "  │ └─Selection_16 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 1, 6), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 0.04 root partition:p0 data:Selection_13",
+          "    └─Selection_13 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 1, 6), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexJoin_13 0.10 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_24(Build) 0.40 root partition:p0 index:Selection_23",
+          "  │ └─Selection_23 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_22 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_12(Probe) 0.32 root partition:p0,p1 index:Selection_11",
+          "    └─Selection_11 0.32 cop[tikv]  in(test_partition_1.t1.b, 1, 6), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (6,1)",
+        "Result": [
+          "1"
+        ],
+        "Plan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_17(Build) 0.04 root partition:p0,p1 data:Selection_16",
+          "  │ └─Selection_16 0.04 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 6, 1), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 0.04 root partition:p0 data:Selection_13",
+          "    └─Selection_13 0.04 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 6, 1), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_15 0.10 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_24(Build) 0.40 root partition:p0 index:Selection_23",
+          "  │ └─Selection_23 0.40 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_22 0.40 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [2 1,2 1], [2 6,2 6], keep order:false, stats:pseudo",
+          "  └─IndexReader_12(Probe) 0.32 root partition:p0,p1 index:Selection_11",
+          "    └─Selection_11 0.32 cop[tikv]  in(test_partition_1.t1.b, 6, 1), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (100,9,6)",
+        "Result": [
+          "0"
+        ],
+        "Plan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_10 0.00 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_17(Build) 0.06 root partition:p1 data:Selection_16",
+          "  │ └─Selection_16 0.06 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 0.06 root partition:dual data:Selection_13",
+          "    └─Selection_13 0.06 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_15 0.23 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_24(Build) 0.60 root partition:dual index:Selection_23",
+          "  │ └─Selection_23 0.60 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_22 0.60 cop[tikv] table:t2, index:a(a, b, id) range:[1 6,1 6], [1 9,1 9], [1 100,1 100], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
+          "  └─IndexReader_12(Probe) 0.48 root partition:p1 index:Selection_11",
+          "    └─Selection_11 0.48 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select /*+ INL_HASH_JOIN(t1,t2) */ count(*) from t2 join t1 on t2.b = t1.b where t2.a in (1,2) and t1.a in (1,6) and t1.b in (100,9,6,1)",
+        "Result": [
+          "1"
+        ],
+        "Plan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─HashJoin_10 0.01 root  inner join, equal:[eq(test_partition.t2.b, test_partition.t1.b)]",
+          "  ├─TableReader_17(Build) 0.08 root partition:p0,p1 data:Selection_16",
+          "  │ └─Selection_16 0.08 cop[tikv]  in(test_partition.t1.a, 1, 6), in(test_partition.t1.b, 100, 9, 6, 1), not(isnull(test_partition.t1.b))",
+          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 0.08 root partition:p0 data:Selection_13",
+          "    └─Selection_13 0.08 cop[tikv]  in(test_partition.t2.a, 1, 2), in(test_partition.t2.b, 100, 9, 6, 1), not(isnull(test_partition.t2.b))",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "StreamAgg_9 1.00 root  funcs:count(1)->Column#9",
+          "└─IndexHashJoin_15 0.41 root  inner join, inner:IndexReader_12, outer key:test_partition_1.t2.b, inner key:test_partition_1.t1.b, equal cond:eq(test_partition_1.t2.b, test_partition_1.t1.b)",
+          "  ├─IndexReader_24(Build) 0.80 root partition:p0 index:Selection_23",
+          "  │ └─Selection_23 0.80 cop[tikv]  not(isnull(test_partition_1.t2.b))",
+          "  │   └─IndexRangeScan_22 0.80 cop[tikv] table:t2, index:a(a, b, id) range:[1 1,1 1], [1 6,1 6], [1 9,1 9], [1 100,1 100], [2 1,2 1], [2 6,2 6], [2 9,2 9], [2 100,2 100], keep order:false, stats:pseudo",
+          "  └─IndexReader_12(Probe) 0.64 root partition:p0,p1 index:Selection_11",
+          "    └─Selection_11 0.64 cop[tikv]  in(test_partition_1.t1.b, 100, 9, 6, 1), not(isnull(test_partition_1.t1.b))",
+          "      └─IndexRangeScan_10 160.00 cop[tikv] table:t1, index:a(a, b, id) range: decided by [eq(test_partition_1.t1.b, test_partition_1.t2.b) in(test_partition_1.t1.a, 1, 6)], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where a in (1,2,3) union select * from t1 where b in (6,7,8) order by a",
+        "Result": [
+          "1 1 1",
+          "2 2 2",
+          "3 3 3",
+          "6 6 6",
+          "7 7 7",
+          "8 8 8"
+        ],
+        "Plan": [
+          "Sort_12 48.00 root  Column#10",
+          "└─HashAgg_14 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
+          "  └─Union_15 60.00 root  ",
+          "    ├─TableReader_19 30.00 root partition:p0 data:Selection_18",
+          "    │ └─Selection_18 30.00 cop[tikv]  in(test_partition.t1.a, 1, 2, 3)",
+          "    │   └─TableFullScan_17 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "    └─TableReader_23 30.00 root partition:p1 data:Selection_22",
+          "      └─Selection_22 30.00 cop[tikv]  in(test_partition.t1.b, 6, 7, 8)",
+          "        └─TableFullScan_21 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ],
+        "IndexPlan": [
+          "Sort_12 48.00 root  Column#10",
+          "└─HashAgg_14 48.00 root  group by:Column#10, Column#11, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11",
+          "  └─Union_15 60.00 root  ",
+          "    ├─IndexReader_18 30.00 root partition:p0 index:IndexRangeScan_17",
+          "    │ └─IndexRangeScan_17 30.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo",
+          "    └─IndexReader_25 30.00 root partition:p1 index:Selection_24",
+          "      └─Selection_24 30.00 cop[tikv]  in(test_partition_1.t1.b, 6, 7, 8)",
+          "        └─IndexFullScan_23 10000.00 cop[tikv] table:t1, index:a(a, b, id) keep order:false, stats:pseudo"
         ]
       }
     ]

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -31,11 +31,13 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
 	"go.uber.org/zap"
@@ -117,7 +119,7 @@ func newPartitionExpr(tblInfo *model.TableInfo) (*PartitionExpr, error) {
 	case model.PartitionTypeHash:
 		return generateHashPartitionExpr(ctx, pi, columns, names)
 	case model.PartitionTypeList:
-		return generateListPartitionExpr(ctx, pi, columns, names)
+		return generateListPartitionExpr(ctx, tblInfo, columns, names)
 	}
 	panic("cannot reach here")
 }
@@ -199,8 +201,169 @@ func parseSimpleExprWithNames(p *parser.Parser, ctx sessionctx.Context, exprStr 
 
 // ForListPruning is used for list partition pruning.
 type ForListPruning struct {
-	Exprs    []expression.Expression
-	ExprCols []*expression.Column
+	// LocateExpr uses to locate list partition by row.
+	LocateExpr expression.Expression
+	// PruneExpr uses to prune list partition in partition pruner.
+	PruneExpr expression.Expression
+	// PruneExprCols is the columns of PruneExpr, it has removed the duplicate columns.
+	PruneExprCols []*expression.Column
+	// valueMap is column value -> partition idx, uses to locate list partition.
+	valueMap map[int64]int
+	// nullPartitionIdx is the partition idx for null value.
+	nullPartitionIdx int
+
+	// For list columns partition pruning
+	ColPrunes []*ForListColumnPruning
+}
+
+// ForListColumnPruning is used for list columns partition pruning.
+type ForListColumnPruning struct {
+	ExprCol  *expression.Column
+	valueTp  *types.FieldType
+	valueMap map[string]ListPartitionLocation
+}
+
+// ListPartitionGroup indicate the group index of the column value in a partition.
+type ListPartitionGroup struct {
+	// Such as: list columns (a,b) (partition p0 values in ((1,5),(1,6)));
+	// For the column a which value is 1, the ListPartitionGroup is:
+	// ListPartitionGroup {
+	//     PartIdx: 0,            // 0 is the partition p0 index in all partitions.
+	//     GroupIdxs: []int{0,1}, // p0 has 2 value group: (1,5) and (1,6), and they both contain the column a where value is 1;
+	// }                          // the value of GroupIdxs `0,1` is the index of the value group that contain the column a which value is 1.
+	PartIdx   int
+	GroupIdxs []int
+}
+
+// ListPartitionLocation indicate the partition location for the column value in list columns partition.
+// Here is an example:
+// Suppose the list columns partition is: list columns (a,b) (partition p0 values in ((1,5),(1,6)), partition p1 values in ((1,7),(9,9)));
+// How to express the location of the column a which value is 1?
+// For the column a which value is 1, both partition p0 and p1 contain the column a which value is 1.
+// In partition p0, both value group0 (1,5) and group1 (1,6) are contain the column a which value is 1.
+// In partition p1, value group0 (1,7) contains the column a which value is 1.
+// So, the ListPartitionLocation of column a which value is 1 is:
+// []ListPartitionGroup{
+// 	{
+// 		PartIdx: 0,               // `0` is the partition p0 index in all partitions.
+// 		GroupIdxs: []int{0, 1}    // `0,1` is the index of the value group0, group1.
+// 	},
+// 	{
+// 		PartIdx: 1,               // `1` is the partition p1 index in all partitions.
+// 		GroupIdxs: []int{0}       // `0` is the index of the value group0.
+// 	},
+// }
+type ListPartitionLocation []ListPartitionGroup
+
+// IsEmpty returns true if the ListPartitionLocation is empty.
+func (ps ListPartitionLocation) IsEmpty() bool {
+	for _, pg := range ps {
+		if len(pg.GroupIdxs) > 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (ps ListPartitionLocation) findByPartitionIdx(partIdx int) int {
+	for i, p := range ps {
+		if p.PartIdx == partIdx {
+			return i
+		}
+	}
+	return -1
+}
+
+type listPartitionLocationHelper struct {
+	initialized bool
+	location    ListPartitionLocation
+}
+
+// NewListPartitionLocationHelper returns a new listPartitionLocationHelper.
+func NewListPartitionLocationHelper() *listPartitionLocationHelper {
+	return &listPartitionLocationHelper{}
+}
+
+// GetLocation gets the list partition location.
+func (p *listPartitionLocationHelper) GetLocation() ListPartitionLocation {
+	return p.location
+}
+
+// UnionPartitionGroup unions with the list-partition-value-group.
+func (p *listPartitionLocationHelper) UnionPartitionGroup(pg ListPartitionGroup) {
+	idx := p.location.findByPartitionIdx(pg.PartIdx)
+	if idx < 0 {
+		// copy the group idx.
+		groupIdxs := make([]int, len(pg.GroupIdxs))
+		copy(groupIdxs, pg.GroupIdxs)
+		p.location = append(p.location, ListPartitionGroup{
+			PartIdx:   pg.PartIdx,
+			GroupIdxs: groupIdxs,
+		})
+		return
+	}
+	p.location[idx].union(pg)
+}
+
+// Union unions with the other location.
+func (p *listPartitionLocationHelper) Union(location ListPartitionLocation) {
+	for _, pg := range location {
+		p.UnionPartitionGroup(pg)
+	}
+}
+
+// Intersect intersect with other location.
+func (p *listPartitionLocationHelper) Intersect(location ListPartitionLocation) bool {
+	if !p.initialized {
+		p.initialized = true
+		p.location = make([]ListPartitionGroup, 0, len(location))
+		p.location = append(p.location, location...)
+		return true
+	}
+	currPgs := p.location
+	var remainPgs []ListPartitionGroup
+	for _, pg := range location {
+		idx := currPgs.findByPartitionIdx(pg.PartIdx)
+		if idx < 0 {
+			continue
+		}
+		if !currPgs[idx].intersect(pg) {
+			continue
+		}
+		remainPgs = append(remainPgs, currPgs[idx])
+	}
+	p.location = remainPgs
+	return len(remainPgs) > 0
+}
+
+func (pg *ListPartitionGroup) intersect(otherPg ListPartitionGroup) bool {
+	if pg.PartIdx != otherPg.PartIdx {
+		return false
+	}
+	var groupIdxs []int
+	for _, gidx := range otherPg.GroupIdxs {
+		if pg.findGroupIdx(gidx) {
+			groupIdxs = append(groupIdxs, gidx)
+		}
+	}
+	pg.GroupIdxs = groupIdxs
+	return len(groupIdxs) > 0
+}
+
+func (pg *ListPartitionGroup) union(otherPg ListPartitionGroup) {
+	if pg.PartIdx != otherPg.PartIdx {
+		return
+	}
+	pg.GroupIdxs = append(pg.GroupIdxs, otherPg.GroupIdxs...)
+}
+
+func (pg *ListPartitionGroup) findGroupIdx(groupIdx int) bool {
+	for _, gidx := range pg.GroupIdxs {
+		if gidx == groupIdx {
+			return true
+		}
+	}
+	return false
 }
 
 // ForRangePruning is used for range partition pruning.
@@ -387,157 +550,237 @@ func extractListPartitionExprColumns(ctx sessionctx.Context, pi *model.Partition
 	for _, col := range cols {
 		if findIdxByColUniqueID(deDupCols, col) < 0 {
 			c := col.Clone().(*expression.Column)
-			c.Index = len(deDupCols)
 			deDupCols = append(deDupCols, c)
 		}
 	}
 	return deDupCols, offset, nil
 }
 
-func generateListPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,
+func generateListPartitionExpr(ctx sessionctx.Context, tblInfo *model.TableInfo,
 	columns []*expression.Column, names types.NameSlice) (*PartitionExpr, error) {
 	// The caller should assure partition info is not nil.
-	locateExprs := make([]expression.Expression, 0, len(pi.Definitions))
-	pruneExprs := make([]expression.Expression, 0, len(pi.Definitions))
-	schema := expression.NewSchema(columns...)
+	pi := tblInfo.GetPartitionInfo()
 	exprCols, offset, err := extractListPartitionExprColumns(ctx, pi, columns, names)
 	if err != nil {
 		return nil, err
 	}
-	p := parser.New()
-	for _, def := range pi.Definitions {
-		exprStr, err := generateListPartitionExprStr(ctx, pi, schema, names, &def, p)
-		if err != nil {
-			return nil, err
-		}
-		expr, err := parseSimpleExprWithNames(p, ctx, exprStr, schema, names)
-		if err != nil {
-			// If it got an error here, ddl may hang forever, so this error log is important.
-			logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", exprStr), zap.Error(err))
-			return nil, errors.Trace(err)
-		}
-		locateExprs = append(locateExprs, expr)
-		pruneExpr := expr.Clone()
-		cols := expression.ExtractColumns(pruneExpr)
-		for _, c := range cols {
-			idx := findIdxByColUniqueID(exprCols, c)
-			if idx < 0 {
-				panic("should never happen")
-			}
-			c.Index = idx
-		}
-
-		pruneExprs = append(pruneExprs, pruneExpr)
+	listPrune := &ForListPruning{}
+	if len(pi.Columns) == 0 {
+		err = listPrune.buildListPruner(ctx, tblInfo, exprCols, columns, names)
+	} else {
+		err = listPrune.buildListColumnsPruner(ctx, tblInfo, columns, names)
+	}
+	if err != nil {
+		return nil, err
 	}
 	ret := &PartitionExpr{
-		InValues:       locateExprs,
-		ForListPruning: &ForListPruning{Exprs: pruneExprs, ExprCols: exprCols},
+		ForListPruning: listPrune,
 		ColumnOffset:   offset,
 	}
 	return ret, nil
 }
 
-func generateListPartitionExprStr(ctx sessionctx.Context, pi *model.PartitionInfo,
-	schema *expression.Schema, names types.NameSlice, def *model.PartitionDefinition, p *parser.Parser) (string, error) {
-	if len(pi.Columns) < 2 {
-		return generateListColumnsPartitionExprStr(ctx, pi, schema, names, def, p)
+func (lp *ForListPruning) buildListPruner(ctx sessionctx.Context, tblInfo *model.TableInfo, exprCols []*expression.Column,
+	columns []*expression.Column, names types.NameSlice) error {
+	pi := tblInfo.GetPartitionInfo()
+	schema := expression.NewSchema(columns...)
+	p := parser.New()
+	expr, err := parseSimpleExprWithNames(p, ctx, pi.Expr, schema, names)
+	if err != nil {
+		// If it got an error here, ddl may hang forever, so this error log is important.
+		logutil.BgLogger().Error("wrong table partition expression", zap.String("expression", pi.Expr), zap.Error(err))
+		return errors.Trace(err)
 	}
-	return generateMultiListColumnsPartitionExprStr(ctx, pi, schema, names, def, p)
+	// Since need to change the column index of the expresion, clone the expression first.
+	lp.LocateExpr = expr.Clone()
+	lp.PruneExprCols = exprCols
+	lp.PruneExpr = expr.Clone()
+	cols := expression.ExtractColumns(lp.PruneExpr)
+	for _, c := range cols {
+		idx := findIdxByColUniqueID(exprCols, c)
+		if idx < 0 {
+			return table.ErrUnknownColumn.GenWithStackByArgs(c.OrigName)
+		}
+		c.Index = idx
+	}
+	err = lp.buildListPartitionValueMap(ctx, tblInfo, schema, names, p)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func generateListColumnsPartitionExprStr(ctx sessionctx.Context, pi *model.PartitionInfo,
-	schema *expression.Schema, names types.NameSlice, def *model.PartitionDefinition, p *parser.Parser) (string, error) {
-	var partStr string
-	if len(pi.Columns) == 0 {
-		partStr = pi.Expr
-	} else if len(pi.Columns) == 1 {
-		partStr = "`" + pi.Columns[0].L + "`"
-	} else {
-		return generateMultiListColumnsPartitionExprStr(ctx, pi, schema, names, def, p)
-	}
-	var buf, nullCondBuf bytes.Buffer
-	fmt.Fprintf(&buf, "(%s in (", partStr)
-	for i, vs := range def.InValues {
-		if i > 0 {
-			buf.WriteByte(',')
+func (lp *ForListPruning) buildListColumnsPruner(ctx sessionctx.Context, tblInfo *model.TableInfo,
+	columns []*expression.Column, names types.NameSlice) error {
+	pi := tblInfo.GetPartitionInfo()
+	schema := expression.NewSchema(columns...)
+	p := parser.New()
+	colPrunes := make([]*ForListColumnPruning, 0, len(pi.Columns))
+	for colIdx := range pi.Columns {
+		colInfo := model.FindColumnInfo(tblInfo.Columns, pi.Columns[colIdx].L)
+		if colInfo == nil {
+			return table.ErrUnknownColumn.GenWithStackByArgs(pi.Columns[colIdx].L)
 		}
-		buf.WriteString(vs[0])
-	}
-	buf.WriteString("))")
-	for _, vs := range def.InValues {
-		nullCondBuf.Reset()
-		hasNull := false
-		for i, value := range vs {
-			expr, err := parseSimpleExprWithNames(p, ctx, value, schema, names)
-			if err != nil {
-				return "", errors.Trace(err)
-			}
-			v, err := expr.Eval(chunk.Row{})
-			if err != nil {
-				return "", errors.Trace(err)
-			}
-			if i > 0 {
-				nullCondBuf.WriteString(" and ")
-			}
-			if v.IsNull() {
-				hasNull = true
-				fmt.Fprintf(&nullCondBuf, "%s is null", partStr)
-			} else {
-				fmt.Fprintf(&nullCondBuf, "%s = %s", partStr, value)
-			}
+		idx := expression.FindFieldNameIdxByColName(names, pi.Columns[colIdx].L)
+		if idx < 0 {
+			return table.ErrUnknownColumn.GenWithStackByArgs(pi.Columns[colIdx].L)
 		}
-		if hasNull {
-			fmt.Fprintf(&buf, " or (%s) ", nullCondBuf.String())
+		colPrune := &ForListColumnPruning{
+			ExprCol:  columns[idx],
+			valueTp:  &colInfo.FieldType,
+			valueMap: make(map[string]ListPartitionLocation),
 		}
+		err := colPrune.buildPartitionValueMap(ctx, tblInfo, colIdx, schema, names, p)
+		if err != nil {
+			return err
+		}
+		colPrunes = append(colPrunes, colPrune)
 	}
-	return buf.String(), nil
+	lp.ColPrunes = colPrunes
+	return nil
 }
 
-func generateMultiListColumnsPartitionExprStr(ctx sessionctx.Context, pi *model.PartitionInfo,
-	schema *expression.Schema, names types.NameSlice, def *model.PartitionDefinition, p *parser.Parser) (string, error) {
-	var buf, nullCondBuf bytes.Buffer
-	var partStr string
-	for i, col := range pi.Columns {
-		if i > 0 {
-			partStr += ","
-		}
-		partStr += "`" + col.L + "`"
-	}
-	fmt.Fprintf(&buf, "((%s) in (", partStr)
-	for i, vs := range def.InValues {
-		if i > 0 {
-			buf.WriteByte(',')
-		}
-		fmt.Fprintf(&buf, "(%s)", strings.Join(vs, ","))
-	}
-	buf.WriteString("))")
-	for _, vs := range def.InValues {
-		nullCondBuf.Reset()
-		hasNull := false
-		for i, value := range vs {
-			expr, err := parseSimpleExprWithNames(p, ctx, value, schema, names)
+// buildListPartitionValueMap builds list partition value map.
+// The map is column value -> partition index.
+// colIdx is the column index in the list columns.
+func (lp *ForListPruning) buildListPartitionValueMap(ctx sessionctx.Context, tblInfo *model.TableInfo,
+	schema *expression.Schema, names types.NameSlice, p *parser.Parser) error {
+	pi := tblInfo.GetPartitionInfo()
+	lp.valueMap = map[int64]int{}
+	lp.nullPartitionIdx = -1
+	for partitionIdx, def := range pi.Definitions {
+		for _, vs := range def.InValues {
+			expr, err := parseSimpleExprWithNames(p, ctx, vs[0], schema, names)
 			if err != nil {
-				return "", errors.Trace(err)
+				return errors.Trace(err)
 			}
-			v, err := expr.Eval(chunk.Row{})
+			v, isNull, err := expr.EvalInt(ctx, chunk.Row{})
 			if err != nil {
-				return "", errors.Trace(err)
+				return errors.Trace(err)
 			}
-			if i > 0 {
-				nullCondBuf.WriteString(" and ")
+			if isNull {
+				lp.nullPartitionIdx = partitionIdx
+				continue
 			}
-			if v.IsNull() {
-				hasNull = true
-				fmt.Fprintf(&nullCondBuf, "%s is null", pi.Columns[i])
-			} else {
-				fmt.Fprintf(&nullCondBuf, "%s = %s", pi.Columns[i], value)
-			}
-		}
-		if hasNull {
-			fmt.Fprintf(&buf, " or (%s) ", nullCondBuf.String())
+			lp.valueMap[v] = partitionIdx
 		}
 	}
-	return buf.String(), nil
+	return nil
+}
+
+// LocatePartition locates partition by the column value
+func (lp *ForListPruning) LocatePartition(value int64, isNull bool) int {
+	if isNull {
+		return lp.nullPartitionIdx
+	}
+	partitionIdx, ok := lp.valueMap[value]
+	if !ok {
+		return -1
+	}
+	return partitionIdx
+}
+
+func (lp *ForListPruning) locateListPartitionByRow(ctx sessionctx.Context, r []types.Datum) (int, error) {
+	value, isNull, err := lp.LocateExpr.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
+	if err != nil {
+		return -1, errors.Trace(err)
+	}
+	idx := lp.LocatePartition(value, isNull)
+	if idx >= 0 {
+		return idx, nil
+	}
+	if isNull {
+		return -1, table.ErrNoPartitionForGivenValue.GenWithStackByArgs("NULL")
+	}
+	return -1, table.ErrNoPartitionForGivenValue.GenWithStackByArgs(strconv.FormatInt(value, 10))
+}
+
+func (lp *ForListPruning) locateListColumnsPartitionByRow(ctx sessionctx.Context, r []types.Datum) (int, error) {
+	helper := NewListPartitionLocationHelper()
+	sc := ctx.GetSessionVars().StmtCtx
+	for _, colPrune := range lp.ColPrunes {
+		location, err := colPrune.LocatePartition(sc, r[colPrune.ExprCol.Index])
+		if err != nil {
+			return -1, errors.Trace(err)
+		}
+		if !helper.Intersect(location) {
+			break
+		}
+	}
+	location := helper.GetLocation()
+	if location.IsEmpty() {
+		return -1, table.ErrNoPartitionForGivenValue.GenWithStackByArgs("from column_list")
+	}
+	return location[0].PartIdx, nil
+}
+
+// buildListPartitionValueMap builds list columns partition value map for the specified column.
+// colIdx is the specified column index in the list columns.
+func (lp *ForListColumnPruning) buildPartitionValueMap(ctx sessionctx.Context, tblInfo *model.TableInfo, colIdx int,
+	schema *expression.Schema, names types.NameSlice, p *parser.Parser) error {
+	pi := tblInfo.GetPartitionInfo()
+	sc := ctx.GetSessionVars().StmtCtx
+	for partitionIdx, def := range pi.Definitions {
+		for groupIdx, vs := range def.InValues {
+			keyBytes, err := lp.genConstExprKey(ctx, sc, vs[colIdx], schema, names, p)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			key := string(keyBytes)
+			location, ok := lp.valueMap[key]
+			if ok {
+				idx := location.findByPartitionIdx(partitionIdx)
+				if idx != -1 {
+					location[idx].GroupIdxs = append(location[idx].GroupIdxs, groupIdx)
+					continue
+				}
+			}
+			location = append(location, ListPartitionGroup{
+				PartIdx:   partitionIdx,
+				GroupIdxs: []int{groupIdx},
+			})
+			lp.valueMap[key] = location
+		}
+	}
+	return nil
+}
+
+func (lp *ForListColumnPruning) genConstExprKey(ctx sessionctx.Context, sc *stmtctx.StatementContext, exprStr string,
+	schema *expression.Schema, names types.NameSlice, p *parser.Parser) ([]byte, error) {
+	expr, err := parseSimpleExprWithNames(p, ctx, exprStr, schema, names)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	v, err := expr.Eval(chunk.Row{})
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	key, err := lp.genKey(sc, v)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return key, nil
+}
+
+func (lp *ForListColumnPruning) genKey(sc *stmtctx.StatementContext, v types.Datum) ([]byte, error) {
+	v, err := v.ConvertTo(sc, lp.valueTp)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return codec.EncodeKey(sc, nil, v)
+}
+
+// LocatePartition locates partition by the column value
+func (lp *ForListColumnPruning) LocatePartition(sc *stmtctx.StatementContext, v types.Datum) (ListPartitionLocation, error) {
+	key, err := lp.genKey(sc, v)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	location, ok := lp.valueMap[string(key)]
+	if !ok {
+		return nil, nil
+	}
+	return location, nil
 }
 
 func generateHashPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo,
@@ -651,34 +894,11 @@ func (t *partitionedTable) locateRangeColumnPartition(ctx sessionctx.Context, pi
 }
 
 func (t *partitionedTable) locateListPartition(ctx sessionctx.Context, pi *model.PartitionInfo, r []types.Datum) (int, error) {
-	for i, expr := range t.partitionExpr.InValues {
-		ret, _, err := expr.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-		if ret > 0 {
-			return i, nil
-		}
+	lp := t.partitionExpr.ForListPruning
+	if len(lp.ColPrunes) == 0 {
+		return lp.locateListPartitionByRow(ctx, r)
 	}
-	// The data does not belong to any of the partition returns `table has no partition for value %s`.
-	var valueMsg string
-	if pi.Expr != "" {
-		e, err := expression.ParseSimpleExprWithTableInfo(ctx, pi.Expr, t.meta)
-		if err == nil {
-			val, isNull, err := e.EvalInt(ctx, chunk.MutRowFromDatums(r).ToRow())
-			if err == nil {
-				if isNull {
-					valueMsg = fmt.Sprintf("NULL")
-				} else {
-					valueMsg = fmt.Sprintf("%d", val)
-				}
-			}
-		}
-	} else {
-		// When the table is partitioned by list columns.
-		valueMsg = "from column_list"
-	}
-	return 0, table.ErrNoPartitionForGivenValue.GenWithStackByArgs(valueMsg)
+	return lp.locateListColumnsPartitionByRow(ctx, r)
 }
 
 func (t *partitionedTable) locateRangePartition(ctx sessionctx.Context, pi *model.PartitionInfo, r []types.Datum) (int, error) {


### PR DESCRIPTION
cherry-pick #21577

-----------------------------------------------------------------------------------------------------------------------------

- <!-- Thank you for contributing to TiDB!

  PR Title Format:
  1. pkg [, pkg2, pkg3]: what's changed
  2. *: what's changed

  -->

  ### What problem does this PR solve?

  close #21383
  close #21778

  ### What is changed and how it works?

  Here is an example:

  The `list clumns` table is:
  ```sql
  create table t (a bigint, b int) 
      partition by list columns (a,b) (
          partition p0 values in ((1,2),(2,2)), 
          partition p1 values in ((3,3))
      );
  ```

  #### Before this PR

  Before this PR, TiDB will use the following expression to locate partition:

  ```go
  ((a,b) in ((1,1),(2,2)))  => partition p0
  ((a,b) in ((3,3))) => partition p1
  ```

  For the query:

  ```sql
  select * from t where a=1;
  ```

  Since only know the `a=1` without the value of column `b`, so TiDB can't locate the partition, then it has to scan all partitions.

  #### This PR 

  This PR Add special partition pruner for `list columns` partition:

  As you can see, if only know `a=1`, we can still know it must locate in partition `p0`, we can build a special map for each column:
  
  #### Version 1

  * For column `a`, the key of the map is the column value, the value of the map is the target partition.

    ```go 
    1 => partition p0
    2 => partition p0
    3 => partition p1
    ```

  * For column `b`, build below map:

    ```go
    1 => partition p0
    2 => partition p0
    3 => partition p1
    ```

  So for the query `select * from t where a=1;`, since already know the value of column `a`, so we can use the map of column a to prune partition.

  another query example is:

  ```sql
  select * from t where a=1 or b = 1;
  ```

  Then we can:

  * for `a=1`, we can use the map of column `a` to locate partition `p0`;
  * for `b=1`, we can use the map of column `b` to locate partition `p0`;

  Then since the condition is `a=1` `or` `b=1`, so we can just merge the upper result to locate partition, and the result is partition `p0`.
  
  #### Version 2
  
  consider this query:
  
  ```sql
  select * from t where a=1 and b = 2;
  ```
  
  * for `a=1`, we can use the map of column `a` to locate partition `p0`;
  * for `b=2`, we can use the map of column `b` to locate partition `p0`;

Then, if just intersection the upper result will locate in partition `p0`;

But in fact, the partion p0 contain the following value group for `(a,b)`:

```go
(1,1),(2,2)
```

as you can see, partition `p0` doesn't contain the value group (1,2), the  prune result is not accurate, Let's improve it.

Now, we will store the value group index for each column value.

  * For column `a`, the key of the map is the column value, the value of the map is the target partition.

    ```go 
    1 => partition p0, value group index is 0
    2 => partition p0, value group index is 1
    3 => partition p1, value group index is 0
    ```

  * For column `b`, build below map:

    ```go
    1 => partition p0, value group index is 0
    2 => partition p0, value group index is 1
    3 => partition p1, value group index is 0
    ```
    
    Now, with the value group index, we will find that `a=1` and `b=2`, they both locate in partition `p0`, but locate in different value group, the last result of partition prune is no partition.
    
#### Version 3

Consider following partition table:

  The `list clumns` table is:
  ```sql
  create table t (a bigint, b int) 
      partition by list columns (a,b) (
          partition p0 values in ((1,1),(1,2)), 
          partition p1 values in ((1,3))
      );
  ```
  
  As you can see, both partition `p0` and `p1` contain the column a which value is `1`. So each column value maybe locate into multi-partitions. We should change the column value map to:

  * For column `a`, build below map:
 
    ```go
    1 => [
           partition p0, value group index is [0,1]; 
           partition p1, value group index is [0]; 
         ]
    ```

  * For column `b`, build below map:

    ```go
    1 => [partition p0, value group index is [0]]
    2 => [partition p0, value group index is [1]]
    3 => [partition p1, value group index is [0]]
    ```

  ### Related changes

  - N/A

  ### Check List <!--REMOVE the items that are not applicable-->

  Tests <!-- At least one of them must be included. -->

  - Unit test(need add more test...)

  Side effects

  - Performance regression
      - Consumes more CPU
      - Consumes more MEM

  ### Release note <!-- bugfixes or new feature need a release note -->
* Add special partition pruner for list columns partition.