### PR TITLE
*: introduce security enhanced mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -186,6 +186,8 @@ type Config struct {
 	// EnableTCP4Only enables net.Listen("tcp4",...)
 	// Note that: it can make lvs with toa work and thus tidb can get real client ip.
 	EnableTCP4Only bool `toml:"enable-tcp4-only" json:"enable-tcp4-only"`
+	// EnableEnhancedSecurity prevents SUPER users from having full access.
+	EnableEnhancedSecurity bool `toml:"enable-enhanced-security" json:"enable-enhanced-security"`
 }
 
 // UpdateTempStoragePath is to update the `TempStoragePath` if port/statusPort was changed
@@ -812,6 +814,7 @@ var defaultConf = Config{
 	TxnScope:                     DefTxnScope,
 	EnableEnumLengthLimit:        true,
 	StoresRefreshInterval:        DefStoresRefreshInterval,
+	EnableEnhancedSecurity:       false,
 }
 
 var (

--- a/infoschema/cluster.go
+++ b/infoschema/cluster.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/security"
 )
 
 // Cluster table list, attention:
@@ -84,6 +85,9 @@ func AppendHostInfoToRows(rows [][]types.Datum) ([][]types.Datum, error) {
 		return nil, err
 	}
 	addr := serverInfo.IP + ":" + strconv.FormatUint(uint64(serverInfo.StatusPort), 10)
+	if security.IsEnabled() {
+		addr = serverInfo.ID
+	}
 	for i := range rows {
 		row := make([]types.Datum, 0, len(rows[i])+1)
 		row = append(row, types.NewStringDatum(addr))

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -35,6 +35,7 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/domainutil"
 	utilparser "github.com/pingcap/tidb/util/parser"
+	"github.com/pingcap/tidb/util/security"
 )
 
 // PreprocessOpt presents optional parameters to `Preprocess` method.
@@ -1203,6 +1204,9 @@ func (p *preprocessor) handleRepairName(tn *ast.TableName) {
 }
 
 func (p *preprocessor) resolveShowStmt(node *ast.ShowStmt) {
+	if security.IsEnabled() && node.Tp == ast.ShowConfig {
+		p.err = errors.New("tidb-server is running in enhanced security mode")
+	}
 	if node.DBName == "" {
 		if node.Table != nil && node.Table.Schema.L != "" {
 			node.DBName = node.Table.Schema.O

--- a/server/server.go
+++ b/server/server.go
@@ -223,7 +223,6 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 		clients:           make(map[uint64]*clientConn),
 		globalConnID:      util.GlobalConnID{ServerID: 0, Is64bits: true},
 	}
-	setTxnScope()
 	tlsConfig, err := util.LoadTLSCertificates(s.cfg.Security.SSLCA, s.cfg.Security.SSLKey, s.cfg.Security.SSLCert)
 	if err != nil {
 		logutil.BgLogger().Error("secure connection cert/key/ca load fail", zap.Error(err))
@@ -298,10 +297,6 @@ func setSSLVariable(ca, key, cert string) {
 	variable.SetSysVar("ssl_cert", cert)
 	variable.SetSysVar("ssl_key", key)
 	variable.SetSysVar("ssl_ca", ca)
-}
-
-func setTxnScope() {
-	variable.SetSysVar("txn_scope", config.GetGlobalConfig().TxnScope)
 }
 
 // Run runs the server.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -361,12 +361,22 @@ func RegisterSysVar(sv *SysVar) {
 }
 
 // UnregisterSysVar removes a sysvar from the SysVars list
-// currently only used in tests.
 func UnregisterSysVar(name string) {
 	name = strings.ToLower(name)
 	sysVarsLock.Lock()
 	delete(sysVars, name)
 	sysVarsLock.Unlock()
+}
+
+// RegisterSysVarFromDefaults is used by the Security Enhanced mode testsuite
+// It re-registers a sysvar from defaultSysVars. It is inefficient because it
+// must scan the defaultSysVars to find a match.
+func RegisterSysVarFromDefaults(name string) {
+	for _, sv := range defaultSysVars {
+		if sv.Name == name {
+			RegisterSysVar(sv)
+		}
+	}
 }
 
 // GetSysVar returns sys var info for name as key.
@@ -465,7 +475,7 @@ var defaultSysVars = []*SysVar{
 		}
 		return normalizedValue, ErrWrongValueForVar.GenWithStackByArgs(ForeignKeyChecks, originalValue)
 	}},
