### PR TITLE
store: fix linter --enable=deadcode check error

### DIFF
--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -96,26 +96,6 @@ func getExecutorList(dagReq *tipb.DAGRequest) ([]*tipb.Executor, error) {
 	return getExecutorListFromRootExec(dagReq.RootExecutor)
 }
 
-func buildClosureExecutorForTiFlash(dagCtx *dagContext, rootExecutor *tipb.Executor) (*closureExecutor, error) {
-	scanExec, err := getScanExecFromRootExec(rootExecutor)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	ce, err := newClosureExecutor(dagCtx, nil, scanExec, false)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	executors, err := getExecutorListFromRootExec(rootExecutor)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	err = buildClosureExecutorFromExecutorList(dagCtx, executors, ce)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return ce, nil
-}
-
 func buildClosureExecutorFromExecutorList(dagCtx *dagContext, executors []*tipb.Executor, ce *closureExecutor) error {
 	scanExec := executors[0]
 	if scanExec.Tp == tipb.ExecType_TypeTableScan {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:  #22979 <!-- REMOVE this line if no issue to close -->

Problem Summary: packages which linter `--enable=deadcode` cannot pass are as follows.

- [X] planner (#23117)
- [ ] plugin
- [X] store (current)
- [X] executor (#23111)
- [X] expression (#23118)

### What is changed and how it works?

What's Changed: directory `store` 
Before fix:
```
store/mockstore/unistore/cophandler/closure_exec.go:99:6: `buildClosureExecutorForTiFlash` is unused (deadcode)
func buildClosureExecutorForTiFlash(dagCtx *dagContext, rootExecutor *tipb.Executor) (*closureExecutor, error) {
     ^
```
This functions and types are deprecated.

How it Works: deprecated code in store has been deleted. golang-linter --enable-deadcode in `store`  can pass.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- none

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
