### PR TITLE
txn: consider forceSyncCommit flag for async commit

### DIFF
--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -625,7 +625,7 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 		status.action = cmdResp.Action
 		status.primaryLock = cmdResp.LockInfo
 
-		if status.primaryLock != nil && status.primaryLock.UseAsyncCommit {
+		if status.primaryLock != nil && status.primaryLock.UseAsyncCommit && !forceSyncCommit {
 			if !lr.store.GetOracle().IsExpired(txnID, cmdResp.LockTtl, &oracle.Option{TxnScope: oracle.GlobalTxnScope}) {
 				status.ttl = cmdResp.LockTtl
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23540 

Problem Summary:
Make the transaction status check for async commit transactions accurate.

### What is changed and how it works?

What's Changed:
If the `forceSyncCommit` flag is set, make the `status` check use the 2pc path instead of the `async commit` path, as the
`UseAsyncCommit` flag in the primary lock is invalid after fallback.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- We may need to add some tests about the fallback transaction resolving in the UTF.

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
