### PR TITLE
statistics: remove existing deleted extended stats when add a new one

### DIFF
--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -2102,3 +2102,42 @@ func (s *testStatsSuite) TestHideExtendedStatsSwitch(c *C) {
 	}
 	tk.MustQuery("show variables like 'tidb_enable_extended_stats'").Check(testkit.Rows())
 }
+
+func (s *testStatsSuite) TestRepetitiveAddDropExtendedStats(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set session tidb_enable_extended_stats = on")
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int)")
+	tk.MustExec("insert into t values(1,1),(2,2),(3,3)")
+	tk.MustExec("alter table t add stats_extended s1 correlation(a,b)")
+	tk.MustQuery("select name, status from mysql.stats_extended where name = 's1'").Sort().Check(testkit.Rows(
+		"s1 0",
+	))
+	result := tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
+	c.Assert(len(result.Rows()), Equals, 0)
+	tk.MustExec("analyze table t")
+	tk.MustQuery("select name, status from mysql.stats_extended where name = 's1'").Sort().Check(testkit.Rows(
+		"s1 1",
+	))
+	result = tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
+	c.Assert(len(result.Rows()), Equals, 1)
+	tk.MustExec("alter table t drop stats_extended s1")
+	tk.MustQuery("select name, status from mysql.stats_extended where name = 's1'").Sort().Check(testkit.Rows(
+		"s1 2",
+	))
+	result = tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
+	c.Assert(len(result.Rows()), Equals, 0)
+	tk.MustExec("alter table t add stats_extended s1 correlation(a,b)")
+	tk.MustQuery("select name, status from mysql.stats_extended where name = 's1'").Sort().Check(testkit.Rows(
+		"s1 0",
+	))
+	result = tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
+	c.Assert(len(result.Rows()), Equals, 0)
+	tk.MustExec("analyze table t")
+	tk.MustQuery("select name, status from mysql.stats_extended where name = 's1'").Sort().Check(testkit.Rows(
+		"s1 1",
+	))
+	result = tk.MustQuery("show stats_extended where db_name = 'test' and table_name = 't'")
+	c.Assert(len(result.Rows()), Equals, 1)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23107

Problem Summary:

`alter table add stats_extended` cannot work after `alter table drop stats_extended`.

### What is changed and how it works?

What's Changed:

Remove existing extended stats record with 'deleted' status in `alter table add stats_extended`. Also, remove the cache item and bump the stats version.

How it Works:

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Remove existing deleted extended stats when add a new one