### PR TITLE
 executor: add new format specifier(%# %@ %.) for str_to_date expression

### DIFF
--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1418,6 +1418,8 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		{"2020-10-10.1", "%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
 		{"abcd2020-10-10.1", "%@%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
 		{"abcd-2020-10-10.1", "%@-%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"2020-10-10", "%Y-%m-%d%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"2020-10-10abcde123abcdef", "%Y-%m-%d%@%#", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
 	}
 
 	fc := funcs[ast.StrToDate]

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -1411,6 +1411,13 @@ func (s *testEvaluatorSuite) TestStrToDate(c *C) {
 		{"15-01-2001 1:9:8.999", "%d-%m-%Y %H:%i:%S.%f", true, time.Date(2001, 1, 15, 1, 9, 8, 999000000, time.Local)},
 		{"2003-01-02 10:11:12 PM", "%Y-%m-%d %H:%i:%S %p", false, time.Time{}},
 		{"10:20:10AM", "%H:%i:%S%p", false, time.Time{}},
+		// test %@(skip alpha), %#(skip number), %.(skip punct)
+		{"2020-10-10ABCD", "%Y-%m-%d%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"2020-10-101234", "%Y-%m-%d%#", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"2020-10-10....", "%Y-%m-%d%.", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"2020-10-10.1", "%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"abcd2020-10-10.1", "%@%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
+		{"abcd-2020-10-10.1", "%@-%Y-%m-%d%.%#%@", true, time.Date(2020, 10, 10, 0, 0, 0, 0, time.Local)},
 	}
 
 	fc := funcs[ast.StrToDate]

--- a/types/time.go
+++ b/types/time.go
@@ -2896,9 +2896,9 @@ var dateFormatParserTable = map[string]dateFormatParser{
 	"%S": secondsNumeric,        // Seconds (00..59)
 	"%T": time24Hour,            // Time, 24-hour (hh:mm:ss)
 	"%Y": yearNumericFourDigits, // Year, numeric, four digits
-	"%#": skipAllNums,           // skip all numbers
-	"%.": skipAllPunct,          // skip all punctation characters
-	"%@": skipAllAlpha,          // skip all alpha characters
+	"%#": skipAllNums,           // Skip all numbers
+	"%.": skipAllPunct,          // Skip all punctation characters
+	"%@": skipAllAlpha,          // Skip all alpha characters
 	// Deprecated since MySQL 5.7.5
 	"%y": yearNumericTwoDigits, // Year, numeric (two digits)
 	// TODO: Add the following...

--- a/types/time.go
+++ b/types/time.go
@@ -2896,6 +2896,9 @@ var dateFormatParserTable = map[string]dateFormatParser{
 	"%S": secondsNumeric,        // Seconds (00..59)
 	"%T": time24Hour,            // Time, 24-hour (hh:mm:ss)
 	"%Y": yearNumericFourDigits, // Year, numeric, four digits
+	"%#": skipAllNums,           // skip all numbers
+	"%.": skipAllPunct,          // skip all punctation characters
+	"%@": skipAllAlpha,          // skip all alpha characters
 	// Deprecated since MySQL 5.7.5
 	"%y": yearNumericTwoDigits, // Year, numeric (two digits)
 	// TODO: Add the following...
@@ -3275,4 +3278,40 @@ func DateTimeIsOverflow(sc *stmtctx.StatementContext, date Time) (bool, error) {
 
 	inRange := (t.After(b) || t.Equal(b)) && (t.Before(e) || t.Equal(e))
 	return !inRange, nil
+}
+
+func skipAllNums(t *CoreTime, input string, ctx map[string]int) (string, bool) {
+	retIdx := 0
+	for i, ch := range input {
+		if unicode.IsNumber(ch) {
+			retIdx = i + 1
+		} else {
+			break
+		}
+	}
+	return input[retIdx:], true
+}
+
+func skipAllPunct(t *CoreTime, input string, ctx map[string]int) (string, bool) {
+	retIdx := 0
+	for i, ch := range input {
+		if unicode.IsPunct(ch) {
+			retIdx = i + 1
+		} else {
+			break
+		}
+	}
+	return input[retIdx:], true
+}
+
+func skipAllAlpha(t *CoreTime, input string, ctx map[string]int) (string, bool) {
+	retIdx := 0
+	for i, ch := range input {
+		if unicode.IsLetter(ch) {
+			retIdx = i + 1
+		} else {
+			break
+		}
+	}
+	return input[retIdx:], true
 }


### PR DESCRIPTION
close #22530 

What's Changed: add three function to parse 
1. %#: skip numbers
2. %.: skip punct
3. %@: skip alpha

How it Works: If got %# in format specifier, iterate input string and skip all number. Same for the other two.

### Related changes
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression: No perfmance regression
- Breaking backward compatibility: No compatibility issue

### Release note <!-- bugfixes or new feature need a release note -->
- add three format specifier for str_to_date expression
