### PR TITLE
statistics: update the count and modify variables of global-stats as well when dumping delta info

### DIFF
--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1000,8 +1000,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20", // global: g.count = p0.count + p1.count
-		"0 9",  // p0
+		"0 20",  // global: g.count = p0.count + p1.count
+		"0 9",   // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -1031,7 +1031,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8", // p0
+			"5 1 8",   // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -1045,7 +1045,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1", // p0
+			"5 1",  // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -879,6 +879,66 @@ func (s *testStatsSuite) TestAnalyzeGlobalStatsWithOpts2(c *C) {
 	s.checkForGlobalStatsWithOpts(c, tk, "p1", 100, 200)
 }
 
+func (s *testStatsSuite) TestGlobalStatsHealthy(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`
+create table t (
+	a int,
+	key(a)
+)
+partition by range (a) (
+	partition p0 values less than (10),
+	partition p1 values less than (20)
+)`)
+
+	checkModifyAndCount := func(gModify, gCount, p0Modify, p0Count, p1Modify, p1Count int) {
+		rs := tk.MustQuery("show stats_meta").Rows()
+		c.Assert(rs[0][4].(string), Equals, fmt.Sprintf("%v", gModify))  // global.modify_count
+		c.Assert(rs[0][5].(string), Equals, fmt.Sprintf("%v", gCount))   // global.row_count
+		c.Assert(rs[1][4].(string), Equals, fmt.Sprintf("%v", p0Modify)) // p0.modify_count
+		c.Assert(rs[1][5].(string), Equals, fmt.Sprintf("%v", p0Count))  // p0.row_count
+		c.Assert(rs[2][4].(string), Equals, fmt.Sprintf("%v", p1Modify)) // p1.modify_count
+		c.Assert(rs[2][5].(string), Equals, fmt.Sprintf("%v", p1Count))  // p1.row_count
+	}
+	checkHealthy := func(gH, p0H, p1H int) {
+		tk.MustQuery("show stats_healthy").Check(testkit.Rows(
+			fmt.Sprintf("test t global %v", gH),
+			fmt.Sprintf("test t p0 %v", p0H),
+			fmt.Sprintf("test t p1 %v", p1H)))
+	}
+
+	tk.MustExec("set @@tidb_analyze_version=2")
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("analyze table t")
+	checkModifyAndCount(0, 0, 0, 0, 0, 0)
+	checkHealthy(100, 100, 100)
+
+	tk.MustExec("insert into t values (1), (2)") // update p0
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	c.Assert(s.do.StatsHandle().Update(s.do.InfoSchema()), IsNil)
+	checkModifyAndCount(2, 2, 2, 2, 0, 0)
+	checkHealthy(0, 0, 100)
+
+	tk.MustExec("insert into t values (11), (12), (13), (14)") // update p1
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	c.Assert(s.do.StatsHandle().Update(s.do.InfoSchema()), IsNil)
+	checkModifyAndCount(6, 6, 2, 2, 4, 4)
+	checkHealthy(0, 0, 0)
+
+	tk.MustExec("analyze table t")
+	checkModifyAndCount(0, 6, 0, 2, 0, 4)
+	checkHealthy(100, 100, 100)
+
+	tk.MustExec("insert into t values (4), (5), (15), (16)") // update p0 and p1 together
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	c.Assert(s.do.StatsHandle().Update(s.do.InfoSchema()), IsNil)
+	checkModifyAndCount(4, 10, 2, 4, 2, 6)
+	checkHealthy(60, 50, 66)
+}
+
 func (s *testStatsSuite) TestGlobalStatsData(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	tk := testkit.NewTestKit(c, s.store)
@@ -940,8 +1000,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20",  // global: g.count = p0.count + p1.count
-		"0 9",   // p0
+		"0 20", // global: g.count = p0.count + p1.count
+		"0 9",  // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -971,7 +1031,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8",   // p0
+			"5 1 8", // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -985,7 +1045,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1",  // p0
+			"5 1", // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)
@@ -1519,7 +1579,7 @@ func (s *testStatsSuite) TestFMSWithAnalyzePartition(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_partition_prune_mode = '" + string(variable.Dynamic) + "'")
 	tk.MustExec("set @@tidb_analyze_version = 2")
-	tk.MustExec(`create table t (a int, key(a)) partition by range(a) 
+	tk.MustExec(`create table t (a int, key(a)) partition by range(a)
 					(partition p0 values less than (10),
 					partition p1 values less than (22))`)
 	tk.MustExec(`insert into t values (1), (2), (3), (10), (11)`)

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -479,12 +479,12 @@ func (h *Handle) dumpTableStatCountToKV(id int64, delta variable.TableDelta) (up
 	}
 	affectedRows := h.mu.ctx.GetSessionVars().StmtCtx.AffectedRows()
 
+	// if it's a partitioned table and its global-stats exists, update its count and modify_count as well.
 	is := infoschema.GetInfoSchema(h.mu.ctx)
 	if is == nil {
 		return false, errors.New("cannot get the information schema")
 	}
 	if tbl, _, _ := is.FindTableByPartitionID(id); tbl != nil {
-		// if it's a partitioned table, update count and modify_count of its global-stats as well.
 		if err = updateStatsMeta(tbl.Meta().ID); err != nil {
 			return
 		}

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -2127,8 +2127,8 @@ func (s *testSerialStatsSuite) TestAutoUpdatePartitionInDynamicOnlyMode(c *C) {
 		c.Assert(h.Update(is), IsNil)
 		globalStats = h.GetTableStats(tableInfo)
 		partitionStats = h.GetPartitionStats(tableInfo, pi.Definitions[0].ID)
-		c.Assert(globalStats.Count, Equals, int64(6))
-		c.Assert(globalStats.ModifyCount, Equals, int64(0))
+		c.Assert(globalStats.Count, Equals, int64(7))
+		c.Assert(globalStats.ModifyCount, Equals, int64(1))
 		c.Assert(partitionStats.Count, Equals, int64(3))
 		c.Assert(partitionStats.ModifyCount, Equals, int64(1))
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: statistics: update the count and modify variables of global-stats as well when dumping delta info

### What is changed and how it works?
statistics: update the count and modify variables of global-stats as well when dumping delta info
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- statistics: update the count and modify variables of global-stats as well when dumping delta info
