### PR TITLE
store/tikv: ignore all locks except the first met lock in autocommit get

### DIFF
--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -480,6 +480,9 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 			if firstLock == nil {
 				firstLock = lock
 			} else if s.version == maxTimestamp && firstLock.TxnID != lock.TxnID {
+				// If it is an autocommit point get, it needs to be blocked only
+				// by the first lock it meets. During retries, if the encountered
+				// lock is different from the first one, we can omit it.
 				cli.resolvedLocks.Put(lock.TxnID)
 				continue
 			}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
-	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/pingcap/tidb/store/tikv/unionstore"
 	"github.com/pingcap/tidb/store/tikv/util"
@@ -414,14 +413,6 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 
 	cli := NewClientHelper(s.store, s.resolvedLocks)
 
-	// Secondary locks or async commit locks cannot be ignored when getting using the max version.
-	// So we concurrently get a TS from PD and use it in retries to avoid unnecessary blocking.
-	var tsFuture oracle.Future
-	if s.version == maxTimestamp {
-		tsFuture = s.store.oracle.GetTimestampAsync(ctx, &oracle.Option{TxnScope: s.txnScope})
-	}
-	failpoint.Inject("snapshotGetTSAsync", nil)
-
 	isStaleness := false
 	var matchStoreLabels []*metapb.StoreLabel
 	s.mu.RLock()
@@ -450,7 +441,10 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 	if len(matchStoreLabels) > 0 {
 		ops = append(ops, WithMatchLabels(matchStoreLabels))
 	}
+
+	var firstLock *Lock
 	for {
+		failpoint.Inject("beforeSendPointGet", nil)
 		loc, err := s.store.regionCache.LocateKey(bo, k)
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -483,25 +477,14 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-
-			snapVer := s.version
-			if s.version == maxTimestamp {
-				newTS, err := tsFuture.Wait()
-				if err != nil {
-					return nil, errors.Trace(err)
-				}
-				s.version = newTS
-				req.Req.(*pb.GetRequest).Version = newTS
-				// skip lock resolving and backoff if the lock does not block the read
-				if newTS < lock.TxnID || newTS < lock.MinCommitTS {
-					continue
-				}
+			if firstLock == nil {
+				firstLock = lock
+			} else if s.version == maxTimestamp && firstLock.TxnID != lock.TxnID {
+				cli.resolvedLocks.Put(lock.TxnID)
+				continue
 			}
 
-			// Use the original snapshot version to resolve locks so we can use MaxUint64
-			// as the callerStartTS if it's an auto-commit point get. This could save us
-			// one write at TiKV by not pushing forward the minCommitTS.
-			msBeforeExpired, err := cli.ResolveLocks(bo, snapVer, []*Lock{lock})
+			msBeforeExpired, err := cli.ResolveLocks(bo, s.version, []*Lock{lock})
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/tikv/tests/snapshot_fail_test.go
+++ b/store/tikv/tests/snapshot_fail_test.go
@@ -140,38 +140,65 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
 }
 
-func (s *testSnapshotFailSuite) TestRetryPointGetWithTS(c *C) {
+func (s *testSnapshotFailSuite) TestRetryMaxTsPointGetSkipLock(c *C) {
 	defer s.cleanup(c)
 
-	snapshot := s.store.GetSnapshot(math.MaxUint64)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/snapshotGetTSAsync", `pause`), IsNil)
-	ch := make(chan error)
-	go func() {
-		_, err := snapshot.Get(context.Background(), []byte("k4"))
-		ch <- err
-	}()
-
+	// Prewrite k1 and k2 with async commit but don't commit them
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	err = txn.Set([]byte("k4"), []byte("v4"))
+	err = txn.Set([]byte("k1"), []byte("v1"))
+	c.Assert(err, IsNil)
+	err = txn.Set([]byte("k2"), []byte("v2"))
 	c.Assert(err, IsNil)
 	txn.SetOption(kv.EnableAsyncCommit, true)
-	txn.SetOption(kv.Enable1PC, false)
-	txn.SetOption(kv.GuaranteeLinearizability, false)
-	// Prewrite an async-commit lock and do not commit it.
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", `return`), IsNil)
+
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/twoPCShortLockTTL", "return"), IsNil)
 	committer, err := txn.NewCommitter(1)
 	c.Assert(err, IsNil)
-	// Sets its minCommitTS to one second later, so the lock will be ignored by point get.
-	committer.SetMinCommitTS(committer.GetStartTS() + (1000 << 18))
 	err = committer.Execute(context.Background())
 	c.Assert(err, IsNil)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/snapshotGetTSAsync"), IsNil)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/twoPCShortLockTTL"), IsNil)
 
-	err = <-ch
-	c.Assert(err, ErrorMatches, ".*key not exist")
+	snapshot := s.store.GetSnapshot(math.MaxUint64)
+	getCh := make(chan []byte)
+	go func() {
+		// Sleep a while to make the TTL of the first txn expire, then we make sure we resolve lock by this get
+		time.Sleep(200 * time.Millisecond)
+		c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/beforeSendPointGet", "1*off->pause"), IsNil)
+		res, err := snapshot.Get(context.Background(), []byte("k2"))
+		c.Assert(err, IsNil)
+		getCh <- res
+	}()
+	// The get should be blocked by the failpoint. But the lock should have been resolved.
+	select {
+	case res := <-getCh:
+		c.Errorf("too early %s", string(res))
+	case <-time.After(1 * time.Second):
+	}
 
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing"), IsNil)
+	// Prewrite k1 and k2 again without committing them
+	txn, err = s.store.Begin()
+	c.Assert(err, IsNil)
+	txn.SetOption(kv.EnableAsyncCommit, true)
+	err = txn.Set([]byte("k1"), []byte("v3"))
+	c.Assert(err, IsNil)
+	err = txn.Set([]byte("k2"), []byte("v4"))
+	c.Assert(err, IsNil)
+	committer, err = txn.NewCommitter(1)
+	c.Assert(err, IsNil)
+	err = committer.Execute(context.Background())
+	c.Assert(err, IsNil)
+
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/beforeSendPointGet"), IsNil)
+
+	// After disabling the failpoint, the get request should bypass the new locks and read the old result
+	select {
+	case res := <-getCh:
+		c.Assert(res, DeepEquals, []byte("v2"))
+	case <-time.After(1 * time.Second):
+		c.Errorf("get timeout")
+	}
 }
 
 func (s *testSnapshotFailSuite) TestRetryPointGetResolveTS(c *C) {


### PR DESCRIPTION
### What is changed and how it works?


This PR reverts https://github.com/pingcap/tidb/pull/22789. In addition, this PR makes point select with max ts ignore all locks except the first one.

The solution is to minimize changes done to the release-5.0 branch.
For the master branch, I think we can use a new protocol that brings the first lock's `start_ts` to reduce invalid retries.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manual test (add detailed scripts or steps below)

Benchmark result:
<img width="711" alt="图片" src="https://user-images.githubusercontent.com/17217495/114992508-6bdc0e00-9ecd-11eb-893d-f1b3fa88ffb7.png">


### Release note <!-- bugfixes or new feature need a release note -->

- `Fix performance regression of point select.`