### PR TITLE
session: add session scope for tidb_enable_clustered_index

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -541,7 +541,12 @@ func (s *testSerialSuite1) TestSetVar(c *C) {
 	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1287 'INT_ONLY' is deprecated and will be removed in a future release. Please use 'ON' or 'OFF' instead"))
 	tk.MustExec(`set @@global.tidb_enable_clustered_index = 'off'`)
 	tk.MustQuery(`show warnings`).Check(testkit.Rows())
-
+	tk.MustExec("set @@tidb_enable_clustered_index = 'off'")
+	tk.MustQuery(`show warnings`).Check(testkit.Rows())
+	tk.MustExec("set @@tidb_enable_clustered_index = 'on'")
+	tk.MustQuery(`show warnings`).Check(testkit.Rows())
+	tk.MustExec("set @@tidb_enable_clustered_index = 'int_only'")
+	tk.MustQuery(`show warnings`).Check(testkit.Rows("Warning 1287 'INT_ONLY' is deprecated and will be removed in a future release. Please use 'ON' or 'OFF' instead"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -477,11 +477,13 @@ const (
 	version66 = 66
 	// version67 restore all SQL bindings.
 	version67 = 67
+	// version68 update the global variable 'tidb_enable_clustered_index' from 'off' to 'int_only'.
+	version68 = 68
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version67
+var currentBootstrapVersion int64 = version68
 
 var (
 	bootstrapVersion = []func(Session, int64){
@@ -552,6 +554,7 @@ var (
 		upgradeToVer65,
 		upgradeToVer66,
 		upgradeToVer67,
+		upgradeToVer68,
 	}
 )
 
@@ -1459,6 +1462,13 @@ func upgradeToVer66(s Session, ver int64) {
 		return
 	}
 	mustExecute(s, "set @@global.tidb_track_aggregate_memory_usage = 1")
+}
+
+func upgradeToVer68(s Session, ver int64) {
+	if ver >= version68 {
+		return
+	}
+	mustExecute(s, "UPDATE mysql.global_variables SET VARIABLE_VALUE = 'INT_ONLY' where VARIABLE_NAME = 'tidb_enable_clustered_index' and VARIABLE_VALUE = 'OFF'")
 }
 
 func writeOOMAction(s Session) {

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -781,7 +781,7 @@ var defaultSysVars = []*SysVar{
 	{Scope: ScopeSession, Name: TiDBFoundInBinding, Value: BoolToOnOff(DefTiDBFoundInBinding), Type: TypeBool, ReadOnly: true},
 	{Scope: ScopeSession, Name: TiDBEnableCollectExecutionInfo, Value: BoolToOnOff(DefTiDBEnableCollectExecutionInfo), Type: TypeBool},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAllowAutoRandExplicitInsert, Value: BoolToOnOff(DefTiDBAllowAutoRandExplicitInsert), Type: TypeBool},
-	{Scope: ScopeGlobal, Name: TiDBEnableClusteredIndex, Value: IntOnly, Type: TypeEnum, PossibleValues: []string{Off, On, IntOnly, "1", "0"}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableClusteredIndex, Value: IntOnly, Type: TypeEnum, PossibleValues: []string{Off, On, IntOnly, "1", "0"}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPartitionPruneMode, Value: string(Static), Type: TypeStr, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		mode := PartitionPruneMode(normalizedValue).Update()
 		if !mode.Valid() {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: To keep consistent between v5.0 and v5.0-rc, we should reserve the session scope of variable `tidb_enable_clustered_index`.

### What is changed and how it works?

What's Changed:

Add bootstrap version 68, upgrade the global variable `tidb_enable_clustered_index` value from `OFF` to `INT_ONLY`.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:!
- Need to cherry-pick to the release branch!

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

NA

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
