### PR TITLE
store/tikv: support injecting customized failure to prewrite

### DIFF
--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -126,27 +126,25 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 	// checked there.
 
 	if c.sessionID > 0 {
-		failpoint.Inject("beforePrewrite", func() {})
-
-		failpoint.Inject("prewritePrimaryFail", func() {
-			if batch.isPrimary {
+		if batch.isPrimary {
+			failpoint.Inject("prewritePrimaryFail", func() {
 				// Delay to avoid cancelling other normally ongoing prewrite requests.
 				time.Sleep(time.Millisecond * 50)
 				logutil.Logger(bo.ctx).Info("[failpoint] injected error on prewriting primary batch",
 					zap.Uint64("txnStartTS", c.startTS))
 				failpoint.Return(errors.New("injected error on prewriting primary batch"))
-			}
-		})
-
-		failpoint.Inject("prewriteSecondaryFail", func() {
-			if !batch.isPrimary {
+			})
+			failpoint.Inject("prewritePrimary", nil) // for other failures like sleep or pause
+		} else {
+			failpoint.Inject("prewriteSecondaryFail", func() {
 				// Delay to avoid cancelling other normally ongoing prewrite requests.
 				time.Sleep(time.Millisecond * 50)
 				logutil.Logger(bo.ctx).Info("[failpoint] injected error on prewriting secondary batch",
 					zap.Uint64("txnStartTS", c.startTS))
 				failpoint.Return(errors.New("injected error on prewriting secondary batch"))
-			}
-		})
+			})
+			failpoint.Inject("prewriteSecondary", nil) // for other failures like sleep or pause
+		}
 	}
 
 	txnSize := uint64(c.regionTxnSize[batch.region.id])


### PR DESCRIPTION

### What is changed and how it works?

We have only `prewritePrimaryFail` and `prewriteSecondaryFail` failpoints for prewrite. If we trigger these failpoints, the transaction fails. Sometimes we just need a pause or a sleep to control the sequential timings without breaking the transaction.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note