### PR TITLE
ddl: fix placement rules compatibility with tiflash

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5832,7 +5832,7 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 			continue
 		}
 		rule.LabelConstraints = append(rule.LabelConstraints, placement.LabelConstraint{
-			Op: NotIn,
+			Op: placement.NotIn,
 			Key: "engine",
 			Values: []string{"tiflash"},
 		})

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5831,6 +5831,9 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 			extraCnt[rule.Role] += rule.Count
 			continue
 		}
+		// refer to tidb#22065.
+		// add -engine=tiflash to every rule to avoid schedules to tiflash instances.
+		// placement rules in SQL is not compatible with `set tiflash replica` yet
 		rule.LabelConstraints = append(rule.LabelConstraints, placement.LabelConstraint{
 			Op:     placement.NotIn,
 			Key:    placement.EngineLabelKey,
@@ -5846,6 +5849,7 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 		if cnt <= 0 {
 			continue
 		}
+		// refer to tidb#22065.
 		newRules = append(newRules, &placement.Rule{
 			GroupID:     bundle.ID,
 			ID:          string(role),

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5833,8 +5833,8 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 		}
 		rule.LabelConstraints = append(rule.LabelConstraints, placement.LabelConstraint{
 			Op:     placement.NotIn,
-			Key:    "engine",
-			Values: []string{"tiflash"},
+			Key:    placement.EngineLabelKey,
+			Values: []string{placement.EngineLabelTiFlash},
 		})
 		rule.GroupID = bundle.ID
 		rule.ID = strconv.Itoa(i)
@@ -5853,6 +5853,11 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 			Count:       cnt,
 			StartKeyHex: startKey,
 			EndKeyHex:   endKey,
+			LabelConstraints: []placement.LabelConstraint{{
+				Op:     placement.NotIn,
+				Key:    placement.EngineLabelKey,
+				Values: []string{placement.EngineLabelTiFlash},
+			}},
 		})
 	}
 	bundle.Rules = newRules

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5822,8 +5822,8 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 	}
 
 	extraCnt := map[placement.PeerRoleType]int{}
-	startKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(partitionID)))
-	endKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(partitionID+1)))
+	startKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(partitionID)))
+	endKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(partitionID+1)))
 	newRules := bundle.Rules[:0]
 	for i, rule := range bundle.Rules {
 		// merge all empty constraints

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5831,6 +5831,11 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 			extraCnt[rule.Role] += rule.Count
 			continue
 		}
