### PR TITLE
planner,cascade: remove useless codes

### DIFF
--- a/planner/cascades/transformation_rules.go
+++ b/planner/cascades/transformation_rules.go
@@ -593,10 +593,6 @@ func (r *PushSelDownAggregation) OnTransform(old *memo.ExprIter) (newExprs []*me
 	aggSchema := old.Children[0].Prop.Schema
 	var pushedExprs []expression.Expression
 	var remainedExprs []expression.Expression
-	exprsOriginal := make([]expression.Expression, 0, len(agg.AggFuncs))
-	for _, aggFunc := range agg.AggFuncs {
-		exprsOriginal = append(exprsOriginal, aggFunc.Args[0])
-	}
 	groupByColumns := expression.NewSchema(agg.GetGroupByCols()...)
 	for _, cond := range sel.Conditions {
 		switch cond.(type) {


### PR DESCRIPTION
Problem Summary:

variable `exprsOriginal` was defined, but it does not really be useful, I think it's copy from old planner implementation of predicate push down.

### What is changed and how it works?

What's Changed:

remove it.

How it Works:

no function new or modified

### Related changes

- Need to cherry-pick to the release branch

Release note

- no release note