### PR TITLE
expression: fix a bug that time-typed user variables cannot be evaluated.

### DIFF
--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -903,7 +903,11 @@ func (b *builtinGetStringVarSig) evalString(row chunk.Row) (string, bool, error)
 	sessionVars.UsersLock.RLock()
 	defer sessionVars.UsersLock.RUnlock()
 	if v, ok := sessionVars.Users[varName]; ok {
-		return v.GetString(), false, nil
+		res, err := v.ToString()
+		if err != nil {
+			return "", true, err
+		}
+		return res, false, nil
 	}
 	return "", true, nil
 }

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -4453,6 +4453,13 @@ func (s *testIntegrationSuite) TestIssues(c *C) {
 		"1", "2", "3", "4", "5", "6", "7", "8", "9", "10"))
 }
 
+func (s *testIntegrationSuite) TestUserDefinedVariable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	defer s.cleanEnv(c)
+	tk.MustExec("set @b = now()")
+	c.Check(tk.MustQuery(`select @b`).Rows()[0][0] != "", IsTrue)
+}
+
 func (s *testIntegrationSuite) TestInPredicate4UnsignedInt(c *C) {
 	// for issue #6661
 	tk := testkit.NewTestKit(c, s.store)


### PR DESCRIPTION
A temporary hotfix, DNM.

### Release note <!-- bugfixes or new feature need a release note -->

- fix the issue that the time-typed user variables cannot be evaluated.
