### PR TITLE
planner, executor: IndexMerge supports reading extraHandleCol in partialTableReader

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2610,6 +2610,9 @@ func buildNoRangeIndexMergeReader(b *executorBuilder, v *plannercore.PhysicalInd
 	}
 	collectTable := false
 	e.tableRequest.CollectRangeCounts = &collectTable
+	if v.ExtraHandleColForPartialReader != nil {
+		e.extraHandleIdx = v.ExtraHandleColForPartialReader.Index
+	}
 	return e, nil
 }
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2610,8 +2610,8 @@ func buildNoRangeIndexMergeReader(b *executorBuilder, v *plannercore.PhysicalInd
 	}
 	collectTable := false
 	e.tableRequest.CollectRangeCounts = &collectTable
-	if v.ExtraHandleColForPartialReader != nil {
-		e.extraHandleIdx = v.ExtraHandleColForPartialReader.Index
+	if v.ExtraHandleCol != nil {
+		e.extraHandleIdx = v.ExtraHandleCol.Index
 	}
 	return e, nil
 }

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -78,3 +78,29 @@ func (s *testSuite1) TestIssue16910(c *C) {
 	tk.MustExec("insert into t2 values (0, 0), (1, 1), (2, 2), (3, 3), (4, 4), (5, 5), (6, 6), (7, 7), (8, 8), (9, 9), (10, 10), (11, 11), (12, 12), (13, 13), (14, 14), (15, 15), (16, 16), (17, 17), (18, 18), (19, 19), (20, 20), (21, 21), (22, 22), (23, 23);")
 	tk.MustQuery("select /*+ USE_INDEX_MERGE(t1, a, b) */ * from t1 partition (p0) join t2 partition (p1) on t1.a = t2.a where t1.a < 40 or t1.b < 30;").Check(testkit.Rows("1 1 1 1"))
 }
+
+func (s *testSuite1) TestIssue23569(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists tt;")
+	tk.MustExec(`create table tt(id bigint(20) NOT NULL,create_time bigint(20) NOT NULL DEFAULT '0' ,driver varchar(64), PRIMARY KEY (id,create_time))
+	PARTITION BY RANGE ( create_time ) (
+		PARTITION p201901 VALUES LESS THAN (1577808000),
+		PARTITION p202001 VALUES LESS THAN (1585670400),
+		PARTITION p202002 VALUES LESS THAN (1593532800),
+		PARTITION p202003 VALUES LESS THAN (1601481600),
+		PARTITION p202004 VALUES LESS THAN (1609430400),
+		PARTITION p202101 VALUES LESS THAN (1617206400),
+		PARTITION p202102 VALUES LESS THAN (1625068800),
+		PARTITION p202103 VALUES LESS THAN (1633017600),
+		PARTITION p202104 VALUES LESS THAN (1640966400),
+		PARTITION p202201 VALUES LESS THAN (1648742400),
+		PARTITION p202202 VALUES LESS THAN (1656604800),
+		PARTITION p202203 VALUES LESS THAN (1664553600),
+		PARTITION p202204 VALUES LESS THAN (1672502400),
+		PARTITION p202301 VALUES LESS THAN (1680278400)
+	);`)
+	tk.MustExec("insert tt value(1, 1577807000, 'jack'), (2, 1577809000, 'mike'), (3, 1585670500, 'right'), (4, 1601481500, 'hello');")
+	tk.MustExec("set @@tidb_enable_index_merge=true;")
+	tk.MustQuery("select count(*) from tt partition(p202003) where _tidb_rowid is null or (_tidb_rowid>=1 and _tidb_rowid<100);").Check(testkit.Rows("1"))
+}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -188,7 +188,8 @@ type PhysicalIndexMergeReader struct {
 	// partialPlans are the partial plans that have not been flatted. The type of each element is permitted PhysicalIndexScan or PhysicalTableScan.
 	partialPlans []PhysicalPlan
 	// tablePlan is a PhysicalTableScan to get the table tuples. Current, it must be not nil.
-	tablePlan PhysicalPlan
+	tablePlan                      PhysicalPlan
+	ExtraHandleColForPartialReader *expression.Column
 }
 
 // PhysicalIndexScan represents an index scan plan.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -188,8 +188,10 @@ type PhysicalIndexMergeReader struct {
 	// partialPlans are the partial plans that have not been flatted. The type of each element is permitted PhysicalIndexScan or PhysicalTableScan.
 	partialPlans []PhysicalPlan
 	// tablePlan is a PhysicalTableScan to get the table tuples. Current, it must be not nil.
