### PR TITLE
executor: fix incompatible escape behaviors in `select into outfile`

### DIFF
--- a/executor/select_into.go
+++ b/executor/select_into.go
@@ -194,10 +194,8 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 				s.fieldBuf = append(s.fieldBuf, row.GetJSON(j).String()...)
 			}
 
-			switch col.GetType().Tp { // only string types need to be escaped
-			case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
-				mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob,
-				mysql.TypeEnum, mysql.TypeSet, mysql.TypeJSON:
+			switch col.GetType().EvalType() {
+			case types.ETString, types.ETJson:
 				s.lineBuf = append(s.lineBuf, s.escapeField(s.fieldBuf)...)
 			default:
 				s.lineBuf = append(s.lineBuf, s.fieldBuf...)

--- a/executor/select_into.go
+++ b/executor/select_into.go
@@ -193,7 +193,15 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 			case mysql.TypeJSON:
 				s.fieldBuf = append(s.fieldBuf, row.GetJSON(j).String()...)
 			}
-			s.lineBuf = append(s.lineBuf, s.escapeField(s.fieldBuf)...)
+
+			switch col.GetType().Tp {
+			case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
+				mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob,
+				mysql.TypeEnum, mysql.TypeSet, mysql.TypeJSON:
+				s.lineBuf = append(s.lineBuf, s.escapeField(s.fieldBuf)...)
+			default:
+				s.lineBuf = append(s.lineBuf, s.fieldBuf...)
+			}
 			if (encloseFlag && !encloseOpt) ||
 				(encloseFlag && encloseOpt && s.considerEncloseOpt(et)) {
 				s.lineBuf = append(s.lineBuf, encloseByte)

--- a/executor/select_into.go
+++ b/executor/select_into.go
@@ -194,7 +194,7 @@ func (s *SelectIntoExec) dumpToOutfile() error {
 				s.fieldBuf = append(s.fieldBuf, row.GetJSON(j).String()...)
 			}
 
-			switch col.GetType().Tp {
+			switch col.GetType().Tp { // only string types need to be escaped
 			case mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar,
 				mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob,
 				mysql.TypeEnum, mysql.TypeSet, mysql.TypeJSON:

--- a/executor/select_into_test.go
+++ b/executor/select_into_test.go
@@ -246,3 +246,23 @@ func (s *testSuite1) TestDumpReal(c *C) {
 		c.Assert(string(buf), Equals, testCase.result)
 	}
 }
+
+func (s *testSuite1) TestEscapeType(c *C) {
+	outfile := randomSelectFilePath("TestEscapeType")
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`create table t (
+	a int,
+	b double,
+	c varchar(10),
+	d blob,
+	e json,
+	f set('1', '2', '3'),
+	g enum('1', '2', '3'))`)
+	tk.MustExec(`insert into t values (1, 1, "1", "1", '{"key": 1}', "1", "1")`)
+
+	tk.MustExec(fmt.Sprintf("select * from t into outfile '%v' fields terminated by ',' escaped by '1'", outfile))
+	cmpAndRm(`1,1,11,11,{"key": 11},11,11
+`, outfile, c)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22055 <!-- REMOVE this line if no issue to close -->

Problem Summary: executor: fix incompatible escape behaviors in `select into outfile`

### What is changed and how it works?

Only string types need to be escaped.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- executor: fix incompatible escape behaviors in `select into outfile`
