### PR TITLE
ddl: make TestNotifyDDLJob stable

### DIFF
--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -102,7 +102,7 @@ func (s *testDDLSuite) TestNotifyDDLJob(c *C) {
 	)
 	defer d.Stop()
 	getFirstNotificationAfterStartDDL(d)
-	// Ensure that the notification is not handled by worker's "start".
+	// Ensure that the notification is not handled in workers `start` function.
 	d.cancel()
 	for _, worker := range d.workers {
 		worker.close()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

```
[2021-03-09T09:00:56.914Z] ----------------------------------------------------------------------
[2021-03-09T09:00:56.914Z] FAIL: ddl_worker_test.go:80: testDDLSuite.TestNotifyDDLJob
[2021-03-09T09:00:56.914Z]
[2021-03-09T09:00:56.914Z] ddl_worker_test.go:128:
[2021-03-09T09:00:56.914Z]     c.Fatal("do not get the add index job notification")
[2021-03-09T09:00:56.914Z] ... Error: do not get the add index job notification
[2021-03-09T09:00:56.914Z]
```

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

How it Works:

Ensure that the notification is not handled by the worker's "start".

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

### Release note <!-- bugfixes or new feature need a release note -->

- No release note. 
