### PR TITLE
sig/execution: fix the bug that Wrong result of comparison operation(type date / type string) #23296 (other method)

### DIFF
--- a/types/time.go
+++ b/types/time.go
@@ -1942,7 +1942,7 @@ func parseTime(sc *stmtctx.StatementContext, str string, tp byte, fsp int8, isFl
 
 	t, err := parseDatetime(sc, str, fsp, isFloat)
 	if err != nil {
-		return NewTime(ZeroCoreTime, tp, DefaultFsp), errors.Trace(err)
+		return NewTime(ZeroCoreTime, tp, DefaultFsp), nil
 	}
 
 	t.SetType(tp)


### PR DESCRIPTION
…r `1`

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23236 <!-- REMOVE this line if no issue to close -->

Problem Summary:
when compare type varchar with date, return NULL, rather 0 or 1.

### What is changed and how it works?
when cast string to date and string is illegal, eg: "2020-0", Column->nullbitMap[index] is 0, and return NULL (in tidb/expression/builtin_compare_vec_generated.go, func (b *builtinNETimeSig) vecEvalInt)
Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note
- bugfix: when compare date with string, return `NULL` rather than `0` 
