### PR TITLE
planner/core: push selection operator to mpp task

### DIFF
--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -130,6 +130,9 @@ func attachPlan2Task(p PhysicalPlan, t task) task {
 	case *rootTask:
 		p.SetChildren(v.p)
 		v.p = p
+	case *mppTask:
+		p.SetChildren(v.p)
+		v.p = p
 	}
 	return t
 }
@@ -1085,6 +1088,9 @@ func (p *PhysicalUnionAll) attach2Task(tasks ...task) task {
 
 func (sel *PhysicalSelection) attach2Task(tasks ...task) task {
 	sessVars := sel.ctx.GetSessionVars()
+	if mppTask, _ := tasks[0].(*mppTask); mppTask != nil { // always push to mpp task.
+		return attachPlan2Task(sel, mppTask.copy())
+	}
 	t := tasks[0].convertToRootTask(sel.ctx)
 	t.addCost(t.count() * sessVars.CPUFactor)
 	return attachPlan2Task(sel, t)

--- a/planner/core/testdata/integration_serial_suite_in.json
+++ b/planner/core/testdata/integration_serial_suite_in.json
@@ -38,6 +38,7 @@
       "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k",
       "explain select count(*) from fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > d1_t.value",
       "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 10",
+      "explain select count(*) from (select case when t1.col1 is null then t2.col1 + 5 else 10 end as col1, t2.d1_k as d1_k from fact_t t1 right join fact_t t2 on t1.d1_k = t2.d1_k) fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 5",
       "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
       "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10",
       "explain select count(*) from fact_t right join d1_t on fact_t.d1_k = d1_t.d1_k and d1_t.value > 10 and fact_t.col1 > d1_t.value",

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -430,6 +430,31 @@
         ]
       },
       {
+        "SQL": "explain select count(*) from (select case when t1.col1 is null then t2.col1 + 5 else 10 end as col1, t2.d1_k as d1_k from fact_t t1 right join fact_t t2 on t1.d1_k = t2.d1_k) fact_t join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col1 > 5",
+        "Plan": [
+          "HashAgg_37 1.00 root  funcs:count(Column#22)->Column#19",
+          "└─TableReader_39 1.00 root  data:ExchangeSender_38",
+          "  └─ExchangeSender_38 1.00 cop[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_15 1.00 cop[tiflash]  funcs:count(1)->Column#22",
+          "      └─HashJoin_20 204.80 cop[tiflash]  inner join, equal:[eq(test.d1_t.d1_k, test.fact_t.d1_k)]",
+          "        ├─ExchangeReceiver_24(Build) 4.00 cop[tiflash]  ",
+          "        │ └─ExchangeSender_23 4.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.d1_t.d1_k",
+          "        │   └─Selection_22 4.00 cop[tiflash]  not(isnull(test.d1_t.d1_k))",
+          "        │     └─TableFullScan_21 4.00 cop[tiflash] table:d1_t keep order:false",
+          "        └─Projection_25(Probe) 102.40 cop[tiflash]  test.fact_t.d1_k",
+          "          └─Selection_27 102.40 cop[tiflash]  gt(case(isnull(test.fact_t.col1), plus(test.fact_t.col1, 5), 10), 5)",
+          "            └─HashJoin_28 128.00 cop[tiflash]  right outer join, equal:[eq(test.fact_t.d1_k, test.fact_t.d1_k)]",
+          "              ├─ExchangeReceiver_32(Build) 16.00 cop[tiflash]  ",
+          "              │ └─ExchangeSender_31 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "              │   └─Selection_30 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "              │     └─TableFullScan_29 16.00 cop[tiflash] table:t1 keep order:false",
+          "              └─ExchangeReceiver_36(Probe) 16.00 cop[tiflash]  ",
+          "                └─ExchangeSender_35 16.00 cop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.fact_t.d1_k",
+          "                  └─Selection_34 16.00 cop[tiflash]  not(isnull(test.fact_t.d1_k))",
+          "                    └─TableFullScan_33 16.00 cop[tiflash] table:t2 keep order:false"
+        ]
+      },
+      {
         "SQL": "explain select count(*) from fact_t left join d1_t on fact_t.d1_k = d1_t.d1_k and fact_t.col2 > 10 and fact_t.col1 > d1_t.value",
         "Plan": [
           "HashAgg_21 1.00 root  funcs:count(Column#12)->Column#11",


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
In TiDB, selection can not appear above a operator except table scan. But in Mpp mode, that's not the case any more.

### What is changed and how it works?

What's Changed:
In attack 2 task phase, selection can be attached to MPP part

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (e2e)

Side effects

None

### Release note <!-- bugfixes or new feature need a release note -->

- push selection operator to mpp task
