### PR TITLE
statistics: add tests for global-stats when add and delete a single partition

### DIFF
--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -305,7 +305,7 @@ func (s *testStatisticsSuite) TestCMSketchCodingTopN(c *C) {
 	DecodeCMSketchAndTopN([]byte{}, rows)
 }
 
-func (s *testStatisticsSuite) TestMergeTopN(c *C) {
+func (s *testSerialStatisticsSuite) TestMergeTopN(c *C) {
 	tests := []struct {
 		topnNum    int
 		n          int

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strconv"
 	"time"
 
 	. "github.com/pingcap/check"
@@ -303,90 +302,4 @@ func (s *testStatisticsSuite) TestCMSketchCodingTopN(c *C) {
 	c.Assert(lSketch.Equal(rSketch), IsTrue)
 	// do not panic
 	DecodeCMSketchAndTopN([]byte{}, rows)
-}
-
-func (s *testSerialStatisticsSuite) TestMergeTopN(c *C) {
-	tests := []struct {
-		topnNum    int
-		n          int
-		maxTopNVal int
-		maxTopNCnt int
-	}{
-		{
-			topnNum:    10,
-			n:          5,
-			maxTopNVal: 50,
-			maxTopNCnt: 100,
-		},
-		{
-			topnNum:    1,
-			n:          5,
-			maxTopNVal: 50,
-			maxTopNCnt: 100,
-		},
-		{
-			topnNum:    5,
-			n:          5,
-			maxTopNVal: 5,
-			maxTopNCnt: 100,
-		},
-		{
-			topnNum:    5,
-			n:          5,
-			maxTopNVal: 10,
-			maxTopNCnt: 100,
-		},
-	}
-	for _, t := range tests {
-		topnNum, n := t.topnNum, t.n
-		maxTopNVal, maxTopNCnt := t.maxTopNVal, t.maxTopNCnt
-
-		// the number of maxTopNVal should be bigger than n.
-		ok := maxTopNVal >= n
-		c.Assert(ok, Equals, true)
-
-		topNs := make([]*TopN, 0, topnNum)
-		res := make(map[int]uint64)
-		rand.Seed(time.Now().Unix())
-		for i := 0; i < topnNum; i++ {
-			topN := NewTopN(n)
-			occur := make(map[int]bool)
-			for j := 0; j < n; j++ {
-				// The range of numbers in the topn structure is in [0, maxTopNVal)
-				// But there cannot be repeated occurrences of value in a topN structure.
-				randNum := rand.Intn(maxTopNVal)
-				for occur[randNum] {
-					randNum = rand.Intn(maxTopNVal)
-				}
-				occur[randNum] = true
-				tString := []byte(fmt.Sprintf("%d", randNum))
-				// The range of the number of occurrences in the topn structure is in [0, maxTopNCnt)
-				randCnt := uint64(rand.Intn(maxTopNCnt))
-				res[randNum] += randCnt
-				topNMeta := TopNMeta{tString, randCnt}
-				topN.TopN = append(topN.TopN, topNMeta)
-			}
-			topNs = append(topNs, topN)
-		}
-		topN, remainTopN := MergeTopN(topNs, uint32(n))
-		cnt := len(topN.TopN)
-		var minTopNCnt uint64
-		for _, topNMeta := range topN.TopN {
-			val, err := strconv.Atoi(string(topNMeta.Encoded))
-			c.Assert(err, IsNil)
-			c.Assert(topNMeta.Count, Equals, res[val])
-			minTopNCnt = topNMeta.Count
-		}
-		if remainTopN != nil {
-			cnt += len(remainTopN)
-			for _, remainTopNMeta := range remainTopN {
-				val, err := strconv.Atoi(string(remainTopNMeta.Encoded))
-				c.Assert(err, IsNil)
-				c.Assert(remainTopNMeta.Count, Equals, res[val])
-				ok = minTopNCnt > remainTopNMeta.Count
-				c.Assert(ok, Equals, true)
-			}
-		}
-		c.Assert(cnt, Equals, len(res))
-	}
 }

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -318,9 +318,9 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 		return
 	}
 	globalTableInfo := globalTable.Meta()
-	partitionNum := globalTableInfo.Partition.Num
+	partitionNum := len(globalTableInfo.Partition.Definitions)
 	partitionIDs := make([]int64, 0, partitionNum)
-	for i := uint64(0); i < partitionNum; i++ {
+	for i := 0; i < partitionNum; i++ {
 		partitionIDs = append(partitionIDs, globalTableInfo.Partition.Definitions[i].ID)
 	}
 
@@ -411,7 +411,7 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 	for i := 0; i < globalStats.Num; i++ {
 		// Merge CMSketch
 		globalStats.Cms[i] = allCms[i][0].Copy()
-		for j := uint64(1); j < partitionNum; j++ {
+		for j := 1; j < partitionNum; j++ {
 			err = globalStats.Cms[i].MergeCMSketch(allCms[i][j])
 			if err != nil {
 				return
@@ -435,7 +435,7 @@ func (h *Handle) MergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 			// For the column stats, we should merge the FMSketch first. And use the FMSketch to calculate the new NDV.
 			// merge FMSketch
 			globalStats.Fms[i] = allFms[i][0].Copy()
-			for j := uint64(1); j < partitionNum; j++ {
+			for j := 1; j < partitionNum; j++ {
 				globalStats.Fms[i].MergeFMSketch(allFms[i][j])
 			}
 

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1350,37 +1350,38 @@ partition by range (a) (
 	tk.MustExec("insert t values (13), (14), (22), (23)")
 	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
 	tk.MustExec("analyze table t partition p2") // it will success since p0 and p1 are both in ver2
-	result := tk.MustQuery("show stats_meta where table_name = 't';").Rows()
-	c.Assert(len(result), Equals, 4)    // p0, p1, p2 and global
-	c.Assert(result[0][5], Equals, "7") // global.count = p0.count + p1.count + p2.count
-	c.Assert(result[1][5], Equals, "3")
-	c.Assert(result[2][5], Equals, "2") // We did not analyze partition p1, so the value here has not changed
-	c.Assert(result[3][5], Equals, "2")
+	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	do := s.do
+	is := do.InfoSchema()
+	h := do.StatsHandle()
+	c.Assert(h.Update(is), IsNil)
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	tableInfo := tbl.Meta()
+	globalStats := h.GetTableStats(tableInfo)
+	// global.count = p0.count(3) + p1.count(2) + p2.count(2)
+	// We did not analyze partition p1, so the value here has not changed
+	c.Assert(globalStats.Count, Equals, int64(7))
 
 	tk.MustExec("analyze table t;")
-	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()
-	c.Assert(len(result), Equals, 4)    // p0, p1, p2 and global
-	c.Assert(result[0][5], Equals, "9") // global.count = p0.count + p1.count + p2.count
-	c.Assert(result[1][5], Equals, "3")
-	c.Assert(result[2][5], Equals, "4")
-	c.Assert(result[3][5], Equals, "2")
+	globalStats = h.GetTableStats(tableInfo)
+	// global.count = p0.count(3) + p1.count(4) + p2.count(4)
+	// The value of p1.Count is correct now.
+	c.Assert(globalStats.Count, Equals, int64(9))
+	c.Assert(globalStats.ModifyCount, Equals, int64(0))
 
 	tk.MustExec("alter table t drop partition p2;")
 	c.Assert(s.do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
-	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()
-	c.Assert(len(result), Equals, 3) // p0, p1 and global
+	globalStats = h.GetTableStats(tableInfo)
 	// The value of global.count will be updated the next time analyze.
-	c.Assert(result[0][5], Equals, "9") // global.count = p0.count + p1.count
-	c.Assert(result[1][5], Equals, "3")
-	c.Assert(result[2][5], Equals, "4")
+	c.Assert(globalStats.Count, Equals, int64(9))
+	c.Assert(globalStats.ModifyCount, Equals, int64(0))
 
 	tk.MustExec("analyze table t;")
-	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()
-	c.Assert(len(result), Equals, 3) // p0, p1 and global
-	// The value of global.count is correct now.
-	c.Assert(result[0][5], Equals, "7") // global.count = p0.count + p1.count
-	c.Assert(result[1][5], Equals, "3")
-	c.Assert(result[2][5], Equals, "4")
+	globalStats = h.GetTableStats(tableInfo)
+	// global.count = p0.count(3) + p1.count(4)
+	// The value of global.Count is correct now.
+	c.Assert(globalStats.Count, Equals, int64(7))
 }
 
 func (s *testStatsSuite) TestExtendedStatsDefaultSwitch(c *C) {

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1541,7 +1541,7 @@ partition by range (a) (
 	// We did not analyze partition p1, so the value here has not changed
 	c.Assert(globalStats.Count, Equals, int64(7))
 
-	tk.MustExec("analyze table t;")
+	tk.MustExec("analyze table t partition p1;")
 	globalStats = h.GetTableStats(tableInfo)
 	// global.count = p0.count(3) + p1.count(4) + p2.count(4)
 	// The value of p1.Count is correct now.

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1352,6 +1352,14 @@ partition by range (a) (
 	tk.MustExec("analyze table t partition p2") // it will success since p0 and p1 are both in ver2
 	result := tk.MustQuery("show stats_meta where table_name = 't';").Rows()
 	c.Assert(len(result), Equals, 4)    // p0, p1, p2 and global
+	c.Assert(result[0][5], Equals, "7") // global.count = p0.count + p1.count + p2.count
+	c.Assert(result[1][5], Equals, "3")
+	c.Assert(result[2][5], Equals, "2") // We did not analyze partition p1, so the value here has not changed
+	c.Assert(result[3][5], Equals, "2")
+
+	tk.MustExec("analyze table t;")
+	result = tk.MustQuery("show stats_meta where table_name = 't';").Rows()
+	c.Assert(len(result), Equals, 4)    // p0, p1, p2 and global
 	c.Assert(result[0][5], Equals, "9") // global.count = p0.count + p1.count + p2.count
 	c.Assert(result[1][5], Equals, "3")
 	c.Assert(result[2][5], Equals, "4")

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -2142,7 +2142,7 @@ func (s *testSerialStatsSuite) TestMergeTopN(c *C) {
 				// The range of the number of occurrences in the topn structure is in [0, maxTopNCnt)
 				randCnt := uint64(rand.Intn(maxTopNCnt))
 				res[randNum] += randCnt
-				topNMeta := statistics.TopNMeta{tString, randCnt}
+				topNMeta := statistics.TopNMeta{Encoded: tString, Count: randCnt}
 				topN.TopN = append(topN.TopN, topNMeta)
 			}
 			topNs = append(topNs, topN)

--- a/statistics/handle/update_test.go
+++ b/statistics/handle/update_test.go
@@ -16,6 +16,7 @@ package handle_test
 import (
 	"fmt"
 	"math"
+	"math/rand"
 	"os"
 	"strconv"
 	"strings"
@@ -2080,6 +2081,93 @@ func (s *testStatsSuite) TestFeedbackCounter(c *C) {
 	newNum := &dto.Metric{}
 	metrics.StoreQueryFeedbackCounter.WithLabelValues(metrics.LblOK).Write(newNum)
 	c.Assert(subtraction(newNum, oldNum), Equals, 20)
+}
+
+func (s *testSerialStatsSuite) TestMergeTopN(c *C) {
+	// Move this test to here to avoid race test.
+	tests := []struct {
+		topnNum    int
+		n          int
+		maxTopNVal int
+		maxTopNCnt int
+	}{
+		{
+			topnNum:    10,
+			n:          5,
+			maxTopNVal: 50,
+			maxTopNCnt: 100,
+		},
+		{
+			topnNum:    1,
+			n:          5,
+			maxTopNVal: 50,
+			maxTopNCnt: 100,
+		},
+		{
+			topnNum:    5,
+			n:          5,
+			maxTopNVal: 5,
+			maxTopNCnt: 100,
+		},
+		{
+			topnNum:    5,
+			n:          5,
+			maxTopNVal: 10,
+			maxTopNCnt: 100,
+		},
+	}
+	for _, t := range tests {
+		topnNum, n := t.topnNum, t.n
+		maxTopNVal, maxTopNCnt := t.maxTopNVal, t.maxTopNCnt
+
+		// the number of maxTopNVal should be bigger than n.
+		ok := maxTopNVal >= n
+		c.Assert(ok, Equals, true)
+
+		topNs := make([]*statistics.TopN, 0, topnNum)
+		res := make(map[int]uint64)
+		rand.Seed(time.Now().Unix())
+		for i := 0; i < topnNum; i++ {
+			topN := statistics.NewTopN(n)
+			occur := make(map[int]bool)
+			for j := 0; j < n; j++ {
+				// The range of numbers in the topn structure is in [0, maxTopNVal)
+				// But there cannot be repeated occurrences of value in a topN structure.
+				randNum := rand.Intn(maxTopNVal)
+				for occur[randNum] {
+					randNum = rand.Intn(maxTopNVal)
+				}
+				occur[randNum] = true
+				tString := []byte(fmt.Sprintf("%d", randNum))
+				// The range of the number of occurrences in the topn structure is in [0, maxTopNCnt)
+				randCnt := uint64(rand.Intn(maxTopNCnt))
+				res[randNum] += randCnt
+				topNMeta := statistics.TopNMeta{tString, randCnt}
+				topN.TopN = append(topN.TopN, topNMeta)
+			}
+			topNs = append(topNs, topN)
+		}
+		topN, remainTopN := statistics.MergeTopN(topNs, uint32(n))
+		cnt := len(topN.TopN)
+		var minTopNCnt uint64
+		for _, topNMeta := range topN.TopN {
+			val, err := strconv.Atoi(string(topNMeta.Encoded))
+			c.Assert(err, IsNil)
+			c.Assert(topNMeta.Count, Equals, res[val])
+			minTopNCnt = topNMeta.Count
+		}
+		if remainTopN != nil {
+			cnt += len(remainTopN)
+			for _, remainTopNMeta := range remainTopN {
+				val, err := strconv.Atoi(string(remainTopNMeta.Encoded))
+				c.Assert(err, IsNil)
+				c.Assert(remainTopNMeta.Count, Equals, res[val])
+				ok = minTopNCnt > remainTopNMeta.Count
+				c.Assert(ok, Equals, true)
+			}
+		}
+		c.Assert(cnt, Equals, len(res))
+	}
 }
 
 func (s *testSerialStatsSuite) TestAutoUpdatePartitionInDynamicOnlyMode(c *C) {

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -25,12 +25,8 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/domain"
-	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
@@ -39,7 +35,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/pingcap/tidb/util/testleak"
 )
 
 func TestT(t *testing.T) {
@@ -51,39 +46,6 @@ func TestT(t *testing.T) {
 }
 
 var _ = Suite(&testStatisticsSuite{})
-var _ = SerialSuites(&testSerialStatisticsSuite{})
-
-type testSerialStatisticsSuite struct {
-	store kv.Storage
-	do    *domain.Domain
-}
-
-func newStoreWithBootstrap() (kv.Storage, *domain.Domain, error) {
-	store, err := mockstore.NewMockStore()
-	if err != nil {
-		return nil, nil, errors.Trace(err)
-	}
-	session.SetSchemaLease(0)
-	session.DisableStats4Test()
-	domain.RunAutoAnalyze = false
-	do, err := session.BootstrapSession(store)
-	do.SetStatsUpdating(true)
-	return store, do, errors.Trace(err)
-}
-
-func (s *testSerialStatisticsSuite) SetUpSuite(c *C) {
-	testleak.BeforeTest()
-	// Add the hook here to avoid data race.
-	var err error
-	s.store, s.do, err = newStoreWithBootstrap()
-	c.Assert(err, IsNil)
-}
-
-func (s *testSerialStatisticsSuite) TearDownSuite(c *C) {
-	s.do.Close()
-	s.store.Close()
-	testleak.AfterTest(c)()
-}
 
 type testStatisticsSuite struct {
 	count   int


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: 
1. Add tests for global-stats when adding and deleting single partitions.
2. fix the race test for `TestCMSketchCodingTopN`

### What is changed and how it works?

* The change in files `statistics/cmsketch_test.go` and `statistics/statistics_test.go` are used to avoid the race test.
* Add tests for global-stats when we add or delete a partition.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
