### PR TITLE
store/tikv: move tikv driver out

### DIFF
--- a/cmd/benchdb/main.go
+++ b/cmd/benchdb/main.go
@@ -55,7 +55,7 @@ func main() {
 	flag.PrintDefaults()
 	err := logutil.InitZapLogger(logutil.NewLogConfig(*logLevel, logutil.DefaultLogFormat, "", logutil.EmptyFileLogConfig, false))
 	terror.MustNil(err)
-	err = store.Register("tikv", tikv.Driver{})
+	err = store.Register("tikv", store.TiKVDriver{})
 	terror.MustNil(err)
 	ut := newBenchDB()
 	works := strings.Split(*runJobs, "|")

--- a/cmd/benchkv/main.go
+++ b/cmd/benchkv/main.go
@@ -28,7 +28,7 @@ import (
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/tikv"
+	storepkg "github.com/pingcap/tidb/store"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"go.uber.org/zap"
@@ -69,7 +69,7 @@ var (
 
 // Init initializes information.
 func Init() {
-	driver := tikv.Driver{}
+	driver := storepkg.TiKVDriver{}
 	var err error
 	store, err = driver.Open(fmt.Sprintf("tikv://%s?cluster=1", *pdAddr))
 	terror.MustNil(err)

--- a/cmd/ddltest/ddl_test.go
+++ b/cmd/ddltest/ddl_test.go
@@ -41,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store"
-	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/logutil"
@@ -1061,5 +1060,5 @@ func addEnvPath(newPath string) {
 
 func init() {
 	rand.Seed(time.Now().UnixNano())
-	store.Register("tikv", tikv.Driver{})
+	store.Register("tikv", store.TiKVDriver{})
 }

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/store"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/mockstore/cluster"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
@@ -178,7 +179,7 @@ func (s *testSessionSuiteBase) SetUpSuite(c *C) {
 	if *withTiKV {
 		initPdAddrs()
 		s.pdAddr = <-pdAddrChan
-		var d tikv.Driver
+		var d store.TiKVDriver
 		config.UpdateGlobal(func(conf *config.Config) {
 			conf.TxnLocalLatches.Enabled = false
 		})

--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -29,5 +29,9 @@ func newMockTikvStore(opt *mockOptions) (kv.Storage, error) {
 	}
 	opt.clusterInspector(cluster)
 
-	return tikv.NewTestTiKVStore(client, pdClient, opt.clientHijacker, opt.pdClientHijacker, opt.txnLocalLatches)
+	kvstore, err := tikv.NewTestTiKVStore(client, pdClient, opt.clientHijacker, opt.pdClientHijacker, opt.txnLocalLatches)
+	if err != nil {
+		return nil, err
+	}
+	return &mockStorage{KVStore: kvstore}, nil
 }

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -46,7 +46,7 @@ type mockStorage struct {
 }
 
 func (s *mockStorage) EtcdAddrs() ([]string, error) {
-	return []string{"mockstore"}, nil
+	return nil, nil
 }
 
 func (s *mockStorage) TLSConfig() *tls.Config {

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -14,6 +14,8 @@
 package mockstore
 
 import (
+	"crypto/tls"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
@@ -31,5 +33,22 @@ func newUnistore(opts *mockOptions) (kv.Storage, error) {
 		Client: pdClient,
 	}
 
-	return tikv.NewTestTiKVStore(client, pdClient, opts.clientHijacker, opts.pdClientHijacker, opts.txnLocalLatches)
+	kvstore, err := tikv.NewTestTiKVStore(client, pdClient, opts.clientHijacker, opts.pdClientHijacker, opts.txnLocalLatches)
+	if err != nil {
+		return nil, err
+	}
+	return &mockStorage{KVStore: kvstore}, nil
+}
+
+// Wraps tikv.KVStore and make it compatible with kv.Storage.
+type mockStorage struct {
+	*tikv.KVStore
+}
+
+func (s *mockStorage) EtcdAddrs() ([]string, error) {
+	return []string{"mockstore"}, nil
+}
+
+func (s *mockStorage) TLSConfig() *tls.Config {
+	return nil
 }

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -40,7 +40,7 @@ type testAsyncCommitCommon struct {
 
 func (s *testAsyncCommitCommon) setUpTest(c *C) {
 	if *WithTiKV {
-		s.store = NewTestStore(c).(*KVStore)
+		s.store = NewTestStore(c)
 		return
 	}
 
@@ -51,7 +51,7 @@ func (s *testAsyncCommitCommon) setUpTest(c *C) {
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 
-	s.store = store.(*KVStore)
+	s.store = store
 }
 
 func (s *testAsyncCommitCommon) putAlphabets(c *C, enableAsyncCommit bool) {

--- a/store/tikv/backoff_test.go
+++ b/store/tikv/backoff_test.go
@@ -28,7 +28,7 @@ type testBackoffSuite struct {
 var _ = Suite(&testBackoffSuite{})
 
 func (s *testBackoffSuite) SetUpTest(c *C) {
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 }
 
 func (s *testBackoffSuite) TearDownTest(c *C) {

--- a/store/tikv/delete_range_test.go
+++ b/store/tikv/delete_range_test.go
@@ -50,7 +50,7 @@ func (s *testDeleteRangeSuite) SetUpTest(c *C) {
 	// )
 	// c.Assert(err, IsNil)
 
-	s.store = store.(*KVStore)
+	s.store = store
 }
 
 func (s *testDeleteRangeSuite) TearDownTest(c *C) {

--- a/store/tikv/isolation_test.go
+++ b/store/tikv/isolation_test.go
@@ -37,7 +37,7 @@ var _ = Suite(&testIsolationSuite{})
 
 func (s *testIsolationSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 }
 
 func (s *testIsolationSuite) TearDownSuite(c *C) {

--- a/store/tikv/lock_test.go
+++ b/store/tikv/lock_test.go
@@ -41,7 +41,7 @@ type testLockSuite struct {
 var _ = Suite(&testLockSuite{})
 
 func (s *testLockSuite) SetUpTest(c *C) {
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 }
 
 func (s *testLockSuite) TearDownTest(c *C) {

--- a/store/tikv/prewrite_test.go
+++ b/store/tikv/prewrite_test.go
@@ -31,7 +31,7 @@ func (s *testPrewriteSuite) SetUpTest(c *C) {
 	unistore.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
-	s.store = store.(*KVStore)
+	s.store = store
 }
 
 func (s *testPrewriteSuite) TestSetMinCommitTSInAsyncCommit(c *C) {

--- a/store/tikv/range_task_test.go
+++ b/store/tikv/range_task_test.go
@@ -77,7 +77,7 @@ func (s *testRangeTaskSuite) SetUpTest(c *C) {
 	// 	}),
 	// )
 	// c.Assert(err, IsNil)
-	s.store = store.(*KVStore)
+	s.store = store
 
 	s.testRanges = []kv.KeyRange{
 		makeRange("", ""),

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -34,7 +34,7 @@ var _ = Suite(&testSafePointSuite{})
 
 func (s *testSafePointSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 	s.prefix = fmt.Sprintf("seek_%d", time.Now().Unix())
 }
 

--- a/store/tikv/scan_mock_test.go
+++ b/store/tikv/scan_mock_test.go
@@ -27,7 +27,7 @@ type testScanMockSuite struct {
 var _ = Suite(&testScanMockSuite{})
 
 func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
-	store := NewTestStore(c).(*KVStore)
+	store := NewTestStore(c)
 	defer store.Close()
 
 	txn, err := store.Begin()
@@ -60,7 +60,7 @@ func (s *testScanMockSuite) TestScanMultipleRegions(c *C) {
 }
 
 func (s *testScanMockSuite) TestReverseScan(c *C) {
-	store := NewTestStore(c).(*KVStore)
+	store := NewTestStore(c)
 	defer store.Close()
 
 	txn, err := store.Begin()

--- a/store/tikv/scan_test.go
+++ b/store/tikv/scan_test.go
@@ -39,7 +39,7 @@ var _ = SerialSuites(&testScanSuite{})
 
 func (s *testScanSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 	s.recordPrefix = tablecodec.GenTableRecordPrefix(1)
 	s.rowNums = append(s.rowNums, 1, scanBatchSize, scanBatchSize+1, scanBatchSize*3)
 	// Avoid using async commit logic.

--- a/store/tikv/snapshot_fail_test.go
+++ b/store/tikv/snapshot_fail_test.go
@@ -36,7 +36,7 @@ func (s *testSnapshotFailSuite) SetUpSuite(c *C) {
 	unistore.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
-	s.store = store.(*KVStore)
+	s.store = store
 }
 
 func (s *testSnapshotFailSuite) TearDownSuite(c *C) {

--- a/store/tikv/snapshot_test.go
+++ b/store/tikv/snapshot_test.go
@@ -40,7 +40,7 @@ var _ = Suite(&testSnapshotSuite{})
 
 func (s *testSnapshotSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 	s.prefix = fmt.Sprintf("snapshot_%d", time.Now().Unix())
 	s.rowNums = append(s.rowNums, 1, 100, 191)
 }

--- a/store/tikv/split_test.go
+++ b/store/tikv/split_test.go
@@ -47,7 +47,7 @@ func (s *testSplitSuite) SetUpTest(c *C) {
 	// 	}),
 	// )
 	// c.Assert(err, IsNil)
-	s.store = store.(*KVStore)
+	s.store = store
 	s.bo = NewBackofferWithVars(context.Background(), 5000, nil)
 }
 

--- a/store/tikv/store_test.go
+++ b/store/tikv/store_test.go
@@ -50,7 +50,7 @@ var _ = Suite(&testStoreSuite{})
 var _ = SerialSuites(&testStoreSerialSuite{})
 
 func (s *testStoreSuiteBase) SetUpTest(c *C) {
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 }
 
 func (s *testStoreSuiteBase) TearDownTest(c *C) {

--- a/store/tikv/test_util.go
+++ b/store/tikv/test_util.go
@@ -16,13 +16,12 @@ package tikv
 import (
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv/config"
 	pd "github.com/tikv/pd/client"
 )
 
 // NewTestTiKVStore creates a test store with Option
-func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, txnLocalLatches uint) (kv.Storage, error) {
+func NewTestTiKVStore(client Client, pdClient pd.Client, clientHijack func(Client) Client, pdClientHijack func(pd.Client) pd.Client, txnLocalLatches uint) (*KVStore, error) {
 	if clientHijack != nil {
 		client = clientHijack(client)
 	}

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -24,7 +25,9 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/tikv/config"
 	"github.com/pingcap/tidb/util/codec"
+	pd "github.com/tikv/pd/client"
 )
 
 var (
@@ -33,15 +36,22 @@ var (
 	pdAddrs            = flag.String("pd-addrs", "127.0.0.1:2379", "pd addrs")
 )
 
-// NewTestStore creates a kv.Storage for testing purpose.
-func NewTestStore(c *C) kv.Storage {
+// NewTestStore creates a KVStore for testing purpose.
+func NewTestStore(c *C) *KVStore {
 	if !flag.Parsed() {
 		flag.Parse()
 	}
 
 	if *WithTiKV {
-		var d Driver
-		store, err := d.Open(fmt.Sprintf("tikv://%s", *pdAddrs))
+		addrs := strings.Split(*pdAddrs, ",")
+		pdClient, err := pd.NewClient(addrs, pd.SecurityOption{})
+		c.Assert(err, IsNil)
+		var securityConfig config.Security
+		tlsConfig, err := securityConfig.ToTLSConfig()
+		c.Assert(err, IsNil)
+		spKV, err := NewEtcdSafePointKV(addrs, tlsConfig)
+		c.Assert(err, IsNil)
+		store, err := NewKVStore("test-store", &CodecPDClient{Client: pdClient}, spKV, NewRPCClient(securityConfig), false, nil)
 		c.Assert(err, IsNil)
 		err = clearStorage(store)
 		c.Assert(err, IsNil)
@@ -55,7 +65,7 @@ func NewTestStore(c *C) kv.Storage {
 	return store
 }
 
-func clearStorage(store kv.Storage) error {
+func clearStorage(store *KVStore) error {
 	txn, err := store.Begin()
 	if err != nil {
 		return errors.Trace(err)
@@ -85,7 +95,7 @@ var _ = Suite(&testTiclientSuite{})
 
 func (s *testTiclientSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	s.store = NewTestStore(c).(*KVStore)
+	s.store = NewTestStore(c)
 	s.prefix = fmt.Sprintf("ticlient_%d", time.Now().Unix())
 }
 

--- a/store/tikv_driver.go
+++ b/store/tikv_driver.go
@@ -1,0 +1,183 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"math/rand"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/config"
+	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/logutil"
+	pd "github.com/tikv/pd/client"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/keepalive"
+)
+
+type storeCache struct {
+	sync.Mutex
+	cache map[string]*tikvStore
+}
+
+var mc storeCache
+
+func init() {
+	mc.cache = make(map[string]*tikvStore)
+	rand.Seed(time.Now().UnixNano())
+}
+
+// TiKVDriver implements engine TiKV.
+type TiKVDriver struct {
+}
+
+// Open opens or creates an TiKV storage with given path.
+// Path example: tikv://etcd-node1:port,etcd-node2:port?cluster=1&disableGC=false
+func (d TiKVDriver) Open(path string) (kv.Storage, error) {
+	mc.Lock()
+	defer mc.Unlock()
+	security := config.GetGlobalConfig().Security
+	pdConfig := config.GetGlobalConfig().PDClient
+	tikvConfig := config.GetGlobalConfig().TiKVClient
+	txnLocalLatches := config.GetGlobalConfig().TxnLocalLatches
+	etcdAddrs, disableGC, err := config.ParsePath(path)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	pdCli, err := pd.NewClient(etcdAddrs, pd.SecurityOption{
+		CAPath:   security.ClusterSSLCA,
+		CertPath: security.ClusterSSLCert,
+		KeyPath:  security.ClusterSSLKey,
+	}, pd.WithGRPCDialOptions(
+		grpc.WithKeepaliveParams(keepalive.ClientParameters{
+			Time:    time.Duration(tikvConfig.GrpcKeepAliveTime) * time.Second,
+			Timeout: time.Duration(tikvConfig.GrpcKeepAliveTimeout) * time.Second,
+		}),
+	), pd.WithCustomTimeoutOption(time.Duration(pdConfig.PDServerTimeout)*time.Second))
+	pdCli = execdetails.InterceptedPDClient{Client: pdCli}
+
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	// FIXME: uuid will be a very long and ugly string, simplify it.
+	uuid := fmt.Sprintf("tikv-%v", pdCli.GetClusterID(context.TODO()))
+	if store, ok := mc.cache[uuid]; ok {
+		return store, nil
+	}
+
+	tlsConfig, err := security.ToTLSConfig()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	spkv, err := tikv.NewEtcdSafePointKV(etcdAddrs, tlsConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	coprCacheConfig := &config.GetGlobalConfig().TiKVClient.CoprCache
+	s, err := tikv.NewKVStore(uuid, &tikv.CodecPDClient{Client: pdCli}, spkv, tikv.NewRPCClient(security), !disableGC, coprCacheConfig)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if txnLocalLatches.Enabled {
+		s.EnableTxnLocalLatches(txnLocalLatches.Capacity)
+	}
+
+	store := &tikvStore{
+		KVStore:   s,
+		etcdAddrs: etcdAddrs,
+		tlsConfig: tlsConfig,
+	}
+
+	mc.cache[uuid] = store
+	return store, nil
+}
+
+type tikvStore struct {
+	*tikv.KVStore
+	etcdAddrs []string
+	tlsConfig *tls.Config
+}
+
+var (
+	ldflagGetEtcdAddrsFromConfig = "0" // 1:Yes, otherwise:No
+)
+
+// EtcdAddrs returns etcd server addresses.
+func (s *tikvStore) EtcdAddrs() ([]string, error) {
+	if s.etcdAddrs == nil {
+		return nil, nil
+	}
+
+	if ldflagGetEtcdAddrsFromConfig == "1" {
+		// For automated test purpose.
+		// To manipulate connection to etcd by mandatorily setting path to a proxy.
+		cfg := config.GetGlobalConfig()
+		return strings.Split(cfg.Path, ","), nil
+	}
+
+	ctx := context.Background()
+	bo := tikv.NewBackoffer(ctx, tikv.GetAllMembersBackoff)
+	etcdAddrs := make([]string, 0)
+	pdClient := s.GetPDClient()
+	if pdClient == nil {
+		return nil, errors.New("Etcd client not found")
+	}
+	for {
+		members, err := pdClient.GetAllMembers(ctx)
+		if err != nil {
+			err := bo.Backoff(tikv.BoRegionMiss, err)
+			if err != nil {
+				return nil, err
+			}
+			continue
+		}
+		for _, member := range members {
+			if len(member.ClientUrls) > 0 {
+				u, err := url.Parse(member.ClientUrls[0])
+				if err != nil {
+					logutil.BgLogger().Error("fail to parse client url from pd members", zap.String("client_url", member.ClientUrls[0]), zap.Error(err))
+					return nil, err
+				}
+				etcdAddrs = append(etcdAddrs, u.Host)
+			}
+		}
+		return etcdAddrs, nil
+	}
+}
+
+// Close and unregister the store.
+func (s *tikvStore) Close() error {
+	mc.Lock()
+	defer mc.Unlock()
+	delete(mc.cache, s.UUID())
+	return s.KVStore.Close()
+}
+
+// TLSConfig returns the tls config to connect to etcd.
+func (s *tikvStore) TLSConfig() *tls.Config {
+	return s.tlsConfig
+}

--- a/store/tikv_driver.go
+++ b/store/tikv_driver.go
@@ -169,15 +169,15 @@ func (s *tikvStore) EtcdAddrs() ([]string, error) {
 	}
 }
 
+// TLSConfig returns the tls config to connect to etcd.
+func (s *tikvStore) TLSConfig() *tls.Config {
+	return s.tlsConfig
+}
+
 // Close and unregister the store.
 func (s *tikvStore) Close() error {
 	mc.Lock()
 	defer mc.Unlock()
 	delete(mc.cache, s.UUID())
 	return s.KVStore.Close()
-}
-
-// TLSConfig returns the tls config to connect to etcd.
-func (s *tikvStore) TLSConfig() *tls.Config {
-	return s.tlsConfig
 }

--- a/store/util_test.go
+++ b/store/util_test.go
@@ -51,7 +51,7 @@ func NewTestStore(c *C) kv.Storage {
 	unistore.BootstrapWithSingleStore(cluster)
 	store, err := tikv.NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
-	return store
+	return &tikvStore{KVStore: store}
 }
 
 func clearStorage(store kv.Storage) error {

--- a/store/util_test.go
+++ b/store/util_test.go
@@ -39,7 +39,7 @@ func NewTestStore(c *C) kv.Storage {
 	}
 
 	if *WithTiKV {
-		var d tikv.Driver
+		var d TiKVDriver
 		store, err := d.Open(fmt.Sprintf("tikv://%s", *pdAddrs))
 		c.Assert(err, IsNil)
 		err = clearStorage(store)

--- a/tests/globalkilltest/Makefile
+++ b/tests/globalkilltest/Makefile
@@ -21,7 +21,7 @@ GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServ
 GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServerIDTimeToKeepAlive=1"
 GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagServerIDTimeToCheckPDConnectionRestored=1"
 GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/domain.ldflagLostConnectionToPDTimeout=5"
-GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/store/tikv.ldflagGetEtcdAddrsFromConfig=1"
+GLOBAL_KILL_TEST_SERVER_LDFLAGS += -X "github.com/pingcap/tidb/store.ldflagGetEtcdAddrsFromConfig=1"
 
 .PHONY: server buildsucc
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -247,7 +247,7 @@ func setHeapProfileTracker() {
 }
 
 func registerStores() {
-	err := kvstore.Register("tikv", tikv.Driver{})
+	err := kvstore.Register("tikv", kvstore.TiKVDriver{})
 	terror.MustNil(err)
 	tikv.NewGCHandlerFunc = gcworker.NewGCWorker
 	err = kvstore.Register("mocktikv", mockstore.MockTiKVDriver{})


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Move `tikv.Driver` out of `store/tikv` to resolve dependency on tidb.

Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- move `tikv.Driver` to `store.TiKVDriver`.
- create `store.tikvStore` to wrap `tikv.KVStore` and provide functions tidb need.
- tests in `store/tikv` use `KVStore` to test instead of `kv.Storage`.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note