### PR TITLE
util: pre-alloc memory for decoding rows

### DIFF
--- a/util/rowDecoder/decoder.go
+++ b/util/rowDecoder/decoder.go
@@ -120,8 +120,8 @@ func (rd *RowDecoder) DecodeAndEvalRowWithMap(ctx sessionctx.Context, handle kv.
 		}
 		rd.mutRow.SetValue(colInfo.Offset, val.GetValue())
 	}
-	keys := make([]int, 0)
-	ids := make(map[int]int)
+	keys := make([]int, 0, len(rd.colMap))
+	ids := make(map[int]int, len(rd.colMap))
 	for k, col := range rd.colMap {
 		keys = append(keys, col.Col.Offset)
 		ids[col.Col.Offset] = int(k)


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
When adding an index for a big table, `DecodeAndEvalRowWithMap` consumes many CPUs in runtime.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Pre-alloc memory in `DecodeAndEvalRowWithMap`.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

1. profile tidb-server when adding an index on a big table
2. compare runtime growslice
master:
![image](https://user-images.githubusercontent.com/4352397/105655576-3db4e680-5efb-11eb-90d7-796c58c676c7.png)
this PR:
![image](https://user-images.githubusercontent.com/4352397/105655541-2fff6100-5efb-11eb-8015-209cfda8b158.png)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
