### PR TITLE
ddl: cancel specific ddl job type retry

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -16,7 +16,6 @@ package ddl
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/table"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -33,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/table"
 	tidbutil "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/dbterror"

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -731,7 +731,7 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		}
 
 		// Some kind of ddl jobs should not retry if failed
-		if err!= nil && errors.ErrorEqual(err,table.ErrUnknownPartition)  {
+		if err != nil && errors.ErrorEqual(err, table.ErrUnknownPartition) {
 			job.State = model.JobStateCancelled
 			return ver, nil
 		}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #22704
Problem Summary:

### What is changed and how it works?

What's Changed:

if error type is ErrUnknownPartition, cancel job and return errors

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note
- fix specific ddl job retry too many times