### PR TITLE
statistics: optimize the global histogram merging algorithm

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -461,8 +461,10 @@ func (h *Handle) mergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 		} else {
 			// For the index stats, we get the final NDV by accumulating the NDV of each bucket in the index histogram.
 			globalStatsNDV := int64(0)
-			for _, bucket := range globalStats.Hg[i].Buckets {
-				globalStatsNDV += bucket.NDV
+			for i := range globalStats.Hg[i].Buckets {
+				globalStatsNDV += globalStats.Hg[i].Buckets[i].NDV
+				// NOTICE: after merging bucket NDVs have the trend to be underestimated, so for safe we don't use them.
+				globalStats.Hg[i].Buckets[i].NDV = 0
 			}
 			globalStats.Hg[i].NDV = globalStatsNDV
 

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -461,10 +461,10 @@ func (h *Handle) mergePartitionStats2GlobalStats(sc sessionctx.Context, opts map
 		} else {
 			// For the index stats, we get the final NDV by accumulating the NDV of each bucket in the index histogram.
 			globalStatsNDV := int64(0)
-			for i := range globalStats.Hg[i].Buckets {
-				globalStatsNDV += globalStats.Hg[i].Buckets[i].NDV
+			for j := range globalStats.Hg[i].Buckets {
+				globalStatsNDV += globalStats.Hg[i].Buckets[j].NDV
 				// NOTICE: after merging bucket NDVs have the trend to be underestimated, so for safe we don't use them.
-				globalStats.Hg[i].Buckets[i].NDV = 0
+				globalStats.Hg[i].Buckets[j].NDV = 0
 			}
 			globalStats.Hg[i].NDV = globalStatsNDV
 

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -989,12 +989,12 @@ partition by range (a) (
 			"test t p1 a 0 0 6 1 11 16 0",
 			"test t p1 a 0 1 10 2 17 19 0"))
 	tk.MustQuery("show stats_buckets where is_index=1").Check(
-		testkit.Rows("test t global a 1 0 7 2 1 6 6",
-			"test t global a 1 1 17 2 6 19 9",
-			"test t p0 a 1 0 4 1 1 4 4",
-			"test t p0 a 1 1 7 2 5 6 2",
-			"test t p1 a 1 0 8 1 11 18 8",
-			"test t p1 a 1 1 10 2 19 19 1"))
+		testkit.Rows("test t global a 1 0 7 2 1 6 0",
+			"test t global a 1 1 17 2 6 19 0",
+			"test t p0 a 1 0 4 1 1 4 0",
+			"test t p0 a 1 1 7 2 5 6 0",
+			"test t p1 a 1 0 8 1 11 18 0",
+			"test t p1 a 1 1 10 2 19 19 0"))
 }
 
 func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
@@ -1350,8 +1350,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tintint p1 a 1 (13, 2) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tintint' and is_index=1").Check(testkit.Rows(
-		"test tintint global a 1 0 6 0 (1, 1) (3, 1) 5",   // (2, 3) is popped into it
-		"test tintint global a 1 1 11 0 (3, 1) (13, 2) 4", // (13, 1) is popped into it
+		"test tintint global a 1 0 6 2 (1, 1) (3, 1) 0",   // (2, 3) is popped into it
+		"test tintint global a 1 1 11 2 (3, 1) (13, 2) 0", // (13, 1) is popped into it
 		"test tintint p0 a 1 0 4 1 (1, 1) (2, 2) 4",
 		"test tintint p0 a 1 1 4 0 (2, 3) (3, 1) 0",
 		"test tintint p1 a 1 0 3 0 (11, 1) (13, 1) 3",

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -991,10 +991,10 @@ partition by range (a) (
 	tk.MustQuery("show stats_buckets where is_index=1").Check(
 		testkit.Rows("test t global a 1 0 7 2 1 6 0",
 			"test t global a 1 1 17 2 6 19 0",
-			"test t p0 a 1 0 4 1 1 4 0",
-			"test t p0 a 1 1 7 2 5 6 0",
-			"test t p1 a 1 0 8 1 11 18 0",
-			"test t p1 a 1 1 10 2 19 19 0"))
+			"test t p0 a 1 0 4 1 1 4 4",
+			"test t p0 a 1 1 7 2 5 6 2",
+			"test t p1 a 1 0 8 1 11 18 8",
+			"test t p1 a 1 1 10 2 19 19 1"))
 }
 
 func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
