### PR TITLE
planner: avoid potential panic when generating hints from joins

### DIFF
--- a/planner/core/hints.go
+++ b/planner/core/hints.go
@@ -89,8 +89,12 @@ func getJoinHints(sctx sessionctx.Context, joinType string, parentOffset int, no
 			continue
 		}
 		var dbName, tableName *model.CIStr
-		if child.SelectBlockOffset() != parentOffset {
-			hintTable := sctx.GetSessionVars().PlannerSelectBlockAsName[child.SelectBlockOffset()]
+		if blockOffset != parentOffset {
+			blockAsNames := sctx.GetSessionVars().PlannerSelectBlockAsName
+			if blockOffset >= len(blockAsNames) {
+				continue
+			}
+			hintTable := blockAsNames[blockOffset]
 			// For sub-queries like `(select * from t) t1`, t1 should belong to its surrounding select block.
 			dbName, tableName, blockOffset = &hintTable.DBName, &hintTable.TableName, parentOffset
 		} else {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22514

Problem Summary:

See the issue description, it is really simple enough.

### What is changed and how it works?

What's Changed:

This is a protective patch to avoid potential panic caused by bugs unknown yet.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Avoid potential panic when generating hints from joins