### PR TITLE
server: check tracing enable before create tracing context

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -939,7 +939,9 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 	}
 
 	span := opentracing.StartSpan("server.dispatch")
-	ctx = opentracing.ContextWithSpan(ctx, span)
+	if config.GetGlobalConfig().OpenTracing.Enable {
+		ctx = opentracing.ContextWithSpan(ctx, span)
+	}
 
 	var cancelFunc context.CancelFunc
 	ctx, cancelFunc = context.WithCancel(ctx)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
-15% Performance regression on sysbench point_select workload.

### What is changed and how it works?

What's Changed:
Check tracing config before set tracing span in context.

How it Works:
When tracing is not enabled, we don't need to pay the tracing cost.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- sysbench benchmark

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
