### PR TITLE
*: using a lru cache in cachedb

### DIFF
--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -622,6 +622,12 @@ func (s *testSerialSuite) TestMemCacheReadLock(c *C) {
 	tk.MustExec("insert point values (1, 1, 'a')")
 	tk.MustExec("insert point values (2, 2, 'b')")
 
+	// Simply check the cached results.
+	s.mustExecDDL(tk, c, "lock tables point read")
+	tk.MustQuery("select id from point where id = 1").Check(testkit.Rows("1"))
+	tk.MustQuery("select id from point where id = 1").Check(testkit.Rows("1"))
+	s.mustExecDDL(tk, c, "unlock tables")
+
 	cases := []struct {
 		sql string
 		r1  bool

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/blacktear23/go-proxyprotocol v0.0.0-20180807104634-af7a81e8dd0d
 	github.com/cheggaaa/pb/v3 v3.0.4 // indirect
 	github.com/codahale/hdrhistogram v0.9.0 // indirect
+	github.com/coocood/freecache v1.1.1
 	github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548
 	github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8
 	github.com/danjacques/gofslock v0.0.0-20191023191349-0a45f885bc37

--- a/go.sum
+++ b/go.sum
@@ -144,6 +144,8 @@ github.com/codahale/hdrhistogram v0.9.0 h1:9GjrtRI+mLEFPtTfR/AZhcxp+Ii8NZYWq5104
 github.com/codahale/hdrhistogram v0.9.0/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64 h1:W1SHiII3e0jVwvaQFglwu3kS9NLxOeTpvik7MbKCyuQ=
 github.com/coocood/bbloom v0.0.0-20190830030839-58deb6228d64/go.mod h1:F86k/6c7aDUdwSUevnLpHS/3Q9hzYCE99jGk2xsHnt0=
+github.com/coocood/freecache v1.1.1 h1:uukNF7QKCZEdZ9gAV7WQzvh0SbjwdMF6m3x3rxEkaPc=
+github.com/coocood/freecache v1.1.1/go.mod h1:OKrEjkGVoxZhyWAJoeFi5BMLUJm2Tit0kpGkIr7NGYY=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2 h1:NnLfQ77q0G4k2Of2c1ceQ0ec6MkLQyDp+IGdVM0D8XM=
 github.com/coocood/rtutil v0.0.0-20190304133409-c84515f646f2/go.mod h1:7qG7YFnOALvsx6tKTNmQot8d7cGFXM9TidzvRFLWYwM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=

--- a/kv/cachedb.go
+++ b/kv/cachedb.go
@@ -16,12 +16,14 @@ package kv
 import (
 	"context"
 	"sync"
+
+	"github.com/coocood/freecache"
 )
 
 type (
 	cacheDB struct {
 		mu        sync.RWMutex
-		memTables map[int64]*memdb
+		memTables map[int64]*freecache.Cache
 	}
 
 	// MemManager adds a cache between transaction buffer and the storage to reduce requests to the storage.
@@ -42,24 +44,18 @@ func (c *cacheDB) set(tableID int64, key Key, value []byte) error {
 	defer c.mu.Unlock()
 	table, ok := c.memTables[tableID]
 	if !ok {
-		table = newMemDB()
+		table = freecache.NewCache(100 * 1024 * 1024)
 		c.memTables[tableID] = table
 	}
-	err := table.Set(key, value)
-	if err != nil && ErrTxnTooLarge.Equal(err) {
-		// If it reaches the upper limit, refresh a new memory buffer.
-		c.memTables[tableID] = newMemDB()
-		return nil
-	}
-	return err
+	return table.Set(key, value, 0)
 }
 
 // Get gets the value from cacheDB.
-func (c *cacheDB) get(ctx context.Context, tableID int64, key Key) []byte {
+func (c *cacheDB) get(tableID int64, key Key) []byte {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	if table, ok := c.memTables[tableID]; ok {
-		if val, err := table.Get(ctx, key); err == nil {
+		if val, err := table.Get(key); err == nil {
 			return val
 		}
 	}
@@ -67,11 +63,11 @@ func (c *cacheDB) get(ctx context.Context, tableID int64, key Key) []byte {
 }
 
 // UnionGet implements MemManager UnionGet interface.
-func (c *cacheDB) UnionGet(ctx context.Context, tid int64, snapshot Snapshot, key Key) ([]byte, error) {
-	val := c.get(ctx, tid, key)
+func (c *cacheDB) UnionGet(ctx context.Context, tid int64, snapshot Snapshot, key Key) (val []byte, err error) {
+	val = c.get(tid, key)
 	// key does not exist then get from snapshot and set to cache
 	if val == nil {
-		val, err := snapshot.Get(ctx, key)
+		val, err = snapshot.Get(ctx, key)
 		if err != nil {
 			return nil, err
 		}
@@ -88,7 +84,7 @@ func (c *cacheDB) UnionGet(ctx context.Context, tid int64, snapshot Snapshot, ke
 func (c *cacheDB) Delete(tableID int64) {
 	c.mu.Lock()
 	if k, ok := c.memTables[tableID]; ok {
-		k.Reset()
+		k.Clear()
 		delete(c.memTables, tableID)
 	}
 	c.mu.Unlock()
@@ -97,6 +93,6 @@ func (c *cacheDB) Delete(tableID int64) {
 // NewCacheDB news the cacheDB.
 func NewCacheDB() MemManager {
 	mm := new(cacheDB)
-	mm.memTables = make(map[int64]*memdb)
+	mm.memTables = make(map[int64]*freecache.Cache)
 	return mm
 }


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
`memdb` will meet transaction too large error when it reaches the upper limit, which may cause the cache hit rate crazy dropping.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Use github.com/coocood/freecache instead of `memdb`.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Using a lru cache in cachedb.
