### PR TITLE
util/codec: add error handling to NewCommonHandle() to avoid panic

### DIFF
--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -274,3 +274,16 @@ func (s *testClusteredSuite) TestClusteredIndexSplitAndAddIndex(c *C) {
 	tk.MustQuery("select a from t order by a;").Check(testkit.Rows("a", "b", "c", "u"))
 	tk.MustQuery("select a from t use index (idx) order by a;").Check(testkit.Rows("a", "b", "c", "u"))
 }
+
+// https://github.com/pingcap/tidb/issues/22453
+func (s *testClusteredSerialSuite) TestClusteredIndexSplitAndAddIndex2(c *C) {
+	tk := s.newTK(c)
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int, b enum('Alice'), c int, primary key (c, b));")
+	tk.MustExec("insert into t values (-1,'Alice',100);")
+	tk.MustExec("insert into t values (-1,'Alice',7000);")
+	tk.MustQuery("split table t between (0,'Alice') and (10000,'Alice') regions 2;").Check(testkit.Rows("1 1"))
+	tk.MustExec("set @@global.tidb_ddl_error_count_limit = 3;")
+	tk.MustExec("alter table t add index idx (c);")
+	tk.MustExec("admin check table t;")
+}

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -921,6 +921,7 @@ func SetRawValues(data []byte, values []types.Datum) error {
 
 // peek peeks the first encoded value from b and returns its length.
 func peek(b []byte) (length int, err error) {
+	originLength := len(b)
 	if len(b) < 1 {
 		return 0, errors.New("invalid encoded key")
 	}
@@ -952,6 +953,10 @@ func peek(b []byte) (length int, err error) {
 		return 0, errors.Trace(err)
 	}
 	length += l
+	if length > originLength {
+		return 0, errors.Errorf("invalid encoded key, " +
+			"expected length: %d, actual length: %d", length, originLength)
+	}
 	return
 }
 

--- a/util/codec/codec.go
+++ b/util/codec/codec.go
@@ -954,7 +954,7 @@ func peek(b []byte) (length int, err error) {
 	}
 	length += l
 	if length > originLength {
-		return 0, errors.Errorf("invalid encoded key, " +
+		return 0, errors.Errorf("invalid encoded key, "+
 			"expected length: %d, actual length: %d", length, originLength)
 	}
 	return

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -927,6 +927,15 @@ func (s *testCodecSuite) TestCut(c *C) {
 	c.Assert(n, Equals, int64(42))
 }
 
+func (s *testCodecSuite) TestCutOneError(c *C) {
+	var b []byte
+	_, _, err := CutOne(b)
+	c.Assert(err, ErrorMatches, "invalid encoded key")
+	b = []byte{4 /* codec.uintFlag */, 0, 0, 0}
+	_, _, err = CutOne(b)
+	c.Assert(err, ErrorMatches, "invalid encoded key.*")
+}
+
 func (s *testCodecSuite) TestSetRawValues(c *C) {
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22453 <!-- REMOVE this line if no issue to close -->

Problem Summary: https://github.com/pingcap/tidb/issues/22453#issuecomment-763478623

### What is changed and how it works?

What's Changed:

This PR make sure that the `peek()` never panic.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the panic problem that creating index after split regions on clustered index tables.
