### PR TITLE
Add Equivalence Rules to Transform BinaryOptSubquery to ExistsSubquery

### DIFF
--- a/planner/core/mock.go
+++ b/planner/core/mock.go
@@ -362,6 +362,56 @@ func MockNoPKTable() *model.TableInfo {
 	return table
 }
 
+// MockNoPKTable is only used for plan related tests.
+func MockNoPKTableString1() *model.TableInfo {
+	// column: a, b
+	col0 := &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    1,
+		Name:      model.NewCIStr("a"),
+		FieldType: newLongType(),
+		ID:        2,
+	}
+	col1 := &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    2,
+		Name:      model.NewCIStr("b_str"),
+		FieldType: newStringType(),
+		ID:        3,
+	}
+	table := &model.TableInfo{
+		Columns:    []*model.ColumnInfo{col0, col1},
+		Name:       model.NewCIStr("ts1"),
+		PKIsHandle: true,
+	}
+	return table
+}
+
+// MockNoPKTable is only used for plan related tests.
+func MockNoPKTableString2() *model.TableInfo {
+	// column: a, b
+	col0 := &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    1,
+		Name:      model.NewCIStr("a"),
+		FieldType: newLongType(),
+		ID:        2,
+	}
+	col1 := &model.ColumnInfo{
+		State:     model.StatePublic,
+		Offset:    2,
+		Name:      model.NewCIStr("b_str"),
+		FieldType: newStringType(),
+		ID:        3,
+	}
+	table := &model.TableInfo{
+		Columns:    []*model.ColumnInfo{col0, col1},
+		Name:       model.NewCIStr("ts2"),
+		PKIsHandle: true,
+	}
+	return table
+}
+
 // MockView is only used for plan related tests.
 func MockView() *model.TableInfo {
 	selectStmt := "select b,c,d from t"

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -46,7 +46,7 @@ type testPlanSuiteBase struct {
 }
 
 func (s *testPlanSuiteBase) SetUpSuite(c *C) {
-	s.is = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable(), core.MockUnsignedTable()})
+	s.is = infoschema.MockInfoSchema([]*model.TableInfo{core.MockSignedTable(), core.MockUnsignedTable(), core.MockNoPKTableString1(), core.MockNoPKTableString2()})
 	s.Parser = parser.New()
 	s.Parser.SetParserConfig(parser.ParserConfig{EnableWindowFunction: true, EnableStrictDoubleTypeCheck: true})
 }

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -335,6 +335,11 @@ func simplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
 	}
 }
 
+func SimplifyOuterJoin(p *LogicalJoin, predicates []expression.Expression) {
+	simplifyOuterJoin(p, predicates)
+	return
+}
+
 // isNullRejected check whether a condition is null-rejected
 // A condition would be null-rejected in one of following cases:
 // If it is a predicate containing a reference to an inner table that evaluates to UNKNOWN or FALSE when one of its arguments is NULL.

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -221,7 +221,10 @@
       // Test Apply.
       "select t.c in (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t",
       "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t",
-      "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t order by t.a"
+      "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t order by t.a",
+      // Test BinaryOptSubquery -> existsSubquery
+      "select ts1.a from ts1 where exists (select * from ts2 where ts1.a = ts2.a and ts1.b_str like ts2.b_str )",
+      "select ts1.a from ts1 where (select count(*) from ts2 where ts1.a = ts2.a and ts1.b_str like ts2.b_str ) > 0"
     ]
   },
   {

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -620,6 +620,14 @@
       {
         "SQL": "select (select count(*) from t s, t t1 where s.a = t.a and s.a = t1.a) from t order by t.a",
         "Best": "MergeLeftOuterJoin{TableReader(Table(t))->MergeInnerJoin{TableReader(Table(t))->TableReader(Table(t))}(test.t.a,test.t.a)->Projection}(test.t.a,test.t.a)->Projection->Projection"
+      },
+      {
+        "SQL": "select ts1.a from ts1 where exists (select * from ts2 where ts1.a = ts2.a and ts1.b_str like ts2.b_str )",
+        "Best": "LeftHashJoin{TableReader(Table(ts1)->Sel([not(isnull(test.ts1.a))]))->TableReader(Table(ts2)->Sel([not(isnull(test.ts2.a))]))}(test.ts1.a,test.ts2.a)"        
+      },
+      {
+        "SQL": "select ts1.a from ts1 where (select count(*) from ts2 where ts1.a = ts2.a and ts1.b_str like ts2.b_str ) > 0",
+        "Best": "LeftHashJoin{TableReader(Table(ts1)->Sel([not(isnull(test.ts1.a))]))->TableReader(Table(ts2)->Sel([not(isnull(test.ts2.a))]))}(test.ts1.a,test.ts2.a)"
       }
     ]
   },


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #10137  <!-- REMOVE this line if no issue to close -->

Problem Summary: 

planner: wrong plan when subquery include LIKE

### What is changed and how it works?

What's Changed:  

Add specific relational algebra equivalence rules to do logical optimization.

How it Works:  

When we encounter sql subquery: ...where (select (*) from ...) > 0, we add extra conditions to identify this case, and then use specific relational algebra equivalence rules to transform the apply functor to the semi-join functor. Therefore, we can get the same logical plan as the sql subquery: ...where exists(select * from ...).

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->Add equivalence rules to transform BinaryOptSubquery to ExistsSubquery.
