### PR TITLE
config: disable prepare plan cache by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -617,7 +617,7 @@ var defaultConf = Config{
 		HeaderTimeout: 5,
 	},
 	PreparedPlanCache: PreparedPlanCache{
-		Enabled:          true,
+		Enabled:          false,
 		Capacity:         100,
 		MemoryGuardRatio: 0.1,
 	},

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -312,7 +312,7 @@ networks = ""
 header-timeout = 5
 
 [prepared-plan-cache]
-enabled = true
+enabled = false
 capacity = 100
 memory-guard-ratio = 0.1
 

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -32,8 +32,8 @@ import (
 
 var (
 	// preparedPlanCacheEnabledValue stores the global config "prepared-plan-cache-enabled".
-	// The value is true unless "prepared-plan-cache-enabled" is FALSE in configuration.
-	preparedPlanCacheEnabledValue int32 = 1
+	// The value is false unless "prepared-plan-cache-enabled" is true in configuration.
+	preparedPlanCacheEnabledValue int32 = 0
 	// PreparedPlanCacheCapacity stores the global config "prepared-plan-cache-capacity".
 	PreparedPlanCacheCapacity uint = 100
 	// PreparedPlanCacheMemoryGuardRatio stores the global config "prepared-plan-cache-memory-guard-ratio".


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23239

Problem Summary:

Disable prepare plan cache by default.

### What is changed and how it works?

What's Changed:

Change default config for prepare plan cache to false.


### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test: current tests should cover this change

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Disable prepare plan cache by default