### PR TITLE
statistics: merge partition-level FMSketch to global-level FMSketch and update the column NDV

### DIFF
--- a/statistics/fmsketch.go
+++ b/statistics/fmsketch.go
@@ -104,6 +104,7 @@ func buildFMSketch(sc *stmtctx.StatementContext, values []types.Datum, maxSize i
 	return s, s.NDV(), nil
 }
 
+// MergeFMSketch merges two FM Sketch.
 func (s *FMSketch) MergeFMSketch(rs *FMSketch) {
 	if s == nil || rs == nil {
 		return

--- a/statistics/fmsketch.go
+++ b/statistics/fmsketch.go
@@ -104,7 +104,10 @@ func buildFMSketch(sc *stmtctx.StatementContext, values []types.Datum, maxSize i
 	return s, s.NDV(), nil
 }
 
-func (s *FMSketch) mergeFMSketch(rs *FMSketch) {
+func (s *FMSketch) MergeFMSketch(rs *FMSketch) {
+	if s == nil || rs == nil {
+		return
+	}
 	if s.mask < rs.mask {
 		s.mask = rs.mask
 		for key := range s.hashset {

--- a/statistics/fmsketch_test.go
+++ b/statistics/fmsketch_test.go
@@ -46,8 +46,8 @@ func (s *testStatisticsSuite) TestSketch(c *C) {
 	c.Check(err, IsNil)
 	c.Check(ndv, Equals, int64(100480))
 
-	sampleSketch.mergeFMSketch(pkSketch)
-	sampleSketch.mergeFMSketch(rcSketch)
+	sampleSketch.MergeFMSketch(pkSketch)
+	sampleSketch.MergeFMSketch(rcSketch)
 	c.Check(sampleSketch.NDV(), Equals, int64(100480))
 
 	maxSize = 2

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -323,6 +323,7 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc *stmtctx.StatementContext, i
 	globalStats.Hg = make([]*statistics.Histogram, globalStats.Num)
 	globalStats.Cms = make([]*statistics.CMSketch, globalStats.Num)
 	globalStats.TopN = make([]*statistics.TopN, globalStats.Num)
+	globalStats.Fms = make([]*statistics.FMSketch, globalStats.Num)
 
 	// The first dimension of slice is means the number of column or index stats in the globalStats.
 	// The second dimension of slice is means the number of partition tables.

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -427,6 +427,7 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc *stmtctx.StatementContext, i
 				}
 				globalStats.Hg[i].NDV = globalStatsNDV
 			}
+			// TODO: if the globalStats.Fms[i] == nil, we should to consider how to update the NDV.
 		} else {
 			// For the index stats, we get the final NDV by accumulating the NDV of each bucket in the index histogram.
 			globalStatsNDV := int64(0)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -420,14 +420,11 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc *stmtctx.StatementContext, i
 			}
 
 			// update the NDV
-			if globalStats.Fms[i] != nil {
-				globalStatsNDV := globalStats.Fms[i].NDV()
-				if globalStatsNDV > globalStats.Count {
-					globalStatsNDV = globalStats.Count
-				}
-				globalStats.Hg[i].NDV = globalStatsNDV
+			globalStatsNDV := globalStats.Fms[i].NDV()
+			if globalStatsNDV > globalStats.Count {
+				globalStatsNDV = globalStats.Count
 			}
-			// TODO: if the globalStats.Fms[i] == nil, we should to consider how to update the NDV.
+			globalStats.Hg[i].NDV = globalStatsNDV
 		} else {
 			// For the index stats, we get the final NDV by accumulating the NDV of each bucket in the index histogram.
 			globalStatsNDV := int64(0)

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -350,7 +350,7 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc *stmtctx.StatementContext, i
 		}
 		tableInfo := partitionTable.Meta()
 		var partitionStats *statistics.Table
-		partitionStats, err = h.TableStatsFromStorage(tableInfo, partitionID, false, 0)
+		partitionStats, err = h.TableStatsFromStorage(tableInfo, partitionID, true, 0)
 		if err != nil {
 			return
 		}

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -705,15 +705,15 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 
 	// Test the 'dynamic-only' mode
 	testKit.MustExec("set @@tidb_partition_prune_mode = 'dynamic-only';")
-	err := testKit.ExecToErr("analyze table t, t1;")
-	c.Assert(err.Error(), Equals, nil)
+	testKit.MustExec("analyze table t, t1;")
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
-	c.Assert(len(result.Rows()), Equals, 3)
-	c.Assert(result.Rows()[0][5], Equals, "1")
-	c.Assert(result.Rows()[1][5], Equals, "2")
+	c.Assert(len(result.Rows()), Equals, 4)
+	c.Assert(result.Rows()[0][5], Equals, "5")
+	c.Assert(result.Rows()[1][5], Equals, "1")
 	c.Assert(result.Rows()[2][5], Equals, "2")
+	c.Assert(result.Rows()[3][5], Equals, "2")
 	result = testKit.MustQuery("show stats_histograms where table_name = 't';").Sort()
-	c.Assert(len(result.Rows()), Equals, 15)
+	c.Assert(len(result.Rows()), Equals, 20)
 
 	result = testKit.MustQuery("show stats_meta where table_name = 't1';").Sort()
 	c.Assert(len(result.Rows()), Equals, 1)
@@ -721,15 +721,15 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 	result = testKit.MustQuery("show stats_histograms where table_name = 't1';").Sort()
 	c.Assert(len(result.Rows()), Equals, 1)
 
-	err = testKit.ExecToErr("analyze table t index idx_t_ab, idx_t_b;")
-	c.Assert(err.Error(), Equals, nil)
+	testKit.MustExec("analyze table t index idx_t_ab, idx_t_b;")
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
-	c.Assert(len(result.Rows()), Equals, 3)
-	c.Assert(result.Rows()[0][5], Equals, "1")
-	c.Assert(result.Rows()[1][5], Equals, "2")
+	c.Assert(len(result.Rows()), Equals, 4)
+	c.Assert(result.Rows()[0][5], Equals, "5")
+	c.Assert(result.Rows()[1][5], Equals, "1")
 	c.Assert(result.Rows()[2][5], Equals, "2")
+	c.Assert(result.Rows()[3][5], Equals, "2")
 	result = testKit.MustQuery("show stats_histograms where table_name = 't';").Sort()
-	c.Assert(len(result.Rows()), Equals, 15)
+	c.Assert(len(result.Rows()), Equals, 20)
 }
 
 func (s *testStatsSuite) TestExtendedStatsDefaultSwitch(c *C) {

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -705,8 +705,7 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 
 	// Test the 'dynamic-only' mode
 	testKit.MustExec("set @@tidb_partition_prune_mode = 'dynamic-only';")
-	err := testKit.ExecToErr("analyze table t, t1;")
-	c.Assert(err.Error(), Equals, "TODO: The merge function of the NDV has not been implemented yet")
+	testKit.MustExec("analyze table t, t1;")
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
 	c.Assert(len(result.Rows()), Equals, 3)
 	c.Assert(result.Rows()[0][5], Equals, "1")
@@ -721,8 +720,7 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 	result = testKit.MustQuery("show stats_histograms where table_name = 't1';").Sort()
 	c.Assert(len(result.Rows()), Equals, 1)
 
-	err = testKit.ExecToErr("analyze table t index idx_t_ab, idx_t_b;")
-	c.Assert(err.Error(), Equals, "TODO: The merge function of the NDV has not been implemented yet")
+	testKit.MustExec("analyze table t index idx_t_ab, idx_t_b;")
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
 	c.Assert(len(result.Rows()), Equals, 3)
 	c.Assert(result.Rows()[0][5], Equals, "1")

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -705,7 +705,8 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 
 	// Test the 'dynamic-only' mode
 	testKit.MustExec("set @@tidb_partition_prune_mode = 'dynamic-only';")
-	testKit.MustExec("analyze table t, t1;")
+	err := testKit.ExecToErr("analyze table t, t1;")
+	c.Assert(err.Error(), Equals, nil)
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
 	c.Assert(len(result.Rows()), Equals, 3)
 	c.Assert(result.Rows()[0][5], Equals, "1")
@@ -720,7 +721,8 @@ func (s *testStatsSuite) TestBuildGlobalLevelStats(c *C) {
 	result = testKit.MustQuery("show stats_histograms where table_name = 't1';").Sort()
 	c.Assert(len(result.Rows()), Equals, 1)
 
-	testKit.MustExec("analyze table t index idx_t_ab, idx_t_b;")
+	err = testKit.ExecToErr("analyze table t index idx_t_ab, idx_t_b;")
+	c.Assert(err.Error(), Equals, nil)
 	result = testKit.MustQuery("show stats_meta where table_name = 't'").Sort()
 	c.Assert(len(result.Rows()), Equals, 3)
 	c.Assert(result.Rows()[0][5], Equals, "1")

--- a/statistics/sample.go
+++ b/statistics/sample.go
@@ -107,7 +107,7 @@ func (c *SampleCollector) MergeSampleCollector(sc *stmtctx.StatementContext, rc 
 	c.NullCount += rc.NullCount
 	c.Count += rc.Count
 	c.TotalSize += rc.TotalSize
-	c.FMSketch.mergeFMSketch(rc.FMSketch)
+	c.FMSketch.MergeFMSketch(rc.FMSketch)
 	if rc.CMSketch != nil {
 		err := c.CMSketch.MergeCMSketch(rc.CMSketch)
 		terror.Log(errors.Trace(err))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

sub PR for #22554 

Problem Summary:
merge partition-level FMSketch to global-level FMSketch and update the column NDV

### What is changed and how it works?
Same as described above.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
