### PR TITLE
store/tikv:Fix a possible boundary bug

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -888,10 +888,11 @@ func (c *RegionCache) LoadRegionsInKeyRange(bo *Backoffer, startKey, endKey []by
 		}
 		regions = append(regions, batchRegions...)
 		endRegion := batchRegions[len(batchRegions)-1]
-		if endRegion.ContainsByEnd(endKey) {
+		regionEndKey := endRegion.EndKey()
+		if endRegion.ContainsByEnd(endKey) || bytes.Equal(regionEndKey, endKey) {
 			break
 		}
-		startKey = endRegion.EndKey()
+		startKey = regionEndKey
 	}
 	return
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

When the `endRegion.EndKey()` completely equals to `endkey` param in `LoadRegionsInKeyRange`, there may be a boundary problem, which will leader to a `PD returned no region` error. However there maybe some regions in previous scanning before.

### What is changed and how it works?

What's Changed:
Compare `endRegion.EndKey()` to `endkey` in `LoadRegionsInKeyRange`.
How it Works:
Avoid to return `PD returned no region` error.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Boundary bug fix in region cache.