### PR TITLE
tests: fix the graceshutdown e2e that is failing

### DIFF
--- a/tests/graceshutdown/go.mod
+++ b/tests/graceshutdown/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/juju/errors v0.0.0-20200330140219-3fe23663418f
 	github.com/juju/testing v0.0.0-20210302031854-2c7ee8570c07 // indirect
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
-	github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9
+	github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463
+	go.uber.org/zap v1.12.0
 )

--- a/tests/graceshutdown/go.sum
+++ b/tests/graceshutdown/go.sum
@@ -60,6 +60,8 @@ github.com/pingcap/errors v0.11.0 h1:DCJQB8jrHbQ1VVlMFIrbj2ApScNNotVmkSNplu2yUt4
 github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9 h1:AJD9pZYm72vMgPcQDww9rkZ1DnWfl0pXV3BOWlkYIjA=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
+github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463 h1:Jboj+s4jSCp5E1WDgmRUv5rIFKFHaaSWuSZ4wMwXIcc=
+github.com/pingcap/log v0.0.0-20200828042413-fce0951f1463/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/tests/graceshutdown/graceshutdown_test.go
+++ b/tests/graceshutdown/graceshutdown_test.go
@@ -107,7 +107,7 @@ func (s *TestGracefulShutdownSuite) connectTiDB(port int) (db *sql.DB, err error
 
 		err = db.Close()
 		if err != nil {
-			log.Warnf("close db failed, retry count %d err %v", i, err)
+			log.Warn("close db failed", zap.Int("retry count", i), zap.Error(err))
 			break
 		}
 		time.Sleep(sleepTime)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

### What is changed and how it works?

I tried to enable e2e testing yesterday after https://github.com/pingcap/tidb/pull/23260 is merged, but it failed again due to the graceshutdown test, see https://internal.pingcap.net/idc-jenkins/blue/organizations/jenkins/tidb_e2e_tests/detail/tidb_e2e_tests/3128/pipeline, and this PR fixed it.

What's Changed:

How it Works:

update the log.Warnf to log.Warn

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
