### PR TITLE
region cache: prevent send read request to learner peer

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1327,9 +1327,9 @@ func (r *Region) AnyStorePeer(rs *RegionStore, followerStoreSeed uint32, op *sto
 		store, peer, accessIdx, storeIdx = r.getKvStorePeer(rs, rs.kvPeer(followerStoreSeed, op))
 		if peer.Role == metapb.PeerRole_Learner {
 			followerStoreSeed++
-		} else {
-			return
+			continue
 		}
+		return
 	}
 	return
 }


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
ref https://github.com/pingcap/tidb/issues/23271

Problem Summary:  


### What is changed and how it works?
What's Changed:  the session variable only says leader and follower, so we do not send to the learner at first. and in the normal TiKV cluster, learner only is a intermediate state.

How it Works: skip the peer role is learner

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note