### PR TITLE
tikv: distinguish server timeout for TiKV and TiFlash

### DIFF
--- a/store/tikv/batch_coprocessor.go
+++ b/store/tikv/batch_coprocessor.go
@@ -387,7 +387,8 @@ func (b *batchCopIterator) handleStreamedBatchCopResponse(ctx context.Context, b
 				return nil
 			}
 
-			if err1 := bo.Backoff(boTiKVRPC, errors.Errorf("recv stream response error: %v, task store addr: %s", err, task.storeAddr)); err1 != nil {
+			// Currently this function is only used in TiFlash batch cop.
+			if err1 := bo.Backoff(boTiFlashRPC, errors.Errorf("recv stream response error: %v, task store addr: %s", err, task.storeAddr)); err1 != nil {
 				return errors.Trace(err)
 			}
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -202,7 +202,7 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndR
 
 	// Currently this function is only used in TiFlash batch cop.
 	// TODO: need code refactoring for these functions.
-	err = bo.Backoff(boTiFlashRPC, errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
+	err = bo.Backoff(boTiFlashRPC, errors.Errorf("send tiflash request error: %v, ctxs: %v, try next peer later", err, ctxs))
 	return errors.Trace(err)
 }
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -199,7 +199,10 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndR
 	// When a store is not available, the leader of related region should be elected quickly.
 	// TODO: the number of retry time should be limited:since region may be unavailable
 	// when some unrecoverable disaster happened.
-	err = bo.Backoff(boTiKVRPC, errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
+
+	// Currently this function is only used in TiFlash batch cop.
+	// TODO: need code refactoring for these functions.
+	err = bo.Backoff(boTiFlashRPC, errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
 	return errors.Trace(err)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

This pr is a follow-up of https://github.com/pingcap/tidb/pull/21109

Problem Summary: Some TiFlash server time out still show `TiKV server timeout`.

### What is changed and how it works?

What's Changed:

Fix it in batch cop requests.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: no 
- Need to cherry-pick to the release branch: no, master/5.0's issue has been fixed in https://github.com/pingcap/tidb/pull/23078

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)
```sql
create table t(a int);
alter table t set tiflash replica 1;
-- let TiFlash hang, for example, pause it while debugging.
explain analyze select * from t; -- cop
[HY000][9012] TiFlash server timeout
explain analyze select count(*) from t; -- batch, before this pr, it's [9002] TiKV server timeout
[HY000][9012] TiFlash server timeout
```

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- Fix a bug that causes TiDB to report `TiKV server timeout` when executing TiFlash batch request.
