### PR TITLE
config: disable statistics feedback by default (#21923)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -702,7 +702,7 @@ var defaultConf = Config{
 		StatsLease:            "3s",
 		RunAutoAnalyze:        true,
 		StmtCountLimit:        5000,
-		FeedbackProbability:   0.05,
+		FeedbackProbability:   0.0,
 		QueryFeedbackLimit:    512,
 		PseudoEstimateRatio:   0.8,
 		ForcePriority:         "NO_PRIORITY",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -257,7 +257,7 @@ stats-lease = "3s"
 run-auto-analyze = true
 
 # Probability to use the query feedback to update stats, 0.0 or 1.0 for always false/true.
-feedback-probability = 0.05
+feedback-probability = 0.0
 
 # The max number of query feedback that cache in memory.
 query-feedback-limit = 512


### PR DESCRIPTION
Cherry-pick #21923 
------
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Due to the unstable behavior. We've already set it to false in 4.0 branch.
Disable it in master branch too.

Problem Summary:

### What is changed and how it works?

Set the feedback probability to false.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`