### PR TITLE
Revert "*: don't allocate SessionIndexUsageCollector when indexUsageLease equals 0"

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -2092,9 +2092,7 @@ func CreateSessionWithOpt(store kv.Storage, opt *Opt) (Session, error) {
 	// which periodically updates stats using the collected data.
 	if do.StatsHandle() != nil && do.StatsUpdating() {
 		s.statsCollector = do.StatsHandle().NewSessionStatsCollector()
-		if GetIndexUsageSyncLease() > 0 {
-			s.idxUsageCollector = do.StatsHandle().NewSessionIndexUsageCollector()
-		}
+		s.idxUsageCollector = do.StatsHandle().NewSessionIndexUsageCollector()
 	}
 
 	return s, nil

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -65,7 +65,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 
 	ddlLease := time.Duration(atomic.LoadInt64(&schemaLease))
 	statisticLease := time.Duration(atomic.LoadInt64(&statsLease))
-	idxUsageSyncLease := GetIndexUsageSyncLease()
+	idxUsageSyncLease := time.Duration(atomic.LoadInt64(&indexUsageSyncLease))
 	err = util.RunWithRetry(util.DefaultMaxRetries, util.RetryInterval, func() (retry bool, err1 error) {
 		logutil.BgLogger().Info("new domain",
 			zap.String("store", store.UUID()),
@@ -159,11 +159,6 @@ func SetStatsLease(lease time.Duration) {
 // SetIndexUsageSyncLease changes the default index usage sync lease time for loading info.
 func SetIndexUsageSyncLease(lease time.Duration) {
 	atomic.StoreInt64(&indexUsageSyncLease, int64(lease))
-}
-
-// GetIndexUsageSyncLease returns the index usage sync lease time.
-func GetIndexUsageSyncLease() time.Duration {
-	return time.Duration(atomic.LoadInt64(&indexUsageSyncLease))
 }
 
 // DisableStats4Test disables the stats for tests.

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -215,24 +215,3 @@ func (s *testMainSuite) TestKeysNeedLock(c *C) {
 	c.Assert(flag.HasPresumeKeyNotExists(), IsTrue)
 	c.Assert(keyNeedToLock(indexKey, deleteVal, flag), IsTrue)
 }
-
-func (s *testMainSuite) TestIndexUsageSyncLease(c *C) {
-	store, err := mockstore.NewMockStore()
-	c.Assert(err, IsNil)
-	do, err := BootstrapSession(store)
-	c.Assert(err, IsNil)
-	do.SetStatsUpdating(true)
-	st, err := CreateSessionWithOpt(store, nil)
-	c.Assert(err, IsNil)
-	se, ok := st.(*session)
-	c.Assert(ok, IsTrue)
-	c.Assert(se.idxUsageCollector, IsNil)
-
-	SetIndexUsageSyncLease(1)
-	defer SetIndexUsageSyncLease(0)
-	st, err = CreateSessionWithOpt(store, nil)
-	c.Assert(err, IsNil)
-	se, ok = st.(*session)
-	c.Assert(ok, IsTrue)
-	c.Assert(se.idxUsageCollector, NotNil)
-}

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -1995,8 +1995,6 @@ type statsSerialSuite struct {
 
 func (s *statsSerialSuite) TestIndexUsageInformation(c *C) {
 	defer cleanEnv(c, s.store, s.do)
-	session.SetIndexUsageSyncLease(1)
-	defer session.SetIndexUsageSyncLease(0)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_idx(a int, b int)")
@@ -2036,8 +2034,6 @@ func (s *statsSerialSuite) TestIndexUsageInformation(c *C) {
 
 func (s *statsSerialSuite) TestGCIndexUsageInformation(c *C) {
 	defer cleanEnv(c, s.store, s.do)
-	session.SetIndexUsageSyncLease(1)
-	defer session.SetIndexUsageSyncLease(0)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t_idx(a int, b int)")


### PR DESCRIPTION
Reverts pingcap/tidb#23861
Revert "*: don't allocate SessionIndexUsageCollector when indexUsageLease equals 0"

### Release note <!-- bugfixes or new feature need a release note -->

- No release note