### PR TITLE
partition: check partition definition with unsigned option (#23428)

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -530,7 +530,19 @@ create table log_message_1 (
 		},
 		{
 			"create table t1 (a bigint unsigned) partition by list (a) (partition p0 values in (10, 20, 30, -1));",
-			ddl.ErrWrongTypeColumnValue,
+			ddl.ErrPartitionConstDomain,
+		},
+		{
+			"create table t1 (a bigint unsigned) partition by range (a) (partition p0 values less than (-1));",
+			ddl.ErrPartitionConstDomain,
+		},
+		{
+			"create table t1 (a int unsigned) partition by range (a) (partition p0 values less than (-1));",
+			ddl.ErrPartitionConstDomain,
+		},
+		{
+			"create table t1 (a tinyint(20) unsigned) partition by range (a) (partition p0 values less than (-1));",
+			ddl.ErrPartitionConstDomain,
 		},
 		{
 			"CREATE TABLE new (a TIMESTAMP NOT NULL PRIMARY KEY) PARTITION BY RANGE (a % 2) (PARTITION p VALUES LESS THAN (20080819));",
@@ -568,6 +580,9 @@ create table log_message_1 (
 	tk.MustExec(`create table t(a int) partition by range columns (a) (
     	partition p0 values less than (10),
     	partition p1 values less than (20));`)
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec(`create table t(a int) partition by range (a) (partition p0 values less than (18446744073709551615));`)
 }
 
 func (s *testIntegrationSuite1) TestDisableTablePartition(c *C) {

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -176,6 +176,8 @@ var (
 	ErrDropLastPartition = dbterror.ClassDDL.NewStd(mysql.ErrDropLastPartition)
 	// ErrTooManyPartitions returns too many partitions were defined.
 	ErrTooManyPartitions = dbterror.ClassDDL.NewStd(mysql.ErrTooManyPartitions)
+	// ErrPartitionConstDomain returns partition constant is out of partition function domain.
+	ErrPartitionConstDomain = dbterror.ClassDDL.NewStd(mysql.ErrPartitionConstDomain)
 	// ErrPartitionFunctionIsNotAllowed returns this partition function is not allowed.
 	ErrPartitionFunctionIsNotAllowed = dbterror.ClassDDL.NewStd(mysql.ErrPartitionFunctionIsNotAllowed)
 	// ErrPartitionFuncNotAllowed returns partition function returns the wrong type.

--- a/errors.toml
+++ b/errors.toml
@@ -261,6 +261,11 @@ error = '''
 Duplicate partition name %-.192s
 '''
 
+["ddl:1563"]
+error = '''
+Partition constant is out of partition function domain
+'''
+
 ["ddl:1564"]
 error = '''
 This partition function is not allowed


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23385

- partition check does not consider the unsigned flag
- overflow on int column can be ignored such as `create table t(a tinyint) partition by range(a) (partition p0 values less than (1234567));`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- fix invalid partition can create success<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
