### PR TITLE
types,execute: fix errcode return like mysql when inserting incorrect int value 

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -294,7 +294,7 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 		err = types.ErrWarnDataOutOfRange.GenWithStackByArgs(colName, rowIdx+1)
 	} else if types.ErrTruncated.Equal(err) {
 		err = types.ErrTruncated.GenWithStackByArgs(colName, rowIdx+1)
-	} else if types.ErrTruncatedWrongVal.Equal(err) && (types.IsTypeInteger(colTp) || colTp == mysql.TypeYear || colTp == mysql.TypeFloat || colTp == mysql.TypeDouble) {
+	} else if types.ErrTruncatedWrongVal.Equal(err) && types.IsTypeInteger(colTp) {
 		valStr, err1 := val.ToString()
 		if err1 != nil {
 			// do nothing

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -299,7 +299,7 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 		if err1 != nil {
 			// do nothing
 		}
-		if unicode.IsDigit(rune(valStr[0])) || (len(valStr) >= 2 && valStr[0] == '.' && unicode.IsDigit(rune(valStr[1]))) {
+		if (len(valStr) >= 1 && unicode.IsDigit(rune(valStr[0]))) || (len(valStr) >= 2 && valStr[0] == '.' && unicode.IsDigit(rune(valStr[1]))) {
 			err = types.ErrTruncated.GenWithStackByArgs(colName, rowIdx+1)
 		} else {
 			err = table.ErrTruncatedWrongValueForField.GenWithStackByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -302,10 +302,7 @@ func (e *InsertValues) handleErr(col *table.Column, val *types.Datum, rowIdx int
 		if unicode.IsDigit(rune(valStr[0])) || (len(valStr) >= 2 && valStr[0] == '.' && unicode.IsDigit(rune(valStr[1]))) {
 			err = types.ErrTruncated.GenWithStackByArgs(colName, rowIdx+1)
 		} else {
-			err = dbterror.ClassTable.NewStdErr(
-				errno.ErrTruncatedWrongValueForField,
-				mysql.Message("Incorrect %-.32s value: '%-.128s' for column '%.192s' at row %d", nil),
-			).GenWithStackByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
+			err = table.ErrTruncatedWrongValueForField.GenWithStackByArgs(types.TypeStr(colTp), valStr, colName, rowIdx+1)
 		}
 	} else if types.ErrTruncatedWrongVal.Equal(err) && types.IsTypeTemporal(colTp) {
 		valStr, err1 := val.ToString()

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -332,34 +332,30 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	_, err = tk.Exec(`insert into t values(2156);`)
 	c.Assert(err.Error(), Equals, `[types:8033]invalid year`)
 
-	//test for Issue#17832
 	tk.MustExec(`drop table if exists t;`)
 	tk.MustExec(`
 	 CREATE TABLE t (
 	  id1 tinyint DEFAULT NULL,
 	  id2 smallint DEFAULT NULL,
 	  id3 mediumint DEFAULT NULL,
-	  id4 float DEFAULT NULL,
-	  id5 double DEFAULT NULL,
-	  id6 bigint DEFAULT NULL,
-	  id7 int DEFAULT NULL,
-	  id8 year DEFAULT NULL
+	  id4 int DEFAULT NULL,
+	  id5 bigint DEFAULT NULL
 	)`)
+	tk.MustGetErrCode(`insert into t(id1) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id1) values('.1asdf')`, errno.WarnDataTruncated)
 	tk.MustGetErrCode(`insert into t(id2) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id2) values('.1asdf')`, errno.WarnDataTruncated)
 	tk.MustGetErrCode(`insert into t(id3) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id3) values('.1asdf')`, errno.WarnDataTruncated)
 	tk.MustGetErrCode(`insert into t(id4) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id4) values('.1asdf')`, errno.WarnDataTruncated)
 	tk.MustGetErrCode(`insert into t(id5) values('1asdf')`, errno.WarnDataTruncated)
-	tk.MustGetErrCode(`insert into t(id6) values('1asdf')`, errno.WarnDataTruncated)
-	tk.MustGetErrCode(`insert into t(id7) values('1asdf')`, errno.WarnDataTruncated)
-	tk.MustGetErrCode(`insert into t(id8) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id5) values('.1asdf')`, errno.WarnDataTruncated)
 	tk.MustGetErrCode(`insert into t(id1) values('asdf')`, errno.ErrTruncatedWrongValueForField)
 	tk.MustGetErrCode(`insert into t(id2) values('asdf')`, errno.ErrTruncatedWrongValueForField)
 	tk.MustGetErrCode(`insert into t(id3) values('asdf')`, errno.ErrTruncatedWrongValueForField)
 	tk.MustGetErrCode(`insert into t(id4) values('asdf')`, errno.ErrTruncatedWrongValueForField)
 	tk.MustGetErrCode(`insert into t(id5) values('asdf')`, errno.ErrTruncatedWrongValueForField)
-	tk.MustGetErrCode(`insert into t(id6) values('asdf')`, errno.ErrTruncatedWrongValueForField)
-	tk.MustGetErrCode(`insert into t(id7) values('asdf')`, errno.ErrTruncatedWrongValueForField)
-	tk.MustGetErrCode(`insert into t(id8) values('asdf')`, errno.ErrTruncatedWrongValueForField)
 	tk.MustExec(`drop table if exists t;`)
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -331,6 +331,36 @@ func (s *testSuite3) TestInsertWrongValueForField(c *C) {
 	tk.MustExec(`create table t (a year);`)
 	_, err = tk.Exec(`insert into t values(2156);`)
 	c.Assert(err.Error(), Equals, `[types:8033]invalid year`)
+
+	//test for Issue#17832
+	tk.MustExec(`drop table if exists t;`)
+	tk.MustExec(`
+	 CREATE TABLE t (
+	  id1 tinyint DEFAULT NULL,
+	  id2 smallint DEFAULT NULL,
+	  id3 mediumint DEFAULT NULL,
+	  id4 float DEFAULT NULL,
+	  id5 double DEFAULT NULL,
+	  id6 bigint DEFAULT NULL,
+	  id7 int DEFAULT NULL,
+	  id8 year DEFAULT NULL
+	)`)
+	tk.MustGetErrCode(`insert into t(id2) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id3) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id4) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id5) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id6) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id7) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id8) values('1asdf')`, errno.WarnDataTruncated)
+	tk.MustGetErrCode(`insert into t(id1) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id2) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id3) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id4) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id5) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id6) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id7) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustGetErrCode(`insert into t(id8) values('asdf')`, errno.ErrTruncatedWrongValueForField)
+	tk.MustExec(`drop table if exists t;`)
 }
 
 func (s *testSuite3) TestInsertDateTimeWithTimeZone(c *C) {

--- a/types/convert.go
+++ b/types/convert.go
@@ -280,6 +280,9 @@ func StrToInt(sc *stmtctx.StatementContext, str string, isFuncCast bool) (int64,
 	validPrefix, err := getValidIntPrefix(sc, str, isFuncCast)
 	iVal, err1 := strconv.ParseInt(validPrefix, 10, 64)
 	if err1 != nil {
+		if err != nil {
+			return iVal, ErrTruncatedWrongVal
+		}
 		return iVal, ErrOverflow.GenWithStackByArgs("BIGINT", validPrefix)
 	}
 	return iVal, errors.Trace(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17832  <!-- REMOVE this line if no issue to close -->
Issue Number: close #22423

Problem Summary:

### What is changed and how it works?

What's Changed:
1.Return ErrTruncatedWrongVal, when invalid string value convert to int in convert.go.
2.Handle the  ErrTruncatedWrongVal about int type in handleErr func in insert_common.go
How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
```
mysql> create table t(id int);
Query OK, 0 rows affected (0.15 sec)
mysql> insert into t values('1asf');
ERROR 1265 (01000): Data truncated for column 'id' at row 1
mysql>
```

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
