### PR TITLE
executor: skip null data in common handle during point-get

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3867,6 +3867,9 @@ func (b *executorBuilder) buildBatchPointGet(plan *plannercore.BatchPointGetPlan
 			}
 		} else {
 			for _, value := range plan.IndexValues {
+				if datumsContainNull(value) {
+					continue
+				}
 				handleBytes, err := EncodeUniqueIndexValuesForKey(e.ctx, e.tblInfo, plan.IndexInfo, value)
 				if err != nil {
 					b.err = err

--- a/executor/clustered_index_test.go
+++ b/executor/clustered_index_test.go
@@ -287,3 +287,10 @@ func (s *testClusteredSerialSuite) TestClusteredIndexSplitAndAddIndex2(c *C) {
 	tk.MustExec("alter table t add index idx (c);")
 	tk.MustExec("admin check table t;")
 }
+
+func (s *testClusteredSuite) TestClusteredIndexSelectWhereInNull(c *C) {
+	tk := s.newTK(c)
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a datetime, b bigint, primary key (a));")
+	tk.MustQuery("select * from t where a in (null);").Check(testkit.Rows( /* empty result */ ))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22480 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The `null` data should not be constructed to `CommonHandle` in point-get, we can skip them safely since no values in the primary key can be `null`.

### What is changed and how it works?

What's Changed:
- skip null handle data during point-get 

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the panic issue that query clustered index tables using `WHERE IN(NULL)`.