### PR TITLE
telemetry: Fix window algorithm

### DIFF
--- a/planner/core/telemetry.go
+++ b/planner/core/telemetry.go
@@ -5,8 +5,8 @@ import (
 	"github.com/pingcap/tidb/util/plancodec"
 )
 
-// GetTiFlashTelemetry execute telemetry for a plan.
-func GetTiFlashTelemetry(plan Plan) (tiFlashPushDown, tiFlashExchangePushDown bool) {
+// IsTiFlashContained returns whether the plan contains TiFlash related executors.
+func IsTiFlashContained(plan Plan) (tiFlashPushDown, tiFlashExchangePushDown bool) {
 	if plan == nil {
 		return
 	}

--- a/telemetry/data.go
+++ b/telemetry/data.go
@@ -25,7 +25,8 @@ type telemetryData struct {
 	TelemetryHostExtra *telemetryHostExtraInfo `json:"hostExtra"`
 	ReportTimestamp    int64                   `json:"reportTimestamp"`
 	TrackingID         string                  `json:"trackingId"`
-	FeatureUsageInfo   *featureUsageInfo       `json:"featureUsageInfo"`
+	FeatureUsage       *featureUsage           `json:"featureUsage"`
+	WindowedStats      []*windowData           `json:"windowedStats"`
 }
 
 func generateTelemetryData(ctx sessionctx.Context, trackingID string) telemetryData {
@@ -39,9 +40,10 @@ func generateTelemetryData(ctx sessionctx.Context, trackingID string) telemetryD
 	if i, err := getClusterInfo(ctx); err == nil {
 		r.Instances = i
 	}
-	if f, err := getTelemetryFeatureUsageInfo(ctx); err == nil {
-		r.FeatureUsageInfo = f
+	if f, err := getFeatureUsage(ctx); err == nil {
+		r.FeatureUsage = f
 	}
+	r.WindowedStats = getWindowData()
 	r.TelemetryHostExtra = getTelemetryHostExtraInfo()
 	return r
 }

--- a/telemetry/data_feature_usage.go
+++ b/telemetry/data_feature_usage.go
@@ -15,191 +15,23 @@ package telemetry
 
 import (
 	"context"
-	"sync"
-	"time"
 
-	"github.com/cznic/mathutil"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
 
-type featureUsageInfo struct {
-	TxnUsageInfo     *TxnUsageInfo              `json:"txnUsageInfo"`
-	CoprCacheUsed    []*CoprCacheUsedWindowItem `json:"coprCacheUsed"`
-	ClusterIndexUsed map[string]bool            `json:"clusterIndexUsed"`
-	TiFlashUsed      []*TiFlashUsageItem        `json:"tiFlashUsed"`
+type featureUsage struct {
+	Txn          *TxnUsage       `json:"txn"`
+	ClusterIndex map[string]bool `json:"clusterIndex"`
 }
 
-// FeatureTaskChan is the update task channel for telemetry feature data.
-var FeatureTaskChan = make(chan *FeatureTask, 1<<16)
-
-// FeatureTask is the update task for telemetry feature data.
-type FeatureTask struct {
-	TiFlashPushDown         bool
-	TiFLashExchangePushDown bool
-	CoprRespTimes           uint64
-	CoprCacheHitNum         uint64
-}
-
-// UpdateFeature update feature data for one task.
-func UpdateFeature(task *FeatureTask) {
-	CoprocessorCacheTelemetry.Lock.Lock()
-	length := len(CoprocessorCacheTelemetry.MinuteWindow)
-	if length == 0 || time.Since(*CoprocessorCacheTelemetry.MinuteWindow[length-1].BeginAt) >= time.Minute {
-		var i int
-		for i = 0; i < length && time.Since(*CoprocessorCacheTelemetry.MinuteWindow[i].BeginAt) >= ReportInterval; i++ {
-		}
-		if i < length {
-			CoprocessorCacheTelemetry.MinuteWindow = CoprocessorCacheTelemetry.MinuteWindow[i:]
-		}
-		CoprocessorCacheTelemetry.MinuteWindow = append(CoprocessorCacheTelemetry.MinuteWindow, CoprCacheUsedWindowItem{})
-		length -= i - 1
-		CoprocessorCacheTelemetry.MinuteWindow[length-1].BeginAt = new(time.Time)
-		*CoprocessorCacheTelemetry.MinuteWindow[length-1].BeginAt = time.Now()
-	}
-	if task.CoprRespTimes > 0 {
-		ratio := float64(task.CoprCacheHitNum) / float64(task.CoprRespTimes)
-		switch {
-		case ratio >= 0:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P0++
-			fallthrough
-		case ratio >= 0.01:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P1++
-			fallthrough
-		case ratio >= 0.1:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P10++
-			fallthrough
-		case ratio >= 0.2:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P20++
-			fallthrough
-		case ratio >= 0.4:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P40++
-			fallthrough
-		case ratio >= 0.8:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P80++
-			fallthrough
-		case ratio >= 1:
-			CoprocessorCacheTelemetry.MinuteWindow[length-1].P100++
-		}
-	} else {
-		CoprocessorCacheTelemetry.MinuteWindow[length-1].P0++
-	}
-	CoprocessorCacheTelemetry.Lock.Unlock()
-
-	TiFlashUsageTelemetry.Lock.Lock()
-	length = len(TiFlashUsageTelemetry.MinuteWindow)
-	if length == 0 || time.Since(*TiFlashUsageTelemetry.MinuteWindow[length-1].BeginAt) >= time.Minute {
-		var i int
-		for i = 0; i < length && time.Since(*TiFlashUsageTelemetry.MinuteWindow[i].BeginAt) >= ReportInterval; i++ {
-		}
-		TiFlashUsageTelemetry.MinuteWindow = TiFlashUsageTelemetry.MinuteWindow[i:]
-		TiFlashUsageTelemetry.MinuteWindow = append(TiFlashUsageTelemetry.MinuteWindow, TiFlashUsageItem{})
-		length -= i - 1
-		TiFlashUsageTelemetry.MinuteWindow[length-1].BeginAt = new(time.Time)
-		*TiFlashUsageTelemetry.MinuteWindow[length-1].BeginAt = time.Now()
-	}
-	TiFlashUsageTelemetry.MinuteWindow[length-1].TotalNumbers++
-	if task.TiFlashPushDown {
-		TiFlashUsageTelemetry.MinuteWindow[length-1].TiFlashPushDownNumbers++
-	}
-	if task.TiFLashExchangePushDown {
-		TiFlashUsageTelemetry.MinuteWindow[length-1].TiFlashExchangePushDownNumbers++
-	}
-	TiFlashUsageTelemetry.Lock.Unlock()
-}
-
-// CoprocessorCacheTelemetry is to save the global coprocessor cache telemetry data.
-var CoprocessorCacheTelemetry = struct {
-	MinuteWindow []CoprCacheUsedWindowItem
-	Lock         sync.RWMutex
-}{Lock: sync.RWMutex{}}
-
-// CoprCacheUsedWindowItem is the coprocessor cache telemetry data struct.
-type CoprCacheUsedWindowItem struct {
-	P0   uint64 `json:"gte0"`
-	P1   uint64 `json:"gte1"`
-	P10  uint64 `json:"gte10"`
-	P20  uint64 `json:"gte20"`
-	P40  uint64 `json:"gte40"`
-	P80  uint64 `json:"gte80"`
-	P100 uint64 `json:"gte100"`
-
-	BeginAt *time.Time `json:"beginAt"`
-}
-
-// TiFlashUsageTelemetry is to save the global TiFlash usage telemetry data.
-var TiFlashUsageTelemetry = struct {
-	MinuteWindow []TiFlashUsageItem
-	Lock         sync.RWMutex
-}{Lock: sync.RWMutex{}}
-
-// TiFlashUsageItem is the TiFlash usage telemetry data struct.
-type TiFlashUsageItem struct {
-	TotalNumbers                   uint64 `json:"totalNumbers"`
-	TiFlashPushDownNumbers         uint64 `json:"tiFlashPushDownNumbers"`
-	TiFlashExchangePushDownNumbers uint64 `json:"tiFlashExchangePushDownNumbers"`
-
-	BeginAt *time.Time `json:"beginAt"`
-}
-
-func getTelemetryFeatureUsageInfo(ctx sessionctx.Context) (*featureUsageInfo, error) {
+func getFeatureUsage(ctx sessionctx.Context) (*featureUsage, error) {
 	// init
-	usageInfo := featureUsageInfo{
-		CoprCacheUsed:    make([]*CoprCacheUsedWindowItem, 0, ReportInterval/time.Hour),
-		ClusterIndexUsed: make(map[string]bool),
-		TiFlashUsed:      make([]*TiFlashUsageItem, 0, ReportInterval/time.Hour),
+	usageInfo := featureUsage{
+		ClusterIndex: make(map[string]bool),
 	}
-
-	// coprocessor cache
-	CoprocessorCacheTelemetry.Lock.Lock()
-	maxLen := 0
-	timeNow := time.Now()
-	for _, window := range CoprocessorCacheTelemetry.MinuteWindow {
-		timeSince := timeNow.Sub(*window.BeginAt)
-		if timeSince >= ReportInterval {
-			continue
-		}
-		maxLen = mathutil.Max(maxLen, int(timeSince/time.Hour))
-		i := maxLen - int(timeSince/time.Hour)
-		if len(usageInfo.CoprCacheUsed) <= i {
-			usageInfo.CoprCacheUsed = append(usageInfo.CoprCacheUsed, &CoprCacheUsedWindowItem{})
-		}
-		usageInfo.CoprCacheUsed[i].P0 += window.P0
-		usageInfo.CoprCacheUsed[i].P1 += window.P1
-		usageInfo.CoprCacheUsed[i].P10 += window.P10
-		usageInfo.CoprCacheUsed[i].P20 += window.P20
-		usageInfo.CoprCacheUsed[i].P40 += window.P40
-		usageInfo.CoprCacheUsed[i].P80 += window.P80
-		usageInfo.CoprCacheUsed[i].P100 += window.P100
-		if usageInfo.CoprCacheUsed[i].BeginAt == nil {
-			usageInfo.CoprCacheUsed[i].BeginAt = window.BeginAt
-		}
-	}
-	CoprocessorCacheTelemetry.Lock.Unlock()
-
-	// TiFlash usage
-	TiFlashUsageTelemetry.Lock.Lock()
-	maxLen = 0
-	for _, window := range TiFlashUsageTelemetry.MinuteWindow {
-		timeSince := timeNow.Sub(*window.BeginAt)
-		if timeSince >= ReportInterval {
-			continue
-		}
-		maxLen = mathutil.Max(maxLen, int(timeSince/time.Hour))
-		i := maxLen - int(timeSince/time.Hour)
-		if len(usageInfo.TiFlashUsed) <= i {
-			usageInfo.TiFlashUsed = append(usageInfo.TiFlashUsed, &TiFlashUsageItem{})
-		}
-		usageInfo.TiFlashUsed[i].TotalNumbers += window.TotalNumbers
-		usageInfo.TiFlashUsed[i].TiFlashPushDownNumbers += window.TiFlashPushDownNumbers
-		usageInfo.TiFlashUsed[i].TiFlashExchangePushDownNumbers += window.TiFlashExchangePushDownNumbers
-		if usageInfo.TiFlashUsed[i].BeginAt == nil {
-			usageInfo.TiFlashUsed[i].BeginAt = window.BeginAt
-		}
-	}
-	TiFlashUsageTelemetry.Lock.Unlock()
 
 	// cluster index
 	exec := ctx.(sqlexec.RestrictedSQLExecutor)
@@ -224,18 +56,18 @@ func getTelemetryFeatureUsageInfo(ctx sessionctx.Context) (*featureUsageInfo, er
 		if row.GetString(1) == "CLUSTERED" {
 			isClustered = true
 		}
-		usageInfo.ClusterIndexUsed[row.GetString(0)] = isClustered
+		usageInfo.ClusterIndex[row.GetString(0)] = isClustered
 	}
 
 	// transaction related feature
-	usageInfo.TxnUsageInfo = GetTxnUsageInfo(ctx)
+	usageInfo.Txn = GetTxnUsageInfo(ctx)
 
 	return &usageInfo, nil
 }
 
-// TxnUsageInfo records the usage info of transaction related features, including
+// TxnUsage records the usage info of transaction related features, including
 // async-commit, 1PC and counters of transactions committed with different protocols.
-type TxnUsageInfo struct {
+type TxnUsage struct {
 	AsyncCommitUsed  bool                     `json:"asyncCommitUsed"`
 	OnePCUsed        bool                     `json:"onePCUsed"`
 	TxnCommitCounter metrics.TxnCommitCounter `json:"txnCommitCounter"`
@@ -244,7 +76,7 @@ type TxnUsageInfo struct {
 var initialTxnCommitCounter metrics.TxnCommitCounter
 
 // GetTxnUsageInfo gets the usage info of transaction related features. It's exported for tests.
-func GetTxnUsageInfo(ctx sessionctx.Context) *TxnUsageInfo {
+func GetTxnUsageInfo(ctx sessionctx.Context) *TxnUsage {
 	asyncCommitUsed := false
 	if val, err := variable.GetGlobalSystemVar(ctx.GetSessionVars(), variable.TiDBEnableAsyncCommit); err == nil {
 		asyncCommitUsed = val == variable.BoolOn
@@ -255,7 +87,7 @@ func GetTxnUsageInfo(ctx sessionctx.Context) *TxnUsageInfo {
 	}
 	curr := metrics.GetTxnCommitCounter()
 	diff := curr.Sub(initialTxnCommitCounter)
-	return &TxnUsageInfo{asyncCommitUsed, onePCUsed, diff}
+	return &TxnUsage{asyncCommitUsed, onePCUsed, diff}
 }
 
 func postReportTxnUsage() {

--- a/telemetry/data_window.go
+++ b/telemetry/data_window.go
@@ -21,14 +21,23 @@ import (
 )
 
 var (
-	CurrentExecuteCount                 atomic.Uint64
-	CurrentTiFlashPushDownCount         atomic.Uint64
+	// CurrentExecuteCount is CurrentExecuteCount
+	CurrentExecuteCount atomic.Uint64
+	// CurrentTiFlashPushDownCount is CurrentTiFlashPushDownCount
+	CurrentTiFlashPushDownCount atomic.Uint64
+	// CurrentTiFlashExchangePushDownCount is CurrentTiFlashExchangePushDownCount
 	CurrentTiFlashExchangePushDownCount atomic.Uint64
-	CurrentCoprCacheHitRatioGTE1Count   atomic.Uint64
-	CurrentCoprCacheHitRatioGTE10Count  atomic.Uint64
-	CurrentCoprCacheHitRatioGTE20Count  atomic.Uint64
-	CurrentCoprCacheHitRatioGTE40Count  atomic.Uint64
-	CurrentCoprCacheHitRatioGTE80Count  atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE1Count is CurrentCoprCacheHitRatioGTE1Count
+	CurrentCoprCacheHitRatioGTE1Count atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE10Count is CurrentCoprCacheHitRatioGTE10Count
+	CurrentCoprCacheHitRatioGTE10Count atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE20Count is CurrentCoprCacheHitRatioGTE20Count
+	CurrentCoprCacheHitRatioGTE20Count atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE40Count is CurrentCoprCacheHitRatioGTE40Count
+	CurrentCoprCacheHitRatioGTE40Count atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE80Count is CurrentCoprCacheHitRatioGTE80Count
+	CurrentCoprCacheHitRatioGTE80Count atomic.Uint64
+	// CurrentCoprCacheHitRatioGTE100Count is CurrentCoprCacheHitRatioGTE100Count
 	CurrentCoprCacheHitRatioGTE100Count atomic.Uint64
 )
 
@@ -68,8 +77,7 @@ var (
 	subWindowsLock    = sync.RWMutex{}
 )
 
-// RotateSubWindow rotates the telemetry sub window. This function is not thread safe. It should
-// be called from domain loop.
+// RotateSubWindow rotates the telemetry sub window.
 func RotateSubWindow() {
 	thisSubWindow := windowData{
 		BeginAt:      time.Now(),
@@ -96,7 +104,7 @@ func RotateSubWindow() {
 	subWindowsLock.Unlock()
 }
 
-// GetWindowData returns data in window size.
+// getWindowData returns data aggregated by window size.
 func getWindowData() []*windowData {
 	results := make([]*windowData, 0)
 

--- a/telemetry/data_window.go
+++ b/telemetry/data_window.go
@@ -1,0 +1,130 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package telemetry
+
+import (
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+)
+
+var (
+	CurrentExecuteCount                 atomic.Uint64
+	CurrentTiFlashPushDownCount         atomic.Uint64
+	CurrentTiFlashExchangePushDownCount atomic.Uint64
+	CurrentCoprCacheHitRatioGTE1Count   atomic.Uint64
+	CurrentCoprCacheHitRatioGTE10Count  atomic.Uint64
+	CurrentCoprCacheHitRatioGTE20Count  atomic.Uint64
+	CurrentCoprCacheHitRatioGTE40Count  atomic.Uint64
+	CurrentCoprCacheHitRatioGTE80Count  atomic.Uint64
+	CurrentCoprCacheHitRatioGTE100Count atomic.Uint64
+)
+
+const (
+	// WindowSize determines how long some data is aggregated by.
+	WindowSize = 1 * time.Hour
+	// SubWindowSize determines how often data is rotated.
+	SubWindowSize = 1 * time.Minute
+
+	maxSubWindowLength         = int(ReportInterval / SubWindowSize) // TODO: Ceiling?
+	maxSubWindowLengthInWindow = int(WindowSize / SubWindowSize)     // TODO: Ceiling?
+)
+
+type windowData struct {
+	BeginAt        time.Time          `json:"beginAt"`
+	ExecuteCount   uint64             `json:"executeCount"`
+	TiFlashUsage   tiFlashUsageData   `json:"tiFlashUsage"`
+	CoprCacheUsage coprCacheUsageData `json:"coprCacheUsage"`
+}
+
+type coprCacheUsageData struct {
+	GTE1   uint64 `json:"gte1"`
+	GTE10  uint64 `json:"gte10"`
+	GTE20  uint64 `json:"gte20"`
+	GTE40  uint64 `json:"gte40"`
+	GTE80  uint64 `json:"gte80"`
+	GTE100 uint64 `json:"gte100"`
+}
+
+type tiFlashUsageData struct {
+	PushDown         uint64 `json:"pushDown"`
+	ExchangePushDown uint64 `json:"exchangePushDown"`
+}
+
+var (
+	rotatedSubWindows = []*windowData{}
+	subWindowsLock    = sync.RWMutex{}
+)
+
+// RotateSubWindow rotates the telemetry sub window. This function is not thread safe. It should
+// be called from domain loop.
+func RotateSubWindow() {
+	thisSubWindow := windowData{
+		BeginAt:      time.Now(),
+		ExecuteCount: CurrentExecuteCount.Swap(0),
+		TiFlashUsage: tiFlashUsageData{
+			PushDown:         CurrentTiFlashPushDownCount.Swap(0),
+			ExchangePushDown: CurrentTiFlashExchangePushDownCount.Swap(0),
+		},
+		CoprCacheUsage: coprCacheUsageData{
+			GTE1:   CurrentCoprCacheHitRatioGTE1Count.Swap(0),
+			GTE10:  CurrentCoprCacheHitRatioGTE10Count.Swap(0),
+			GTE20:  CurrentCoprCacheHitRatioGTE20Count.Swap(0),
+			GTE40:  CurrentCoprCacheHitRatioGTE40Count.Swap(0),
+			GTE80:  CurrentCoprCacheHitRatioGTE80Count.Swap(0),
+			GTE100: CurrentCoprCacheHitRatioGTE100Count.Swap(0),
+		},
+	}
+	subWindowsLock.Lock()
+	rotatedSubWindows = append(rotatedSubWindows, &thisSubWindow)
+	if len(rotatedSubWindows) > maxSubWindowLength {
+		// Only retain last N sub windows, according to the report interval.
+		rotatedSubWindows = rotatedSubWindows[len(rotatedSubWindows)-maxSubWindowLength:]
+	}
+	subWindowsLock.Unlock()
+}
+
+// GetWindowData returns data in window size.
+func getWindowData() []*windowData {
+	results := make([]*windowData, 0)
+
+	subWindowsLock.RLock()
+
+	i := 0
+	for i < len(rotatedSubWindows) {
+		thisWindow := *rotatedSubWindows[i]
+		aggregatedSubWindows := 1
+		// Aggregate later sub windows
+		i++
+		for i < len(rotatedSubWindows) && aggregatedSubWindows < maxSubWindowLengthInWindow {
+			thisWindow.ExecuteCount += rotatedSubWindows[i].ExecuteCount
+			thisWindow.TiFlashUsage.PushDown += rotatedSubWindows[i].TiFlashUsage.PushDown
+			thisWindow.TiFlashUsage.ExchangePushDown += rotatedSubWindows[i].TiFlashUsage.ExchangePushDown
+			thisWindow.CoprCacheUsage.GTE1 += rotatedSubWindows[i].CoprCacheUsage.GTE1
+			thisWindow.CoprCacheUsage.GTE10 += rotatedSubWindows[i].CoprCacheUsage.GTE10
+			thisWindow.CoprCacheUsage.GTE20 += rotatedSubWindows[i].CoprCacheUsage.GTE20
+			thisWindow.CoprCacheUsage.GTE40 += rotatedSubWindows[i].CoprCacheUsage.GTE40
+			thisWindow.CoprCacheUsage.GTE80 += rotatedSubWindows[i].CoprCacheUsage.GTE80
+			thisWindow.CoprCacheUsage.GTE100 += rotatedSubWindows[i].CoprCacheUsage.GTE100
+			aggregatedSubWindows++
+			i++
+		}
+		results = append(results, &thisWindow)
+	}
+
+	subWindowsLock.RUnlock()
+
+	return results
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Fix the issue that telemetry window is wrong calculated or panics.

### What is changed and how it works?

1. Data Collector: Always report to a global counters
2. Data Rotater: Rotate global counters to a local buffer, every 1 minute.
3. Data Reporter: Aggregate everything in the local buffer, by every 1 hour window, then upload.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test: Change WindowSize to 1m and SubWindowSize to 1s to test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix telemetry window algorithm