### PR TITLE
execution: no slow query log after dumpTableStatCountToKV

### DIFF
--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -511,7 +511,9 @@ func (h *Handle) dumpTableStatColSizeToKV(id int64, delta variable.TableDelta) e
 	}
 	sql := fmt.Sprintf("insert into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, tot_col_size) "+
 		"values %s on duplicate key update tot_col_size = tot_col_size + values(tot_col_size)", strings.Join(values, ","))
-	_, _, err := h.execRestrictedSQL(context.Background(), sql)
+	h.mu.Lock()
+	_, err := h.mu.ctx.(sqlexec.SQLExecutor).ExecuteInternal(context.Background(), sql)
+	h.mu.Unlock()
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21787

Problem Summary:

### What is changed and how it works?

no slow query log after dumpTableStatCountToKV

How it Works:
query sql with ``ExecuteInternal``

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- execution: no slow query log after dumpTableStatCountToKV
