### PR TITLE
expression: fix linter --enable=deadcode check error

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -706,10 +706,6 @@ type dateTimeGener struct {
 	randGen *defaultRandGen
 }
 
-func newDateTimeGener(fsp, year, month, day int) *dateTimeGener {
-	return &dateTimeGener{fsp, year, month, day, newDefaultRandGen()}
-}
-
 func (g *dateTimeGener) gen() interface{} {
 	if g.Year == 0 {
 		g.Year = 1970 + g.randGen.Intn(100)

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -68,10 +68,6 @@ type dateTimeUnitStrGener struct {
 	randGen *defaultRandGen
 }
 
-func newDateTimeUnitStrGener() *dateTimeUnitStrGener {
-	return &dateTimeUnitStrGener{newDefaultRandGen()}
-}
-
 // tzStrGener is used to generate strings which are timezones
 type tzStrGener struct{}
 

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -50,23 +50,6 @@ func newLonglong(value int64) *Constant {
 	}
 }
 
-func newDate(year, month, day int) *Constant {
-	return newTimeConst(year, month, day, 0, 0, 0, mysql.TypeDate)
-}
-
-func newTimestamp(yy, mm, dd, hh, min, ss int) *Constant {
-	return newTimeConst(yy, mm, dd, hh, min, ss, mysql.TypeTimestamp)
-}
-
-func newTimeConst(yy, mm, dd, hh, min, ss int, tp uint8) *Constant {
-	var tmp types.Datum
-	tmp.SetMysqlTime(types.NewTime(types.FromDate(yy, mm, dd, 0, 0, 0, 0), tp, types.DefaultFsp))
-	return &Constant{
-		Value:   tmp,
-		RetType: types.NewFieldType(tp),
-	}
-}
-
 func newFunction(funcName string, args ...Expression) Expression {
 	typeLong := types.NewFieldType(mysql.TypeLonglong)
 	return NewFunctionInternal(mock.NewContext(), funcName, typeLong, args...)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:  #22979 <!-- REMOVE this line if no issue to close -->

Problem Summary: packages which linter `--enable=deadcode` cannot pass are as follows.

- [X] planner (#23117)
- [ ] plugin
- [ ] store
- [X] executor (#23111)
- [X] expression (current)

### What is changed and how it works?

What's Changed: directory `expression` 
Before fix:
```
expression/bench_test.go:709:6: `newDateTimeGener` is unused (deadcode)
func newDateTimeGener(fsp, year, month, day int) *dateTimeGener {
     ^
expression/builtin_time_vec_test.go:71:6: `newDateTimeUnitStrGener` is unused (deadcode)
func newDateTimeUnitStrGener() *dateTimeUnitStrGener {
     ^
expression/constant_test.go:53:6: `newDate` is unused (deadcode)
func newDate(year, month, day int) *Constant {
     ^
expression/constant_test.go:57:6: `newTimestamp` is unused (deadcode)
func newTimestamp(yy, mm, dd, hh, min, ss int) *Constant {
     ^
```
These functions and types are deprecated.

How it Works: deprecated code in expression has been deleted. golang-linter --enable-deadcode in `expression`  can pass.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- none

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
