### PR TITLE
ddl: add truncate partition all support

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -6588,6 +6588,7 @@ func (s *testSerialDBSuite) TestIssue22819(c *C) {
 	tk1.MustExec("update t1 set v = 2 where v = 1")
 
 	tk2.MustExec("alter table t1 truncate partition p0")
+	tk2.MustExec("alter table t1 truncate partition all")
 
 	_, err := tk1.Exec("commit")
 	c.Assert(err, ErrorMatches, ".*8028.*Information schema is changed during the execution of the statement.*")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -6600,8 +6600,8 @@ func (s *testSerialSuite) TestTruncateAllPartitions(c *C) {
 	defer func() {
 		tk1.MustExec("drop table if exists partition_table;")
 	}()
-	tk1.MustExec("create table partition_table (v int) partition by hash (v) partitions 2;")
-	tk1.MustExec("insert into partition_table values (1);")
+	tk1.MustExec("create table partition_table (v int) partition by hash (v) partitions 10;")
+	tk1.MustExec("insert into partition_table values (0),(1),(2),(3),(4),(5),(6),(7),(8),(9),(10);")
 	tk1.MustExec("alter table partition_table truncate partition all;")
 	tk1.MustQuery("select count(*) from partition_table;").Check(testkit.Rows("0"))
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2971,12 +2971,19 @@ func (d *ddl) TruncateTablePartition(ctx sessionctx.Context, ident ast.Ident, sp
 	}
 
 	pids := make([]int64, len(spec.PartitionNames))
-	for i, name := range spec.PartitionNames {
-		pid, err := tables.FindPartitionByName(meta, name.L)
-		if err != nil {
-			return errors.Trace(err)
+	if spec.OnAllPartitions {
+		pids = make([]int64, len(meta.GetPartitionInfo().Definitions))
+		for i, def := range meta.GetPartitionInfo().Definitions {
+			pids[i] = def.ID
 		}
-		pids[i] = pid
+	} else {
+		for i, name := range spec.PartitionNames {
+			pid, err := tables.FindPartitionByName(meta, name.L)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			pids[i] = pid
+		}
 	}
 
 	job := &model.Job{

--- a/go.mod
+++ b/go.mod
@@ -92,6 +92,4 @@ require (
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
-replace github.com/pingcap/parser v0.0.0-20210310110710-c7333a4927e6 => github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399
-
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
 	github.com/pingcap/kvproto v0.0.0-20210308063835-39b884695fb8
 	github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8
-	github.com/pingcap/parser v0.0.0-20210311132237-9841cb715606
+	github.com/pingcap/parser v0.0.0-20210314080929-ed8900c94180
 	github.com/pingcap/sysutil v0.0.0-20210221112134-a07bda3bde99
 	github.com/pingcap/tidb-tools v4.0.9-0.20201127090955-2707c97b3853+incompatible
 	github.com/pingcap/tipb v0.0.0-20210309080453-72c4feaa6da7

--- a/go.mod
+++ b/go.mod
@@ -91,5 +91,7 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-replace github.com/pingcap/parser v0.0.0-20210310110710-c7333a4927e6 => github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2
+
+replace github.com/pingcap/parser v0.0.0-20210310110710-c7333a4927e6 => github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399
+
 go 1.13

--- a/go.mod
+++ b/go.mod
@@ -91,5 +91,5 @@ require (
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
-
+replace github.com/pingcap/parser v0.0.0-20210310110710-c7333a4927e6 => github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -449,8 +449,8 @@ github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8 h1:M+DNpOu/I3uDmwee6vcnoPd6GgSMqND4gxvDQ/W584U=
 github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
-github.com/pingcap/parser v0.0.0-20210311132237-9841cb715606 h1:/d3CdGzpfCRbdKn38gYH4FGEXgTJCzfI8yroEfKcwbA=
-github.com/pingcap/parser v0.0.0-20210311132237-9841cb715606/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
+github.com/pingcap/parser v0.0.0-20210314080929-ed8900c94180 h1:pnTbjUpOib2uhBfm9R9P6n1huAvl5a9CtMysvI493hQ=
+github.com/pingcap/parser v0.0.0-20210314080929-ed8900c94180/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210221112134-a07bda3bde99 h1:/ogXgm4guJzow4UafiyXZ6ciAIPzxImaXYiFvTpKzKY=
 github.com/pingcap/sysutil v0.0.0-20210221112134-a07bda3bde99/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=

--- a/go.sum
+++ b/go.sum
@@ -25,10 +25,6 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0 h1:UDpwYIwla4jHGzZJaEJYx1tOejbgSoNqsAfHAUYe2r8=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2 h1:fGj6XwgHnkFBWwiMzAnIk2q8WHfDdWfd0EFIgNGHxB4=
-github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
-github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399 h1:NeX16l7yVilrHHqBlJXzBvH42EUu+60vf0ODWp+QQ3M=
-github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,10 @@ cloud.google.com/go/storage v1.5.0/go.mod h1:tpKbwo567HUNpVclU5sGELwQWBDZ8gh0Zeo
 cloud.google.com/go/storage v1.6.0 h1:UDpwYIwla4jHGzZJaEJYx1tOejbgSoNqsAfHAUYe2r8=
 cloud.google.com/go/storage v1.6.0/go.mod h1:N7U0C8pVQ/+NIKOBQyamJIeKQKkZ+mxpohlUTyfDhBk=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2 h1:fGj6XwgHnkFBWwiMzAnIk2q8WHfDdWfd0EFIgNGHxB4=
+github.com/AndrewDi/parser v0.0.0-20210301125952-abc04df118c2/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
+github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399 h1:NeX16l7yVilrHHqBlJXzBvH42EUu+60vf0ODWp+QQ3M=
+github.com/AndrewDi/parser v0.0.0-20210313124806-d0cf71c13399/go.mod h1:GbEr2PgY72/4XqPZzmzstlOU/+il/wrjeTNFs6ihsSE=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22704

Problem Summary:

### What is changed and how it works?

What's Changed:

if ddl contains `truncate partition all`, all current partition id will pass to `ddl_api`

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
- alter table truncate partition now support `all` option 