### PR TITLE
store/tikv: ignore all other locks except the first one met by autocommit point select

### DIFF
--- a/store/tikv/snapshot_fail_test.go
+++ b/store/tikv/snapshot_fail_test.go
@@ -139,38 +139,65 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
 }
 
-func (s *testSnapshotFailSuite) TestRetryPointGetWithTS(c *C) {
+func (s *testSnapshotFailSuite) TestRetryMaxTsPointGetSkipLock(c *C) {
 	defer s.cleanup(c)
 
-	snapshot := s.store.GetSnapshot(maxTimestamp)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/snapshotGetTSAsync", `pause`), IsNil)
-	ch := make(chan error)
-	go func() {
-		_, err := snapshot.Get(context.Background(), []byte("k4"))
-		ch <- err
-	}()
-
+	// Prewrite k1 and k2 with async commit but don't commit them
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	err = txn.Set([]byte("k4"), []byte("v4"))
+	err = txn.Set([]byte("k1"), []byte("v1"))
+	c.Assert(err, IsNil)
+	err = txn.Set([]byte("k2"), []byte("v2"))
 	c.Assert(err, IsNil)
 	txn.SetOption(kv.EnableAsyncCommit, true)
-	txn.SetOption(kv.Enable1PC, false)
-	txn.SetOption(kv.GuaranteeLinearizability, false)
-	// Prewrite an async-commit lock and do not commit it.
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", `return`), IsNil)
+
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/twoPCShortLockTTL", "return"), IsNil)
 	committer, err := newTwoPhaseCommitterWithInit(txn, 1)
 	c.Assert(err, IsNil)
-	// Sets its minCommitTS to one second later, so the lock will be ignored by point get.
-	committer.minCommitTS = committer.startTS + (1000 << 18)
 	err = committer.execute(context.Background())
 	c.Assert(err, IsNil)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/snapshotGetTSAsync"), IsNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/twoPCShortLockTTL"), IsNil)
 
-	err = <-ch
-	c.Assert(err, ErrorMatches, ".*key not exist")
+	snapshot := s.store.GetSnapshot(maxTimestamp)
+	getCh := make(chan []byte)
+	go func() {
+		// Sleep a while to make the TTL of the first txn expire, then we make sure we resolve lock by this get
+		time.Sleep(200 * time.Millisecond)
+		c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/beforeSendPointGet", "1*off->pause"), IsNil)
+		res, err := snapshot.Get(context.Background(), []byte("k2"))
+		c.Assert(err, IsNil)
+		getCh <- res
+	}()
+	// The get should be blocked by the failpoint. But the lock should have been resolved.
+	select {
+	case res := <-getCh:
+		c.Errorf("too early %s", string(res))
+	case <-time.After(1 * time.Second):
+	}
 
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing"), IsNil)
+	// Prewrite k1 and k2 again without committing them
+	txn, err = s.store.Begin()
+	c.Assert(err, IsNil)
+	txn.SetOption(kv.EnableAsyncCommit, true)
+	err = txn.Set([]byte("k1"), []byte("v3"))
+	c.Assert(err, IsNil)
+	err = txn.Set([]byte("k2"), []byte("v4"))
+	c.Assert(err, IsNil)
+	committer, err = newTwoPhaseCommitterWithInit(txn, 1)
+	c.Assert(err, IsNil)
+	err = committer.execute(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/beforeSendPointGet"), IsNil)
+
+	// After disabling the failpoint, the get request should bypass the new locks and read the old result
+	select {
+	case res := <-getCh:
+		c.Assert(res, DeepEquals, []byte("v2"))
+	case <-time.After(1 * time.Second):
+		c.Errorf("get timeout")
+	}
 }
 
 func (s *testSnapshotFailSuite) TestRetryPointGetResolveTS(c *C) {


### PR DESCRIPTION
### What is changed and how it works?


This PR reverts https://github.com/pingcap/tidb/pull/22789. In addition, this PR makes point select with max ts ignore all locks except the first one.

The solution is to minimize changes done to the release-5.0 branch.
For the master branch, I think we can use a new protocol that brings the first lock's `start_ts` to reduce invalid retries.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Benchmark result:
<img width="711" alt="图片" src="https://user-images.githubusercontent.com/17217495/114992508-6bdc0e00-9ecd-11eb-893d-f1b3fa88ffb7.png">


### Release note <!-- bugfixes or new feature need a release note -->

- `Fix performance regression of point select.`