### PR TITLE
executor: skip TestPrepareStmtAfterIsolationReadChange when race enable

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
+	"github.com/pingcap/tidb/util/israce"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
@@ -78,6 +79,9 @@ func (s *testSuite1) TestIgnorePlanCache(c *C) {
 }
 
 func (s *testSerialSuite) TestPrepareStmtAfterIsolationReadChange(c *C) {
+	if israce.RaceEnabled {
+		c.Skip("race test for this case takes too long time")
+	}
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.Se.Auth(&auth.UserIdentity{Username: "root", Hostname: "localhost", CurrentUser: true, AuthUsername: "root", AuthHostname: "%"}, nil, []byte("012345678901234567890"))
 


### PR DESCRIPTION
Signed-off-by: lzmhhh123 <lzmhhh123@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: part of https://github.com/pingcap/tidb/issues/24130 

### What is changed and how it works?

How it Works: skip TestPrepareStmtAfterIsolationReadChange when race enable. It takes about 40s for this test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- none.
