### PR TITLE
*: create int primary key table as nonclustered by default

### DIFF
--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -94,7 +94,7 @@ func newTester(name string) *tester {
 	t.enableQueryLog = true
 	t.ctx = mock.NewContext()
 	t.ctx.GetSessionVars().EnableWindowFunction = true
-
+	t.ctx.GetSessionVars().IntPrimaryKeyDefaultAsClustered = true
 	return t
 }
 
@@ -658,6 +658,7 @@ func main() {
 		"set @@tidb_projection_concurrency=4",
 		"set @@tidb_distsql_scan_concurrency=15",
 		"set @@global.tidb_enable_clustered_index=0;",
+		"set @@tidb_int_primary_key_default_as_clustered=1",
 	}
 	for _, sql := range resets {
 		if _, err = mdb.Exec(sql); err != nil {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1448,10 +1448,11 @@ func buildTableInfo(
 				}
 			case model.PrimaryKeyTypeDefault:
 				alterPKConf := config.GetGlobalConfig().AlterPrimaryKey
+				clustered := !alterPKConf && ctx.GetSessionVars().EnableClusteredIndex
 				if isSingleIntPK(constr, lastCol) {
-					tbInfo.PKIsHandle = !alterPKConf
+					tbInfo.PKIsHandle = clustered || (!alterPKConf && ctx.GetSessionVars().IntPrimaryKeyDefaultAsClustered)
 				} else {
-					tbInfo.IsCommonHandle = !alterPKConf && ctx.GetSessionVars().EnableClusteredIndex && noBinlog
+					tbInfo.IsCommonHandle = clustered && noBinlog
 					if tbInfo.IsCommonHandle {
 						tbInfo.CommonHandleVersion = 1
 					}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1453,11 +1453,10 @@ func buildTableInfo(
 				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = true --> int pk must be clustered
 				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = false --> all pk must be nonclustered [Default]
 				alterPKConf := config.GetGlobalConfig().AlterPrimaryKey
-				clustered := !alterPKConf && ctx.GetSessionVars().EnableClusteredIndex
 				if isSingleIntPK(constr, lastCol) {
-					tbInfo.PKIsHandle = clustered || (!alterPKConf && ctx.GetSessionVars().IntPrimaryKeyDefaultAsClustered)
+					tbInfo.PKIsHandle = !alterPKConf && (ctx.GetSessionVars().EnableClusteredIndex || ctx.GetSessionVars().IntPrimaryKeyDefaultAsClustered)
 				} else {
-					tbInfo.IsCommonHandle = clustered && noBinlog
+					tbInfo.IsCommonHandle = !alterPKConf && ctx.GetSessionVars().EnableClusteredIndex && noBinlog
 					if tbInfo.IsCommonHandle {
 						tbInfo.CommonHandleVersion = 1
 					}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1447,6 +1447,11 @@ func buildTableInfo(
 					}
 				}
 			case model.PrimaryKeyTypeDefault:
+				// AlterPrimaryKey = true ----> all pk must be nonclustered
+				// AlterPrimaryKey = false + EnableClusteredIndex = true + noBinlog ---> all pk must be clustered
+				// AlterPrimaryKey = false + EnableClusteredIndex = true + HasBinlog ---> int pk must be clustered, other must be nonclustered
+				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = true --> int pk must be clustered
+				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = false --> all pk must be nonclustered [Default]
 				alterPKConf := config.GetGlobalConfig().AlterPrimaryKey
 				clustered := !alterPKConf && ctx.GetSessionVars().EnableClusteredIndex
 				if isSingleIntPK(constr, lastCol) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1447,11 +1447,11 @@ func buildTableInfo(
 					}
 				}
 			case model.PrimaryKeyTypeDefault:
-				// AlterPrimaryKey = true ----> all pk must be nonclustered
-				// AlterPrimaryKey = false + EnableClusteredIndex = true + noBinlog ---> all pk must be clustered
-				// AlterPrimaryKey = false + EnableClusteredIndex = true + HasBinlog ---> int pk must be clustered, other must be nonclustered
-				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = true --> int pk must be clustered
-				// AlterPrimaryKey = false + EnableClusteredIndex = false + IntPrimaryKeyDefaultAsClustered = false --> all pk must be nonclustered [Default]
+				// (AlterPrimaryKey = true) ----> all pk must be nonclustered
+				// (AlterPrimaryKey = false) + (EnableClusteredIndex = true) + noBinlog ---> all pk must be clustered
+				// (AlterPrimaryKey = false) + (EnableClusteredIndex = true) + HasBinlog ---> int pk must be clustered, other must be nonclustered
+				// (AlterPrimaryKey = false) + (EnableClusteredIndex = false) + (IntPrimaryKeyDefaultAsClustered = true) --> int pk must be clustered
+				// (AlterPrimaryKey = false) + (EnableClusteredIndex = false) + (IntPrimaryKeyDefaultAsClustered = false) --> all pk must be nonclustered [Default]
 				alterPKConf := config.GetGlobalConfig().AlterPrimaryKey
 				if isSingleIntPK(constr, lastCol) {
 					tbInfo.PKIsHandle = !alterPKConf && (ctx.GetSessionVars().EnableClusteredIndex || ctx.GetSessionVars().IntPrimaryKeyDefaultAsClustered)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/versioninfo"
 	"go.uber.org/zap"
@@ -109,6 +110,7 @@ func (cli *testServerClient) getDSN(overriders ...configOverrider) string {
 	config.Net = "tcp"
 	config.Addr = fmt.Sprintf("127.0.0.1:%d", cli.port)
 	config.DBName = "test"
+	config.Params = map[string]string{variable.TiDBIntPrimaryKeyDefaultAsClustered: "true"}
 	for _, overrider := range overriders {
 		if overrider != nil {
 			overrider(config)
@@ -403,7 +405,7 @@ func (cli *testServerClient) runTestPreparedTimestamp(t *C) {
 func (cli *testServerClient) runTestLoadDataWithSelectIntoOutfile(c *C, server *Server) {
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "SelectIntoOutfile", func(dbt *DBTest) {
 		dbt.mustExec("create table t (i int, r real, d decimal(10, 5), s varchar(100), dt datetime, ts timestamp, j json)")
 		dbt.mustExec("insert into t values (1, 1.1, 0.1, 'a', '2000-01-01', '01:01:01', '[1]')")
@@ -467,7 +469,7 @@ func (cli *testServerClient) runTestLoadDataForSlowLog(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_slow_query", func(dbt *DBTest) {
 		dbt.mustExec("create table t_slow (a int key, b int)")
 		defer func() {
@@ -558,7 +560,7 @@ func (cli *testServerClient) runTestLoadDataAutoRandom(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_batch_dml", func(dbt *DBTest) {
 		// Set batch size, and check if load data got a invalid txn error.
 		dbt.mustExec("set @@session.tidb_dml_batch_size = 128")
@@ -583,7 +585,7 @@ func (cli *testServerClient) runTestLoadDataForListPartition(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_list_partition", func(dbt *DBTest) {
 		dbt.mustExec("set @@session.tidb_enable_list_partition = ON")
 		dbt.mustExec(`create table t (id int, name varchar(10),
@@ -632,7 +634,7 @@ func (cli *testServerClient) runTestLoadDataForListPartition2(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_list_partition", func(dbt *DBTest) {
 		dbt.mustExec("set @@session.tidb_enable_list_partition = ON")
 		dbt.mustExec(`create table t (id int, name varchar(10),b int generated always as (length(name)+1) virtual,
@@ -681,7 +683,7 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_list_partition", func(dbt *DBTest) {
 		dbt.mustExec("set @@session.tidb_enable_list_partition = ON")
 		dbt.mustExec(`create table t (id int, name varchar(10),
@@ -730,7 +732,7 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition2(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "load_data_list_partition", func(dbt *DBTest) {
 		dbt.mustExec("set @@session.tidb_enable_list_partition = ON")
 		dbt.mustExec(`create table t (location varchar(10), id int, a int, unique index idx (location,id)) partition by list columns (location,id) (
@@ -834,7 +836,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 	// support ClientLocalFiles capability
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("set @@tidb_dml_batch_size = 3")
 		dbt.mustExec("create table test (a varchar(255), b varchar(255) default 'default value', c int not null auto_increment, primary key(c))")
@@ -976,7 +978,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("create table test (str varchar(10) default null, i int default null)")
 		dbt.mustExec("set @@tidb_dml_batch_size = 3")
@@ -1022,7 +1024,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("create table test (a date, b date, c date not null, d date)")
 		dbt.mustExec("set @@tidb_dml_batch_size = 3")
@@ -1076,7 +1078,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("create table test (a varchar(20), b varchar(20))")
 		dbt.mustExec("set @@tidb_dml_batch_size = 3")
@@ -1172,7 +1174,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists pn")
 		dbt.mustExec("create table pn (c1 int, c2 int)")
@@ -1224,7 +1226,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists pn")
 		dbt.mustExec("create table pn (c1 int, c2 int)")
@@ -1268,7 +1270,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists pn")
 		dbt.mustExec("create table pn (c1 int, c2 int, c3 int)")
@@ -1315,7 +1317,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "LoadData", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists pn")
 		dbt.mustExec("create table pn (c1 int, c2 int, c3 int)")
@@ -1349,7 +1351,7 @@ func (cli *testServerClient) runTestLoadData(c *C, server *Server) {
 func (cli *testServerClient) runTestConcurrentUpdate(c *C) {
 	dbName := "Concurrent"
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, dbName, func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists test2")
 		dbt.mustExec("create table test2 (a int, b int)")
@@ -1609,7 +1611,7 @@ func (cli *testServerClient) runTestDBNameEscape(c *C) {
 
 func (cli *testServerClient) runTestResultFieldTableIsNull(c *C) {
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}, "ResultFieldTableIsNull", func(dbt *DBTest) {
 		dbt.mustExec("drop table if exists test;")
 		dbt.mustExec("create table test (c int);")
@@ -1697,7 +1699,7 @@ func (cli *testServerClient) runFailedTestMultiStatements(c *C) {
 func (cli *testServerClient) runTestMultiStatements(c *C) {
 
 	cli.runTestsOnNewDB(c, func(config *mysql.Config) {
-		config.Params = map[string]string{"multiStatements": "true"}
+		config.Params["multiStatements"] = "true"
 	}, "MultiStatements", func(dbt *DBTest) {
 		// Create Table
 		dbt.mustExec("CREATE TABLE `test` (`id` int(11) NOT NULL, `value` int(11) NOT NULL) ")

--- a/server/statistics_handler_test.go
+++ b/server/statistics_handler_test.go
@@ -212,7 +212,7 @@ func (ds *testDumpStatsSuite) checkCorrelation(c *C) {
 func (ds *testDumpStatsSuite) checkData(c *C, path string) {
 	db, err := sql.Open("mysql", ds.getDSN(func(config *mysql.Config) {
 		config.AllowAllFiles = true
-		config.Params = map[string]string{"sql_mode": "''"}
+		config.Params["sql_mode"] = "''"
 	}))
 	c.Assert(err, IsNil, Commentf("Error connecting"))
 	dbt := &DBTest{c, db}

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -166,7 +166,7 @@ const (
   		description 		TEXT NOT NULL,
   		example 			TEXT NOT NULL,
   		url 				TEXT NOT NULL,
-  		PRIMARY KEY (help_topic_id),
+  		PRIMARY KEY (help_topic_id) clustered,
   		UNIQUE KEY name (name)
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8 STATS_PERSISTENT=0 COMMENT='help topics';`
 

--- a/session/session.go
+++ b/session/session.go
@@ -2011,6 +2011,7 @@ func CreateSession4TestWithOpt(store kv.Storage, opt *Opt) (Session, error) {
 		// initialize session variables for test.
 		s.GetSessionVars().InitChunkSize = 2
 		s.GetSessionVars().MaxChunkSize = 32
+		s.GetSessionVars().IntPrimaryKeyDefaultAsClustered = true
 	}
 	return s, err
 }

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -818,6 +818,10 @@ type SessionVars struct {
 	// AllowFallbackToTiKV indicates the engine types whose unavailability triggers fallback to TiKV.
 	// Now we only support TiFlash.
 	AllowFallbackToTiKV map[kv.StoreType]struct{}
+
+	// IntPrimaryKeyDefaultAsClustered indicates whether create integer primary table as clustered
+	// when `@@tidb_enable_clustered_index=0` and create-table stmt without `clustered`, like 4.0 behavior.
+	IntPrimaryKeyDefaultAsClustered bool
 }
 
 // CheckAndGetTxnScope will return the transaction scope we should use in the current session.
@@ -1758,6 +1762,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 				s.AllowFallbackToTiKV[kv.TiFlash] = struct{}{}
 			}
 		}
+	case TiDBIntPrimaryKeyDefaultAsClustered:
+		s.IntPrimaryKeyDefaultAsClustered = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -820,7 +820,7 @@ type SessionVars struct {
 	AllowFallbackToTiKV map[kv.StoreType]struct{}
 
 	// IntPrimaryKeyDefaultAsClustered indicates whether create integer primary table as clustered
-	// when `@@tidb_enable_clustered_index=0` and create-table stmt without `clustered`, like 4.0 behavior.
+	// If it's true, the behavior is the same as the TiDB 4.0 and the below versions.
 	IntPrimaryKeyDefaultAsClustered bool
 }
 

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -694,6 +694,7 @@ var defaultSysVars = []*SysVar{
 		}
 		return formatVal, nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBIntPrimaryKeyDefaultAsClustered, Value: BoolToOnOff(false), Type: TypeBool},
 	/* The following variable is defined as session scope but is actually server scope. */
 	{Scope: ScopeSession, Name: TiDBGeneralLog, Value: BoolToOnOff(DefTiDBGeneralLog), Type: TypeBool},
 	{Scope: ScopeSession, Name: TiDBPProfSQLCPU, Value: strconv.Itoa(DefTiDBPProfSQLCPU), Type: TypeInt, MinValue: 0, MaxValue: 1},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -529,6 +529,9 @@ const (
 	// TiDBAllowFallbackToTiKV indicates the engine types whose unavailability triggers fallback to TiKV.
 	// Now we only support TiFlash.
 	TiDBAllowFallbackToTiKV = "tidb_allow_fallback_to_tikv"
+
+	// TiDBIntPrimaryKeyDefaultAsClustered indicates whether create int primary key as clustered as 4.0 behavior.
+	TiDBIntPrimaryKeyDefaultAsClustered = "tidb_int_primary_key_default_as_clustered"
 )
 
 // TiDB vars that have only global scope
@@ -709,6 +712,7 @@ var FeatureSwitchVariables = []string{
 	TiDBTrackAggregateMemoryUsage,
 	TiDBAnalyzeVersion,
 	TiDBPartitionPruneMode,
+	TiDBIntPrimaryKeyDefaultAsClustered,
 }
 
 // FilterImplicitFeatureSwitch is used to filter result of show variables, these switches should be turn blind to users.


### PR DESCRIPTION
Signed-off-by: lysu <sulifx@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

- [x] tidb-test https://github.com/pingcap/tidb-test/pull/1167
- [x] update BR CI https://github.com/pingcap/br/pull/830
- [ ] update CDC CI https://github.com/pingcap/ticdc/pull/1503
- [ ] update dumpling CI [manually test]
- [ ] update tics 
- [x] update tispark https://github.com/pingcap/tispark/pull/1938

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed, How it Works:

- create nonclustered primary key for int  as default
- make test case pass(so add a invisible variable --- `@@tidb_int_primary_key_default_as_clustered`  to help change test)

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: In clustered index project - TODO

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - default Int PK table will have addition lookup from index to table data.
    - but hotspot problem can be better handle in default settings

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/23046)
<!-- Reviewable:end -->
