### PR TITLE
*: upgrade go version to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 # Builder image
-FROM golang:1.13-alpine as builder
+FROM golang:1.16-alpine as builder
 
 RUN apk add --no-cache \
     wget \

--- a/go.mod
+++ b/go.mod
@@ -84,4 +84,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-go 1.13
+go 1.16

--- a/tests/globalkilltest/go.mod
+++ b/tests/globalkilltest/go.mod
@@ -1,6 +1,6 @@
 module github.com/pingcap/tests/globalkilltest
 
-go 1.13
+go 1.16
 
 require (
 	github.com/go-sql-driver/mysql v1.5.0

--- a/tools/check/go.mod
+++ b/tools/check/go.mod
@@ -20,4 +20,4 @@ require (
 	honnef.co/go/tools v0.0.0-20180920025451-e3ad64cb4ed3
 )
 
-go 1.13
+go 1.16


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
go version is too old.

### What is changed and how it works?
What's Changed:
- use latest

### Release note <!-- bugfixes or new feature need a release note -->
- No release note