+		rule.LabelConstraints = append(rule.LabelConstraints, placement.LabelConstraint{
+			Op: NotIn,
+			Key: "engine",
+			Values: []string{"tiflash"},
+		})
 		rule.GroupID = bundle.ID
 		rule.ID = strconv.Itoa(i)
 		rule.StartKeyHex = startKey

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5832,8 +5832,8 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 			continue
 		}
 		rule.LabelConstraints = append(rule.LabelConstraints, placement.LabelConstraint{
-			Op: placement.NotIn,
-			Key: "engine",
+			Op:     placement.NotIn,
+			Key:    "engine",
 			Values: []string{"tiflash"},
 		})
 		rule.GroupID = bundle.ID

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -270,7 +270,7 @@ func checkTiFlashPeerStoreAtLeastOne(stores []*metapb.Store, peers []*metapb.Pee
 
 func storeHasEngineTiFlashLabel(store *metapb.Store) bool {
 	for _, label := range store.Labels {
-		if label.Key == "engine" && label.Value == "tiflash" {
+		if label.Key == placement.EngineLabelKey && label.Value == placement.EngineLabelTiFlash {
 			return true
 		}
 	}

--- a/ddl/placement/const.go
+++ b/ddl/placement/const.go
@@ -43,4 +43,7 @@ const (
 	// EngineLabelTiFlash is the label value, which a TiFlash instance will have with
 	// a label key of EngineLabelKey.
 	EngineLabelTiFlash = "tiflash"
+	// EngineLabelTiKV is the label value used in some tests. And possibly TiKV will
+	// set the engine label with a value of EngineLabelTiKV.
+	EngineLabelTiKV = "tikv"
 )

--- a/ddl/placement/const.go
+++ b/ddl/placement/const.go
@@ -33,6 +33,14 @@ const (
 	RuleIndexIndex
 )
 
-// DCLabelKey indicates the key of label which represents the dc for Store.
-// FIXME: currently we assumes "zone" is the dcLabel key in Store
-const DCLabelKey = "zone"
+const (
+	// DCLabelKey indicates the key of label which represents the dc for Store.
+	// FIXME: currently we assumes "zone" is the dcLabel key in Store
+	DCLabelKey = "zone"
+	// EngineLabelKey is the label that indicates the backend of store instance:
+	// tikv or tiflash. TiFlash instance will contain a label of 'engine: tiflash'.
+	EngineLabelKey = "engine"
+	// EngineLabelTiFlash is the label value, which a TiFlash instance will have with
+	// a label key of EngineLabelKey.
+	EngineLabelTiFlash = "tiflash"
+)

--- a/ddl/placement/utils.go
+++ b/ddl/placement/utils.go
@@ -56,6 +56,10 @@ func checkLabelConstraint(label string) (LabelConstraint, error) {
 		return r, errors.Errorf("label constraint should be in format '{+|-}key=value', but got '%s'", label)
 	}
 
+	if op == In && key == "engine" && strings.ToLower(val) == "tiflash" {
+		return r, errors.Errorf("unsupported label constraint '%s'", label)
+	}
+
 	r.Key = key
 	r.Op = op
 	r.Values = []string{val}

--- a/ddl/placement/utils.go
+++ b/ddl/placement/utils.go
@@ -56,7 +56,7 @@ func checkLabelConstraint(label string) (LabelConstraint, error) {
 		return r, errors.Errorf("label constraint should be in format '{+|-}key=value', but got '%s'", label)
 	}
 
-	if op == In && key == "engine" && strings.ToLower(val) == "tiflash" {
+	if op == In && key == EngineLabelKey && strings.ToLower(val) == EngineLabelTiFlash {
 		return r, errors.Errorf("unsupported label constraint '%s'", label)
 	}
 

--- a/ddl/placement/utils.go
+++ b/ddl/placement/utils.go
@@ -152,8 +152,8 @@ func BuildPlacementDropBundle(partitionID int64) *Bundle {
 func BuildPlacementCopyBundle(oldBundle *Bundle, newID int64) *Bundle {
 	newBundle := oldBundle.Clone()
 	newBundle.ID = GroupID(newID)
-	startKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(newID)))
-	endKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(newID+1)))
+	startKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(newID)))
+	endKey := hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(newID+1)))
 	for _, rule := range newBundle.Rules {
 		rule.GroupID = newBundle.ID
 		rule.StartKeyHex = startKey

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -420,8 +420,8 @@ func (s *testPlacementSuite) TestPlacementBuildTruncate(c *C) {
 				ID: placement.GroupID(1),
 				Rules: []*placement.Rule{{
 					GroupID:     placement.GroupID(1),
-					StartKeyHex: hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(1))),
-					EndKeyHex:   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(2))),
+					StartKeyHex: hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(1))),
+					EndKeyHex:   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2))),
 				}},
 			},
 		},
@@ -431,8 +431,8 @@ func (s *testPlacementSuite) TestPlacementBuildTruncate(c *C) {
 				ID: placement.GroupID(2),
 				Rules: []*placement.Rule{{
 					GroupID:     placement.GroupID(2),
-					StartKeyHex: hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(2))),
-					EndKeyHex:   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(3))),
+					StartKeyHex: hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2))),
+					EndKeyHex:   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(3))),
 				}},
 			},
 		},

