### PR TITLE
executor: fix tidb can not show view data_type

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -569,7 +569,7 @@ func (e *hugeMemTableRetriever) setDataForColumns(ctx context.Context, sctx sess
 
 func (e *hugeMemTableRetriever) dataForColumnsInTable(ctx context.Context, sctx sessionctx.Context, schema *model.DBInfo, tbl *model.TableInfo) {
 	if tbl.IsView() {
-		// retrieve view columns info
+		// Retrieve view columns info.
 		planBuilder, _ := plannercore.NewPlanBuilder(sctx, infoschema.GetInfoSchema(sctx), &hint.BlockHintProcessor{})
 		if viewLogicalPlan, err := planBuilder.BuildDataSourceFromView(ctx, schema.Name, tbl); err == nil {
 			viewSchema := viewLogicalPlan.Schema()

--- a/executor/show.go
+++ b/executor/show.go
@@ -459,25 +459,8 @@ func (e *ShowExec) fetchShowColumns(ctx context.Context) error {
 	} else {
 		cols = tb.VisibleCols()
 	}
-	if tb.Meta().IsView() {
-		// Because view's undertable's column could change or recreate, so view's column type may change overtime.
-		// To avoid this situation we need to generate a logical plan and extract current column types from Schema.
-		planBuilder, _ := plannercore.NewPlanBuilder(e.ctx, e.is, &hint.BlockHintProcessor{})
-		viewLogicalPlan, err := planBuilder.BuildDataSourceFromView(ctx, e.DBName, tb.Meta())
-		if err != nil {
-			return err
-		}
-		viewSchema := viewLogicalPlan.Schema()
-		viewOutputNames := viewLogicalPlan.OutputNames()
-		for _, col := range cols {
-			idx := expression.FindFieldNameIdxByColName(viewOutputNames, col.Name.L)
-			if idx >= 0 {
-				col.FieldType = *viewSchema.Columns[idx].GetType()
-			}
-			if col.Tp == mysql.TypeVarString {
-				col.Tp = mysql.TypeVarchar
-			}
-		}
+	if err := tryFillViewColumnType(ctx, e.ctx, e.is, e.DBName, tb.Meta()); err != nil {
+		return err
 	}
 	for _, col := range cols {
 		if e.Column != nil && e.Column.Name.L != col.Name.L {
@@ -1642,6 +1625,32 @@ func (e *ShowExec) fillRegionsToChunk(regions []regionMeta) {
 func (e *ShowExec) fetchShowBuiltins() error {
 	for _, f := range expression.GetBuiltinList() {
 		e.appendRow([]interface{}{f})
+	}
+	return nil
+}
+
+// tryFillViewColumnType fill the columns type info of a view.
+// Because view's underlying table's column could change or recreate, so view's column type may change over time.
+// To avoid this situation we need to generate a logical plan and extract current column types from Schema.
+func tryFillViewColumnType(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, dbName model.CIStr, tbl *model.TableInfo) error {
+	if tbl.IsView() {
+		// Retrieve view columns info.
+		planBuilder, _ := plannercore.NewPlanBuilder(sctx, is, &hint.BlockHintProcessor{})
+		if viewLogicalPlan, err := planBuilder.BuildDataSourceFromView(ctx, dbName, tbl); err == nil {
+			viewSchema := viewLogicalPlan.Schema()
+			viewOutputNames := viewLogicalPlan.OutputNames()
+			for _, col := range tbl.Columns {
+				idx := expression.FindFieldNameIdxByColName(viewOutputNames, col.Name.L)
+				if idx >= 0 {
+					col.FieldType = *viewSchema.Columns[idx].GetType()
+				}
+				if col.Tp == mysql.TypeVarString {
+					col.Tp = mysql.TypeVarchar
+				}
+			}
+		} else {
+			return err
+		}
 	}
 	return nil
 }

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -21,7 +21,9 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/parser/auth"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
@@ -669,4 +671,35 @@ func (ts *testSuite) TestConstraintCheckForUniqueIndex(c *C) {
 	tk1.Exec("commit")
 	// The data in channel is 1 means tk2 is blocked, that's the expected behavior.
 	c.Assert(<-ch, Equals, 1)
+}
+
+func (ts *testSuite) TestViewColumns(c *C) {
+	se, err := session.CreateSession4Test(ts.store)
+	c.Assert(err, IsNil)
+	c.Assert(se.Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil), IsTrue)
+	tk := testkit.NewTestKitWithSession(c, ts.store, se)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int primary key, b varchar(20))")
+	tk.MustExec("drop view if exists v")
+	tk.MustExec("create view v as select * from t")
+	tk.MustExec("drop view if exists va")
+	tk.MustExec("create view va as select count(a) from t")
+	testCases := []struct {
+		query    string
+		expected []string
+	}{
+		{"select data_type from INFORMATION_SCHEMA.columns where table_name = 'v'", []string{types.TypeToStr(mysql.TypeLong, ""), types.TypeToStr(mysql.TypeVarchar, "")}},
+		{"select data_type from INFORMATION_SCHEMA.columns where table_name = 'va'", []string{types.TypeToStr(mysql.TypeLonglong, "")}},
+	}
+	for _, testCase := range testCases {
+		tk.MustQuery(testCase.query).Check(testutil.RowsWithSep("|", testCase.expected...))
+	}
+	tk.MustExec("drop table if exists t")
+	for _, testCase := range testCases {
+		c.Assert(tk.MustQuery(testCase.query).Rows(), HasLen, 0)
+		tk.MustQuery("show warnings").Check(testutil.RowsWithSep("|",
+			"Warning|1356|View 'test.v' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them",
+			"Warning|1356|View 'test.va' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them"))
+	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22316

Problem Summary: When run "select * from INFORMATION_SCHEMA.columns where table_name=‘some_view’", the row "data_type" and "column_type" can't get correct result.

### What is changed and how it works?

What's Changed: When we fetch column info of a view via "INFORMATION_SCHEMA.columns", we build this view to get the real output schema.

How it Works: When we fetch column info of a view via "INFORMATION_SCHEMA.columns", we build this view to get the real output schema. Just like what we do in fetchShowColumns(executor/show.go).

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test

Side effects

- None


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
