### PR TITLE
store/tikv:use unionstore.Iterator instead of kv.Iterator

### DIFF
--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -328,7 +328,7 @@ func (s *tikvStore) BeginWithOption(option kv.TransactionOption) (kv.Transaction
 // GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
 // if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
 func (s *tikvStore) GetSnapshot(ver kv.Version) kv.Snapshot {
-	return s.KVStore.GetSnapshot(ver.Ver)
+	return txn_driver.NewSnapshot(s.KVStore.GetSnapshot(ver.Ver))
 }
 
 // CurrentVersion returns current max committed version with the given txnScope (local or global).

--- a/store/driver/txn/snapshot.go
+++ b/store/driver/txn/snapshot.go
@@ -25,6 +25,11 @@ type tikvSnapshot struct {
 	*tikv.KVSnapshot
 }
 
+// NewSnapshot creates a kv.Snapshot with tikv.KVSnapshot.
+func NewSnapshot(snapshot *tikv.KVSnapshot) kv.Snapshot {
+	return &tikvSnapshot{snapshot}
+}
+
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
 // The map will not contain nonexistent keys.
 func (s *tikvSnapshot) BatchGet(ctx context.Context, keys []kv.Key) (map[string][]byte, error) {

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -60,8 +60,49 @@ func (txn *tikvTxn) GetSnapshot() kv.Snapshot {
 	return &tikvSnapshot{txn.KVTxn.GetSnapshot()}
 }
 
+// Iter creates an Iterator positioned on the first entry that k <= entry's key.
+// If such entry is not found, it returns an invalid Iterator with no error.
+// It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
+// The Iterator must be Closed after use.
+func (txn *tikvTxn) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
+	return txn.KVTxn.Iter(k, upperBound)
+}
+
+// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
+// The returned iterator will iterate from greater key to smaller key.
+// If k is nil, the returned iterator will be positioned at the last key.
+// TODO: Add lower bound limit
+func (txn *tikvTxn) IterReverse(k kv.Key) (kv.Iterator, error) {
+	return txn.KVTxn.IterReverse(k)
+}
+
+type memBuffer struct {
+	*unionstore.MemDB
+}
+
 func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {
-	return txn.KVTxn.GetMemBuffer()
+	return &memBuffer{txn.KVTxn.GetMemBuffer()}
+}
+
+// Iter creates an Iterator positioned on the first entry that k <= entry's key.
+// If such entry is not found, it returns an invalid Iterator with no error.
+// It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
+// The Iterator must be Closed after use.
+func (m *memBuffer) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
+	return m.MemDB.Iter(k, upperBound)
+}
+
+// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
+// The returned iterator will iterate from greater key to smaller key.
+// If k is nil, the returned iterator will be positioned at the last key.
+// TODO: Add lower bound limit
+func (m *memBuffer) IterReverse(k kv.Key) (kv.Iterator, error) {
+	return m.MemDB.IterReverse(k)
+}
+
+// SnapshotIter returns a Iterator for a snapshot of MemBuffer.
+func (m *memBuffer) SnapshotIter(k, upperbound kv.Key) kv.Iterator {
+	return m.MemDB.SnapshotIter(k, upperbound)
 }
 
 func (txn *tikvTxn) GetUnionStore() kv.UnionStore {
@@ -114,5 +155,17 @@ type tikvUnionStore struct {
 }
 
 func (u *tikvUnionStore) GetMemBuffer() kv.MemBuffer {
-	return u.KVUnionStore.GetMemBuffer()
+	return &memBuffer{u.KVUnionStore.GetMemBuffer()}
+}
+
+func (u *tikvUnionStore) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
+	return u.KVUnionStore.Iter(k, upperBound)
+}
+
+// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
+// The returned iterator will iterate from greater key to smaller key.
+// If k is nil, the returned iterator will be positioned at the last key.
+// TODO: Add lower bound limit
+func (u *tikvUnionStore) IterReverse(k kv.Key) (kv.Iterator, error) {
+	return u.KVUnionStore.IterReverse(k)
 }

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -138,7 +138,7 @@ func (s *testGCWorkerSuite) mustGetNone(c *C, key string, ts uint64) {
 	if err != nil {
 		// Unistore's gc is based on compaction filter.
 		// So skip the error check if err == nil.
-		c.Assert(err, Equals, kv.ErrNotExist)
+		c.Assert(kv.ErrNotExist.Equal(err), IsTrue)
 	}
 }
 

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -113,7 +113,7 @@ func (s *mockStorage) BeginWithOption(option kv.TransactionOption) (kv.Transacti
 // GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
 // if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
 func (s *mockStorage) GetSnapshot(ver kv.Version) kv.Snapshot {
-	return s.KVStore.GetSnapshot(ver.Ver)
+	return driver.NewSnapshot(s.KVStore.GetSnapshot(ver.Ver))
 }
 
 // CurrentVersion returns current max committed version with the given txnScope (local or global).

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"github.com/pingcap/tidb/store/tikv/unionstore"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/util/execdetails"
 	"go.uber.org/zap"
@@ -534,13 +535,13 @@ func (s *KVSnapshot) mergeExecDetail(detail *pb.ExecDetailsV2) {
 }
 
 // Iter return a list of key-value pair after `k`.
-func (s *KVSnapshot) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterator, error) {
+func (s *KVSnapshot) Iter(k tidbkv.Key, upperBound tidbkv.Key) (unionstore.Iterator, error) {
 	scanner, err := newScanner(s, k, upperBound, scanBatchSize, false)
 	return scanner, errors.Trace(err)
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
-func (s *KVSnapshot) IterReverse(k tidbkv.Key) (tidbkv.Iterator, error) {
+func (s *KVSnapshot) IterReverse(k tidbkv.Key) (unionstore.Iterator, error) {
 	scanner, err := newScanner(s, nil, k, scanBatchSize, true)
 	return scanner, errors.Trace(err)
 }

--- a/store/tikv/tests/scan_test.go
+++ b/store/tikv/tests/scan_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
+	"github.com/pingcap/tidb/store/tikv/unionstore"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"go.uber.org/zap"
 )
@@ -84,7 +85,7 @@ func (s *testScanSuite) makeValue(i int) []byte {
 }
 
 func (s *testScanSuite) TestScan(c *C) {
-	check := func(c *C, scan tidbkv.Iterator, rowNum int, keyOnly bool) {
+	check := func(c *C, scan unionstore.Iterator, rowNum int, keyOnly bool) {
 		for i := 0; i < rowNum; i++ {
 			k := scan.Key()
 			expectedKey := s.makeKey(i)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -170,12 +170,12 @@ func (txn *KVTxn) String() string {
 // If such entry is not found, it returns an invalid Iterator with no error.
 // It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
 // The Iterator must be Closed after use.
-func (txn *KVTxn) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterator, error) {
+func (txn *KVTxn) Iter(k tidbkv.Key, upperBound tidbkv.Key) (unionstore.Iterator, error) {
 	return txn.us.Iter(k, upperBound)
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
-func (txn *KVTxn) IterReverse(k tidbkv.Key) (tidbkv.Iterator, error) {
+func (txn *KVTxn) IterReverse(k tidbkv.Key) (unionstore.Iterator, error) {
 	return txn.us.IterReverse(k)
 }
 

--- a/store/tikv/unionstore/memdb_iterator.go
+++ b/store/tikv/unionstore/memdb_iterator.go
@@ -34,7 +34,7 @@ type MemdbIterator struct {
 // If such entry is not found, it returns an invalid Iterator with no error.
 // It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
 // The Iterator must be Closed after use.
-func (db *MemDB) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterator, error) {
+func (db *MemDB) Iter(k tidbkv.Key, upperBound tidbkv.Key) (Iterator, error) {
 	i := &MemdbIterator{
 		db:    db,
 		start: k,
@@ -48,7 +48,7 @@ func (db *MemDB) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterator, err
 // The returned iterator will iterate from greater key to smaller key.
 // If k is nil, the returned iterator will be positioned at the last key.
 // TODO: Add lower bound limit
-func (db *MemDB) IterReverse(k tidbkv.Key) (tidbkv.Iterator, error) {
+func (db *MemDB) IterReverse(k tidbkv.Key) (Iterator, error) {
 	i := &MemdbIterator{
 		db:      db,
 		end:     k,

--- a/store/tikv/unionstore/memdb_snapshot.go
+++ b/store/tikv/unionstore/memdb_snapshot.go
@@ -28,7 +28,7 @@ func (db *MemDB) SnapshotGetter() tidbkv.Getter {
 }
 
 // SnapshotIter returns a Iterator for a snapshot of MemBuffer.
-func (db *MemDB) SnapshotIter(start, end tidbkv.Key) tidbkv.Iterator {
+func (db *MemDB) SnapshotIter(start, end tidbkv.Key) Iterator {
 	it := &memdbSnapIter{
 		MemdbIterator: &MemdbIterator{
 			db:    db,

--- a/store/tikv/unionstore/memdb_test.go
+++ b/store/tikv/unionstore/memdb_test.go
@@ -32,7 +32,6 @@ import (
 type Key = tidbkv.Key
 type KeyFlags = kv.KeyFlags
 type StagingHandle = tidbkv.StagingHandle
-type Iterator = tidbkv.Iterator
 
 func init() {
 	testMode = true

--- a/store/tikv/unionstore/mock.go
+++ b/store/tikv/unionstore/mock.go
@@ -46,11 +46,11 @@ func (s *mockSnapshot) BatchGet(ctx context.Context, keys []kv.Key) (map[string]
 	return m, nil
 }
 
-func (s *mockSnapshot) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
+func (s *mockSnapshot) Iter(k kv.Key, upperBound kv.Key) (Iterator, error) {
 	return s.store.Iter(k, upperBound)
 }
 
-func (s *mockSnapshot) IterReverse(k kv.Key) (kv.Iterator, error) {
+func (s *mockSnapshot) IterReverse(k kv.Key) (Iterator, error) {
 	return s.store.IterReverse(k)
 }
 

--- a/store/tikv/unionstore/union_iter.go
+++ b/store/tikv/unionstore/union_iter.go
@@ -21,8 +21,8 @@ import (
 
 // UnionIter is the iterator on an UnionStore.
 type UnionIter struct {
-	dirtyIt    tidbkv.Iterator
-	snapshotIt tidbkv.Iterator
+	dirtyIt    Iterator
+	snapshotIt Iterator
 
 	dirtyValid    bool
 	snapshotValid bool
@@ -33,7 +33,7 @@ type UnionIter struct {
 }
 
 // NewUnionIter returns a union iterator for BufferStore.
-func NewUnionIter(dirtyIt tidbkv.Iterator, snapshotIt tidbkv.Iterator, reverse bool) (*UnionIter, error) {
+func NewUnionIter(dirtyIt Iterator, snapshotIt Iterator, reverse bool) (*UnionIter, error) {
 	it := &UnionIter{
 		dirtyIt:       dirtyIt,
 		snapshotIt:    snapshotIt,

--- a/store/tikv/unionstore/union_store.go
+++ b/store/tikv/unionstore/union_store.go
@@ -20,16 +20,43 @@ import (
 	"github.com/pingcap/tidb/store/tikv/kv"
 )
 
+// Iterator is the interface for a iterator on KV store.
+type Iterator interface {
+	Valid() bool
+	Key() tidbkv.Key
+	Value() []byte
+	Next() error
+	Close()
+}
+
+// uSnapshot defines the interface for the snapshot fetched from KV store.
+type uSnapshot interface {
+	// Get gets the value for key k from kv store.
+	// If corresponding kv pair does not exist, it returns nil and ErrNotExist.
+	Get(ctx context.Context, k tidbkv.Key) ([]byte, error)
+	// Iter creates an Iterator positioned on the first entry that k <= entry's key.
+	// If such entry is not found, it returns an invalid Iterator with no error.
+	// It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.
+	// The Iterator must be Closed after use.
+	Iter(k tidbkv.Key, upperBound tidbkv.Key) (Iterator, error)
+
+	// IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
+	// The returned iterator will iterate from greater key to smaller key.
+	// If k is nil, the returned iterator will be positioned at the last key.
+	// TODO: Add lower bound limit
+	IterReverse(k tidbkv.Key) (Iterator, error)
+}
+
 // KVUnionStore is an in-memory Store which contains a buffer for write and a
 // snapshot for read.
 type KVUnionStore struct {
 	memBuffer *MemDB
-	snapshot  tidbkv.Snapshot
+	snapshot  uSnapshot
 	opts      options
 }
 
 // NewUnionStore builds a new unionStore.
-func NewUnionStore(snapshot tidbkv.Snapshot) *KVUnionStore {
+func NewUnionStore(snapshot uSnapshot) *KVUnionStore {
 	return &KVUnionStore{
 		snapshot:  snapshot,
 		memBuffer: newMemDB(),
@@ -58,7 +85,7 @@ func (us *KVUnionStore) Get(ctx context.Context, k tidbkv.Key) ([]byte, error) {
 }
 
 // Iter implements the Retriever interface.
-func (us *KVUnionStore) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterator, error) {
+func (us *KVUnionStore) Iter(k tidbkv.Key, upperBound tidbkv.Key) (Iterator, error) {
 	bufferIt, err := us.memBuffer.Iter(k, upperBound)
 	if err != nil {
 		return nil, err
@@ -71,7 +98,7 @@ func (us *KVUnionStore) Iter(k tidbkv.Key, upperBound tidbkv.Key) (tidbkv.Iterat
 }
 
 // IterReverse implements the Retriever interface.
-func (us *KVUnionStore) IterReverse(k tidbkv.Key) (tidbkv.Iterator, error) {
+func (us *KVUnionStore) IterReverse(k tidbkv.Key) (Iterator, error) {
 	bufferIt, err := us.memBuffer.IterReverse(k)
 	if err != nil {
 		return nil, err

--- a/store/tikv/unionstore/union_store_test.go
+++ b/store/tikv/unionstore/union_store_test.go
@@ -125,7 +125,7 @@ func (s *testUnionStoreSuite) TestIterReverse(c *C) {
 	checkIterator(c, iter, [][]byte{[]byte("2"), []byte("0")}, [][]byte{[]byte("2"), []byte("0")})
 }
 
-func checkIterator(c *C, iter kv.Iterator, keys [][]byte, values [][]byte) {
+func checkIterator(c *C, iter Iterator, keys [][]byte, values [][]byte) {
 	defer iter.Close()
 	c.Assert(len(keys), Equals, len(values))
 	for i, k := range keys {


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR tries to use unionstore.Iterator instead of kv.Iterator in tikv package.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note