### PR TITLE
store/tikv:remove set/delete option from kv.Transaction

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -1336,7 +1337,7 @@ func (w *updateColumnWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (t
 	errInTxn = kv.RunInNewTxn(context.Background(), w.sessCtx.GetStore(), true, func(ctx context.Context, txn kv.Transaction) error {
 		taskCtx.addedCount = 0
 		taskCtx.scanCount = 0
-		txn.SetOption(kv.Priority, w.priority)
+		txn.(option.Setter).SetOption(kv.Priority, w.priority)
 
 		rowRecords, nextKey, taskDone, err := w.fetchRowColVals(txn, handleRange)
 		if err != nil {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -1159,7 +1160,7 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 	errInTxn = kv.RunInNewTxn(context.Background(), w.sessCtx.GetStore(), true, func(ctx context.Context, txn kv.Transaction) error {
 		taskCtx.addedCount = 0
 		taskCtx.scanCount = 0
-		txn.SetOption(kv.Priority, w.priority)
+		txn.(option.Setter).SetOption(kv.Priority, w.priority)
 
 		idxRecords, nextKey, taskDone, err := w.fetchRowColVals(txn, handleRange)
 		if err != nil {
@@ -1371,7 +1372,7 @@ func (w *cleanUpIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (t
 	errInTxn = kv.RunInNewTxn(context.Background(), w.sessCtx.GetStore(), true, func(ctx context.Context, txn kv.Transaction) error {
 		taskCtx.addedCount = 0
 		taskCtx.scanCount = 0
-		txn.SetOption(kv.Priority, w.priority)
+		txn.(option.Setter).SetOption(kv.Priority, w.priority)
 
 		idxRecords, nextKey, taskDone, err := w.fetchRowColVals(txn, handleRange)
 		if err != nil {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
@@ -626,7 +627,7 @@ func UpdateForUpdateTS(seCtx sessionctx.Context, newForUpdateTS uint64) error {
 		newForUpdateTS = version.Ver
 	}
 	seCtx.GetSessionVars().TxnCtx.SetForUpdateTS(newForUpdateTS)
-	txn.SetOption(kv.SnapshotTS, seCtx.GetSessionVars().TxnCtx.GetForUpdateTS())
+	txn.(option.Setter).SetOption(kv.SnapshotTS, seCtx.GetSessionVars().TxnCtx.GetForUpdateTS())
 	return nil
 }
 

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -947,9 +948,9 @@ func (e *AnalyzeFastExec) activateTxnForRowCount() (rollbackFn func() error, err
 			return nil, errors.Trace(err)
 		}
 	}
-	txn.SetOption(kv.Priority, kv.PriorityLow)
-	txn.SetOption(kv.IsolationLevel, kv.RC)
-	txn.SetOption(kv.NotFillCache, true)
+	txn.(option.Setter).SetOption(kv.Priority, kv.PriorityLow)
+	txn.(option.Setter).SetOption(kv.IsolationLevel, kv.RC)
+	txn.(option.Setter).SetOption(kv.NotFillCache, true)
 	return rollbackFn, nil
 }
 

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	tikvutil "github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
@@ -600,10 +601,10 @@ func (e *SimpleExec) executeBegin(ctx context.Context, s *ast.BeginStmt) error {
 		return err
 	}
 	if e.ctx.GetSessionVars().TxnCtx.IsPessimistic {
-		txn.SetOption(kv.Pessimistic, true)
+		txn.(option.Setter).SetOption(kv.Pessimistic, true)
 	}
 	if s.CausalConsistencyOnly {
-		txn.SetOption(kv.GuaranteeLinearizability, false)
+		txn.(option.Setter).SetOption(kv.GuaranteeLinearizability, false)
 	}
 	return nil
 }

--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -44,18 +44,6 @@ func (t *mockTxn) LockKeys(_ context.Context, _ *LockCtx, _ ...Key) error {
 	return nil
 }
 
-func (t *mockTxn) SetOption(opt Option, val interface{}) {
-	t.opts[opt] = val
-}
-
-func (t *mockTxn) DelOption(opt Option) {
-	delete(t.opts, opt)
-}
-
-func (t *mockTxn) GetOption(opt Option) interface{} {
-	return t.opts[opt]
-}
-
 func (t *mockTxn) IsReadOnly() bool {
 	return true
 }

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -264,13 +264,6 @@ type Transaction interface {
 	String() string
 	// LockKeys tries to lock the entries with the keys in KV store.
 	LockKeys(ctx context.Context, lockCtx *LockCtx, keys ...Key) error
-	// SetOption sets an option with a value, when val is nil, uses the default
-	// value of this option.
-	SetOption(opt Option, val interface{})
-	// GetOption returns the option
-	GetOption(opt Option) interface{}
-	// DelOption deletes an option.
-	DelOption(opt Option)
 	// IsReadOnly checks if the transaction has only performed read operations.
 	IsReadOnly() bool
 	// StartTS returns the transaction start timestamp.

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -40,12 +40,7 @@ func (s testMockSuite) TestInterface(c *C) {
 	c.Check(err, IsNil)
 	err = transaction.LockKeys(context.Background(), new(LockCtx), Key("lock"))
 	c.Check(err, IsNil)
-	transaction.SetOption(Option(23), struct{}{})
-	if mock, ok := transaction.(*mockTxn); ok {
-		mock.GetOption(Option(23))
-	}
 	transaction.StartTS()
-	transaction.DelOption(Option(23))
 	if transaction.IsReadOnly() {
 		_, err = transaction.Get(context.TODO(), Key("lock"))
 		c.Check(err, IsNil)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
+	kvoption "github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/structure"
 	"github.com/pingcap/tidb/util/dbterror"
 	"github.com/pingcap/tidb/util/logutil"
@@ -93,8 +94,8 @@ type Meta struct {
 // NewMeta creates a Meta in transaction txn.
 // If the current Meta needs to handle a job, jobListKey is the type of the job's list.
 func NewMeta(txn kv.Transaction, jobListKeys ...JobListKeyType) *Meta {
-	txn.SetOption(kv.Priority, kv.PriorityHigh)
-	txn.SetOption(kv.SyncLog, true)
+	txn.(kvoption.Setter).SetOption(kv.Priority, kv.PriorityHigh)
+	txn.(kvoption.Setter).SetOption(kv.SyncLog, true)
 	t := structure.NewStructure(txn, txn, mMetaPrefix)
 	listKey := DefaultJobListKey
 	if len(jobListKeys) != 0 {

--- a/owner/fail_test.go
+++ b/owner/fail_test.go
@@ -63,9 +63,9 @@ var (
 
 func (s *testSuite) TestFailNewSession(c *C) {
 	ln, err := net.Listen("unix", "new_session:0")
+	c.Assert(err, IsNil)
 	addr := ln.Addr()
 	endpoints := []string{fmt.Sprintf("%s://%s", addr.Network(), addr.String())}
-	c.Assert(err, IsNil)
 	srv := grpc.NewServer(grpc.ConnectionTimeout(time.Minute))
 	var stop sync.WaitGroup
 	stop.Add(1)

--- a/session/session.go
+++ b/session/session.go
@@ -65,6 +65,7 @@ import (
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/statistics/handle"
 	"github.com/pingcap/tidb/store/tikv"
+	kvoption "github.com/pingcap/tidb/store/tikv/option"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	tikvutil "github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
@@ -1949,7 +1950,7 @@ func (s *session) NewTxn(ctx context.Context) error {
 	}
 	txn.SetVars(s.sessionVars.KVVars)
 	if s.GetSessionVars().GetReplicaRead().IsFollowerRead() {
-		txn.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
+		txn.(kvoption.Setter).SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
 	}
 	s.txn.changeInvalidToValid(txn)
 	is := domain.GetDomain(s).InfoSchema()
@@ -2783,8 +2784,8 @@ func (s *session) NewTxnWithStalenessOption(ctx context.Context, option sessionc
 		return s.NewTxn(ctx)
 	}
 	txn.SetVars(s.sessionVars.KVVars)
-	txn.SetOption(kv.IsStalenessReadOnly, true)
-	txn.SetOption(kv.TxnScope, txnScope)
+	txn.(kvoption.Setter).SetOption(kv.IsStalenessReadOnly, true)
+	txn.(kvoption.Setter).SetOption(kv.TxnScope, txnScope)
 	s.txn.changeInvalidToValid(txn)
 	is := domain.GetDomain(s).InfoSchema()
 	s.sessionVars.TxnCtx = &variable.TransactionContext{

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -294,7 +294,7 @@ func SetDDLBinlog(client *pumpcli.PumpsClient, txn kv.Transaction, jobID int64, 
 		},
 		Client: client,
 	}
-	txn.SetOption(kv.BinlogInfo, info)
+	txn.GetUnionStore().SetOption(kv.BinlogInfo, info)
 }
 
 const specialPrefix = `/*T! `

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/store/tikv/option"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tipb/go-binlog"
@@ -294,7 +295,7 @@ func SetDDLBinlog(client *pumpcli.PumpsClient, txn kv.Transaction, jobID int64, 
 		},
 		Client: client,
 	}
-	txn.GetUnionStore().SetOption(kv.BinlogInfo, info)
+	txn.(option.Setter).SetOption(kv.BinlogInfo, info)
 }
 
 const specialPrefix = `/*T! `

--- a/store/tikv/option/option.go
+++ b/store/tikv/option/option.go
@@ -1,0 +1,17 @@
+package option
+
+import (
+	"github.com/pingcap/tidb/kv"
+)
+
+type Setter interface {
+	// SetOption sets an option with a value, when val is nil, uses the default
+	// value of this option. Only ReplicaRead is supported for snapshot
+	SetOption(opt kv.Option, val interface{})
+	// DelOption deletes an option.
+	DelOption(opt kv.Option)
+}
+
+type Getter interface {
+	GetOption(opt kv.Option) interface{}
+}

--- a/store/tikv/option/option.go
+++ b/store/tikv/option/option.go
@@ -1,9 +1,23 @@
+// Copyright 2021 PingCAP, Inc.
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package option
 
 import (
 	"github.com/pingcap/tidb/kv"
 )
 
+// Setter provides functions to set and delete options.
 type Setter interface {
 	// SetOption sets an option with a value, when val is nil, uses the default
 	// value of this option. Only ReplicaRead is supported for snapshot
@@ -12,6 +26,7 @@ type Setter interface {
 	DelOption(opt kv.Option)
 }
 
+// Getter provides the function to get the value of option.
 type Getter interface {
 	GetOption(opt kv.Option) interface{}
 }

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -51,12 +51,12 @@ const (
 
 // tikvSnapshot implements the kv.Snapshot interface.
 type tikvSnapshot struct {
-	store           *KVStore
-	version         kv.Version
-	isolationLevel  kv.IsoLevel
-	priority        pb.CommandPri
-	notFillCache    bool
-	syncLog         bool
+	store          *KVStore
+	version        kv.Version
+	isolationLevel kv.IsoLevel
+	priority       pb.CommandPri
+	notFillCache   bool
+	//syncLog         bool
 	keyOnly         bool
 	vars            *kv.Variables
 	replicaReadSeed uint32
@@ -533,7 +533,7 @@ func (s *tikvSnapshot) SetOption(opt kv.Option, val interface{}) {
 	case kv.NotFillCache:
 		s.notFillCache = val.(bool)
 	case kv.SyncLog:
-		s.syncLog = val.(bool)
+		//s.syncLog = val.(bool)
 	case kv.KeyOnly:
 		s.keyOnly = val.(bool)
 	case kv.SnapshotTS:

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -51,12 +51,12 @@ const (
 
 // tikvSnapshot implements the kv.Snapshot interface.
 type tikvSnapshot struct {
-	store          *KVStore
-	version        kv.Version
-	isolationLevel kv.IsoLevel
-	priority       pb.CommandPri
-	notFillCache   bool
-	//syncLog         bool
+	store           *KVStore
+	version         kv.Version
+	isolationLevel  kv.IsoLevel
+	priority        pb.CommandPri
+	notFillCache    bool
+	syncLog         bool
 	keyOnly         bool
 	vars            *kv.Variables
 	replicaReadSeed uint32
@@ -533,7 +533,7 @@ func (s *tikvSnapshot) SetOption(opt kv.Option, val interface{}) {
 	case kv.NotFillCache:
 		s.notFillCache = val.(bool)
 	case kv.SyncLog:
-		//s.syncLog = val.(bool)
+		s.syncLog = val.(bool)
 	case kv.KeyOnly:
 		s.keyOnly = val.(bool)
 	case kv.SnapshotTS:


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR moves functions (set/delete/get option) from `kv.Transaction` and create new interface to manage options in `tikv` package since `Option` is only supported by `tikv`
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note