### PR TITLE
privilege: remove leading and trailing space when create user and role

### DIFF
--- a/executor/simple.go
+++ b/executor/simple.go
@@ -702,6 +702,8 @@ func (e *SimpleExec) executeCreateUser(ctx context.Context, s *ast.CreateUserStm
 	users := make([]string, 0, len(s.Specs))
 	privs := make([]string, 0, len(s.Specs))
 	for _, spec := range s.Specs {
+		spec.User.Username = strings.TrimSpace(spec.User.Username)
+		spec.User.Hostname = strings.TrimSpace(spec.User.Hostname)
 		exists, err1 := userExists(e.ctx, spec.User.Username, spec.User.Hostname)
 		if err1 != nil {
 			return err1

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -477,7 +477,10 @@ func (s *testSuite7) TestUser(c *C) {
 	tk.MustExec(alterUserSQL)
 	tk.MustQuery(querySQL).Check(testkit.Rows("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9"))
 
-	tk.MustExec("create user `\ntest\n`@\nlocalhost\n`;")
+	tk.MustExec("create user `\ntest\n`@`\nlocalhost\n`;")
+	tk.MustQuery(`select user, host from mysql.user where user = 'test';`).Check(testkit.Rows("test localhost"))
+
+	tk.MustExec("create role `\ntestrole\n`@`\nlocalhost\n`;")
 	tk.MustQuery(`select user, host from mysql.user where user = 'test';`).Check(testkit.Rows("test localhost"))
 }
 

--- a/executor/simple_test.go
+++ b/executor/simple_test.go
@@ -476,6 +476,9 @@ func (s *testSuite7) TestUser(c *C) {
 	alterUserSQL = `alter user test3@'%' IDENTIFIED WITH 'mysql_native_password' AS '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9';`
 	tk.MustExec(alterUserSQL)
 	tk.MustQuery(querySQL).Check(testkit.Rows("*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9"))
+
+	tk.MustExec("create user `\ntest\n`@\nlocalhost\n`;")
+	tk.MustQuery(`select user, host from mysql.user where user = 'test';`).Check(testkit.Rows("test localhost"))
 }
 
 func (s *testSuite3) TestSetPwd(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/20592

remove `user` and `host` leading and trailing space when `create user` and role


Tests <!-- At least one of them must be included. -->

- Unit test



### Release note <!-- bugfixes or new feature need a release note -->

- fix a bug that `create user` may contain a line breaker in prefix or suffix<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
