### PR TITLE
store/tikv: set short pessimistic lock TTL through failpoints

### DIFF
--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -833,6 +833,12 @@ type ttlManager struct {
 }
 
 func (tm *ttlManager) run(c *twoPhaseCommitter, lockCtx *kv.LockCtx) {
+	failpoint.Inject("runTTLManager", func() {
+		logutil.BgLogger().Info("[failpoint] injected failure at running ttlManager",
+			zap.Uint64("txnStartTS", c.startTS))
+		failpoint.Return()
+	})
+
 	// Run only once.
 	if !atomic.CompareAndSwapUint32((*uint32)(&tm.state), uint32(stateUninitialized), uint32(stateRunning)) {
 		return

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -833,12 +833,6 @@ type ttlManager struct {
 }
 
 func (tm *ttlManager) run(c *twoPhaseCommitter, lockCtx *kv.LockCtx) {
-	failpoint.Inject("runTTLManager", func() {
-		logutil.BgLogger().Info("[failpoint] injected failure at running ttlManager",
-			zap.Uint64("txnStartTS", c.startTS))
-		failpoint.Return()
-	})
-
 	// Run only once.
 	if !atomic.CompareAndSwapUint32((*uint32)(&tm.state), uint32(stateUninitialized), uint32(stateRunning)) {
 		return

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -14,6 +14,7 @@
 package tikv
 
 import (
+	"encoding/hex"
 	"math/rand"
 	"strings"
 	"sync/atomic"
@@ -73,12 +74,22 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		mutations[i] = mut
 	}
 	elapsed := uint64(time.Since(c.txn.startTime) / time.Millisecond)
+	ttl := elapsed + atomic.LoadUint64(&ManagedLockTTL)
+	failpoint.Inject("shortPessimisticLockTTL", func() {
+		ttl = 1
+		keys := make([]string, 0, len(mutations))
+		for _, m := range mutations {
+			keys = append(keys, hex.EncodeToString(m.Key))
+		}
+		logutil.BgLogger().Info("[failpoint] injected lock ttl = 1 on pessimistic lock",
+			zap.Uint64("txnStartTS", c.startTS), zap.Strings("keys", keys))
+	})
 	req := tikvrpc.NewRequest(tikvrpc.CmdPessimisticLock, &pb.PessimisticLockRequest{
 		Mutations:    mutations,
 		PrimaryLock:  c.primary(),
 		StartVersion: c.startTS,
 		ForUpdateTs:  c.forUpdateTS,
-		LockTtl:      elapsed + atomic.LoadUint64(&ManagedLockTTL),
+		LockTtl:      ttl,
 		IsFirstLock:  c.isFirstLock,
 		WaitTimeout:  action.LockWaitTime,
 		ReturnValues: action.ReturnValues,


### PR DESCRIPTION
### What is changed and how it works?

Make it possible to set short TTL for pessimistic locks and skip running TTL manager. It helps tests (for example https://github.com/tikv/tikv/issues/9523).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
