### PR TITLE
plan, partition: re-implement hash partition pruning to support `in` and `or` and some other functions (#18574)

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2882,7 +2882,7 @@ func buildKvRangesForIndexJoin(ctx sessionctx.Context, tableID, indexID int64, l
 		return kvRanges, nil
 	}
 
-	tmpDatumRanges, err = ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges)
+	tmpDatumRanges, err = ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges, true)
 	if err != nil {
 		return nil, err
 	}

--- a/expression/testdata/partition_pruner_in.json
+++ b/expression/testdata/partition_pruner_in.json
@@ -6,7 +6,6 @@
       "explain select * from t3 where id = 9 and a = 1",
       "explain select * from t2 where id = 9 and a = -110",
       "explain select * from t1 where id = -17",
-      "explain select * from t2 where id = a and a = b and b = 2",
       "explain select * from t1 join t2 on (t1.id = t2.id) where t1.id = 5 and t2.a = 7",
       "explain select * from t1 left join t2 on t1.id = 1 and t2.a = 2 where t2.id = 7",
       "explain select * from t2 join t1 on t1.id = t2.id and t2.a = t1.id and t2.id = 12",
@@ -17,8 +16,14 @@
       "explain select * from t5 where d = '2019-10-07'",
       "explain select * from t6 where a is null",
       "explain select * from t6 where b is null",
+      "explain select * from t6 where a = 7 or a = 6",
+      "explain select * from t6 where a in (6, 7)",
       "explain select * from t5 where d is null",
-      "explain select * from t7 where b = -3 and a is null"
+      "explain select * from t7 where b = -3 and a is null",
+      "explain select * from t7 where (a, b) in ((3, 4), (5, 6))",
+      "explain select * from t7 where (a = 1 and b = 2) or (a = 3 and b = 4)",
+      "explain select * from t7 where (a = 1 and b = 2) or (a = 1 and b = 2)",
+      "explain select * from t7 partition(p0) where (a = 1 and b = 2) or (a = 3 and b = 4)"
     ]
   }
 ]

