### PR TITLE
store/tikv: add more probe functions for tests

### DIFF
--- a/store/tikv/test_probe.go
+++ b/store/tikv/test_probe.go
@@ -16,12 +16,14 @@ package tikv
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/store/tikv/unionstore"
+	pd "github.com/tikv/pd/client"
 )
 
 // StoreProbe wraps KVSTore and exposes internal states for testing purpose.
@@ -32,6 +34,43 @@ type StoreProbe struct {
 // NewLockResolver creates a new LockResolver instance.
 func (s StoreProbe) NewLockResolver() LockResolverProbe {
 	return LockResolverProbe{LockResolver: newLockResolver(s.KVStore)}
+}
+
+// GetTimestampWithRetry returns latest timestamp.
+func (s StoreProbe) GetTimestampWithRetry(bo *Backoffer, scope string) (uint64, error) {
+	return s.getTimestampWithRetry(bo, scope)
+}
+
+// Begin starts a transaction.
+func (s StoreProbe) Begin() (TxnProbe, error) {
+	txn, err := s.KVStore.Begin()
+	return TxnProbe{KVTxn: txn}, err
+}
+
+// SetRegionCachePDClient replaces pd client inside region cache.
+func (s StoreProbe) SetRegionCachePDClient(client pd.Client) {
+	s.regionCache.pdClient = client
+}
+
+// ClearTxnLatches clears store's txn latch scheduler.
+func (s StoreProbe) ClearTxnLatches() {
+	s.txnLatches = nil
+}
+
+// SendTxnHeartbeat renews a txn's ttl.
+func (s StoreProbe) SendTxnHeartbeat(ctx context.Context, key []byte, startTS uint64, ttl uint64) (uint64, error) {
+	bo := NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil)
+	return sendTxnHeartBeat(bo, s.KVStore, key, startTS, ttl)
+}
+
+// LoadSafePoint from safepoint kv.
+func (s StoreProbe) LoadSafePoint() (uint64, error) {
+	return loadSafePoint(s.GetSafePointKV())
+}
+
+// SaveSafePoint saves safepoint to kv.
+func (s StoreProbe) SaveSafePoint(v uint64) error {
+	return saveSafePoint(s.GetSafePointKV(), v)
 }
 
 // TxnProbe wraps a txn and exports internal states for testing purpose.
@@ -75,14 +114,25 @@ func (txn TxnProbe) SetCommitter(committer CommitterProbe) {
 	txn.committer = committer.twoPhaseCommitter
 }
 
-// ClearStoreTxnLatches clears store's txn latch scheduler.
-func (txn TxnProbe) ClearStoreTxnLatches() {
-	txn.store.txnLatches = nil
-}
-
 // CollectLockedKeys returns all locked keys of a transaction.
 func (txn TxnProbe) CollectLockedKeys() [][]byte {
 	return txn.collectLockedKeys()
+}
+
+// BatchGetSingleRegion gets a batch of keys from a region.
+func (txn TxnProbe) BatchGetSingleRegion(bo *Backoffer, region RegionVerID, keys [][]byte, collect func([]byte, []byte)) error {
+	snapshot := txn.GetSnapshot()
+	return snapshot.batchGetSingleRegion(bo, batchKeys{region: region, keys: keys}, collect)
+}
+
+// NewScanner returns a scanner to iterate given key range.
+func (txn TxnProbe) NewScanner(start, end []byte, batchSize int, reverse bool) (*Scanner, error) {
+	return newScanner(txn.GetSnapshot(), start, end, batchSize, reverse)
+}
+
+// GetStartTime returns the time when txn starts.
+func (txn TxnProbe) GetStartTime() time.Time {
+	return txn.startTime
 }
 
 func newTwoPhaseCommitterWithInit(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, error) {
@@ -146,6 +196,11 @@ func (c CommitterProbe) SetMinCommitTS(ts uint64) {
 	c.minCommitTS = ts
 }
 
+// SetMaxCommitTS sets the max commit ts can be used.
+func (c CommitterProbe) SetMaxCommitTS(ts uint64) {
+	c.maxCommitTS = ts
+}
+
 // SetSessionID sets the session id of the committer.
 func (c CommitterProbe) SetSessionID(id uint64) {
 	c.sessionID = id
@@ -171,6 +226,16 @@ func (c CommitterProbe) GetLockTTL() uint64 {
 	return c.lockTTL
 }
 
+// SetLockTTL sets the lock ttl duration.
+func (c CommitterProbe) SetLockTTL(ttl uint64) {
+	c.lockTTL = ttl
+}
+
+// SetLockTTLByTimeAndSize sets the lock ttl duration by time and size.
+func (c CommitterProbe) SetLockTTLByTimeAndSize(start time.Time, size int) {
+	c.lockTTL = txnLockTTL(start, size)
+}
+
 // SetTxnSize resets the txn size of the committer and updates lock TTL.
 func (c CommitterProbe) SetTxnSize(sz int) {
 	c.txnSize = sz
@@ -187,9 +252,14 @@ func (c CommitterProbe) Execute(ctx context.Context) error {
 	return c.execute(ctx)
 }
 
-// PrewriteMutations performs the first phase of commit.
-func (c CommitterProbe) PrewriteMutations(ctx context.Context) error {
-	return c.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), c.mutations)
+// PrewriteAllMutations performs the first phase of commit.
+func (c CommitterProbe) PrewriteAllMutations(ctx context.Context) error {
+	return c.PrewriteMutations(ctx, c.mutations)
+}
+
+// PrewriteMutations performs the first phase of commit for given keys.
+func (c CommitterProbe) PrewriteMutations(ctx context.Context, mutations CommitterMutations) error {
+	return c.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), mutations)
 }
 
 // CommitMutations performs the second phase of commit.
