### PR TITLE
ddl: fix secondary index len check for clustered index

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1542,7 +1542,7 @@ CREATE TABLE t (
 	tk.MustGetErrCode("create index idx2 on t(c03, c04)", errno.ErrTooLongKey)
 	tk.MustExec("drop table t")
 
-	// test create index
+	// test change/modify column
 	tk.MustExec(`
 CREATE TABLE t (
   c01 varchar(255) NOT NULL,
@@ -1556,6 +1556,7 @@ CREATE TABLE t (
 )`)
 	tk.MustExec("alter table t change c03 c10 varchar(256) default null")
 	tk.MustGetErrCode("alter table t change c10 c100 varchar(1024) default null", errno.ErrTooLongKey)
+	tk.MustGetErrCode("alter table t modify c10 varchar(600) default null", errno.ErrTooLongKey)
 }
 
 func (s *testIntegrationSuite3) TestAlterColumn(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1586,7 +1586,7 @@ CREATE TABLE t (
 	tk.MustGetErrCode("alter table t change c10 c100 varchar(1024) default null", errno.ErrTooLongKey)
 	tk.MustGetErrCode("alter table t modify c10 varchar(600) default null", errno.ErrTooLongKey)
 	tk.MustExec("alter table t modify c06 varchar(600) default null")
-	tk.MustGetErrCode("alter table t modify c01 varchar(510) default null", errno.ErrTooLongKey)
+	tk.MustGetErrCode("alter table t modify c01 varchar(510)", errno.ErrTooLongKey)
 	tk.MustExec("create table t2 like t")
 }
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1527,6 +1527,18 @@ CREATE TABLE t (
   KEY c04 (c04)
 )`, errno.ErrTooLongKey)
 
+	// test create long clustered primary key.
+	tk.MustGetErrCode(`
+CREATE TABLE t (
+  c01 varchar(255) NOT NULL,
+  c02 varchar(255) NOT NULL,
+  c03 varchar(255) NOT NULL,
+  c04 varchar(255) NOT NULL,
+  c05 varchar(255) DEFAULT NULL,
+  c06 varchar(255) DEFAULT NULL,
+  PRIMARY KEY (c01,c02,c03,c04) clustered
+)`, errno.ErrTooLongKey)
+
 	// test create table with unique key
 	tk.MustExec(`
 CREATE TABLE t (

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1514,7 +1514,7 @@ func (s *testIntegrationSuite8) TestCreateSecondaryIndexInCluster(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 
-	// test create table
+	// test create table with non-unique key
 	tk.MustGetErrCode(`
 CREATE TABLE t (
   c01 varchar(255) NOT NULL,
@@ -1527,7 +1527,7 @@ CREATE TABLE t (
   KEY c04 (c04)
 )`, errno.ErrTooLongKey)
 
-	// test create table
+	// test create table with unique key
 	tk.MustExec(`
 CREATE TABLE t (
   c01 varchar(255) NOT NULL,
@@ -1575,6 +1575,7 @@ CREATE TABLE t (
 	tk.MustGetErrCode("alter table t modify c10 varchar(600) default null", errno.ErrTooLongKey)
 	tk.MustExec("alter table t modify c06 varchar(600) default null")
 	tk.MustGetErrCode("alter table t modify c01 varchar(510) default null", errno.ErrTooLongKey)
+	tk.MustExec("create table t2 like t")
 }
 
 func (s *testIntegrationSuite3) TestAlterColumn(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1527,6 +1527,20 @@ CREATE TABLE t (
   KEY c04 (c04)
 )`, errno.ErrTooLongKey)
 
+	// test create table
+	tk.MustExec(`
+CREATE TABLE t (
+  c01 varchar(255) NOT NULL,
+  c02 varchar(255) NOT NULL,
+  c03 varchar(255) NOT NULL,
+  c04 varchar(255) DEFAULT NULL,
+  c05 varchar(255) DEFAULT NULL,
+  c06 varchar(255) DEFAULT NULL,
+  PRIMARY KEY (c01,c02,c03) clustered,
+  unique key c04 (c04)
+)`)
+	tk.MustExec("drop table t")
+
 	// test create index
 	tk.MustExec(`
 CREATE TABLE t (
@@ -1540,6 +1554,7 @@ CREATE TABLE t (
 )`)
 	tk.MustExec("create index idx1 on t(c03)")
 	tk.MustGetErrCode("create index idx2 on t(c03, c04)", errno.ErrTooLongKey)
+	tk.MustExec("create unique index uk2 on t(c03, c04)")
 	tk.MustExec("drop table t")
 
 	// test change/modify column
@@ -1552,11 +1567,14 @@ CREATE TABLE t (
   c05 varchar(255) DEFAULT NULL,
   c06 varchar(255) DEFAULT NULL,
   PRIMARY KEY (c01,c02) clustered,
-  Index idx1(c03)
+  Index idx1(c03),
+  unique index uk1(c06)
 )`)
 	tk.MustExec("alter table t change c03 c10 varchar(256) default null")
 	tk.MustGetErrCode("alter table t change c10 c100 varchar(1024) default null", errno.ErrTooLongKey)
 	tk.MustGetErrCode("alter table t modify c10 varchar(600) default null", errno.ErrTooLongKey)
+	tk.MustExec("alter table t modify c06 varchar(600) default null")
+	tk.MustGetErrCode("alter table t modify c01 varchar(510) default null", errno.ErrTooLongKey)
 }
 
 func (s *testIntegrationSuite3) TestAlterColumn(c *C) {

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -1566,8 +1566,8 @@ CREATE TABLE t (
   c04 varchar(255) DEFAULT NULL,
   c05 varchar(255) DEFAULT NULL,
   c06 varchar(255) DEFAULT NULL,
-  PRIMARY KEY (c01,c02) clustered,
   Index idx1(c03),
+  PRIMARY KEY (c01,c02) clustered,
   unique index uk1(c06)
 )`)
 	tk.MustExec("alter table t change c03 c10 varchar(256) default null")

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1513,7 +1513,7 @@ func buildTableInfo(
 			return
 		}
 		for _, idx := range tbInfo.Indices {
-			if idx.Primary || idx.Unique {
+			if idx.Unique {
 				// only need check for secondary and non-unique index
 				continue
 			}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3972,9 +3972,15 @@ func checkColumnWithIndexConstraint(tbInfo *model.TableInfo, originalCol, newCol
 	}
 
 	// check primary key first, because pk maybe not in first item in tblInfo.Indices
-	pkModified, err := checkOneIndex(pkIndex, 0, true)
-	if err != nil {
-		return err
+	var (
+		pkModified bool
+		err        error
+	)
+	if pkIndex != nil {
+		pkModified, err = checkOneIndex(pkIndex, 0, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	// check secondary index

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1506,7 +1506,7 @@ func buildTableInfo(
 		tbInfo.Indices = append(tbInfo.Indices, idxInfo)
 	}
 	if tbInfo.IsCommonHandle {
-		// ensure tblInfo's each non-unique secondary-index's len + primary-key's len <= MaxIndexLength for clustered index table
+		// Ensure tblInfo's each non-unique secondary-index's len + primary-key's len <= MaxIndexLength for clustered index table.
 		var pkLen, idxLen int
 		pkLen, err = indexColumnsLen(tbInfo.Columns, tables.FindPrimaryIndex(tbInfo).Columns)
 		if err != nil {
@@ -1514,7 +1514,7 @@ func buildTableInfo(
 		}
 		for _, idx := range tbInfo.Indices {
 			if idx.Unique {
-				// only need check for secondary and non-unique index
+				// Only need check for non-unique secondary-index.
 				continue
 			}
 			idxLen, err = indexColumnsLen(tbInfo.Columns, idx.Columns)
@@ -3927,13 +3927,13 @@ func (d *ddl) getModifiableColumnJob(ctx sessionctx.Context, ident ast.Ident, or
 // Index has a max-prefix-length constraint. eg: a varchar(100), index idx(a), modifying column a to a varchar(4000)
 // will cause index idx to break the max-prefix-length constraint.
 //
-// for clustered index:
-//  change column in pk need recheck all non-unique index, new pk len + index len < maxIndexLength
-//  change column in secondary only need related index, pk len + new index len < maxIndexLength
+// For clustered index:
+//  Change column in pk need recheck all non-unique index, new pk len + index len < maxIndexLength.
+//  Change column in secondary only need related index, pk len + new index len < maxIndexLength.
 func checkColumnWithIndexConstraint(tbInfo *model.TableInfo, originalCol, newCol *model.ColumnInfo) error {
 	columns := make([]*model.ColumnInfo, 0, len(tbInfo.Columns))
 	columns = append(columns, tbInfo.Columns...)
-	// replace old column with new column.
+	// Replace old column with new column.
 	for i, col := range columns {
 		if col.Name.L != originalCol.Name.L {
 			continue
@@ -3971,7 +3971,7 @@ func checkColumnWithIndexConstraint(tbInfo *model.TableInfo, originalCol, newCol
 		return
 	}
 
-	// check primary key first, because pk maybe not in first item in tblInfo.Indices
+	// Check primary key first and get "does primary key's column has be modified?" info.
 	var (
 		pkModified bool
 		err        error
@@ -3983,7 +3983,7 @@ func checkColumnWithIndexConstraint(tbInfo *model.TableInfo, originalCol, newCol
 		}
 	}
 
-	// check secondary index
+	// Check secondary indexes.
 	for _, indexInfo := range tbInfo.Indices {
 		if indexInfo.Primary {
 			continue
@@ -5087,7 +5087,7 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast.Inde
 	}
 
 	if !unique && tblInfo.IsCommonHandle {
-		// ensure new created non-unique secondary-index's len + primary-key's len <= MaxIndexLength in clustered index table
+		// Ensure new created non-unique secondary-index's len + primary-key's len <= MaxIndexLength in clustered index table.
 		var pkLen, idxLen int
 		pkLen, err = indexColumnsLen(tblInfo.Columns, tables.FindPrimaryIndex(tblInfo).Columns)
 		if err != nil {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1506,15 +1506,8 @@ func buildTableInfo(
 		tbInfo.Indices = append(tbInfo.Indices, idxInfo)
 	}
 	if tbInfo.IsCommonHandle {
-		var pkIdx *model.IndexInfo
-		for _, idx := range tbInfo.Indices {
-			if idx.Primary {
-				pkIdx = idx
-				break
-			}
-		}
 		var pkLen, idxLen int
-		pkLen, err = indexColumnLen(tbInfo.Columns, pkIdx.Columns)
+		pkLen, err = indexColumnLen(tbInfo.Columns, tables.FindPrimaryIndex(tbInfo).Columns)
 		if err != nil {
 			return
 		}
@@ -5057,15 +5050,8 @@ func (d *ddl) CreateIndex(ctx sessionctx.Context, ti ast.Ident, keyType ast.Inde
 	}
 
 	if tblInfo.IsCommonHandle {
-		var pkIdx *model.IndexInfo
-		for _, idx := range tblInfo.Indices {
-			if idx.Primary {
-				pkIdx = idx
-				break
-			}
-		}
 		var pkLen, idxLen int
-		pkLen, err = indexColumnLen(tblInfo.Columns, pkIdx.Columns)
+		pkLen, err = indexColumnLen(tblInfo.Columns, tables.FindPrimaryIndex(tblInfo).Columns)
 		if err != nil {
 			return err
 		}

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -112,15 +112,8 @@ func checkPKOnGeneratedColumn(tblInfo *model.TableInfo, indexPartSpecifications 
 func checkIndexPrefixLength(tbInfo *model.TableInfo, columns []*model.ColumnInfo, idxColumns []*model.IndexColumn) error {
 	var pkLen int
 	if tbInfo.IsCommonHandle {
-		var pkIdx *model.IndexInfo
-		for _, idx := range tbInfo.Indices {
-			if idx.Primary {
-				pkIdx = idx
-				break
-			}
-		}
 		var err error
-		pkLen, err = indexColumnLen(columns, pkIdx.Columns)
+		pkLen, err = indexColumnLen(columns, tables.FindPrimaryIndex(tbInfo).Columns)
 		if err != nil {
 			return err
 		}
@@ -494,15 +487,8 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 		indexInfo.ID = allocateIndexID(tblInfo)
 		tblInfo.Indices = append(tblInfo.Indices, indexInfo)
 		if tblInfo.IsCommonHandle && !indexInfo.Primary {
-			var pkIdx *model.IndexInfo
-			for _, idx := range tblInfo.Indices {
-				if idx.Primary {
-					pkIdx = idx
-					break
-				}
-			}
 			var pkLen, idxLen int
-			pkLen, err = indexColumnLen(tblInfo.Columns, pkIdx.Columns)
+			pkLen, err = indexColumnLen(tblInfo.Columns, tables.FindPrimaryIndex(tblInfo).Columns)
 			if err != nil {
 				return
 			}

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -478,22 +478,6 @@ func (w *worker) onCreateIndex(d *ddlCtx, t *meta.Meta, job *model.Job, isPK boo
 		indexInfo.Global = global
 		indexInfo.ID = allocateIndexID(tblInfo)
 		tblInfo.Indices = append(tblInfo.Indices, indexInfo)
-		if tblInfo.IsCommonHandle && !indexInfo.Primary && !indexInfo.Unique {
-			// ensure new created non-unique secondary-index's len + primary-key's len <= MaxIndexLength in clustered index table
-			var pkLen, idxLen int
-			pkLen, err = indexColumnsLen(tblInfo.Columns, tables.FindPrimaryIndex(tblInfo).Columns)
-			if err != nil {
-				return
-			}
-			idxLen, err = indexColumnsLen(tblInfo.Columns, indexInfo.Columns)
-			if err != nil {
-				return
-			}
-			if pkLen+idxLen > config.GetGlobalConfig().MaxIndexLength {
-				err = errTooLongKey.GenWithStackByArgs(config.GetGlobalConfig().MaxIndexLength)
-				return
-			}
-		}
 		if err = checkTooManyIndexes(tblInfo.Indices); err != nil {
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23631 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed, How it Works:

calculate non-unique secondary index len = pk len + index len

when 

- create table
- create index
- change column len for index
- change column len for pk



### Related changes

- Need to cherry-pick to the release branch 5.0
- Need update document

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/23710)
<!-- Reviewable:end -->
