### PR TITLE
fix load data bug

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1250,6 +1250,8 @@ func processStream(ctx context.Context, cc *clientConn, loadDataInfo *executor.L
 			if len(prevData) == 0 {
 				break
 			}
+		} else if curData[len(curData)-1] == '\n' {
+			curData = curData[0 : len(curData)-1]
 		}
 		select {
 		case <-loadDataInfo.QuitCh:


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
cannot load value of last column of last item correctly

Problem Summary:
when load data from csv file, the value of the last column of the last item in the csv file cannot be load under expected format. 
### What is changed and how it works?

What's Changed:
remove the last character --'\n', when tidb reads data from csv file every time
How it Works:
if the line terminator is not '\n' and the line terminator does not follow the last item of the records, the '\n' is regarded as a character of the value of the last column of the last item of record. if remove '\n', the problem can be resolved.
### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
fix load data bug
- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
