### PR TITLE
planner: fix correlated columns in filter or access in MPP apply

### DIFF
--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -151,11 +151,11 @@ func (s *testSuite3) TestCorColToRanges(c *C) {
 	tk.MustExec("insert into t values(1, 1, 1), (2, 2 ,2), (3, 3, 3), (4, 4, 4), (5, 5, 5), (6, 6, 6), (7, 7, 7), (8, 8, 8), (9, 9, 9)")
 	tk.MustExec("analyze table t")
 	// Test single read on table.
-	tk.MustQuery("select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
+	tk.MustQuery("select t.c in (select count(*) from t s ignore index(idx), t t1 where s.a = t.a and s.a = t1.a) from t order by 1 desc").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
 	// Test single read on index.
-	tk.MustQuery("select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
+	tk.MustQuery("select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.a = t1.a) from t order by 1 desc").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
 	// Test IndexLookUpReader.
-	tk.MustQuery("select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
+	tk.MustQuery("select t.c in (select count(*) from t s use index(idx), t t1 where s.b = t.a and s.c = t1.a) from t order by 1 desc").Check(testkit.Rows("1", "0", "0", "0", "0", "0", "0", "0", "0"))
 }
 
 func (s *testSuiteP1) TestUniqueKeyNullValueSelect(c *C) {

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -139,6 +139,7 @@ func (e *MPPGather) Next(ctx context.Context, chk *chunk.Chunk) error {
 
 // Close and release the used resources.
 func (e *MPPGather) Close() error {
+	e.mppReqs = nil
 	if e.respIter != nil {
 		return e.respIter.Close()
 	}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
-	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/logutil"
@@ -139,28 +138,9 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 	}
 	if e.corColInAccess {
 		ts := e.plans[0].(*plannercore.PhysicalTableScan)
-		access := ts.AccessCondition
-		if e.table.Meta().IsCommonHandle {
-			pkIdx := tables.FindPrimaryIndex(ts.Table)
-			idxCols, idxColLens := expression.IndexInfo2PrefixCols(ts.Columns, ts.Schema().Columns, pkIdx)
-			for _, cond := range access {
-				newCond, err1 := expression.SubstituteCorCol2Constant(cond)
-				if err1 != nil {
-					return err1
-				}
-				access = append(access, newCond)
-			}
-			res, err := ranger.DetachCondAndBuildRangeForIndex(e.ctx, access, idxCols, idxColLens)
-			if err != nil {
-				return err
-			}
-			e.ranges = res.Ranges
-		} else {
-			pkTP := ts.Table.GetPkColInfo().FieldType
-			e.ranges, err = ranger.BuildTableRange(access, e.ctx.GetSessionVars().StmtCtx, &pkTP)
-			if err != nil {
-				return err
-			}
+		err := ts.ResolveCorrelatedColumns()
+		if err != nil {
+			return err
 		}
 	}
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -138,7 +138,7 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 	}
 	if e.corColInAccess {
 		ts := e.plans[0].(*plannercore.PhysicalTableScan)
-		err := ts.ResolveCorrelatedColumns()
+		e.ranges, err = ts.ResolveCorrelatedColumns()
 		if err != nil {
 			return err
 		}

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -402,3 +402,30 @@ func (s *tiflashTestSuite) TestMppGoroutinesExitFromErrors(c *C) {
 	c.Assert(failpoint.Disable(mppNonRootTaskError), IsNil)
 	c.Assert(failpoint.Disable(hang), IsNil)
 }
+
+func (s *tiflashTestSuite) TestMppApply(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists x1")
+	tk.MustExec("create table x1(a int primary key, b int);")
+	tk.MustExec("alter table x1 set tiflash replica 1")
+	tb := testGetTableByName(c, tk.Se, "test", "x1")
+	err := domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
+	c.Assert(err, IsNil)
+	tk.MustExec("insert into x1 values(1, 1),(2, 2);")
+
+	tk.MustExec("create table x2(a int primary key, b int);")
+	tk.MustExec("alter table x2 set tiflash replica 1")
+	tb = testGetTableByName(c, tk.Se, "test", "x2")
+	err = domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
+	c.Assert(err, IsNil)
+	tk.MustExec("insert into x2 values(1,2);")
+	tk.MustExec("analyze table x1, x2;")
+
+	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
+	tk.MustExec("set @@session.tidb_allow_mpp=ON")
+	// table full scan with correlated filter
+	tk.MustQuery(" select /*+ agg_to_cop(), hash_agg()*/ a from x1 where a > any (select a from x2 where x1.a = x2.a);").Check(testkit.Rows())
+	// range scan with correlated access conditions
+	tk.MustQuery("select /*+ agg_to_cop(), hash_agg()*/ * from x1 where b > any (select x2.a from x2 where x1.a = x2.a);").Check(testkit.Rows())
+}

--- a/planner/core/fragment.go
+++ b/planner/core/fragment.go
@@ -158,7 +158,7 @@ func (e *mppTaskGenerator) constructMPPTasksImpl(ctx context.Context, ts *Physic
 		// update ranges according to correlated columns in access conditions like in the Open() of TableReaderExecutor
 		for _, cond := range ts.AccessCondition {
 			if len(expression.ExtractCorColumns(cond)) > 0 {
-				err := ts.ResolveCorrelatedColumns()
+				_, err := ts.ResolveCorrelatedColumns()
 				if err != nil {
 					return nil, err
 				}

--- a/planner/core/fragment.go
+++ b/planner/core/fragment.go
@@ -156,17 +156,13 @@ func partitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds 
 func (e *mppTaskGenerator) constructMPPTasksImpl(ctx context.Context, ts *PhysicalTableScan) ([]*kv.MPPTask, error) {
 	if ts != nil {
 		// update ranges according to correlated columns in access conditions like in the Open() of TableReaderExecutor
-		hasCorCol := false
 		for _, cond := range ts.AccessCondition {
 			if len(expression.ExtractCorColumns(cond)) > 0 {
-				hasCorCol = true
+				err := ts.ResolveCorrelatedColumns()
+				if err != nil {
+					return nil, err
+				}
 				break
-			}
-		}
-		if hasCorCol {
-			err := ts.ResolveCorrelatedColumns()
-			if err != nil {
-				return nil, err
 			}
 		}
 

--- a/planner/core/fragment.go
+++ b/planner/core/fragment.go
@@ -15,6 +15,7 @@ package core
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/distsql"

--- a/store/mockstore/unistore/cophandler/closure_exec.go
+++ b/store/mockstore/unistore/cophandler/closure_exec.go
@@ -77,6 +77,8 @@ func getExecutorListFromRootExec(rootExec *tipb.Executor) ([]*tipb.Executor, err
 			currentExec = currentExec.Limit.Child
 		case tipb.ExecType_TypeExchangeSender:
 			currentExec = currentExec.ExchangeSender.Child
+		case tipb.ExecType_TypeSelection:
+			currentExec = currentExec.Selection.Child
 		default:
 			return nil, errors.New("unsupported executor type " + currentExec.Tp.String())
 		}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tics/issues/1606, https://github.com/pingcap/tics/issues/1607, https://github.com/pingcap/tics/issues/1612 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
mpp gather does not consider `apply` operator, which updates correlated columns during execution.
How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test 

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
