### PR TITLE
util/chunk: trigger disk spill for sort properly

### DIFF
--- a/util/chunk/row_container.go
+++ b/util/chunk/row_container.go
@@ -501,7 +501,9 @@ func (a *SortAndSpillDiskAction) Action(t *memory.Tracker) {
 	a.m.Lock()
 	defer a.m.Unlock()
 	// Guarantee that each partition size is at least 10% of the threshold, to avoid opening too many files.
-	if a.getStatus() == notSpilled && a.c.GetMemTracker().BytesConsumed() > t.GetBytesLimit()/10 {
+	currMem := a.c.GetMemTracker().BytesConsumed()
+	totalMemLimit := t.GetBytesLimit()
+	if a.getStatus() == notSpilled && currMem > totalMemLimit/10 {
 		a.once.Do(func() {
 			logutil.BgLogger().Info("memory exceeds quota, spill to disk now.",
 				zap.Int64("consumed", t.BytesConsumed()), zap.Int64("quota", t.GetBytesLimit()))
@@ -525,7 +527,7 @@ func (a *SortAndSpillDiskAction) Action(t *memory.Tracker) {
 	}
 	a.cond.L.Unlock()
 
-	if !t.CheckExceed() {
+	if !t.CheckExceed() || (currMem > 0 && currMem <= totalMemLimit/10 && t.BytesConsumed() < totalMemLimit+currMem) {
 		return
 	}
 	if fallback := a.GetFallback(); fallback != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22410

Problem Summary:

Disk spill for sort may not be able to trigger when memory quota has been used up.

### What is changed and how it works?

What's Changed:

When memory usage exceeds less than 1/10 of the bytes limit, previously we would directly fallback to the upper oom action, which is panic when` oom-action` is set "cancel". For these cases, we let them to continue consuming memory until the 1/10 threshold is hit, and then the spill would be triggered to reduce the memory to the original bytes limit.


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test: execute the reproduction steps in the issue, the result is as expected now:
```
MySQL [test]> set @@tidb_mem_quota_query = 200 << 10;
Query OK, 0 rows affected (0.00 sec)

MySQL [test]> explain analyze select /*+ stream_agg() */ count(1) from t group by a;
+----------------------------+----------+---------+-----------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+----------+----------+
| id                         | estRows  | actRows | task      | access object | execution info                                                                                                                                                                                                      | operator info                               | memory   | disk     |
+----------------------------+----------+---------+-----------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+----------+----------+
| StreamAgg_8                | 50000.00 | 50000   | root      |               | time:286.3ms, loops:50                                                                                                                                                                                              | group by:test.t.a, funcs:count(1)->Column#3 | N/A      | N/A      |
| └─Sort_13                  | 50000.00 | 50000   | root      |               | time:277.2ms, loops:50                                                                                                                                                                                              | test.t.a                                    | 462.1 KB | 781.2 KB |
|   └─TableReader_12         | 50000.00 | 50000   | root      |               | time:44.9ms, loops:50, cop_task: {num: 1, max: 39.1ms, proc_keys: 0, tot_proc: 38ms, rpc_num: 1, rpc_time: 39.1ms, copr_cache_hit_ratio: 0.00}                                                                      | data:TableFullScan_11                       | 192.0 KB | N/A      |
|     └─TableFullScan_11     | 50000.00 | 50000   | cop[tikv] | table:t       | tikv_task:{time:14.1ms, loops:50000}, scan_detail: {total_process_keys: 0, total_keys: 0, rocksdb: {delete_skipped_count: 0, key_skipped_count: 0, block: {cache_hit_count: 0, read_count: 0, read_byte: 0 Bytes}}} | keep order:false                            | N/A      | N/A      |
+----------------------------+----------+---------+-----------+---------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------------------------------------+----------+----------+
4 rows in set (0.28 sec)
```

and the tidb.log indicates the disk spill has been triggered now:
```
[2021/01/15 01:29:22.571 +08:00] [INFO] [coprocessor.go:1384] ["memory exceeds quota, rateLimitAction delegate to fallback action"] ["total token count"=1]
[2021/01/15 01:29:22.571 +08:00] [INFO] [row_container.go:508] ["memory exceeds quota, spill to disk now."] [consumed=225589] [quota=204800]
```

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Trigger disk spill for sort properly