### PR TITLE
executor: check not exist error in batch point get for cached tables

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -443,7 +443,10 @@ func (b *cacheBatchGetter) BatchGet(ctx context.Context, keys []kv.Key) (map[str
 	for _, key := range keys {
 		val, err := cacheDB.UnionGet(ctx, b.tid, b.snapshot, key)
 		if err != nil {
-			return nil, err
+			if !kv.ErrNotExist.Equal(err) {
+				return nil, err
+			}
+			continue
 		}
 		vals[string(key)] = val
 	}

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -620,48 +620,57 @@ func (s *testSerialSuite) TestPointGetReadLock(c *C) {
 	tk.MustExec("insert point values (1, 1, 'a')")
 	tk.MustExec("insert point values (2, 2, 'b')")
 
-	sqls := []string{
-		"explain analyze select * from point where id = 1",
-		"explain analyze select * from point where id in (1, 2)",
+	cases := []struct {
+		sql string
+		r1  bool
+		r2  bool
+	}{
+		{"explain analyze select * from point where id = 1", false, false},
+		{"explain analyze select * from point where id in (1, 2)", false, false},
+
+		// Cases for not exist keys.
+		{"explain analyze select * from point where id = 3", true, true},
+		{"explain analyze select * from point where id in (1, 3)", true, true},
+		{"explain analyze select * from point where id in (3, 4)", true, true},
 	}
 
-	for _, sql := range sqls {
+	for _, ca := range cases {
 		s.mustExecDDL(tk, c, "lock tables point read")
 
-		rows := tk.MustQuery(sql).Rows()
-		c.Assert(len(rows), Equals, 1, Commentf("%v", sql))
+		rows := tk.MustQuery(ca.sql).Rows()
+		c.Assert(len(rows), Equals, 1, Commentf("%v", ca.sql))
 		explain := fmt.Sprintf("%v", rows[0])
 		c.Assert(explain, Matches, ".*num_rpc.*")
 
-		rows = tk.MustQuery(sql).Rows()
+		rows = tk.MustQuery(ca.sql).Rows()
 		c.Assert(len(rows), Equals, 1)
 		explain = fmt.Sprintf("%v", rows[0])
 		ok := strings.Contains(explain, "num_rpc")
-		c.Assert(ok, IsFalse)
+		c.Assert(ok, Equals, ca.r1, Commentf("%v", ca.sql))
 		s.mustExecDDL(tk, c, "unlock tables")
 
-		rows = tk.MustQuery(sql).Rows()
+		rows = tk.MustQuery(ca.sql).Rows()
 		c.Assert(len(rows), Equals, 1)
 		explain = fmt.Sprintf("%v", rows[0])
 		c.Assert(explain, Matches, ".*num_rpc.*")
 
 		// Test cache release after unlocking tables.
 		s.mustExecDDL(tk, c, "lock tables point read")
-		rows = tk.MustQuery(sql).Rows()
+		rows = tk.MustQuery(ca.sql).Rows()
 		c.Assert(len(rows), Equals, 1)
 		explain = fmt.Sprintf("%v", rows[0])
 		c.Assert(explain, Matches, ".*num_rpc.*")
 
-		rows = tk.MustQuery(sql).Rows()
+		rows = tk.MustQuery(ca.sql).Rows()
 		c.Assert(len(rows), Equals, 1)
 		explain = fmt.Sprintf("%v", rows[0])
 		ok = strings.Contains(explain, "num_rpc")
-		c.Assert(ok, IsFalse)
+		c.Assert(ok, Equals, ca.r2, Commentf("%v", ca.sql))
 
 		s.mustExecDDL(tk, c, "unlock tables")
 		s.mustExecDDL(tk, c, "lock tables point read")
 
-		rows = tk.MustQuery(sql).Rows()
+		rows = tk.MustQuery(ca.sql).Rows()
 		c.Assert(len(rows), Equals, 1)
 		explain = fmt.Sprintf("%v", rows[0])
 		c.Assert(explain, Matches, ".*num_rpc.*")


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
https://github.com/pingcap/tidb/pull/22165 doesn't check not exist error in batch point get, which raise not expected error.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Check not exists error.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- Check not exist error in batch point get for cached tables.
