### PR TITLE
planner: unify the commas in the comments

### DIFF
--- a/planner/core/rule_aggregation_elimination.go
+++ b/planner/core/rule_aggregation_elimination.go
@@ -140,7 +140,7 @@ func rewriteExpr(ctx sessionctx.Context, aggFunc *aggregation.AggFuncDesc) (bool
 
 func rewriteCount(ctx sessionctx.Context, exprs []expression.Expression, targetTp *types.FieldType) expression.Expression {
 	// If is count(expr), we will change it to if(isnull(expr), 0, 1).
-	// If is count(distinct x, y, z) we will change it to if(isnull(x) or isnull(y) or isnull(z), 0, 1).
+	// If is count(distinct x, y, z), we will change it to if(isnull(x) or isnull(y) or isnull(z), 0, 1).
 	// If is count(expr not null), we will change it to constant 1.
 	isNullExprs := make([]expression.Expression, 0, len(exprs))
 	for _, expr := range exprs {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: unify the commas in the comments in `rule_aggregation_elimination.go`

### What is changed and how it works?

What's Changed: comments.

How it Works: No work.

### Related changes

- None


Tests <!-- At least one of them must be included. -->

- No code

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->

- No release note

### Other

Is there an approach to give a suggestion on the blog post [TiDB 源码阅读系列文章（二十一）基于规则的优化 II
](https://pingcap.com/blog-cn/tidb-source-code-reading-21/)? It said that the [`Not Null` optimization of aggregation elimination](https://github.com/pingcap/tidb/commit/e45e6999cbd29fbd14cf8c93669b2e45907b4154#diff-8cfa47b1f791408df330dcc58ac41404b416aee0c9e418c1897a3a665511374c) is not added yet. However, it has been completed by [Kingwl](https://github.com/Kingwl) 2 years ago. So, maybe it is a good idea to update the corresponding blog post.