### PR TITLE
types/json: replace binary.Read with binary.BigEndian.Uint16

### DIFF
--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -137,11 +137,8 @@ func decodeEscapedUnicode(s []byte) (char [4]byte, size int, err error) {
 		// The unicode must can be represented in 2 bytes.
 		return char, 0, errors.Trace(err)
 	}
-	var unicode uint16
-	err = binary.Read(bytes.NewReader(char[0:2]), binary.BigEndian, &unicode)
-	if err != nil {
-		return char, 0, errors.Trace(err)
-	}
+
+	unicode := binary.BigEndian.Uint16(char[0:2])
 	size = utf8.RuneLen(rune(unicode))
 	utf8.EncodeRune(char[0:size], rune(unicode))
 	return

--- a/types/json/binary_functions_test.go
+++ b/types/json/binary_functions_test.go
@@ -13,6 +13,8 @@
 package json
 
 import (
+	"testing"
+
 	. "github.com/pingcap/check"
 )
 
@@ -28,4 +30,11 @@ func (s *testJSONFuncSuite) TestdecodeEscapedUnicode(c *C) {
 	c.Assert(size, Equals, 3)
 	c.Assert(err, IsNil)
 
+}
+
+func BenchmarkDecodeEscapedUnicode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		in := "597d"
+		decodeEscapedUnicode([]byte(in))
+	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: 
`binary.Read` allocates extra memory which will increase GC pressure

### What is changed and how it works?

What's Changed:

Replace `binary.Read` with `binary.BigEndian.Uint16`

How it Works:

`binary.Read` will allocate extra memory, which is slower. Using `binary.BigEndian.Uint16` achieves 0 allocs/op

### Related changes

Tests 

- Unit test
- Benchmark test

Side effects

Benchmark result

```
name                     old time/op    new time/op    delta
DecodeEscapedUnicode-16     151ns ± 0%      23ns ± 0%   -85.00%  (p=0.000 n=9+10)

name                     old alloc/op   new alloc/op   delta
DecodeEscapedUnicode-16     56.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)

name                     old allocs/op  new allocs/op  delta
DecodeEscapedUnicode-16      4.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
```

### Release note <!-- bugfixes or new feature need a release note -->

- Improve performance by replacing `binary.Read`
