### PR TITLE
planner/core: point get only work on TiKV

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -698,7 +698,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 				p: dual,
 			}, cntPlan, nil
 		}
-		canConvertPointGet := len(path.Ranges) > 0 && path.StoreType != kv.TiFlash
+		canConvertPointGet := len(path.Ranges) > 0 && path.StoreType == kv.TiKV
 		if canConvertPointGet && !path.IsIntHandlePath {
 			// We simply do not build [batch] point get for prefix indexes. This can be optimized.
 			canConvertPointGet = path.Index.Unique && !path.Index.HasPrefixIndex()


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #24117

Problem Summary:

The truth is that point get only works on TiKV. But we check if it is not TiFlash. And other settings work with more coupled logic. We correct the code semantic and decouple with additional logics.

### What is changed and how it works?

What's Changed:

condition `path.StoreType != kv.TiKV` is actually `path.StoreType == kv.TiKV`

How it Works:

As described above.

### Check List <!--REMOVE the items that are not applicable-->

It should be covered by existing tests.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
