### PR TITLE
statistics: print log when tidb marks extended stats as deleted internally

### DIFF
--- a/statistics/handle/gc.go
+++ b/statistics/handle/gc.go
@@ -70,6 +70,7 @@ func (h *Handle) gcTableStats(is infoschema.InfoSchema, physicalID int64) error 
 	tbl, ok := h.getTableByPhysicalID(is, physicalID)
 	h.mu.Unlock()
 	if !ok {
+		logutil.BgLogger().Info("remove stats in GC due to dropped table", zap.Int64("table_id", physicalID))
 		return errors.Trace(h.DeleteTableStatsFromKV([]int64{physicalID}))
 	}
 	tblInfo := tbl.Meta()
@@ -122,6 +123,7 @@ func (h *Handle) gcTableStats(is infoschema.InfoSchema, physicalID int64) error 
 				}
 			}
 			if !found {
+				logutil.BgLogger().Info("mark mysql.stats_extended record as 'deleted' in GC due to dropped columns", zap.String("table_name", tblInfo.Name.L), zap.Int64("table_id", physicalID), zap.String("stats_name", statsName), zap.Int64("dropped_column_id", colID))
 				err = h.MarkExtendedStatsDeleted(statsName, physicalID, true)
 				if err != nil {
 					logutil.BgLogger().Debug("update stats_extended status failed", zap.String("stats_name", statsName), zap.Error(err))


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23675

Problem Summary:

Not a problem, add more logs for easier trace.

### What is changed and how it works?

What's Changed:

Print log when stats GC marks extended stats records as 'deleted'.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test:

```
create table t(a int, b int);
set session tidb_enable_extended_stats = on;
alter table t add stats_extended s1 correlation(a,b);
alter table t drop column b;
-- wait for 2 rounds of stats GC, and check the tidb logs
drop table t;
-- wait for 2 rounds of stats GC, and check the tidb logs
```

expected logs are successfully found.

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- N/A