@@ -1035,7 +1035,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustQuery("show stats_buckets where is_index=0").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
 		"test tint global c 0 0 5 2 1 4 0", // bucket.ndv is not maintained for column histograms
-		"test tint global c 0 1 12 2 4 17 0",
+		"test tint global c 0 1 12 2 17 17 0",
 		"test tint p0 c 0 0 2 1 1 2 0",
 		"test tint p0 c 0 1 3 1 3 3 0",
 		"test tint p1 c 0 0 3 1 11 13 0",
@@ -1048,8 +1048,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("show stats_buckets where is_index=1").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
-		"test tint global c 1 0 5 0 1 5 4", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
-		"test tint global c 1 1 12 2 5 17 6",
+		"test tint global c 1 0 5 2 1 4 0", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
+		"test tint global c 1 1 12 2 4 17 0",
 		"test tint p0 c 1 0 3 0 1 4 3",
 		"test tint p0 c 1 1 3 0 5 5 0",
 		"test tint p1 c 1 0 5 0 11 16 5",
@@ -1094,7 +1094,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustQuery("show stats_buckets where table_name='tdouble' and is_index=0 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
 		"test tdouble global c 0 0 5 2 1 4 0", // bucket.ndv is not maintained for column histograms
-		"test tdouble global c 0 1 12 2 4 17 0",
+		"test tdouble global c 0 1 12 2 17 17 0",
 		"test tdouble p0 c 0 0 2 1 1 2 0",
 		"test tdouble p0 c 0 1 3 1 3 3 0",
 		"test tdouble p1 c 0 0 3 1 11 13 0",
@@ -1110,8 +1110,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("show stats_buckets where table_name='tdouble' and is_index=1 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
-		"test tdouble global c 1 0 5 0 1 5 4", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
-		"test tdouble global c 1 1 12 2 5 17 6",
+		"test tdouble global c 1 0 5 2 1 4 0", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
+		"test tdouble global c 1 1 12 2 4 17 0",
 		"test tdouble p0 c 1 0 3 0 1 4 3",
 		"test tdouble p0 c 1 1 3 0 5 5 0",
 		"test tdouble p1 c 1 0 5 0 11 16 5",
@@ -1159,7 +1159,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustQuery("show stats_buckets where table_name='tdecimal' and is_index=0 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
 		"test tdecimal global c 0 0 5 2 1.00 4.00 0", // bucket.ndv is not maintained for column histograms
-		"test tdecimal global c 0 1 12 2 4.00 17.00 0",
+		"test tdecimal global c 0 1 12 2 17.00 17.00 0",
 		"test tdecimal p0 c 0 0 2 1 1.00 2.00 0",
 		"test tdecimal p0 c 0 1 3 1 3.00 3.00 0",
 		"test tdecimal p1 c 0 0 3 1 11.00 13.00 0",
@@ -1175,8 +1175,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("show stats_buckets where table_name='tdecimal' and is_index=1 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
-		"test tdecimal global c 1 0 5 0 1.00 5.00 4", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
-		"test tdecimal global c 1 1 12 2 5.00 17.00 6",
+		"test tdecimal global c 1 0 5 2 1.00 4.00 0", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
+		"test tdecimal global c 1 1 12 2 4.00 17.00 0",
 		"test tdecimal p0 c 1 0 3 0 1.00 4.00 3",
 		"test tdecimal p0 c 1 1 3 0 5.00 5.00 0",
 		"test tdecimal p1 c 1 0 5 0 11.00 16.00 5",
@@ -1224,7 +1224,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustQuery("show stats_buckets where table_name='tdatetime' and is_index=0 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
 		"test tdatetime global c 0 0 5 2 2000-01-01 00:00:00 2000-01-04 00:00:00 0", // bucket.ndv is not maintained for column histograms
-		"test tdatetime global c 0 1 12 2 2000-01-04 00:00:00 2000-01-17 00:00:00 0",
+		"test tdatetime global c 0 1 12 2 2000-01-17 00:00:00 2000-01-17 00:00:00 0",
 		"test tdatetime p0 c 0 0 2 1 2000-01-01 00:00:00 2000-01-02 00:00:00 0",
 		"test tdatetime p0 c 0 1 3 1 2000-01-03 00:00:00 2000-01-03 00:00:00 0",
 		"test tdatetime p1 c 0 0 3 1 2000-01-11 00:00:00 2000-01-13 00:00:00 0",
@@ -1240,8 +1240,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("show stats_buckets where table_name='tdatetime' and is_index=1 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
-		"test tdatetime global c 1 0 5 0 2000-01-01 00:00:00 2000-01-05 00:00:00 4", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
-		"test tdatetime global c 1 1 12 2 2000-01-05 00:00:00 2000-01-17 00:00:00 6",
+		"test tdatetime global c 1 0 5 2 2000-01-01 00:00:00 2000-01-04 00:00:00 0", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
+		"test tdatetime global c 1 1 12 2 2000-01-04 00:00:00 2000-01-17 00:00:00 0",
 		"test tdatetime p0 c 1 0 3 0 2000-01-01 00:00:00 2000-01-04 00:00:00 3",
 		"test tdatetime p0 c 1 1 3 0 2000-01-05 00:00:00 2000-01-05 00:00:00 0",
 		"test tdatetime p1 c 1 0 5 0 2000-01-11 00:00:00 2000-01-16 00:00:00 5",
@@ -1289,7 +1289,7 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 	tk.MustQuery("show stats_buckets where table_name='tstring' and is_index=0 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
 		"test tstring global c 0 0 5 2 a1 a4 0", // bucket.ndv is not maintained for column histograms
-		"test tstring global c 0 1 12 2 a4 b17 0",
+		"test tstring global c 0 1 12 2 b17 b17 0",
 		"test tstring p0 c 0 0 2 1 a1 a2 0",
 		"test tstring p0 c 0 1 3 1 a3 a3 0",
 		"test tstring p1 c 0 0 3 1 b11 b13 0",
@@ -1305,8 +1305,8 @@ func (s *testStatsSuite) TestGlobalStatsData2(c *C) {
 
 	tk.MustQuery("show stats_buckets where table_name='tstring' and is_index=1 and column_name='c'").Check(testkit.Rows(
 		// db, tbl, part, col, isIdx, bucketID, count, repeat, lower, upper, ndv
-		"test tstring global c 1 0 5 0 a1 a5 4", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
-		"test tstring global c 1 1 12 2 a5 b17 6",
+		"test tstring global c 1 0 5 2 a1 a4 0", // 4 is popped from p0.TopN, so g.ndv = p0.ndv+1
+		"test tstring global c 1 1 12 2 a4 b17 0",
 		"test tstring p0 c 1 0 3 0 a1 a4 3",
 		"test tstring p0 c 1 1 3 0 a5 a5 0",
 		"test tstring p1 c 1 0 5 0 b11 b16 5",
@@ -1350,8 +1350,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tintint p1 a 1 (13, 2) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tintint' and is_index=1").Check(testkit.Rows(
-		"test tintint global a 1 0 6 2 (1, 1) (3, 1) 0",   // (2, 3) is popped into it
-		"test tintint global a 1 1 11 2 (3, 1) (13, 2) 0", // (13, 1) is popped into it
+		"test tintint global a 1 0 6 2 (1, 1) (2, 3) 0",   // (2, 3) is popped into it
+		"test tintint global a 1 1 11 2 (2, 3) (13, 1) 0", // (13, 1) is popped into it
 		"test tintint p0 a 1 0 4 1 (1, 1) (2, 2) 4",
 		"test tintint p0 a 1 1 4 0 (2, 3) (3, 1) 0",
 		"test tintint p1 a 1 0 3 0 (11, 1) (13, 1) 3",
@@ -1384,8 +1384,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tintstr p1 a 1 (13, 2) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tintstr' and is_index=1").Check(testkit.Rows(
-		"test tintstr global a 1 0 6 0 (1, 1) (3, 1) 5",   // (2, 3) is popped into it
-		"test tintstr global a 1 1 11 0 (3, 1) (13, 2) 4", // (13, 1) is popped into it
+		"test tintstr global a 1 0 6 2 (1, 1) (2, 3) 0",   // (2, 3) is popped into it
+		"test tintstr global a 1 1 11 2 (2, 3) (13, 1) 0", // (13, 1) is popped into it
 		"test tintstr p0 a 1 0 4 1 (1, 1) (2, 2) 4",
 		"test tintstr p0 a 1 1 4 0 (2, 3) (3, 1) 0",
 		"test tintstr p1 a 1 0 3 0 (11, 1) (13, 1) 3",
@@ -1418,8 +1418,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tintdouble p1 a 1 (13, 2) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tintdouble' and is_index=1").Check(testkit.Rows(
-		"test tintdouble global a 1 0 6 0 (1, 1) (3, 1) 5",   // (2, 3) is popped into it
-		"test tintdouble global a 1 1 11 0 (3, 1) (13, 2) 4", // (13, 1) is popped into it
+		"test tintdouble global a 1 0 6 2 (1, 1) (2, 3) 0",   // (2, 3) is popped into it
+		"test tintdouble global a 1 1 11 2 (2, 3) (13, 1) 0", // (13, 1) is popped into it
 		"test tintdouble p0 a 1 0 4 1 (1, 1) (2, 2) 4",
 		"test tintdouble p0 a 1 1 4 0 (2, 3) (3, 1) 0",
 		"test tintdouble p1 a 1 0 3 0 (11, 1) (13, 1) 3",
@@ -1452,8 +1452,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tdoubledecimal p1 a 1 (13, 2.00) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tdoubledecimal' and is_index=1").Check(testkit.Rows(
-		"test tdoubledecimal global a 1 0 6 0 (1, 1.00) (3, 1.00) 5",   // (2, 3) is popped into it
-		"test tdoubledecimal global a 1 1 11 0 (3, 1.00) (13, 2.00) 4", // (13, 1) is popped into it
+		"test tdoubledecimal global a 1 0 6 2 (1, 1.00) (2, 3.00) 0",   // (2, 3) is popped into it
+		"test tdoubledecimal global a 1 1 11 2 (2, 3.00) (13, 1.00) 0", // (13, 1) is popped into it
 		"test tdoubledecimal p0 a 1 0 4 1 (1, 1.00) (2, 2.00) 4",
 		"test tdoubledecimal p0 a 1 1 4 0 (2, 3.00) (3, 1.00) 0",
 		"test tdoubledecimal p1 a 1 0 3 0 (11, 1.00) (13, 1.00) 3",
@@ -1486,8 +1486,8 @@ func (s *testStatsSuite) TestGlobalStatsData3(c *C) {
 		"test tstrdt p1 a 1 (13, 2000-01-02 00:00:00) 3"))
 
 	tk.MustQuery("show stats_buckets where table_name='tstrdt' and is_index=1").Check(testkit.Rows(
-		"test tstrdt global a 1 0 6 0 (1, 2000-01-01 00:00:00) (3, 2000-01-01 00:00:00) 5",   // (2, 3) is popped into it
-		"test tstrdt global a 1 1 11 0 (3, 2000-01-01 00:00:00) (13, 2000-01-02 00:00:00) 4", // (13, 1) is popped into it
+		"test tstrdt global a 1 0 6 2 (1, 2000-01-01 00:00:00) (2, 2000-01-03 00:00:00) 0",   // (2, 3) is popped into it
+		"test tstrdt global a 1 1 11 2 (2, 2000-01-03 00:00:00) (13, 2000-01-01 00:00:00) 0", // (13, 1) is popped into it
 		"test tstrdt p0 a 1 0 4 1 (1, 2000-01-01 00:00:00) (2, 2000-01-02 00:00:00) 4",
 		"test tstrdt p0 a 1 1 4 0 (2, 2000-01-03 00:00:00) (3, 2000-01-01 00:00:00) 0",
 		"test tstrdt p1 a 1 0 3 0 (11, 2000-01-01 00:00:00) (13, 2000-01-01 00:00:00) 3",

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -1927,13 +1927,10 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 			bucketNDV = 0
 		}
 	}
-
 	if r > 0 {
 		bucketSum := int64(0)
-		bucketNDV := int64(0)
 		for _, b := range buckets[:r] {
 			bucketSum += b.Count
-			bucketNDV += b.NDV
 		}
 
 		if len(globalBuckets) > 0 && bucketSum < gBucketCountThreshold { // merge them into the previous global bucket
@@ -1947,7 +1944,6 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 		}
 		globalBuckets = append(globalBuckets, merged)
 	}
-
 	// Because we merge backwards, we need to flip the slices.
 	for i, j := 0, len(globalBuckets)-1; i < j; i, j = i+1, j-1 {
 		globalBuckets[i], globalBuckets[j] = globalBuckets[j], globalBuckets[i]

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -1946,7 +1946,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	}
 
 	// Calc the bucket lower.
-	if minValue == nil { // both hists and popedTopN are empty, returns an empty hist in this case
+	if minValue == nil || len(globalBuckets) == 0 { // both hists and popedTopN are empty, returns an empty hist in this case
 		return NewHistogram(hists[0].ID, 0, totNull, hists[0].LastUpdateVersion, hists[0].Tp, len(globalBuckets), totColSize), nil
 	}
 	globalBuckets[0].lower = minValue.Clone()

--- a/statistics/histogram.go
+++ b/statistics/histogram.go
@@ -1685,7 +1685,7 @@ func mergeBucketNDV(sc *stmtctx.StatementContext, left *bucket4Merging, right *b
 		// |-ratio-|
 		// ndv = ratio * left.ndv + max((1-ratio) * left.ndv, right.ndv)
 		ratio := calcFraction4Datums(left.lower, left.upper, right.lower)
-		res.NDV = int64(math.Ceil(ratio*float64(left.NDV) + math.Max((1-ratio)*float64(left.NDV), float64(right.NDV))))
+		res.NDV = int64(ratio*float64(left.NDV) + math.Max((1-ratio)*float64(left.NDV), float64(right.NDV)))
 		res.lower = left.lower.Clone()
 		return &res, nil
 	}
@@ -1722,9 +1722,9 @@ func mergeBucketNDV(sc *stmtctx.StatementContext, left *bucket4Merging, right *b
 	//		+ (1-upperRatio) * right.ndv
 	if lowerCompare >= 0 {
 		lowerRatio := calcFraction4Datums(left.lower, left.upper, right.lower)
-		res.NDV = int64(math.Ceil(lowerRatio*float64(left.NDV) +
+		res.NDV = int64(lowerRatio*float64(left.NDV) +
 			math.Max((1-lowerRatio)*float64(left.NDV), upperRatio*float64(right.NDV)) +
-			(1-upperRatio)*float64(right.NDV)))
+			(1-upperRatio)*float64(right.NDV))
 		res.lower = left.lower.Clone()
 		return &res, nil
 	}
@@ -1736,9 +1736,9 @@ func mergeBucketNDV(sc *stmtctx.StatementContext, left *bucket4Merging, right *b
 	//		+ max(left.ndv + (upperRatio - lowerRatio) * right.ndv)
 	//		+ (1-upperRatio) * right.ndv
 	lowerRatio := calcFraction4Datums(right.lower, right.upper, left.lower)
-	res.NDV = int64(math.Ceil(lowerRatio*float64(right.NDV) +
+	res.NDV = int64(lowerRatio*float64(right.NDV) +
 		math.Max(float64(left.NDV), (upperRatio-lowerRatio)*float64(right.NDV)) +
-		(1-upperRatio)*float64(right.NDV)))
+		(1-upperRatio)*float64(right.NDV))
 	return &res, nil
 }
 
@@ -1898,7 +1898,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	var sum, prevSum int64
 	r, prevR := len(buckets), 0
 	bucketCount := int64(1)
-	gBucketThreshold := (totCount / expBucketNumber) * 99 / 100 // expectedBucketSize * 0.95
+	gBucketThreshold := (totCount / expBucketNumber) * 95 / 100 // expectedBucketSize * 0.95
 	for i := len(buckets) - 1; i >= 0; i-- {
 		sum += buckets[i].Count
 		if sum >= totCount*bucketCount/expBucketNumber && sum-prevSum >= gBucketThreshold {
@@ -1951,7 +1951,7 @@ func MergePartitionHist2GlobalHist(sc *stmtctx.StatementContext, hists []*Histog
 	}
 	globalBuckets[0].lower = minValue.Clone()
 	for i := 1; i < len(globalBuckets); i++ {
-		if globalBuckets[i].NDV == 1 {
+		if globalBuckets[i].NDV == 1 { // there is only 1 value so lower = upper
 			globalBuckets[i].lower = globalBuckets[i].upper.Clone()
 		} else {
 			globalBuckets[i].lower = globalBuckets[i-1].upper.Clone()

--- a/statistics/histogram_test.go
+++ b/statistics/histogram_test.go
@@ -372,7 +372,7 @@ func (s *testStatisticsSuite) TestMergePartitionLevelHist(c *C) {
 		},
 	}
 
-	for i, t := range tests {
+	for _, t := range tests {
 		var expTotColSize int64
 		hists := make([]*Histogram, 0, len(t.partitionHists))
 		for i := range t.partitionHists {

--- a/statistics/histogram_test.go
+++ b/statistics/histogram_test.go
@@ -250,7 +250,7 @@ func (s *testStatisticsSuite) TestMergePartitionLevelHist(c *C) {
 					upper:  7,
 					count:  7,
 					repeat: 3,
-					ndv:    4,
+					ndv:    5,
 				},
 				{
 					lower:  7,
@@ -264,7 +264,7 @@ func (s *testStatisticsSuite) TestMergePartitionLevelHist(c *C) {
 					upper:  17,
 					count:  22,
 					repeat: 1,
-					ndv:    5,
+					ndv:    6,
 				},
 			},
 			expBucketNumber: 3,
@@ -358,21 +358,21 @@ func (s *testStatisticsSuite) TestMergePartitionLevelHist(c *C) {
 					upper:  12,
 					count:  22,
 					repeat: 3,
-					ndv:    5,
+					ndv:    6,
 				},
 				{
 					lower:  12,
 					upper:  18,
 					count:  33,
 					repeat: 5,
-					ndv:    5,
+					ndv:    6,
 				},
 			},
 			expBucketNumber: 3,
 		},
 	}
 
-	for _, t := range tests {
+	for i, t := range tests {
 		var expTotColSize int64
 		hists := make([]*Histogram, 0, len(t.partitionHists))
 		for i := range t.partitionHists {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: statistics: optimize the global histogram merging algorithm

### What is changed and how it works?

statistics: optimize the global histogram merging algorithm
1. remove empty buckets
2. introduce a damping factor when calculating bucket NDV
3. limit the minimum size of global buckets
4. adjust bucket boundaries according to NDV
5. disable bucket NDV in global-stats

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- statistics: optimize the global histogram merging algorithm
