### PR TITLE
planner: fix panic while get part of partition key values

### DIFF
--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -450,9 +450,9 @@ func (s *testPartitionPruneSuit) TestListColumnsPartitionPrunerRandom(c *C) {
 
 func (s *testPartitionPruneSuit) TestIssue22396(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("drop database if exists test_partition;")
-	tk.MustExec("create database test_partition")
-	tk.MustExec("use test_partition")
+	tk.MustExec("drop database if exists test_22396;")
+	tk.MustExec("create database test_22396")
+	tk.MustExec("use test_22396")
 	tk.MustExec("CREATE TABLE tbl_311 ( COL1 INT, COL2 VARCHAR(20), COL3 bigint, COL4 FLOAT, COL5 DATETIME, primary key (COL1, col2, col3)) PARTITION BY RANGE (COL1 + COL3) (" +
 		"PARTITION p0 VALUES LESS THAN (0)," +
 		"PARTITION p1 VALUES LESS THAN(10)," +

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -925,9 +925,6 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	if !ok {
 		return ret, false
 	}
-	if op.FuncName.L != p.partFn.FuncName.L {
-		return ret, false
-	}
 	switch op.FuncName.L {
 	case ast.EQ, ast.LT, ast.GT, ast.LE, ast.GE:
 		ret.op = op.FuncName.L
@@ -961,6 +958,10 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	// Current expression is 'col op const'
 	var constExpr expression.Expression
 	if p.partFn != nil {
+		// If the partition function is not equal with the op function, pruning should not be allowed.
+		if p.partFn.FuncName.L != op.FuncName.L {
+			return ret, false
+		}
 		// If the partition function is not monotone, only EQ condition can be pruning.
 		if p.monotonous == monotoneModeInvalid && ret.op != ast.EQ {
 			return ret, false

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -927,6 +927,10 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	}
 	switch op.FuncName.L {
 	case ast.EQ, ast.LT, ast.GT, ast.LE, ast.GE:
+		switch p.partFn.FuncName.L {
+		case ast.Plus, ast.Minus, ast.Mul, ast.Div:
+			return ret, false
+		}
 		ret.op = op.FuncName.L
 	case ast.IsNull:
 		// isnull(col)
@@ -958,10 +962,6 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	// Current expression is 'col op const'
 	var constExpr expression.Expression
 	if p.partFn != nil {
-		// If the partition function is not equal with the op function, pruning should not be allowed.
-		if p.partFn.FuncName.L != op.FuncName.L {
-			return ret, false
-		}
 		// If the partition function is not monotone, only EQ condition can be pruning.
 		if p.monotonous == monotoneModeInvalid && ret.op != ast.EQ {
 			return ret, false

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -925,6 +925,9 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	if !ok {
 		return ret, false
 	}
+	if op.FuncName.L != p.partFn.FuncName.L {
+		return ret, false
+	}
 	switch op.FuncName.L {
 	case ast.EQ, ast.LT, ast.GT, ast.LE, ast.GE:
 		ret.op = op.FuncName.L

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -927,9 +927,11 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	}
 	switch op.FuncName.L {
 	case ast.EQ, ast.LT, ast.GT, ast.LE, ast.GE:
-		switch p.partFn.FuncName.L {
-		case ast.Plus, ast.Minus, ast.Mul, ast.Div:
-			return ret, false
+		if p.partFn != nil {
+			switch p.partFn.FuncName.L {
+			case ast.Plus, ast.Minus, ast.Mul, ast.Div:
+				return ret, false
+			}
 		}
 		ret.op = op.FuncName.L
 	case ast.IsNull:

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -758,15 +758,9 @@ func makePartitionByFnCol(sctx sessionctx.Context, columns []*expression.Column,
 		fn = raw
 		args := fn.GetArgs()
 		if len(args) > 0 {
-			colCount := 0
-			for _, arg := range args {
-				if c, ok1 := arg.(*expression.Column); ok1 {
-					col = c
-					colCount++
-				}
-			}
-			if colCount > 1 {
-				return nil, raw, monotoneModeNonStrict, nil
+			arg0 := args[0]
+			if c, ok1 := arg0.(*expression.Column); ok1 {
+				col = c
 			}
 		}
 		monotonous = getMonotoneMode(raw.FuncName.L)
@@ -983,6 +977,9 @@ func (p *rangePruner) extractDataForPrune(sctx sessionctx.Context, expr expressi
 	} else {
 		// If the partition expression is col, use constExpr.
 		constExpr = con
+	}
+	if !constExpr.ConstItem(sctx.GetSessionVars().StmtCtx) {
+		return ret, false
 	}
 	c, isNull, err := constExpr.EvalInt(sctx, chunk.Row{})
 	if err == nil && !isNull {

--- a/planner/core/testdata/partition_pruner_in.json
+++ b/planner/core/testdata/partition_pruner_in.json
@@ -311,5 +311,11 @@
         "Pruner": "t1: p0; t1: p1"
       }
     ]
+  },
+  {
+    "name": "TestIssue22396",
+    "cases": [
+      "select * from tbl_311 where col1 = 1"
+    ]
   }
 ]

--- a/planner/core/testdata/partition_pruner_out.json
+++ b/planner/core/testdata/partition_pruner_out.json
@@ -1868,5 +1868,21 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestIssue22396",
+    "Cases": [
+      {
+        "SQL": "select * from tbl_311 where col1 = 1",
+        "Result": [
+          "1 a 11 <nil> <nil>"
+        ],
+        "Plan": [
+          "IndexLookUp_10 10.00 root partition:all ",
+          "├─IndexRangeScan_8(Build) 10.00 cop[tikv] table:tbl_311, index:PRIMARY(COL1, COL2, COL3) range:[1,1], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_9(Probe) 10.00 cop[tikv] table:tbl_311 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #22396  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
fix panic while get part of partition key values
How it Works:
check whether `constExpr` is constant, if it is not, pruning can't be executed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
