### PR TITLE
executor: fix update panic on join having statement

### DIFF
--- a/executor/update_test.go
+++ b/executor/update_test.go
@@ -517,3 +517,12 @@ func (s *testPointGetSuite) TestIssue21447(c *C) {
 	tk1.MustQuery("select * from t1 where id in (1, 2) for update").Check(testkit.Rows("1 xyz"))
 	tk1.MustExec("commit")
 }
+
+func (s *testSuite11) TestIssue23553(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec(`drop table if exists tt`)
+	tk.MustExec(`create table tt (m0 varchar(64), status tinyint not null)`)
+	tk.MustExec(`insert into tt values('1',0),('1',0),('1',0)`)
+	tk.MustExec(`update tt a inner join (select m0 from tt where status!=1 group by m0 having count(*)>1) b on a.m0=b.m0 set a.status=1`)
+}

--- a/planner/core/rule_eliminate_projection.go
+++ b/planner/core/rule_eliminate_projection.go
@@ -117,6 +117,9 @@ func doPhysicalProjectionElimination(p PhysicalPlan) PhysicalPlan {
 		return p
 	}
 	child := p.Children()[0]
+	if childProj, ok := child.(*PhysicalProjection); ok {
+		childProj.SetSchema(p.Schema())
+	}
 	return child
 }
 


### PR DESCRIPTION
Signed-off-by: lzmhhh123 <lzmhhh123@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23553

### What is changed and how it works?

How it Works: when pruning projection, for the two continuous projections, the top one has been pruning, but the below one has a different schema. Then it causes their parent operator recognising some schema columns as unused columns, then cause update panic.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

- fix update panic on join having statement.