### PR TITLE
server, session: use sqlexec escaping library

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -715,7 +715,11 @@ func (cc *clientConn) dispatch(ctx context.Context, data []byte) error {
 func (cc *clientConn) useDB(ctx context.Context, db string) (err error) {
 	// if input is "use `SELECT`", mysql client just send "SELECT"
 	// so we add `` around db.
-	_, err = cc.ctx.Execute(ctx, "use `"+db+"`")
+	sql, err := sqlexec.EscapeSQL("use %n", db)
+	if err != nil {
+		return err
+	}
+	_, err = cc.ctx.Execute(ctx, sql)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/server/conn.go
+++ b/server/conn.go
@@ -64,6 +64,7 @@ import (
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/memory"
+	"github.com/pingcap/tidb/util/sqlexec"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 )

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -276,8 +276,8 @@ func (s *testUtilsSuite) TestEscapeSQL(c *C) {
 		{
 			name:   "time 3",
 			input:  "select %?",
-			params: []interface{}{time.Unix(0, 888888888)},
-			output: "select '1970-01-01 08:00:00.888888'",
+			params: []interface{}{time.Unix(0, 888888888).UTC()},
+			output: "select '1970-01-01 00:00:00.888888'",
 			err:    "",
 		},
 		{


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

use sqlexec formatting library for 3.0 branch on packages server and session.

There is also a case where the testsuite is dependent on +8:00 timezone which has been fixed.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note