### PR TITLE
store/tikv: use mocktikv instead of unistore

### DIFF
--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -867,7 +867,11 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	case tikvrpc.CmdPrewrite:
 		failpoint.Inject("rpcPrewriteResult", func(val failpoint.Value) {
-			switch val.(string) {
+			v, ok := val.(string)
+			if !ok {
+				return
+			}
+			switch v {
 			case "notLeader":
 				failpoint.Return(&tikvrpc.Response{
 					Resp: &kvrpcpb.PrewriteResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},

--- a/store/mockstore/mocktikv/rpc.go
+++ b/store/mockstore/mocktikv/rpc.go
@@ -867,19 +867,17 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 
 	case tikvrpc.CmdPrewrite:
 		failpoint.Inject("rpcPrewriteResult", func(val failpoint.Value) {
-			v, ok := val.(string)
-			if !ok {
-				return
-			}
-			switch v {
-			case "notLeader":
-				failpoint.Return(&tikvrpc.Response{
-					Resp: &kvrpcpb.PrewriteResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
-				}, nil)
-			case "writeConflict":
-				failpoint.Return(&tikvrpc.Response{
-					Resp: &kvrpcpb.PrewriteResponse{Errors: []*kvrpcpb.KeyError{{Conflict: &kvrpcpb.WriteConflict{}}}},
-				}, nil)
+			if v, ok := val.(string); ok {
+				switch v {
+				case "notLeader":
+					failpoint.Return(&tikvrpc.Response{
+						Resp: &kvrpcpb.PrewriteResponse{RegionError: &errorpb.Error{NotLeader: &errorpb.NotLeader{}}},
+					}, nil)
+				case "writeConflict":
+					failpoint.Return(&tikvrpc.Response{
+						Resp: &kvrpcpb.PrewriteResponse{Errors: []*kvrpcpb.KeyError{{Conflict: &kvrpcpb.WriteConflict{}}}},
+					}, nil)
+				}
 			}
 		})
 

--- a/store/tikv/async_commit_fail_test.go
+++ b/store/tikv/async_commit_fail_test.go
@@ -41,15 +41,15 @@ func (s *testAsyncCommitFailSuite) SetUpTest(c *C) {
 // TestFailCommitPrimaryRpcErrors tests rpc errors are handled properly when
 // committing primary region task.
 func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
-	// This test doesn't support tikv mode because it needs setting failpoint in unistore.
+	// This test doesn't support tikv mode because it needs setting failpoint in mocktikv.
 	if *WithTiKV {
 		return
 	}
 
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/noRetryOnRpcError", "return(true)"), IsNil)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout", `return(true)`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteTimeout", `return(true)`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout"), IsNil)
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteTimeout"), IsNil)
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/noRetryOnRpcError"), IsNil)
 	}()
 	// The rpc error will be wrapped to ErrResultUndetermined.
@@ -73,7 +73,7 @@ func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
 }
 
 func (s *testAsyncCommitFailSuite) TestAsyncCommitPrewriteCancelled(c *C) {
-	// This test doesn't support tikv mode because it needs setting failpoint in unistore.
+	// This test doesn't support tikv mode because it needs setting failpoint in mocktikv.
 	if *WithTiKV {
 		return
 	}
@@ -88,9 +88,9 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitPrewriteCancelled(c *C) {
 	s.cluster.Split(loc.Region.GetID(), newRegionID, []byte(splitKey), []uint64{newPeerID}, newPeerID)
 	s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("writeConflict")->sleep(50)`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteResult", `1*return("writeConflict")->sleep(50)`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcPrewriteResult"), IsNil)
 	}()
 
 	t1 := s.beginAsyncCommit(c)

--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/mockstore/cluster"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -44,9 +44,9 @@ func (s *testAsyncCommitCommon) setUpTest(c *C) {
 		return
 	}
 
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
 	c.Assert(err, IsNil)
-	unistore.BootstrapWithSingleStore(cluster)
+	mocktikv.BootstrapWithSingleStore(cluster)
 	s.cluster = cluster
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)

--- a/store/tikv/prewrite_test.go
+++ b/store/tikv/prewrite_test.go
@@ -16,7 +16,7 @@ package tikv
 import (
 	. "github.com/pingcap/check"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testPrewriteSuite struct {
@@ -26,9 +26,9 @@ type testPrewriteSuite struct {
 var _ = Suite(&testPrewriteSuite{})
 
 func (s *testPrewriteSuite) SetUpTest(c *C) {
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
 	c.Assert(err, IsNil)
-	unistore.BootstrapWithSingleStore(cluster)
+	mocktikv.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 	s.store = store

--- a/store/tikv/rawkv_test.go
+++ b/store/tikv/rawkv_test.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	. "github.com/pingcap/check"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/mockstore/cluster"
 )
 
@@ -33,9 +33,9 @@ type testRawKVSuite struct {
 var _ = Suite(&testRawKVSuite{})
 
 func (s *testRawKVSuite) SetUpTest(c *C) {
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
 	c.Assert(err, IsNil)
-	unistore.BootstrapWithSingleStore(cluster)
+	mocktikv.BootstrapWithSingleStore(cluster)
 	s.cluster = cluster
 	s.client = &RawKVClient{
 		clusterID:   0,

--- a/store/tikv/snapshot_fail_test.go
+++ b/store/tikv/snapshot_fail_test.go
@@ -19,7 +19,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 )
 
 type testSnapshotFailSuite struct {
@@ -31,9 +31,9 @@ var _ = SerialSuites(&testSnapshotFailSuite{})
 
 func (s *testSnapshotFailSuite) SetUpSuite(c *C) {
 	s.OneByOneSuite.SetUpSuite(c)
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
 	c.Assert(err, IsNil)
-	unistore.BootstrapWithSingleStore(cluster)
+	mocktikv.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 	s.store = store
@@ -74,9 +74,9 @@ func (s *testSnapshotFailSuite) TestBatchGetResponseKeyError(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcBatchGetResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcBatchGetResult", `1*return("keyError")`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcBatchGetResult"), IsNil)
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcBatchGetResult"), IsNil)
 	}()
 
 	txn, err = s.store.Begin()
@@ -105,7 +105,7 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcScanResult", `1*return("keyError")`), IsNil)
 	txn, err = s.store.Begin()
 	c.Assert(err, IsNil)
 	iter, err := txn.Iter([]byte("a"), []byte("z"))
@@ -120,9 +120,9 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(iter.Value(), DeepEquals, []byte("v3"))
 	c.Assert(iter.Next(), IsNil)
 	c.Assert(iter.Valid(), IsFalse)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcScanResult"), IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcScanResult", `1*return("keyError")`), IsNil)
 	txn, err = s.store.Begin()
 	c.Assert(err, IsNil)
 	iter, err = txn.Iter([]byte("k2"), []byte("k4"))
@@ -134,7 +134,7 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(iter.Value(), DeepEquals, []byte("v3"))
 	c.Assert(iter.Next(), IsNil)
 	c.Assert(iter.Valid(), IsFalse)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/mocktikv/rpcScanResult"), IsNil)
 }
 
 func (s *testSnapshotFailSuite) TestRetryPointGetWithTS(c *C) {

--- a/store/tikv/ticlient_test.go
+++ b/store/tikv/ticlient_test.go
@@ -24,7 +24,7 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/mockstore/unistore"
+	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv/config"
 	"github.com/pingcap/tidb/store/tikv/util/codec"
 	pd "github.com/tikv/pd/client"
@@ -57,9 +57,9 @@ func NewTestStore(c *C) *KVStore {
 		c.Assert(err, IsNil)
 		return store
 	}
-	client, pdClient, cluster, err := unistore.New("")
+	client, cluster, pdClient, err := mocktikv.NewTiKVAndPDClient("")
 	c.Assert(err, IsNil)
-	unistore.BootstrapWithSingleStore(cluster)
+	mocktikv.BootstrapWithSingleStore(cluster)
 	store, err := NewTestTiKVStore(client, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 	return store


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
`store/tikv` uses both `mocktikv` and `unistore`.
Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- Switch unistore usages to mocktikv
- Add failpoint injection points

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note