### PR TITLE
planner: fix point-get response's original name

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1029,6 +1029,7 @@ func buildSchemaFromFields(
 				TblName:     tblName,
 				OrigColName: col.Name,
 				ColName:     asName,
+				OrigColName: col.Name,
 			})
 			columns = append(columns, colInfoToColumn(col, len(columns)))
 		}

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -410,6 +410,18 @@ func (s *testSessionSuite) TestAffectedRows(c *C) {
 	c.Assert(int(tk.Se.AffectedRows()), Equals, 2)
 }
 
+func (s *testSessionSuite3) TestOriginalColName(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int primary key, v int)")
+	rs, err := tk.Exec("select id as i from t")
+	c.Assert(err, IsNil)
+	c.Assert(rs.Fields()[0].Column.Name.L, Equals, "id")
+	rs, err = tk.Exec("select id as i from t where id = 1")
+	c.Assert(err, IsNil)
+	c.Assert(rs.Fields()[0].Column.Name.L, Equals, "id")
+}
+
 func (s *testSessionSuite3) TestLastMessage(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #23921 <!-- REMOVE this line if no issue to close -->

Problem Summary:

point-get executor not set original name property

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed, How it Works:

tiny change, just set original name property

### Related changes

- Need to cherry-pick to the release branch?

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test 

```
execute issue's script and pcap check response packet
```

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix point-get statement return alias name as original name<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pingcap/tidb/23922)
<!-- Reviewable:end -->
