### PR TITLE
session: fix the duplicate binding case when updating bind info

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
+	"github.com/pingcap/tidb/expression"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -36,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
-	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -1305,11 +1305,20 @@ func upgradeToVer60(s Session, ver int64) {
 	doReentrantDDL(s, CreateStatsExtended)
 }
 
+type bindInfo struct {
+	bindSQL string
+	status string
+	createTime types.Time
+	charset string
+	collation string
+	source string
+}
+
 func upgradeToVer61(s Session, ver int64) {
 	if ver >= version61 {
 		return
 	}
-	bindMap := make(map[string]types.Time)
+	bindMap := make(map[string]bindInfo)
 	h := &bindinfo.BindHandle{}
 	var err error
 	mustExecute(s, "BEGIN PESSIMISTIC")
@@ -1324,7 +1333,11 @@ func upgradeToVer61(s Session, ver int64) {
 	}()
 	mustExecute(s, h.LockBindInfoSQL())
 	var recordSets []sqlexec.RecordSet
-	recordSets, err = s.ExecuteInternal(context.Background(), "SELECT original_sql, bind_sql, default_db, charset, collation, update_time from mysql.bind_info where source != 'builtin'")
+	recordSets, err = s.ExecuteInternal(context.Background(),
+		`SELECT bind_sql, default_db, status, create_time, charset, collation, source
+			FROM mysql.bind_info
+			WHERE source != 'builtin'
+			ORDER BY update_time DESC`)
 	if err != nil {
 		logutil.BgLogger().Fatal("upgradeToVer61 error", zap.Error(err))
 	}
@@ -1345,40 +1358,50 @@ func upgradeToVer61(s Session, ver int64) {
 		}
 		updateBindInfo(s, iter, p, now.String(), bindMap)
 	}
+
+	mustExecute(s, "DELETE FROM mysql.bind_info where source != 'builtin'")
+	for original, bind := range bindMap {
+		mustExecute(s, fmt.Sprintf("INSERT INTO mysql.bind_info VALUES(%s, %s, '', %s, %s, %s, %s, %s, %s)",
+			expression.Quote(original),
+			expression.Quote(bind.bindSQL),
+			expression.Quote(bind.status),
+			expression.Quote(bind.createTime.String()),
+			expression.Quote(now.String()),
+			expression.Quote(bind.charset),
+			expression.Quote(bind.collation),
+			expression.Quote(bind.source),
+		))
+	}
 }
 
-func updateBindInfo(s Session, iter *chunk.Iterator4Chunk, p *parser.Parser, now string, bindMap map[string]types.Time) {
+func updateBindInfo(s Session, iter *chunk.Iterator4Chunk, p *parser.Parser, now string, bindMap map[string]bindInfo) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		original := row.GetString(0)
-		bind := row.GetString(1)
-		db := row.GetString(2)
-		charset := row.GetString(3)
-		collation := row.GetString(4)
-		updateTime := row.GetTime(5)
+		bind := row.GetString(0)
+		db := row.GetString(1)
+		charset := row.GetString(4)
+		collation := row.GetString(5)
 		stmt, err := p.ParseOneStmt(bind, charset, collation)
 		if err != nil {
 			logutil.BgLogger().Fatal("updateBindInfo error", zap.Error(err))
 		}
 		originWithDB := parser.Normalize(utilparser.RestoreWithDefaultDB(stmt, db))
-		if latest, ok := bindMap[originWithDB]; ok {
-			// In the following cases, duplicate originWithDB may occur
+		if _, ok := bindMap[originWithDB]; ok {
+			// The results are sorted in descending order of time.
+			// And in the following cases, duplicate originWithDB may occur
 			//      originalText         	|bindText                                   	|DB
 			//		`select * from t` 		|`select /*+ use_index(t, idx) */ * from t` 	|`test`
 			// 		`select * from test.t`  |`select /*+ use_index(t, idx) */ * from test.t`|``
-			// If repeated, we will keep the latest binding.
-			if updateTime.Compare(latest) <= 0 {
-				continue
-			}
-			mustExecute(s, fmt.Sprintf(`DELETE FROM mysql.bind_info WHERE original_sql=%s`, expression.Quote(original)))
-			original = originWithDB
+			// Therefore, if repeated, we can skip to keep the latest binding.
+			continue
 		}
-		bindMap[originWithDB] = updateTime
-		bindWithDB := utilparser.RestoreWithDefaultDB(stmt, db)
-		mustExecute(s, fmt.Sprintf(`UPDATE mysql.bind_info SET original_sql=%s, bind_sql=%s, default_db='', update_time=%s where original_sql=%s`,
-			expression.Quote(originWithDB),
-			expression.Quote(bindWithDB),
-			expression.Quote(now),
-			expression.Quote(original)))
+		bindMap[originWithDB] = bindInfo{
+			bindSQL: utilparser.RestoreWithDefaultDB(stmt, db),
+			status: row.GetString(2),
+			createTime: row.GetTime(3),
+			charset: charset,
+			collation: collation,
+			source: row.GetString(6),
+		}
 	}
 }
 

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -22,7 +22,6 @@ import (
 	"encoding/hex"
 	"flag"
 	"fmt"
-	"github.com/pingcap/tidb/expression"
 	"runtime/debug"
 	"strconv"
 	"strings"
@@ -37,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -1306,12 +1306,12 @@ func upgradeToVer60(s Session, ver int64) {
 }
 
 type bindInfo struct {
-	bindSQL string
-	status string
+	bindSQL    string
+	status     string
 	createTime types.Time
-	charset string
-	collation string
-	source string
+	charset    string
+	collation  string
+	source     string
 }
 
 func upgradeToVer61(s Session, ver int64) {
@@ -1356,7 +1356,7 @@ func upgradeToVer61(s Session, ver int64) {
 		if req.NumRows() == 0 {
 			break
 		}
-		updateBindInfo(s, iter, p, now.String(), bindMap)
+		updateBindInfo(iter, p, bindMap)
 	}
 
 	mustExecute(s, "DELETE FROM mysql.bind_info where source != 'builtin'")
@@ -1374,7 +1374,7 @@ func upgradeToVer61(s Session, ver int64) {
 	}
 }
 
-func updateBindInfo(s Session, iter *chunk.Iterator4Chunk, p *parser.Parser, now string, bindMap map[string]bindInfo) {
+func updateBindInfo(iter *chunk.Iterator4Chunk, p *parser.Parser, bindMap map[string]bindInfo) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		bind := row.GetString(0)
 		db := row.GetString(1)
@@ -1395,12 +1395,12 @@ func updateBindInfo(s Session, iter *chunk.Iterator4Chunk, p *parser.Parser, now
 			continue
 		}
 		bindMap[originWithDB] = bindInfo{
-			bindSQL: utilparser.RestoreWithDefaultDB(stmt, db),
-			status: row.GetString(2),
+			bindSQL:    utilparser.RestoreWithDefaultDB(stmt, db),
+			status:     row.GetString(2),
 			createTime: row.GetTime(3),
-			charset: charset,
-			collation: collation,
-			source: row.GetString(6),
+			charset:    charset,
+			collation:  collation,
+			source:     row.GetString(6),
 		}
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22309 <!-- REMOVE this line if no issue to close -->

Problem Summary:

This PR will fix the duplicate binding case when updating bind info

New update method used.
We will read all bindings in the memory first. Then remove the duplicate bindings and keep only the latest. Finally, insert bindings after restoring with DB.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- session: fix the duplicate binding case when updating bind info
