### PR TITLE
store/mockstore: move mock storage to standalone package

### DIFF
--- a/store/mockstore/mockstorage/storage.go
+++ b/store/mockstore/mockstorage/storage.go
@@ -1,0 +1,115 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mockstorage
+
+import (
+	"crypto/tls"
+
+	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/copr"
+	driver "github.com/pingcap/tidb/store/driver/txn"
+	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/config"
+	"github.com/pingcap/tidb/store/tikv/oracle"
+)
+
+// Wraps tikv.KVStore and make it compatible with kv.Storage.
+type mockStorage struct {
+	*tikv.KVStore
+	*copr.Store
+	memCache kv.MemManager
+}
+
+// NewMockStorage wraps tikv.KVStore as kv.Storage.
+func NewMockStorage(tikvStore *tikv.KVStore) kv.Storage {
+	coprConfig := config.DefaultConfig().TiKVClient.CoprCache
+	coprStore, err := copr.NewStore(tikvStore, &coprConfig)
+	if err != nil {
+		panic(err)
+	}
+	return &mockStorage{
+		KVStore:  tikvStore,
+		Store:    coprStore,
+		memCache: kv.NewCacheDB(),
+	}
+}
+
+func (s *mockStorage) EtcdAddrs() ([]string, error) {
+	return nil, nil
+}
+
+func (s *mockStorage) TLSConfig() *tls.Config {
+	return nil
+}
+
+// GetMemCache return memory mamager of the storage
+func (s *mockStorage) GetMemCache() kv.MemManager {
+	return s.memCache
+}
+
+func (s *mockStorage) StartGCWorker() error {
+	return nil
+}
+
+func (s *mockStorage) Name() string {
+	return "mock-storage"
+}
+
+func (s *mockStorage) Describe() string {
+	return ""
+}
+
+// Begin a global transaction.
+func (s *mockStorage) Begin() (kv.Transaction, error) {
+	txn, err := s.KVStore.Begin()
+	return newTiKVTxn(txn, err)
+}
+
+// BeginWithOption begins a transaction with given option
+func (s *mockStorage) BeginWithOption(option kv.TransactionOption) (kv.Transaction, error) {
+	txnScope := option.TxnScope
+	if txnScope == "" {
+		txnScope = oracle.GlobalTxnScope
+	}
+	if option.StartTS != nil {
+		return newTiKVTxn(s.BeginWithStartTS(txnScope, *option.StartTS))
+	} else if option.PrevSec != nil {
+		return newTiKVTxn(s.BeginWithExactStaleness(txnScope, *option.PrevSec))
+	}
+	return newTiKVTxn(s.BeginWithTxnScope(txnScope))
+}
+
+// GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
+// if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
+func (s *mockStorage) GetSnapshot(ver kv.Version) kv.Snapshot {
+	return driver.NewSnapshot(s.KVStore.GetSnapshot(ver.Ver))
+}
+
+// CurrentVersion returns current max committed version with the given txnScope (local or global).
+func (s *mockStorage) CurrentVersion(txnScope string) (kv.Version, error) {
+	ver, err := s.KVStore.CurrentTimestamp(txnScope)
+	return kv.NewVersion(ver), err
+}
+
+func newTiKVTxn(txn *tikv.KVTxn, err error) (kv.Transaction, error) {
+	if err != nil {
+		return nil, err
+	}
+	return driver.NewTiKVTxn(txn), nil
+}
+
+func (s *mockStorage) Close() error {
+	s.Store.Close()
+	return s.KVStore.Close()
+}

--- a/store/mockstore/mocktikv/executor_test.go
+++ b/store/mockstore/mocktikv/executor_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
-	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/pingcap/tidb/store/mockstore/mockstorage"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -48,7 +48,7 @@ func (s *testExecutorSuite) SetUpSuite(c *C) {
 	s.mvccStore = rpcClient.MvccStore
 	store, err := tikv.NewTestTiKVStore(rpcClient, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
-	s.store = mockstore.NewMockStorage(store)
+	s.store = mockstorage.NewMockStorage(store)
 	session.SetSchemaLease(0)
 	session.DisableStats4Test()
 	s.dom, err = session.BootstrapSession(s.store)

--- a/store/mockstore/tikv.go
+++ b/store/mockstore/tikv.go
@@ -16,6 +16,7 @@ package mockstore
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/store/mockstore/mockstorage"
 	"github.com/pingcap/tidb/store/mockstore/mocktikv"
 	"github.com/pingcap/tidb/store/tikv"
 )
