### PR TITLE
store/tikv: Add failpoints to inject error when prewriting secondary keys

### DIFF
--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -138,7 +138,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		})
 	}
 
-	if c.connID > 0 {
+	if c.sessionID > 0 {
 		failpoint.Inject("prewriteSecondaryFail", func() {
 			if !batch.isPrimary {
 				// Delay to avoid cancelling other normally ongoing prewrite requests.

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -129,6 +129,8 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 	if c.connID > 0 {
 		failpoint.Inject("prewritePrimaryFail", func() {
 			if batch.isPrimary {
+				// Delay to avoid cancelling other normally ongoing prewrite requests.
+				time.Sleep(time.Millisecond * 50)
 				logutil.Logger(bo.ctx).Info("[failpoint] injected error on prewriting primary batch",
 					zap.Uint64("txnStartTS", c.startTS))
 				failpoint.Return(errors.New("injected error on prewriting primary batch"))
@@ -139,6 +141,8 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 	if c.connID > 0 {
 		failpoint.Inject("prewriteSecondaryFail", func() {
 			if !batch.isPrimary {
+				// Delay to avoid cancelling other normally ongoing prewrite requests.
+				time.Sleep(time.Millisecond * 50)
 				logutil.Logger(bo.ctx).Info("[failpoint] injected error on prewriting secondary batch",
 					zap.Uint64("txnStartTS", c.startTS))
 				failpoint.Return(errors.New("injected error on prewriting secondary batch"))


### PR DESCRIPTION
Signed-off-by: MyonKeminta <MyonKeminta@users.noreply.github.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: The current failpoints is not sufficient to construct cases for testing resolve locks for async commit transactions that primary key is prewritten but transaction is failed.

### What is changed and how it works?

What's Changed: Added a failpoint "prewriteSecondaryFail".

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- 

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