--- a/expression/testdata/partition_pruner_out.json
+++ b/expression/testdata/partition_pruner_out.json
@@ -28,14 +28,6 @@
         ]
       },
       {
-        "SQL": "explain select * from t2 where id = a and a = b and b = 2",
-        "Result": [
-          "TableReader_8 8.00 root  data:Selection_7",
-          "└─Selection_7 8.00 cop[tikv]  eq(test_partition.t2.a, test_partition.t2.b), eq(test_partition.t2.b, 2), eq(test_partition.t2.id, test_partition.t2.a)",
-          "  └─TableFullScan_6 10000.00 cop[tikv] table:t2, partition:p4 keep order:false, stats:pseudo"
-        ]
-      },
-      {
         "SQL": "explain select * from t1 join t2 on (t1.id = t2.id) where t1.id = 5 and t2.a = 7",
         "Result": [
           "HashJoin_10 1.00 root  CARTESIAN inner join",
@@ -115,6 +107,30 @@
         ]
       },
       {
+        "SQL": "explain select * from t6 where a = 7 or a = 6",
+        "Result": [
+          "PartitionUnion_8 40.00 root  ",
+          "├─TableReader_11 20.00 root  data:Selection_10",
+          "│ └─Selection_10 20.00 cop[tikv]  or(eq(test_partition.t6.a, 7), eq(test_partition.t6.a, 6))",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t6, partition:p0 keep order:false, stats:pseudo",
+          "└─TableReader_14 20.00 root  data:Selection_13",
+          "  └─Selection_13 20.00 cop[tikv]  or(eq(test_partition.t6.a, 7), eq(test_partition.t6.a, 6))",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t6, partition:p1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t6 where a in (6, 7)",
+        "Result": [
+          "PartitionUnion_8 40.00 root  ",
+          "├─TableReader_11 20.00 root  data:Selection_10",
+          "│ └─Selection_10 20.00 cop[tikv]  in(test_partition.t6.a, 6, 7)",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t6, partition:p0 keep order:false, stats:pseudo",
+          "└─TableReader_14 20.00 root  data:Selection_13",
+          "  └─Selection_13 20.00 cop[tikv]  in(test_partition.t6.a, 6, 7)",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t6, partition:p1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
         "SQL": "explain select * from t5 where d is null",
         "Result": [
           "TableDual_6 0.00 root  rows:0"
@@ -126,6 +142,44 @@
           "TableReader_8 0.01 root  data:Selection_7",
           "└─Selection_7 0.01 cop[tikv]  eq(test_partition.t7.b, -3), isnull(test_partition.t7.a)",
           "  └─TableFullScan_6 10000.00 cop[tikv] table:t7, partition:p0 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t7 where (a, b) in ((3, 4), (5, 6))",
+        "Result": [
+          "PartitionUnion_8 16000.00 root  ",
+          "├─TableReader_11 8000.00 root  data:Selection_10",
+          "│ └─Selection_10 8000.00 cop[tikv]  or(and(eq(test_partition.t7.a, 3), eq(test_partition.t7.b, 4)), and(eq(test_partition.t7.a, 5), eq(test_partition.t7.b, 6)))",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t7, partition:p1 keep order:false, stats:pseudo",
+          "└─TableReader_14 8000.00 root  data:Selection_13",
+          "  └─Selection_13 8000.00 cop[tikv]  or(and(eq(test_partition.t7.a, 3), eq(test_partition.t7.b, 4)), and(eq(test_partition.t7.a, 5), eq(test_partition.t7.b, 6)))",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t7, partition:p7 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t7 where (a = 1 and b = 2) or (a = 3 and b = 4)",
+        "Result": [
+          "PartitionUnion_8 16000.00 root  ",
+          "├─TableReader_11 8000.00 root  data:Selection_10",
+          "│ └─Selection_10 8000.00 cop[tikv]  or(and(eq(test_partition.t7.a, 1), eq(test_partition.t7.b, 2)), and(eq(test_partition.t7.a, 3), eq(test_partition.t7.b, 4)))",
+          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t7, partition:p3 keep order:false, stats:pseudo",
+          "└─TableReader_14 8000.00 root  data:Selection_13",
+          "  └─Selection_13 8000.00 cop[tikv]  or(and(eq(test_partition.t7.a, 1), eq(test_partition.t7.b, 2)), and(eq(test_partition.t7.a, 3), eq(test_partition.t7.b, 4)))",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t7, partition:p7 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t7 where (a = 1 and b = 2) or (a = 1 and b = 2)",
+        "Result": [
+          "TableReader_8 8000.00 root  data:Selection_7",
+          "└─Selection_7 8000.00 cop[tikv]  or(and(eq(test_partition.t7.a, 1), eq(test_partition.t7.b, 2)), and(eq(test_partition.t7.a, 1), eq(test_partition.t7.b, 2)))",
+          "  └─TableFullScan_6 10000.00 cop[tikv] table:t7, partition:p3 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "explain select * from t7 partition(p0) where (a = 1 and b = 2) or (a = 3 and b = 4)",
+        "Result": [
+          "TableDual_6 0.00 root  rows:0"
         ]
       }
     ]

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -148,8 +148,7 @@ func getEqOrInColOffset(expr expression.Expression, cols []*expression.Column) i
 // detachCNFCondAndBuildRangeForIndex will detach the index filters from table filters. These conditions are connected with `and`
 // It will first find the point query column and then extract the range query column.
 // considerDNF is true means it will try to extract access conditions from the DNF expressions.
-func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column,
-	tpSlice []*types.FieldType, lengths []int, considerDNF bool) (*DetachRangeResult, error) {
+func (d *rangeDetacher) detachCNFCondAndBuildRangeForIndex(conditions []expression.Expression, tpSlice []*types.FieldType, considerDNF bool) (*DetachRangeResult, error) {
 	var (
 		eqCount int
 		ranges  []*Range
@@ -157,7 +156,7 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 	)
 	res := &DetachRangeResult{}
 
-	accessConds, filterConds, newConditions, emptyRange := ExtractEqAndInCondition(sctx, conditions, cols, lengths)
+	accessConds, filterConds, newConditions, emptyRange := ExtractEqAndInCondition(d.sctx, conditions, d.cols, d.lengths)
 	if emptyRange {
 		return res, nil
 	}
@@ -170,9 +169,9 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 	eqOrInCount := len(accessConds)
 	res.EqCondCount = eqCount
 	res.EqOrInCount = eqOrInCount
-	if eqOrInCount == len(cols) {
+	if eqOrInCount == len(d.cols) {
 		filterConds = append(filterConds, newConditions...)
-		ranges, err = buildCNFIndexRange(sctx.GetSessionVars().StmtCtx, cols, tpSlice, lengths, eqOrInCount, accessConds)
+		ranges, err = d.buildCNFIndexRange(tpSlice, eqOrInCount, accessConds)
 		if err != nil {
 			return res, err
 		}
@@ -182,12 +181,12 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 		return res, nil
 	}
 	checker := &conditionChecker{
-		colUniqueID:   cols[eqOrInCount].UniqueID,
-		length:        lengths[eqOrInCount],
-		shouldReserve: lengths[eqOrInCount] != types.UnspecifiedLength,
+		colUniqueID:   d.cols[eqOrInCount].UniqueID,
+		length:        d.lengths[eqOrInCount],
+		shouldReserve: d.lengths[eqOrInCount] != types.UnspecifiedLength,
 	}
 	if considerDNF {
-		accesses, filters := detachColumnCNFConditions(sctx, newConditions, checker)
+		accesses, filters := detachColumnCNFConditions(d.sctx, newConditions, checker)
 		accessConds = append(accessConds, accesses...)
 		filterConds = append(filterConds, filters...)
 	} else {
@@ -199,7 +198,7 @@ func detachCNFCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []ex
 			accessConds = append(accessConds, cond)
 		}
 	}
-	ranges, err = buildCNFIndexRange(sctx.GetSessionVars().StmtCtx, cols, tpSlice, lengths, eqOrInCount, accessConds)
+	ranges, err = d.buildCNFIndexRange(tpSlice, eqOrInCount, accessConds)
 	res.Ranges = ranges
 	res.AccessConds = accessConds
 	res.RemainedConds = filterConds
@@ -268,13 +267,12 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 
 // detachDNFCondAndBuildRangeForIndex will detach the index filters from table filters when it's a DNF.
 // We will detach the conditions of every DNF items, then compose them to a DNF.
-func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expression.ScalarFunction,
-	cols []*expression.Column, newTpSlice []*types.FieldType, lengths []int) ([]*Range, []expression.Expression, bool, error) {
-	sc := sctx.GetSessionVars().StmtCtx
+func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression.ScalarFunction, newTpSlice []*types.FieldType) ([]*Range, []expression.Expression, bool, error) {
+	sc := d.sctx.GetSessionVars().StmtCtx
 	firstColumnChecker := &conditionChecker{
-		colUniqueID:   cols[0].UniqueID,
-		shouldReserve: lengths[0] != types.UnspecifiedLength,
-		length:        lengths[0],
+		colUniqueID:   d.cols[0].UniqueID,
+		shouldReserve: d.lengths[0] != types.UnspecifiedLength,
+		length:        d.lengths[0],
 	}
 	rb := builder{sc: sc}
 	dnfItems := expression.FlattenDNFConditions(condition)
@@ -285,7 +283,7 @@ func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expr
 		if sf, ok := item.(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicAnd {
 			cnfItems := expression.FlattenCNFConditions(sf)
 			var accesses, filters []expression.Expression
-			res, err := detachCNFCondAndBuildRangeForIndex(sctx, cnfItems, cols, newTpSlice, lengths, true)
+			res, err := d.detachCNFCondAndBuildRangeForIndex(cnfItems, newTpSlice, true)
 			if err != nil {
 				return nil, nil, false, nil
 			}
@@ -299,11 +297,11 @@ func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expr
 				hasResidual = true
 			}
 			totalRanges = append(totalRanges, ranges...)
-			newAccessItems = append(newAccessItems, expression.ComposeCNFCondition(sctx, accesses...))
+			newAccessItems = append(newAccessItems, expression.ComposeCNFCondition(d.sctx, accesses...))
 		} else if firstColumnChecker.check(item) {
 			if firstColumnChecker.shouldReserve {
 				hasResidual = true
-				firstColumnChecker.shouldReserve = lengths[0] != types.UnspecifiedLength
+				firstColumnChecker.shouldReserve = d.lengths[0] != types.UnspecifiedLength
 			}
 			points := rb.build(item)
 			ranges, err := points2Ranges(sc, points, newTpSlice[0])
@@ -318,15 +316,15 @@ func detachDNFCondAndBuildRangeForIndex(sctx sessionctx.Context, condition *expr
 	}
 
 	// Take prefix index into consideration.
-	if hasPrefix(lengths) {
-		fixPrefixColRange(totalRanges, lengths, newTpSlice)
+	if hasPrefix(d.lengths) {
+		fixPrefixColRange(totalRanges, d.lengths, newTpSlice)
 	}
-	totalRanges, err := UnionRanges(sc, totalRanges)
+	totalRanges, err := UnionRanges(sc, totalRanges, d.mergeConsecutive)
 	if err != nil {
 		return nil, nil, false, errors.Trace(err)
 	}
 
-	return totalRanges, []expression.Expression{expression.ComposeDNFCondition(sctx, newAccessItems...)}, hasResidual, nil
+	return totalRanges, []expression.Expression{expression.ComposeDNFCondition(d.sctx, newAccessItems...)}, hasResidual, nil
 }
 
 // DetachRangeResult wraps up results when detaching conditions and builing ranges.
@@ -349,14 +347,33 @@ type DetachRangeResult struct {
 // The returned values are encapsulated into a struct DetachRangeResult, see its comments for explanation.
 func DetachCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column,
 	lengths []int) (*DetachRangeResult, error) {
+	d := &rangeDetacher{
+		sctx:             sctx,
+		allConds:         conditions,
+		cols:             cols,
+		lengths:          lengths,
+		mergeConsecutive: true,
+	}
+	return d.detachCondAndBuildRangeForCols()
+}
+
+type rangeDetacher struct {
+	sctx             sessionctx.Context
+	allConds         []expression.Expression
+	cols             []*expression.Column
+	lengths          []int
+	mergeConsecutive bool
+}
+
+func (d *rangeDetacher) detachCondAndBuildRangeForCols() (*DetachRangeResult, error) {
 	res := &DetachRangeResult{}
-	newTpSlice := make([]*types.FieldType, 0, len(cols))
-	for _, col := range cols {
+	newTpSlice := make([]*types.FieldType, 0, len(d.cols))
+	for _, col := range d.cols {
 		newTpSlice = append(newTpSlice, newFieldType(col.RetType))
 	}
-	if len(conditions) == 1 {
-		if sf, ok := conditions[0].(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicOr {
-			ranges, accesses, hasResidual, err := detachDNFCondAndBuildRangeForIndex(sctx, sf, cols, newTpSlice, lengths)
+	if len(d.allConds) == 1 {
+		if sf, ok := d.allConds[0].(*expression.ScalarFunction); ok && sf.FuncName.L == ast.LogicOr {
+			ranges, accesses, hasResidual, err := d.detachDNFCondAndBuildRangeForIndex(sf, newTpSlice)
 			if err != nil {
 				return res, errors.Trace(err)
 			}
@@ -365,13 +382,13 @@ func DetachCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions []expre
 			res.IsDNFCond = true
 			// If this DNF have something cannot be to calculate range, then all this DNF should be pushed as filter condition.
 			if hasResidual {
-				res.RemainedConds = conditions
+				res.RemainedConds = d.allConds
 				return res, nil
 			}
 			return res, nil
 		}
 	}
-	return detachCNFCondAndBuildRangeForIndex(sctx, conditions, cols, newTpSlice, lengths, true)
+	return d.detachCNFCondAndBuildRangeForIndex(d.allConds, newTpSlice, true)
 }
 
 // DetachSimpleCondAndBuildRangeForIndex will detach the index filters from table filters.
@@ -382,7 +399,14 @@ func DetachSimpleCondAndBuildRangeForIndex(sctx sessionctx.Context, conditions [
 	for _, col := range cols {
 		newTpSlice = append(newTpSlice, newFieldType(col.RetType))
 	}
-	res, err := detachCNFCondAndBuildRangeForIndex(sctx, conditions, cols, newTpSlice, lengths, false)
+	d := &rangeDetacher{
+		sctx:             sctx,
+		allConds:         conditions,
+		cols:             cols,
+		lengths:          lengths,
+		mergeConsecutive: true,
+	}
+	res, err := d.detachCNFCondAndBuildRangeForIndex(conditions, newTpSlice, false)
 	return res.Ranges, res.AccessConds, err
 }
 

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -537,3 +537,17 @@ func points2EqOrInCond(ctx sessionctx.Context, points []point, expr expression.E
 	f := expression.NewFunctionInternal(ctx, funcName, sf.GetType(), args...)
 	return f
 }
+
+// DetachCondAndBuildRangeForPartition will detach the index filters from table filters.
+// The returned values are encapsulated into a struct DetachRangeResult, see its comments for explanation.
+func DetachCondAndBuildRangeForPartition(sctx sessionctx.Context, conditions []expression.Expression, cols []*expression.Column,
+	lengths []int) (*DetachRangeResult, error) {
+	d := &rangeDetacher{
+		sctx:             sctx,
+		allConds:         conditions,
+		cols:             cols,
+		lengths:          lengths,
+		mergeConsecutive: false,
+	}
+	return d.detachCondAndBuildRangeForCols()
+}

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -274,7 +274,7 @@ func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.Stat
 				ran.HighExclude = false
 			}
 		}
-		ranges, err = UnionRanges(sc, ranges)
+		ranges, err = UnionRanges(sc, ranges, true)
 		if err != nil {
 			return nil, err
 		}
@@ -296,14 +296,15 @@ func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContex
 }
 
 // buildCNFIndexRange builds the range for index where the top layer is CNF.
-func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column, newTp []*types.FieldType, lengths []int,
+func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 	eqAndInCount int, accessCondition []expression.Expression) ([]*Range, error) {
+	sc := d.sctx.GetSessionVars().StmtCtx
 	rb := builder{sc: sc}
 	var (
 		ranges []*Range
 		err    error
 	)
-	for _, col := range cols {
+	for _, col := range d.cols {
 		newTp = append(newTp, newFieldType(col.RetType))
 	}
 	for i := 0; i < eqAndInCount; i++ {
@@ -342,9 +343,9 @@ func buildCNFIndexRange(sc *stmtctx.StatementContext, cols []*expression.Column,
 	}
 
 	// Take prefix index into consideration.
-	if hasPrefix(lengths) {
-		if fixPrefixColRange(ranges, lengths, newTp) {
-			ranges, err = UnionRanges(sc, ranges)
+	if hasPrefix(d.lengths) {
+		if fixPrefixColRange(ranges, d.lengths, newTp) {
+			ranges, err = UnionRanges(sc, ranges, d.mergeConsecutive)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -364,7 +365,7 @@ type sortRange struct {
 // For two intervals [a, b], [c, d], we have guaranteed that a <= c. If b >= c. Then two intervals are overlapped.
 // And this two can be merged as [a, max(b, d)].
 // Otherwise they aren't overlapped.
-func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range) ([]*Range, error) {
+func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range, mergeConsecutive bool) ([]*Range, error) {
 	if len(ranges) == 0 {
 		return nil, nil
 	}
@@ -392,7 +393,8 @@ func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range) ([]*Range, error
 	ranges = ranges[:0]
 	lastRange := objects[0]
 	for i := 1; i < len(objects); i++ {
-		if bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0 {
+		if (mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) >= 0) ||
+			(!mergeConsecutive && bytes.Compare(lastRange.encodedEnd, objects[i].encodedStart) > 0) {
 			if bytes.Compare(lastRange.encodedEnd, objects[i].encodedEnd) < 0 {
 				lastRange.encodedEnd = objects[i].encodedEnd
 				lastRange.originalValue.HighVal = objects[i].originalValue.HighVal

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -77,6 +77,34 @@ func (ran *Range) IsPoint(sc *stmtctx.StatementContext) bool {
 	return !ran.LowExclude && !ran.HighExclude
 }
 
+// IsPointNullable returns if the range is a point.
+func (ran *Range) IsPointNullable(sc *stmtctx.StatementContext) bool {
+	if len(ran.LowVal) != len(ran.HighVal) {
+		return false
+	}
+	for i := range ran.LowVal {
+		a := ran.LowVal[i]
+		b := ran.HighVal[i]
+		if a.Kind() == types.KindMinNotNull || b.Kind() == types.KindMaxValue {
+			return false
+		}
+		cmp, err := a.CompareDatum(sc, &b)
+		if err != nil {
+			return false
+		}
+		if cmp != 0 {
+			return false
+		}
+
+		if a.IsNull() {
+			if !b.IsNull() {
+				return false
+			}
+		}
+	}
+	return !ran.LowExclude && !ran.HighExclude
+}
+
 //IsFullRange check if the range is full scan range
 func (ran *Range) IsFullRange() bool {
 	if len(ran.LowVal) != len(ran.HighVal) {


### PR DESCRIPTION
### What problem does this PR solve?

Cherry-pick  https://github.com/pingcap/tidb/pull/18574 and https://github.com/pingcap/tidb/pull/19486

https://github.com/pingcap/tidb/pull/18574 fix hash partition pruning for `in` expression, the other one is required to make it build successful.

### Release note <!-- bugfixes or new feature need a release note -->

- re-implement hash partition pruning to support `in` and `or` and some other functions