### PR TITLE
gcworker: remove handler interface

### DIFF
--- a/session/session_test.go
+++ b/session/session_test.go
@@ -183,7 +183,7 @@ func (s *testSessionSuiteBase) SetUpSuite(c *C) {
 		config.UpdateGlobal(func(conf *config.Config) {
 			conf.TxnLocalLatches.Enabled = false
 		})
-		store, err := d.Open(fmt.Sprintf("tikv://%s", s.pdAddr))
+		store, err := d.Open(fmt.Sprintf("tikv://%s?disableGC=true", s.pdAddr))
 		c.Assert(err, IsNil)
 		err = clearStorage(store)
 		c.Assert(err, IsNil)

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -69,7 +69,7 @@ type GCWorker struct {
 }
 
 // NewGCWorker creates a GCWorker instance.
-func NewGCWorker(store tikv.Storage, pdClient pd.Client) (GCHandler, error) {
+func NewGCWorker(store tikv.Storage, pdClient pd.Client) (*GCWorker, error) {
 	ver, err := store.CurrentVersion(oracle.GlobalTxnScope)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -2183,16 +2183,3 @@ func (s *mergeLockScanner) physicalScanLocksForStore(ctx context.Context, safePo
 
 	return nil
 }
-
-// GCHandler runs garbage collection job.
-type GCHandler interface {
-	// Start starts the GCHandler.
-	Start()
-
-	// Close closes the GCHandler.
-	Close()
-}
-
-// NewGCHandlerFunc creates a new GCHandler.
-// To enable real GC, we should assign the function to `gcworker.NewGCWorker`.
-var NewGCHandlerFunc func(storage tikv.Storage, pdClient pd.Client) (GCHandler, error)

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -102,7 +102,7 @@ func (s *testGCWorkerSuite) SetUpTest(c *C) {
 	c.Assert(err, IsNil)
 	gcWorker.Start()
 	gcWorker.Close()
-	s.gcWorker = gcWorker.(*GCWorker)
+	s.gcWorker = gcWorker
 }
 
 func (s *testGCWorkerSuite) TearDownTest(c *C) {

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -69,7 +69,6 @@ type testGCWorkerSuite struct {
 var _ = SerialSuites(&testGCWorkerSuite{})
 
 func (s *testGCWorkerSuite) SetUpTest(c *C) {
-	NewGCHandlerFunc = NewGCWorker
 	hijackClient := func(client tikv.Client) tikv.Client {
 		s.client = &testGCWorkerClient{
 			Client: client,

--- a/store/tikv_driver.go
+++ b/store/tikv_driver.go
@@ -175,7 +175,7 @@ type tikvStore struct {
 	tlsConfig *tls.Config
 	pdClient  pd.Client
 	enableGC  bool
-	gcWorker  gcworker.GCHandler
+	gcWorker  *gcworker.GCWorker
 }
 
 var (
@@ -232,11 +232,11 @@ func (s *tikvStore) TLSConfig() *tls.Config {
 
 // StartGCWorker starts GC worker, it's called in BootstrapSession, don't call this function more than once.
 func (s *tikvStore) StartGCWorker() error {
-	if !s.enableGC || gcworker.NewGCHandlerFunc == nil {
+	if !s.enableGC {
 		return nil
 	}
 
-	gcWorker, err := gcworker.NewGCHandlerFunc(s, s.pdClient)
+	gcWorker, err := gcworker.NewGCWorker(s, s.pdClient)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -48,7 +48,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	kvstore "github.com/pingcap/tidb/store"
-	"github.com/pingcap/tidb/store/gcworker"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/storeutil"
@@ -249,7 +248,6 @@ func setHeapProfileTracker() {
 func registerStores() {
 	err := kvstore.Register("tikv", kvstore.TiKVDriver{})
 	terror.MustNil(err)
-	gcworker.NewGCHandlerFunc = gcworker.NewGCWorker
 	err = kvstore.Register("mocktikv", mockstore.MockTiKVDriver{})
 	terror.MustNil(err)
 	err = kvstore.Register("unistore", mockstore.EmbedUnistoreDriver{})

--- a/util/testleak/leaktest.go
+++ b/util/testleak/leaktest.go
@@ -38,7 +38,6 @@ func interestingGoroutines() (gs []string) {
 		"check.(*suiteRunner).runFunc",
 		"check.(*suiteRunner).parallelRun",
 		"localstore.(*dbStore).scheduler",
-		"tikv.(*noGCHandler).Start",
 		"ddl.(*ddl).start",
 		"ddl.(*delRange).startEmulator",
 		"domain.NewDomain",


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Remove the GCHandler interface and use the concrete GCWorker directly.
Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- remove GCHandler  interface
- remove NewGCHandlerFunc 

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note
