### PR TITLE
ddl:fix Error in accuracy when adding CURRENT_TIMESTAMP column

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -1726,11 +1726,20 @@ func generateOriginDefaultValue(col *model.ColumnInfo) (interface{}, error) {
 		}
 	}
 
+	timeFormat := types.TimeFormat
+	if col.Decimal != 0 {
+		pend := "."
+		for i := 1; i <= col.Decimal; i++ {
+			pend += "9"
+		}
+		timeFormat = types.TimeFormat + pend
+	}
+
 	if odValue == strings.ToUpper(ast.CurrentTimestamp) {
 		if col.Tp == mysql.TypeTimestamp {
-			odValue = time.Now().UTC().Format(types.TimeFormat)
+			odValue = time.Now().UTC().Format(timeFormat)
 		} else if col.Tp == mysql.TypeDatetime {
-			odValue = time.Now().Format(types.TimeFormat)
+			odValue = time.Now().Format(timeFormat)
 		}
 	}
 	return odValue, nil


### PR DESCRIPTION
###  What problem does this PR solve?
Issue Number: #23784

Problem Summary:

### 1. Minimal reproduce step (Required)
create table test(id int,update_time datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6));
insert into test(id) values (1);
select * from test;
alter table test add column update_time1 datetime(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6) ;
select * from test;

### 2. What did you expect to see? (Required)
mysql> select * from test;
+------+----------------------------+----------------------------+
| id | update_time | update_time1 |
+------+----------------------------+----------------------------+
| 1 | 2021-03-31 19:13:15.441962 | 2021-03-31 19:13:28.381179 |
+------+----------------------------+----------------------------+
1 row in set (0.01 sec)

### 3. What did you see instead (Required)
mysql> select * from test;
+------+----------------------------+----------------------------+
| id | update_time | update_time1 |
+------+----------------------------+----------------------------+
| 1 | 2021-03-31 19:13:15.441962 | 2021-03-31 19:13:28.000000 |
+------+----------------------------+----------------------------+
1 row in set (0.01 sec)


### What is changed and how it works?
What's Changed:
repair Error in accuracy when adding CURRENT_TIMESTAMP column.
How it Works:
Allows formatting to specified precision when CURRENT_TIMESTAMP adds columns. 

### Related changes

- Need to cherry-pick to the release branch
   cherry-pick: V3.0,V3.1,V4.0


### Check List
Tests

- Unit test

### Release note
- fix Error in accuracy when adding CURRENT_TIMESTAMP column.