### PR TITLE
server, session: use sqlexec escaping library

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -989,7 +989,11 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 func (cc *clientConn) useDB(ctx context.Context, db string) (err error) {
 	// if input is "use `SELECT`", mysql client just send "SELECT"
 	// so we add `` around db.
-	_, err = cc.ctx.Execute(ctx, "use `"+db+"`")
+	sql, err := sqlexec.EscapeSQL("use %n", db)
+	if err != nil {
+		return err
+	}
+	_, err = cc.ctx.Execute(ctx, sql)
 	if err != nil {
 		return err
 	}

--- a/server/sql_info_fetcher.go
+++ b/server/sql_info_fetcher.go
@@ -284,7 +284,11 @@ func (sh *sqlInfoFetcher) getStatsForTable(pair tableNamePair) (*handle.JSONTabl
 }
 
 func (sh *sqlInfoFetcher) getShowCreateTable(pair tableNamePair, zw *zip.Writer) error {
-	recordSets, err := sh.s.(sqlexec.SQLExecutor).Execute(context.TODO(), fmt.Sprintf("show create table `%v`.`%v`", pair.DBName, pair.TableName))
+	sql, err := sqlexec.EscapeSQL("SHOW CREATE TABLE %n.%n", pair.DBName, pair.TableName)
+	if err != nil {
+		return err
+	}
+	recordSets, err := sh.s.(sqlexec.SQLExecutor).Execute(context.TODO(), sql)
 	if len(recordSets) > 0 {
 		defer terror.Call(recordSets[0].Close)
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -934,8 +934,7 @@ func (s *session) GetAllSysVars() (map[string]string, error) {
 	if s.Value(sessionctx.Initing) != nil {
 		return nil, nil
 	}
-	sql := `SELECT VARIABLE_NAME, VARIABLE_VALUE FROM %s.%s;`
-	sql = fmt.Sprintf(sql, mysql.SystemDB, mysql.GlobalVariablesTable)
+	sql := sqlexec.MustEscapeSQL("SELECT VARIABLE_NAME, VARIABLE_VALUE FROM %n.%n", mysql.SystemDB, mysql.GlobalVariablesTable)
 	rows, _, err := s.ExecRestrictedSQL(s, sql)
 	if err != nil {
 		return nil, err
@@ -954,8 +953,7 @@ func (s *session) GetGlobalSysVar(name string) (string, error) {
 		// When running bootstrap or upgrade, we should not access global storage.
 		return "", nil
 	}
-	sql := fmt.Sprintf(`SELECT VARIABLE_VALUE FROM %s.%s WHERE VARIABLE_NAME="%s";`,
-		mysql.SystemDB, mysql.GlobalVariablesTable, name)
+	sql := sqlexec.MustEscapeSQL(`SELECT VARIABLE_VALUE FROM %n.%n WHERE VARIABLE_NAME=%?`, mysql.SystemDB, mysql.GlobalVariablesTable, name)
 	sysVar, err := s.getExecRet(s, sql)
 	if err != nil {
 		if executor.ErrResultIsEmpty.Equal(err) {
@@ -984,8 +982,7 @@ func (s *session) SetGlobalSysVar(name, value string) error {
 		return err
 	}
 	name = strings.ToLower(name)
-	sql := fmt.Sprintf(`REPLACE %s.%s VALUES ('%s', '%s');`,
-		mysql.SystemDB, mysql.GlobalVariablesTable, name, sVal)
+	sql := sqlexec.MustEscapeSQL(`REPLACE %n.%n VALUES (%?, %?);`, mysql.SystemDB, mysql.GlobalVariablesTable, name, sVal)
 	_, _, err = s.ExecRestrictedSQL(s, sql)
 	return err
 }

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -276,8 +276,8 @@ func (s *testUtilsSuite) TestEscapeSQL(c *C) {
 		{
 			name:   "time 3",
 			input:  "select %?",
-			params: []interface{}{time.Unix(0, 888888888)},
-			output: "select '1970-01-01 08:00:00.888888'",
+			params: []interface{}{time.Unix(0, 888888888).UTC()},
+			output: "select '1970-01-01 00:00:00.888888'",
 			err:    "",
 		},
 		{


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

use sqlexec formatting library for 3.0 branch on packages server and session.

There is also a case where the testsuite is dependent on +8:00 timezone which has been fixed.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No Release Note
