### PR TITLE
planner, util/ranger:  apply PushDownNot to condition before pruning partition

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2716,10 +2716,17 @@ func (s *testIntegrationSuite) TestIssue22199(c *C) {
 func (s *testIntegrationSuite) TestIssue22892(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_partition_prune_mode='static'")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a int) partition by hash (a) partitions 5;")
 	tk.MustExec("insert into t1 values (0);")
 	tk.MustQuery("select * from t1 where a not between 1 and 2;").Check(testkit.Rows("0"))
+
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t2(a int) partition by hash (a) partitions 5;")
+	tk.MustExec("insert into t2 values (0);")
+	tk.MustQuery("select * from t2 where a not between 1 and 2;").Check(testkit.Rows("0"))
 }
 
 func (s *testIntegrationSerialSuite) TestPushDownProjectionForTiFlash(c *C) {

--- a/planner/core/partition_prune.go
+++ b/planner/core/partition_prune.go
@@ -27,6 +27,12 @@ func PartitionPruning(ctx sessionctx.Context, tbl table.PartitionedTable, conds 
 	columns []*expression.Column, names types.NameSlice) ([]int, error) {
 	s := partitionProcessor{}
 	pi := tbl.Meta().Partition
+	// PushDownNot here can convert condition 'not (a != 1)' to 'a = 1'. When we build range from conds, the condition like
+	// 'not (a != 1)' would not be handled so we need to convert it to 'a = 1', which can be handled when building range.
+	// TODO: there may be a better way to push down Not once for all.
+	for i, cond := range conds {
+		conds[i] = expression.PushDownNot(ctx, cond)
+	}
 	switch pi.Type {
 	case model.PartitionTypeHash:
 		return s.pruneHashPartition(ctx, tbl, partitionNames, conds, columns, names)

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -501,7 +501,7 @@ func (s *testPartitionPruneSuit) Test22396(c *C) {
 
 func (s *testPartitionPruneSuit) TestIssue23608(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_partition_prune_mode='static'")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a int) partition by hash (a) partitions 10")
 	tk.MustExec("insert into t1 values (1), (2), (12), (3), (11), (13)")
@@ -529,4 +529,16 @@ partition by range (a) (
 		"└─TableReader 3333.33 root  data:Selection",
 		"  └─Selection 3333.33 cop[tikv]  ge(test.t2.a, 5)",
 		"    └─TableFullScan 10000.00 cop[tikv] table:t2, partition:p2 keep order:false, stats:pseudo"))
+
+	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
+	tk.MustExec("drop table if exists t3")
+	tk.MustExec("create table t3(a int) partition by hash (a) partitions 10")
+	tk.MustExec("insert into t3 values (1), (2), (12), (3), (11), (13)")
+	tk.MustQuery("select * from t3 where a not between 2 and 2").Sort().Check(testkit.Rows("1", "11", "12", "13", "3"))
+	tk.MustQuery("select * from t3 where not (a < -20 or a > 20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t3 where not (a > 0 and a < 10)").Sort().Check(testkit.Rows("11", "12", "13"))
+	tk.MustQuery("select * from t3 where not (a < -20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t3 where not (a > 20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t3 where not (a = 1)").Sort().Check(testkit.Rows("11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t3 where not (a != 1)").Check(testkit.Rows("1"))
 }

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -505,12 +505,12 @@ func (s *testPartitionPruneSuit) TestIssue23608(c *C) {
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a int) partition by hash (a) partitions 10")
 	tk.MustExec("insert into t1 values (1), (2), (12), (3), (11), (13)")
-	tk.MustQuery("select * from t1 where a not between 2 and 2").Check(testkit.Rows("1", "11", "12", "3", "13"))
-	tk.MustQuery("select * from t1 where not (a < -20 or a > 20)").Check(testkit.Rows("1", "11", "2", "12", "3", "13"))
-	tk.MustQuery("selecmat * from t1 where not (a > 0 and a < 10)").Check(testkit.Rows("11", "12", "13"))
-	tk.MustQuery("select * from t1 where not (a < -20)").Check(testkit.Rows("1", "11", "2", "12", "3", "13"))
-	tk.MustQuery("select * from t1 where not (a > 20)").Check(testkit.Rows("1", "11", "2", "12", "3", "13"))
-	tk.MustQuery("select * from t1 where not (a = 1)").Check(testkit.Rows("11", "2", "12", "3", "13"))
+	tk.MustQuery("select * from t1 where a not between 2 and 2").Sort().Check(testkit.Rows("1", "11", "12",  "13", "3"))
+	tk.MustQuery("select * from t1 where not (a < -20 or a > 20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t1 where not (a > 0 and a < 10)").Sort().Check(testkit.Rows("11", "12", "13"))
+	tk.MustQuery("select * from t1 where not (a < -20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t1 where not (a > 20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
+	tk.MustQuery("select * from t1 where not (a = 1)").Sort().Check(testkit.Rows("11", "12", "13", "2", "3"))
 	tk.MustQuery("select * from t1 where not (a != 1)").Check(testkit.Rows("1"))
 
 	tk.MustExec("drop table if exists t2")
@@ -521,7 +521,7 @@ partition by range (a) (
     partition p1 values less than (10),
     partition p2 values less than (20)
 )`)
-	tk.MustQuery("explain format='brief' select * from t2 where not (a < 5)").Check(testkit.Rows(
+	tk.MustQuery("explain format = 'brief' select * from t2 where not (a < 5)").Check(testkit.Rows(
 		"PartitionUnion 6666.67 root  ",
 		"├─TableReader 3333.33 root  data:Selection",
 		"│ └─Selection 3333.33 cop[tikv]  ge(test.t2.a, 5)",

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -501,6 +501,7 @@ func (s *testPartitionPruneSuit) Test22396(c *C) {
 
 func (s *testPartitionPruneSuit) TestIssue23608(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_partition_prune_mode='static'")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a int) partition by hash (a) partitions 10")

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -505,7 +505,7 @@ func (s *testPartitionPruneSuit) TestIssue23608(c *C) {
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a int) partition by hash (a) partitions 10")
 	tk.MustExec("insert into t1 values (1), (2), (12), (3), (11), (13)")
-	tk.MustQuery("select * from t1 where a not between 2 and 2").Sort().Check(testkit.Rows("1", "11", "12",  "13", "3"))
+	tk.MustQuery("select * from t1 where a not between 2 and 2").Sort().Check(testkit.Rows("1", "11", "12", "13", "3"))
 	tk.MustQuery("select * from t1 where not (a < -20 or a > 20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))
 	tk.MustQuery("select * from t1 where not (a > 0 and a < 10)").Sort().Check(testkit.Rows("11", "12", "13"))
 	tk.MustQuery("select * from t1 where not (a < -20)").Sort().Check(testkit.Rows("1", "11", "12", "13", "2", "3"))

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -534,6 +534,11 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 	if pi == nil {
 		return ds, nil
 	}
+	// PushDownNot here can convert condition 'not (a != 1)' to 'a = 1'. When we build range from ds.allConds, the condition
+	// like 'not (a != 1)' would not be handled so we need to convert it to 'a = 1', which can be handled when building range.
+	for i, cond := range ds.allConds {
+		ds.allConds[i] = expression.PushDownNot(ds.ctx, cond)
+	}
 	// Try to locate partition directly for hash partition.
 	switch pi.Type {
 	case model.PartitionTypeRange:

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -543,6 +543,7 @@ func (s *partitionProcessor) prune(ds *DataSource) (LogicalPlan, error) {
 	}
 	// PushDownNot here can convert condition 'not (a != 1)' to 'a = 1'. When we build range from ds.allConds, the condition
 	// like 'not (a != 1)' would not be handled so we need to convert it to 'a = 1', which can be handled when building range.
+	// TODO: there may be a better way to push down Not once for all.
 	for i, cond := range ds.allConds {
 		ds.allConds[i] = expression.PushDownNot(ds.ctx, cond)
 	}

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -639,7 +639,10 @@ func (r *builder) buildFromNot(expr *expression.ScalarFunction) []*point {
 		endPoint := &point{value: types.MaxValueDatum()}
 		return []*point{startPoint, endPoint}
 	}
-	return nil
+	// TODO: currently we don't handle ast.LogicAnd, ast.LogicOr, ast.GT, ast.LT and so on. Most of those cases are eliminated
+	// by PushDownNot but they may happen. For now, we return full range for those unhandled cases in order to keep correctness.
+	// Later we need to cover those cases and set r.err when meeting some unexpected case.
+	return getFullRange()
 }
 
 func (r *builder) buildFromScalarFunc(expr *expression.ScalarFunction) []*point {

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -638,8 +638,6 @@ func (r *builder) buildFromNot(expr *expression.ScalarFunction) []*point {
 		startPoint := &point{value: types.MinNotNullDatum(), start: true}
 		endPoint := &point{value: types.MaxValueDatum()}
 		return []*point{startPoint, endPoint}
-	case ast.LogicAnd:
-		return r.intersection(r.build(expr.GetArgs()[0]), r.build(expr.GetArgs()[1]))
 	}
 	return nil
 }
@@ -667,6 +665,8 @@ func (r *builder) buildFromScalarFunc(expr *expression.ScalarFunction) []*point 
 		startPoint := &point{start: true}
 		endPoint := &point{}
 		return []*point{startPoint, endPoint}
+	case ast.UnaryNot:
+		return r.buildFromNot(expr.GetArgs()[0].(*expression.ScalarFunction))
 	}
 
 	return nil

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -667,8 +667,6 @@ func (r *builder) buildFromScalarFunc(expr *expression.ScalarFunction) []*point 
 		startPoint := &point{start: true}
 		endPoint := &point{}
 		return []*point{startPoint, endPoint}
-	case ast.UnaryNot:
-		return r.buildFromNot(expr.GetArgs()[0].(*expression.ScalarFunction))
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23608, close #23617 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The result of hash partition table with not expression in where clause is incorrect.

### What is changed and how it works?

What's Changed & How it Works:
Apply PushDownNot to condition before pruning partition.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- fix the wrong result of querying hash partition table with not expression in where clause<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