-	{Scope: ScopeNone, Name: Hostname, Value: ServerHostname},
+	{Scope: ScopeNone, Name: Hostname, Value: DefHostname},
 	{Scope: ScopeSession, Name: Timestamp, Value: ""},
 	{Scope: ScopeGlobal | ScopeSession, Name: CharacterSetFilesystem, Value: "binary", Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		return checkCharacterValid(normalizedValue, CharacterSetFilesystem)
@@ -741,6 +751,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAnalyzeVersion, Value: strconv.Itoa(DefTiDBAnalyzeVersion), Type: TypeInt, MinValue: 1, MaxValue: 2},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableIndexMergeJoin, Value: BoolToOnOff(DefTiDBEnableIndexMergeJoin), Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBTrackAggregateMemoryUsage, Value: BoolToOnOff(DefTiDBTrackAggregateMemoryUsage), Type: TypeBool},
+	{Scope: ScopeNone, Name: TiDBEnableEnhancedSecurity, Value: BoolToOnOff(config.GetGlobalConfig().EnableEnhancedSecurity), Type: TypeBool},
 
 	/* tikv gc metrics */
 	{Scope: ScopeGlobal, Name: TiDBGCEnable, Value: BoolOn, Type: TypeBool},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -15,7 +15,6 @@ package variable
 
 import (
 	"math"
-	"os"
 
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
@@ -516,6 +515,9 @@ const (
 
 	// TiDBTrackAggregateMemoryUsage indicates whether track the memory usage of aggregate function.
 	TiDBTrackAggregateMemoryUsage = "tidb_track_aggregate_memory_usage"
+
+	// TiDBEnableEnancedSecurity restricts SUPER users from certain operations.
+	TiDBEnableEnhancedSecurity = "tidb_enable_enhanced_security"
 )
 
 // TiDB vars that have only global scope
@@ -673,7 +675,6 @@ var (
 	// DDLSlowOprThreshold is the threshold for ddl slow operations, uint is millisecond.
 	DDLSlowOprThreshold            uint32 = DefTiDBDDLSlowOprThreshold
 	ForcePriority                         = int32(DefTiDBForcePriority)
-	ServerHostname, _                     = os.Hostname()
 	MaxOfMaxAllowedPacket          uint64 = 1073741824
 	ExpensiveQueryTimeThreshold    uint64 = DefTiDBExpensiveQueryTimeThreshold
 	MinExpensiveQueryTimeThreshold uint64 = 10 // 10s

--- a/util/security/security.go
+++ b/util/security/security.go
@@ -1,0 +1,180 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"os"
+	"strings"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/sessionctx/variable"
+)
+
+const (
+	bindInfo              = "bind_info"
+	columnsPriv           = "columns_priv"
+	db                    = "db"
+	defaultRoles          = "default_roles"
+	globalPriv            = "global_priv"
+	helpTopic             = "help_topic" // TODO: will this cause client problems?
+	roleEdges             = "role_edges"
+	schemaIndexUsage      = "schema_index_usage"
+	statsBuckets          = "stats_buckets"
+	statsExtended         = "stats_extended"
+	statsFeedback         = "stats_feedback"
+	statsHistograms       = "stats_histograms"
+	statsMeta             = "stats_meta"
+	statsTopN             = "stats_top_n"
+	tablesPriv            = "tables_priv"
+	user                  = "user"
+	metricsSchema         = "metrics_schema"
+	exprPushdownBlacklist = "expr_pushdown_blacklist"
+	gcDeleteRange         = "gc_delete_range"
+	gcDeleteRangeDone     = "gc_delete_range_done"
+	optRuleBlacklist      = "opt_rule_blacklist"
+	tidb                  = "tidb"
+	globalVariables       = "global_variables"
+	informationSchema     = "information_schema"
+	clusterConfig         = "cluster_config"
+	clusterHardware       = "cluster_hardware"
+	clusterLoad           = "cluster_load"
+	clusterLog            = "cluster_log"
+	clusterSystemInfo     = "cluster_systeminfo"
+	inspectionResult      = "inspection_result"
+	inspectionRules       = "inspection_rules"
+	inspectionSummary     = "inspection_summary"
+	metricsSummary        = "metrics_summary"
+	metricsSummaryByLabel = "metrics_summary_by_label"
+	metricsTables         = "metrics_tables"
+	tidbHotRegions        = "tidb_hot_regions"
+	performanceSchema     = "performance_schema"
+	pdProfileAllocs       = "pd_profile_allocs"
+	pdProfileBlock        = "pd_profile_block"
+	pdProfileCPU          = "pd_profile_cpu"
+	pdProfileGoroutines   = "pd_profile_goroutines"
+	pdProfileMemory       = "pd_profile_memory"
+	pdProfileMutex        = "pd_profile_mutex"
+	tidbProfileAllocs     = "tidb_profile_allocs"
+	tidbProfileBlock      = "tidb_profile_block"
+	tidbProfileCPU        = "tidb_profile_cpu"
+	tidbProfileGoroutines = "tidb_profile_goroutines"
+	tidbProfileMemory     = "tidb_profile_memory"
+	tidbProfileMutex      = "tidb_profile_mutex"
+	tikvProfileCPU        = "tikv_profile_cpu"
+)
+
+var secureVarsList = []string{
+	variable.TiDBDDLSlowOprThreshold, // ddl_slow_threshold
+	variable.TiDBAllowRemoveAutoInc,
+	variable.TiDBCheckMb4ValueInUTF8,
+	variable.TiDBConfig,
+	variable.TiDBEnableSlowLog,
+	variable.TiDBEnableTelemetry,
+	variable.TiDBExpensiveQueryTimeThreshold,
+	variable.TiDBForcePriority,
+	variable.TiDBGeneralLog,
+	variable.TiDBMetricSchemaRangeDuration,
+	variable.TiDBMetricSchemaStep,
+	variable.TiDBOptWriteRowID,
+	variable.TiDBPProfSQLCPU,
+	variable.TiDBRecordPlanInSlowLog,
+	variable.TiDBRowFormatVersion,
+	variable.TiDBSlowQueryFile,
+	variable.TiDBSlowLogThreshold,
+	variable.TiDBEnableCollectExecutionInfo,
+	variable.TiDBMemoryUsageAlarmRatio,
+}
+
+// Enable enables SEM. This is intended to be used by the test-suite.
+// Dynamic configuration by users may be a security risk.
+func Enable() {
+	variable.SetSysVar(variable.Hostname, variable.DefHostname)
+	for _, name := range secureVarsList {
+		variable.UnregisterSysVar(name)
+	}
+	config.GetGlobalConfig().EnableEnhancedSecurity = true
+}
+
+// Disable disables SEM. This is intended to be used by the test-suite.
+// Dynamic configuration by users may be a security risk.
+func Disable() {
+	if hostname, err := os.Hostname(); err != nil {
+		variable.SetSysVar(variable.Hostname, hostname)
+	}
+	for _, name := range secureVarsList {
+		variable.RegisterSysVarFromDefaults(name)
+	}
+	config.GetGlobalConfig().EnableEnhancedSecurity = false
+}
+
+// IsEnabled checks if Security Enhanced Mode (SEM) is enabled
+func IsEnabled() bool {
+	return config.GetGlobalConfig().EnableEnhancedSecurity
+}
+
+// IsReadOnlySystemTable returns true if SEM is enabled
+// and the tblLowerName needs to be read-only
+func IsReadOnlySystemTable(tblLowerName string) bool {
+	if !IsEnabled() {
+		return false
+	}
+	switch tblLowerName {
+	case bindInfo, columnsPriv, db, defaultRoles, globalPriv, helpTopic,
+		roleEdges, schemaIndexUsage, statsBuckets, statsExtended, statsFeedback,
+		statsHistograms, statsMeta, statsTopN, tablesPriv, user:
+		return true
+	}
+	return false
+}
+
+// IsInvisibleSchema returns true if SEM is enabled
+// and the dbName needs to be hidden
+func IsInvisibleSchema(dbName string) bool {
+	if !IsEnabled() {
+		return false
+	}
+	return strings.EqualFold(dbName, metricsSchema)
+}
+
+// IsInvisibleTable returns true if SEM is enabled and the
+// table needs to be hidden
+func IsInvisibleTable(dbLowerName, tblLowerName string) bool {
+	if !IsEnabled() {
+		return false
+	}
+	switch dbLowerName {
+	case mysql.SystemDB:
+		switch tblLowerName {
+		case exprPushdownBlacklist, gcDeleteRange, gcDeleteRangeDone, optRuleBlacklist, tidb, globalVariables:
+			return true
+		}
+	case informationSchema:
+		switch tblLowerName {
+		case clusterConfig, clusterHardware, clusterLoad, clusterLog, clusterSystemInfo, inspectionResult,
+			inspectionRules, inspectionSummary, metricsSummary, metricsSummaryByLabel, metricsTables, tidbHotRegions:
+			return true
+		}
+	case performanceSchema:
+		switch tblLowerName {
+		case pdProfileAllocs, pdProfileBlock, pdProfileCPU, pdProfileGoroutines, pdProfileMemory,
+			pdProfileMutex, tidbProfileAllocs, tidbProfileBlock, tidbProfileCPU, tidbProfileGoroutines,
+			tidbProfileMemory, tidbProfileMutex, tikvProfileCPU:
+			return true
+		}
+	case metricsSchema:
+		return true
+	}
+	return false
+}

--- a/util/security/security_test.go
+++ b/util/security/security_test.go
@@ -1,0 +1,126 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/sessionctx/variable"
+
+	. "github.com/pingcap/check"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testSecurity{})
+
+type testSecurity struct{}
+
+func (s *testSecurity) TestGetSetSysVars(c *C) {
+	svList := variable.GetSysVars()
+	c.Assert(IsEnabled(), IsFalse) // default OFF
+	for _, name := range secureVarsList {
+		_, ok := svList[name]
+		c.Assert(ok, IsTrue)
+	}
+	Enable()
+	for _, name := range secureVarsList {
+		_, ok := svList[name]
+		c.Assert(ok, IsFalse)
+	}
+	Disable()
+	c.Assert(IsEnabled(), IsFalse)
+}
+
+func (s *testSecurity) TestIsReadOnlySystemTable(c *C) {
+
+	Enable()
+	tbls := []string{bindInfo, columnsPriv, db, defaultRoles, globalPriv, helpTopic,
+		roleEdges, schemaIndexUsage, statsBuckets, statsExtended, statsFeedback,
+		statsHistograms, statsMeta, statsTopN, tablesPriv, user}
+
+	for _, tbl := range tbls {
+		c.Assert(IsReadOnlySystemTable(tbl), IsTrue)
+	}
+
+	Disable()
+
+	for _, tbl := range tbls {
+		c.Assert(IsReadOnlySystemTable(tbl), IsFalse)
+	}
+
+}
+
+func (s *testSecurity) TestInvisibleSchema(c *C) {
+
+	Enable()
+
+	c.Assert(IsInvisibleSchema(metricsSchema), IsTrue)
+	c.Assert(IsInvisibleSchema("METRICS_ScHEma"), IsTrue)
+	c.Assert(IsInvisibleSchema("mysql"), IsFalse)
+	c.Assert(IsInvisibleSchema(informationSchema), IsFalse)
+	c.Assert(IsInvisibleSchema("Bogusname"), IsFalse)
+
+	Disable()
+
+	c.Assert(IsInvisibleSchema(metricsSchema), IsFalse)
+	c.Assert(IsInvisibleSchema("Bogusname"), IsFalse)
+
+}
+
+func (s *testSecurity) TestIsInvisibleTable(c *C) {
+
+	Enable()
+
+	mysqlTbls := []string{exprPushdownBlacklist, gcDeleteRange, gcDeleteRangeDone, optRuleBlacklist, tidb, globalVariables}
+	infoSchemaTbls := []string{clusterConfig, clusterHardware, clusterLoad, clusterLog, clusterSystemInfo, inspectionResult,
+		inspectionRules, inspectionSummary, metricsSummary, metricsSummaryByLabel, metricsTables, tidbHotRegions}
+	perfSChemaTbls := []string{pdProfileAllocs, pdProfileBlock, pdProfileCPU, pdProfileGoroutines, pdProfileMemory,
+		pdProfileMutex, tidbProfileAllocs, tidbProfileBlock, tidbProfileCPU, tidbProfileGoroutines,
+		tidbProfileMemory, tidbProfileMutex, tikvProfileCPU}
+
+	for _, tbl := range mysqlTbls {
+		c.Assert(IsInvisibleTable(mysql.SystemDB, tbl), IsTrue)
+	}
+	for _, tbl := range infoSchemaTbls {
+		c.Assert(IsInvisibleTable(informationSchema, tbl), IsTrue)
+	}
+	for _, tbl := range perfSChemaTbls {
+		c.Assert(IsInvisibleTable(performanceSchema, tbl), IsTrue)
+	}
+
+	c.Assert(IsInvisibleTable(metricsSchema, "acdc"), IsTrue)
+	c.Assert(IsInvisibleTable(metricsSchema, "fdsgfd"), IsTrue)
+	c.Assert(IsInvisibleTable("test", "t1"), IsFalse)
+
+	Disable()
+
+	for _, tbl := range mysqlTbls {
+		c.Assert(IsInvisibleTable(mysql.SystemDB, tbl), IsFalse)
+	}
+	for _, tbl := range infoSchemaTbls {
+		c.Assert(IsInvisibleTable(informationSchema, tbl), IsFalse)
+	}
+	for _, tbl := range perfSChemaTbls {
+		c.Assert(IsInvisibleTable(performanceSchema, tbl), IsFalse)
+	}
+
+	c.Assert(IsInvisibleTable(metricsSchema, "acdc"), IsFalse)
+	c.Assert(IsInvisibleTable(metricsSchema, "fdsgfd"), IsFalse)
+	c.Assert(IsInvisibleTable("test", "t1"), IsFalse)
+
+}


### PR DESCRIPTION
### What problem does this PR solve?

Design doc: https://github.com/pingcap/tidb/issues/22373

Problem Summary:

Currently the `SUPER` privilege is an umbrella for too many uses. The intention for DBaaS is that users should be permitted `SUPER`, but some of the higher risk operations will be denied.

The implementation is via a new "security enhanced mode". The design is not DBaaS specific, and it's quite possible that on-premises users may elect to enable this feature.

### What is changed and how it works?

What's Changed:

When SEM is enabled, access is restricted:
- To certain system variables
- Statements (SHOW CONFIG)
- Information schema tables
- Columns of information_schema tables.

### Related changes

- The docs should read well for users of SEM. For example: https://github.com/pingcap/docs/pull/4552
- I intend to update docs to describe if variables / commands / tables are impacted by SEM. Because I expect the exact implementation to change during review, I will start the docs PR later :-)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Increased code complexity
- Increased docs complexity

### Release note <!-- bugfixes or new feature need a release note -->

- Security Enhanced mode has been introduced, providing a way to prevent access to higher risk commands, variables and meta data tables.