@@ -33,5 +34,5 @@ func newMockTikvStore(opt *mockOptions) (kv.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewMockStorage(kvstore), nil
+	return mockstorage.NewMockStorage(kvstore), nil
 }

--- a/store/mockstore/unistore.go
+++ b/store/mockstore/unistore.go
@@ -14,16 +14,11 @@
 package mockstore
 
 import (
-	"crypto/tls"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
-	"github.com/pingcap/tidb/store/copr"
-	driver "github.com/pingcap/tidb/store/driver/txn"
+	"github.com/pingcap/tidb/store/mockstore/mockstorage"
 	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/pingcap/tidb/store/tikv"
-	"github.com/pingcap/tidb/store/tikv/config"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/util"
 )
 
@@ -41,95 +36,5 @@ func newUnistore(opts *mockOptions) (kv.Storage, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewMockStorage(kvstore), nil
-}
-
-// Wraps tikv.KVStore and make it compatible with kv.Storage.
-type mockStorage struct {
-	*tikv.KVStore
-	*copr.Store
-	memCache kv.MemManager
-}
-
-// NewMockStorage wraps tikv.KVStore as kv.Storage.
-func NewMockStorage(tikvStore *tikv.KVStore) kv.Storage {
-	coprConfig := config.DefaultConfig().TiKVClient.CoprCache
-	coprStore, err := copr.NewStore(tikvStore, &coprConfig)
-	if err != nil {
-		panic(err)
-	}
-	return &mockStorage{
-		KVStore:  tikvStore,
-		Store:    coprStore,
-		memCache: kv.NewCacheDB(),
-	}
-}
-
-func (s *mockStorage) EtcdAddrs() ([]string, error) {
-	return nil, nil
-}
-
-func (s *mockStorage) TLSConfig() *tls.Config {
-	return nil
-}
-
-// GetMemCache return memory mamager of the storage
-func (s *mockStorage) GetMemCache() kv.MemManager {
-	return s.memCache
-}
-
-func (s *mockStorage) StartGCWorker() error {
-	return nil
-}
-
-func (s *mockStorage) Name() string {
-	return "mock-storage"
-}
-
-func (s *mockStorage) Describe() string {
-	return ""
-}
-
-// Begin a global transaction.
-func (s *mockStorage) Begin() (kv.Transaction, error) {
-	txn, err := s.KVStore.Begin()
-	return newTiKVTxn(txn, err)
-}
-
-// BeginWithOption begins a transaction with given option
-func (s *mockStorage) BeginWithOption(option kv.TransactionOption) (kv.Transaction, error) {
-	txnScope := option.TxnScope
-	if txnScope == "" {
-		txnScope = oracle.GlobalTxnScope
-	}
-	if option.StartTS != nil {
-		return newTiKVTxn(s.BeginWithStartTS(txnScope, *option.StartTS))
-	} else if option.PrevSec != nil {
-		return newTiKVTxn(s.BeginWithExactStaleness(txnScope, *option.PrevSec))
-	}
-	return newTiKVTxn(s.BeginWithTxnScope(txnScope))
-}
-
-// GetSnapshot gets a snapshot that is able to read any data which data is <= ver.
-// if ver is MaxVersion or > current max committed version, we will use current version for this snapshot.
-func (s *mockStorage) GetSnapshot(ver kv.Version) kv.Snapshot {
-	return driver.NewSnapshot(s.KVStore.GetSnapshot(ver.Ver))
-}
-
-// CurrentVersion returns current max committed version with the given txnScope (local or global).
-func (s *mockStorage) CurrentVersion(txnScope string) (kv.Version, error) {
-	ver, err := s.KVStore.CurrentTimestamp(txnScope)
-	return kv.NewVersion(ver), err
-}
-
-func newTiKVTxn(txn *tikv.KVTxn, err error) (kv.Transaction, error) {
-	if err != nil {
-		return nil, err
-	}
-	return driver.NewTiKVTxn(txn), nil
-}
-
-func (s *mockStorage) Close() error {
-	s.Store.Close()
-	return s.KVStore.Close()
+	return mockstorage.NewMockStorage(kvstore), nil
 }


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Mock mockstorage to standalone package to resolve cycle dependency when I want to split mocktikv into copr and kv.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note