### PR TITLE
store/tikv: move memcache out

### DIFF
--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -37,12 +37,16 @@ func newUnistore(opts *mockOptions) (kv.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &mockStorage{KVStore: kvstore}, nil
+	return &mockStorage{
+		KVStore:  kvstore,
+		memCache: kv.NewCacheDB(),
+	}, nil
 }
 
 // Wraps tikv.KVStore and make it compatible with kv.Storage.
 type mockStorage struct {
 	*tikv.KVStore
+	memCache kv.MemManager
 }
 
 func (s *mockStorage) EtcdAddrs() ([]string, error) {
@@ -55,4 +59,9 @@ func (s *mockStorage) TLSConfig() *tls.Config {
 
 func (s *mockStorage) StartGCWorker() error {
 	return nil
+}
+
+// GetMemCache returns memory mamager of the storage
+func (s *mockStorage) GetMemCache() kv.MemManager {
+	return s.memCache
 }

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -76,8 +76,7 @@ type KVStore struct {
 	spMutex   sync.RWMutex  // this is used to update safePoint and spTime
 	closed    chan struct{} // this is used to nofity when the store is closed
 
-	replicaReadSeed uint32        // this is used to load balance followers / learners when replica read is enabled
-	memCache        kv.MemManager // this is used to query from memory
+	replicaReadSeed uint32 // this is used to load balance followers / learners when replica read is enabled
 }
 
 // UpdateSPCache updates cached safepoint.
@@ -128,7 +127,6 @@ func NewKVStore(uuid string, pdClient pd.Client, spkv SafePointKV, client Client
 		spTime:          time.Now(),
 		closed:          make(chan struct{}),
 		replicaReadSeed: rand.Uint32(),
-		memCache:        kv.NewCacheDB(),
 	}
 	store.lockResolver = newLockResolver(store)
 
@@ -384,9 +382,4 @@ func (s *KVStore) SetTiKVClient(client Client) {
 // GetTiKVClient gets the client instance.
 func (s *KVStore) GetTiKVClient() (client Client) {
 	return s.client
-}
-
-// GetMemCache return memory mamager of the storage
-func (s *KVStore) GetMemCache() kv.MemManager {
-	return s.memCache
 }

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -44,7 +44,7 @@ const bigTxnThreshold = 16
 
 // LockResolver resolves locks and also caches resolved txn status.
 type LockResolver struct {
-	store Storage
+	store *KVStore
 	mu    struct {
 		sync.RWMutex
 		// resolved caches resolved txns (FIFO, txn id -> txnStatus).
@@ -56,7 +56,7 @@ type LockResolver struct {
 	}
 }
 
-func newLockResolver(store Storage) *LockResolver {
+func newLockResolver(store *KVStore) *LockResolver {
 	r := &LockResolver{
 		store: store,
 	}

--- a/store/tikv_driver.go
+++ b/store/tikv_driver.go
@@ -163,6 +163,7 @@ func (d TiKVDriver) OpenWithOptions(path string, options ...DriverOption) (kv.St
 		tlsConfig: tlsConfig,
 		pdClient:  &pdClient,
 		enableGC:  !disableGC,
+		memCache:  kv.NewCacheDB(),
 	}
 
 	mc.cache[uuid] = store
@@ -176,6 +177,7 @@ type tikvStore struct {
 	pdClient  pd.Client
 	enableGC  bool
 	gcWorker  gcworker.GCHandler
+	memCache  kv.MemManager // this is used to query from memory
 }
 
 var (
@@ -254,4 +256,9 @@ func (s *tikvStore) Close() error {
 		s.gcWorker.Close()
 	}
 	return s.KVStore.Close()
+}
+
+// GetMemCache returns memory mamager of the storage
+func (s *tikvStore) GetMemCache() kv.MemManager {
+	return s.memCache
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Move MemCache out of store/tikv.
Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- Move MemCache out of store/tikv.
- Add MemCache for `store.tikvStore` and `mockstore.MockStore`.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note
