### PR TITLE
metrics: add server info metric

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -37,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
@@ -794,6 +795,8 @@ func getServerInfo(id string, serverIDGetter func() uint64) *ServerInfo {
 	}
 	info.Version = mysql.ServerVersion
 	info.GitHash = versioninfo.TiDBGitHash
+
+	metrics.ServerInfo.WithLabelValues(mysql.TiDBReleaseVersion, info.GitHash).Set(float64(info.StartTimestamp))
 
 	failpoint.Inject("mockServerInfo", func(val failpoint.Value) {
 		if val.(bool) {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -174,4 +174,5 @@ func RegisterMetrics() {
 	prometheus.MustRegister(MaxProcs)
 	prometheus.MustRegister(GOGC)
 	prometheus.MustRegister(ConnIdleDurationHistogram)
+	prometheus.MustRegister(ServerInfo)
 }

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -195,6 +195,14 @@ var (
 			Help:      "Bucketed histogram of connection idle time (s).",
 			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 29), // 0.5ms ~ 1.5days
 		}, []string{LblInTxn})
+
+	ServerInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "server",
+			Name:      "info",
+			Help:      "Indicate the tidb server info, and the value is the start timestamp (s).",
+		}, []string{LblVersion, LblHash})
 )
 
 // ExecuteErrorToLabel converts an execute error to label.

--- a/metrics/session.go
+++ b/metrics/session.go
@@ -144,4 +144,6 @@ const (
 	LblGet         = "get"
 	LblLockKeys    = "lock_keys"
 	LblInTxn       = "in_txn"
+	LblVersion     = "version"
+	LblHash        = "hash"
 )


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Add TiDB server info in Prometheus metrics. This is use for DBaaS metrics.

### What is changed and how it works?

N/A

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```shell
# start the tidb-server first, also start the prometheus server
▶ bin/tidb-server
# query the metrics info:
▶ curl '127.0.0.1:9090/api/v1/query?query=tidb_server_info&time=2021-01-27T04:58:40.781Z'
{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"tidb_server_info","hash":"6d2f1b079dfed8bc0c24cb9ec29f01906159549d","instance":"127.0.0.1:10080","job":"tidb","version":"v4.0.0-beta.2-2056-g6d2f1b079"},"value":[1611723520.781,"1611723502"]}]}}%
```

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- N/A