### PR TITLE
execution: reuse iterator in hash join

### DIFF
--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -891,6 +891,7 @@ func prepare4HashJoin(testCase *hashJoinTestCase, innerExec, outerExec Executor)
 	childrenUsedSchema := markChildrenUsedCols(e.Schema(), e.children[0].Schema(), e.children[1].Schema())
 	defaultValues := make([]types.Datum, e.buildSideExec.Schema().Len())
 	lhsTypes, rhsTypes := retTypes(innerExec), retTypes(outerExec)
+	e.iterators = make([]chunk.Iterator4Slice, e.concurrency)
 	e.joiners = make([]joiner, e.concurrency)
 	for i := uint(0); i < e.concurrency; i++ {
 		e.joiners[i] = newJoiner(testCase.ctx, e.joinType, true, defaultValues,

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1186,6 +1186,7 @@ func (b *executorBuilder) buildHashJoin(v *plannercore.PhysicalHashJoin) Executo
 	}
 	e.buildSideEstCount = b.buildSideEstCount(v)
 	childrenUsedSchema := markChildrenUsedCols(v.Schema(), v.Children()[0].Schema(), v.Children()[1].Schema())
+	e.iterators = make([]chunk.Iterator4Slice, e.concurrency)
 	e.joiners = make([]joiner, e.concurrency)
 	for i := uint(0); i < e.concurrency; i++ {
 		e.joiners[i] = newJoiner(b.ctx, v.JoinType, v.InnerChildIdx == 0, defaultValues,

--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -17,7 +17,7 @@ var (
 	_ Iterator = (*Iterator4Chunk)(nil)
 	_ Iterator = (*iterator4RowPtr)(nil)
 	_ Iterator = (*iterator4List)(nil)
-	_ Iterator = (*iterator4Slice)(nil)
+	_ Iterator = (*Iterator4Slice)(nil)
 	_ Iterator = (*iterator4RowContainer)(nil)
 	_ Iterator = (*multiIterator)(nil)
 )
@@ -52,16 +52,23 @@ type Iterator interface {
 
 // NewIterator4Slice returns a Iterator for Row slice.
 func NewIterator4Slice(rows []Row) Iterator {
-	return &iterator4Slice{rows: rows}
+	return &Iterator4Slice{rows: rows}
 }
 
-type iterator4Slice struct {
+// Iterator4Slice is used to iterate rows inside a slice.
+type Iterator4Slice struct {
 	rows   []Row
 	cursor int
 }
 
+// Reset reset by rows
+func (it *Iterator4Slice) Reset(rows []Row) {
+	it.rows = rows
+	it.cursor = 0
+}
+
 // Begin implements the Iterator interface.
-func (it *iterator4Slice) Begin() Row {
+func (it *Iterator4Slice) Begin() Row {
 	if it.Len() == 0 {
 		return it.End()
 	}
@@ -70,7 +77,7 @@ func (it *iterator4Slice) Begin() Row {
 }
 
 // Next implements the Iterator interface.
-func (it *iterator4Slice) Next() Row {
+func (it *Iterator4Slice) Next() Row {
 	if len := it.Len(); it.cursor >= len {
 		it.cursor = len + 1
 		return it.End()
@@ -81,7 +88,7 @@ func (it *iterator4Slice) Next() Row {
 }
 
 // Current implements the Iterator interface.
-func (it *iterator4Slice) Current() Row {
+func (it *Iterator4Slice) Current() Row {
 	if it.cursor == 0 || it.cursor > it.Len() {
 		return it.End()
 	}
@@ -89,22 +96,22 @@ func (it *iterator4Slice) Current() Row {
 }
 
 // End implements the Iterator interface.
-func (it *iterator4Slice) End() Row {
+func (it *Iterator4Slice) End() Row {
 	return Row{}
 }
 
 // ReachEnd implements the Iterator interface.
-func (it *iterator4Slice) ReachEnd() {
+func (it *Iterator4Slice) ReachEnd() {
 	it.cursor = it.Len() + 1
 }
 
 // Len implements the Iterator interface.
-func (it *iterator4Slice) Len() int {
+func (it *Iterator4Slice) Len() int {
 	return len(it.rows)
 }
 
 // Error returns none-nil error if anything wrong happens during the iteration.
-func (it *iterator4Slice) Error() error {
+func (it *Iterator4Slice) Error() error {
 	return nil
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/pingcap/tidb/issues/14466

Problem Summary:

the method joinMatchedProbeSideRow2Chunk uses the method NewIterator4Slice to create a lot of iterators whereas these iterators can be reused.

### What is changed and how it works?

How it Works:

reset iterator with ``[]Row`` when using it

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

```
name                                                                                                        old time/op  new time/op  delta
HashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-6   1.18s ± 2%   1.18s ± 3%  +0.32%  (p=0.739 n=10+10)
HashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:false)-6     249ms ± 1%   247ms ± 0%  -0.52%  (p=0.004 n=9+9)
HashJoinExec/(rows:100000,_cols:[bigint(20)_var_string(5)],_concurency:4,_joinKeyIdx:_[0],_disk:true)-6      9.15s ± 2%   9.10s ± 3%  -0.53%  (p=0.278 n=9+10)
HashJoinExec/(rows:5,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-6                72.7µs ± 2%  72.0µs ± 3%  -0.86%  (p=0.247 n=10+10)
HashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0_1],_disk:false)-6         32.6ms ± 3%  32.5ms ± 3%  -0.51%  (p=0.247 n=10+10)
HashJoinExec/(rows:100000,_cols:[bigint(20)_double],_concurency:4,_joinKeyIdx:_[0],_disk:false)-6           29.9ms ± 2%  30.2ms ± 1%  +0.99%  (p=0.089 n=10+10)
```

Side effects

- Performance regression
    - Consumes less CPU
    - Consumes lessMEM

### Release note <!-- bugfixes or new feature need a release note -->

- execution: reuse iterator in hash join
