### PR TITLE
statistics: add a test case which builds global-stats on different versions of partition-stats

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -991,7 +991,7 @@ const (
 	ErrInvalidTableSample                  = 8128
 	ErrJSONObjectKeyTooLong                = 8129
 	ErrMultiStatementDisabled              = 8130
-	ErrBuildGlobalLevelStatsFailed         = 8131
+	ErrPartitionStatsMissing               = 8131
 
 	// Error codes used by TiDB ddl package
 	ErrUnsupportedDDLOperation            = 8200

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1032,8 +1032,8 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 
 	ErrInvalidTableSample: mysql.Message("Invalid TABLESAMPLE: %s", nil),
 
-	ErrJSONObjectKeyTooLong:        mysql.Message("TiDB does not yet support JSON objects with the key length >= 65536", nil),
-	ErrBuildGlobalLevelStatsFailed: mysql.Message("Build table: %s global-level stats failed due to missing partition-level stats", nil),
+	ErrJSONObjectKeyTooLong:  mysql.Message("TiDB does not yet support JSON objects with the key length >= 65536", nil),
+	ErrPartitionStatsMissing: mysql.Message("Build table: %s global-level stats failed due to missing partition-level stats", nil),
 
 	ErrInvalidPlacementSpec:   mysql.Message("Invalid placement policy '%s': %s", nil),
 	ErrPlacementPolicyCheck:   mysql.Message("Placement policy didn't meet the constraint, reason: %s", nil),

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -172,7 +172,7 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		for globalStatsID, info := range globalStatsMap {
 			globalStats, err := statsHandle.MergePartitionStats2GlobalStats(e.ctx, e.opts, infoschema.GetInfoSchema(e.ctx), globalStatsID.tableID, info.isIndex, info.idxID)
 			if err != nil {
-				if types.ErrBuildGlobalLevelStatsFailed.Equal(err) {
+				if types.ErrPartitionStatsMissing.Equal(err) {
 					// When we find some partition-level stats are missing, we need to report warning.
 					e.ctx.GetSessionVars().StmtCtx.AppendWarning(err)
 					continue

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -381,12 +381,12 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 				}
 				errMsg = fmt.Sprintf("`%s` index: `%s`", tableInfo.Name.L, indexName)
 			}
-			err = types.ErrBuildGlobalLevelStatsFailed.GenWithStackByArgs(errMsg)
+			err = types.ErrPartitionStatsMissing.GenWithStackByArgs(errMsg)
 			return
 		}
 		statistics.CheckAnalyzeVerOnTable(partitionStats, &statsVer)
 		if statsVer != statistics.Version2 { // global-stats only support stats-ver2
-			return nil, fmt.Errorf("[stats]: global statistics for partitioned tables only available in statistics version2, please set tidb_analyze_version to 2")
+			return nil, fmt.Errorf("[stats]: some partition level statistics are not in statistics version 2, please set tidb_analyze_version to 2 and analyze the this table")
 		}
 		for i := 0; i < globalStats.Num; i++ {
 			ID := tableInfo.Columns[i].ID

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -387,7 +387,6 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 		statistics.CheckAnalyzeVerOnTable(partitionStats, &statsVer)
 		if statsVer != statistics.Version2 { // global-stats only support stats-ver2
 			return nil, fmt.Errorf("[stats]: global statistics for partitioned tables only available in statistics version2, please set tidb_analyze_version to 2")
-
 		}
 		for i := 0; i < globalStats.Num; i++ {
 			ID := tableInfo.Columns[i].ID

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1000,8 +1000,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20", // global: g.count = p0.count + p1.count
-		"0 9",  // p0
+		"0 20",  // global: g.count = p0.count + p1.count
+		"0 9",   // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -1031,7 +1031,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8", // p0
+			"5 1 8",   // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -1045,7 +1045,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1", // p0
+			"5 1",  // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -940,8 +940,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20",  // global: g.count = p0.count + p1.count
-		"0 9",   // p0
+		"0 20", // global: g.count = p0.count + p1.count
+		"0 9",  // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -971,7 +971,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8",   // p0
+			"5 1 8", // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -985,7 +985,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1",  // p0
+			"5 1", // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)
@@ -1280,6 +1280,33 @@ partition by range (a) (
 	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 3) // p0 + p1 + global
 }
 
+func (s *testStatsSuite) TestGlobalStatsVer1AndVer2(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`
+create table t (
+	a int
+)
+partition by range (a) (
+	partition p0 values less than (10),
+	partition p1 values less than (20)
+)`)
+	tk.MustExec("set @@tidb_partition_prune_mode='static'")
+	tk.MustExec("set @@tidb_analyze_version=1")
+	tk.MustExec("analyze table t")
+
+	tk.MustExec("insert into t values (1), (11)")
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	tk.MustExec("analyze table t") // p0 and p1 are in stats1
+
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("set @@tidb_analyze_version=2")
+	tk.MustExec("analyze table t partition p1") // let p1 in stats2
+	tk.MustQuery("show warnings").Check(testkit.Rows("xxx"))
+}
+
 func (s *testStatsSuite) TestExtendedStatsDefaultSwitch(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	tk := testkit.NewTestKit(c, s.store)
@@ -1525,7 +1552,7 @@ func (s *testStatsSuite) TestPartitionPruneModeSessionVariable(c *C) {
 	tk2.MustExec("set @@tidb_partition_prune_mode = '" + string(variable.Static) + "'")
 	tk2.MustExec(`set @@tidb_analyze_version=2`)
 
-	tk1.MustExec(`create table t (a int, key(a)) partition by range(a) 
+	tk1.MustExec(`create table t (a int, key(a)) partition by range(a)
 					(partition p0 values less than (10),
 					partition p1 values less than (22))`)
 
@@ -1576,7 +1603,7 @@ func (s *testStatsSuite) TestFMSWithAnalyzePartition(c *C) {
 	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_partition_prune_mode = '" + string(variable.Dynamic) + "'")
 	tk.MustExec("set @@tidb_analyze_version = 2")
-	tk.MustExec(`create table t (a int, key(a)) partition by range(a) 
+	tk.MustExec(`create table t (a int, key(a)) partition by range(a)
 					(partition p0 values less than (10),
 					partition p1 values less than (22))`)
 	tk.MustExec(`insert into t values (1), (2), (3), (10), (11)`)

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -940,8 +940,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20",  // global: g.count = p0.count + p1.count
-		"0 9",   // p0
+		"0 20", // global: g.count = p0.count + p1.count
+		"0 9",  // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -971,7 +971,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8",   // p0
+			"5 1 8", // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -985,7 +985,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1",  // p0
+			"5 1", // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)
@@ -1284,6 +1284,12 @@ partition by range (a) (
 
 	tk.MustExec("analyze table t") // both p0 and p1 are in ver2
 	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 3)
+
+	tk.MustExec("alter table t add partition (partition p2 values less than (30))")
+	tk.MustExec("insert t values (13), (14)")
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	tk.MustExec("analyze table t partition p2")                      // it will success since p0 and p1 are both in ver2
+	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 4) // p0, p1, p2 and global
 }
 
 func (s *testStatsSuite) TestExtendedStatsDefaultSwitch(c *C) {

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -940,8 +940,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20", // global: g.count = p0.count + p1.count
-		"0 9",  // p0
+		"0 20",  // global: g.count = p0.count + p1.count
+		"0 9",   // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -971,7 +971,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8", // p0
+			"5 1 8",   // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -985,7 +985,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1", // p0
+			"5 1",  // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)
@@ -1266,45 +1266,24 @@ partition by range (a) (
 	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
 
 	tk.MustExec("set @@tidb_partition_prune_mode='static'")
-	tk.MustExec("analyze table t")
-	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 2) // p0 + p1
+	tk.MustExec("set @@tidb_analyze_version=1")
+	tk.MustExec("analyze table t") // both p0 and p1 are in ver1
+	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 2)
 
 	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
 	tk.MustExec("set @@tidb_analyze_version=1")
-	err := tk.ExecToErr("analyze table t")
+	err := tk.ExecToErr("analyze table t") // try to build global-stats on ver1
 	c.Assert(err, NotNil)
-	c.Assert(err.Error(), Equals, "[stats]: global statistics for partitioned tables only available in statistics version2, please set tidb_analyze_version to 2")
-
-	tk.MustExec("set @@tidb_analyze_version=2")
-	tk.MustExec("analyze table t")
-	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 3) // p0 + p1 + global
-}
-
-func (s *testStatsSuite) TestGlobalStatsVer1AndVer2(c *C) {
-	defer cleanEnv(c, s.store, s.do)
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t")
-	tk.MustExec(`
-create table t (
-	a int
-)
-partition by range (a) (
-	partition p0 values less than (10),
-	partition p1 values less than (20)
-)`)
-	tk.MustExec("set @@tidb_partition_prune_mode='static'")
-	tk.MustExec("set @@tidb_analyze_version=1")
-	tk.MustExec("analyze table t")
-
-	tk.MustExec("insert into t values (1), (11)")
-	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
-	tk.MustExec("analyze table t") // p0 and p1 are in stats1
+	c.Assert(err.Error(), Equals, "[stats]: some partition level statistics are not in statistics version 2, please set tidb_analyze_version to 2 and analyze the this table")
 
 	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
 	tk.MustExec("set @@tidb_analyze_version=2")
-	tk.MustExec("analyze table t partition p1") // let p1 in stats2
-	tk.MustQuery("show warnings").Check(testkit.Rows("xxx"))
+	err = tk.ExecToErr("analyze table t partition p1") // only analyze p1 to let it in ver2 while p0 is in ver1
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "[stats]: some partition level statistics are not in statistics version 2, please set tidb_analyze_version to 2 and analyze the this table")
+
+	tk.MustExec("analyze table t") // both p0 and p1 are in ver2
+	c.Assert(len(tk.MustQuery("show stats_meta").Rows()), Equals, 3)
 }
 
 func (s *testStatsSuite) TestExtendedStatsDefaultSwitch(c *C) {

--- a/types/errors.go
+++ b/types/errors.go
@@ -83,7 +83,7 @@ var (
 	ErrWrongValue = dbterror.ClassTypes.NewStdErr(mysql.ErrTruncatedWrongValue, mysql.MySQLErrName[mysql.ErrWrongValue])
 	// ErrWrongValueForType is returned when the input value is in wrong format for function.
 	ErrWrongValueForType = dbterror.ClassTypes.NewStdErr(mysql.ErrWrongValueForType, mysql.MySQLErrName[mysql.ErrWrongValueForType])
-	// ErrBuildGlobalLevelStatsFailed is returned when the partition-level stats is missing and the build global-level stats fails.
+	// ErrPartitionStatsMissing is returned when the partition-level stats is missing and the build global-level stats fails.
 	// Put this error here is to prevent `import cycle not allowed`.
-	ErrBuildGlobalLevelStatsFailed = dbterror.ClassTypes.NewStd(mysql.ErrBuildGlobalLevelStatsFailed)
+	ErrPartitionStatsMissing = dbterror.ClassTypes.NewStd(mysql.ErrPartitionStatsMissing)
 )


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: statistics: add a test case which builds global-stats on different versions of partition-stats

### What is changed and how it works?

statistics: add a test case which builds global-stats on different versions of partition-stats

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- statistics: add a test case which builds global-stats on different versions of partition-stats
