### PR TITLE
test: stabilize test case

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -714,8 +714,10 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 	}()
 
 	timeoutErr := <-timeoutErrCh
+	c.Assert(timeoutErr, NotNil)
 	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
 	timeoutErr = <-timeoutErrCh
+	c.Assert(timeoutErr, NotNil)
 	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
 
 	// tk4 lock c1 = 2

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -713,9 +713,9 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 		tk5.MustExec("rollback")
 	}()
 
-	timeoutErr := <- timeoutErrCh
+	timeoutErr := <-timeoutErrCh
 	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
-	timeoutErr = <- timeoutErrCh
+	timeoutErr = <-timeoutErrCh
 	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
 
 	// tk4 lock c1 = 2

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -655,6 +655,11 @@ func (s *testPessimisticSuite) TestConcurrentInsert(c *C) {
 }
 
 func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
+	// Increasing the ManagedLockTTL so that the lock may not be resolved testing with TiKV.
+	atomic.StoreUint64(&tikv.ManagedLockTTL, 5000)
+	defer func() {
+		atomic.StoreUint64(&tikv.ManagedLockTTL, 300)
+	}()
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("drop table if exists tk")
 	tk.MustExec("create table tk (c1 int primary key, c2 int)")
@@ -771,6 +776,11 @@ func (s *testPessimisticSuite) TestPushConditionCheckForPessimisticTxn(c *C) {
 }
 
 func (s *testPessimisticSuite) TestInnodbLockWaitTimeoutWaitStart(c *C) {
+	// Increasing the ManagedLockTTL so that the lock may not be resolved testing with TiKV.
+	atomic.StoreUint64(&tikv.ManagedLockTTL, 5000)
+	defer func() {
+		atomic.StoreUint64(&tikv.ManagedLockTTL, 300)
+	}()
 	// prepare work
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	defer tk.MustExec("drop table if exists tk")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #21912 #17991

Problem Summary:
If the lock is resolved and no lock error reportes, the test may panic like this:
[2020-12-23T18:27:10.707Z] PANIC: pessimistic_test.go:657: testPessimisticSuite.TestInnodbLockWaitTimeout
[2020-12-23T18:27:10.707Z] 
[2020-12-23T18:27:10.707Z] ... Panic: runtime error: invalid memory address or nil pointer dereference (PC=0x1392B31)
[2020-12-23T18:27:10.707Z] 
[2020-12-23T18:27:10.707Z] /usr/local/go/src/runtime/panic.go:679
[2020-12-23T18:27:10.707Z]   in gopanic
[2020-12-23T18:27:10.707Z] /usr/local/go/src/runtime/panic.go:199
[2020-12-23T18:27:10.707Z]   in panicmem
[2020-12-23T18:27:10.707Z] /usr/local/go/src/runtime/signal_unix.go:394
[2020-12-23T18:27:10.707Z]   in sigpanic
[2020-12-23T18:27:10.707Z] pessimistic_test.go:739
[2020-12-23T18:27:10.707Z]   in testPessimisticSuite.TestInnodbLockWaitTimeout
[2020-12-23T18:27:10.707Z] /usr/local/go/src/reflect/value.go:321
[2020-12-23T18:27:10.707Z]   in Value.Call


### What is changed and how it works?

What's Changed:
The default set for test 300ms is a bit short, try increasing the `ManagedLockTTL` in the test so that the lock will not be resolved testing with TiKV.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
