### PR TITLE
txn: change check logic for column type change for amend

### DIFF
--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -205,8 +205,8 @@ func (a *amendCollector) collectModifyColAmendOps(tblAtStart, tblAtCommit table.
 			// is newly added or modified from an original column.Report error to solve the issue
 			// https://github.com/pingcap/tidb/issues/21470. This change will make amend fail for adding column
 			// and modifying columns at the same time.
-			return nil, errors.Trace(errors.Errorf("column=%v id=%v is not found for table=%v checking column modify",
-				colAtCommit.Name, colAtCommit.ID, tblAtCommit.Meta().Name.String()))
+			return nil, errors.Errorf("column=%v id=%v is not found for table=%v checking column modify",
+				colAtCommit.Name, colAtCommit.ID, tblAtCommit.Meta().Name.String())
 		}
 	}
 	return nil, nil

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -190,8 +190,8 @@ func colChangeAmendable(colAtStart *model.ColumnInfo, colAtCommit *model.ColumnI
 	return nil
 }
 
-// collectModifyColAmendOps is used to check if there is column change from nullable to not null by now.
-// TODO allow column change from nullable to not null, and generate keys check operation.
+// collectModifyColAmendOps is used to check if there is only column size increasing change.Other column type changes
+// such as column change from nullable to not null or column type change are not supported by now.
 func (a *amendCollector) collectModifyColAmendOps(tblAtStart, tblAtCommit table.Table) ([]amendOp, error) {
 	for _, colAtCommit := range tblAtCommit.Cols() {
 		colAtStart := findColByID(tblAtStart, colAtCommit.ID)

--- a/session/schema_amender.go
+++ b/session/schema_amender.go
@@ -200,6 +200,13 @@ func (a *amendCollector) collectModifyColAmendOps(tblAtStart, tblAtCommit table.
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			// If the column could not be found in the original schema, it could not be decided if this column
+			// is newly added or modified from an original column.Report error to solve the issue
+			// https://github.com/pingcap/tidb/issues/21470. This change will make amend fail for adding column
+			// and modifying columns at the same time.
+			return nil, errors.Trace(errors.Errorf("column=%v id=%v is not found for table=%v checking column modify",
+				colAtCommit.Name, colAtCommit.ID, tblAtCommit.Meta().Name.String()))
 		}
 	}
 	return nil, nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21470 

Problem Summary:
On the 5.0 or the master branch, the change column ddl may **NOT** keep the original column id as in the release-4.0 branch, checking the modify colum action type in amend phase could not decide whether it's a newly added column or if this column type change is accepatable, so report error for such branches. 

### What is changed and how it works?

What's Changed:
Report error for checking modify colum action type if the column could not be found in early schema version though column type change is not GA release currently. This change will make the amend fail for ddl change with both adding column and modifying column.

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note`.
