### PR TITLE
statistics: fix inaccurate row count estimation caused by cross validation using invalid column stats

### DIFF
--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -750,7 +750,7 @@ func (s *testStatsSuite) TestIndexEstimationCrossValidate(c *C) {
 		"└─IndexRangeScan_5 1.00 cop[tikv] table:t, index:a(a, b) range:[1 2,1 2], keep order:false"))
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/statistics/table/mockQueryBytesMaxUint64"), IsNil)
 
-	// Test issue 22486
+	// Test issue 22466
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t2(a int, b int, key b(b))")
 	tk.MustExec("insert into t2 values(1, 1), (2, 2), (3, 3), (4, 4), (5,5)")

--- a/statistics/table.go
+++ b/statistics/table.go
@@ -472,6 +472,9 @@ func (coll *HistColl) crossValidationSelectivity(sc *stmtctx.StatementContext, i
 			break
 		}
 		if col, ok := coll.Columns[colID]; ok {
+			if col.IsInvalid(sc, coll.Pseudo) {
+				continue
+			}
 			lowExclude := idxPointRange.LowExclude
 			highExclude := idxPointRange.HighExclude
 			// Consider this case:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #22466 


### What is changed and how it works?

Check if column stats are valid when doing cross validation.

### Related changes

Cross validation is introduced in https://github.com/pingcap/tidb/pull/20264 and it's not cherry-picked to earlier branch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- no release note.
