### PR TITLE
planner: do not ban tiflash engine when statement not read-only

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1534,41 +1534,6 @@ func (s *testIntegrationSuite) TestOptimizeHintOnPartitionTable(c *C) {
 	}
 }
 
-func (s *testIntegrationSerialSuite) TestNotReadOnlySQLOnTiFlash(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t (a int, b varchar(20))")
-	tk.MustExec(`set @@tidb_isolation_read_engines = "tiflash"`)
-	// Create virtual tiflash replica info.
-	dom := domain.GetDomain(tk.Se)
-	is := dom.InfoSchema()
-	db, exists := is.SchemaByName(model.NewCIStr("test"))
-	c.Assert(exists, IsTrue)
-	for _, tblInfo := range db.Tables {
-		if tblInfo.Name.L == "t" {
-			tblInfo.TiFlashReplica = &model.TiFlashReplicaInfo{
-				Count:     1,
-				Available: true,
-			}
-		}
-	}
-	err := tk.ExecToErr("select * from t for update")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, `[planner:1815]Internal : Can not find access path matching 'tidb_isolation_read_engines'(value: 'tiflash'). Available values are 'tiflash, tikv'.`)
-
-	err = tk.ExecToErr("insert into t select * from t")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, `[planner:1815]Internal : Can not find access path matching 'tidb_isolation_read_engines'(value: 'tiflash'). Available values are 'tiflash, tikv'.`)
-
-	tk.MustExec("prepare stmt_insert from 'insert into t select * from t where t.a = ?'")
-	tk.MustExec("set @a=1")
-	err = tk.ExecToErr("execute stmt_insert using @a")
-	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, `[planner:1815]Internal : Can not find access path matching 'tidb_isolation_read_engines'(value: 'tiflash'). Available values are 'tiflash, tikv'.`)
-}
-
 func (s *testIntegrationSuite) TestSelectLimit(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -79,17 +79,6 @@ func IsReadOnly(node ast.Node, vars *variable.SessionVars) bool {
 func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (plannercore.Plan, types.NameSlice, error) {
 	sessVars := sctx.GetSessionVars()
 
-	// Because for write stmt, TiFlash has a different results when lock the data in point get plan. We ban the TiFlash
-	// engine in not read only stmt.
-	_, isDDL := node.(ast.DDLNode)
-	_, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]
-	if isolationReadContainTiFlash && !IsReadOnly(node, sessVars) && !isDDL {
-		delete(sessVars.IsolationReadEngines, kv.TiFlash)
-		defer func() {
-			sessVars.IsolationReadEngines[kv.TiFlash] = struct{}{}
-		}()
-	}
-
 	if _, isolationReadContainTiKV := sessVars.IsolationReadEngines[kv.TiKV]; isolationReadContainTiKV {
 		var fp plannercore.Plan
 		if fpv, ok := sctx.Value(plannercore.PointPlanKey).(plannercore.PointPlanVal); ok {

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -81,7 +81,9 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 
 	// Because for write stmt, TiFlash has a different results when lock the data in point get plan. We ban the TiFlash
 	// engine in not read only stmt.
-	if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(node, sessVars) {
+	_, isDDL := node.(ast.DDLNode)
+	_, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]
+	if isolationReadContainTiFlash && !IsReadOnly(node, sessVars) && !isDDL {
 		delete(sessVars.IsolationReadEngines, kv.TiFlash)
 		defer func() {
 			sessVars.IsolationReadEngines[kv.TiFlash] = struct{}{}


### PR DESCRIPTION
Signed-off-by: lzmhhh123 <lzmhhh123@gmail.com><!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: as the title says.

reference pull request: #18458

### What is changed and how it works?

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- do not ban tiflash engine when the statement not read-only
