### PR TITLE
ddl: fix the upper-case name bug for expression index

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2211,6 +2211,8 @@ func (s *testIntegrationSuite7) TestAddExpressionIndex(c *C) {
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, key((a+1)), key((a+2)), key idx((a+3)), key((a+4)));")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("CREATE TABLE t (A INT, B INT, UNIQUE KEY ((A * 2)));")
 
 	// Test experiment switch.
 	config.UpdateGlobal(func(conf *config.Config) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -4860,8 +4860,8 @@ func buildHiddenColumnInfo(ctx sessionctx.Context, indexPartSpecifications []*as
 		}
 		checkDependencies := make(map[string]struct{})
 		for _, colName := range findColumnNamesInExpr(idxPart.Expr) {
-			colInfo.Dependences[colName.Name.O] = struct{}{}
-			checkDependencies[colName.Name.O] = struct{}{}
+			colInfo.Dependences[colName.Name.L] = struct{}{}
+			checkDependencies[colName.Name.L] = struct{}{}
 		}
 		if err = checkDependedColExist(checkDependencies, existCols); err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22377 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Can't use the upper-case name for expression index.


### What is changed and how it works?


checkDependencies should save the lower-case name. 

### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- fix the upper-case name bug for expression index