### PR TITLE
MPP: fix 2-phase agg chose wrong partition column during planning

### DIFF
--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -146,7 +146,7 @@ func (s *tiflashTestSuite) TestMppExecution(c *C) {
 	tk.MustExec("insert into t values(2,0)")
 	tk.MustExec("insert into t values(3,0)")
 
-	tk.MustExec("create table t1(a int not null primary key, b int not null)")
+	tk.MustExec("create table t1(a int primary key, b int not null)")
 	tk.MustExec("alter table t1 set tiflash replica 1")
 	tb = testGetTableByName(c, tk.Se, "test", "t1")
 	err = domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
@@ -162,7 +162,7 @@ func (s *tiflashTestSuite) TestMppExecution(c *C) {
 		tk.MustQuery("select count(*) from t1 , t where t1.a = t.a").Check(testkit.Rows("3"))
 	}
 	// test multi-way join
-	tk.MustExec("create table t2(a int not null primary key, b int not null)")
+	tk.MustExec("create table t2(a int primary key, b int not null)")
 	tk.MustExec("alter table t2 set tiflash replica 1")
 	tb = testGetTableByName(c, tk.Se, "test", "t2")
 	err = domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
@@ -190,6 +190,9 @@ func (s *tiflashTestSuite) TestMppExecution(c *C) {
 	tk.MustQuery("select count(*) k, t2.b * t2.a from t2 group by t2.b * t2.a").Check(testkit.Rows("3 0"))
 	tk.MustQuery("select count(*) k, t2.a/2 m from t2 group by t2.a / 2 order by m").Check(testkit.Rows("1 0.5000", "1 1.0000", "1 1.5000"))
 	tk.MustQuery("select count(*) k, t2.a div 2 from t2 group by t2.a div 2 order by k").Check(testkit.Rows("1 0", "2 1"))
+
+	tk.MustQuery("select count(*) from ( select * from t2 group by a, b) A group by A.b").Check(testkit.Rows("3"))
+	tk.MustQuery("select count(*) from t1 where t1.a+100 > ( select count(*) from t2 where t1.a=t2.a and t1.b=t2.b) group by t1.b").Check(testkit.Rows("4"))
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (c1 decimal(8, 5) not null, c2 decimal(9, 5), c3 decimal(9, 4) , c4 decimal(8, 4) not null)")
@@ -223,7 +226,6 @@ func (s *tiflashTestSuite) TestInjectExtraProj(c *C) {
 
 	tk.MustQuery("select avg(a) from t").Check(testkit.Rows("9223372036854775807.0000"))
 	tk.MustQuery("select avg(a), a from t group by a").Check(testkit.Rows("9223372036854775807.0000 9223372036854775807"))
-
 }
 
 func (s *tiflashTestSuite) TestPartitionTable(c *C) {

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2306,7 +2306,7 @@ func (la *LogicalAggregation) tryToGetMppHashAggs(prop *property.PhysicalPropert
 		}
 		// TODO: permute various partition columns from group-by columns
 		// 1-phase agg
-		// If there are no available parititon cols, but still have group by items, that means group by items are all expressions or constants.
+		// If there are no available partition cols, but still have group by items, that means group by items are all expressions or constants.
 		// To avoid mess, we don't do any one-phase aggregation in this case.
 		if len(partitionCols) != 0 {
 			childProp := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, PartitionTp: property.HashType, PartitionCols: partitionCols, CanAddEnforcer: true}
@@ -2321,6 +2321,7 @@ func (la *LogicalAggregation) tryToGetMppHashAggs(prop *property.PhysicalPropert
 		agg := NewPhysicalHashAgg(la, la.stats.ScaleByExpectCnt(prop.ExpectedCnt), childProp)
 		agg.SetSchema(la.schema.Clone())
 		agg.MppRunMode = Mpp2Phase
+		agg.MppPartitionCols = partitionCols
 		hashAggs = append(hashAggs, agg)
 
 		// agg runs on TiDB with a partial agg on TiFlash if possible

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -940,9 +940,10 @@ const (
 type basePhysicalAgg struct {
 	physicalSchemaProducer
 
-	AggFuncs     []*aggregation.AggFuncDesc
-	GroupByItems []expression.Expression
-	MppRunMode   AggMppRunMode
+	AggFuncs         []*aggregation.AggFuncDesc
+	GroupByItems     []expression.Expression
+	MppRunMode       AggMppRunMode
+	MppPartitionCols []*expression.Column
 }
 
 func (p *basePhysicalAgg) isFinalAgg() bool {

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -1756,18 +1756,19 @@ func (p *PhysicalHashAgg) attach2TaskForMpp(tasks ...task) task {
 			return invalidTask
 		}
 		attachPlan2Task(partialAgg, mpp)
-		if len(p.MppPartitionCols) == 0 {
+		partitionCols := p.MppPartitionCols
+		if len(partitionCols) == 0 {
 			items := finalAgg.(*PhysicalHashAgg).GroupByItems
-			p.MppPartitionCols = make([]*expression.Column, 0, len(items))
+			partitionCols = make([]*expression.Column, 0, len(items))
 			for _, expr := range items {
 				col, ok := expr.(*expression.Column)
 				if !ok {
 					return invalidTask
 				}
-				p.MppPartitionCols = append(p.MppPartitionCols, col)
+				partitionCols = append(partitionCols, col)
 			}
 		}
-		prop := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, PartitionTp: property.HashType, PartitionCols: p.MppPartitionCols}
+		prop := &property.PhysicalProperty{TaskTp: property.MppTaskType, ExpectedCnt: math.MaxFloat64, PartitionTp: property.HashType, PartitionCols: partitionCols}
 		newMpp := mpp.enforceExchangerImpl(prop)
 		attachPlan2Task(finalAgg, newMpp)
 		if proj != nil {

--- a/planner/core/testdata/integration_serial_suite_in.json
+++ b/planner/core/testdata/integration_serial_suite_in.json
@@ -215,7 +215,9 @@
       "desc format = 'brief' select count(distinct value),id from t group by id",
       "desc format = 'brief' select count(distinct value),sum(distinct value),id from t group by id",
       "desc format = 'brief' select * from t join ( select count(distinct value), id from t group by id) as A on A.id = t.id",
-      "desc format = 'brief' select * from t join ( select count(1/value), id from t group by id) as A on A.id = t.id"
+      "desc format = 'brief' select * from t join ( select count(1/value), id from t group by id) as A on A.id = t.id",
+      "desc format = 'brief' select /*+hash_agg()*/ sum(id) from (select value, id from t where id > value group by id, value)A group by value /*the exchange should have only one partition column: test.t.value*/",
+      "desc format = 'brief' select /*+hash_agg()*/ sum(B.value) from t as B where B.id+1 > (select count(*) from t where t.id= B.id and t.value=B.value) group by B.id /*the exchange should have only one partition column: test.t.id*/"
     ]
   },
   {

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -1559,7 +1559,7 @@
           "            └─Projection 7984.01 batchCop[tiflash]  Column#14, test.t.c1, test.t.c2, test.t.c3",
           "              └─HashAgg 7984.01 batchCop[tiflash]  group by:test.t.c1, test.t.c2, test.t.c3, funcs:sum(Column#23)->Column#14, funcs:firstrow(test.t.c1)->test.t.c1, funcs:firstrow(test.t.c2)->test.t.c2, funcs:firstrow(test.t.c3)->test.t.c3",
           "                └─ExchangeReceiver 7984.01 batchCop[tiflash]  ",
-          "                  └─ExchangeSender 7984.01 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.c1, test.t.c2, test.t.c3",
+          "                  └─ExchangeSender 7984.01 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.c2, test.t.c3, test.t.c1",
           "                    └─HashAgg 7984.01 batchCop[tiflash]  group by:test.t.c1, test.t.c2, test.t.c3, funcs:count(1)->Column#23",
           "                      └─Selection 9980.01 batchCop[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2))",
           "                        └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
@@ -1957,13 +1957,14 @@
           "TableReader 6400.00 root  data:ExchangeSender",
           "└─ExchangeSender 6400.00 batchCop[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 6400.00 batchCop[tiflash]  Column#4",
-          "    └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.value, funcs:sum(test.t.id)->Column#4",
-          "      └─Projection 6400.00 batchCop[tiflash]  test.t.id, test.t.value",
-          "        └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.id, test.t.value, funcs:firstrow(test.t.id)->test.t.id, funcs:firstrow(test.t.value)->test.t.value",
-          "          └─ExchangeReceiver 8000.00 batchCop[tiflash]  ",
-          "            └─ExchangeSender 8000.00 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.value",
-          "              └─Selection 8000.00 batchCop[tiflash]  gt(cast(test.t.id, decimal(20,0) BINARY), test.t.value)",
-          "                └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
+          "    └─HashAgg 6400.00 batchCop[tiflash]  group by:Column#22, funcs:sum(Column#21)->Column#4",
+          "      └─Projection 6400.00 batchCop[tiflash]  cast(test.t.id, decimal(32,0) BINARY)->Column#21, test.t.value",
+          "        └─Projection 6400.00 batchCop[tiflash]  test.t.id, test.t.value",
+          "          └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.id, test.t.value, funcs:firstrow(test.t.id)->test.t.id, funcs:firstrow(test.t.value)->test.t.value",
+          "            └─ExchangeReceiver 8000.00 batchCop[tiflash]  ",
+          "              └─ExchangeSender 8000.00 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.value",
+          "                └─Selection 8000.00 batchCop[tiflash]  gt(cast(test.t.id, decimal(20,0) BINARY), test.t.value)",
+          "                  └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -1950,6 +1950,43 @@
           "        └─Selection 9990.00 batchCop[tiflash]  not(isnull(test.t.id))",
           "          └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
         ]
+      },
+      {
+        "SQL": "desc format = 'brief' select /*+hash_agg()*/ sum(id) from (select value, id from t where id > value group by id, value)A group by value /*the exchange should have only one partition column: test.t.value*/",
+        "Plan": [
+          "TableReader 6400.00 root  data:ExchangeSender",
+          "└─ExchangeSender 6400.00 batchCop[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 6400.00 batchCop[tiflash]  Column#4",
+          "    └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.value, funcs:sum(test.t.id)->Column#4",
+          "      └─Projection 6400.00 batchCop[tiflash]  test.t.id, test.t.value",
+          "        └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.id, test.t.value, funcs:firstrow(test.t.id)->test.t.id, funcs:firstrow(test.t.value)->test.t.value",
+          "          └─ExchangeReceiver 8000.00 batchCop[tiflash]  ",
+          "            └─ExchangeSender 8000.00 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.value",
+          "              └─Selection 8000.00 batchCop[tiflash]  gt(cast(test.t.id, decimal(20,0) BINARY), test.t.value)",
+          "                └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "desc format = 'brief' select /*+hash_agg()*/ sum(B.value) from t as B where B.id+1 > (select count(*) from t where t.id= B.id and t.value=B.value) group by B.id /*the exchange should have only one partition column: test.t.id*/",
+        "Plan": [
+          "TableReader 6400.00 root  data:ExchangeSender",
+          "└─ExchangeSender 6400.00 batchCop[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 6400.00 batchCop[tiflash]  Column#8",
+          "    └─HashAgg 6400.00 batchCop[tiflash]  group by:test.t.id, funcs:sum(test.t.value)->Column#8",
+          "      └─Selection 8000.00 batchCop[tiflash]  gt(plus(test.t.id, 1), ifnull(Column#7, 0))",
+          "        └─HashJoin 10000.00 batchCop[tiflash]  left outer join, equal:[eq(test.t.id, test.t.id) eq(test.t.value, test.t.value)]",
+          "          ├─Selection(Build) 6387.21 batchCop[tiflash]  gt(plus(test.t.id, 1), ifnull(Column#7, 0))",
+          "          │ └─Projection 7984.01 batchCop[tiflash]  Column#7, test.t.id, test.t.value",
+          "          │   └─HashAgg 7984.01 batchCop[tiflash]  group by:test.t.id, test.t.value, funcs:sum(Column#24)->Column#7, funcs:firstrow(test.t.id)->test.t.id, funcs:firstrow(test.t.value)->test.t.value",
+          "          │     └─ExchangeReceiver 7984.01 batchCop[tiflash]  ",
+          "          │       └─ExchangeSender 7984.01 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.id",
+          "          │         └─HashAgg 7984.01 batchCop[tiflash]  group by:test.t.id, test.t.value, funcs:count(1)->Column#24",
+          "          │           └─Selection 9980.01 batchCop[tiflash]  not(isnull(test.t.id)), not(isnull(test.t.value))",
+          "          │             └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo",
+          "          └─ExchangeReceiver(Probe) 10000.00 batchCop[tiflash]  ",
+          "            └─ExchangeSender 10000.00 batchCop[tiflash]  ExchangeType: HashPartition, Hash Cols: test.t.id",
+          "              └─TableFullScan 10000.00 batchCop[tiflash] table:B keep order:false, stats:pseudo"
+        ]
       }
     ]
   },

--- a/statistics/handle/gc_test.go
+++ b/statistics/handle/gc_test.go
@@ -113,7 +113,7 @@ func (s *testStatsSuite) TestGCExtendedStats(c *C) {
 	h := s.do.StatsHandle()
 	ddlLease := time.Duration(0)
 	c.Assert(h.GCStats(s.do.InfoSchema(), ddlLease), IsNil)
-	testKit.MustQuery("select name, type, column_ids, stats, status from mysql.stats_extended").Check(testkit.Rows(
+	testKit.MustQuery("select name, type, column_ids, stats, status from mysql.stats_extended").Sort().Check(testkit.Rows(
 		"s1 2 [1,2] 1.000000 2",
 		"s2 2 [2,3] 1.000000 1",
 	))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tics/issues/1648 <!-- REMOVE this line if no issue to close -->
introduced by plan/core: support mpp group by expressions. (#23133)

Problem Summary:
the parent's partition columns properity in exhaust_plan is removed during `attach2TaskForMpp`

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: recover the partition column properity from parent

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
