### PR TITLE
sig/execution: fix the bug that Wrong result of comparison operation(type date / type string)

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7813,3 +7813,12 @@ func (s *testSuiteP1) TestIssue22941(c *C) {
 	rs = tk.MustQuery(`SELECT  bmp.mpid,  bmp.mpid IS NULL,bmp.mpid IS NOT NULL FROM m c LEFT JOIN mp bmp ON c.mid = bmp.mid  WHERE c.ParentId = '0'`)
 	rs.Check(testkit.Rows("<nil> 1 0"))
 }
+
+func (s *testSuite1) TestIssue23411(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(col1 varbinary(20))")
+	tk.MustExec("insert into t1 values(\".1pingcap\");")
+
+	tk.MustQuery("select col1, col1 + 1 from t1;").Check(testkit.Rows(".1pingcap 1.1"))
+}

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1131,7 +1131,7 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 		if lhsFieldType.Tp == rhsFieldType.Tp {
 			cmpType = lhsFieldType.EvalType()
 		} else {
-			cmpType = types.ETDatetime
+			cmpType = types.ETString
 		}
 	} else if lhsFieldType.Tp == mysql.TypeDuration && rhsFieldType.Tp == mysql.TypeDuration {
 		// duration <cmp> duration

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1124,15 +1124,9 @@ func GetAccurateCmpType(lhs, rhs Expression) types.EvalType {
 	if (lhsEvalType.IsStringKind() && rhsFieldType.Tp == mysql.TypeJSON) ||
 		(lhsFieldType.Tp == mysql.TypeJSON && rhsEvalType.IsStringKind()) {
 		cmpType = types.ETJson
-	} else if cmpType == types.ETString && (types.IsTypeTime(lhsFieldType.Tp) || types.IsTypeTime(rhsFieldType.Tp)) {
+	} else if cmpType == types.ETString && types.IsTypeTime(lhsFieldType.Tp) && types.IsTypeTime(rhsFieldType.Tp) {
 		// date[time] <cmp> date[time]
-		// string <cmp> date[time]
-		// compare as time
-		if lhsFieldType.Tp == rhsFieldType.Tp {
-			cmpType = lhsFieldType.EvalType()
-		} else {
-			cmpType = types.ETString
-		}
+		cmpType = lhsFieldType.EvalType()
 	} else if lhsFieldType.Tp == mysql.TypeDuration && rhsFieldType.Tp == mysql.TypeDuration {
 		// duration <cmp> duration
 		// compare as duration

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -157,8 +157,8 @@ func (s *testEvaluatorSuite) TestCompare(c *C) {
 	bf, err = funcs[ast.LT].getFunction(s.ctx, []Expression{timeCol, stringCon})
 	c.Assert(err, IsNil)
 	args = bf.getArgs()
-	c.Assert(args[0].GetType().Tp, Equals, mysql.TypeDatetime)
-	c.Assert(args[1].GetType().Tp, Equals, mysql.TypeDatetime)
+	c.Assert(args[0].GetType().Tp, Equals, mysql.TypeVarString)
+	c.Assert(args[1].GetType().Tp, Equals, mysql.TypeVarchar)
 }
 
 func (s *testEvaluatorSuite) TestCoalesce(c *C) {


### PR DESCRIPTION
…r `1`

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23236 <!-- REMOVE this line if no issue to close -->

Problem Summary:
when compare type varchar with date, return NULL, rather 0 or 1.

### What is changed and how it works?
this is a little bug, when found date compared with varchar, varchar casts to date, rather date casts to varchar
Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note
- bugfix: when compare date with string, return `NULL` rather than `0` 
