### PR TITLE
planner, executor: reset NotNullFlag when merge schema for join

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7660,3 +7660,29 @@ func (s *testSerialSuite) TestStalenessTransactionSchemaVer(c *C) {
 		check()
 	}
 }
+
+func (s *testSuiteP1) TestIssue22941(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists m, mp")
+	tk.MustExec(`CREATE TABLE m (
+		mid varchar(50) NOT NULL,
+		ParentId varchar(50) DEFAULT NULL,
+		PRIMARY KEY (mid),
+		KEY ind_bm_parent (ParentId,mid)
+	)`)
+
+	tk.MustExec(`CREATE TABLE mp (
+		mpid bigint(20) unsigned NOT NULL DEFAULT '0',
+		mid varchar(50) DEFAULT NULL COMMENT '模块主键',
+	PRIMARY KEY (mpid)
+	);`)
+
+	tk.MustExec(`insert into mp values("1","1");`)
+	tk.MustExec(`insert into m values("0", "0");`)
+	rs := tk.MustQuery(`SELECT ( SELECT COUNT(1) FROM m WHERE ParentId = c.mid ) expand,  bmp.mpid,  bmp.mpid IS NULL,bmp.mpid IS NOT NULL FROM m c LEFT JOIN mp bmp ON c.mid = bmp.mid  WHERE c.ParentId = '0'`)
+	rs.Check(testkit.Rows("1 <nil> 1 0"))
+
+	rs = tk.MustQuery(`SELECT  bmp.mpid,  bmp.mpid IS NULL,bmp.mpid IS NOT NULL FROM m c LEFT JOIN mp bmp ON c.mid = bmp.mid  WHERE c.ParentId = '0'`)
+	rs.Check(testkit.Rows("<nil> 1 0"))
+}

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -317,6 +317,13 @@ func (p *LogicalJoin) mergeSchema() {
 		p.schema.Append(joinCol)
 	} else {
 		p.schema = expression.MergeSchema(lChild.Schema(), rChild.Schema())
+		switch p.JoinType {
+		case LeftOuterJoin, LeftOuterSemiJoin, AntiLeftOuterSemiJoin:
+			resetNotNullFlag(p.schema, p.children[1].Schema().Len(), p.schema.Len())
+		case RightOuterJoin:
+			resetNotNullFlag(p.schema, 0, p.children[0].Schema().Len())
+		default:
+		}
 	}
 }
 

--- a/planner/core/rule_column_pruning.go
+++ b/planner/core/rule_column_pruning.go
@@ -318,7 +318,7 @@ func (p *LogicalJoin) mergeSchema() {
 	} else {
 		p.schema = expression.MergeSchema(lChild.Schema(), rChild.Schema())
 		switch p.JoinType {
-		case LeftOuterJoin, LeftOuterSemiJoin, AntiLeftOuterSemiJoin:
+		case LeftOuterJoin:
 			resetNotNullFlag(p.schema, p.children[1].Schema().Len(), p.schema.Len())
 		case RightOuterJoin:
 			resetNotNullFlag(p.schema, 0, p.children[0].Schema().Len())


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/22941 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Root cause: The not null flag of a column is set to true wrongly even if this column is from the inner child of an outer join. Suppose the column is `a`, when calling `foldConstant(isnull(a))`, it'll be optimized to `0` because the optimizer thinks `a` will never be null.

### What is changed and how it works?

What's Changed:
Reset notNullFlag in mergeSchema.

How it Works:

1. Before this commit, [buildJoin](https://github.com/pingcap/tidb/blob/master/planner/core/logical_plan_builder.go#L710) will `resetNotNullFlag` for outer join. 
2. When doing column pruning, we'll [rebuild the schema](https://github.com/pingcap/tidb/blob/master/planner/core/rule_column_pruning.go#L319) for join using the schema of its children directly, thus the `notNullFlag` reset operation before is **rollbacked**.
3. In normal cases, `isnull` function is built when building the logical plan. Thus this bug will not be triggered because we'll not call foldConstant on isnull function.
4. But when the `projection elimination` rule is called, [foldConstant](https://github.com/pingcap/tidb/blob/master/planner/core/rule_eliminate_projection.go#L177) will be invoked on the `isnull` funtion, and the isnull is optimized to 0 wrongly.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the bug when the argument of the `is null` function is the inner side of an outer join.