### PR TITLE
.build.ps1: enable varcheck for powershell building script

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -154,7 +154,7 @@ task DownloadLinter -If (-not (Test-Path $tools.Linter.Path)) {
 }
 
 task RunLinter DownloadLinter, {
-    exec { & $tools.Linter.Path run -v --disable-all --deadline=3m --enable=misspell --enable=ineffassign $directories }
+    exec { & $tools.Linter.Path run -v --disable-all --deadline=3m --enable=misspell --enable=ineffassign --enable=varcheck $directories }
 }
 
 task GoModTidy {


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
`varcheck` is enabled in `Makefile`, but missed in `.build.ps1`.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Enable `varcheck` in `.build.ps1`.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
