### PR TITLE
executor,distsql: clean up useless interface

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -436,7 +436,6 @@ func (dc *ddlCtx) buildDescTableScan(ctx context.Context, startTS uint64, tbl ta
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	result.Fetch(ctx)
 	return result, nil
 }
 

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -87,7 +87,6 @@ func (s *testSuite) createSelectNormal(batch, totalRows int, c *C, planIDs []int
 
 func (s *testSuite) TestSelectNormal(c *C) {
 	response, colTypes := s.createSelectNormal(1, 2, c, nil)
-	response.Fetch(context.TODO())
 
 	// Test Next.
 	chk := chunk.New(colTypes, 32, 32)
@@ -108,7 +107,6 @@ func (s *testSuite) TestSelectNormal(c *C) {
 
 func (s *testSuite) TestSelectMemTracker(c *C) {
 	response, colTypes := s.createSelectNormal(2, 6, c, nil)
-	response.Fetch(context.TODO())
 
 	// Test Next.
 	chk := chunk.New(colTypes, 3, 3)
@@ -123,7 +121,6 @@ func (s *testSuite) TestSelectMemTracker(c *C) {
 func (s *testSuite) TestSelectNormalChunkSize(c *C) {
 	s.sctx.GetSessionVars().EnableChunkRPC = false
 	response, colTypes := s.createSelectNormal(100, 1000000, c, nil)
-	response.Fetch(context.TODO())
 	s.testChunkSize(response, colTypes, c)
 	c.Assert(response.Close(), IsNil)
 	c.Assert(response.memTracker.BytesConsumed(), Equals, int64(0))
@@ -140,8 +137,6 @@ func (s *testSuite) TestSelectWithRuntimeStats(c *C) {
 			c.Fatal("invalid copPlanIDs")
 		}
 	}
-
-	response.Fetch(context.TODO())
 
 	// Test Next.
 	chk := chunk.New(colTypes, 32, 32)
@@ -247,7 +242,6 @@ func (s *testSuite) createSelectStreaming(batch, totalRows int, c *C) (*streamRe
 
 func (s *testSuite) TestSelectStreaming(c *C) {
 	response, colTypes := s.createSelectStreaming(1, 2, c)
-	response.Fetch(context.TODO())
 
 	// Test Next.
 	chk := chunk.New(colTypes, 32, 32)
@@ -267,7 +261,6 @@ func (s *testSuite) TestSelectStreaming(c *C) {
 
 func (s *testSuite) TestSelectStreamingWithNextRaw(c *C) {
 	response, _ := s.createSelectStreaming(1, 2, c)
-	response.Fetch(context.TODO())
 	data, err := response.NextRaw(context.TODO())
 	c.Assert(err, IsNil)
 	c.Assert(len(data), Equals, 16)
@@ -275,7 +268,6 @@ func (s *testSuite) TestSelectStreamingWithNextRaw(c *C) {
 
 func (s *testSuite) TestSelectStreamingChunkSize(c *C) {
 	response, colTypes := s.createSelectStreaming(100, 1000000, c)
-	response.Fetch(context.TODO())
 	s.testChunkSize(response, colTypes, c)
 	c.Assert(response.Close(), IsNil)
 }
@@ -343,8 +335,6 @@ func (s *testSuite) TestAnalyze(c *C) {
 	c.Assert(result.label, Equals, "analyze")
 	c.Assert(result.sqlType, Equals, "internal")
 
-	response.Fetch(context.TODO())
-
 	bytes, err := response.NextRaw(context.TODO())
 	c.Assert(err, IsNil)
 	c.Assert(len(bytes), Equals, 16)
@@ -367,8 +357,6 @@ func (s *testSuite) TestChecksum(c *C) {
 	c.Assert(ok, IsTrue)
 	c.Assert(result.label, Equals, "checksum")
 	c.Assert(result.sqlType, Equals, "general")
-
-	response.Fetch(context.TODO())
 
 	bytes, err := response.NextRaw(context.TODO())
 	c.Assert(err, IsNil)
@@ -519,7 +507,6 @@ func BenchmarkSelectResponseChunk_BigResponse(b *testing.B) {
 		s.sctx.GetSessionVars().InitChunkSize = 32
 		s.sctx.GetSessionVars().MaxChunkSize = 1024
 		selectResult, colTypes := createSelectNormal(4000, 20000, s.sctx)
-		selectResult.Fetch(context.TODO())
 		chk := chunk.NewChunkWithCapacity(colTypes, 1024)
 		b.StartTimer()
 		for {
@@ -544,7 +531,6 @@ func BenchmarkSelectResponseChunk_SmallResponse(b *testing.B) {
 		s.sctx.GetSessionVars().InitChunkSize = 32
 		s.sctx.GetSessionVars().MaxChunkSize = 1024
 		selectResult, colTypes := createSelectNormal(32, 3200, s.sctx)
-		selectResult.Fetch(context.TODO())
 		chk := chunk.NewChunkWithCapacity(colTypes, 1024)
 		b.StartTimer()
 		for {

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -61,8 +61,6 @@ var (
 
 // SelectResult is an iterator of coprocessor partial results.
 type SelectResult interface {
-	// Fetch fetches partial results from client.
-	Fetch(context.Context)
 	// NextRaw gets the next raw result.
 	NextRaw(context.Context) ([]byte, error)
 	// Next reads the data into chunk.
@@ -101,9 +99,6 @@ type selectResult struct {
 	memTracker       *memory.Tracker
 
 	stats *selectResultRuntimeStats
-}
-
-func (r *selectResult) Fetch(ctx context.Context) {
 }
 
 func (r *selectResult) fetchResp(ctx context.Context) error {

--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -49,8 +49,6 @@ type streamResult struct {
 	durationReported bool
 }
 
-func (r *streamResult) Fetch(context.Context) {}
-
 func (r *streamResult) Next(ctx context.Context, chk *chunk.Chunk) error {
 	chk.Reset()
 	for !chk.IsFull() {

--- a/executor/admin.go
+++ b/executor/admin.go
@@ -135,7 +135,6 @@ func (e *CheckIndexRangeExec) Open(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	e.result.Fetch(ctx)
 	return nil
 }
 
@@ -285,7 +284,6 @@ func (e *RecoverIndexExec) buildTableScan(ctx context.Context, txn kv.Transactio
 	if err != nil {
 		return nil, err
 	}
-	result.Fetch(ctx)
 	return result, nil
 }
 
@@ -748,7 +746,6 @@ func (e *CleanupIndexExec) buildIndexScan(ctx context.Context, txn kv.Transactio
 	if err != nil {
 		return nil, err
 	}
-	result.Fetch(ctx)
 	return result, nil
 }
 

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -353,7 +353,6 @@ func (e *AnalyzeIndexExec) fetchAnalyzeResult(ranges []*ranger.Range, isNullRang
 	if err != nil {
 		return err
 	}
-	result.Fetch(ctx)
 	if isNullRange {
 		e.countNullRes = result
 	} else {
@@ -620,7 +619,6 @@ func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectRe
 	if err != nil {
 		return nil, err
 	}
-	result.Fetch(ctx)
 	return result, nil
 }
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3431,7 +3431,6 @@ func (builder *dataReaderBuilder) buildTableReaderBase(ctx context.Context, e *T
 	if err != nil {
 		return nil, err
 	}
-	result.Fetch(ctx)
 	e.resultHandler.open(nil, result)
 	return e, nil
 }

--- a/executor/checksum.go
+++ b/executor/checksum.go
@@ -132,7 +132,6 @@ func (e *ChecksumTableExec) handleChecksumRequest(req *kv.Request) (resp *tipb.C
 	if err != nil {
 		return nil, err
 	}
-	res.Fetch(ctx)
 	defer func() {
 		if err1 := res.Close(); err1 != nil {
 			err = err1

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -288,7 +288,6 @@ func (e *IndexReaderExecutor) open(ctx context.Context, kvRanges []kv.KeyRange) 
 		e.feedback.Invalidate()
 		return err
 	}
-	e.result.Fetch(ctx)
 	return nil
 }
 
@@ -479,7 +478,6 @@ func (e *IndexLookUpExecutor) startIndexWorker(ctx context.Context, kvRanges []k
 	if err != nil {
 		return err
 	}
-	result.Fetch(ctx)
 	worker := &indexWorker{
 		idxLookup:       e,
 		workCh:          workCh,

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -211,7 +211,6 @@ func (e *IndexMergeReaderExecutor) startPartialIndexWorker(ctx context.Context, 
 		return err
 	}
 
-	result.Fetch(ctx)
 	worker := &partialIndexWorker{
 		stats:        e.stats,
 		idxID:        e.getPartitalPlanID(workID),

--- a/executor/mpp_gather.go
+++ b/executor/mpp_gather.go
@@ -126,7 +126,6 @@ func (e *MPPGather) Open(ctx context.Context) (err error) {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	e.respIter.Fetch(ctx)
 	return nil
 }
 

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -242,7 +242,6 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	if err != nil {
 		return nil, err
 	}
-	result.Fetch(ctx)
 	return result, nil
 }
 

--- a/executor/table_readers_required_rows_test.go
+++ b/executor/table_readers_required_rows_test.go
@@ -42,7 +42,6 @@ type requiredRowsSelectResult struct {
 	numNextCalled   int
 }
 
-func (r *requiredRowsSelectResult) Fetch(context.Context)                   {}
 func (r *requiredRowsSelectResult) NextRaw(context.Context) ([]byte, error) { return nil, nil }
 func (r *requiredRowsSelectResult) Close() error                            { return nil }
 

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2
 	github.com/pierrec/lz4 v2.5.2+incompatible // indirect
 	github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19
-	github.com/pingcap/br v5.0.0-nightly.0.20210329063924-86407e1a7324+incompatible
+	github.com/pingcap/br v5.0.0-nightly.0.20210407061032-be5523713acf+incompatible
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
 	github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19 h1:IXpGy7y9HyoShA
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19/go.mod h1:LyrqUOHZrUDf9oGi1yoz1+qw9ckSIhQb5eMa1acOLNQ=
 github.com/pingcap/br v5.0.0-nightly.0.20210329063924-86407e1a7324+incompatible h1:jvboV3W5zD0N4zyVzqBvGOzb/6MxUW1SIT8hw51Fgko=
 github.com/pingcap/br v5.0.0-nightly.0.20210329063924-86407e1a7324+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
+github.com/pingcap/br v5.0.0-nightly.0.20210407061032-be5523713acf+incompatible h1:pkfMiswYXWh4W8ehyOTQxaxQzSvP8NCeVfc2LxmQAAg=
+github.com/pingcap/br v5.0.0-nightly.0.20210407061032-be5523713acf+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=
 github.com/pingcap/check v0.0.0-20191107115940-caf2b9e6ccf4/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=
 github.com/pingcap/check v0.0.0-20191216031241-8a5a85928f12/go.mod h1:PYMCGwN0JHjoqGr3HrZoD+b8Tgx8bKnArhSq8YVzUMc=

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,6 @@ github.com/pierrec/lz4 v2.5.2+incompatible h1:WCjObylUIOlKy/+7Abdn34TLIkXiA4UWUM
 github.com/pierrec/lz4 v2.5.2+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19 h1:IXpGy7y9HyoShAFmzW2OPF0xCA5EOoSTyZHwsgYk9Ro=
 github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19/go.mod h1:LyrqUOHZrUDf9oGi1yoz1+qw9ckSIhQb5eMa1acOLNQ=
-github.com/pingcap/br v5.0.0-nightly.0.20210329063924-86407e1a7324+incompatible h1:jvboV3W5zD0N4zyVzqBvGOzb/6MxUW1SIT8hw51Fgko=
-github.com/pingcap/br v5.0.0-nightly.0.20210329063924-86407e1a7324+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
 github.com/pingcap/br v5.0.0-nightly.0.20210407061032-be5523713acf+incompatible h1:pkfMiswYXWh4W8ehyOTQxaxQzSvP8NCeVfc2LxmQAAg=
 github.com/pingcap/br v5.0.0-nightly.0.20210407061032-be5523713acf+incompatible/go.mod h1:ymVmo50lQydxib0tmK5hHk4oteB7hZ0IMCArunwy3UQ=
 github.com/pingcap/check v0.0.0-20190102082844-67f458068fc8/go.mod h1:B1+S9LNcuMyLH/4HMTViQOJevkGiik3wW2AN9zb2fNQ=


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #23880 

Problem Summary: The `Fetch(context.Context)` interface is removed in #13274, but related code is not cleaned. The implementation of `Fetch(context.Context)` is empty, so this PR is trivial. Follow [br#990](https://github.com/pingcap/br/pull/990)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
