### PR TITLE
planner: fix "can't find column" when projection wrongly added above table reader after agg pushed down

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1751,10 +1751,11 @@ func (ds *DataSource) getOriginalPhysicalTableScan(prop *property.PhysicalProper
 		physicalTableID: ds.physicalTableID,
 		Ranges:          path.Ranges,
 		AccessCondition: path.AccessConds,
-		filterCondition: path.TableFilters,
 		StoreType:       path.StoreType,
 		IsGlobalRead:    path.IsTiFlashGlobalRead,
 	}.Init(ds.ctx, ds.blockOffset)
+	ts.filterCondition = make([]expression.Expression, len(path.TableFilters))
+	copy(ts.filterCondition, path.TableFilters)
 	ts.SetSchema(ds.schema.Clone())
 	if ts.Table.PKIsHandle {
 		if pkColInfo := ts.Table.GetPkColInfo(); pkColInfo != nil {

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3138,10 +3138,14 @@ func (s *testIntegrationSuite) TestMultiColMaxOneRow(c *C) {
 func (s *testIntegrationSuite) TestIssue23736(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t0, t1")
 	tk.MustExec("create table t0(a int, b int, c int as (a + b) virtual, unique index (c) invisible);")
 	tk.MustExec("create table t1(a int, b int, c int as (a + b) virtual);")
 	tk.MustExec("insert into t0(a, b) values (12, -1), (8, 7);")
 	tk.MustExec("insert into t1(a, b) values (12, -1), (8, 7);")
 	tk.MustQuery("select /*+ stream_agg() */ count(1) from t0 where c > 10 and b < 2;").Check(testkit.Rows("1"))
 	tk.MustQuery("select /*+ stream_agg() */ count(1) from t1 where c > 10 and b < 2;").Check(testkit.Rows("1"))
+	tk.MustExec("delete from t0")
+	tk.MustExec("insert into t0(a, b) values (5, 1);")
+	tk.MustQuery("select /*+ stream_agg() */ count(1) from t1 where c > 10 and b < 2;").Check(testkit.Rows("0"))
 }

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3111,3 +3111,14 @@ func (s *testIntegrationSuite) TestGetVarExprWithBitLiteral(c *C) {
 	tk.MustExec("set @a = 0b11000100110101;")
 	tk.MustQuery("execute stmt using @a;").Check(testkit.Rows("1"))
 }
+
+func (s *testIntegrationSuite) TestIssue23736(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t0(a int, b int, c int as (a + b) virtual, unique index (c) invisible);")
+	tk.MustExec("create table t1(a int, b int, c int as (a + b) virtual);")
+	tk.MustExec("insert into t0(a, b) values (12, -1), (8, 7);")
+	tk.MustExec("insert into t1(a, b) values (12, -1), (8, 7);")
+	tk.MustQuery("select /*+ stream_agg() */ count(1) from t0 where c > 10 and b < 2;").Check(testkit.Rows("1"))
+	tk.MustQuery("select /*+ stream_agg() */ count(1) from t1 where c > 10 and b < 2;").Check(testkit.Rows("1"))
+}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3147,5 +3147,5 @@ func (s *testIntegrationSuite) TestIssue23736(c *C) {
 	tk.MustQuery("select /*+ stream_agg() */ count(1) from t1 where c > 10 and b < 2;").Check(testkit.Rows("1"))
 	tk.MustExec("delete from t0")
 	tk.MustExec("insert into t0(a, b) values (5, 1);")
-	tk.MustQuery("select /*+ stream_agg() */ count(1) from t1 where c > 10 and b < 2;").Check(testkit.Rows("0"))
+	tk.MustQuery("select /*+ nth_plan(3) */ count(1) from t0 where c > 10 and b < 2;").Check(testkit.Rows("0"))
 }

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3148,4 +3148,7 @@ func (s *testIntegrationSuite) TestIssue23736(c *C) {
 	tk.MustExec("delete from t0")
 	tk.MustExec("insert into t0(a, b) values (5, 1);")
 	tk.MustQuery("select /*+ nth_plan(3) */ count(1) from t0 where c > 10 and b < 2;").Check(testkit.Rows("0"))
+
+	// Should not use invisible index
+	c.Assert(tk.MustUseIndex("select /*+ stream_agg() */ count(1) from t0 where c > 10 and b < 2", "c"), IsFalse)
 }

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -963,7 +963,7 @@ func (t *copTask) convertToRootTaskImpl(ctx sessionctx.Context) *rootTask {
 
 		// If agg was pushed down in attach2Task(), the partial agg was placed on the top of tablePlan, the final agg was
 		// placed above the PhysicalTableReader, and the schema should have been set correctly for them, the schema of
-		// placed contains the columns needed by the final agg.
+		// partial agg contains the columns needed by the final agg.
 		// If we add the projection here, the projection will be between the final agg and the partial agg, then the
 		// schema will be broken, the final agg will fail to find needed columns in ResolveIndices().
 		// Besides, the agg would only be pushed down if it doesn't contain virtual columns, so virtual column should not be affected.

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -960,7 +960,14 @@ func (t *copTask) convertToRootTaskImpl(ctx sessionctx.Context) *rootTask {
 		}.Init(ctx, t.tablePlan.SelectBlockOffset())
 		p.PartitionInfo = t.partitionInfo
 		p.stats = t.tablePlan.statsInfo()
-		if needExtraProj {
+
+		aggPushedDown := false
+		switch p.tablePlan.(type) {
+		case *PhysicalHashAgg, *PhysicalStreamAgg:
+			aggPushedDown = true
+		}
+
+		if needExtraProj && !aggPushedDown {
 			proj := PhysicalProjection{Exprs: expression.Column2Exprs(prevSchema.Columns)}.Init(ts.ctx, ts.stats, ts.SelectBlockOffset(), nil)
 			proj.SetSchema(prevSchema)
 			proj.SetChildren(p)

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -961,9 +961,9 @@ func (t *copTask) convertToRootTaskImpl(ctx sessionctx.Context) *rootTask {
 		p.PartitionInfo = t.partitionInfo
 		p.stats = t.tablePlan.statsInfo()
 
-		// If agg was pushed down, the partial agg was placed on the top of tablePlan, the final agg will be placed
-		// above the PhysicalTableReader, and the schema should have been set correctly for them, the schema of partial
-		// contains the columns needed by the final agg.
+		// If agg was pushed down in attach2Task(), the partial agg was placed on the top of tablePlan, the final agg was
+		// placed above the PhysicalTableReader, and the schema should have been set correctly for them, the schema of
+		// placed contains the columns needed by the final agg.
 		// If we add the projection here, the projection will be between the final agg and the partial agg, then the
 		// schema will be broken, the final agg will fail to find needed columns in ResolveIndices().
 		// Besides, the agg would only be pushed down if it doesn't contain virtual columns, so virtual column should not be affected.


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #23736 

Problem Summary:

A projection was added between the partial agg and the final agg, and the schema between them was broken.

### What is changed and how it works?


Not to add the extra projection if the agg was pushed down.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test


### Release note <!-- bugfixes or new feature need a release note -->

- no release note.
