### PR TITLE
store/tikv/kv:move tikv/error.go to tikv/kv/error.go

### DIFF
--- a/ddl/split_region.go
+++ b/ddl/split_region.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.uber.org/zap"
@@ -138,7 +138,7 @@ func waitScatterRegionFinish(ctx context.Context, store kv.SplittableStore, regi
 		if err != nil {
 			logutil.BgLogger().Warn("[ddl] wait scatter region failed", zap.Uint64("regionID", regionID), zap.Error(err))
 			// We don't break for PDError because it may caused by ScatterRegion request failed.
-			if _, ok := errors.Cause(err).(*tikv.PDError); !ok {
+			if _, ok := errors.Cause(err).(*tikvstore.PDError); !ok {
 				break
 			}
 		}

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -42,7 +42,6 @@ import (
 	"github.com/pingcap/tidb/plugin"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/store/tikv"
 	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
@@ -638,7 +637,7 @@ func (a *ExecStmt) handlePessimisticLockError(ctx context.Context, err error) (E
 	}
 	txnCtx := sessVars.TxnCtx
 	var newForUpdateTS uint64
-	if deadlock, ok := errors.Cause(err).(*tikv.ErrDeadlock); ok {
+	if deadlock, ok := errors.Cause(err).(*tikvstore.ErrDeadlock); ok {
 		if !deadlock.IsRetryable {
 			return nil, ErrDeadlock
 		}

--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -535,15 +536,15 @@ func (s *testPointGetSuite) TestSelectCheckVisibility(c *C) {
 		c.Assert(expectErr.Equal(err), IsTrue)
 	}
 	// Test point get.
-	checkSelectResultError("select * from t where a='1'", tikv.ErrGCTooEarly)
+	checkSelectResultError("select * from t where a='1'", tikvstore.ErrGCTooEarly)
 	// Test batch point get.
-	checkSelectResultError("select * from t where a in ('1','2')", tikv.ErrGCTooEarly)
+	checkSelectResultError("select * from t where a in ('1','2')", tikvstore.ErrGCTooEarly)
 	// Test Index look up read.
-	checkSelectResultError("select * from t where b > 0 ", tikv.ErrGCTooEarly)
+	checkSelectResultError("select * from t where b > 0 ", tikvstore.ErrGCTooEarly)
 	// Test Index read.
-	checkSelectResultError("select b from t where b > 0 ", tikv.ErrGCTooEarly)
+	checkSelectResultError("select b from t where b > 0 ", tikvstore.ErrGCTooEarly)
 	// Test table read.
-	checkSelectResultError("select * from t", tikv.ErrGCTooEarly)
+	checkSelectResultError("select * from t", tikvstore.ErrGCTooEarly)
 }
 
 func (s *testPointGetSuite) TestReturnValues(c *C) {

--- a/server/conn.go
+++ b/server/conn.go
@@ -75,7 +75,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util/arena"
 	"github.com/pingcap/tidb/util/chunk"
@@ -1499,7 +1499,7 @@ func (cc *clientConn) handleQuery(ctx context.Context, sql string) (err error) {
 		retryable, err = cc.handleStmt(ctx, stmt, parserWarns, i == len(stmts)-1)
 		if err != nil {
 			_, allowTiFlashFallback := cc.ctx.GetSessionVars().AllowFallbackToTiKV[kv.TiFlash]
-			if allowTiFlashFallback && errors.ErrorEqual(err, tikv.ErrTiFlashServerTimeout) && retryable {
+			if allowTiFlashFallback && errors.ErrorEqual(err, tikvstore.ErrTiFlashServerTimeout) && retryable {
 				// When the TiFlash server seems down, we append a warning to remind the user to check the status of the TiFlash
 				// server and fallback to TiKV.
 				warns := append(parserWarns, stmtctx.SQLWarn{Level: stmtctx.WarnLevelError, Err: err})
@@ -1799,10 +1799,10 @@ func (cc *clientConn) writeChunks(ctx context.Context, rs ResultSet, binary bool
 		failpoint.Inject("fetchNextErr", func(value failpoint.Value) {
 			switch value.(string) {
 			case "firstNext":
-				failpoint.Return(firstNext, tikv.ErrTiFlashServerTimeout)
+				failpoint.Return(firstNext, tikvstore.ErrTiFlashServerTimeout)
 			case "secondNext":
 				if !firstNext {
-					failpoint.Return(firstNext, tikv.ErrTiFlashServerTimeout)
+					failpoint.Return(firstNext, tikvstore.ErrTiFlashServerTimeout)
 				}
 			}
 		})

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -50,7 +50,7 @@ import (
 	"github.com/pingcap/tidb/metrics"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/hack"
@@ -196,7 +196,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 	ctx = context.WithValue(ctx, execdetails.StmtExecDetailKey, &execdetails.StmtExecDetails{})
 	retryable, err := cc.executePreparedStmtAndWriteResult(ctx, stmt, args, useCursor)
 	_, allowTiFlashFallback := cc.ctx.GetSessionVars().AllowFallbackToTiKV[kv.TiFlash]
-	if allowTiFlashFallback && err != nil && errors.ErrorEqual(err, tikv.ErrTiFlashServerTimeout) && retryable {
+	if allowTiFlashFallback && err != nil && errors.ErrorEqual(err, tikvstore.ErrTiFlashServerTimeout) && retryable {
 		// When the TiFlash server seems down, we append a warning to remind the user to check the status of the TiFlash
 		// server and fallback to TiKV.
 		prevErr := err

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -608,7 +609,7 @@ func (s *testPessimisticSuite) TestWaitLockKill(c *C) {
 	_, err := tk2.Exec("update test_kill set c = c + 1 where id = 1")
 	wg.Done()
 	c.Assert(err, NotNil)
-	c.Assert(terror.ErrorEqual(err, tikv.ErrQueryInterrupted), IsTrue)
+	c.Assert(terror.ErrorEqual(err, tikvstore.ErrQueryInterrupted), IsTrue)
 	tk.MustExec("rollback")
 }
 
@@ -730,10 +731,10 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 
 	timeoutErr := <-timeoutErrCh
 	c.Assert(timeoutErr, NotNil)
-	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Assert(timeoutErr.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 	timeoutErr = <-timeoutErrCh
 	c.Assert(timeoutErr, NotNil)
-	c.Assert(timeoutErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Assert(timeoutErr.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 
 	// tk4 lock c1 = 2
 	tk4.MustExec("begin pessimistic")
@@ -746,7 +747,7 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 	_, err := tk2.Exec("delete from tk where c1 = 2")
 	c.Check(time.Since(start), GreaterEqual, 1000*time.Millisecond)
 	c.Check(time.Since(start), Less, 3000*time.Millisecond) // unit test diff should not be too big
-	c.Check(err.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(err.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 
 	tk4.MustExec("commit")
 
@@ -764,7 +765,7 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeout(c *C) {
 	_, err = tk2.Exec("delete from tk where c1 = 3") // tk2 tries to lock c1 = 3 fail, this delete should be rollback, but previous update should be keeped
 	c.Check(time.Since(start), GreaterEqual, 1000*time.Millisecond)
 	c.Check(time.Since(start), Less, 3000*time.Millisecond) // unit test diff should not be too big
-	c.Check(err.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(err.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 
 	tk2.MustExec("commit")
 	tk3.MustExec("commit")
@@ -838,7 +839,7 @@ func (s *testPessimisticSuite) TestInnodbLockWaitTimeoutWaitStart(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/PessimisticLockErrWriteConflict"), IsNil)
 	waitErr := <-done
 	c.Assert(waitErr, NotNil)
-	c.Check(waitErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(waitErr.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 	c.Check(duration, GreaterEqual, 1000*time.Millisecond)
 	c.Check(duration, LessEqual, 3000*time.Millisecond)
 	tk2.MustExec("rollback")
@@ -1128,11 +1129,11 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err := tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 4 for update nowait")
-	c.Check(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 7 for update nowait")
-	c.Check(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 
@@ -1144,9 +1145,9 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err = tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 6 for update nowait")
-	c.Check(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 }
@@ -1276,10 +1277,10 @@ func (s *testPessimisticSuite) TestBatchPointGetLockIndex(c *C) {
 	tk2.MustExec("begin pessimistic")
 	err := tk2.ExecToErr("insert into t1 values(2, 2, 2)")
 	c.Assert(err, NotNil)
-	c.Assert(tikv.ErrLockWaitTimeout.Equal(err), IsTrue)
+	c.Assert(tikvstore.ErrLockWaitTimeout.Equal(err), IsTrue)
 	err = tk2.ExecToErr("select * from t1 where c2 = 3 for update nowait")
 	c.Assert(err, NotNil)
-	c.Assert(tikv.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Assert(tikvstore.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk2.MustExec("rollback")
 }
@@ -1426,12 +1427,12 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk2.MustExec("begin pessimistic")
 		err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(2, 2);")
 		err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		// test batch point get lock
 		tk.MustExec("begin pessimistic")
@@ -1440,12 +1441,12 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk2.MustExec("begin pessimistic")
 		err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(5, 6);")
 		err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikv.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		tk.MustExec("commit")
 		tk2.MustExec("commit")
@@ -1465,14 +1466,14 @@ func (s *testPessimisticSuite) TestTxnWithExpiredPessimisticLocks(c *C) {
 	tk.MustQuery("select * from t1 where c1 in(1, 5) for update").Check(testkit.Rows("1 1 1", "5 5 5"))
 	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 1)
 	err := tk.ExecToErr("select * from t1 where c1 in(1, 5)")
-	c.Assert(terror.ErrorEqual(err, tikv.ErrLockExpire), IsTrue)
+	c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockExpire), IsTrue)
 	tk.MustExec("commit")
 
 	tk.MustExec("begin pessimistic")
 	tk.MustQuery("select * from t1 where c1 in(1, 5) for update").Check(testkit.Rows("1 1 1", "5 5 5"))
 	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 1)
 	err = tk.ExecToErr("update t1 set c2 = c2 + 1")
-	c.Assert(terror.ErrorEqual(err, tikv.ErrLockExpire), IsTrue)
+	c.Assert(terror.ErrorEqual(err, tikvstore.ErrLockExpire), IsTrue)
 	atomic.StoreUint32(&tk.Se.GetSessionVars().TxnCtx.LockExpire, 0)
 	tk.MustExec("update t1 set c2 = c2 + 1")
 	tk.MustExec("rollback")
@@ -1993,11 +1994,11 @@ func (s *testPessimisticSuite) TestSelectForUpdateWaitSeconds(c *C) {
 	waitErr2 := <-errCh
 	waitErr3 := <-errCh
 	c.Assert(waitErr, NotNil)
-	c.Check(waitErr.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(waitErr.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 	c.Assert(waitErr2, NotNil)
-	c.Check(waitErr2.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(waitErr2.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 	c.Assert(waitErr3, NotNil)
-	c.Check(waitErr3.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Check(waitErr3.Error(), Equals, tikvstore.ErrLockWaitTimeout.Error())
 	c.Assert(time.Since(start).Seconds(), Less, 45.0)
 	tk2.MustExec("commit")
 	tk3.MustExec("rollback")

--- a/session/session.go
+++ b/session/session.go
@@ -679,7 +679,7 @@ func (s *session) isTxnRetryableError(err error) bool {
 func (s *session) checkTxnAborted(stmt sqlexec.Statement) error {
 	var err error
 	if atomic.LoadUint32(&s.GetSessionVars().TxnCtx.LockExpire) > 0 {
-		err = tikv.ErrLockExpire
+		err = tikvstore.ErrLockExpire
 	} else {
 		return nil
 	}

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -265,7 +266,7 @@ func (b *batchCopIterator) recvFromRespCh(ctx context.Context) (resp *batchCopRe
 			return
 		case <-ticker.C:
 			if atomic.LoadUint32(b.vars.Killed) == 1 {
-				resp = &batchCopResponse{err: tikv.ErrQueryInterrupted}
+				resp = &batchCopResponse{err: tikvstore.ErrQueryInterrupted}
 				ok = true
 				return
 			}
@@ -391,7 +392,7 @@ func (b *batchCopIterator) handleStreamedBatchCopResponse(ctx context.Context, b
 			} else {
 				logutil.BgLogger().Info("stream unknown error", zap.Error(err))
 			}
-			return tikv.ErrTiFlashServerTimeout
+			return tikvstore.ErrTiFlashServerTimeout
 		}
 	}
 }

--- a/store/copr/batch_request_sender.go
+++ b/store/copr/batch_request_sender.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -71,7 +72,7 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *tikv.Backoffer, ctxs []copTas
 	if errors.Cause(err) == context.Canceled || status.Code(errors.Cause(err)) == codes.Canceled {
 		return errors.Trace(err)
 	} else if atomic.LoadUint32(&tikv.ShuttingDown) > 0 {
-		return tikv.ErrTiDBShuttingDown
+		return kv.ErrTiDBShuttingDown
 	}
 
 	for _, failedCtx := range ctxs {

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/kv"
 	tidbmetrics "github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -470,7 +471,7 @@ func (it *copIterator) recvFromRespCh(ctx context.Context, respCh <-chan *copRes
 			return
 		case <-ticker.C:
 			if atomic.LoadUint32(it.vars.Killed) == 1 {
-				resp = &copResponse{err: tikv.ErrQueryInterrupted}
+				resp = &copResponse{err: tikvstore.ErrQueryInterrupted}
 				ok = true
 				return
 			}
@@ -974,11 +975,11 @@ type CopRuntimeStats struct {
 func (worker *copIteratorWorker) handleTiDBSendReqErr(err error, task *copTask, ch chan<- *copResponse) error {
 	errCode := errno.ErrUnknown
 	errMsg := err.Error()
-	if terror.ErrorEqual(err, tikv.ErrTiKVServerTimeout) {
+	if terror.ErrorEqual(err, tikvstore.ErrTiKVServerTimeout) {
 		errCode = errno.ErrTiKVServerTimeout
 		errMsg = "TiDB server timeout, address is " + task.storeAddr
 	}
-	if terror.ErrorEqual(err, tikv.ErrTiFlashServerTimeout) {
+	if terror.ErrorEqual(err, tikvstore.ErrTiFlashServerTimeout) {
 		errCode = errno.ErrTiFlashServerTimeout
 		errMsg = "TiDB server timeout, address is " + task.storeAddr
 	}

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/unionstore"
 	"github.com/pingcap/tidb/table/tables"
@@ -75,7 +76,7 @@ func (txn *tikvTxn) GetUnionStore() kv.UnionStore {
 }
 
 func (txn *tikvTxn) extractKeyErr(err error) error {
-	if e, ok := errors.Cause(err).(*tikv.ErrKeyExist); ok {
+	if e, ok := errors.Cause(err).(*tikvstore.ErrKeyExist); ok {
 		return txn.extractKeyExistsErr(e.GetKey())
 	}
 	return errors.Trace(err)

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -44,6 +44,7 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv"
+	tikvstore "github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -1085,7 +1086,7 @@ retryScanAndResolve:
 			continue
 		}
 		if resp.Resp == nil {
-			return stat, errors.Trace(tikv.ErrBodyMissing)
+			return stat, errors.Trace(tikvstore.ErrBodyMissing)
 		}
 		locksResp := resp.Resp.(*kvrpcpb.ScanLockResponse)
 		if locksResp.GetError() != nil {
@@ -1266,7 +1267,7 @@ func (w *GCWorker) registerLockObservers(ctx context.Context, safePoint uint64, 
 			return errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return errors.Trace(tikv.ErrBodyMissing)
+			return errors.Trace(tikvstore.ErrBodyMissing)
 		}
 		errStr := resp.Resp.(*kvrpcpb.RegisterLockObserverResponse).Error
 		if len(errStr) > 0 {
@@ -1307,7 +1308,7 @@ func (w *GCWorker) checkLockObservers(ctx context.Context, safePoint uint64, sto
 			continue
 		}
 		if resp.Resp == nil {
-			logError(store, tikv.ErrBodyMissing)
+			logError(store, tikvstore.ErrBodyMissing)
 			continue
 		}
 		respInner := resp.Resp.(*kvrpcpb.CheckLockObserverResponse)
@@ -1373,7 +1374,7 @@ func (w *GCWorker) removeLockObservers(ctx context.Context, safePoint uint64, st
 			continue
 		}
 		if resp.Resp == nil {
-			logError(store, tikv.ErrBodyMissing)
+			logError(store, tikvstore.ErrBodyMissing)
 			continue
 		}
 		errStr := resp.Resp.(*kvrpcpb.RemoveLockObserverResponse).Error
@@ -1600,7 +1601,7 @@ func (w *GCWorker) doGCForRegion(bo *tikv.Backoffer, safePoint uint64, region ti
 	}
 
 	if resp.Resp == nil {
-		return nil, errors.Trace(tikv.ErrBodyMissing)
+		return nil, errors.Trace(tikvstore.ErrBodyMissing)
 	}
 	gcResp := resp.Resp.(*kvrpcpb.GCResponse)
 	if gcResp.GetError() != nil {
@@ -2184,7 +2185,7 @@ func (s *mergeLockScanner) physicalScanLocksForStore(ctx context.Context, safePo
 			return errors.Trace(err)
 		}
 		if response.Resp == nil {
-			return errors.Trace(tikv.ErrBodyMissing)
+			return errors.Trace(tikvstore.ErrBodyMissing)
 		}
 		resp := response.Resp.(*kvrpcpb.PhysicalScanLockResponse)
 		if len(resp.Error) > 0 {

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -307,7 +307,7 @@ func newTwoPhaseCommitter(txn *KVTxn, sessionID uint64) (*twoPhaseCommitter, err
 	}, nil
 }
 
-func (c *twoPhaseCommitter) extractKeyExistsErr(err *ErrKeyExist) error {
+func (c *twoPhaseCommitter) extractKeyExistsErr(err *kv.ErrKeyExist) error {
 	if !c.txn.us.HasPresumeKeyNotExists(err.GetKey()) {
 		return errors.Errorf("session %d, existErr for key:%s should not be nil", c.sessionID, err.GetKey())
 	}
@@ -802,7 +802,7 @@ func sendTxnHeartBeat(bo *Backoffer, store *KVStore, primary []byte, startTS, tt
 			continue
 		}
 		if resp.Resp == nil {
-			return 0, errors.Trace(ErrBodyMissing)
+			return 0, errors.Trace(kv.ErrBodyMissing)
 		}
 		cmdResp := resp.Resp.(*pb.TxnHeartBeatResponse)
 		if keyErr := cmdResp.GetError(); keyErr != nil {

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -25,7 +25,8 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb/kv"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/util/execdetails"
@@ -133,7 +134,7 @@ const (
 	boMaxTsNotSynced
 )
 
-func (t BackoffType) createFn(vars *kv.Variables) func(context.Context, int) int {
+func (t BackoffType) createFn(vars *tidbkv.Variables) func(context.Context, int) int {
 	if vars.Hook != nil {
 		vars.Hook(t.String(), vars)
 	}
@@ -193,25 +194,25 @@ func (t BackoffType) String() string {
 func (t BackoffType) TError() error {
 	switch t {
 	case BoTiKVRPC:
-		return ErrTiKVServerTimeout
+		return kv.ErrTiKVServerTimeout
 	case BoTiFlashRPC:
-		return ErrTiFlashServerTimeout
+		return kv.ErrTiFlashServerTimeout
 	case BoTxnLock, BoTxnLockFast, boTxnNotFound:
-		return ErrResolveLockTimeout
+		return kv.ErrResolveLockTimeout
 	case BoPDRPC:
-		return ErrPDServerTimeout
+		return kv.ErrPDServerTimeout
 	case BoRegionMiss:
-		return ErrRegionUnavailable
+		return kv.ErrRegionUnavailable
 	case boTiKVServerBusy:
-		return ErrTiKVServerBusy
+		return kv.ErrTiKVServerBusy
 	case boTiFlashServerBusy:
-		return ErrTiFlashServerBusy
+		return kv.ErrTiFlashServerBusy
 	case boStaleCmd:
-		return ErrTiKVStaleCommand
+		return kv.ErrTiKVStaleCommand
 	case boMaxTsNotSynced:
-		return ErrTiKVMaxTimestampNotSynced
+		return kv.ErrTiKVMaxTimestampNotSynced
 	}
-	return ErrUnknown
+	return kv.ErrUnknown
 }
 
 // Maximum total sleep time(in ms) for kv/cop commands.
@@ -251,7 +252,7 @@ type Backoffer struct {
 	totalSleep int
 	errors     []error
 	types      []fmt.Stringer
-	vars       *kv.Variables
+	vars       *tidbkv.Variables
 	noop       bool
 
 	backoffSleepMS map[BackoffType]int
@@ -268,12 +269,12 @@ func NewBackoffer(ctx context.Context, maxSleep int) *Backoffer {
 	return &Backoffer{
 		ctx:      ctx,
 		maxSleep: maxSleep,
-		vars:     kv.DefaultVars,
+		vars:     tidbkv.DefaultVars,
 	}
 }
 
-// NewBackofferWithVars creates a Backoffer with maximum sleep time(in ms) and kv.Variables.
-func NewBackofferWithVars(ctx context.Context, maxSleep int, vars *kv.Variables) *Backoffer {
+// NewBackofferWithVars creates a Backoffer with maximum sleep time(in ms) and tidbkv.Variables.
+func NewBackofferWithVars(ctx context.Context, maxSleep int, vars *tidbkv.Variables) *Backoffer {
 	return NewBackoffer(ctx, maxSleep).withVars(vars)
 }
 
@@ -282,8 +283,8 @@ func NewNoopBackoff(ctx context.Context) *Backoffer {
 	return &Backoffer{ctx: ctx, noop: true}
 }
 
-// withVars sets the kv.Variables to the Backoffer and return it.
-func (b *Backoffer) withVars(vars *kv.Variables) *Backoffer {
+// withVars sets the tidbkv.Variables to the Backoffer and return it.
+func (b *Backoffer) withVars(vars *tidbkv.Variables) *Backoffer {
 	if vars != nil {
 		b.vars = vars
 	}
@@ -309,7 +310,7 @@ func (b *Backoffer) Backoff(typ BackoffType, err error) error {
 // BackoffWithMaxSleep sleeps a while base on the backoffType and records the error message
 // and never sleep more than maxSleepMs for each sleep.
 func (b *Backoffer) BackoffWithMaxSleep(typ BackoffType, maxSleepMs int, err error) error {
-	if strings.Contains(err.Error(), mismatchClusterID) {
+	if strings.Contains(err.Error(), kv.MismatchClusterID) {
 		logutil.BgLogger().Fatal("critical error", zap.Error(err))
 	}
 	select {
@@ -364,7 +365,7 @@ func (b *Backoffer) BackoffWithMaxSleep(typ BackoffType, maxSleepMs int, err err
 
 	if b.vars != nil && b.vars.Killed != nil {
 		if atomic.LoadUint32(b.vars.Killed) == 1 {
-			return ErrQueryInterrupted
+			return kv.ErrQueryInterrupted
 		}
 	}
 
@@ -414,7 +415,7 @@ func (b *Backoffer) Fork() (*Backoffer, context.CancelFunc) {
 }
 
 // GetVars returns the binded vars.
-func (b *Backoffer) GetVars() *kv.Variables {
+func (b *Backoffer) GetVars() *tidbkv.Variables {
 	return b.vars
 }
 

--- a/store/tikv/commit.go
+++ b/store/tikv/commit.go
@@ -76,7 +76,7 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 		return errors.Trace(err)
 	}
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return errors.Trace(kv.ErrBodyMissing)
 	}
 	commitResp := resp.Resp.(*pb.CommitResponse)
 	// Here we can make sure tikv has processed the commit primary key request. So

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -19,7 +19,8 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/tidb/kv"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
 
@@ -78,7 +79,7 @@ func (t *DeleteRangeTask) Execute(ctx context.Context) error {
 }
 
 // Execute performs the delete range operation.
-func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (RangeTaskStat, error) {
+func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r tidbkv.KeyRange) (RangeTaskStat, error) {
 	startKey, rangeEndKey := r.StartKey, r.EndKey
 	var stat RangeTaskStat
 	for {
@@ -127,7 +128,7 @@ func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (Ra
 			continue
 		}
 		if resp.Resp == nil {
-			return stat, errors.Trace(ErrBodyMissing)
+			return stat, errors.Trace(kv.ErrBodyMissing)
 		}
 		deleteRangeResp := resp.Resp.(*kvrpcpb.DeleteRangeResponse)
 		if err := deleteRangeResp.GetError(); err != "" {

--- a/store/tikv/kv/error.go
+++ b/store/tikv/kv/error.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package tikv
+package kv
 
 import (
 	"github.com/pingcap/errors"
@@ -28,8 +28,8 @@ var (
 	ErrTiDBShuttingDown = errors.New("tidb server shutting down")
 )
 
-// mismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
-const mismatchClusterID = "mismatch cluster id"
+// MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
+const MismatchClusterID = "mismatch cluster id"
 
 // MySQL error instances.
 var (

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -23,7 +23,8 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
-	"github.com/pingcap/tidb/kv"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -32,7 +33,7 @@ import (
 )
 
 type actionPessimisticLock struct {
-	*kv.LockCtx
+	*tidbkv.LockCtx
 }
 type actionPessimisticRollback struct{}
 
@@ -98,14 +99,14 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		if action.LockWaitTime > 0 {
 			timeLeft := action.LockWaitTime - (time.Since(lockWaitStartTime)).Milliseconds()
 			if timeLeft <= 0 {
-				req.PessimisticLock().WaitTimeout = kv.LockNoWait
+				req.PessimisticLock().WaitTimeout = tidbkv.LockNoWait
 			} else {
 				req.PessimisticLock().WaitTimeout = timeLeft
 			}
 		}
 		failpoint.Inject("PessimisticLockErrWriteConflict", func() error {
 			time.Sleep(300 * time.Millisecond)
-			return kv.ErrWriteConflict
+			return tidbkv.ErrWriteConflict
 		})
 		startTime := time.Now()
 		resp, err := c.store.SendReq(bo, req, batch.region, ReadTimeoutShort)
@@ -129,7 +130,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			return errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return errors.Trace(kv.ErrBodyMissing)
 		}
 		lockResp := resp.Resp.(*pb.PessimisticLockResponse)
 		keyErrs := lockResp.GetErrors()
@@ -137,7 +138,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			if action.ReturnValues {
 				action.ValuesLock.Lock()
 				for i, mutation := range mutations {
-					action.Values[string(mutation.Key)] = kv.ReturnedValue{Value: lockResp.Values[i]}
+					action.Values[string(mutation.Key)] = tidbkv.ReturnedValue{Value: lockResp.Values[i]}
 				}
 				action.ValuesLock.Unlock()
 			}
@@ -147,11 +148,11 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		for _, keyErr := range keyErrs {
 			// Check already exists error
 			if alreadyExist := keyErr.GetAlreadyExist(); alreadyExist != nil {
-				e := &ErrKeyExist{AlreadyExist: alreadyExist}
+				e := &kv.ErrKeyExist{AlreadyExist: alreadyExist}
 				return c.extractKeyExistsErr(e)
 			}
 			if deadlock := keyErr.Deadlock; deadlock != nil {
-				return &ErrDeadlock{Deadlock: deadlock}
+				return &kv.ErrDeadlock{Deadlock: deadlock}
 			}
 
 			// Extract lock from key error
@@ -175,14 +176,14 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 		// If msBeforeTxnExpired is not zero, it means there are still locks blocking us acquiring
 		// the pessimistic lock. We should return acquire fail with nowait set or timeout error if necessary.
 		if msBeforeTxnExpired > 0 {
-			if action.LockWaitTime == kv.LockNoWait {
-				return ErrLockAcquireFailAndNoWaitSet
-			} else if action.LockWaitTime == kv.LockAlwaysWait {
+			if action.LockWaitTime == tidbkv.LockNoWait {
+				return kv.ErrLockAcquireFailAndNoWaitSet
+			} else if action.LockWaitTime == tidbkv.LockAlwaysWait {
 				// do nothing but keep wait
 			} else {
 				// the lockWaitTime is set, we should return wait timeout if we are still blocked by a lock
 				if time.Since(lockWaitStartTime).Milliseconds() >= action.LockWaitTime {
-					return errors.Trace(ErrLockWaitTimeout)
+					return errors.Trace(kv.ErrLockWaitTimeout)
 				}
 			}
 			if action.LockCtx.PessimisticLockWaited != nil {
@@ -198,7 +199,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			// actionPessimisticLock runs on each region parallelly, we have to consider that
 			// the error may be dropped.
 			if atomic.LoadUint32(action.Killed) == 1 {
-				return errors.Trace(ErrQueryInterrupted)
+				return errors.Trace(kv.ErrQueryInterrupted)
 			}
 		}
 	}
@@ -229,7 +230,7 @@ func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Bac
 	return nil
 }
 
-func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *kv.LockCtx, mutations CommitterMutations) error {
+func (c *twoPhaseCommitter) pessimisticLockMutations(bo *Backoffer, lockCtx *tidbkv.LockCtx, mutations CommitterMutations) error {
 	if c.sessionID > 0 {
 		failpoint.Inject("beforePessimisticLock", func(val failpoint.Value) {
 			// Pass multiple instructions in one string, delimited by commas, to trigger multiple behaviors, like

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/failpoint"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv/config"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
@@ -184,7 +185,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 			return errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return errors.Trace(kv.ErrBodyMissing)
 		}
 		prewriteResp := resp.Resp.(*pb.PrewriteResponse)
 		keyErrs := prewriteResp.GetErrors()
@@ -248,7 +249,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		for _, keyErr := range keyErrs {
 			// Check already exists error
 			if alreadyExist := keyErr.GetAlreadyExist(); alreadyExist != nil {
-				e := &ErrKeyExist{AlreadyExist: alreadyExist}
+				e := &kv.ErrKeyExist{AlreadyExist: alreadyExist}
 				return c.extractKeyExistsErr(e)
 			}
 

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv/config"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	pd "github.com/tikv/pd/client"
@@ -97,7 +98,7 @@ func (c *RawKVClient) Get(key []byte) ([]byte, error) {
 		return nil, errors.Trace(err)
 	}
 	if resp.Resp == nil {
-		return nil, errors.Trace(ErrBodyMissing)
+		return nil, errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawGetResponse)
 	if cmdResp.GetError() != "" {
@@ -123,7 +124,7 @@ func (c *RawKVClient) BatchGet(keys [][]byte) ([][]byte, error) {
 	}
 
 	if resp.Resp == nil {
-		return nil, errors.Trace(ErrBodyMissing)
+		return nil, errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawBatchGetResponse)
 
@@ -159,7 +160,7 @@ func (c *RawKVClient) Put(key, value []byte) error {
 		return errors.Trace(err)
 	}
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawPutResponse)
 	if cmdResp.GetError() != "" {
@@ -201,7 +202,7 @@ func (c *RawKVClient) Delete(key []byte) error {
 		return errors.Trace(err)
 	}
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawDeleteResponse)
 	if cmdResp.GetError() != "" {
@@ -223,7 +224,7 @@ func (c *RawKVClient) BatchDelete(keys [][]byte) error {
 		return errors.Trace(err)
 	}
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawBatchDeleteResponse)
 	if cmdResp.GetError() != "" {
@@ -253,7 +254,7 @@ func (c *RawKVClient) DeleteRange(startKey []byte, endKey []byte) error {
 			return errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return errors.Trace(kv.ErrBodyMissing)
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawDeleteRangeResponse)
 		if cmdResp.GetError() != "" {
@@ -289,7 +290,7 @@ func (c *RawKVClient) Scan(startKey, endKey []byte, limit int) (keys [][]byte, v
 			return nil, nil, errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return nil, nil, errors.Trace(ErrBodyMissing)
+			return nil, nil, errors.Trace(kv.ErrBodyMissing)
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawScanResponse)
 		for _, pair := range cmdResp.Kvs {
@@ -333,7 +334,7 @@ func (c *RawKVClient) ReverseScan(startKey, endKey []byte, limit int) (keys [][]
 			return nil, nil, errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return nil, nil, errors.Trace(ErrBodyMissing)
+			return nil, nil, errors.Trace(kv.ErrBodyMissing)
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawScanResponse)
 		for _, pair := range cmdResp.Kvs {
@@ -471,7 +472,7 @@ func (c *RawKVClient) doBatchReq(bo *Backoffer, batch batch, cmdType tikvrpc.Cmd
 		batchResp.resp = resp
 	case tikvrpc.CmdRawBatchDelete:
 		if resp.Resp == nil {
-			batchResp.err = errors.Trace(ErrBodyMissing)
+			batchResp.err = errors.Trace(kv.ErrBodyMissing)
 			return batchResp
 		}
 		cmdResp := resp.Resp.(*kvrpcpb.RawBatchDeleteResponse)
@@ -630,7 +631,7 @@ func (c *RawKVClient) doBatchPut(bo *Backoffer, batch batch) error {
 	}
 
 	if resp.Resp == nil {
-		return errors.Trace(ErrBodyMissing)
+		return errors.Trace(kv.ErrBodyMissing)
 	}
 	cmdResp := resp.Resp.(*kvrpcpb.RawBatchPutResponse)
 	if cmdResp.GetError() != "" {

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -254,11 +254,11 @@ func (s *RegionRequestSender) SendReqCtx(
 			}
 		case "requestTiDBStoreError":
 			if sType == tidbkv.TiDB {
-				failpoint.Return(nil, nil, ErrTiKVServerTimeout)
+				failpoint.Return(nil, nil, kv.ErrTiKVServerTimeout)
 			}
 		case "requestTiFlashError":
 			if sType == tidbkv.TiFlash {
-				failpoint.Return(nil, nil, ErrTiFlashServerTimeout)
+				failpoint.Return(nil, nil, kv.ErrTiFlashServerTimeout)
 			}
 		}
 	})
@@ -303,7 +303,7 @@ func (s *RegionRequestSender) SendReqCtx(
 
 		// recheck whether the session/query is killed during the Next()
 		if bo.vars != nil && bo.vars.Killed != nil && atomic.LoadUint32(bo.vars.Killed) == 1 {
-			return nil, nil, ErrQueryInterrupted
+			return nil, nil, kv.ErrQueryInterrupted
 		}
 		failpoint.Inject("mockRetrySendReqToRegion", func(val failpoint.Value) {
 			if val.(bool) {
@@ -531,7 +531,7 @@ func (s *RegionRequestSender) getStoreToken(st *Store, limit int64) error {
 		return nil
 	}
 	metrics.TiKVStoreLimitErrorCounter.WithLabelValues(st.addr, strconv.FormatUint(st.storeID, 10)).Inc()
-	return ErrTokenLimit.GenWithStackByArgs(st.storeID)
+	return kv.ErrTokenLimit.GenWithStackByArgs(st.storeID)
 
 }
 
@@ -557,7 +557,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 	if errors.Cause(err) == context.Canceled {
 		return errors.Trace(err)
 	} else if atomic.LoadUint32(&ShuttingDown) > 0 {
-		return ErrTiDBShuttingDown
+		return kv.ErrTiDBShuttingDown
 	}
 	if status.Code(errors.Cause(err)) == codes.Canceled {
 		select {

--- a/store/tikv/safepoint_test.go
+++ b/store/tikv/safepoint_test.go
@@ -21,7 +21,8 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/tidb/kv"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 )
 
 type testSafePointSuite struct {
@@ -50,8 +51,8 @@ func (s *testSafePointSuite) beginTxn(c *C) *KVTxn {
 	return txn
 }
 
-func mymakeKeys(rowNum int, prefix string) []kv.Key {
-	keys := make([]kv.Key, 0, rowNum)
+func mymakeKeys(rowNum int, prefix string) []tidbkv.Key {
+	keys := make([]tidbkv.Key, 0, rowNum)
 	for i := 0; i < rowNum; i++ {
 		k := encodeKey(prefix, s08d("key", i))
 		keys = append(keys, k)
@@ -90,8 +91,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, geterr2 := txn2.Get(context.TODO(), encodeKey(s.prefix, s08d("key", 0)))
 	c.Assert(geterr2, NotNil)
-	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
-	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), kv.ErrGCTooEarly)
+	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), kv.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind := isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -102,8 +103,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, seekerr := txn3.Iter(encodeKey(s.prefix, ""), nil)
 	c.Assert(seekerr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), kv.ErrGCTooEarly)
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), kv.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -116,8 +117,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 	snapshot := newTiKVSnapshot(s.store, txn4.StartTS(), 0)
 	_, batchgeterr := snapshot.BatchGet(context.Background(), keys)
 	c.Assert(batchgeterr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrGCTooEarly)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), kv.ErrGCTooEarly)
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), kv.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 }

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -313,7 +313,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, collec
 			return errors.Trace(err)
 		}
 		if resp.Resp == nil {
-			return errors.Trace(ErrBodyMissing)
+			return errors.Trace(kv.ErrBodyMissing)
 		}
 		batchGetResp := resp.Resp.(*pb.BatchGetResponse)
 		var (
@@ -474,7 +474,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k tidbkv.Key) ([]by
 			continue
 		}
 		if resp.Resp == nil {
-			return nil, errors.Trace(ErrBodyMissing)
+			return nil, errors.Trace(kv.ErrBodyMissing)
 		}
 		cmdGetResp := resp.Resp.(*pb.GetResponse)
 		if cmdGetResp.ExecDetailsV2 != nil {

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -24,7 +24,8 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
-	"github.com/pingcap/tidb/kv"
+	tidbkv "github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/store/tikv/util"
@@ -60,7 +61,7 @@ func (s *KVStore) splitBatchRegionsReq(bo *Backoffer, keys [][]byte, scatter boo
 			zap.Int("split key count", len(keys)),
 			zap.Int("batch count", len(batches)),
 			zap.Uint64("first batch, region ID", batches[0].regionID.id),
-			zap.Stringer("first split key", kv.Key(batches[0].keys[0])))
+			zap.Stringer("first split key", tidbkv.Key(batches[0].keys[0])))
 	}
 	if len(batches) == 1 {
 		resp := s.batchSendSingleRegion(bo, batches[0], scatter, tableID)
@@ -159,7 +160,7 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bool
 	}
 	logutil.BgLogger().Info("batch split regions complete",
 		zap.Uint64("batch region ID", batch.regionID.id),
-		zap.Stringer("first at", kv.Key(batch.keys[0])),
+		zap.Stringer("first at", tidbkv.Key(batch.keys[0])),
 		zap.String("first new region left", newRegionLeft),
 		zap.Int("new region count", len(spResp.Regions)))
 
@@ -171,20 +172,20 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bool
 		if err = s.scatterRegion(bo, r.Id, tableID); err == nil {
 			logutil.BgLogger().Info("batch split regions, scatter region complete",
 				zap.Uint64("batch region ID", batch.regionID.id),
-				zap.Stringer("at", kv.Key(batch.keys[i])),
+				zap.Stringer("at", tidbkv.Key(batch.keys[i])),
 				zap.Stringer("new region left", logutil.Hex(r)))
 			continue
 		}
 
 		logutil.BgLogger().Info("batch split regions, scatter region failed",
 			zap.Uint64("batch region ID", batch.regionID.id),
-			zap.Stringer("at", kv.Key(batch.keys[i])),
+			zap.Stringer("at", tidbkv.Key(batch.keys[i])),
 			zap.Stringer("new region left", logutil.Hex(r)),
 			zap.Error(err))
 		if batchResp.err == nil {
 			batchResp.err = err
 		}
-		if ErrPDServerTimeout.Equal(err) {
+		if kv.ErrPDServerTimeout.Equal(err) {
 			break
 		}
 	}
@@ -218,7 +219,7 @@ func (s *KVStore) scatterRegion(bo *Backoffer, regionID uint64, tableID *int64) 
 
 		if val, err2 := MockScatterRegionTimeout.Eval(); err2 == nil {
 			if val.(bool) {
-				err = ErrPDServerTimeout
+				err = kv.ErrPDServerTimeout
 			}
 		}
 
@@ -293,7 +294,7 @@ func (s *KVStore) WaitScatterRegionFinish(ctx context.Context, regionID uint64, 
 				return nil
 			}
 			if resp.GetHeader().GetError() != nil {
-				err = errors.AddStack(&PDError{
+				err = errors.AddStack(&kv.PDError{
 					Err: resp.Header.Error,
 				})
 				logutil.BgLogger().Warn("wait scatter region error",

--- a/store/tikv/tests/2pc_test.go
+++ b/store/tikv/tests/2pc_test.go
@@ -880,13 +880,13 @@ func (s *testCommitterSuite) TestAcquireFalseTimeoutLock(c *C) {
 	lockCtx = &tidbkv.LockCtx{ForUpdateTS: txn2.StartTS(), LockWaitTime: tidbkv.LockNoWait, WaitStartTime: time.Now()}
 	err = txn2.LockKeys(context.Background(), lockCtx, k2)
 	// cannot acquire lock immediately thus error
-	c.Assert(err.Error(), Equals, tikv.ErrLockAcquireFailAndNoWaitSet.Error())
+	c.Assert(err.Error(), Equals, kv.ErrLockAcquireFailAndNoWaitSet.Error())
 
 	// test for wait limited time (200ms)
 	lockCtx = &tidbkv.LockCtx{ForUpdateTS: txn2.StartTS(), LockWaitTime: 200, WaitStartTime: time.Now()}
 	err = txn2.LockKeys(context.Background(), lockCtx, k2)
 	// cannot acquire lock in time thus error
-	c.Assert(err.Error(), Equals, tikv.ErrLockWaitTimeout.Error())
+	c.Assert(err.Error(), Equals, kv.ErrLockWaitTimeout.Error())
 }
 
 func (s *testCommitterSuite) getLockInfo(c *C, key []byte) *kvrpcpb.LockInfo {
@@ -1023,7 +1023,7 @@ func (s *testCommitterSuite) TestPessimisticLockPrimary(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/txnNotFoundRetTTL"), IsNil)
 	c.Assert(err, IsNil)
 	waitErr := <-doneCh
-	c.Assert(tikv.ErrLockWaitTimeout.Equal(waitErr), IsTrue)
+	c.Assert(kv.ErrLockWaitTimeout.Equal(waitErr), IsTrue)
 }
 
 func (s *testCommitterSuite) TestResolvePessimisticLock(c *C) {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -410,7 +410,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tidbkv.LockCtx, keysInp
 		} else if txn.IsPessimistic() {
 			if checkKeyExists && valueExist {
 				alreadyExist := kvrpcpb.AlreadyExist{Key: key}
-				e := &ErrKeyExist{AlreadyExist: &alreadyExist}
+				e := &kv.ErrKeyExist{AlreadyExist: &alreadyExist}
 				return txn.committer.extractKeyExistsErr(e)
 			}
 		}
@@ -475,7 +475,7 @@ func (txn *KVTxn) LockKeys(ctx context.Context, lockCtx *tidbkv.LockCtx, keysInp
 			// If there is only 1 key and lock fails, no need to do pessimistic rollback.
 			if len(keys) > 1 || keyMayBeLocked {
 				wg := txn.asyncPessimisticRollback(ctx, keys)
-				if dl, ok := errors.Cause(err).(*ErrDeadlock); ok && hashInKeys(dl.DeadlockKeyHash, keys) {
+				if dl, ok := errors.Cause(err).(*kv.ErrDeadlock); ok && hashInKeys(dl.DeadlockKeyHash, keys) {
 					dl.IsRetryable = true
 					// Wait for the pessimistic rollback to finish before we retry the statement.
 					wg.Wait()


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR move tikv/error.go to tikv/kv/error.go, it is preparing for laster PR.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note