### PR TITLE
server, sessionctx: change default for tidb_multi_statement_mode

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -750,7 +750,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAnalyzeVersion, Value: strconv.Itoa(DefTiDBAnalyzeVersion), Type: TypeInt, MinValue: 1, MaxValue: 2},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableIndexMergeJoin, Value: BoolToOnOff(DefTiDBEnableIndexMergeJoin), Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBTrackAggregateMemoryUsage, Value: BoolToOnOff(DefTiDBTrackAggregateMemoryUsage), Type: TypeBool},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMultiStatementMode, Value: Warn, Type: TypeEnum, PossibleValues: []string{Off, On, Warn}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBMultiStatementMode, Value: Off, Type: TypeEnum, PossibleValues: []string{Off, On, Warn}},
 
 	/* tikv gc metrics */
 	{Scope: ScopeGlobal, Name: TiDBGCEnable, Value: BoolOn, Type: TypeBool},


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In https://github.com/pingcap/tidb/pull/22351 a workaround was added to support the upgrade case of client multi-statement. The issue is that some clients require multi-statement, but are not able to set the option for their client driver.

The patch in https://github.com/pingcap/tidb/pull/22351 favored backwards compatibility over security. and was intended for the release branch. The value `WARN` does actually not prevent multi-statement SQL injection, and **this change is intended for the `master` branch**.

### What is changed and how it works?

What's Changed:

This changes the default for new installations in TiDB 5.0 to use the more secure `OFF` default. It does not *yet* upgrade users from earlier releases to use the new default, and this is not intended to be cherry-picked.

Changing the value for existing installations still needs to be done (for security reasons). I did not do it in this PR _because_ bootstrap upgrade tasks a ordinal. i.e. if I apply bootstrap63 to master and don't cherry pick it to the release branch yet, then nobody will be able to introduce any new bootstrap tasks to the release branch.

I will coordinate with QA when the future PR will occur that changes existing installs. The future PR will roughly be:

```
diff --git a/session/bootstrap.go b/session/bootstrap.go
index e1dfbcabb..56a0d1aa3 100644
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -459,9 +459,11 @@ const (
        version61 = 61
        // version62 add column ndv for mysql.stats_buckets.
        version62 = 62
+       // version63 changes the default for TiDBMultiStatementMode
+       version63 = 63
 
        // please make sure this is the largest version
-       currentBootstrapVersion = version62
+       currentBootstrapVersion = version63
 )
 
 var (
@@ -528,6 +530,7 @@ var (
                upgradeToVer60,
                upgradeToVer61,
                upgradeToVer62,
+               upgradeToVer63,
        }
 )
 
@@ -1423,6 +1426,40 @@ func upgradeToVer62(s Session, ver int64) {
        doReentrantDDL(s, "ALTER TABLE mysql.stats_buckets ADD COLUMN `ndv` bigint not null default 0", infoschema.ErrColumnExists)
 }
 
+func upgradeToVer63(s Session, ver int64) {
+       if ver >= version63 {
+               return
+       }
+
+       // The option TiDBMultiStatementMode was introduced with the default of WARN.
+       // This was intentional to provide an upgrade path for users who are incorrectly
+       // relying on multi-statement support, but not setting the multi-statement client flag.
+       // (TiDB previously always permitted multi-statement, and did not check this client flag).
+       //
+       // Both WARN and ON increase the surface area of attacks, since a DROP TBALE
+       // can easily be inserted in a SQL injection. SQL injection is still possible with OFF,
+       // but the risk is more likely information leak and not data destruction.
+       //
+       // The upgrade path from TiDBMultiStatementMode is as follows:
+       // - Introduced as default WARN
+       // - If the user sees warnings, they are encouraged to set the value as ON.
+       // - If they see no warnings, they should set the value to OFF.
+       // - After time elapses  (this bootstrap procedure), TiDB force-changes any user with a value WARN to be OFF
+       //   - Users with the value of ON/OFF are unaffected.
+       //   - Users previously relying on WARN can revert if needed.
+       //
+       // Why? Defaults are important. The value WARN does not actually provide protection, and
+       // warnings are frequently ignored by clients. The error message has deliberately been written with the steps
+       // to restore the previous behavior if necessary:
+       //
+       // Error 8130: client has multi-statement capability disabled. Run SET GLOBAL tidb_multi_statement_mode='ON' after you understand the security risk
+
+       sql := fmt.Sprintf("UPDATE HIGH_PRIORITY %s.%s SET variable_value = 'OFF' WHERE variable_name = 'tidb_multi_statement_mode' AND variable_value='WARN';",
+               mysql.SystemDB, mysql.GlobalVariablesTable)
+       mustExecute(s, sql)
+
+}
+
```

How it Works:

The default is changed in master for new installs. Eventually a bootstrap task will be written as well to convert existing installs.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: none yet.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility (for security reasons: it's critical)

### Release note <!-- bugfixes or new feature need a release note -->

- The default value for tidb_multi_statement_mode has changed to `OFF`. This helps mitigate the impact of SQL injections.