### PR TITLE
distsql: fix cop stats string display when there is only 1 rpc (#21901)

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -191,6 +191,17 @@ func (s *testSuite) TestSelectResultRuntimeStats(c *C) {
 	c.Assert(stats.String(), Equals, expect)
 	// Test for idempotence.
 	c.Assert(stats.String(), Equals, expect)
+
+	s1 = &selectResultRuntimeStats{
+		copRespTime:      []time.Duration{time.Second},
+		procKeys:         []int64{100},
+		backoffSleep:     map[string]time.Duration{"RegionMiss": time.Millisecond},
+		totalProcessTime: time.Second,
+		totalWaitTime:    time.Second,
+		rpcStat:          tikv.NewRegionRequestRuntimeStats(),
+	}
+	expect = "cop_task: {num: 1, max: 1s, proc_keys: 100, tot_proc: 1s, tot_wait: 1s, copr_cache_hit_ratio: 0.00}, backoff{RegionMiss: 1ms}"
+	c.Assert(s1.String(), Equals, expect)
 }
 
 func (s *testSuite) createSelectStreaming(batch, totalRows int, c *C) (*streamResult, []*types.FieldType) {

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -435,13 +435,13 @@ func (s *selectResultRuntimeStats) String() string {
 				buf.WriteString(", p95_proc_keys: ")
 				buf.WriteString(strconv.FormatInt(keyP95, 10))
 			}
-			if s.totalProcessTime > 0 {
-				buf.WriteString(", tot_proc: ")
-				buf.WriteString(execdetails.FormatDuration(s.totalProcessTime))
-				if s.totalWaitTime > 0 {
-					buf.WriteString(", tot_wait: ")
-					buf.WriteString(execdetails.FormatDuration(s.totalWaitTime))
-				}
+		}
+		if s.totalProcessTime > 0 {
+			buf.WriteString(", tot_proc: ")
+			buf.WriteString(execdetails.FormatDuration(s.totalProcessTime))
+			if s.totalWaitTime > 0 {
+				buf.WriteString(", tot_wait: ")
+				buf.WriteString(execdetails.FormatDuration(s.totalWaitTime))
 			}
 		}
 		copRPC := rpcStat.Stats[tikvrpc.CmdCop]


### PR DESCRIPTION
cherry-pick #21901

------------------------------

Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
 create table t (a int auto_increment key, b int);
insert into t values (1,1),(2,2);
```

Before this PR:

```sql
test> explain analyze select * from t;
+-------------------+---------+---------+-----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
| id                | estRows | actRows | task      | access object | execution info                                                                                                                                                                                | operator info                  | memory    | disk |
+-------------------+---------+---------+-----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
| TableReader_5     | 2.00    | 2       | root      |               | time:769.1µs, loops:2, cop_task: {num: 1, max: 712.8µs, proc_keys: 2, rpc_num: 1, rpc_time: 673.8µs, copr_cache_hit_ratio: 0.00}                                                              | data:TableFullScan_4           | 235 Bytes | N/A  |
| └─TableFullScan_4 | 2.00    | 2       | cop[tikv] | table:t       | tikv_task:{time:1ms, loops:1}, total_keys: 5, processed_keys: 2, rocksdb: {delete_skipped_count: 2, key_skipped_count: 6, block_cache_hit_count: 0, block_read_count: 0, block_read: 0 Bytes} | keep order:false, stats:pseudo | N/A       | N/A  |
+-------------------+---------+---------+-----------+---------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
2 rows in set
```

The problem is, when there is only 1 cop task, the execution info doesn't display the `tot_proc` time information.

This PR:

```sql
test> explain analyze select * from t;
+-------------------+---------+---------+-----------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
| id                | estRows | actRows | task      | access object | execution info                                                                                                                                                                               | operator info                  | memory    | disk |
+-------------------+---------+---------+-----------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
| TableReader_5     | 2.00    | 2       | root      |               | time:1.28ms, loops:2, cop_task: {num: 1, max: 1.22ms, proc_keys: 2, tot_proc: 1ms, rpc_num: 1, rpc_time: 1.2ms, copr_cache: disabled}                                                        | data:TableFullScan_4           | 231 Bytes | N/A  |
| └─TableFullScan_4 | 2.00    | 2       | cop[tikv] | table:t       | tikv_task:{time:0s, loops:1}, total_keys: 5, processed_keys: 2, rocksdb: {delete_skipped_count: 2, key_skipped_count: 6, block_cache_hit_count: 0, block_read_count: 0, block_read: 0 Bytes} | keep order:false, stats:pseudo | N/A       | N/A  |
+-------------------+---------+---------+-----------+---------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------+-----------+------+
2 rows in set
Time: 0.013s
```

### What is changed and how it works?

N/A

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

-  N/A
### Release note <!-- bugfixes or new feature need a release note -->

- N/A