### PR TITLE
store/tikv: extract GetTiFlashAddrs from MPPClient

### DIFF
--- a/store/tikv/mpp.go
+++ b/store/tikv/mpp.go
@@ -43,14 +43,10 @@ func (c *batchCopTask) GetAddress() string {
 
 func (c *MPPClient) selectAllTiFlashStore() []kv.MPPTaskMeta {
 	resultTasks := make([]kv.MPPTaskMeta, 0)
-	c.store.regionCache.storeMu.RLock()
-	for _, st := range c.store.regionCache.storeMu.stores {
-		if st.storeType == kv.TiFlash {
-			task := &batchCopTask{storeAddr: st.addr, cmdType: tikvrpc.CmdMPPTask}
-			resultTasks = append(resultTasks, task)
-		}
+	for _, addr := range c.store.regionCache.GetTiFlashStoreAddrs() {
+		task := &batchCopTask{storeAddr: addr, cmdType: tikvrpc.CmdMPPTask}
+		resultTasks = append(resultTasks, task)
 	}
-	c.store.regionCache.storeMu.RUnlock()
 	return resultTasks
 }
 

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1244,6 +1244,19 @@ func (c *RegionCache) PDClient() pd.Client {
 	return c.pdClient
 }
 
+// GetTiFlashStoreAddrs returns addresses of all tiflash nodes.
+func (c *RegionCache) GetTiFlashStoreAddrs() []string {
+	c.storeMu.RLock()
+	defer c.storeMu.RUnlock()
+	var addrs []string
+	for _, s := range c.storeMu.stores {
+		if s.storeType == kv.TiFlash {
+			addrs = append(addrs, s.addr)
+		}
+	}
+	return addrs
+}
+
 // btreeItem is BTree's Item that uses []byte to compare.
 type btreeItem struct {
 	key          []byte


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
MPPClient is tightly coupled with RegionCache. Hard to move out of store/tikv.
Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- extract a new function for RegionCache 

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note