### PR TITLE
executor: fix the point get use a wrong snapshot

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -84,7 +84,8 @@ func (e *BatchPointGetExec) buildVirtualColumnInfo() {
 // Open implements the Executor interface.
 func (e *BatchPointGetExec) Open(context.Context) error {
 	e.snapshotTS = e.startTS
-	txnCtx := e.ctx.GetSessionVars().TxnCtx
+	sessVars := e.ctx.GetSessionVars()
+	txnCtx := sessVars.TxnCtx
 	if e.lock {
 		e.snapshotTS = txnCtx.GetForUpdateTS()
 	}
@@ -94,7 +95,7 @@ func (e *BatchPointGetExec) Open(context.Context) error {
 	}
 	e.txn = txn
 	var snapshot kv.Snapshot
-	if txn.Valid() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
+	if sessVars.InTxn() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
 		// We can safely reuse the transaction snapshot if startTS is equal to forUpdateTS.
 		// The snapshot may contains cache that can reduce RPC call.
 		snapshot = txn.GetSnapshot()

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -118,7 +118,8 @@ func (e *PointGetExecutor) buildVirtualColumnInfo() {
 
 // Open implements the Executor interface.
 func (e *PointGetExecutor) Open(context.Context) error {
-	txnCtx := e.ctx.GetSessionVars().TxnCtx
+	sessVars := e.ctx.GetSessionVars()
+	txnCtx := sessVars.TxnCtx
 	snapshotTS := e.startTS
 	if e.lock {
 		snapshotTS = txnCtx.GetForUpdateTS()
@@ -128,7 +129,7 @@ func (e *PointGetExecutor) Open(context.Context) error {
 	if err != nil {
 		return err
 	}
-	if e.txn.Valid() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
+	if sessVars.InTxn() && txnCtx.StartTS == txnCtx.GetForUpdateTS() {
 		e.snapshot = e.txn.GetSnapshot()
 	} else {
 		e.snapshot = e.ctx.GetStore().GetSnapshot(kv.Version{Ver: snapshotTS})


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22436

I've tested it in the v4.0.10 and now master in the real cluster and there is no error in v4.0.10. I find that it's is solved partially by https://github.com/pingcap/tidb/pull/18145 and this pr try to refer some code from that.

### What is changed and how it works?

What's Changed:
set the right snapshot when we `OPEN` the point get executor.


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

test it in the cluster.
```
mysql> select * from xx;
+----+
| id |
+----+
|  1 |
|  7 |
|  8 |
|  9 |
| 10 |
+----+
5 rows in set (0.00 sec)

mysql> select now();
+---------------------+
| now()               |
+---------------------+
| 2021-01-20 18:32:50 |
+---------------------+
1 row in set (0.00 sec)

mysql> insert into xx values(11);
Query OK, 1 row affected (0.01 sec)

mysql> set @@tidb_snapshot='2021-01-20 18:32:50';
Query OK, 0 rows affected (0.01 sec)

mysql> explain select * from xx where id = 11;
+-------------+---------+------+---------------+---------------+
| id          | estRows | task | access object | operator info |
+-------------+---------+------+---------------+---------------+
| Point_Get_1 | 1.00    | root | table:xx      | handle:11     |
+-------------+---------+------+---------------+---------------+
1 row in set (0.00 sec)

mysql> select * from xx where id = 11;
Empty set (0.00 sec)

mysql> select * from xx;
+----+
| id |
+----+
|  1 |
|  7 |
|  8 |
|  9 |
| 10 |
+----+
5 rows in set (0.00 sec)
```

### Release note <!-- bugfixes or new feature need a release note -->

- executor: fix the point get use a wrong snapshot.
