### PR TITLE
expression, types: fix overflow ret val in mydecimal.ToUint

### DIFF
--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -1049,7 +1049,7 @@ func (d *MyDecimal) ToInt() (int64, error) {
 // ToUint returns int part of the decimal, returns the result and errcode.
 func (d *MyDecimal) ToUint() (uint64, error) {
 	if d.negative {
-		return uint64(math.MaxInt64+1), ErrOverflow
+		return uint64(math.MaxInt64 + 1), ErrOverflow
 	}
 	var x uint64
 	wordIdx := 0

--- a/types/mydecimal.go
+++ b/types/mydecimal.go
@@ -1049,7 +1049,7 @@ func (d *MyDecimal) ToInt() (int64, error) {
 // ToUint returns int part of the decimal, returns the result and errcode.
 func (d *MyDecimal) ToUint() (uint64, error) {
 	if d.negative {
-		return 0, ErrOverflow
+		return uint64(math.MaxInt64+1), ErrOverflow
 	}
 	var x uint64
 	wordIdx := 0

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -14,6 +14,7 @@
 package types
 
 import (
+	"math"
 	"strings"
 	"testing"
 
@@ -100,7 +101,8 @@ func (s *testMyDecimalSuite) TestToUint(c *C) {
 		/* ULLONG_MAX = 18446744073709551615ULL */
 		{"18446744073709551615", 18446744073709551615, nil},
 		{"18446744073709551616", 18446744073709551615, ErrOverflow},
-		{"-1", 0, ErrOverflow},
+		{"-1", uint64(math.MaxInt64+1), ErrOverflow},
+		{"-9223372036854775809", uint64(math.MaxInt64+1), ErrOverflow},
 		{"1.23", 1, ErrTruncated},
 		{"9999999999999999999999999.000", 18446744073709551615, ErrOverflow},
 	}

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -101,8 +101,8 @@ func (s *testMyDecimalSuite) TestToUint(c *C) {
 		/* ULLONG_MAX = 18446744073709551615ULL */
 		{"18446744073709551615", 18446744073709551615, nil},
 		{"18446744073709551616", 18446744073709551615, ErrOverflow},
-		{"-1", uint64(math.MaxInt64+1), ErrOverflow},
-		{"-9223372036854775809", uint64(math.MaxInt64+1), ErrOverflow},
+		{"-1", uint64(math.MaxInt64 + 1), ErrOverflow},
+		{"-9223372036854775809", uint64(math.MaxInt64 + 1), ErrOverflow},
 		{"1.23", 1, ErrTruncated},
 		{"9999999999999999999999999.000", 18446744073709551615, ErrOverflow},
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #22827 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed: `mydecimal.ToUint()` returns correct overflow value if mydecimal is negative.

How it Works:
In current version, `mydecimal.ToUint()` returns 0 if `mydecimal` is negative, leading to #22827. 

During parsing of `cast`, only expressions smaller than `math.MinInt64` will be treated as `myDecimal`. 

Queries like `select cast(val as unsigned)` actually treat val as BIGINT, therefore if val is smaller than `math.MinInt64`, overflow happens, but `cast` tolerates overflow and returns truncated result instead, i.e. val truncated to `math.Min/MaxInt64`.

```
select cast(-92233720368547758099999999999999999999999009999 as unsigned);         
+--------------------------------------------------------------------+
| cast(-92233720368547758099999999999999999999999009999 as unsigned) |
+--------------------------------------------------------------------+
| 9223372036854775808                                                |
+--------------------------------------------------------------------+
```

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- fix overflow ret val in mydecimal.ToUint