### PR TITLE
server: conn.go was changed

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -1250,6 +1250,8 @@ func processStream(ctx context.Context, cc *clientConn, loadDataInfo *executor.L
 			if len(prevData) == 0 {
 				break
 			}
+		} else if curData[len(curData)-1] == '\n' {
+			curData = curData[0 : len(curData)-1]
 		}
 		select {
 		case <-loadDataInfo.QuitCh:


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:
Cannot load value of last column of last item correctly

### What is changed and how it works?

What's Changed:
Remove the last character --'\n', when tidb read data from csv file every time.
How it Works:
if the line terminator is not '\n' and the line terminator does not follow the last item of the records, the '\n' will be treated as the character of the value of the last column of the last item of the records. If the '\n' added by tidb is removed, the data read from csv file can be process correctly.
### Related changes

- Need to cherry-pick to the release branch


Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- * fix data load bug
