### PR TITLE
txn: fix retry with non autocommit

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -664,18 +664,6 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 			if err != nil {
 				return err
 			}
-			pessTxnConf := config.GetGlobalConfig().PessimisticTxn
-			if pessTxnConf.Enable {
-				if s.sessionVars.TxnMode == ast.Pessimistic {
-					s.sessionVars.TxnCtx.IsPessimistic = true
-				}
-			}
-			// Complete the missing settings using `NewTxn` compared with lazy activation `txn.Txn(true)`.
-			// More refactors are needed in the future to make the inner logic of transaction activation
-			// interfaces the same.
-			if s.sessionVars.TxnCtx.IsPessimistic {
-				s.txn.SetOption(kv.Pessimistic, true)
-			}
 			if !s.sessionVars.IsAutocommit() {
 				s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
 			}

--- a/session/session.go
+++ b/session/session.go
@@ -670,6 +670,15 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 					s.sessionVars.TxnCtx.IsPessimistic = true
 				}
 			}
+			// Complete the missing settings using `NewTxn` compared with lazy activation `txn.Txn(true)`.
+			// More refactors are needed in the future to make the inner logic of transaction activation
+			// interfaces the same.
+			if s.sessionVars.TxnCtx.IsPessimistic {
+				s.txn.SetOption(kv.Pessimistic, true)
+			}
+			if !s.sessionVars.IsAutocommit() {
+				s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
+			}
 		} else {
 			s.PrepareTxnCtx(ctx)
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -664,9 +664,7 @@ func (s *session) retry(ctx context.Context, maxCnt uint) (err error) {
 			if err != nil {
 				return err
 			}
-			if !s.sessionVars.IsAutocommit() {
-				s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
-			}
+			s.sessionVars.SetStatusFlag(mysql.ServerStatusInTrans, true)
 		} else {
 			s.PrepareTxnCtx(ctx)
 		}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -3486,3 +3486,64 @@ func (s *testSessionSerialSuite) TestProcessInfoIssue22068(c *C) {
 	c.Assert(pi.Plan, IsNil)
 	wg.Wait()
 }
+
+func (s *testSessionSuite2) TestNonAutocommitTxnRetry(c *C) {
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("drop table if exists t")
+	tk1.MustExec("create table t(pk varchar(50), c1 varchar(50), c2 varchar(50), key k1(c1, c2), primary key(pk))")
+	tk1.MustExec("insert into t values ('1', '10', '100')")
+
+	tk1.MustExec("set tidb_disable_txn_auto_retry = 0")
+	tk1.MustExec("set autocommit = 0")
+	tk1.MustExec("set tidb_txn_mode = ''")
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("update t set c1 = '11' where pk = '1'")
+	tk1.MustExec("update t set c2 = '101' where pk = '1'")
+	tk2.MustExec("begin optimistic")
+	tk2.MustQuery("select * from t for update").Check(testkit.Rows("1 10 100"))
+	tk2.MustExec("commit")
+	tk1.MustExec("commit")
+	tk2.MustExec("admin check table t")
+	tk2.MustQuery("select * from t use index(k1)").Check(testkit.Rows("1 11 101"))
+	tk2.MustQuery("select * from t where pk = '1'").Check(testkit.Rows("1 11 101"))
+}
+
+func (s *testSessionSuite2) TestAutocommitTxnRetry(c *C) {
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("drop table if exists t")
+	tk1.MustExec("create table t(pk varchar(50), c1 varchar(50), c2 varchar(50), key k1(c1, c2), primary key(pk))")
+	tk1.MustExec("insert into t values ('1', '10', '100')")
+
+	tk1.MustExec("set tidb_disable_txn_auto_retry = 0")
+	tk1.MustExec("set autocommit = 0")
+	tk1.MustExec("begin optimistic")
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("update t set c1 = '11' where pk = '1'")
+	tk1.MustExec("update t set c2 = '101' where pk = '1'")
+	tk2.MustExec("begin optimistic")
+	tk2.MustQuery("select * from t for update").Check(testkit.Rows("1 10 100"))
+	tk2.MustExec("commit")
+	tk1.MustExec("commit")
+	tk2.MustExec("admin check table t")
+	tk2.MustQuery("select * from t use index(k1)").Check(testkit.Rows("1 11 101"))
+	tk2.MustQuery("select * from t where pk = '1'").Check(testkit.Rows("1 11 101"))
+}
+
+func (s *testSessionSuite2) TestRetryWithSet(c *C) {
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	tk1.MustExec("drop table if exists t")
+	tk1.MustExec("create table t(pk varchar(50), c1 bigint, c2 varchar(50), key k1(c1, c2), primary key(pk))")
+	tk1.MustExec("insert into t values ('1', '10', '100')")
+
+	tk1.MustExec("set tidb_disable_txn_auto_retry = 0")
+	tk1.MustExec("set autocommit = 0")
+	tk1.MustQuery("select * from t").Check(testkit.Rows("1 10 100"))
+	tk1.MustExec("set @a=@@tidb_current_ts")
+	tk1.MustExec("update t set c1 = @a where pk = '1'")
+	tk2 := testkit.NewTestKitWithInit(c, s.store)
+	tk2.MustExec("begin optimistic")
+	tk2.MustQuery("select * from t for update").Check(testkit.Rows("1 10 100"))
+	tk2.MustExec("commit")
+	tk1.MustExec("commit")
+	tk1.MustQuery("select c1 > 0 from t").Check(testkit.Rows("1"))
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22874 

Problem Summary:
The txn retry for non autocommit mode does not set flag correctly like `mysql.ServerStatusInTrans`.

### What is changed and how it works?


What's Changed:
- ~~Try to make transaction activiation use the same logic for common and retrying transactions.~~
- ~~Make multiple transaction activiation interfaces use the same inner activiation logic, avoid maintaining duplicate codes.(There is still some refactor work need to do for this part, these transaction interfaces are diffuicult to distinguish and use).~~
- ~~There are three different transaction activiation interfaces, `NewTxn`, `txn.Txn(true)`, `initTxnWithStartTS`, and they have some their own initilizing logic.~~
- Above issues will be recorded as refactor tasks in the future, to lower the changing risk in release branch.
- Add flag for the multiple statments transaction retry path.

How it Works:

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that transaction retry with non-autocommit mode may write incorrect data. 
