### PR TITLE
domain: remove the exit chan, use context

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -747,7 +747,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 	callback := &ddlCallback{do: do}
 	d := do.ddl
 	do.ddl = ddl.NewDDL(
-		do,
+		do.Context,
 		ddl.WithEtcdClient(do.etcdClient),
 		ddl.WithStore(do.store),
 		ddl.WithInfoHandle(do.infoHandle),

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -690,6 +690,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 		indexUsageSyncLease: idxUsageSyncLease,
 	}
 
+	do.Context, do.cancel = context.WithCancel(context.Background())
 	do.SchemaValidator = NewSchemaValidator(ddlLease, do)
 	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do.Context)
 	return do
@@ -743,7 +744,6 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 		return sysFactory(do)
 	}
 	sysCtxPool := pools.NewResourcePool(sysFac, 2, 2, resourceIdleTimeout)
-	do.Context, do.cancel = context.WithCancel(context.Background())
 	callback := &ddlCallback{do: do}
 	d := do.ddl
 	do.ddl = ddl.NewDDL(

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -582,7 +582,7 @@ func (do *Domain) mustRestartSyncer() error {
 	syncer := do.ddl.SchemaSyncer()
 
 	for {
-		err := syncer.Restart(do)
+		err := syncer.Restart(do.Context)
 		if err == nil {
 			return nil
 		}
@@ -691,7 +691,7 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 	}
 
 	do.SchemaValidator = NewSchemaValidator(ddlLease, do)
-	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do)
+	do.expensiveQueryHandle = expensivequery.NewExpensiveQueryHandle(do.Context)
 	return do
 }
 
@@ -768,7 +768,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 	})
 
 	skipRegisterToDashboard := config.GetGlobalConfig().SkipRegisterToDashboard
-	err = do.ddl.SchemaSyncer().Init(do)
+	err = do.ddl.SchemaSyncer().Init(do.Context)
 	if err != nil {
 		return err
 	}
@@ -791,7 +791,7 @@ func (do *Domain) Init(ddlLease time.Duration, sysFactory func(*Domain) (pools.R
 		}
 	}
 
