### PR TITLE
planner: fix a panic caused by unmatched FieldNames and ColsInfo in partition pruning

### DIFF
--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -461,6 +461,18 @@ CREATE TABLE t1 (
 PARTITION BY HASH( a )
 PARTITIONS 4`)
 	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows()) // work fine without any error
+
+	tk.MustExec("insert into t1 values (1, 1)")
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 1"))
+
+	tk.MustExec("insert into t1 values (2, 2), (2, 2)")
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 2"))
+
+	tk.MustExec("insert into t1 values (3, 3), (3, 3), (3, 3)")
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("1 3"))
+
+	tk.MustExec("insert into t1 values (4, 4), (4, 4), (4, 4), (4, 4)")
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows("4 4"))
 }
 
 func (s *testPartitionPruneSuit) TestIssue22898(c *C) {

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -449,6 +449,20 @@ func (s *testPartitionPruneSuit) TestListColumnsPartitionPrunerRandom(c *C) {
 	}
 }
 
+func (s *testPartitionPruneSuit) TestIssue22635(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("USE test;")
+	tk.MustExec("DROP TABLE IF EXISTS t1")
+	tk.MustExec(`
+CREATE TABLE t1 (
+  a int(11) DEFAULT NULL,
+  b int(11) DEFAULT NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY HASH( a )
+PARTITIONS 4`)
+	tk.MustQuery("SELECT (SELECT tt.a FROM t1  tt LIMIT 1) aa, COUNT(DISTINCT b) FROM t1  GROUP BY aa").Check(testkit.Rows()) // work fine without any error
+}
+
 func (s *testPartitionPruneSuit) TestIssue22898(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("USE test;")

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -107,7 +107,6 @@ type partitionTable interface {
 
 func generateHashPartitionExpr(ctx sessionctx.Context, pi *model.PartitionInfo, columns []*expression.Column, names types.NameSlice) (expression.Expression, error) {
 	schema := expression.NewSchema(columns...)
-	fmt.Printf(">>>>>>>>>>>>>>>>>>>>>>>>> ParseSimpleExprsWithNames, pi.Expr: %v, schema: %v, names: %v \n", pi.Expr, schema.String(), names)
 	exprs, err := expression.ParseSimpleExprsWithNames(ctx, pi.Expr, schema, names)
 	if err != nil {
 		return nil, err
@@ -216,6 +215,16 @@ func (s *partitionProcessor) recoverTableColNames(ds *DataSource) ([]*types.Fiel
 	names := make([]*types.FieldName, 0, len(ds.TblCols))
 	colsInfo := ds.table.FullHiddenColsAndVisibleCols()
 	for _, colExpr := range ds.TblCols {
+		if colExpr.ID == model.ExtraHandleID {
+			names = append(names, &types.FieldName{
+				DBName:      ds.DBName,
+				TblName:     ds.tableInfo.Name,
+				ColName:     model.ExtraHandleName,
+				OrigColName: model.ExtraHandleName,
+			})
+			continue
+		}
+
 		found := false
 		for _, colInfo := range colsInfo {
 			if colInfo.ID == colExpr.ID {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22635 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix a panic caused by unmatched FieldNames and ColsInfo

### What is changed and how it works?

The panic is caused by we propagate unmatched `FieldsName` and `ColsInfo` to the expression rewriter in `processHashPartition`.
This PR solves this problem by reconstructing `FieldsName` there before calling the expression rewriter.


Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: fix a panic caused by unmatched FieldNames and ColsInfo