### PR TITLE
executor: refineArgs() bug fix when compare int with very small decimal

### DIFF
--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1351,13 +1351,15 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	isExceptional, finalArg0, finalArg1 := false, args[0], args[1]
 	isPositiveInfinite, isNegativeInfinite := false, false
 	// int non-constant [cmp] non-int constant
-    // Why check not null flag
-    // eg: int_col > const_val(which is less than min_int32)
-    // If int_col got null, compare result cannot be true
-	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon && mysql.HasNotNullFlag(arg0Type.Flag) {
+	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon {
 		arg1, isExceptional = RefineComparedConstant(ctx, *arg0Type, arg1, c.op)
-		finalArg1 = arg1
-		if isExceptional && arg1.GetType().EvalType() == types.ETInt {
+		// Why check not null flag
+		// eg: int_col > const_val(which is less than min_int32)
+		// If int_col got null, compare result cannot be true
+		if !isExceptional || (isExceptional && mysql.HasNotNullFlag(arg0Type.Flag)) {
+			finalArg1 = arg1
+		}
+		if isExceptional && arg1.GetType().EvalType() == types.ETInt && mysql.HasNotNullFlag(arg0Type.Flag) {
 			// Judge it is inf or -inf
 			// For int:
 			//			inf:  01111111 & 1 == 1
@@ -1373,10 +1375,12 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 		}
 	}
 	// non-int constant [cmp] int non-constant
-	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon && mysql.HasNotNullFlag(arg1Type.Flag) {
+	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon {
 		arg0, isExceptional = RefineComparedConstant(ctx, *arg1Type, arg0, symmetricOp[c.op])
-		finalArg0 = arg0
-		if isExceptional && arg0.GetType().EvalType() == types.ETInt {
+		if !isExceptional || (isExceptional && mysql.HasNotNullFlag(arg1Type.Flag)) {
+			finalArg0 = arg0
+		}
+		if isExceptional && arg0.GetType().EvalType() == types.ETInt && mysql.HasNotNullFlag(arg1Type.Flag) {
 			if arg0.Value.GetInt64()&1 == 1 {
 				isNegativeInfinite = true
 			} else {

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1351,7 +1351,10 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	isExceptional, finalArg0, finalArg1 := false, args[0], args[1]
 	isPositiveInfinite, isNegativeInfinite := false, false
 	// int non-constant [cmp] non-int constant
-	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon {
+    // Why check not null flag
+    // eg: int_col > const_val(which is less than min_int32)
+    // If int_col got null, compare result cannot be true
+	if arg0IsInt && !arg0IsCon && !arg1IsInt && arg1IsCon && mysql.HasNotNullFlag(arg0Type.Flag) {
 		arg1, isExceptional = RefineComparedConstant(ctx, *arg0Type, arg1, c.op)
 		finalArg1 = arg1
 		if isExceptional && arg1.GetType().EvalType() == types.ETInt {
@@ -1370,7 +1373,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 		}
 	}
 	// non-int constant [cmp] int non-constant
-	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon {
+	if arg1IsInt && !arg1IsCon && !arg0IsInt && arg0IsCon && mysql.HasNotNullFlag(arg1Type.Flag) {
 		arg0, isExceptional = RefineComparedConstant(ctx, *arg1Type, arg0, symmetricOp[c.op])
 		finalArg0 = arg0
 		if isExceptional && arg0.GetType().EvalType() == types.ETInt {

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func (s *testEvaluatorSuite) TestCompareFunctionWithRefine(c *C) {
-	tblInfo := newTestTableBuilder("").add("a", mysql.TypeLong).build()
+	tblInfo := newTestTableBuilder("").add("a", mysql.TypeLong, mysql.NotNullFlag).build()
 	tests := []struct {
 		exprStr string
 		result  string

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -35,7 +35,7 @@ func (s *testEvaluatorSuite) TestNewValuesFunc(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestEvaluateExprWithNull(c *C) {
-	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong).add("col1", mysql.TypeLonglong).build()
+	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong, 0).add("col1", mysql.TypeLonglong, 0).build()
 	schema := tableInfoToSchemaForTest(tblInfo)
 	col0 := schema.Columns[0]
 	col1 := schema.Columns[1]
@@ -142,15 +142,17 @@ type testTableBuilder struct {
 	tableName   string
 	columnNames []string
 	tps         []byte
+	flags       []uint
 }
 
 func newTestTableBuilder(tableName string) *testTableBuilder {
 	return &testTableBuilder{tableName: tableName}
 }
 
-func (builder *testTableBuilder) add(name string, tp byte) *testTableBuilder {
+func (builder *testTableBuilder) add(name string, tp byte, flag uint) *testTableBuilder {
 	builder.columnNames = append(builder.columnNames, name)
 	builder.tps = append(builder.tps, tp)
+	builder.flags = append(builder.flags, flag)
 	return builder
 }
 
@@ -165,6 +167,7 @@ func (builder *testTableBuilder) build() *model.TableInfo {
 		fieldType := types.NewFieldType(tp)
 		fieldType.Flen, fieldType.Decimal = mysql.GetDefaultFieldLengthAndDecimal(tp)
 		fieldType.Charset, fieldType.Collate = types.DefaultCharsetForType(tp)
+		fieldType.Flag = builder.flags[i]
 		ti.Columns = append(ti.Columns, &model.ColumnInfo{
 			ID:        int64(i + 1),
 			Name:      model.NewCIStr(colName),

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -8946,3 +8946,12 @@ func (s *testIntegrationSerialSuite) TestCollationForBinaryLiteral(c *C) {
 	tk.MustQuery("select * from t where col1 not in (0x1B,0x20) order by col1").Check(testkit.Rows("\x1e \xec 6966939640596047133"))
 	tk.MustExec("drop table t")
 }
+
+func (s *testIntegrationSuite) TestIssue23623(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1(c1 int);")
+	tk.MustExec("insert into t1 values(-2147483648), (-2147483648), (null);")
+	tk.MustQuery("select count(*) from t1 where c1 > (select sum(c1) from t1);").Check(testkit.Rows("2"))
+}

--- a/planner/core/cbo_test.go
+++ b/planner/core/cbo_test.go
@@ -453,7 +453,7 @@ func (s *testAnalyzeSuite) TestPreparedNullParam(c *C) {
 		testKit := testkit.NewTestKit(c, store)
 		testKit.MustExec("use test")
 		testKit.MustExec("drop table if exists t")
-		testKit.MustExec("create table t (id int, KEY id (id))")
+		testKit.MustExec("create table t (id int not null, KEY id (id))")
 		testKit.MustExec("insert into t values (1), (2), (3)")
 
 		sql := "select * from t where id = ?"


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: 
close #23623 
close #23684 <!-- REMOVE this line if no issue to close -->

Problem Summary: In the following case, output of select stmt should be 2, but current result is 3. 

Why: c1 is nullable, so we cannot assuse all value in c1 will be greater than the result of subquery, which is less than int32_min. Because result of `null > xxx` is NULL

    drop table if exists t1;
    create table t1(c1 int);
    insert into t1 values(-2147483648), (-2147483648), (null);
    select count(*) from t1 where c1 > (select sum(c1) from t1);

### What is changed and how it works?


What's Changed: when `refineArgs()`, should check if column is nullable. If is nullable, we should not try to optimize compare expression.


### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Integration test


Side effects

- Performance regression
    - Consumes more CPU: may cause performance regression compared when compare int_column with const if int_column is nullable.


### Release note <!-- bugfixes or new feature need a release note -->

- fix bug when compare int_column with constant value
