### PR TITLE
store/tikv: fix misuse of PD client's GetStore

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1773,8 +1773,7 @@ func (s *Store) initResolve(bo *Backoffer, c *RegionCache) (addr string, err err
 // A quick and dirty solution to found whether an err is caused by StoreNotFound.
 // todo: A better solution, maybe some err-code based error handling?
 func isStoreNotFoundError(err error) bool {
-	return err.Error() == "[pd] store field in rpc response not set" ||
-		(strings.Contains(err.Error(), "invalid store ID") && strings.Contains(err.Error(), "not found"))
+	return strings.Contains(err.Error(), "invalid store ID") && strings.Contains(err.Error(), "not found")
 }
 
 // reResolve try to resolve addr for store that need check. Returns false if the region is in tombstone state or is
@@ -1787,9 +1786,9 @@ func (s *Store) reResolve(c *RegionCache) (bool, error) {
 	} else {
 		metrics.RegionCacheCounterWithGetStoreOK.Inc()
 	}
-	// `err` here can mean "load Store from PD failed" or "store not found"
-	// if load Store from PD is successful but pd didn't found the store
-	// these error should be handled by next `if` instead of here
+	// `err` here can mean either "load Store from PD failed" or "store not found"
+	// If load Store from PD is successful but PD didn't find the store
+	// the err should be handled by next `if` instead of here
 	if err != nil && !isStoreNotFoundError(err) {
 		logutil.BgLogger().Error("loadStore from PD failed", zap.Uint64("id", s.storeID), zap.Error(err))
 		// we cannot do backoff in reResolve loop but try check other store and wait tick.


### PR DESCRIPTION
Signed-off-by: longfangsong <longfangsong@icloud.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23676

Problem Summary:

- TiDB wrongly uses the PD client's `GetStore()`, which may result in dead loops. 
- `store.State` isn't changed if it becomes a tombstone

### What is changed and how it works?

What's Changed: 

Skip the early-return `if` branch  when "load Store from PD success but pd didn't found the store"

How it Works:

By checking the error message. This is a quick and dirty solution. A better solution (which needs to change the pdClient, and maybe the whole way of our error handling process) needs more discussion.

### Related changes

- Need to cherry-pick to the release branch
  Needs to cherry-pick to 5.0.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
