### PR TITLE
server: use ParseWithParams to avoid injection

### DIFF
--- a/server/sql_info_fetcher.go
+++ b/server/sql_info_fetcher.go
@@ -88,7 +88,12 @@ func (sh *sqlInfoFetcher) zipInfoForSQL(w http.ResponseWriter, r *http.Request) 
 	timeoutString := r.FormValue("timeout")
 	curDB := strings.ToLower(r.FormValue("current_db"))
 	if curDB != "" {
-		_, err = sh.s.Execute(reqCtx, fmt.Sprintf("use %v", curDB))
+		stmts, err := sh.s.ParseWithParams(reqCtx, "use %n", curDB)
+		if err != nil {
+			serveError(w, http.StatusInternalServerError, fmt.Sprintf("use database %v failed, err: %v", curDB, err))
+			return
+		}
+		_, err = sh.s.ExecuteStmt(reqCtx, stmts[0])
 		if err != nil {
 			serveError(w, http.StatusInternalServerError, fmt.Sprintf("use database %v failed, err: %v", curDB, err))
 			return


### PR DESCRIPTION
### What problem does this PR solve?

Part of pingcap/tidb-test#1152

### What is changed and how it works?

What's Changed:

This removes any string concatenation from the `server` package.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Covered by existing tests

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note