### PR TITLE
gc: central GC mode is deprecated

### DIFF
--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -951,11 +951,9 @@ func (w *GCWorker) checkUseDistributedGC() bool {
 			zap.String("uuid", w.uuid),
 			zap.Error(err))
 		metrics.GCJobFailureCounter.WithLabelValues("check_gc_mode").Inc()
-	}
-	if strings.EqualFold(mode, gcModeCentral) {
+	} else if strings.EqualFold(mode, gcModeCentral) {
 		logutil.BgLogger().Warn("[gc worker] distributed mode will be used as central mode is deprecated")
-	}
-	if !strings.EqualFold(mode, gcModeDistributed) {
+	} else if !strings.EqualFold(mode, gcModeDistributed) {
 		logutil.BgLogger().Warn("[gc worker] distributed mode will be used",
 			zap.String("invalid gc mode", mode))
 	}


### PR DESCRIPTION
Signed-off-by: qupeng <qupeng@pingcap.com>

### What problem does this PR solve?

TiKV 5.0 doesn't support central GC mode any more. So also deprecate it in TiDB.

### What is changed and how it works?

Deprecate central GC mode.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->
* deprecated central GC mode