@@ -281,6 +351,12 @@ func (c CommitterProbe) SetPrimaryKeyBlocker(ac, bk chan struct{}) {
 	c.testingKnobs.bkAfterCommitPrimary = bk
 }
 
+// CleanupMutations performs the clean up phase.
+func (c CommitterProbe) CleanupMutations(ctx context.Context) error {
+	bo := NewBackofferWithVars(ctx, cleanupMaxBackoff, nil)
+	return c.cleanupMutations(bo, c.mutations)
+}
+
 // LockProbe exposes some lock utilities for testing purpose.
 type LockProbe struct {
 }
@@ -299,6 +375,11 @@ func (l LockProbe) NewLockStatus(keys [][]byte, useAsyncCommit bool, minCommitTS
 			MinCommitTs:    minCommitTS,
 		},
 	}
+}
+
+// GetPrimaryKeyFromTxnStatus returns the primary key of the transaction.
+func (l LockProbe) GetPrimaryKeyFromTxnStatus(s TxnStatus) []byte {
+	return s.primaryLock.Key
 }
 
 // LockResolverProbe wraps a LockResolver and exposes internal stats for testing purpose.
@@ -344,6 +425,25 @@ func (l LockResolverProbe) SetMeetLockCallback(f func([]*Lock)) {
 	l.testingKnobs.meetLock = f
 }
 
+// CheckAllSecondaries checks the secondary locks of an async commit transaction to find out the final
+// status of the transaction.
+func (l LockResolverProbe) CheckAllSecondaries(bo *Backoffer, lock *Lock, status *TxnStatus) error {
+	_, err := l.checkAllSecondaries(bo, lock, status)
+	return err
+}
+
+// IsErrNotFound checks if an error is caused by txnNotFoundErr.
+func (l LockResolverProbe) IsErrorNotFound(err error) bool {
+	_, ok := errors.Cause(err).(txnNotFoundErr)
+	return ok
+}
+
+// IsNonAsyncCommitLock checks if an error is nonAsyncCommitLock error.
+func (l LockResolverProbe) IsNonAsyncCommitLock(err error) bool {
+	_, ok := errors.Cause(err).(*nonAsyncCommitLock)
+	return ok
+}
+
 // ConfigProbe exposes configurations and global variables for testing purpose.
 type ConfigProbe struct{}
 
