### PR TITLE
collation: fix tidb panic when compare string with collation

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -8160,6 +8160,7 @@ func (s *testIntegrationSerialSuite) TestIssue23506(c *C) {
 
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test;`)
+	tk.MustExec("drop table if exists t;")
 	tk.MustExec(`create table t(a char(10) collate utf8mb4_general_ci, b char(10) collate utf8mb4_unicode_ci);`)
 	tk.MustExec(`insert into t values ('a', 'a')`)
 	tk.MustExec(`insert into t values ('一', '一')`)

--- a/util/collate/collate.go
+++ b/util/collate/collate.go
@@ -47,14 +47,6 @@ var (
 const (
 	// DefaultLen is set for datum if the string datum don't know its length.
 	DefaultLen = 0
-	// first byte of a 2-byte encoding starts 110 and carries 5 bits of data
-	b2Mask = 0x1F // 0001 1111
-	// first byte of a 3-byte encoding starts 1110 and carries 4 bits of data
-	b3Mask = 0x0F // 0000 1111
-	// first byte of a 4-byte encoding starts 11110 and carries 3 bits of data
-	b4Mask = 0x07 // 0000 0111
-	// non-first bytes start 10 and carry 6 bits of data
-	mbMask = 0x3F // 0011 1111
 )
 
 // Collator provides functionality for comparing strings for a given
@@ -245,31 +237,6 @@ func sign(i int) int {
 		return 1
 	}
 	return 0
-}
-
-// decode rune by hand
-func decodeRune(s string, si int) (r rune, newIndex int) {
-	switch b := s[si]; {
-	case b < 0x80:
-		r = rune(b)
-		newIndex = si + 1
-	case b < 0xE0:
-		r = rune(b&b2Mask)<<6 |
-			rune(s[1+si]&mbMask)
-		newIndex = si + 2
-	case b < 0xF0:
-		r = rune(b&b3Mask)<<12 |
-			rune(s[si+1]&mbMask)<<6 |
-			rune(s[si+2]&mbMask)
-		newIndex = si + 3
-	default:
-		r = rune(b&b4Mask)<<18 |
-			rune(s[si+1]&mbMask)<<12 |
-			rune(s[si+2]&mbMask)<<6 |
-			rune(s[si+3]&mbMask)
-		newIndex = si + 4
-	}
-	return
 }
 
 // IsCICollation returns if the collation is case-sensitive

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -151,7 +151,7 @@ func (s *testCollateSuite) TestUnicodeCICollator(c *C) {
 		{"a\t", "a", 1},
 		{"ß", "s", 1},
 		{"ß", "ss", 0},
-		{"\x80", "a", 1},
+		{"\x80", "a", -1},
 	}
 	keyTable := []keyTable{
 		{"a", []byte{0x0E, 0x33}},

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -118,6 +118,7 @@ func (s *testCollateSuite) TestGeneralCICollator(c *C) {
 		{"😜", "😃", 0},
 		{"a ", "a  ", 0},
 		{"a\t", "a", 1},
+		{"\x80", "a", 1},
 	}
 	keyTable := []keyTable{
 		{"a", []byte{0x0, 0x41}},
@@ -128,6 +129,7 @@ func (s *testCollateSuite) TestGeneralCICollator(c *C) {
 			0x3, 0x0, 0x20, 0x0, 0x51, 0x0, 0x55, 0x0, 0x58}},
 		{"a ", []byte{0x0, 0x41}},
 		{"a", []byte{0x0, 0x41}},
+		{"\x80\x81", []byte{}},
 	}
 	testCompareTable(compareTable, "utf8mb4_general_ci", c)
 	testKeyTable(keyTable, "utf8mb4_general_ci", c)
@@ -149,6 +151,7 @@ func (s *testCollateSuite) TestUnicodeCICollator(c *C) {
 		{"a\t", "a", 1},
 		{"ß", "s", 1},
 		{"ß", "ss", 0},
+		{"\x80", "a", 1},
 	}
 	keyTable := []keyTable{
 		{"a", []byte{0x0E, 0x33}},
@@ -160,6 +163,7 @@ func (s *testCollateSuite) TestUnicodeCICollator(c *C) {
 			0xB4, 0x10, 0x1F, 0x10, 0x5A}},
 		{"a ", []byte{0x0E, 0x33}},
 		{"ﷻ", []byte{0x13, 0x5E, 0x13, 0xAB, 0x02, 0x09, 0x13, 0x5E, 0x13, 0xAB, 0x13, 0x50, 0x13, 0xAB, 0x13, 0xB7}},
+		{"\x80\x81", []byte{}},
 	}
 
 	testCompareTable(compareTable, "utf8mb4_unicode_ci", c)

--- a/util/collate/unicode_ci.go
+++ b/util/collate/unicode_ci.go
@@ -132,25 +132,6 @@ func convertRuneUnicodeCI(r rune) (first, second uint64) {
 	return mapTable[r], 0
 }
 
-func getWeight(an, as uint64, a string) (uint64, uint64, string) {
-	if an == 0 {
-		if as == 0 {
-			for an == 0 && len(a) > 0 {
-				ar, ai := utf8.DecodeRuneInString(a)
-				if ar == utf8.RuneError && ai == 1 {
-					return utf8.RuneError, 1, a
-				}
-				a = a[ai:]
-				an, as = convertRuneUnicodeCI(ar)
-			}
-		} else {
-			return as, 0, a
-		}
-	}
-
-	return an, as, a
-}
-
 // Pattern implements Collator interface.
 func (uc *unicodeCICollator) Pattern() WildcardPattern {
 	return &unicodePattern{}

--- a/util/collate/unicode_ci.go
+++ b/util/collate/unicode_ci.go
@@ -15,7 +15,6 @@ package collate
 
 import (
 	"github.com/pingcap/tidb/util/stringutil"
-	"strings"
 	"unicode/utf8"
 )
 
@@ -45,7 +44,8 @@ func (uc *unicodeCICollator) Compare(a, b string) int {
 				for an == 0 && len(a) > 0 {
 					ar, asize = utf8.DecodeRuneInString(a)
 					if ar == utf8.RuneError && asize == 1 {
-						return strings.Compare(a, b)
+						an = 0
+						break
 					}
 					a = a[asize:]
 					an, as = convertRuneUnicodeCI(ar)
@@ -61,7 +61,8 @@ func (uc *unicodeCICollator) Compare(a, b string) int {
 				for bn == 0 && len(b) > 0 {
 					br, bsize = utf8.DecodeRuneInString(b)
 					if br == utf8.RuneError && bsize == 1 {
-						return strings.Compare(a, b)
+						bn = 0
+						break
 					}
 					b = b[bsize:]
 					bn, bs = convertRuneUnicodeCI(br)

--- a/util/collate/unicode_ci.go
+++ b/util/collate/unicode_ci.go
@@ -14,8 +14,9 @@
 package collate
 
 import (
-	"github.com/pingcap/tidb/util/stringutil"
 	"unicode/utf8"
+
+	"github.com/pingcap/tidb/util/stringutil"
 )
 
 const (


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23506

Problem Summary:

please see https://github.com/pingcap/tidb/issues/23506#issuecomment-807967385

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

since we have to check the string is valid or not, we almost have 20%-25% performance loss.

```
                                                                before                                after
BenchmarkUtf8mb4Bin_CompareShort-8              162474816                6.57 ns/op  | 179831926                6.58 ns/op
BenchmarkUtf8mb4GeneralCI_CompareShort-8         3879333               303 ns/op     |  3253285               395 ns/op
BenchmarkUtf8mb4UnicodeCI_CompareShort-8         3134563               344 ns/op     |  2195716               530 ns/op
BenchmarkUtf8mb4Bin_CompareMid-8                178230032                7.07 ns/op  | 162510152                6.54 ns/op
BenchmarkUtf8mb4GeneralCI_CompareMid-8             44064             26646 ns/op     |    33656             33831 ns/op
BenchmarkUtf8mb4UnicodeCI_CompareMid-8             39220             31158 ns/op     |    26828             43504 ns/op
BenchmarkUtf8mb4Bin_CompareLong-8               181071398                6.59 ns/op  | 182394769                6.76 ns/op
BenchmarkUtf8mb4GeneralCI_CompareLong-8               40          29085788 ns/op     |       30          37835873 ns/op
BenchmarkUtf8mb4UnicodeCI_CompareLong-8               33          34574309 ns/op     |       24          47649571 ns/op
BenchmarkUtf8mb4Bin_KeyShort-8                  29053438                38.4 ns/op   | 30192324                37.8 ns/op
BenchmarkUtf8mb4GeneralCI_KeyShort-8             4607634               237 ns/op     |  3934675               290 ns/op
BenchmarkUtf8mb4UnicodeCI_KeyShort-8             4929477               242 ns/op     |  3906382               296 ns/op
BenchmarkUtf8mb4Bin_KeyMid-8                     1829863               609 ns/op     |  1790952               623 ns/op
BenchmarkUtf8mb4GeneralCI_KeyMid-8                 70951             16994 ns/op     |    54698             21047 ns/op
BenchmarkUtf8mb4UnicodeCI_KeyMid-8                 61971             19005 ns/op     |    52916             22115 ns/op
BenchmarkUtf8mb4Bin_KeyLong-8                       3148            364115 ns/op     |     4012            347909 ns/op
BenchmarkUtf8mb4GeneralCI_KeyLong-8                   64          18180270 ns/op     |       52          21789504 ns/op
BenchmarkUtf8mb4UnicodeCI_KeyLong-8                   60          20579898 ns/op     |       54          23992131 ns/op
```

### Release note <!-- bugfixes or new feature need a release note -->

- fix tidb panic when compare string with collation<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
