### PR TITLE
ranger: handle decimal overflow properly when building index ranges

### DIFF
--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -97,6 +97,10 @@ func convertPoint(sc *stmtctx.StatementContext, point *point, tp *types.FieldTyp
 			// see issue #20101: overflow when converting integer to year
 		} else if tp.Tp == mysql.TypeBit && terror.ErrorEqual(err, types.ErrDataTooLong) {
 			// see issue #19067: we should ignore the types.ErrDataTooLong when we convert value to TypeBit value
+		} else if tp.Tp == mysql.TypeNewDecimal && terror.ErrorEqual(err, types.ErrOverflow) {
+			// Ignore the types.ErrOverflow when we convert TypeNewDecimal values.
+			// A trimmed valid boundary point value would be returned then. Accordingly, the `excl` of the point
+			// would be adjusted. Impossible ranges would be skipped by the `validInterval` call later.
 		} else {
 			return point, errors.Trace(err)
 		}

--- a/util/ranger/testdata/ranger_suite_in.json
+++ b/util/ranger/testdata/ranger_suite_in.json
@@ -84,5 +84,22 @@
       "select * from t where a > -1;",
       "select * from t where a > 3;"
     ]
+  },
+  {
+    "name": "TestIndexRangeForDecimal",
+    "cases": [
+      "select * from t1 use index(a) where a in (-1,0);",
+      "select * from t1 use index(a) where a = -1;",
+      "select * from t1 use index(a) where a > -1;",
+      "select * from t1 use index(a) where a < -1;",
+      "select * from t1 use index(a) where a <= -1;",
+      "select * from t1 use index(a) where a >= -1;",
+      "select * from t2 use index(idx) where a = 1 and b in (-1,0);",
+      "select * from t2 use index(idx) where a = 1 and b = -1;",
+      "select * from t2 use index(idx) where a = 1 and b > -1;",
+      "select * from t2 use index(idx) where a = 1 and b < -1;",
+      "select * from t2 use index(idx) where a = 1 and b <= -1;",
+      "select * from t2 use index(idx) where a = 1 and b >= -1;"
+    ]
   }
 ]

--- a/util/ranger/testdata/ranger_suite_out.json
+++ b/util/ranger/testdata/ranger_suite_out.json
@@ -553,5 +553,112 @@
         "Result": null
       }
     ]
+  },
+  {
+    "Name": "TestIndexRangeForDecimal",
+    "Cases": [
+      {
+        "SQL": "select * from t1 use index(a) where a in (-1,0);",
+        "Plan": [
+          "IndexReader 10.00 root  index:IndexRangeScan",
+          "└─IndexRangeScan 10.00 cop[tikv] table:t1, index:a(a) range:[0,0], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "0"
+        ]
+      },
+      {
+        "SQL": "select * from t1 use index(a) where a = -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t1 use index(a) where a > -1;",
+        "Plan": [
+          "IndexReader 3333.33 root  index:IndexRangeScan",
+          "└─IndexRangeScan 3333.33 cop[tikv] table:t1, index:a(a) range:[0,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "0"
+        ]
+      },
+      {
+        "SQL": "select * from t1 use index(a) where a < -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t1 use index(a) where a <= -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t1 use index(a) where a >= -1;",
+        "Plan": [
+          "IndexReader 3333.33 root  index:IndexRangeScan",
+          "└─IndexRangeScan 3333.33 cop[tikv] table:t1, index:a(a) range:[0,+inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "0"
+        ]
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b in (-1,0);",
+        "Plan": [
+          "IndexReader 0.10 root  index:IndexRangeScan",
+          "└─IndexRangeScan 0.10 cop[tikv] table:t2, index:idx(a, b) range:[1 0,1 0], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b = -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b > -1;",
+        "Plan": [
+          "IndexReader 33.33 root  index:IndexRangeScan",
+          "└─IndexRangeScan 33.33 cop[tikv] table:t2, index:idx(a, b) range:[1 0,1 +inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b < -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b <= -1;",
+        "Plan": [
+          "TableDual 0.00 root  rows:0"
+        ],
+        "Result": null
+      },
+      {
+        "SQL": "select * from t2 use index(idx) where a = 1 and b >= -1;",
+        "Plan": [
+          "IndexReader 33.33 root  index:IndexRangeScan",
+          "└─IndexRangeScan 33.33 cop[tikv] table:t2, index:idx(a, b) range:[1 0,1 +inf], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 0"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23483

Problem Summary:

Planner reports error for a query.

### What is changed and how it works?

What's Changed: Ignore the overflow error for decimal type in ranger.

How it Works: `zeroMyDecimal` would be returned if overflow error occurs, so `convertPoint` would adjust the `excl` of the boundary accordingly, and impossible ranges would be removed by consequent `validIntervals()`.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Handle decimal overflow properly when building index ranges