### PR TITLE
planner, expression: fix error when using IN combined with subquery (#22080)

### DIFF
--- a/expression/builtin_other_vec_generated.go
+++ b/expression/builtin_other_vec_generated.go
@@ -53,9 +53,8 @@ func (b *builtinInIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 	}
 	isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -73,9 +72,13 @@ func (b *builtinInIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 				}
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalInt(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -153,10 +156,9 @@ func (b *builtinInStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column
 		}
 	}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
 		collator := collate.GetCollator(b.collation)
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -168,9 +170,13 @@ func (b *builtinInStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column
 				result.SetNull(i, false)
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalString(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -232,9 +238,8 @@ func (b *builtinInDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 		}
 	}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -250,9 +255,13 @@ func (b *builtinInDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 				result.SetNull(i, false)
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalDecimal(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -319,9 +328,8 @@ func (b *builtinInRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		}
 	}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -333,9 +341,13 @@ func (b *builtinInRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 				result.SetNull(i, false)
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalReal(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -399,9 +411,8 @@ func (b *builtinInTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 		}
 	}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -413,9 +424,13 @@ func (b *builtinInTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 				result.SetNull(i, false)
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalTime(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -479,9 +494,8 @@ func (b *builtinInDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 		}
 	}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	if len(b.hashSet) != 0 {
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -493,9 +507,13 @@ func (b *builtinInDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 				result.SetNull(i, false)
 			}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalDuration(b.ctx, input, buf1); err != nil {
 			return err
 		}
@@ -553,9 +571,9 @@ func (b *builtinInJSONSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 	}
 	hasNull := make([]bool, n)
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEvalJSON(b.ctx, input, buf1); err != nil {
 			return err
 		}

--- a/expression/generator/other_vec.go
+++ b/expression/generator/other_vec.go
@@ -144,13 +144,12 @@ func (b *{{.SigName}}) vecEvalInt(input *chunk.Chunk, result *chunk.Column) erro
 		isUnsigned0 := mysql.HasUnsignedFlag(b.args[0].GetType().Flag)
 	{{- end }}
 	var compareResult int
-	args := b.args
+	args := b.args[1:]
 	{{- if not $InputJSON}}
 	if len(b.hashSet) != 0 {
 		{{- if $InputString }}
 			collator := collate.GetCollator(b.collation)
 		{{- end }}
-		args = b.nonConstArgs
 		for i := 0; i < n; i++ {
 			if buf0.IsNull(i) {
 				hasNull[i] = true
@@ -202,10 +201,14 @@ func (b *{{.SigName}}) vecEvalInt(input *chunk.Chunk, result *chunk.Column) erro
 				{{- end }}
 			{{- end }}
 		}
+		args = args[:0]
+		for _, i := range b.nonConstArgsIdx {
+			args = append(args, b.args[i])
+		}
 	}
 	{{- end }}
 
-	for j := 1; j < len(args); j++ {
+	for j := 0; j < len(args); j++ {
 		if err := args[j].VecEval{{ .Input.TypeName }}(b.ctx, input, buf1); err != nil {
 			return err
 		}

--- a/expression/scalar_function.go
+++ b/expression/scalar_function.go
@@ -428,29 +428,6 @@ func (sf *ScalarFunction) ResolveIndices(schema *Schema) (Expression, error) {
 }
 
 func (sf *ScalarFunction) resolveIndices(schema *Schema) error {
-	if sf.FuncName.L == ast.In {
-		args := []Expression{}
-		switch inFunc := sf.Function.(type) {
-		case *builtinInIntSig:
-			args = inFunc.nonConstArgs
-		case *builtinInStringSig:
-			args = inFunc.nonConstArgs
-		case *builtinInTimeSig:
-			args = inFunc.nonConstArgs
-		case *builtinInDurationSig:
-			args = inFunc.nonConstArgs
-		case *builtinInRealSig:
-			args = inFunc.nonConstArgs
-		case *builtinInDecimalSig:
-			args = inFunc.nonConstArgs
-		}
-		for _, arg := range args {
-			err := arg.resolveIndices(schema)
-			if err != nil {
-				return err
-			}
-		}
-	}
 	for _, arg := range sf.GetArgs() {
 		err := arg.resolveIndices(schema)
 		if err != nil {

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1823,3 +1823,12 @@ func (s *testIntegrationSuite) TestReorderSimplifiedOuterJoins(c *C) {
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
 }
+
+func (s *testIntegrationSuite) TestIssue22071(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values(1),(2),(5)")
+	tk.MustQuery("select n in (1,2) from (select a in (1,2) as n from t) g;").Sort().Check(testkit.Rows("0", "1", "1"))
+	tk.MustQuery("select n in (1,n) from (select a in (1,2) as n from t) g;").Check(testkit.Rows("1", "1", "1"))
+}


### PR DESCRIPTION
cherry-pick #22080 to release-4.0

---

### What problem does this PR solve?

Issue Number: close #22071 


### What is changed and how it works?

In #13594, we did an optimization for IN expression. In this optimization, we save the non-const args of the IN function in `baseInSig.nonConstArgs`. 
When eliminating projection, sometimes we will rewrite args of `Exprs` of `LogicalProjection`. Forgetting to consider the `nonConstArgs` at this stage caused this bug. 

Now we don't store the args, we store the indexes of the non-const args instead.


### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- no release note
