### PR TITLE
expression: enable arithmetic Mod push down

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -973,6 +973,7 @@ func canFuncBePushed(sf *ScalarFunction, storeType kv.StoreType) bool {
 		ast.Mul,
 		ast.Div,
 		ast.Abs,
+		ast.Mod,
 
 		// math functions.
 		ast.Ceil,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
For now TiDB won't push down mod expression, while TiFlash and TiKV has implemented it.

### What is changed and how it works?

What's Changed:
- enable mod push down

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- Support arithmetic mod expression push down