### PR TITLE
types: Add a limitation about float data type (#20929)

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
 )
 
 func (s *testSuite3) TestInsertOnDuplicateKey(c *C) {
@@ -800,12 +801,17 @@ func (s *testSuite3) TestDMLCast(c *C) {
 func (s *testSuite3) TestInsertFloatOverflow(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`drop table if exists t,t1;`)
 	tk.MustExec("create table t(col1 FLOAT, col2 FLOAT(10,2), col3 DOUBLE, col4 DOUBLE(10,2), col5 DECIMAL, col6 DECIMAL(10,2));")
 	_, err := tk.Exec("insert into t values (-3.402823466E+68, -34028234.6611, -1.7976931348623157E+308, -17976921.34, -9999999999, -99999999.99);")
 	c.Assert(err.Error(), Equals, "[types:1264]Out of range value for column 'col1' at row 1")
 	_, err = tk.Exec("insert into t values (-34028234.6611, -3.402823466E+68, -1.7976931348623157E+308, -17976921.34, -9999999999, -99999999.99);")
 	c.Assert(err.Error(), Equals, "[types:1264]Out of range value for column 'col2' at row 1")
+	tk.Exec("create table t1(id1 float,id2 float)")
+	tk.Exec("insert ignore into t1 values(999999999999999999999999999999999999999,-999999999999999999999999999999999999999)")
+	tk.MustQuery("select @@warning_count").Check(testutil.RowsWithSep("|", "2"))
+	tk.MustQuery("select convert(id1,decimal(65)),convert(id2,decimal(65)) from t1").Check(testkit.Rows("340282346638528860000000000000000000000 -340282346638528860000000000000000000000"))
+	tk.MustExec("drop table if exists t,t1")
 }
 
 // There is a potential issue in MySQL: when the value of auto_increment_offset is greater

--- a/types/datum.go
+++ b/types/datum.go
@@ -839,8 +839,14 @@ func ProduceFloatWithSpecifiedTp(f float64, target *FieldType, sc *stmtctx.State
 			return f, errors.Trace(err)
 		}
 	}
-	if (mysql.HasUnsignedFlag(target.Flag) && f < 0) || (target.Tp == mysql.TypeFloat && (f > math.MaxFloat32 || f < -math.MaxFloat32)) {
+	if mysql.HasUnsignedFlag(target.Flag) && f < 0 {
 		return 0, overflow(f, target.Tp)
+	}
+	if target.Tp == mysql.TypeFloat && (f > math.MaxFloat32 || f < -math.MaxFloat32) {
+		if f > 0 {
+			return math.MaxFloat32, overflow(f, target.Tp)
+		}
+		return -math.MaxFloat32, overflow(f, target.Tp)
 	}
 	return f, nil
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->
cherry-pick #20929 to release-3.0
### What problem does this PR solve?

Issue Number: close #16039 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
The bug has already been fixed by #20158. But the case of insert ignore also should be considered.
How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
```
mysql> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: None
Edition: Community
Git Commit Hash: None
Git Branch: None
UTC Build Time: None
GoVersion: go1.14.6
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
1 row in set (0.00 sec)

mysql> create table t(id float);
Query OK, 0 rows affected (0.01 sec)

mysql> insert ignore into t values(999999999999999999999999999999999999999999999999999);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> insert ignore into t values(-999999999999999999999999999999999999999999999999999);
Query OK, 1 row affected, 1 warning (0.00 sec)

mysql> select * from t;
+-------------+
| id          |
+-------------+
|  3.40282e38 |
| -3.40282e38 |
+-------------+
2 rows in set (0.00 sec)

mysql>
```

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
