### PR TITLE
statistic: solve write write conflicts of mysql.stats_histograms

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -688,7 +688,7 @@ func (h *Handle) FlushStats() {
 		}
 	}
 	if err := h.DumpStatsDeltaToKV(DumpAll); err != nil {
-		logutil.BgLogger().Error("[stats] dump stats delta fail", zap.Error(err))
+		logutil.BgLogger().Error("[stats] dump stats all fail", zap.Error(err))
 	}
 	if err := h.DumpStatsFeedbackToKV(); err != nil {
 		logutil.BgLogger().Error("[stats] dump stats feedback fail", zap.Error(err))


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/21787

Problem Summary:
the internal SQL in the slow log should not be check write conflict

### What is changed and how it works?

How it Works:
run query in pessimistic transaction.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- statistic: solve write write conflicts of mysql.stats_histograms
