### PR TITLE
util/timeutil: fix timeutil/time_test.go on Windows

### DIFF
--- a/util/timeutil/time_test.go
+++ b/util/timeutil/time_test.go
@@ -68,22 +68,22 @@ func (s *testTimeSuite) TestLocal(c *C) {
 }
 
 func (s *testTimeSuite) TestInferOneStepLinkForPath(c *C) {
-	os.Remove("/tmp/testlink1")
-	os.Remove("/tmp/testlink2")
-	os.Remove("/tmp/testlink3")
+	os.Remove(filepath.Join(os.TempDir(), "testlink1"))
+	os.Remove(filepath.Join(os.TempDir(), "testlink2"))
+	os.Remove(filepath.Join(os.TempDir(), "testlink3"))
 	var link2, link3 string
 	var err error
 	var link1 *os.File
-	link1, err = os.Create("/tmp/testlink1")
+	link1, err = os.Create(filepath.Join(os.TempDir(), "testlink1"))
 	c.Assert(err, IsNil)
-	err = os.Symlink(link1.Name(), "/tmp/testlink2")
+	err = os.Symlink(link1.Name(), filepath.Join(os.TempDir(), "testlink2"))
 	c.Assert(err, IsNil)
-	err = os.Symlink("/tmp/testlink2", "/tmp/testlink3")
+	err = os.Symlink(filepath.Join(os.TempDir(), "testlink2"), filepath.Join(os.TempDir(), "testlink3"))
 	c.Assert(err, IsNil)
-	link2, err = inferOneStepLinkForPath("/tmp/testlink3")
+	link2, err = inferOneStepLinkForPath(filepath.Join(os.TempDir(), "testlink3"))
 	c.Assert(err, IsNil)
-	c.Assert(link2, Equals, "/tmp/testlink2")
-	link3, err = filepath.EvalSymlinks("/tmp/testlink3")
+	c.Assert(link2, Equals, filepath.Join(os.TempDir(), "testlink2"))
+	link3, err = filepath.EvalSymlinks(filepath.Join(os.TempDir(), "testlink3"))
 	c.Assert(err, IsNil)
 	c.Assert(strings.Index(link3, link1.Name()), Not(Equals), -1)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: The test case fails on Windows because of pure Unix paths.

### What is changed and how it works?

What's Changed: Switching to `filepath.Join(os.TempDir(), "path")`.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note


