### PR TITLE
expression: handle duration type infer in least and greatest (#22271)

### DIFF
--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -310,6 +310,10 @@ func (s *testEvaluatorSuite) TestGreatestLeastFunc(c *C) {
 			"12:59:59", "123", false, false,
 		},
 		{
+			[]interface{}{duration, duration},
+			"12:59:59", "12:59:59", false, false,
+		},
+		{
 			[]interface{}{"123", nil, "123"},
 			nil, nil, true, false,
 		},


### PR DESCRIPTION
cherry-pick #22271 to release-4.0
You can switch your code base to this Pull Request by using [git-extras](https://github.com/tj/git-extras):
```bash
# In tidb repo:
git pr https://github.com/pingcap/tidb/pull/22421
```

After apply modifications, you can push your change to this PR via:
```bash
git push git@github.com:ti-srebot/tidb.git pr/22421:release-4.0-4658536793d5
```

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22200 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

This pull request compares duration as string while they are formalized which will prevent panicking while encountering a non-handled duration type infer.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- expression: handle duration type infer in least and greatest
