### PR TITLE
kv/kv.go:remove UpdateFlags from interface MemBuffer

### DIFF
--- a/kv/kv.go
+++ b/kv/kv.go
@@ -116,8 +116,6 @@ type MemBuffer interface {
 	GetFlags(Key) (tikvstore.KeyFlags, error)
 	// SetWithFlags put key-value into the last active staging buffer with the given KeyFlags.
 	SetWithFlags(Key, []byte, ...tikvstore.FlagsOp) error
-	// UpdateFlags update the flags associated with key.
-	UpdateFlags(Key, ...tikvstore.FlagsOp)
 	// DeleteWithFlags delete key with the given KeyFlags
 	DeleteWithFlags(Key, ...tikvstore.FlagsOp) error
 

--- a/store/driver/txn/unionstore_driver.go
+++ b/store/driver/txn/unionstore_driver.go
@@ -130,10 +130,6 @@ func (m *memBuffer) SetWithFlags(key kv.Key, value []byte, ops ...kv.FlagsOp) er
 	return m.MemDB.SetWithFlags(key, value, ops...)
 }
 
-func (m *memBuffer) UpdateFlags(key kv.Key, ops ...kv.FlagsOp) {
-	m.MemDB.UpdateFlags(key, ops...)
-}
-
 // Iter creates an Iterator positioned on the first entry that k <= entry's key.
 // If such entry is not found, it returns an invalid Iterator with no error.
 // It yields only keys that < upperBound. If upperBound is nil, it means the upperBound is unbounded.


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR removes `UpdateFlags` from interface `MemBuffer` since we do not need it anymore.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note