-	tablePlan                      PhysicalPlan
-	ExtraHandleColForPartialReader *expression.Column
+	tablePlan PhysicalPlan
+	// ExtraHandleCol indicates the index of extraHandleCol when the partial
+	// reader is TableReader.
+	ExtraHandleCol *expression.Column
 }
 
 // PhysicalIndexScan represents an index scan plan.

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -367,11 +367,11 @@ func (p *PhysicalIndexMergeReader) ResolveIndices() (err error) {
 	for i := 0; i < len(p.partialPlans); i++ {
 		switch x := p.partialPlans[i].(type) {
 		case *PhysicalTableReader:
-			newCol, err := p.ExtraHandleColForPartialReader.ResolveIndices(x.Schema())
+			newCol, err := p.ExtraHandleCol.ResolveIndices(x.Schema())
 			if err != nil {
 				return err
 			}
-			p.ExtraHandleColForPartialReader = newCol.(*expression.Column)
+			p.ExtraHandleCol = newCol.(*expression.Column)
 		}
 		err = p.partialPlans[i].ResolveIndices()
 		if err != nil {

--- a/planner/core/resolve_indices.go
+++ b/planner/core/resolve_indices.go
@@ -365,6 +365,14 @@ func (p *PhysicalIndexMergeReader) ResolveIndices() (err error) {
 		}
 	}
 	for i := 0; i < len(p.partialPlans); i++ {
+		switch x := p.partialPlans[i].(type) {
+		case *PhysicalTableReader:
+			newCol, err := p.ExtraHandleColForPartialReader.ResolveIndices(x.Schema())
+			if err != nil {
+				return err
+			}
+			p.ExtraHandleColForPartialReader = newCol.(*expression.Column)
+		}
 		err = p.partialPlans[i].ResolveIndices()
 		if err != nil {
 			return err

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -725,7 +725,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 		cst: t.cst,
 	}
 	if t.idxMergePartPlans != nil {
-		p := PhysicalIndexMergeReader{partialPlans: t.idxMergePartPlans, tablePlan: t.tablePlan, ExtraHandleColForPartialReader: t.extraHandleCol}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
+		p := PhysicalIndexMergeReader{partialPlans: t.idxMergePartPlans, tablePlan: t.tablePlan, ExtraHandleCol: t.extraHandleCol}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
 		setTableScanToTableRowIDScan(p.tablePlan)
 		newTask.p = p
 		return newTask

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -725,7 +725,7 @@ func finishCopTask(ctx sessionctx.Context, task task) task {
 		cst: t.cst,
 	}
 	if t.idxMergePartPlans != nil {
-		p := PhysicalIndexMergeReader{partialPlans: t.idxMergePartPlans, tablePlan: t.tablePlan}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
+		p := PhysicalIndexMergeReader{partialPlans: t.idxMergePartPlans, tablePlan: t.tablePlan, ExtraHandleColForPartialReader: t.extraHandleCol}.Init(ctx, t.idxMergePartPlans[0].SelectBlockOffset())
 		setTableScanToTableRowIDScan(p.tablePlan)
 		newTask.p = p
 		return newTask


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23569 

Problem Summary:
PartialTableWorker for IndexMerge does not support reading extraHandleCol.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- IndexMerge supports reading extraHandleCol in partialTableReader