### PR TITLE
*: Add the metric about the SQL with TiFlash Success

### DIFF
--- a/store/tikv/client_batch.go
+++ b/store/tikv/client_batch.go
@@ -485,7 +485,7 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 		if len(entries) < int(cfg.MaxBatchSize) && cfg.MaxBatchWaitTime > 0 {
 			// If the target TiKV is overload, wait a while to collect more requests.
 			if atomic.LoadUint64(&a.tikvTransportLayerLoad) >= uint64(cfg.OverloadThreshold) {
-				metrics.TiKvBatchWaitOverLoad.Add(1)
+				metrics.TiKVBatchWaitOverLoad.Inc()
 				fetchMorePendingRequests(
 					a.batchCommandsCh, int(cfg.MaxBatchSize), int(bestBatchWaitSize),
 					cfg.MaxBatchWaitTime, &entries, &requests,

--- a/store/tikv/metrics/metrics.go
+++ b/store/tikv/metrics/metrics.go
@@ -412,7 +412,6 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVNoAvailableConnectionCounter)
 	prometheus.MustRegister(TiKVAsyncCommitTxnCounter)
 	prometheus.MustRegister(TiKVOnePCTxnCounter)
-	prometheus.MustRegister(TiKVReadDuration)
 	prometheus.MustRegister(TiFlashExecuteErrorCounter)
 	prometheus.MustRegister(TiFlashExecuteCounter)
 }

--- a/store/tikv/metrics/metrics.go
+++ b/store/tikv/metrics/metrics.go
@@ -36,7 +36,7 @@ var (
 	TiKVStatusCounter                      *prometheus.CounterVec
 	TiKVBatchWaitDuration                  prometheus.Histogram
 	TiKVBatchSendLatency                   prometheus.Histogram
-	TiKvBatchWaitOverLoad                  prometheus.Counter
+	TiKVBatchWaitOverLoad                  prometheus.Counter
 	TiKVBatchPendingRequests               *prometheus.HistogramVec
 	TiKVBatchRequests                      *prometheus.HistogramVec
 	TiKVBatchClientUnavailable             prometheus.Histogram
@@ -50,6 +50,8 @@ var (
 	TiKVNoAvailableConnectionCounter       prometheus.Counter
 	TiKVAsyncCommitTxnCounter              *prometheus.CounterVec
 	TiKVOnePCTxnCounter                    *prometheus.CounterVec
+	TiFlashExecuteErrorCounter             *prometheus.CounterVec
+	TiFlashExecuteCounter                  prometheus.Counter
 )
 
 // Label constants.
@@ -231,7 +233,7 @@ func initMetrics(namespace, subsystem string) {
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
 			Help:      "batch send latency",
 		})
-	TiKvBatchWaitOverLoad = prometheus.NewCounter(
+	TiKVBatchWaitOverLoad = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
 			Subsystem: subsystem,
@@ -304,6 +306,7 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Bucketed histogram of the txn_heartbeat request duration.",
 			Buckets:   prometheus.ExponentialBuckets(0.001, 2, 20), // 1ms ~ 524s
 		}, []string{LblType})
+
 	TiKVPessimisticLockKeysDuration = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: namespace,
@@ -345,6 +348,22 @@ func initMetrics(namespace, subsystem string) {
 			Help:      "Counter of 1PC transactions.",
 		}, []string{LblType})
 
+	TiFlashExecuteErrorCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "tiflash_execute_error_total",
+			Help:      "Counter of TiFlash execute errors.",
+		}, []string{LblType})
+
+	TiFlashExecuteCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "tiflash_execute_total",
+			Help:      "Counter of TiFlash execute.",
+		})
+
 	initShortcuts()
 }
 
@@ -379,7 +398,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVStatusCounter)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
 	prometheus.MustRegister(TiKVBatchSendLatency)
-	prometheus.MustRegister(TiKvBatchWaitOverLoad)
+	prometheus.MustRegister(TiKVBatchWaitOverLoad)
 	prometheus.MustRegister(TiKVBatchPendingRequests)
 	prometheus.MustRegister(TiKVBatchRequests)
 	prometheus.MustRegister(TiKVBatchClientUnavailable)
@@ -393,4 +412,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVNoAvailableConnectionCounter)
 	prometheus.MustRegister(TiKVAsyncCommitTxnCounter)
 	prometheus.MustRegister(TiKVOnePCTxnCounter)
+	prometheus.MustRegister(TiKVReadDuration)
+	prometheus.MustRegister(TiFlashExecuteErrorCounter)
+	prometheus.MustRegister(TiFlashExecuteCounter)
 }


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
This pull request is for the TiDB SLO，to add the metric about the SQL with TiFlash

### What is changed and how it works?

What's Changed:
Add two metrics for coprocessor send to promethus.

TiFlashExecuteCounter: The total num of SQL request send TiFlash.
TiFlashExecuteErrorCounter: The total num of SQL request error send TiFlash.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- Add the metric about the SQL with TiFlash Success<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