@@ -355,4 +455,49 @@ func (c ConfigProbe) GetTxnCommitBatchSize() uint64 {
 // GetBigTxnThreshold returns the txn size to be considered as big txn.
 func (c ConfigProbe) GetBigTxnThreshold() int {
 	return bigTxnThreshold
+}
+
+// GetScanBatchSize returns the batch size to scan ranges.
+func (c ConfigProbe) GetScanBatchSize() int {
+	return scanBatchSize
+}
+
+// GetDefaultLockTTL returns the default lock TTL.
+func (c ConfigProbe) GetDefaultLockTTL() uint64 {
+	return defaultLockTTL
+}
+
+// GetTTLFactor returns the factor to calculate txn TTL.
+func (c ConfigProbe) GetTTLFactor() int {
+	return ttlFactor
+}
+
+// GetGetMaxBackoff returns the max sleep for get command.
+func (c ConfigProbe) GetGetMaxBackoff() int {
+	return getMaxBackoff
+}
+
+// LoadPreSplitDetectThreshold returns presplit detect threshold config.
+func (c ConfigProbe) LoadPreSplitDetectThreshold() uint32 {
+	return atomic.LoadUint32(&preSplitDetectThreshold)
+}
+
+// StorePreSplitDetectThreshold updates presplit detect threshold config.
+func (c ConfigProbe) StorePreSplitDetectThreshold(v uint32) {
+	atomic.StoreUint32(&preSplitDetectThreshold, v)
+}
+
+// LoadPreSplitSizeThreshold returns presplit size threshold config.
+func (c ConfigProbe) LoadPreSplitSizeThreshold() uint32 {
+	return atomic.LoadUint32(&preSplitSizeThreshold)
+}
+
+// StorePreSplitSizeThreshold updates presplit size threshold config.
+func (c ConfigProbe) StorePreSplitSizeThreshold(v uint32) {
+	atomic.StoreUint32(&preSplitSizeThreshold, v)
+}
+
+// SetOracleUpdateInterval sets the interval of updating cached ts.
+func (c ConfigProbe) SetOracleUpdateInterval(v int) {
+	oracleUpdateInterval = v
 }

--- a/store/tikv/test_probe.go
+++ b/store/tikv/test_probe.go
@@ -432,7 +432,7 @@ func (l LockResolverProbe) CheckAllSecondaries(bo *Backoffer, lock *Lock, status
 	return err
 }
 
-// IsErrNotFound checks if an error is caused by txnNotFoundErr.
+// IsErrorNotFound checks if an error is caused by txnNotFoundErr.
 func (l LockResolverProbe) IsErrorNotFound(err error) bool {
 	_, ok := errors.Cause(err).(txnNotFoundErr)
 	return ok

--- a/store/tikv/tests/2pc_test.go
+++ b/store/tikv/tests/2pc_test.go
@@ -48,7 +48,7 @@ var (
 type testCommitterSuite struct {
 	OneByOneSuite
 	cluster cluster.Cluster
-	store   *tikv.KVStore
+	store   tikv.StoreProbe
 }
 
 var _ = SerialSuites(&testCommitterSuite{})
@@ -86,7 +86,7 @@ func (s *testCommitterSuite) SetUpTest(c *C) {
 	// )
 	// c.Assert(err, IsNil)
 
-	s.store = store
+	s.store = tikv.StoreProbe{KVStore: store}
 }
 
 func (s *testCommitterSuite) TearDownSuite(c *C) {
@@ -98,14 +98,14 @@ func (s *testCommitterSuite) TearDownSuite(c *C) {
 func (s *testCommitterSuite) begin(c *C) tikv.TxnProbe {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	return tikv.TxnProbe{KVTxn: txn}
+	return txn
 }
 
 func (s *testCommitterSuite) beginAsyncCommit(c *C) tikv.TxnProbe {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
 	txn.SetOption(kv.EnableAsyncCommit, true)
-	return tikv.TxnProbe{KVTxn: txn}
+	return txn
 }
 
 func (s *testCommitterSuite) checkValues(c *C, m map[string]string) {
@@ -158,7 +158,7 @@ func (s *testCommitterSuite) TestDeleteYourWritesTTL(c *C) {
 		c.Assert(err, IsNil)
 		committer, err := txn.NewCommitter(0)
 		c.Assert(err, IsNil)
-		err = committer.PrewriteMutations(context.Background())
+		err = committer.PrewriteAllMutations(context.Background())
 		c.Assert(err, IsNil)
 		c.Check(committer.IsTTLRunning(), IsTrue)
 	}
@@ -173,7 +173,7 @@ func (s *testCommitterSuite) TestDeleteYourWritesTTL(c *C) {
 		c.Assert(err, IsNil)
 		committer, err := txn.NewCommitter(0)
 		c.Assert(err, IsNil)
-		err = committer.PrewriteMutations(context.Background())
+		err = committer.PrewriteAllMutations(context.Background())
 		c.Assert(err, IsNil)
 		c.Check(committer.IsTTLRunning(), IsTrue)
 	}
@@ -218,7 +218,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := txn1.NewCommitter(0)
 	c.Assert(err, IsNil)
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(err, IsNil)
 
 	txn2 := s.begin(c)
@@ -226,7 +226,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(v, BytesEquals, []byte("a0"))
 
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	if err != nil {
 		// Retry.
 		txn1 = s.begin(c)
@@ -236,7 +236,7 @@ func (s *testCommitterSuite) TestPrewriteRollback(c *C) {
 		c.Assert(err, IsNil)
 		committer, err = txn1.NewCommitter(0)
 		c.Assert(err, IsNil)
-		err = committer.PrewriteMutations(ctx)
+		err = committer.PrewriteAllMutations(ctx)
 		c.Assert(err, IsNil)
 	}
 	commitTS, err := s.store.GetOracle().GetTimestamp(ctx, &oracle.Option{TxnScope: oracle.GlobalTxnScope})
@@ -262,7 +262,7 @@ func (s *testCommitterSuite) TestContextCancel(c *C) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel() // cancel the context
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(errors.Cause(err), Equals, context.Canceled)
 }
 
@@ -288,7 +288,7 @@ func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := txn1.NewCommitter(0)
 	c.Assert(err, IsNil)
-	err = committer.PrewriteMutations(context.Background())
+	err = committer.PrewriteAllMutations(context.Background())
 	c.Assert(err, IsNil)
 	// txn3 writes "c"
 	err = txn3.Set([]byte("c"), []byte("c3"))
@@ -317,7 +317,7 @@ func (s *testCommitterSuite) TestContextCancelCausingUndetermined(c *C) {
 	c.Assert(err, IsNil)
 	committer, err := txn.NewCommitter(0)
 	c.Assert(err, IsNil)
-	committer.PrewriteMutations(context.Background())
+	committer.PrewriteAllMutations(context.Background())
 	c.Assert(err, IsNil)
 
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/rpcContextCancelErr", `return(true)`), IsNil)
@@ -435,7 +435,7 @@ func (s *testCommitterSuite) TestCommitBeforePrewrite(c *C) {
 	c.Assert(err, IsNil)
 	ctx := context.Background()
 	committer.Cleanup(ctx)
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(err, NotNil)
 	errMsgMustContain(c, err, "already rolled back")
 }
@@ -547,7 +547,7 @@ func (s *testCommitterSuite) TestPrewriteTxnSize(c *C) {
 	c.Assert(err, IsNil)
 
 	ctx := context.Background()
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(err, IsNil)
 
 	// Check the written locks in the first region (50 keys)
@@ -677,7 +677,7 @@ func (s *testCommitterSuite) TestPessimisticTTL(c *C) {
 	msBeforeLockExpired := s.store.GetOracle().UntilExpired(txn.StartTS(), lockInfo.LockTtl, &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 	c.Assert(msBeforeLockExpired, GreaterEqual, int64(100))
 
-	lr := tikv.StoreProbe{KVStore: s.store}.NewLockResolver()
+	lr := s.store.NewLockResolver()
 	bo := tikv.NewBackofferWithVars(context.Background(), 5000, nil)
 	status, err := lr.GetTxnStatus(bo, txn.StartTS(), key2, 0, txn.StartTS(), true, false, nil)
 	c.Assert(err, IsNil)
@@ -746,7 +746,7 @@ func (s *testCommitterSuite) TestDeleteYourWriteCauseGhostPrimary(c *C) {
 	// insert k1, k2, k3 and delete k1
 	txn1 := s.begin(c)
 	txn1.DelOption(kv.Pessimistic)
-	txn1.ClearStoreTxnLatches()
+	s.store.ClearTxnLatches()
 	txn1.Get(context.Background(), k1)
 	txn1.GetMemBuffer().SetWithFlags(k1, []byte{0}, kv.SetPresumeKeyNotExists)
 	txn1.Set(k2, []byte{1})
@@ -771,7 +771,7 @@ func (s *testCommitterSuite) TestDeleteYourWriteCauseGhostPrimary(c *C) {
 	// start txn2 to read k3(prewrite success and primary should be committed)
 	txn2 := s.begin(c)
 	txn2.DelOption(kv.Pessimistic)
-	txn2.ClearStoreTxnLatches()
+	s.store.ClearTxnLatches()
 	v, err := txn2.Get(context.Background(), k3)
 	c.Assert(err, IsNil) // should resolve lock and read txn1 k3 result instead of rollback it.
 	c.Assert(v[0], Equals, byte(2))
@@ -788,7 +788,7 @@ func (s *testCommitterSuite) TestDeleteAllYourWrites(c *C) {
 	// insert k1, k2, k3 and delete k1, k2, k3
 	txn1 := s.begin(c)
 	txn1.DelOption(kv.Pessimistic)
-	txn1.ClearStoreTxnLatches()
+	s.store.ClearTxnLatches()
 	txn1.GetMemBuffer().SetWithFlags(k1, []byte{0}, kv.SetPresumeKeyNotExists)
 	txn1.Delete(k1)
 	txn1.GetMemBuffer().SetWithFlags(k2, []byte{1}, kv.SetPresumeKeyNotExists)
@@ -808,7 +808,7 @@ func (s *testCommitterSuite) TestDeleteAllYourWritesWithSFU(c *C) {
 	// insert k1, k2, k2 and delete k1
 	txn1 := s.begin(c)
 	txn1.DelOption(kv.Pessimistic)
-	txn1.ClearStoreTxnLatches()
+	s.store.ClearTxnLatches()
 	txn1.GetMemBuffer().SetWithFlags(k1, []byte{0}, kv.SetPresumeKeyNotExists)
 	txn1.Delete(k1)
 	err := txn1.LockKeys(context.Background(), &tidbkv.LockCtx{}, k2, k3) // select * from t where x in (k2, k3) for update
@@ -832,7 +832,7 @@ func (s *testCommitterSuite) TestDeleteAllYourWritesWithSFU(c *C) {
 	// start txn2 to read k3
 	txn2 := s.begin(c)
 	txn2.DelOption(kv.Pessimistic)
-	txn2.ClearStoreTxnLatches()
+	s.store.ClearTxnLatches()
 	err = txn2.Set(k3, []byte{33})
 	c.Assert(err, IsNil)
 	var meetLocks []*tikv.Lock
@@ -1119,7 +1119,7 @@ func (s *testCommitterSuite) TestPushPessimisticLock(c *C) {
 	// Strip the prewrite of the primary key.
 	committer.SetMutations(committer.GetMutations().Slice(1, 2))
 	c.Assert(err, IsNil)
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(err, IsNil)
 	// The primary lock is a pessimistic lock and the secondary lock is a optimistic lock.
 	lock1 := s.getLockInfo(c, k1)
@@ -1171,7 +1171,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 	committer := txn1.GetCommitter()
 	err = committer.InitKeysAndMutations()
 	c.Assert(err, IsNil)
-	err = committer.PrewriteMutations(ctx)
+	err = committer.PrewriteAllMutations(ctx)
 	c.Assert(err, IsNil)
 	// lock the pessimistic keys
 	err = txn1.LockKeys(context.Background(), lockCtx, pessimisticLockKey)

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -181,7 +181,7 @@ func (s *testAsyncCommitSuite) lockKeysWithAsyncCommit(c *C, keys, values [][]by
 	tpc.SetPrimaryKey(primaryKey)
 
 	ctx := context.Background()
-	err = tpc.PrewriteMutations(ctx)
+	err = tpc.PrewriteAllMutations(ctx)
 	c.Assert(err, IsNil)
 
 	if commitPrimary {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Add more probe utilities in `test_probe.go` so later we can move tests files into `tests` directory.

Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- add new function and utilities. (most of them are not used yet)

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note