### PR TITLE
kv: unify the BeginWith... function into one

### DIFF
--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -63,9 +63,18 @@ func (s *InjectedStore) Begin() (Transaction, error) {
 	}, err
 }
 
-// BeginWithStartTS creates an injected Transaction with startTS.
-func (s *InjectedStore) BeginWithStartTS(txnScope string, startTS uint64) (Transaction, error) {
-	txn, err := s.Storage.BeginWithStartTS(txnScope, startTS)
+// BeginWithTxnScope creates an injected Transaction with txnScope.
+func (s *InjectedStore) BeginWithTxnScope(txnScope string) (Transaction, error) {
+	txn, err := s.Storage.BeginWithTxnScope(txnScope)
+	return &InjectedTransaction{
+		Transaction: txn,
+		cfg:         s.cfg,
+	}, err
+}
+
+// BeginWithOption creates an injected Transaction with given option.
+func (s *InjectedStore) BeginWithOption(txnScope string, option TransactionOption) (Transaction, error) {
+	txn, err := s.Storage.BeginWithOption(txnScope, option)
 	return &InjectedTransaction{
 		Transaction: txn,
 		cfg:         s.cfg,

--- a/kv/fault_injection.go
+++ b/kv/fault_injection.go
@@ -63,18 +63,9 @@ func (s *InjectedStore) Begin() (Transaction, error) {
 	}, err
 }
 
-// BeginWithTxnScope creates an injected Transaction with txnScope.
-func (s *InjectedStore) BeginWithTxnScope(txnScope string) (Transaction, error) {
-	txn, err := s.Storage.BeginWithTxnScope(txnScope)
-	return &InjectedTransaction{
-		Transaction: txn,
-		cfg:         s.cfg,
-	}, err
-}
-
 // BeginWithOption creates an injected Transaction with given option.
-func (s *InjectedStore) BeginWithOption(txnScope string, option TransactionOption) (Transaction, error) {
-	txn, err := s.Storage.BeginWithOption(txnScope, option)
+func (s *InjectedStore) BeginWithOption(option TransactionOption) (Transaction, error) {
+	txn, err := s.Storage.BeginWithOption(option)
 	return &InjectedTransaction{
 		Transaction: txn,
 		cfg:         s.cfg,

--- a/kv/fault_injection_test.go
+++ b/kv/fault_injection_test.go
@@ -35,7 +35,7 @@ func (s testFaultInjectionSuite) TestFaultInjectionBasic(c *C) {
 	storage := NewInjectedStore(newMockStorage(), &cfg)
 	txn, err := storage.Begin()
 	c.Assert(err, IsNil)
-	_, err = storage.BeginWithStartTS(oracle.GlobalTxnScope, 0)
+	_, err = storage.BeginWithOption(oracle.GlobalTxnScope, WithStartTSOption(0))
 	c.Assert(err, IsNil)
 	ver := Version{Ver: 1}
 	snap := storage.GetSnapshot(ver)

--- a/kv/fault_injection_test.go
+++ b/kv/fault_injection_test.go
@@ -35,7 +35,7 @@ func (s testFaultInjectionSuite) TestFaultInjectionBasic(c *C) {
 	storage := NewInjectedStore(newMockStorage(), &cfg)
 	txn, err := storage.Begin()
 	c.Assert(err, IsNil)
-	_, err = storage.BeginWithOption(oracle.GlobalTxnScope, WithStartTSOption(0))
+	_, err = storage.BeginWithOption(TransactionOption{}.SetTxnScope(oracle.GlobalTxnScope).SetStartTs(0))
 	c.Assert(err, IsNil)
 	ver := Version{Ver: 1}
 	snap := storage.GetSnapshot(ver)

--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -158,11 +158,7 @@ func (s *mockStorage) Begin() (Transaction, error) {
 	return newMockTxn(), nil
 }
 
-func (s *mockStorage) BeginWithTxnScope(txnScope string) (Transaction, error) {
-	return newMockTxn(), nil
-}
-
-func (s *mockStorage) BeginWithOption(txnScope string, option TransactionOption) (Transaction, error) {
+func (s *mockStorage) BeginWithOption(option TransactionOption) (Transaction, error) {
 	return newMockTxn(), nil
 }
 

--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -162,18 +162,12 @@ func (s *mockStorage) BeginWithTxnScope(txnScope string) (Transaction, error) {
 	return newMockTxn(), nil
 }
 
+func (s *mockStorage) BeginWithOption(txnScope string, option TransactionOption) (Transaction, error) {
+	return newMockTxn(), nil
+}
+
 func (*mockTxn) IsPessimistic() bool {
 	return false
-}
-
-// BeginWithStartTS begins transaction with given txnScope and startTS.
-func (s *mockStorage) BeginWithStartTS(txnScope string, startTS uint64) (Transaction, error) {
-	return s.Begin()
-}
-
-// BeginWithExactStaleness begins transaction with given exact staleness
-func (s *mockStorage) BeginWithExactStaleness(txnScope string, prevSec uint64) (Transaction, error) {
-	return s.Begin()
 }
 
 func (s *mockStorage) GetSnapshot(ver Version) Snapshot {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -467,6 +467,39 @@ type Driver interface {
 	Open(path string) (Storage, error)
 }
 
+// TransactionOptionType indicates the method when beginning a transaction
+type TransactionOptionType uint8
+
+const (
+	// WithStartTS indicates the startTS option
+	WithStartTS TransactionOptionType = iota
+	// WithPrevSec indicates the prevSec option
+	WithPrevSec
+)
+
+// TransactionOption indicates the option when beginning a transaction
+type TransactionOption struct {
+	TransactionOptionType
+	StartTS uint64
+	PrevSec uint64
+}
+
+// WithStartTSOption provides a option startTS
+func WithStartTSOption(startTS uint64) TransactionOption {
+	return TransactionOption{
+		TransactionOptionType: WithStartTS,
+		StartTS:               startTS,
+	}
+}
+
+// WithPrevSecOption provides a option with prevSec
+func WithPrevSecOption(prevSec uint64) TransactionOption {
+	return TransactionOption{
+		TransactionOptionType: WithPrevSec,
+		PrevSec:               prevSec,
+	}
+}
+
 // Storage defines the interface for storage.
 // Isolation should be at least SI(SNAPSHOT ISOLATION)
 type Storage interface {
@@ -474,12 +507,9 @@ type Storage interface {
 	Begin() (Transaction, error)
 	// Begin a transaction with the given txnScope (local or global)
 	BeginWithTxnScope(txnScope string) (Transaction, error)
-	// BeginWithStartTS begins transaction with given txnScope and startTS.
-	BeginWithStartTS(txnScope string, startTS uint64) (Transaction, error)
-	// BeginWithStalenessTS begins transaction with given staleness
-	BeginWithExactStaleness(txnScope string, prevSec uint64) (Transaction, error)
+	// Begin a transaction with given option
+	BeginWithOption(txnScope string, option TransactionOption) (Transaction, error)
 	// GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
-	// if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
 	GetSnapshot(ver Version) Snapshot
 	// GetClient gets a client instance.
 	GetClient() Client

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -510,6 +510,7 @@ type Storage interface {
 	// Begin a transaction with given option
 	BeginWithOption(txnScope string, option TransactionOption) (Transaction, error)
 	// GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
+	// if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
 	GetSnapshot(ver Version) Snapshot
 	// GetClient gets a client instance.
 	GetClient() Client

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -467,37 +467,28 @@ type Driver interface {
 	Open(path string) (Storage, error)
 }
 
-// TransactionOptionType indicates the method when beginning a transaction
-type TransactionOptionType uint8
-
-const (
-	// WithStartTS indicates the startTS option
-	WithStartTS TransactionOptionType = iota
-	// WithPrevSec indicates the prevSec option
-	WithPrevSec
-)
-
 // TransactionOption indicates the option when beginning a transaction
 type TransactionOption struct {
-	TransactionOptionType
-	StartTS uint64
-	PrevSec uint64
+	TxnScope string
+	StartTS  *uint64
+	PrevSec  *uint64
 }
 
-// WithStartTSOption provides a option startTS
-func WithStartTSOption(startTS uint64) TransactionOption {
-	return TransactionOption{
-		TransactionOptionType: WithStartTS,
-		StartTS:               startTS,
-	}
+// SetStartTs ...
+func (to TransactionOption) SetStartTs(startTS uint64) TransactionOption {
+	to.StartTS = &startTS
+	return to
 }
 
 // WithPrevSecOption provides a option with prevSec
-func WithPrevSecOption(prevSec uint64) TransactionOption {
-	return TransactionOption{
-		TransactionOptionType: WithPrevSec,
-		PrevSec:               prevSec,
-	}
+func (to TransactionOption) SetPrevSec(prevSec uint64) TransactionOption {
+	to.PrevSec = &prevSec
+	return to
+}
+
+func (to TransactionOption) SetTxnScope(txnScope string) TransactionOption {
+	to.TxnScope = txnScope
+	return to
 }
 
 // Storage defines the interface for storage.
@@ -505,10 +496,8 @@ func WithPrevSecOption(prevSec uint64) TransactionOption {
 type Storage interface {
 	// Begin a global transaction
 	Begin() (Transaction, error)
-	// Begin a transaction with the given txnScope (local or global)
-	BeginWithTxnScope(txnScope string) (Transaction, error)
 	// Begin a transaction with given option
-	BeginWithOption(txnScope string, option TransactionOption) (Transaction, error)
+	BeginWithOption(option TransactionOption) (Transaction, error)
 	// GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
 	// if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
 	GetSnapshot(ver Version) Snapshot

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -474,18 +474,19 @@ type TransactionOption struct {
 	PrevSec  *uint64
 }
 
-// SetStartTs ...
+// SetStartTs set startTS
 func (to TransactionOption) SetStartTs(startTS uint64) TransactionOption {
 	to.StartTS = &startTS
 	return to
 }
 
-// WithPrevSecOption provides a option with prevSec
+// SetPrevSec set prevSec
 func (to TransactionOption) SetPrevSec(prevSec uint64) TransactionOption {
 	to.PrevSec = &prevSec
 	return to
 }
 
+// SetTxnScope set txnScope
 func (to TransactionOption) SetTxnScope(txnScope string) TransactionOption {
 	to.TxnScope = txnScope
 	return to

--- a/session/session.go
+++ b/session/session.go
@@ -1943,7 +1943,7 @@ func (s *session) NewTxn(ctx context.Context) error {
 			zap.String("txnScope", txnScope))
 	}
 
-	txn, err := s.store.BeginWithTxnScope(s.sessionVars.CheckAndGetTxnScope())
+	txn, err := s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(s.sessionVars.CheckAndGetTxnScope()))
 	if err != nil {
 		return err
 	}
@@ -2736,7 +2736,7 @@ func (s *session) InitTxnWithStartTS(startTS uint64) error {
 	}
 
 	// no need to get txn from txnFutureCh since txn should init with startTs
-	txn, err := s.store.BeginWithOption(s.GetSessionVars().CheckAndGetTxnScope(), kv.WithStartTSOption(startTS))
+	txn, err := s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(s.GetSessionVars().CheckAndGetTxnScope()).SetStartTs(startTS))
 	if err != nil {
 		return err
 	}
@@ -2769,12 +2769,12 @@ func (s *session) NewTxnWithStalenessOption(ctx context.Context, option sessionc
 	txnScope := s.GetSessionVars().CheckAndGetTxnScope()
 	switch option.Mode {
 	case ast.TimestampBoundReadTimestamp:
-		txn, err = s.store.BeginWithOption(txnScope, kv.WithStartTSOption(option.StartTS))
+		txn, err = s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(txnScope).SetStartTs(option.StartTS))
 		if err != nil {
 			return err
 		}
 	case ast.TimestampBoundExactStaleness:
-		txn, err = s.store.BeginWithOption(txnScope, kv.WithPrevSecOption(option.PrevSec))
+		txn, err = s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(txnScope).SetPrevSec(option.PrevSec))
 		if err != nil {
 			return err
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -2736,7 +2736,7 @@ func (s *session) InitTxnWithStartTS(startTS uint64) error {
 	}
 
 	// no need to get txn from txnFutureCh since txn should init with startTs
-	txn, err := s.store.BeginWithStartTS(s.GetSessionVars().CheckAndGetTxnScope(), startTS)
+	txn, err := s.store.BeginWithOption(s.GetSessionVars().CheckAndGetTxnScope(), kv.WithStartTSOption(startTS))
 	if err != nil {
 		return err
 	}
@@ -2769,12 +2769,12 @@ func (s *session) NewTxnWithStalenessOption(ctx context.Context, option sessionc
 	txnScope := s.GetSessionVars().CheckAndGetTxnScope()
 	switch option.Mode {
 	case ast.TimestampBoundReadTimestamp:
-		txn, err = s.store.BeginWithStartTS(txnScope, option.StartTS)
+		txn, err = s.store.BeginWithOption(txnScope, kv.WithStartTSOption(option.StartTS))
 		if err != nil {
 			return err
 		}
 	case ast.TimestampBoundExactStaleness:
-		txn, err = s.store.BeginWithExactStaleness(txnScope, option.PrevSec)
+		txn, err = s.store.BeginWithOption(txnScope, kv.WithPrevSecOption(option.PrevSec))
 		if err != nil {
 			return err
 		}

--- a/session/txn.go
+++ b/session/txn.go
@@ -351,7 +351,6 @@ func (tf *txnFuture) wait() (kv.Transaction, error) {
 	startTS, err := tf.future.Wait()
 	if err == nil {
 		return tf.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(tf.txnScope).SetStartTs(startTS))
-		//return tf.store.BeginWithOption(tf.txnScope, kv.WithStartTSOption(startTS))
 	} else if config.GetGlobalConfig().Store == "unistore" {
 		return nil, err
 	}

--- a/session/txn.go
+++ b/session/txn.go
@@ -350,14 +350,15 @@ type txnFuture struct {
 func (tf *txnFuture) wait() (kv.Transaction, error) {
 	startTS, err := tf.future.Wait()
 	if err == nil {
-		return tf.store.BeginWithOption(tf.txnScope, kv.WithStartTSOption(startTS))
+		return tf.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(tf.txnScope).SetStartTs(startTS))
+		//return tf.store.BeginWithOption(tf.txnScope, kv.WithStartTSOption(startTS))
 	} else if config.GetGlobalConfig().Store == "unistore" {
 		return nil, err
 	}
 
 	logutil.BgLogger().Warn("wait tso failed", zap.Error(err))
 	// It would retry get timestamp.
-	return tf.store.BeginWithTxnScope(tf.txnScope)
+	return tf.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(tf.txnScope))
 }
 
 func (s *session) getTxnFuture(ctx context.Context) *txnFuture {

--- a/session/txn.go
+++ b/session/txn.go
@@ -350,7 +350,7 @@ type txnFuture struct {
 func (tf *txnFuture) wait() (kv.Transaction, error) {
 	startTS, err := tf.future.Wait()
 	if err == nil {
-		return tf.store.BeginWithStartTS(tf.txnScope, startTS)
+		return tf.store.BeginWithOption(tf.txnScope, kv.WithStartTSOption(startTS))
 	} else if config.GetGlobalConfig().Store == "unistore" {
 		return nil, err
 	}

--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/tidb/store/gcworker"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/config"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/logutil"
 	pd "github.com/tikv/pd/client"
@@ -293,9 +292,14 @@ func (s *tikvStore) GetMemCache() kv.MemManager {
 
 // Begin a global transaction.
 func (s *tikvStore) Begin() (kv.Transaction, error) {
-	return s.BeginWithTxnScope(oracle.GlobalTxnScope)
+	txn, err := s.KVStore.Begin()
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return txn_driver.NewTiKVTxn(txn), err
 }
 
+// BeginWithTxnScope creates a Transaction with txnScope.
 func (s *tikvStore) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
 	txn, err := s.KVStore.BeginWithTxnScope(txnScope)
 	if err != nil {
@@ -304,18 +308,9 @@ func (s *tikvStore) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
 	return txn_driver.NewTiKVTxn(txn), err
 }
 
-// BeginWithStartTS begins a transaction with startTS.
-func (s *tikvStore) BeginWithStartTS(txnScope string, startTS uint64) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithStartTS(txnScope, startTS)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return txn_driver.NewTiKVTxn(txn), err
-}
-
-// BeginWithExactStaleness begins transaction with given staleness
-func (s *tikvStore) BeginWithExactStaleness(txnScope string, prevSec uint64) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithExactStaleness(txnScope, prevSec)
+// BeginWithOption begins a transaction with given option
+func (s *tikvStore) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
+	txn, err := s.KVStore.BeginWithOption(txnScope, option)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -299,18 +299,9 @@ func (s *tikvStore) Begin() (kv.Transaction, error) {
 	return txn_driver.NewTiKVTxn(txn), err
 }
 
-// BeginWithTxnScope creates a Transaction with txnScope.
-func (s *tikvStore) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithTxnScope(txnScope)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return txn_driver.NewTiKVTxn(txn), err
-}
-
 // BeginWithOption begins a transaction with given option
-func (s *tikvStore) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithOption(txnScope, option)
+func (s *tikvStore) BeginWithOption(option kv.TransactionOption) (kv.Transaction, error) {
+	txn, err := s.KVStore.BeginWithOption(option)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -49,8 +49,7 @@ import (
 type Storage interface {
 	Begin() (kv.Transaction, error)
 	BeginWithTxnScope(txnScope string) (kv.Transaction, error)
-	BeginWithStartTS(txnScope string, startTS uint64) (kv.Transaction, error)
-	BeginWithExactStaleness(txnScope string, prevSec uint64) (kv.Transaction, error)
+	BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error)
 	GetSnapshot(ver kv.Version) kv.Snapshot
 	GetClient() kv.Client
 	GetMPPClient() kv.MPPClient

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -48,8 +48,7 @@ import (
 // Methods copied from kv.Storage and tikv.Storage due to limitation of go1.13.
 type Storage interface {
 	Begin() (kv.Transaction, error)
-	BeginWithTxnScope(txnScope string) (kv.Transaction, error)
-	BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error)
+	BeginWithOption(option kv.TransactionOption) (kv.Transaction, error)
 	GetSnapshot(ver kv.Version) kv.Snapshot
 	GetClient() kv.Client
 	GetMPPClient() kv.MPPClient

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -95,15 +95,9 @@ func (s *mockStorage) Begin() (kv.Transaction, error) {
 	return newTiKVTxn(txn, err)
 }
 
-// BeginWithTxnScope creates a Transaction with txnScope.
-func (s *mockStorage) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithTxnScope(txnScope)
-	return newTiKVTxn(txn, err)
-}
-
 // BeginWithOption begins a transaction with given option
-func (s *mockStorage) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithOption(txnScope, option)
+func (s *mockStorage) BeginWithOption(option kv.TransactionOption) (kv.Transaction, error) {
+	txn, err := s.KVStore.BeginWithOption(option)
 	return newTiKVTxn(txn, err)
 }
 

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -95,20 +95,15 @@ func (s *mockStorage) Begin() (kv.Transaction, error) {
 	return newTiKVTxn(txn, err)
 }
 
+// BeginWithTxnScope creates a Transaction with txnScope.
 func (s *mockStorage) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
 	txn, err := s.KVStore.BeginWithTxnScope(txnScope)
 	return newTiKVTxn(txn, err)
 }
 
-// BeginWithStartTS begins a transaction with startTS.
-func (s *mockStorage) BeginWithStartTS(txnScope string, startTS uint64) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithStartTS(txnScope, startTS)
-	return newTiKVTxn(txn, err)
-}
-
-// BeginWithExactStaleness begins transaction with given staleness
-func (s *mockStorage) BeginWithExactStaleness(txnScope string, prevSec uint64) (kv.Transaction, error) {
-	txn, err := s.KVStore.BeginWithExactStaleness(txnScope, prevSec)
+// BeginWithOption begins a transaction with given option
+func (s *mockStorage) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
+	txn, err := s.KVStore.BeginWithOption(txnScope, option)
 	return newTiKVTxn(txn, err)
 }
 

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -610,12 +610,12 @@ func (s *testCommitterSuite) TestRejectCommitTS(c *C) {
 	// Use max.Uint64 to read the data and success.
 	// That means the final commitTS > startTS+2, it's not the one we provide.
 	// So we cover the rety commitTS logic.
-	txn1, err := s.store.BeginWithStartTS(oracle.GlobalTxnScope, committer.startTS+2)
+	txn1, err := s.store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(committer.startTS+2))
 	c.Assert(err, IsNil)
 	_, err = txn1.Get(bo.ctx, []byte("x"))
 	c.Assert(kv.IsErrNotFound(err), IsTrue)
 
-	txn2, err := s.store.BeginWithStartTS(oracle.GlobalTxnScope, math.MaxUint64)
+	txn2, err := s.store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(math.MaxUint64))
 	c.Assert(err, IsNil)
 	val, err := txn2.Get(bo.ctx, []byte("x"))
 	c.Assert(err, IsNil)

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -610,12 +610,12 @@ func (s *testCommitterSuite) TestRejectCommitTS(c *C) {
 	// Use max.Uint64 to read the data and success.
 	// That means the final commitTS > startTS+2, it's not the one we provide.
 	// So we cover the rety commitTS logic.
-	txn1, err := s.store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(committer.startTS+2))
+	txn1, err := s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(oracle.GlobalTxnScope).SetStartTs(committer.startTS + 2))
 	c.Assert(err, IsNil)
 	_, err = txn1.Get(bo.ctx, []byte("x"))
 	c.Assert(kv.IsErrNotFound(err), IsTrue)
 
-	txn2, err := s.store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(math.MaxUint64))
+	txn2, err := s.store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(oracle.GlobalTxnScope).SetStartTs(math.MaxUint64))
 	c.Assert(err, IsNil)
 	val, err := txn2.Get(bo.ctx, []byte("x"))
 	c.Assert(err, IsNil)

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -170,24 +170,21 @@ func (s *KVStore) Begin() (*KVTxn, error) {
 	return s.beginWithTxnScope(oracle.GlobalTxnScope)
 }
 
-// BeginWithTxnScope begins a transaction with given txnScope
-func (s *KVStore) BeginWithTxnScope(txnScope string) (*KVTxn, error) {
-	return s.beginWithTxnScope(txnScope)
-}
-
 // BeginWithOption begins a transaction with given option
-func (s *KVStore) BeginWithOption(txnScope string, option kv.TransactionOption) (*KVTxn, error) {
-	switch option.TransactionOptionType {
-	case kv.WithStartTS:
-		return s.beginWithStartTS(txnScope, option.StartTS)
-	case kv.WithPrevSec:
-		return s.beginWithExactStaleness(txnScope, option.PrevSec)
-	default:
+func (s *KVStore) BeginWithOption(option kv.TransactionOption) (*KVTxn, error) {
+	txnScope := option.TxnScope
+	if txnScope == "" {
+		txnScope = oracle.GlobalTxnScope
+	}
+	if option.StartTS != nil {
+		return s.beginWithStartTS(txnScope, *option.StartTS)
+	} else if option.PrevSec != nil {
+		return s.beginWithExactStaleness(txnScope, *option.PrevSec)
 	}
 	return s.beginWithTxnScope(txnScope)
 }
 
-// BeginWithTxnScope begins a transaction with the given txnScope (local or global)
+// beginWithTxnScope begins a transaction with the given txnScope (local or global)
 func (s *KVStore) beginWithTxnScope(txnScope string) (*KVTxn, error) {
 	txn, err := newTiKVTxn(s, txnScope)
 	if err != nil {

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -17,6 +17,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -26,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/kvcache"
@@ -211,7 +211,7 @@ func (c *Context) InitTxnWithStartTS(startTS uint64) error {
 		return nil
 	}
 	if c.Store != nil {
-		txn, err := c.Store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(startTS))
+		txn, err := c.Store.BeginWithOption(kv.TransactionOption{}.SetTxnScope(oracle.GlobalTxnScope).SetStartTs(startTS))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -17,7 +17,6 @@ package mock
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -27,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/owner"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/kvcache"

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -211,7 +211,7 @@ func (c *Context) InitTxnWithStartTS(startTS uint64) error {
 		return nil
 	}
 	if c.Store != nil {
-		txn, err := c.Store.BeginWithStartTS(oracle.GlobalTxnScope, startTS)
+		txn, err := c.Store.BeginWithOption(oracle.GlobalTxnScope, kv.WithStartTSOption(startTS))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/util/mock/store.go
+++ b/util/mock/store.go
@@ -37,13 +37,8 @@ func (s *Store) GetOracle() oracle.Oracle { return nil }
 // Begin implements kv.Storage interface.
 func (s *Store) Begin() (kv.Transaction, error) { return nil, nil }
 
-// BeginWithTxnScope implements kv.Storage interface.
-func (s *Store) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
-	return s.Begin()
-}
-
 // BeginWithOption implements kv.Storage interface.
-func (s *Store) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
+func (s *Store) BeginWithOption(option kv.TransactionOption) (kv.Transaction, error) {
 	return s.Begin()
 }
 

--- a/util/mock/store.go
+++ b/util/mock/store.go
@@ -38,15 +38,12 @@ func (s *Store) GetOracle() oracle.Oracle { return nil }
 func (s *Store) Begin() (kv.Transaction, error) { return nil, nil }
 
 // BeginWithTxnScope implements kv.Storage interface.
-func (s *Store) BeginWithTxnScope(txnScope string) (kv.Transaction, error) { return nil, nil }
-
-// BeginWithStartTS implements kv.Storage interface.
-func (s *Store) BeginWithStartTS(txnScope string, startTS uint64) (kv.Transaction, error) {
+func (s *Store) BeginWithTxnScope(txnScope string) (kv.Transaction, error) {
 	return s.Begin()
 }
 
-// BeginWithExactStaleness implements kv.Storage interface
-func (s *Store) BeginWithExactStaleness(txnScope string, prevSec uint64) (kv.Transaction, error) {
+// BeginWithOption implements kv.Storage interface.
+func (s *Store) BeginWithOption(txnScope string, option kv.TransactionOption) (kv.Transaction, error) {
 	return s.Begin()
 }
 


### PR DESCRIPTION
Signed-off-by: Song Gao <disxiaofei@163.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Currently, we have serval `BeginWithXXX` functions in `kv.Storage`. In future, we are going to support time-bounded staleness transaction which may continue to add more `BeginWithXXX` functions.

### What is changed and how it works?

This request unify all the `BeginWithXXX` functions into one and only leave 2 function like following:

```golang
	Begin() (Transaction, error)
	BeginWithOption(option TransactionOption) (Transaction, error)
```

### Release note <!-- bugfixes or new feature need a release note -->

* No release note
