### PR TITLE
session,executor: fix point get under @@tidb_snapshot

### DIFF
--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -896,7 +896,7 @@ func (s *testPointGetSuite) TestWithTiDBSnapshot(c *C) {
 
 	// Unrelated code, to make this test pass in the unit test.
 	// The `tikv_gc_safe_point` global variable must be there, otherwise the 'set @@tidb_snapshot' operation fails.
-	timeSafe := time.Now().Add(-time.Duration(48 * 60 * 60 * time.Second)).Format("20060102-15:04:05 -0700 MST")
+	timeSafe := time.Now().Add(-48 * 60 * 60 * time.Second).Format("20060102-15:04:05 -0700 MST")
 	safePointSQL := `INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('tikv_gc_safe_point', '%[1]s', '')
 			       ON DUPLICATE KEY
 			       UPDATE variable_value = '%[1]s'`

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -884,3 +884,36 @@ func (s *testPointGetSuite) TestPointGetLockExistKey(c *C) {
 		c.Assert(err, IsNil)
 	}
 }
+
+func (s *testPointGetSuite) TestWithTiDBSnapshot(c *C) {
+	// Fix issue https://github.com/pingcap/tidb/issues/22436
+	// Point get should not use math.MaxUint64 when variable @@tidb_snapshot is set.
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists xx")
+	tk.MustExec(`create table xx (id int key)`)
+	tk.MustExec(`insert into xx values (1), (7)`)
+
+	// Unrelated code, to make this test pass in the unit test.
+	// The `tikv_gc_safe_point` global variable must be there, otherwise the 'set @@tidb_snapshot' operation fails.
+	timeSafe := time.Now().Add(-time.Duration(48 * 60 * 60 * time.Second)).Format("20060102-15:04:05 -0700 MST")
+	safePointSQL := `INSERT HIGH_PRIORITY INTO mysql.tidb VALUES ('tikv_gc_safe_point', '%[1]s', '')
+			       ON DUPLICATE KEY
+			       UPDATE variable_value = '%[1]s'`
+	tk.MustExec(fmt.Sprintf(safePointSQL, timeSafe))
+
+	// Record the current tso.
+	tk.MustExec("begin")
+	tso := tk.Se.GetSessionVars().TxnCtx.StartTS
+	tk.MustExec("rollback")
+	c.Assert(tso > 0, IsTrue)
+
+	// Insert data.
+	tk.MustExec("insert into xx values (8)")
+
+	// Change the snapshot before the tso, the inserted data should not be seen.
+	tk.MustExec(fmt.Sprintf("set @@tidb_snapshot = '%d'", tso))
+	tk.MustQuery("select * from xx where id = 8").Check(testkit.Rows())
+
+	tk.MustQuery("select * from xx").Check(testkit.Rows("1", "7"))
+}

--- a/session/session.go
+++ b/session/session.go
@@ -2567,6 +2567,11 @@ func (s *session) PrepareTxnCtx(ctx context.Context) {
 
 // PrepareTSFuture uses to try to get ts future.
 func (s *session) PrepareTSFuture(ctx context.Context) {
+	if s.sessionVars.SnapshotTS != 0 {
+		// Do nothing when @@tidb_snapshot is set.
+		// In case the latest tso is misused.
+		return
+	}
 	if !s.txn.validOrPending() {
 		// Prepare the transaction future if the transaction is invalid (at the beginning of the transaction).
 		txnFuture := s.getTxnFuture(ctx)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22436

Problem Summary:

When the `@@tidb_snapshot` variable is set, a point get request still gets the latest data rather than a snapshot.

### What is changed and how it works?

What's Changed:

- In `PrepareTSFuture`, if `sessionVars.SnapshotTS` is not 0, do nothing
- In `buildExecutor`, check `sessionVars.SnapshotTS` before `useMaxTS`

How it Works:

In `buildExecutor`, the `useMaxTS` logic have a higher priority than `sessionVars.SnapshotTS`, 
so even the @@tidb_snapshot variable is set, the MaxTS is used by point get query.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix a bug that point get query does not get the snapshot data when the `@@tidb_snapshot` variable is set.