### PR TITLE
mocktikv: move split test into mockstore

### DIFF
--- a/store/mockstore/cluster_test.go
+++ b/store/mockstore/cluster_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package mocktikv_test
+package mockstore
 
 import (
 	"bytes"


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Split test involves a lot SQL related dependency.

Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- move it out of store/tikv.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note