### PR TITLE
txn: fix the ttlmanager and cleanup logic for 1pc and async commit

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -2484,7 +2484,7 @@ func (s *testPessimisticSuite) TestAsyncCommitCalTSFail(c *C) {
 	c.Assert(tk.ExecToErr("commit"), NotNil)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/failCheckSchemaValid"), IsNil)
 
-	// The DDL should not be blocked.
+	// The lock should not be blocked.
 	tk2.MustExec("set innodb_lock_wait_timeout = 5")
 	tk2.MustExec("begin pessimistic")
 	tk2.MustExec("update tk set c2 = c2 + 1")

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -1171,7 +1171,6 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 			zap.Uint64("startTS", c.startTS), zap.Uint64("commitTS", c.commitTS),
 			zap.Uint64("sessionID", c.sessionID))
 		go func() {
-			defer c.ttlManager.close()
 			failpoint.Inject("asyncCommitDoNothing", func() {
 				failpoint.Return()
 			})

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -171,7 +171,8 @@ func (l *Lock) String() string {
 	prettyWriteKey(buf, l.Key)
 	buf.WriteString(", primary: ")
 	prettyWriteKey(buf, l.Primary)
-	return fmt.Sprintf("%s, txnStartTS: %d, lockForUpdateTS:%d, minCommitTs:%d, ttl: %d, type: %s", buf.String(), l.TxnID, l.LockForUpdateTS, l.MinCommitTS, l.TTL, l.LockType)
+	return fmt.Sprintf("%s, txnStartTS: %d, lockForUpdateTS:%d, minCommitTs:%d, ttl: %d, type: %s, UseAsyncCommit: %t",
+		buf.String(), l.TxnID, l.LockForUpdateTS, l.MinCommitTS, l.TTL, l.LockType, l.UseAsyncCommit)
 }
 
 // NewLock creates a new *Lock.

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -248,16 +248,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 		}
 		txn.committer = committer
 	}
-	defer func() {
-		// For async commit transactions, the ttl manager will be closed in the asynchronous commit goroutine.
-		if committer.isAsyncCommit() || committer.isOnePC() {
-			if err != nil {
-				committer.ttlManager.close()
-			}
-		} else {
-			committer.ttlManager.close()
-		}
-	}()
+	defer committer.ttlManager.close()
 
 	initRegion := trace.StartRegion(ctx, "InitKeys")
 	err = committer.initKeysAndMutations()

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -250,7 +250,11 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	}
 	defer func() {
 		// For async commit transactions, the ttl manager will be closed in the asynchronous commit goroutine.
-		if !committer.isAsyncCommit() {
+		if committer.isAsyncCommit() || committer.isOnePC() {
+			if err != nil {
+				committer.ttlManager.close()
+			}
+		} else {
 			committer.ttlManager.close()
 		}
 	}()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23331 

Problem Summary:
There are two problems:

- The left pessimistic locks are not cleaned up using 1pc protocol to commit, blocking other concurrent transactions on these keys.
- The ttlManager is not closed, if the max ts caculation error is reported using async commit or 1pc, thus the left pessimistic locks could not be resolved by the ddl backfill worker. 

### What is changed and how it works?

What's Changed:
1. Do cleanup if the error is reported when 1pc protocol is used.
2. Close the `ttlManager` if the execution result of `twoPhaseCommitter` is error.


How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
