### PR TITLE
planner: fix analyze clustered index table can't trigger index primary

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -929,6 +929,7 @@ func (s *testSerialSuite2) TestIssue20874(c *C) {
 
 func (s *testSuite1) TestAnalyzeClusteredIndexPrimary(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t0")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t0(a varchar(20), primary key(a) clustered)")
@@ -937,5 +938,7 @@ func (s *testSuite1) TestAnalyzeClusteredIndexPrimary(c *C) {
 	tk.MustExec("insert into t1 values('1111')")
 	tk.MustExec("analyze table t0 index primary")
 	tk.MustExec("analyze table t1 index primary")
-	tk.MustQuery("show stats_buckets").Check(testkit.Rows(""))
+	tk.MustQuery("show stats_buckets").Check(testkit.Rows(
+		"test t0  PRIMARY 1 0 1 1 1111 1111 0",
+		"test t1  PRIMARY 1 0 1 1 1111 1111 0"))
 }

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -926,3 +926,16 @@ func (s *testSerialSuite2) TestIssue20874(c *C) {
 		"test t  idxb 1 1 3 2 \x00C \x00C 0",
 	))
 }
+
+func (s *testSuite1) TestAnalyzeClusteredIndexPrimary(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("drop table if exists t0")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t0(a varchar(20), primary key(a) clustered)")
+	tk.MustExec("create table t1(a varchar(20), primary key(a))")
+	tk.MustExec("insert into t0 values('1111')")
+	tk.MustExec("insert into t1 values('1111')")
+	tk.MustExec("analyze table t0 index primary")
+	tk.MustExec("analyze table t1 index primary")
+	tk.MustQuery("show stats_buckets").Check(testkit.Rows(""))
+}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1749,7 +1749,6 @@ func (b *PlanBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt, opts map[ast.A
 					}
 					p.ColTasks = append(p.ColTasks, AnalyzeColumnsTask{HandleCols: handleCols, analyzeInfo: info, TblInfo: tblInfo})
 				}
-				continue
 			}
 		}
 		idx := tblInfo.FindIndexByName(idxName.L)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1735,7 +1735,8 @@ func (b *PlanBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt, opts map[ast.A
 	for _, idxName := range as.IndexNames {
 		if isPrimaryIndex(idxName) {
 			handleCols := BuildHandleColsForAnalyze(b.ctx, tblInfo)
-			if handleCols != nil {
+			// Fast analyze use analyze column to solve int handle.
+			if handleCols != nil && handleCols.IsInt() && b.ctx.GetSessionVars().EnableFastAnalyze {
 				for i, id := range physicalIDs {
 					if id == tblInfo.ID {
 						id = -1
@@ -1749,6 +1750,7 @@ func (b *PlanBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt, opts map[ast.A
 					}
 					p.ColTasks = append(p.ColTasks, AnalyzeColumnsTask{HandleCols: handleCols, analyzeInfo: info, TblInfo: tblInfo})
 				}
+				continue
 			}
 		}
 		idx := tblInfo.FindIndexByName(idxName.L)


### PR DESCRIPTION
Signed-off-by: lzmhhh123 <lzmhhh123@gmail.com><!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23230

### What is changed and how it works?

How it Works: only use analyze columns to handle analyze index primary when fast analyze int handle.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- none