### PR TITLE
.github: update the label for sig/infra

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -22,10 +22,15 @@ sig/planner:
 component/statistics:
   - statistics/*
 
-sig/DDL:
+sig/infra:
   - ddl/*
   - domain/*
   - infoschema/*
+  - session/*
+  - server/*
+  - privilege/*
+  - plugin/*
+  - config/*
   - meta/*
   - owner/*
 

--- a/.github/workflows/assign_project.yml
+++ b/.github/workflows/assign_project.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run issues assignment to project SIG DDL Kanban
       uses: srggrs/assign-one-project-github-action@1.2.0
       if: |
-        contains(github.event.issue.labels.*.name, 'sig/DDL') ||
+        contains(github.event.issue.labels.*.name, 'sig/infra') ||
         contains(github.event.issue.labels.*.name, 'component/binlog') ||
         contains(github.event.issue.labels.*.name, 'component/charset') ||
         contains(github.event.issue.labels.*.name, 'component/infoschema') ||


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: The GitHub labeler is still using `sig/DDL` after it renamed.

### What is changed and how it works?

What's Changed: Change `sig/DDL` to `sig/infra` and add some components to it.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
