### PR TITLE
planner: reorder inner joins simplified from outer joins

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2521,3 +2521,27 @@ func (s *testIntegrationSerialSuite) TestPushDownProjectionForMPP(c *C) {
 		res.Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func (s *testIntegrationSuite) TestReorderSimplifiedOuterJoins(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1,t2,t3")
+	tk.MustExec("create table t1 (pk char(32) primary key, col1 char(32), col2 varchar(40), col3 char(32), key (col1), key (col3), key (col2,col3), key (col1,col3))")
+	tk.MustExec("create table t2 (pk char(32) primary key, col1 varchar(100))")
+	tk.MustExec("create table t3 (pk char(32) primary key, keycol varchar(100), pad1 tinyint(1) default null, pad2 varchar(40), key (keycol,pad1,pad2))")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -677,6 +677,8 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (Logica
 	}
 
 	b.optFlag = b.optFlag | flagPredicatePushDown
+	// Add join reorder flag regardless of inner join or outer join.
+	b.optFlag = b.optFlag | flagJoinReOrder
 
 	leftPlan, err := b.buildResultSetNode(ctx, joinNode.Left)
 	if err != nil {
@@ -712,7 +714,6 @@ func (b *PlanBuilder) buildJoin(ctx context.Context, joinNode *ast.Join) (Logica
 		joinPlan.JoinType = RightOuterJoin
 		resetNotNullFlag(joinPlan.schema, 0, leftPlan.Schema().Len())
 	default:
-		b.optFlag = b.optFlag | flagJoinReOrder
 		joinPlan.JoinType = InnerJoin
 	}
 

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -255,5 +255,13 @@
     "cases": [
       "explain SELECT /*+ use_index_merge(t1)*/ COUNT(*) FROM t1 WHERE (key4=42 AND key6 IS NOT NULL) OR (key1=4 AND key3=6)"
     ]
+  },
+  {
+    "name": "TestReorderSimplifiedOuterJoins",
+    "cases": [
+      // Query with INNER JOIN or LEFT JOIN should have the same plan.
+      "EXPLAIN SELECT t1.pk FROM t1 INNER JOIN t2 ON t1.col1 = t2.pk INNER JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'",
+      "EXPLAIN SELECT t1.pk FROM t1 LEFT JOIN t2 ON t1.col1 = t2.pk LEFT JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -50,14 +50,15 @@
       {
         "SQL": "explain select * from t t1 left join t t2 on t1.a=t2.a where from_unixtime(t2.b);",
         "Plan": [
-          "HashJoin_7 9990.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
-          "├─Selection_15(Build) 7992.00 root  from_unixtime(cast(test.t.b))",
-          "│ └─TableReader_14 7992.00 root  data:Selection_13",
-          "│   └─Selection_13 7992.00 cop[tikv]  not(isnull(test.t.a))",
-          "│     └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_11(Probe) 9990.00 root  data:Selection_10",
-          "  └─Selection_10 9990.00 cop[tikv]  not(isnull(test.t.a))",
-          "    └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "Projection_9 9990.00 root  test.t.a, test.t.b, test.t.a, test.t.b",
+          "└─HashJoin_11 9990.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
+          "  ├─Selection_15(Build) 7992.00 root  from_unixtime(cast(test.t.b))",
+          "  │ └─TableReader_14 7992.00 root  data:Selection_13",
+          "  │   └─Selection_13 7992.00 cop[tikv]  not(isnull(test.t.a))",
+          "  │     └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_18(Probe) 9990.00 root  data:Selection_17",
+          "    └─Selection_17 9990.00 cop[tikv]  not(isnull(test.t.a))",
+          "      └─TableFullScan_16 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ]
       }
     ]
@@ -1383,6 +1384,51 @@
           "  └─StreamAgg_9 1.00 cop[tikv]  funcs:count(1)->Column#12",
           "    └─Selection_19 10.00 cop[tikv]  or(and(eq(test.t1.key4, 42), not(isnull(test.t1.key6))), and(eq(test.t1.key1, 4), eq(test.t1.key3, 6)))",
           "      └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestReorderSimplifiedOuterJoins",
+    "Cases": [
+      {
+        "SQL": "EXPLAIN SELECT t1.pk FROM t1 INNER JOIN t2 ON t1.col1 = t2.pk INNER JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'",
+        "Plan": [
+          "IndexJoin_20 13.81 root  inner join, inner:IndexLookUp_19, outer key:test.t1.col1, inner key:test.t2.pk, equal cond:eq(test.t1.col1, test.t2.pk)",
+          "├─IndexJoin_69(Build) 12.50 root  inner join, inner:IndexLookUp_68, outer key:test.t3.pk, inner key:test.t1.col3, equal cond:eq(test.t3.pk, test.t1.col3)",
+          "│ ├─IndexLookUp_110(Build) 10.00 root  ",
+          "│ │ ├─IndexRangeScan_108(Build) 10.00 cop[tikv] table:t3, index:keycol(keycol, pad1, pad2) range:[\"c\",\"c\"], keep order:false, stats:pseudo",
+          "│ │ └─TableRowIDScan_109(Probe) 10.00 cop[tikv] table:t3 keep order:false, stats:pseudo",
+          "│ └─IndexLookUp_68(Probe) 1.25 root  ",
+          "│   ├─Selection_66(Build) 1.81 cop[tikv]  not(isnull(test.t1.col3))",
+          "│   │ └─IndexRangeScan_64 1.81 cop[tikv] table:t1, index:col2(col2, col3) range: decided by [eq(test.t1.col3, test.t3.pk) eq(test.t1.col2, a)], keep order:false, stats:pseudo",
+          "│   └─Selection_67(Probe) 1.25 cop[tikv]  ne(test.t1.col1, \"aaaaaa\"), ne(test.t1.col1, \"abcdef\"), not(isnull(test.t1.col1))",
+          "│     └─TableRowIDScan_65 1.81 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─IndexLookUp_19(Probe) 1.00 root  ",
+          "  ├─Selection_17(Build) 1.00 cop[tikv]  ne(test.t2.pk, \"aaaaaa\"), ne(test.t2.pk, \"abcdef\")",
+          "  │ └─IndexRangeScan_15 1.00 cop[tikv] table:t2, index:PRIMARY(pk) range: decided by [eq(test.t2.pk, test.t1.col1)], keep order:false, stats:pseudo",
+          "  └─Selection_18(Probe) 1.00 cop[tikv]  in(test.t2.col1, \"a\", \"b\")",
+          "    └─TableRowIDScan_16 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "EXPLAIN SELECT t1.pk FROM t1 LEFT JOIN t2 ON t1.col1 = t2.pk LEFT JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'",
+        "Plan": [
+          "IndexJoin_20 13.81 root  inner join, inner:IndexLookUp_19, outer key:test.t1.col1, inner key:test.t2.pk, equal cond:eq(test.t1.col1, test.t2.pk)",
+          "├─IndexJoin_69(Build) 12.50 root  inner join, inner:IndexLookUp_68, outer key:test.t3.pk, inner key:test.t1.col3, equal cond:eq(test.t3.pk, test.t1.col3)",
+          "│ ├─IndexLookUp_110(Build) 10.00 root  ",
+          "│ │ ├─IndexRangeScan_108(Build) 10.00 cop[tikv] table:t3, index:keycol(keycol, pad1, pad2) range:[\"c\",\"c\"], keep order:false, stats:pseudo",
+          "│ │ └─TableRowIDScan_109(Probe) 10.00 cop[tikv] table:t3 keep order:false, stats:pseudo",
+          "│ └─IndexLookUp_68(Probe) 1.25 root  ",
+          "│   ├─Selection_66(Build) 1.81 cop[tikv]  not(isnull(test.t1.col3))",
+          "│   │ └─IndexRangeScan_64 1.81 cop[tikv] table:t1, index:col2(col2, col3) range: decided by [eq(test.t1.col3, test.t3.pk) eq(test.t1.col2, a)], keep order:false, stats:pseudo",
+          "│   └─Selection_67(Probe) 1.25 cop[tikv]  ne(test.t1.col1, \"aaaaaa\"), ne(test.t1.col1, \"abcdef\"), not(isnull(test.t1.col1))",
+          "│     └─TableRowIDScan_65 1.81 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─IndexLookUp_19(Probe) 1.00 root  ",
+          "  ├─Selection_17(Build) 1.00 cop[tikv]  ne(test.t2.pk, \"aaaaaa\"), ne(test.t2.pk, \"abcdef\")",
+          "  │ └─IndexRangeScan_15 1.00 cop[tikv] table:t2, index:PRIMARY(pk) range: decided by [eq(test.t2.pk, test.t1.col1)], keep order:false, stats:pseudo",
+          "  └─Selection_18(Probe) 1.00 cop[tikv]  in(test.t2.col1, \"a\", \"b\")",
+          "    └─TableRowIDScan_16 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ]
       }
     ]

--- a/planner/core/testdata/partition_pruner_out.json
+++ b/planner/core/testdata/partition_pruner_out.json
@@ -45,12 +45,12 @@
       {
         "SQL": "explain select * from t1 left join t2 on t1.id = 1 and t2.a = 2 where t2.id = 7",
         "Result": [
-          "HashJoin_7 1.00 root  CARTESIAN inner join",
-          "├─IndexLookUp_13(Build) 1.00 root partition:p9 ",
-          "│ ├─IndexRangeScan_11(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[7 2,7 2], keep order:false, stats:pseudo",
-          "│ └─TableRowIDScan_12(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_10(Probe) 1.00 root partition:p1 data:TableRangeScan_9",
-          "  └─TableRangeScan_9 1.00 cop[tikv] table:t1 range:[1,1], keep order:false, stats:pseudo"
+          "HashJoin_8 1.00 root  CARTESIAN inner join",
+          "├─IndexLookUp_14(Build) 1.00 root partition:p9 ",
+          "│ ├─IndexRangeScan_12(Build) 1.00 cop[tikv] table:t2, index:PRIMARY(id, a) range:[7 2,7 2], keep order:false, stats:pseudo",
+          "│ └─TableRowIDScan_13(Probe) 1.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "└─TableReader_11(Probe) 1.00 root partition:p1 data:TableRangeScan_10",
+          "  └─TableRangeScan_10 1.00 cop[tikv] table:t1 range:[1,1], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -640,26 +640,27 @@
         "SQL": "select * from t1 left join t3 on t1.id = t3.id where (t1.a=1 or t1.a = 3) and t3.a in (6,7,8)",
         "Result": null,
         "Plan": [
-          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t3.id)]",
-          "├─TableReader_11(Build) 19.98 root partition:p0 data:Selection_10",
-          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
-          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─TableReader_14(Probe) 29.97 root partition:p1 data:Selection_13",
-          "  └─Selection_13 29.97 cop[tikv]  in(test_partition.t3.a, 6, 7, 8), not(isnull(test_partition.t3.id))",
-          "    └─TableFullScan_12 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"
+          "HashJoin_9 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t3.id)]",
+          "├─TableReader_12(Build) 19.98 root partition:p0 data:Selection_11",
+          "│ └─Selection_11 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "│   └─TableFullScan_10 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─TableReader_15(Probe) 29.97 root partition:p1 data:Selection_14",
+          "  └─Selection_14 29.97 cop[tikv]  in(test_partition.t3.a, 6, 7, 8), not(isnull(test_partition.t3.id))",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "select * from t3 right join t2 on t3.id = t2.id where (t3.a=1 or t3.a = 3) and t2.a in (6,7,8) and t2.b = 6",
         "Result": null,
         "Plan": [
-          "HashJoin_7 0.04 root  inner join, equal:[eq(test_partition.t3.id, test_partition.t2.id)]",
-          "├─TableReader_14(Build) 0.03 root partition:p1 data:Selection_13",
-          "│ └─Selection_13 0.03 cop[tikv]  eq(test_partition.t2.b, 6), in(test_partition.t2.a, 6, 7, 8), not(isnull(test_partition.t2.id))",
-          "│   └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "└─TableReader_11(Probe) 19.98 root partition:p0 data:Selection_10",
-          "  └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t3.id)), or(eq(test_partition.t3.a, 1), eq(test_partition.t3.a, 3))",
-          "    └─TableFullScan_9 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"
+          "Projection_9 0.04 root  test_partition.t3.b, test_partition.t3.id, test_partition.t3.a, test_partition.t2.a, test_partition.t2.id, test_partition.t2.b",
+          "└─HashJoin_11 0.04 root  inner join, equal:[eq(test_partition.t2.id, test_partition.t3.id)]",
+          "  ├─TableReader_14(Build) 0.03 root partition:p1 data:Selection_13",
+          "  │ └─Selection_13 0.03 cop[tikv]  eq(test_partition.t2.b, 6), in(test_partition.t2.a, 6, 7, 8), not(isnull(test_partition.t2.id))",
+          "  │   └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_17(Probe) 19.98 root partition:p0 data:Selection_16",
+          "    └─Selection_16 19.98 cop[tikv]  not(isnull(test_partition.t3.id)), or(eq(test_partition.t3.a, 1), eq(test_partition.t3.a, 3))",
+          "      └─TableFullScan_15 10000.00 cop[tikv] table:t3 keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1081,24 +1082,25 @@
           "3 3 3 7 7 7"
         ],
         "Plan": [
-          "Sort_7 80.16 root  test_partition.t1.id, test_partition.t1.a",
-          "└─HashJoin_10 80.16 root  CARTESIAN inner join",
-          "  ├─TableReader_17(Build) 8.00 root partition:p1 data:Selection_16",
-          "  │ └─Selection_16 8.00 cop[tikv]  1, eq(test_partition.t2.b, 7), eq(test_partition.t2.id, 7), in(test_partition.t2.a, 6, 7, 8)",
-          "  │   └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
-          "  └─TableReader_14(Probe) 10.02 root partition:p0 data:Selection_13",
-          "    └─Selection_13 10.02 cop[tikv]  1, or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 3), in(test_partition.t1.b, 3, 5)))",
-          "      └─TableFullScan_12 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+          "Sort_9 80.16 root  test_partition.t1.id, test_partition.t1.a",
+          "└─Projection_12 80.16 root  test_partition.t1.id, test_partition.t1.a, test_partition.t1.b, test_partition.t2.id, test_partition.t2.a, test_partition.t2.b",
+          "  └─HashJoin_14 80.16 root  CARTESIAN inner join",
+          "    ├─TableReader_17(Build) 8.00 root partition:p1 data:Selection_16",
+          "    │ └─Selection_16 8.00 cop[tikv]  1, eq(test_partition.t2.b, 7), eq(test_partition.t2.id, 7), in(test_partition.t2.a, 6, 7, 8)",
+          "    │   └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "    └─TableReader_20(Probe) 10.02 root partition:p0 data:Selection_19",
+          "      └─Selection_19 10.02 cop[tikv]  1, or(eq(test_partition.t1.a, 1), and(eq(test_partition.t1.a, 3), in(test_partition.t1.b, 3, 5)))",
+          "        └─TableFullScan_18 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "Sort_7 0.05 root  test_partition_1.t1.id, test_partition_1.t1.a",
-          "└─HashJoin_11 0.05 root  CARTESIAN inner join",
-          "  ├─IndexReader_14(Build) 0.02 root partition:p0 index:Selection_13",
-          "  │ └─Selection_13 0.02 cop[tikv]  or(eq(test_partition_1.t1.a, 1), and(eq(test_partition_1.t1.a, 3), in(test_partition_1.t1.b, 3, 5)))",
-          "  │   └─IndexRangeScan_12 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
-          "  └─IndexReader_17(Probe) 2.40 root partition:p1 index:Selection_16",
-          "    └─Selection_16 2.40 cop[tikv]  1",
-          "      └─IndexRangeScan_15 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 7 7,6 7 7], [7 7 7,7 7 7], [8 7 7,8 7 7], keep order:false, stats:pseudo"
+          "Sort_8 0.05 root  test_partition_1.t1.id, test_partition_1.t1.a",
+          "└─HashJoin_12 0.05 root  CARTESIAN inner join",
+          "  ├─IndexReader_15(Build) 0.02 root partition:p0 index:Selection_14",
+          "  │ └─Selection_14 0.02 cop[tikv]  or(eq(test_partition_1.t1.a, 1), and(eq(test_partition_1.t1.a, 3), in(test_partition_1.t1.b, 3, 5)))",
+          "  │   └─IndexRangeScan_13 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "  └─IndexReader_18(Probe) 2.40 root partition:p1 index:Selection_17",
+          "    └─Selection_17 2.40 cop[tikv]  1",
+          "      └─IndexRangeScan_16 3.00 cop[tikv] table:t2, index:a(a, b, id) range:[6 7 7,6 7 7], [7 7 7,7 7 7], [8 7 7,8 7 7], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1636,22 +1638,22 @@
         "SQL": "select * from t1 left join t2 on t1.id = t2.id where (t1.a=1 or t1.a = 3) and t2.a in (6,7,8)",
         "Result": null,
         "Plan": [
-          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
-          "├─TableReader_11(Build) 19.98 root partition:p0 data:Selection_10",
-          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
-          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─TableReader_14(Probe) 29.97 root partition:p1 data:Selection_13",
-          "  └─Selection_13 29.97 cop[tikv]  in(test_partition.t2.a, 6, 7, 8), not(isnull(test_partition.t2.id))",
-          "    └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "HashJoin_9 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
+          "├─TableReader_12(Build) 19.98 root partition:p0 data:Selection_11",
+          "│ └─Selection_11 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "│   └─TableFullScan_10 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─TableReader_15(Probe) 29.97 root partition:p1 data:Selection_14",
+          "  └─Selection_14 29.97 cop[tikv]  in(test_partition.t2.a, 6, 7, 8), not(isnull(test_partition.t2.id))",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
-          "├─IndexReader_11(Build) 19.98 root partition:p0 index:Selection_10",
-          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
-          "│   └─IndexRangeScan_9 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
-          "└─IndexReader_14(Probe) 29.97 root partition:p1 index:Selection_13",
-          "  └─Selection_13 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
-          "    └─IndexRangeScan_12 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[6,6], [7,7], [8,8], keep order:false, stats:pseudo"
+          "HashJoin_9 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
+          "├─IndexReader_12(Build) 19.98 root partition:p0 index:Selection_11",
+          "│ └─Selection_11 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "│   └─IndexRangeScan_10 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─IndexReader_15(Probe) 29.97 root partition:p1 index:Selection_14",
+          "  └─Selection_14 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
+          "    └─IndexRangeScan_13 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[6,6], [7,7], [8,8], keep order:false, stats:pseudo"
         ]
       },
       {
@@ -1661,22 +1663,22 @@
           "3 3 3 3 3 3"
         ],
         "Plan": [
-          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
-          "├─TableReader_11(Build) 19.98 root partition:p0 data:Selection_10",
-          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
-          "│   └─TableFullScan_9 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
-          "└─TableReader_14(Probe) 29.97 root partition:p0 data:Selection_13",
-          "  └─Selection_13 29.97 cop[tikv]  in(test_partition.t2.a, 1, 2, 3), not(isnull(test_partition.t2.id))",
-          "    └─TableFullScan_12 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+          "HashJoin_9 24.98 root  inner join, equal:[eq(test_partition.t1.id, test_partition.t2.id)]",
+          "├─TableReader_12(Build) 19.98 root partition:p0 data:Selection_11",
+          "│ └─Selection_11 19.98 cop[tikv]  not(isnull(test_partition.t1.id)), or(eq(test_partition.t1.a, 1), eq(test_partition.t1.a, 3))",
+          "│   └─TableFullScan_10 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo",
+          "└─TableReader_15(Probe) 29.97 root partition:p0 data:Selection_14",
+          "  └─Selection_14 29.97 cop[tikv]  in(test_partition.t2.a, 1, 2, 3), not(isnull(test_partition.t2.id))",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
         ],
         "IndexPlan": [
-          "HashJoin_8 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
-          "├─IndexReader_11(Build) 19.98 root partition:p0 index:Selection_10",
-          "│ └─Selection_10 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
-          "│   └─IndexRangeScan_9 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
-          "└─IndexReader_14(Probe) 29.97 root partition:p0 index:Selection_13",
-          "  └─Selection_13 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
-          "    └─IndexRangeScan_12 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo"
+          "HashJoin_9 24.98 root  inner join, equal:[eq(test_partition_1.t1.id, test_partition_1.t2.id)]",
+          "├─IndexReader_12(Build) 19.98 root partition:p0 index:Selection_11",
+          "│ └─Selection_11 19.98 cop[tikv]  not(isnull(test_partition_1.t1.id))",
+          "│   └─IndexRangeScan_10 20.00 cop[tikv] table:t1, index:a(a, b, id) range:[1,1], [3,3], keep order:false, stats:pseudo",
+          "└─IndexReader_15(Probe) 29.97 root partition:p0 index:Selection_14",
+          "  └─Selection_14 29.97 cop[tikv]  not(isnull(test_partition_1.t2.id))",
+          "    └─IndexRangeScan_13 30.00 cop[tikv] table:t2, index:a(a, b, id) range:[1,1], [2,2], [3,3], keep order:false, stats:pseudo"
         ]
       },
       {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22384

Problem Summary:

Plan for query containing outer join is not optimal.

### What is changed and how it works?

What's Changed:

Add `flagJoinReOrder` when building `LogicalJoin` regardless of the join types. `joinReorderSolver` itself can check if the reorder is applicable.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Reorder inner joins simplified from outer joins