### PR TITLE
store/tikv: pipe the split and scatter task

### DIFF
--- a/ddl/split_region.go
+++ b/ddl/split_region.go
@@ -15,6 +15,7 @@ package ddl
 
 import (
 	"context"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
@@ -133,6 +134,7 @@ func splitIndexRegion(store kv.SplittableStore, tblInfo *model.TableInfo, scatte
 }
 
 func waitScatterRegionFinish(ctx context.Context, store kv.SplittableStore, regionIDs ...uint64) {
+	start := time.Now()
 	for _, regionID := range regionIDs {
 		err := store.WaitScatterRegionFinish(ctx, regionID, 0)
 		if err != nil {
@@ -143,4 +145,5 @@ func waitScatterRegionFinish(ctx context.Context, store kv.SplittableStore, regi
 			}
 		}
 	}
+	logutil.BgLogger().Info("wait scatter region finished", zap.Duration("cost-time", time.Since(start)), zap.String("action", "ddl"), zap.Int("region-numbers", len(regionIDs)))
 }

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -646,6 +646,7 @@ type batch struct {
 }
 
 type singleBatchResp struct {
-	resp *tikvrpc.Response
-	err  error
+	regionID RegionVerID
+	resp     *tikvrpc.Response
+	err      error
 }

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -84,7 +84,6 @@ func (s *KVStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter boo
 					ch <- singleBatchResp{err: errors.Errorf("%v", r)}
 				}
 			})
-
 		}(batch1)
 	}
 
@@ -116,7 +115,6 @@ func (s *KVStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter boo
 						ch <- singleBatchResp{err: errors.Errorf("%v", r)}
 					}
 				})
-
 			}()
 		}
 	}
@@ -221,7 +219,6 @@ func (s *KVStore) scatterRegionsInBatchSplitResp(bo *Backoffer, tableID *int64, 
 	}
 	spResp := batchResp.resp.Resp.(*kvrpcpb.SplitRegionResponse)
 	for _, r := range spResp.Regions {
-
 		if err = s.scatterRegion(bo, r.Id, tableID); err == nil {
 			logutil.BgLogger().Info("batch split regions, scatter single region complete",
 				zap.Uint64("batch region ID", batchResp.regionID.id),


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

close https://github.com/pingcap/tidb/issues/22969

Problem Summary:
Splitting and Scattering at the same time will cause multiple conflicts on the same region.
![image](https://user-images.githubusercontent.com/6428910/111289009-af99e880-867f-11eb-99e6-d441a3b2acf3.png)


### What is changed and how it works?

pipeline all splits task and scatter tasks


### Release note <!-- bugfixes or new feature need a release note -->

- Make the time consuming of `split table` more stable 
```
I have run multiple times  to split 4000 regions, and the time is stale about `1m30s`
2021/03/17 17:25:57 split single sql result: [map[SCATTER_FINISH_RATIO:1 TOTAL_SPLIT_REGION:2001]]
2021/03/17 17:25:57 split all sql run total cost: 1m28.908304306s
2021/03/17 17:25:57 split all sql run success!!!

```