### PR TITLE
load data bug

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1249,6 +1249,10 @@ func processStream(ctx context.Context, cc *clientConn, loadDataInfo *executor.L
 			if len(prevData) == 0 {
 				break
 			}
+		}else {
+			if curData[len(curData) - 1] == '\n' {
+				curData = curData[0:len(curData) - 1]
+			}
 		}
 		select {
 		case <-loadDataInfo.QuitCh:


### PR DESCRIPTION
issue: #22735

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
When read data from file in client end, a '\n' will be add to the end of the byte array. This amy result to the exception of inserting last fields of the last terms.  

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
delete  '\n' at the end of the byte array while read data from client file

How it Works:
'\n' make the last field of the last term out of the format. after moving it, the problem can be resolved
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
