### PR TITLE
config, session: promise the compatibility of oom-action when upgrading

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -853,8 +853,8 @@ func isAllDeprecatedConfigItems(items []string) bool {
 // is set by the user.
 var IsMemoryQuotaQuerySetByUser bool
 
-// IsMemoryQuotaQuerySetByUser indicates whether the config item mem-action is
-// set by the user.
+// IsOOMActionSetByUser indicates whether the config item mem-action is set by
+// the user.
 var IsOOMActionSetByUser bool
 
 // InitializeConfig initialize the global config handler.

--- a/config/config.go
+++ b/config/config.go
@@ -853,6 +853,10 @@ func isAllDeprecatedConfigItems(items []string) bool {
 // is set by the user.
 var IsMemoryQuotaQuerySetByUser bool
 
+// IsMemoryQuotaQuerySetByUser indicates whether the config item mem-action is
+// set by the user.
+var IsOOMActionSetByUser bool
+
 // InitializeConfig initialize the global config handler.
 // The function enforceCmdArgs is used to merge the config file with command arguments:
 // For example, if you start TiDB by the command "./tidb-server --port=3000", the port number should be
@@ -910,6 +914,9 @@ func (c *Config) Load(confFile string) error {
 	}
 	if metaData.IsDefined("mem-quota-query") {
 		IsMemoryQuotaQuerySetByUser = true
+	}
+	if metaData.IsDefined("oom-action") {
+		IsOOMActionSetByUser = true
 	}
 	if len(c.ServerVersion) > 0 {
 		mysql.ServerVersion = c.ServerVersion

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -368,6 +368,9 @@ const (
 	// The variable name in mysql.tidb table and it records the default value of
 	// mem-quota-query when upgrade from v3.0.x to v4.0.9+.
 	tidbDefMemoryQuotaQuery = "default_memory_quota_query"
+	// The variable name in mysql.tidb table and it records the default value of
+	// oom-action when upgrade from v3.0.x to v4.0.11+.
+	tidbDefOOMAction = "default_oom_action"
 	// Const for TiDB server version 2.
 	version2  = 2
 	version3  = 3
@@ -434,7 +437,7 @@ const (
 	version52 = 52
 	// version53 introduce Global variable tidb_enable_strict_double_type_check
 	version53 = 53
-	// version54 writes a variable `mem_quota_query` to mysql.tidb if it's a cluster upgraded from v3.0.x to v4.0.9.
+	// version54 writes a variable `mem_quota_query` to mysql.tidb if it's a cluster upgraded from v3.0.x to v4.0.9+.
 	version54 = 54
 	// version55 fixes the bug that upgradeToVer48 would be missed when upgrading from v4.0 to a new version
 	version55 = 55
@@ -444,9 +447,11 @@ const (
 	version57 = 57
 	// version58 add `Repl_client_priv` and `Repl_slave_priv` to `mysql.user`
 	version58 = 58
+	// version59 add writes a variable `oom-action` to mysql.tidb if it's a cluster upgraded from v3.0.x to v4.0.11+.
+	version59 = 59
 
 	// please make sure this is the largest version
-	currentBootstrapVersion = version58
+	currentBootstrapVersion = version59
 )
 
 var (
@@ -509,6 +514,7 @@ var (
 		upgradeToVer56,
 		upgradeToVer57,
 		upgradeToVer58,
+		upgradeToVer59,
 	}
 )
 
@@ -1267,10 +1273,32 @@ func upgradeToVer58(s Session, ver int64) {
 	mustExecute(s, "UPDATE HIGH_PRIORITY mysql.user SET Repl_slave_priv='Y',Repl_client_priv='Y'")
 }
 
+func upgradeToVer59(s Session, ver int64) {
+	if ver >= version59 {
+		return
+	}
+	// The oom-action default value is log by default in v3.0, and cancel by
+	// default in v4.0.11+.
+	// If a cluster is upgraded from v3.0.x (bootstrapVer <= version59) to
+	// v4.0.11+, we'll write the default value to mysql.tidb. Thus we can get
+	// the default value of oom-action, and promise the compatibility even if
+	// the tidb-server restarts.
+	// If it's a newly deployed cluster, we do not need to write the value into
+	// mysql.tidb, since no compatibility problem will happen.
+	writeOOMAction(s)
+}
+
 func writeMemoryQuotaQuery(s Session) {
-	comment := "memory_quota_query is 32GB by default in v3.0.x, 1GB by default in v4.0.x"
+	comment := "memory_quota_query is 32GB by default in v3.0.x, 1GB by default in v4.0.x+"
 	sql := fmt.Sprintf(`INSERT HIGH_PRIORITY INTO %s.%s VALUES ("%s", '%d', '%s') ON DUPLICATE KEY UPDATE VARIABLE_VALUE='%d'`,
 		mysql.SystemDB, mysql.TiDBTable, tidbDefMemoryQuotaQuery, 32<<30, comment, 32<<30)
+	mustExecute(s, sql)
+}
+
+func writeOOMAction(s Session) {
+	comment := "oom-action is `log` by default in v3.0.x, `cancel` by default in v4.0.11+"
+	sql := fmt.Sprintf(`INSERT HIGH_PRIORITY INTO %s.%s VALUES ("%s", '%s', '%s') ON DUPLICATE KEY UPDATE VARIABLE_VALUE='%s'`,
+		mysql.SystemDB, mysql.TiDBTable, tidbDefOOMAction, config.OOMActionLog, comment, config.OOMActionLog)
 	mustExecute(s, sql)
 }
 

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -343,6 +343,7 @@ func (s *testBootstrapSuite) TestIssue17979_2(c *C) {
 	req := r.NewChunk()
 	r.Next(ctx, req)
 	c.Assert(req.NumRows(), Equals, 0)
+	c.Assert(config.GetGlobalConfig().OOMAction, Equals, config.OOMActionCancel)
 }
 
 func (s *testBootstrapSuite) TestIssue20900_1(c *C) {

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
 	"github.com/pingcap/parser/auth"
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
@@ -269,6 +270,79 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 	c.Assert(req.NumRows(), Equals, 1)
 	c.Assert(req.GetRow(0).GetString(0), Equals, "False")
 	c.Assert(r.Close(), IsNil)
+}
+
+func (s *testBootstrapSuite) TestIssue17979_1(c *C) {
+	ctx := context.Background()
+	defer testleak.AfterTest(c)()
+	store, _ := newStoreWithBootstrap(c, s.dbName)
+	defer store.Close()
+
+	// test issue 20900, upgrade from v3.0 to v4.0.11+
+	seV3 := newSession(c, store, s.dbName)
+	txn, err := store.Begin()
+	c.Assert(err, IsNil)
+	m := meta.NewMeta(txn)
+	err = m.FinishBootstrap(int64(58))
+	c.Assert(err, IsNil)
+	err = txn.Commit(context.Background())
+	c.Assert(err, IsNil)
+	mustExecSQL(c, seV3, "update mysql.tidb set variable_value='58' where variable_name='tidb_server_version'")
+	mustExecSQL(c, seV3, "delete from mysql.tidb where variable_name='default_oom_action'")
+	mustExecSQL(c, seV3, "commit")
+	unsetStoreBootstrapped(store.UUID())
+	ver, err := getBootstrapVersion(seV3)
+	c.Assert(err, IsNil)
+	c.Assert(ver, Equals, int64(58))
+
+	domV4, err := BootstrapSession(store)
+	c.Assert(err, IsNil)
+	defer domV4.Close()
+	seV4 := newSession(c, store, s.dbName)
+	ver, err = getBootstrapVersion(seV4)
+	c.Assert(err, IsNil)
+	c.Assert(ver, Equals, int64(currentBootstrapVersion))
+	r := mustExecSQL(c, seV4, "select variable_value from mysql.tidb where variable_name='default_oom_action'")
+	req := r.NewChunk()
+	r.Next(ctx, req)
+	c.Assert(req.GetRow(0).GetString(0), Equals, "log")
+	c.Assert(config.GetGlobalConfig().OOMAction, Equals, config.OOMActionLog)
+}
+
+func (s *testBootstrapSuite) TestIssue17979_2(c *C) {
+	ctx := context.Background()
+	defer testleak.AfterTest(c)()
+	store, _ := newStoreWithBootstrap(c, s.dbName)
+	defer store.Close()
+
+	// test issue 20900, upgrade from v4.0.11 to v4.0.11
+	seV3 := newSession(c, store, s.dbName)
+	txn, err := store.Begin()
+	c.Assert(err, IsNil)
+	m := meta.NewMeta(txn)
+	err = m.FinishBootstrap(int64(59))
+	c.Assert(err, IsNil)
+	err = txn.Commit(context.Background())
+	c.Assert(err, IsNil)
+	mustExecSQL(c, seV3, "update mysql.tidb set variable_value=59 where variable_name='tidb_server_version'")
+	mustExecSQL(c, seV3, "delete from mysql.tidb where variable_name='default_iim_action'")
+	mustExecSQL(c, seV3, "commit")
+	unsetStoreBootstrapped(store.UUID())
+	ver, err := getBootstrapVersion(seV3)
+	c.Assert(err, IsNil)
+	c.Assert(ver, Equals, int64(59))
+
+	domV4, err := BootstrapSession(store)
+	c.Assert(err, IsNil)
+	defer domV4.Close()
+	seV4 := newSession(c, store, s.dbName)
+	ver, err = getBootstrapVersion(seV4)
+	c.Assert(err, IsNil)
+	c.Assert(ver, Equals, int64(currentBootstrapVersion))
+	r := mustExecSQL(c, seV4, "select variable_value from mysql.tidb where variable_name='default_oom_action'")
+	req := r.NewChunk()
+	r.Next(ctx, req)
+	c.Assert(req.NumRows(), Equals, 0)
 }
 
 func (s *testBootstrapSuite) TestIssue20900_1(c *C) {

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -273,6 +273,12 @@ func (s *testBootstrapSuite) TestUpgrade(c *C) {
 }
 
 func (s *testBootstrapSuite) TestIssue17979_1(c *C) {
+	oomAction := config.GetGlobalConfig().OOMAction
+	defer func() {
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.OOMAction = oomAction
+		})
+	}()
 	ctx := context.Background()
 	defer testleak.AfterTest(c)()
 	store, _ := newStoreWithBootstrap(c, s.dbName)
@@ -310,6 +316,12 @@ func (s *testBootstrapSuite) TestIssue17979_1(c *C) {
 }
 
 func (s *testBootstrapSuite) TestIssue17979_2(c *C) {
+	oomAction := config.GetGlobalConfig().OOMAction
+	defer func() {
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.OOMAction = oomAction
+		})
+	}()
 	ctx := context.Background()
 	defer testleak.AfterTest(c)()
 	store, _ := newStoreWithBootstrap(c, s.dbName)

--- a/session/session.go
+++ b/session/session.go
@@ -1898,9 +1898,9 @@ func loadDefOOMAction(se *session) (string, error) {
 	defOOMAction, err := loadParameter(se, tidbDefOOMAction)
 	if err != nil {
 		if err == errResultIsEmpty {
-			return config.OOMActionCancel, nil
+			return config.GetGlobalConfig().OOMAction, nil
 		}
-		return config.OOMActionCancel, err
+		return config.GetGlobalConfig().OOMAction, err
 	}
 	if defOOMAction != config.OOMActionLog {
 		logutil.BgLogger().Warn("Unexpected value of 'default_oom_action' in 'mysql.tidb', use 'log' instead",

--- a/session/session.go
+++ b/session/session.go
@@ -1995,9 +1995,9 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 		return nil, err
 	}
 	if !config.IsOOMActionSetByUser {
-		newCfg := *(config.GetGlobalConfig())
-		newCfg.OOMAction = newOOMAction
-		config.StoreGlobalConfig(&newCfg)
+		config.UpdateGlobal(func(conf *config.Config) {
+			conf.OOMAction = newOOMAction
+		})
 	}
 
 	dom := domain.GetDomain(se)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17979 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Write the default value(log) into mysql.tidb if the cluster is upgraded from 3.0.x to 4.0.11+.
When start tidb-server, check:

whether oom-action is configured by the user. If so, use the value. If not, goto 2
whether the var default_oom_action exists in mysql.tidb. If so, use the value. If not, goto 3.
Use the default value(cancel) in 4.0.11+.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Keep the default value of the config item `oom-action` when upgrading.
