### PR TITLE
*: fix parser error format when value overflow

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1578,27 +1578,3 @@ func (s *testSuite10) TestBinaryLiteralInsertToSet(c *C) {
 	tk.MustExec("insert into bintest(h) values(0x61)")
 	tk.MustQuery("select * from bintest").Check(testkit.Rows("a"))
 }
-
-func (s *testSuite10) TestParserOverflow(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec(`use test`)
-	tk.MustExec("drop table if exists t")
-
-	tk.MustExec(`
-	create table t (
-		col_int int,
-		col_float float,
-		col_double double,
-		col_decimal decimal
-	)`)
-	tk.MustGetErrCode("insert into t(col_int) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
-	tk.MustGetErrCode("insert into t(col_float) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
-	tk.MustGetErrCode("insert into t(col_float) values(1e100000)", errno.ErrIllegalValueForType)
-	_, err := tk.Exec("insert into t(col_double) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)")
-	c.Assert(err, IsNil)
-	tk.MustQuery("select col_double from t").Check(testkit.Rows("1e65"))
-	tk.MustGetErrCode("insert into t(col_decimal) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
-	tk.MustQuery("select 888888888888888888888888888888888888888888888888888888888888888888888888888888888888").Check(testkit.Rows("99999999999999999999999999999999999999999999999999999999999999999"))
-	tk.MustQuery("show warnings;").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect DECIMAL value: '888888888888888888888888888888888888888888888888888888888888888888888888888888888888'"))
-	tk.MustExec("drop table if exists t")
-}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -8690,3 +8690,27 @@ func (s *testIntegrationSerialSuite) TestCollationUnion2(c *C) {
 	tk.MustQuery("select * from (select a from t) aaa union all select null as a order by a").Check(testkit.Rows("<nil>", "aaaaaaaaa", "天王盖地虎宝塔镇河妖"))
 	tk.MustExec("drop table if exists t")
 }
+
+func (s *testIntegrationSerialSuite) TestParserOverflow(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec("drop table if exists t")
+
+	tk.MustExec(`
+	create table t (
+		col_int int,
+		col_float float,
+		col_double double,
+		col_decimal decimal
+	)`)
+	tk.MustGetErrCode("insert into t(col_int) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
+	tk.MustGetErrCode("insert into t(col_float) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
+	tk.MustGetErrCode("insert into t(col_float) values(1e100000)", errno.ErrIllegalValueForType)
+	_, err := tk.Exec("insert into t(col_double) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)")
+	c.Assert(err, IsNil)
+	tk.MustQuery("select col_double from t").Check(testkit.Rows("1e65"))
+	tk.MustGetErrCode("insert into t(col_decimal) values(888888888888888888888888888888888888888888888888888888888888888888888888888888888888)", errno.ErrWarnDataOutOfRange)
+	tk.MustQuery("select 888888888888888888888888888888888888888888888888888888888888888888888888888888888888").Check(testkit.Rows("99999999999999999999999999999999999999999999999999999999999999999"))
+	tk.MustQuery("show warnings;").Check(testutil.RowsWithSep("|", "Warning|1292|Truncated incorrect DECIMAL value: '888888888888888888888888888888888888888888888888888888888888888888888888888888888888'"))
+	tk.MustExec("drop table if exists t")
+}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	plannercore "github.com/pingcap/tidb/planner/core"

--- a/util/misc.go
+++ b/util/misc.go
@@ -183,6 +183,13 @@ func SyntaxWarn(err error) error {
 	if err == nil {
 		return nil
 	}
+	// If the error is already a terror with stack, pass it through.
+	if errors.HasStack(err) {
+		cause := errors.Cause(err)
+		if _, ok := cause.(*terror.Error); ok {
+			return err
+		}
+	}
 	return parser.ErrParse.GenWithStackByArgs(syntaxErrorPrefix, err.Error())
 }
 

--- a/util/misc.go
+++ b/util/misc.go
@@ -183,6 +183,8 @@ func SyntaxWarn(err error) error {
 	if err == nil {
 		return nil
 	}
+	logutil.BgLogger().Debug("syntax error", zap.Error(err))
+
 	// If the error is already a terror with stack, pass it through.
 	if errors.HasStack(err) {
 		cause := errors.Cause(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #17489 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
1.Add AppendWarn func in lexer.go.
2.Generate a warning when decimal value out of range. And return the default value.
3.Add test case in tidb pr.
How it Works:

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
```
MySQL [test]> select 888888888888888888888888888888888888888888888888888888888888888888888888888888888888;
+--------------------------------------------------------------------------------------+
| 888888888888888888888888888888888888888888888888888888888888888888888888888888888888 |
+--------------------------------------------------------------------------------------+
|                    99999999999999999999999999999999999999999999999999999999999999999 |
+--------------------------------------------------------------------------------------+
1 row in set, 1 warning (0.00 sec)
MySQL [test]> show warnings;
+---------+------+---------------------------------------------------------------------------------------------------------------------------+
| Level   | Code | Message                                                                                                                   |
+---------+------+---------------------------------------------------------------------------------------------------------------------------+
| Warning | 1292 | Truncated incorrect DECIMAL value: '888888888888888888888888888888888888888888888888888888888888888888888888888888888888' |
+---------+------+---------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
MySQL [test]> 
```

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
