### PR TITLE
planner: hide the switch of dynamic-pruning and global-stats

### DIFF
--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -707,6 +707,7 @@ var FeatureSwitchVariables = []string{
 	TiDBGuaranteeLinearizability,
 	TiDBEnableClusteredIndex,
 	TiDBTrackAggregateMemoryUsage,
+	TiDBPartitionPruneMode,
 }
 
 // FilterImplicitFeatureSwitch is used to filter result of show variables, these switches should be turn blind to users.

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1012,8 +1012,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustExec("analyze table tint with 2 topn, 2 buckets")
 
 	tk.MustQuery("select modify_count, count from mysql.stats_meta order by table_id asc").Check(testkit.Rows(
-		"0 20", // global: g.count = p0.count + p1.count
-		"0 9",  // p0
+		"0 20",  // global: g.count = p0.count + p1.count
+		"0 9",   // p0
 		"0 11")) // p1
 
 	tk.MustQuery("show stats_topn where table_name='tint' and is_index=0").Check(testkit.Rows(
@@ -1043,7 +1043,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count, tot_col_size from mysql.stats_histograms where is_index=0 order by table_id asc").Check(
 		testkit.Rows("12 1 19", // global, g = p0 + p1
-			"5 1 8", // p0
+			"5 1 8",   // p0
 			"7 0 11")) // p1
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
@@ -1057,7 +1057,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("select distinct_count, null_count from mysql.stats_histograms where is_index=1 order by table_id asc").Check(
 		testkit.Rows("12 1", // global, g = p0 + p1
-			"5 1", // p0
+			"5 1",  // p0
 			"7 0")) // p1
 
 	// double + (column + index with 1 column)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: hide the switch of dynamic-pruning and global-stats

### What is changed and how it works?

planner: hide the switch of dynamic-pruning and global-stats since these two features are not GA.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: hide the switch of dynamic-pruning and global-stats