### PR TITLE
types: fix clustered keyword regexp

### DIFF
--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -650,6 +650,10 @@ func (s *testBinlogSuite) TestAddSpecialComment(c *C) {
 			"create table clustered (id int)",
 			"create table clustered (id int)",
 		},
+		{
+			"create table t1 (id int, a varchar(255) key clustered);",
+			"create table t1 (id int, a varchar(255) key /*T![clustered_index] clustered */ );",
+		},
 	}
 	for _, ca := range testCase {
 		re := binloginfo.AddSpecialComment(ca.input)

--- a/types/parser_driver/special_cmt_ctrl.go
+++ b/types/parser_driver/special_cmt_ctrl.go
@@ -68,5 +68,5 @@ var FeatureIDPatterns = map[featureID]*regexp.Regexp{
 	FeatureIDAutoRandom:     regexp.MustCompile(`(?P<REPLACE>(?i)AUTO_RANDOM\b\s*(\s*\(\s*\d+\s*\)\s*)?)`),
 	FeatureIDAutoIDCache:    regexp.MustCompile(`(?P<REPLACE>(?i)AUTO_ID_CACHE\s*=?\s*\d+\s*)`),
 	FeatureIDAutoRandomBase: regexp.MustCompile(`(?P<REPLACE>(?i)AUTO_RANDOM_BASE\s*=?\s*\d+\s*)`),
-	FeatureClusteredIndex:   regexp.MustCompile(`(?i)PRIMARY\s+KEY(\s*\(.*\))?\s+(?P<REPLACE>(NON)?CLUSTERED\b)`),
+	FeatureClusteredIndex:   regexp.MustCompile(`(?i)(PRIMARY)?\s+KEY(\s*\(.*\))?\s+(?P<REPLACE>(NON)?CLUSTERED\b)`),
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

According to MySQL documentation,
> The key attribute PRIMARY KEY can also be specified as just KEY when given in a column definition.

We should also match the pattern for statements like 

```sql
create table t1 (id int, a varchar(255) key clustered);
```

### What is changed and how it works?

This is a patch for https://github.com/pingcap/tidb/pull/23247.

### Related changes

NA

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

NA

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