--- a/ddl/placement_rule_test.go
+++ b/ddl/placement_rule_test.go
@@ -64,6 +64,26 @@ func (s *testPlacementSuite) TestPlacementBuild(c *C) {
 				Role:        ast.PlacementRoleVoter,
 				Tp:          ast.PlacementAdd,
 				Replicas:    3,
+				Constraints: `["+zone=sh", "+engine=tiflash"]`,
+			}},
+			err: ".*unsupported label constraint.*",
+		},
+
+		{
+			input: []*ast.PlacementSpec{{
+				Role:        ast.PlacementRoleVoter,
+				Tp:          ast.PlacementAdd,
+				Replicas:    3,
+				Constraints: `["+zone=sh", "+engine=TiFlash"]`,
+			}},
+			err: ".*unsupported label constraint.*",
+		},
+
+		{
+			input: []*ast.PlacementSpec{{
+				Role:        ast.PlacementRoleVoter,
+				Tp:          ast.PlacementAdd,
+				Replicas:    3,
 				Constraints: "",
 			}},
 			output: []*placement.Rule{{

--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -341,10 +341,16 @@ add placement policy
 	replicas=0`)
 	c.Assert(err, ErrorMatches, ".*Invalid placement option REPLICAS, it is not allowed to be 0.*")
 
-	tk.MustExec("drop table if exists t1")
-	tk.MustExec("create table t1 (c int)")
+	// ban tiflash
+	_, err = tk.Exec(`alter table t1 alter partition p0
+add placement policy
+	constraints='["+zone=sh", "+engine=tiflash"]'
+	role=follower
+	replicas=3`)
+	c.Assert(err, ErrorMatches, ".*unsupported label.*")
 
-	_, err = tk.Exec(`alter table t1 alter partition p
+	// invalid partition
+	_, err = tk.Exec(`alter table t1 alter partition p9
 add placement policy
 	constraints='["+zone=sh"]'
 	role=follower

--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -350,7 +350,9 @@ add placement policy
 	c.Assert(err, ErrorMatches, ".*unsupported label.*")
 
 	// invalid partition
-	_, err = tk.Exec(`alter table t1 alter partition p9
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (c int)")
+	_, err = tk.Exec(`alter table t1 alter partition p
 add placement policy
 	constraints='["+zone=sh"]'
 	role=follower

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -1517,14 +1518,12 @@ func GetPDServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	return servers, nil
 }
 
-const tiflashLabel = "tiflash"
-
 // GetStoreServerInfo returns all store nodes(TiKV or TiFlash) cluster information
 func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 	isTiFlashStore := func(store *metapb.Store) bool {
 		isTiFlash := false
 		for _, label := range store.Labels {
-			if label.GetKey() == "engine" && label.GetValue() == tiflashLabel {
+			if label.GetKey() == placement.EngineLabelKey && label.GetValue() == placement.EngineLabelTiFlash {
 				isTiFlash = true
 			}
 		}
@@ -1558,7 +1557,7 @@ func GetStoreServerInfo(ctx sessionctx.Context) ([]ServerInfo, error) {
 		}
 		var tp string
 		if isTiFlashStore(store) {
-			tp = tiflashLabel
+			tp = kv.TiFlash.Name()
 		} else {
 			tp = tikv.GetStoreTypeByMeta(store).Name()
 		}
@@ -1587,7 +1586,7 @@ func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 		return cnt, err
 	}
 	for _, store := range stores {
-		if store.ServerType == tiflashLabel {
+		if store.ServerType == kv.TiFlash.Name() {
 			cnt++
 		}
 	}

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tipb/go-tipb"
@@ -161,7 +162,7 @@ type rpcHandler struct {
 
 func isTiFlashStore(store *metapb.Store) bool {
 	for _, l := range store.GetLabels() {
-		if l.GetKey() == "engine" && l.GetValue() == "tiflash" {
+		if l.GetKey() == placement.EngineLabelKey && l.GetValue() == placement.EngineLabelTiFlash {
 			return true
 		}
 	}

--- a/store/tikv/gcworker/gc_worker.go
+++ b/store/tikv/gcworker/gc_worker.go
@@ -826,9 +826,8 @@ func needsGCOperationForStore(store *metapb.Store) (bool, error) {
 		// skip physical resolve locks for it.
 		return false, nil
 
-	case "":
+	case placement.EngineLabelTiKV, "":
 		// If no engine label is set, it should be a TiKV node.
-		// For now, TiKV node does not set any label
 		return true, nil
 
 	default:

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -531,7 +531,7 @@ func (s *testGCWorkerSuite) TestNeedsGCOperationForStore(c *C) {
 		res, err = needsGCOperationForStore(newStore(state, true, ""))
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, needGC)
-		res, err = needsGCOperationForStore(newStore(state, true, kv.TiKV.Name()))
+		res, err = needsGCOperationForStore(newStore(state, true, placement.EngineLabelTiKV))
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, needGC)
 

--- a/store/tikv/gcworker/gc_worker_test.go
+++ b/store/tikv/gcworker/gc_worker_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/errorpb"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -516,7 +517,7 @@ func (s *testGCWorkerSuite) TestNeedsGCOperationForStore(c *C) {
 		store := &metapb.Store{}
 		store.State = state
 		if hasEngineLabel {
-			store.Labels = []*metapb.StoreLabel{{Key: engineLabelKey, Value: engineLabel}}
+			store.Labels = []*metapb.StoreLabel{{Key: placement.EngineLabelKey, Value: engineLabel}}
 		}
 		return store
 	}
@@ -530,12 +531,12 @@ func (s *testGCWorkerSuite) TestNeedsGCOperationForStore(c *C) {
 		res, err = needsGCOperationForStore(newStore(state, true, ""))
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, needGC)
-		res, err = needsGCOperationForStore(newStore(state, true, engineLabelTiKV))
+		res, err = needsGCOperationForStore(newStore(state, true, kv.TiKV.Name()))
 		c.Assert(err, IsNil)
 		c.Assert(res, Equals, needGC)
 
 		// TiFlash does not need these operations.
-		res, err = needsGCOperationForStore(newStore(state, true, engineLabelTiFlash))
+		res, err = needsGCOperationForStore(newStore(state, true, placement.EngineLabelTiFlash))
 		c.Assert(err, IsNil)
 		c.Assert(res, IsFalse)
 	}

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/util"
@@ -1532,8 +1533,8 @@ func (s *Store) initResolve(bo *Backoffer, c *RegionCache) (addr string, err err
 func GetStoreTypeByMeta(store *metapb.Store) kv.StoreType {
 	tp := kv.TiKV
 	for _, label := range store.Labels {
-		if label.Key == "engine" {
-			if label.Value == kv.TiFlash.Name() {
+		if label.Key == placement.EngineLabelKey {
+			if label.Value == placement.EngineLabelTiFlash {
 				tp = kv.TiFlash
 			}
 			break


### PR DESCRIPTION
### What problem does this PR solve?

Issue: close #22171

Problem Summary: When PD scheduels a partition to tiflash, TiFlash will validate the keyrange if there is a `_r` suffix. Using GenTableRecordPrefix instead of GenTablePrefix can fix this problem.

But placement rules are not compatible with the old `set tiflash replica` syntax, so the second commit simply forbids using `+engine=tiflash`, and will add `-engine=tiflash` to every rule to avoid scheduels to tiflash instance. Maybe that will be reverted in the future.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

```
set global tidb_enable_alter_placement=on;
drop table if exists test.t1;
create table test.t1 (a int) partition by hash(a) partitions 2;
alter table test.t1 alter partition p1 alter placement policy CONSTRAINTS='["+engine=tiflash"]' ROLE=follower REPLICAS=1;
(8234, 'Invalid placement policy \'alter placement policy constraints=\'["+engine=tiflash"]\' role=follower replicas=1\': unsupported label constraint \'+engine=tiflash\'')
```

### Release note <!-- bugfixes or new feature need a release note -->

- Forbid adding tiflash replica by placement rules in SQL
