### PR TITLE
server: add tiflash fallback testcase

### DIFF
--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -778,7 +778,11 @@ func (ts *ConnTestSuite) TestTiFlashFallback(c *C) {
 	c.Assert(cc.handleQuery(ctx, "select * from t t1 join t t2 on t1.a = t2.a"), NotNil)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/server/secondNextErr"), IsNil)
 
-	// TODO: simple TiFlash query (unary + non-streaming)
+	// simple TiFlash query (unary + non-streaming)
+	tk.MustExec("set @@tidb_allow_batch_cop=0; set @@tidb_allow_mpp=0;")
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/tikvStoreSendReqResult", "return(\"requestTiFlashError\")"), IsNil)
+	testFallbackWork(c, tk, cc, "select sum(a) from t")
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/tikvStoreSendReqResult"), IsNil)
 
 	// TiFlash query based on batch cop (batch + streaming)
 	tk.MustExec("set @@tidb_allow_batch_cop=1; set @@tidb_allow_mpp=0;")

--- a/store/mockstore/unistore/rpc.go
+++ b/store/mockstore/unistore/rpc.go
@@ -223,11 +223,6 @@ func (c *RPCClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	case tikvrpc.CmdRawScan:
 		resp.Resp, err = c.rawHandler.RawScan(ctx, req.RawScan())
 	case tikvrpc.CmdCop:
-		failpoint.Inject("copRpcErr"+addr, func(value failpoint.Value) {
-			if value.(string) == addr {
-				failpoint.Return(nil, errors.New("cop rpc error"))
-			}
-		})
 		resp.Resp, err = c.usSvr.Coprocessor(ctx, req.Cop())
 	case tikvrpc.CmdCopStream:
 		resp.Resp, err = c.handleCopStream(ctx, req.Cop())

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -255,6 +255,10 @@ func (s *RegionRequestSender) SendReqCtx(
 			if sType == kv.TiDB {
 				failpoint.Return(nil, nil, ErrTiKVServerTimeout)
 			}
+		case "requestTiFlashError":
+			if sType == kv.TiFlash {
+				failpoint.Return(nil, nil, ErrTiFlashServerTimeout)
+			}
 		}
 	})
 


### PR DESCRIPTION
### What problem does this PR solve?

Related PR: #22459, #23103, #23226

### What is changed and how it works?

What's Changed:

Add TiFlash fallback testcase for simple TiFlash query (unary + non-streaming).

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- add TiFlash fallback testcase<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