-	do.info, err = infosync.GlobalInfoSyncerInit(do, do.ddl.GetID(), do.ServerID, do.etcdClient, skipRegisterToDashboard)
+	do.info, err = infosync.GlobalInfoSyncerInit(do.Context, do.ddl.GetID(), do.ServerID, do.etcdClient, skipRegisterToDashboard)
 	if err != nil {
 		return err
 	}

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -486,7 +486,7 @@ func (do *Domain) infoSyncerKeeper() {
 			} else {
 				logutil.BgLogger().Info("server info syncer restarted")
 			}
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}
@@ -515,7 +515,7 @@ func (do *Domain) topologySyncerKeeper() {
 			} else {
 				logutil.BgLogger().Info("server topology syncer restarted")
 			}
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}
@@ -574,7 +574,7 @@ func (do *Domain) loadSchemaInLoop(lease time.Duration) {
 			}
 			do.SchemaValidator.Restart()
 			logutil.BgLogger().Info("schema syncer restarted")
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}
@@ -620,7 +620,7 @@ func (do *Domain) mustReload() (exitLoop bool) {
 
 func (do *Domain) isClose() bool {
 	select {
-	case <-do.Done():
+	case <-do.ctx.Done():
 		logutil.BgLogger().Info("domain is closed")
 		return true
 	default:
@@ -921,7 +921,7 @@ func (do *Domain) LoadPrivilegeLoop(sctx sessionctx.Context) error {
 		for {
 			ok := true
 			select {
-			case <-do.Done():
+			case <-do.ctx.Done():
 				return
 			case _, ok = <-watchCh:
 			case <-time.After(duration):
@@ -985,7 +985,7 @@ func (do *Domain) globalBindHandleWorkerLoop() {
 		defer bindWorkerTicker.Stop()
 		for {
 			select {
-			case <-do.Done():
+			case <-do.ctx.Done():
 				return
 			case <-bindWorkerTicker.C:
 				err := do.bindHandle.Update(false)
@@ -1013,7 +1013,7 @@ func (do *Domain) handleEvolvePlanTasksLoop(ctx sessionctx.Context) {
 		owner := do.newOwnerManager(bindinfo.Prompt, bindinfo.OwnerKey)
 		for {
 			select {
-			case <-do.Done():
+			case <-do.ctx.Done():
 				owner.Cancel()
 				return
 			case <-time.After(bindinfo.Lease):
@@ -1042,7 +1042,7 @@ func (do *Domain) TelemetryLoop(ctx sessionctx.Context) {
 		owner := do.newOwnerManager(telemetry.Prompt, telemetry.OwnerKey)
 		for {
 			select {
-			case <-do.Done():
+			case <-do.ctx.Done():
 				owner.Cancel()
 				return
 			case <-time.After(telemetry.ReportInterval):
@@ -1176,7 +1176,7 @@ func (do *Domain) loadStatsWorker() {
 			if err != nil {
 				logutil.BgLogger().Debug("load histograms failed", zap.Error(err))
 			}
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}
@@ -1194,7 +1194,7 @@ func (do *Domain) syncIndexUsageWorker(owner owner.Manager) {
 	}()
 	for {
 		select {
-		case <-do.Done():
+		case <-do.ctx.Done():
 			// TODO: need flush index usage
 			return
 		case <-idxUsageSyncTicker.C:
@@ -1231,7 +1231,7 @@ func (do *Domain) updateStatsWorker(ctx sessionctx.Context, owner owner.Manager)
 	}()
 	for {
 		select {
-		case <-do.Done():
+		case <-do.ctx.Done():
 			statsHandle.FlushStats()
 			owner.Cancel()
 			return
@@ -1288,7 +1288,7 @@ func (do *Domain) autoAnalyzeWorker(owner owner.Manager) {
 			if owner.IsOwner() {
 				statsHandle.HandleAutoAnalyze(do.InfoSchema())
 			}
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}
@@ -1547,7 +1547,7 @@ func (do *Domain) serverIDKeeper() {
 			//   So just set `do.serverIDSession = nil` to restart `serverID` session in `retrieveServerIDSession()`.
 			logutil.BgLogger().Info("serverIDSession need restart")
 			do.serverIDSession = nil
-		case <-do.Done():
+		case <-do.ctx.Done():
 			return
 		}
 	}

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -121,9 +121,8 @@ func TestInfo(t *testing.T) {
 	cli := clus.RandClient()
 	dom.etcdClient = cli
 	// Mock new DDL and init the schema syncer with etcd client.
-	goCtx := context.Background()
 	dom.ddl = ddl.NewDDL(
-		goCtx,
+		dom.Context,
 		ddl.WithEtcdClient(dom.GetEtcdClient()),
 		ddl.WithStore(s),
 		ddl.WithInfoHandle(dom.infoHandle),
@@ -152,20 +151,20 @@ func TestInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	info, err := infosync.GetServerInfoByID(goCtx, ddlID)
+	info, err := infosync.GetServerInfoByID(dom.Context, ddlID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if serverInfo.ID != info.ID {
 		t.Fatalf("server self info %v, info %v", serverInfo, info)
 	}
-	_, err = infosync.GetServerInfoByID(goCtx, "not_exist_id")
+	_, err = infosync.GetServerInfoByID(dom.Context, "not_exist_id")
 	if err == nil || (err != nil && err.Error() != "[info-syncer] get /tidb/server/info/not_exist_id failed") {
 		t.Fatal(err)
 	}
 
 	// Test for GetAllServerInfo.
-	infos, err := infosync.GetAllServerInfo(goCtx)
+	infos, err := infosync.GetAllServerInfo(dom.Context)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -215,17 +214,17 @@ func TestInfo(t *testing.T) {
 
 	// Test for RemoveServerInfo.
 	dom.info.RemoveServerInfo()
-	infos, err = infosync.GetAllServerInfo(goCtx)
+	infos, err = infosync.GetAllServerInfo(dom.Context)
 	if err != nil || len(infos) != 0 {
 		t.Fatalf("err %v, infos %v", err, infos)
 	}
 
 	// Test for acquireServerID & refreshServerIDTTL
-	err = dom.acquireServerID(goCtx)
+	err = dom.acquireServerID()
 	if err != nil || dom.ServerID() == 0 {
 		t.Fatalf("dom.acquireServerID err %v, serverID %v", err, dom.ServerID())
 	}
-	err = dom.refreshServerIDTTL(goCtx)
+	err = dom.refreshServerIDTTL()
 	if err != nil {
 		t.Fatalf("dom.refreshServerIDTTL err %v", err)
 	}

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -122,7 +122,7 @@ func TestInfo(t *testing.T) {
 	dom.etcdClient = cli
 	// Mock new DDL and init the schema syncer with etcd client.
 	dom.ddl = ddl.NewDDL(
-		dom.Context,
+		dom.ctx,
 		ddl.WithEtcdClient(dom.GetEtcdClient()),
 		ddl.WithStore(s),
 		ddl.WithInfoHandle(dom.infoHandle),
@@ -151,20 +151,20 @@ func TestInfo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	info, err := infosync.GetServerInfoByID(dom.Context, ddlID)
+	info, err := infosync.GetServerInfoByID(dom.ctx, ddlID)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if serverInfo.ID != info.ID {
 		t.Fatalf("server self info %v, info %v", serverInfo, info)
 	}
-	_, err = infosync.GetServerInfoByID(dom.Context, "not_exist_id")
+	_, err = infosync.GetServerInfoByID(dom.ctx, "not_exist_id")
 	if err == nil || (err != nil && err.Error() != "[info-syncer] get /tidb/server/info/not_exist_id failed") {
 		t.Fatal(err)
 	}
 
 	// Test for GetAllServerInfo.
-	infos, err := infosync.GetAllServerInfo(dom.Context)
+	infos, err := infosync.GetAllServerInfo(dom.ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -214,7 +214,7 @@ func TestInfo(t *testing.T) {
 
 	// Test for RemoveServerInfo.
 	dom.info.RemoveServerInfo()
-	infos, err = infosync.GetAllServerInfo(dom.Context)
+	infos, err = infosync.GetAllServerInfo(dom.ctx)
 	if err != nil || len(infos) != 0 {
 		t.Fatalf("err %v, infos %v", err, infos)
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -2110,10 +2110,10 @@ func loadParameter(se *session, name string) (string, error) {
 }
 
 // BootstrapSession runs the first time when the TiDB server start.
-func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
+func BootstrapSession(ctx context.Context, store kv.Storage) (*domain.Domain, error) {
 	cfg := config.GetGlobalConfig()
 	if len(cfg.Plugin.Load) > 0 {
-		err := plugin.Load(context.Background(), plugin.Config{
+		err := plugin.Load(ctx, plugin.Config{
 			Plugins:        strings.Split(cfg.Plugin.Load, ","),
 			PluginDir:      cfg.Plugin.Dir,
 			PluginVarNames: &variable.PluginVarNames,
@@ -2136,7 +2136,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	}
 
 	// get system tz from mysql.tidb
-	tz, err := se.getTableValue(context.TODO(), mysql.TiDBTable, "system_tz")
+	tz, err := se.getTableValue(ctx, mysql.TiDBTable, "system_tz")
 	if err != nil {
 		return nil, err
 	}
@@ -2198,7 +2198,7 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	}
 
 	if len(cfg.Plugin.Load) > 0 {
-		err := plugin.Init(context.Background(), plugin.Config{EtcdClient: dom.GetEtcdClient()})
+		err := plugin.Init(ctx, plugin.Config{EtcdClient: dom.GetEtcdClient()})
 		if err != nil {
 			return nil, err
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -2110,7 +2110,9 @@ func loadParameter(se *session, name string) (string, error) {
 }
 
 // BootstrapSession runs the first time when the TiDB server start.
-func BootstrapSession(ctx context.Context, store kv.Storage) (*domain.Domain, error) {
+func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
+	ctx := context.Background()
+
 	cfg := config.GetGlobalConfig()
 	if len(cfg.Plugin.Load) > 0 {
 		err := plugin.Load(ctx, plugin.Config{

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -265,7 +265,7 @@ func createStoreAndDomain() {
 	storage, err = kvstore.New(fullPath)
 	terror.MustNil(err)
 	// Bootstrap a session to load information schema.
-	dom, err = session.BootstrapSession(storage)
+	dom, err = session.BootstrapSession(context.Background(), storage)
 	terror.MustNil(err)
 }
 

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -265,7 +265,7 @@ func createStoreAndDomain() {
 	storage, err = kvstore.New(fullPath)
 	terror.MustNil(err)
 	// Bootstrap a session to load information schema.
-	dom, err = session.BootstrapSession(context.Background(), storage)
+	dom, err = session.BootstrapSession(storage)
 	terror.MustNil(err)
 }
 

--- a/util/expensivequery/expensivequery.go
+++ b/util/expensivequery/expensivequery.go
@@ -14,6 +14,7 @@
 package expensivequery
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"strings"
@@ -31,13 +32,13 @@ import (
 
 // Handle is the handler for expensive query.
 type Handle struct {
-	exitCh chan struct{}
-	sm     atomic.Value
+	ctx context.Context
+	sm  atomic.Value
 }
 
 // NewExpensiveQueryHandle builds a new expensive query handler.
-func NewExpensiveQueryHandle(exitCh chan struct{}) *Handle {
-	return &Handle{exitCh: exitCh}
+func NewExpensiveQueryHandle(ctx context.Context) *Handle {
+	return &Handle{ctx: ctx}
 }
 
 // SetSessionManager sets the SessionManager which is used to fetching the info
@@ -80,7 +81,7 @@ func (eqh *Handle) Run() {
 			if record.err == nil {
 				record.alarm4ExcessiveMemUsage(sm)
 			}
-		case <-eqh.exitCh:
+		case <-eqh.ctx.Done():
 			return
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

We have two close logic in domain: one is `do.exit`, another one is `do.cancel`. This PR:

1. removed `do.exit`, let `Domain` implement `context.Context`,  replace `do.exit` with `do.Done()`
2. did a clean up on `BootstrapSession`: now all `context.Context` used in the function come from one single `context.Background()`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
