### PR TITLE
server: return OK when there is no stmt

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1387,6 +1387,10 @@ func (cc *clientConn) handleQuery(ctx context.Context, sql string) (err error) {
 		return err
 	}
 
+	if len(stmts) == 0 {
+		return cc.writeOK(ctx)
+	}
+
 	var appendMultiStmtWarning bool
 
 	if len(stmts) > 1 {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1122,7 +1122,7 @@ func (cli *testServerClient) runTestIssue22646(c *C) {
 			c1 <- "success"
 		}()
 		select {
-		case <-time.After(4 * time.Second):
+		case <-time.After(30 * time.Second):
 			panic("read empty query statement timed out.")
 		}
 	})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1122,6 +1122,8 @@ func (cli *testServerClient) runTestIssue22646(c *C) {
 			c1 <- "success"
 		}()
 		select {
+		case res := <-c1:
+			fmt.Println(res)
 		case <-time.After(30 * time.Second):
 			panic("read empty query statement timed out.")
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1114,6 +1114,20 @@ func (cli *testServerClient) runTestIssue3680(c *C) {
 	c.Assert(err.Error(), Equals, "Error 1045: Access denied for user 'non_existing_user'@'127.0.0.1' (using password: NO)")
 }
 
+func (cli *testServerClient) runTestIssue22646(c *C) {
+	cli.runTests(c, nil, func(dbt *DBTest) {
+		c1 := make(chan string, 1)
+		go func() {
+			dbt.mustExec(``) // empty query.
+			c1 <- "success"
+		}()
+		select {
+		case <-time.After(4 * time.Second):
+			panic("read empty query statement timed out.")
+		}
+	})
+}
+
 func (cli *testServerClient) runTestIssue3682(c *C) {
 	cli.runTests(c, nil, func(dbt *DBTest) {
 		dbt.mustExec(`CREATE USER 'issue3682'@'%' IDENTIFIED BY '123';`)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -176,6 +176,7 @@ func (ts *tidbTestSuite) TestIssues(c *C) {
 	c.Parallel()
 	ts.runTestIssue3662(c)
 	ts.runTestIssue3680(c)
+	ts.runTestIssue22646(c)
 }
 
 func (ts *tidbTestSuite) TestDBNameEscape(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: Fixes https://github.com/pingcap/tidb/issues/22646

Problem Summary:

There was a regression introduced in the 4.0 branch by a cherry-pick. The issue does not exist in the master branch, or any public released binaries yet. It was caught before 4.0.11 was released. It does not exist in 4.0.10.

I am unsure if connectors rely on this functionality. There is a `COM_PING` protocol feature, but it's possible that an incorrectly implemented driver uses an empty query instead. In which case it could be quite a serious issue.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note