### PR TITLE
*: support txn retry when auto id meets duplicate entry

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -916,6 +916,7 @@ const (
 	ErrAdminCheckTable                     = 8003
 	ErrTxnTooLarge                         = 8004
 	ErrWriteConflictInTiDB                 = 8005
+	ErrAllocatedAutoIDInvalid              = 8006
 	ErrUnsupportedReloadPlugin             = 8018
 	ErrUnsupportedReloadPluginVar          = 8019
 	ErrTableLocked                         = 8020

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -920,6 +920,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrAdminCheckTable:            mysql.Message("TiDB admin check table failed.", nil),
 	ErrTxnTooLarge:                mysql.Message("Transaction is too large, size: %d", nil),
 	ErrWriteConflictInTiDB:        mysql.Message("Write conflict, txnStartTS %d is stale", nil),
+	ErrAllocatedAutoIDInvalid:     mysql.Message("Allocated ID conflict, column: %s, value: %d", nil),
 	ErrInvalidPluginID:            mysql.Message("Wrong plugin id: %s, valid plugin id is [name]-[version], both name and version should not contain '-'", nil),
 	ErrInvalidPluginManifest:      mysql.Message("Cannot read plugin %s's manifest", nil),
 	ErrInvalidPluginName:          mysql.Message("Plugin load with %s but got wrong name %s", nil),

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -717,7 +717,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				return nil, err
 			}
 			e.ctx.GetSessionVars().StmtCtx.InsertID = uint64(recordID)
-			retryInfo.AddAutoID(recordID, autoid.AutoIncrementType)
+			retryInfo.AddAutoID(recordID, kv.AutoIDTypeIncrement)
 			continue
 		}
 
@@ -765,7 +765,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 				if err != nil {
 					return nil, err
 				}
-				retryInfo.AddAutoID(id, autoid.AutoIncrementType)
+				retryInfo.AddAutoID(id, kv.AutoIDTypeIncrement)
 			}
 			continue
 		}
@@ -774,7 +774,7 @@ func (e *InsertValues) lazyAdjustAutoIncrementDatum(ctx context.Context, rows []
 		if err != nil {
 			return nil, err
 		}
-		retryInfo.AddAutoID(recordID, autoid.AutoIncrementType)
+		retryInfo.AddAutoID(recordID, kv.AutoIDTypeIncrement)
 	}
 	return rows, nil
 }
@@ -807,7 +807,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 			return types.Datum{}, err
 		}
 		e.ctx.GetSessionVars().StmtCtx.InsertID = uint64(recordID)
-		retryInfo.AddAutoID(recordID, autoid.AutoIncrementType)
+		retryInfo.AddAutoID(recordID, kv.AutoIDTypeIncrement)
 		return d, nil
 	}
 
@@ -829,7 +829,7 @@ func (e *InsertValues) adjustAutoIncrementDatum(ctx context.Context, d types.Dat
 	if err != nil {
 		return types.Datum{}, err
 	}
-	retryInfo.AddAutoID(recordID, autoid.AutoIncrementType)
+	retryInfo.AddAutoID(recordID, kv.AutoIDTypeIncrement)
 	return d, nil
 }
 
@@ -884,7 +884,7 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 		}
 		e.ctx.GetSessionVars().StmtCtx.InsertID = uint64(recordID)
 		d.SetAutoID(recordID, c.Flag)
-		retryInfo.AddAutoID(recordID, autoid.AutoRandomType)
+		retryInfo.AddAutoID(recordID, kv.AutoIDTypeRandom)
 		return d, nil
 	}
 
@@ -906,7 +906,7 @@ func (e *InsertValues) adjustAutoRandomDatum(ctx context.Context, d types.Datum,
 	if err != nil {
 		return types.Datum{}, err
 	}
-	retryInfo.AddAutoID(recordID, autoid.AutoRandomType)
+	retryInfo.AddAutoID(recordID, kv.AutoIDTypeRandom)
 	return d, nil
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -922,8 +922,8 @@ func (s *testSuite3) TestInsertWithAutoidSchema(c *C) {
 		if strings.HasPrefix(tt.insert, "retry : ") {
 			// it's the last retry insert case, change the sessionVars.
 			retryInfo := &variable.RetryInfo{Retrying: true}
-			retryInfo.AddAutoIncrementID(1000)
-			retryInfo.AddAutoIncrementID(1001)
+			retryInfo.AddAutoID(1000, autoid.AutoIncrementType)
+			retryInfo.AddAutoID(1001, autoid.AutoIncrementType)
 			tk.Se.GetSessionVars().RetryInfo = retryInfo
 			tk.MustExec(tt.insert[8:])
 			tk.Se.GetSessionVars().RetryInfo = &variable.RetryInfo{}

--- a/kv/error.go
+++ b/kv/error.go
@@ -51,6 +51,8 @@ var (
 	// ErrWriteConflictInTiDB is the error when the commit meets an write conflict error when local latch is enabled.
 	ErrWriteConflictInTiDB = dbterror.ClassKV.NewStdErr(mysql.ErrWriteConflictInTiDB,
 		pmysql.Message(mysql.MySQLErrName[mysql.ErrWriteConflictInTiDB].Raw+" "+TxnRetryableMark, nil))
+	// ErrAllocatedAutoIDInvalid is the error when allocated auto_id is exist.
+	ErrAllocatedAutoIDInvalid = dbterror.ClassKV.NewStd(mysql.ErrAllocatedAutoIDInvalid)
 )
 
 // IsTxnRetryableError checks if the error could safely retry the transaction.
@@ -59,7 +61,10 @@ func IsTxnRetryableError(err error) bool {
 		return false
 	}
 
-	if ErrTxnRetryable.Equal(err) || ErrWriteConflict.Equal(err) || ErrWriteConflictInTiDB.Equal(err) {
+	if ErrTxnRetryable.Equal(err) ||
+		ErrWriteConflict.Equal(err) ||
+		ErrWriteConflictInTiDB.Equal(err) ||
+		ErrAllocatedAutoIDInvalid.Equal(err) {
 		return true
 	}
 

--- a/kv/interface_mock_test.go
+++ b/kv/interface_mock_test.go
@@ -16,7 +16,6 @@ package kv
 import (
 	"context"
 
-	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 )
 
@@ -134,11 +133,7 @@ func (t *mockTxn) GetVars() *Variables {
 	return nil
 }
 
-func (t *mockTxn) CacheTableInfo(id int64, info *model.TableInfo) {
-
-}
-
-func (t *mockTxn) GetTableInfo(id int64) *model.TableInfo {
+func (t *mockTxn) GetContextAccessor() *ContextAccessor {
 	return nil
 }
 

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -187,9 +187,11 @@ type Transaction interface {
 	GetContextAccessor() *ContextAccessor
 }
 
+// AutoIDType represents the auto id type in RetryInfo.
 type AutoIDType int8
 
 const (
+	// AutoIDTypeRowID is reserved for future use.
 	AutoIDTypeRowID AutoIDType = iota
 	AutoIDTypeIncrement
 	AutoIDTypeRandom
@@ -201,24 +203,29 @@ type ContextAccessor struct {
 	autoIDConflictChecker func(int64, AutoIDType) bool
 }
 
+// NewContextAccessor creates a ContextAccessor.
 func NewContextAccessor() *ContextAccessor {
 	return &ContextAccessor{
 		tableInfoCache: make(map[int64]*model.TableInfo),
 	}
 }
 
+// CacheTableInfo stores the TableInfo to the transaction.
 func (c *ContextAccessor) CacheTableInfo(id int64, info *model.TableInfo) {
 	c.tableInfoCache[id] = info
 }
 
+// GetTableInfo gets the TableInfo that stored by `CacheTableInfo`.
 func (c *ContextAccessor) GetTableInfo(id int64) *model.TableInfo {
 	return c.tableInfoCache[id]
 }
 
+// CacheAutoIDConflictChecker stores the auto IDs conflict checker to the transaction.
 func (c *ContextAccessor) CacheAutoIDConflictChecker(checker func(int64, AutoIDType) bool) {
 	c.autoIDConflictChecker = checker
 }
 
+// GetAutoIDConflictChecker gets the checker that stored by CacheAutoIDConflictChecker.
 func (c *ContextAccessor) GetAutoIDConflictChecker() func(int64, AutoIDType) bool {
 	return c.autoIDConflictChecker
 }

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -145,6 +145,7 @@ type Allocator interface {
 	// NextGlobalAutoID returns the next global autoID.
 	NextGlobalAutoID(tableID int64) (int64, error)
 	GetType() AllocatorType
+	Invalidate()
 }
 
 // Allocators represents a set of `Allocator`s.
@@ -398,6 +399,10 @@ func (alloc *allocator) RebaseSeq(tableID, requiredBase int64) (int64, bool, err
 
 func (alloc *allocator) GetType() AllocatorType {
 	return alloc.allocType
+}
+
+func (alloc *allocator) Invalidate() {
+	alloc.base = alloc.end
 }
 
 // NextStep return new auto id step according to previous step and consuming time.

--- a/session/session.go
+++ b/session/session.go
@@ -555,6 +555,7 @@ func (s *session) doCommitWithRetry(ctx context.Context) error {
 			// We make larger transactions retry less times to prevent cluster resource outage.
 			txnSizeRate := float64(txnSize) / float64(kv.TxnTotalSizeLimit)
 			maxRetryCount := commitRetryLimit - int64(float64(commitRetryLimit-1)*txnSizeRate)
+			s.sessionVars.RetryInfo.SetAutoIDConflicted(err)
 			err = s.retry(ctx, uint(maxRetryCount))
 		} else if !errIsNoisy(err) {
 			logutil.Logger(ctx).Warn("can not retry txn",

--- a/session/txn.go
+++ b/session/txn.go
@@ -24,7 +24,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/kv"
@@ -57,14 +56,9 @@ type TxnState struct {
 	writeSLI      sli.TxnWriteThroughputSLI
 }
 
-// GetTableInfo returns the cached index name.
-func (txn *TxnState) GetTableInfo(id int64) *model.TableInfo {
-	return txn.Transaction.GetTableInfo(id)
-}
-
-// CacheTableInfo caches the index name.
-func (txn *TxnState) CacheTableInfo(id int64, info *model.TableInfo) {
-	txn.Transaction.CacheTableInfo(id, info)
+// GetContextAccessor returns the ContextAccessor.
+func (txn *TxnState) GetContextAccessor() *kv.ContextAccessor {
+	return txn.Transaction.GetContextAccessor()
 }
 
 func (txn *TxnState) init() {

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -67,14 +67,17 @@ type RetryInfo struct {
 	autoRandomIDs          retryInfoAutoIDs
 }
 
+// CanReuseAutoIDs indicates if the auto IDs can be reused.
 func (r *RetryInfo) CanReuseAutoIDs() bool {
 	return r.Retrying && !r.autoIDConflicted
 }
 
+// NeedInvalidateAutoIDCache indicates the corresponding allocator need to invalidate its cache.
 func (r *RetryInfo) NeedInvalidateAutoIDCache() bool {
 	return r.autoIDConflicted
 }
 
+// SetAutoIDConflicted mark itself as auto-id-conflict if the error is `ErrAllocatedAutoIDInvalid`.
 func (r *RetryInfo) SetAutoIDConflicted(retryableErr error) {
 	if kv.ErrAllocatedAutoIDInvalid.Equal(retryableErr) {
 		r.autoIDConflicted = true
@@ -101,15 +104,16 @@ func (r *RetryInfo) ResetOffset() {
 }
 
 // AddAutoID adds an allocating auto id to the RetryInfo.
-func (r *RetryInfo) AddAutoID(id int64, tp autoid.AllocatorType) {
+func (r *RetryInfo) AddAutoID(id int64, tp kv.AutoIDType) {
 	switch tp {
-	case autoid.AutoIncrementType:
+	case kv.AutoIDTypeIncrement:
 		r.autoIncrementIDs.autoIDs = append(r.autoIncrementIDs.autoIDs, id)
-	case autoid.AutoRandomType:
+	case kv.AutoIDTypeRandom:
 		r.autoRandomIDs.autoIDs = append(r.autoRandomIDs.autoIDs, id)
 	}
 }
 
+// GetAutoID gets the current auto id according to the type.
 func (r *RetryInfo) GetAutoID(tp kv.AutoIDType) (int64, bool) {
 	switch tp {
 	case kv.AutoIDTypeIncrement:
@@ -120,6 +124,7 @@ func (r *RetryInfo) GetAutoID(tp kv.AutoIDType) (int64, bool) {
 	return 0, false
 }
 
+// CheckAutoIDExists checks whether the id exists in the RetryInfo.
 func (r *RetryInfo) CheckAutoIDExists(id int64, tp kv.AutoIDType) bool {
 	var ids retryInfoAutoIDs
 	switch tp {

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -149,7 +149,8 @@ func (c *index) GenIndexKey(sc *stmtctx.StatementContext, indexedValues []types.
 // Create will return the existing entry's handle as the first return value, ErrKeyExists as the second return value.
 func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValues []types.Datum, h kv.Handle, handleRestoreData []types.Datum, opts ...table.CreateIdxOptFunc) (kv.Handle, error) {
 	if c.Meta().Unique {
-		txn.CacheTableInfo(c.phyTblID, c.tblInfo)
+		txn.GetContextAccessor().CacheTableInfo(c.phyTblID, c.tblInfo)
+		txn.GetContextAccessor().CacheAutoIDConflictChecker(sctx.GetSessionVars().RetryInfo.CheckAutoIDExists)
 	}
 	var opt table.CreateIdxOpt
 	for _, fn := range opts {

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -618,7 +618,8 @@ func (t *TableCommon) AddRecord(sctx sessionctx.Context, r []types.Datum, opts .
 		hasRecordID = true
 	} else {
 		tblInfo := t.Meta()
-		txn.CacheTableInfo(t.physicalTableID, tblInfo)
+		txn.GetContextAccessor().CacheTableInfo(t.physicalTableID, tblInfo)
+		txn.GetContextAccessor().CacheAutoIDConflictChecker(sctx.GetSessionVars().RetryInfo.CheckAutoIDExists)
 		if tblInfo.PKIsHandle {
 			recordID = kv.IntHandle(r[tblInfo.GetPkColInfo().Offset].GetInt64())
 			hasRecordID = true

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -67,18 +67,11 @@ func (txn *wrapTxn) GetUnionStore() kv.UnionStore {
 	return txn.Transaction.GetUnionStore()
 }
 
-func (txn *wrapTxn) CacheTableInfo(id int64, info *model.TableInfo) {
-	if txn.Transaction == nil {
-		return
-	}
-	txn.Transaction.CacheTableInfo(id, info)
-}
-
-func (txn *wrapTxn) GetTableInfo(id int64) *model.TableInfo {
+func (txn *wrapTxn) GetContextAccessor() *kv.ContextAccessor {
 	if txn.Transaction == nil {
 		return nil
 	}
-	return txn.Transaction.GetTableInfo(id)
+	return txn.Transaction.GetContextAccessor()
 }
 
 // Execute implements sqlexec.SQLExecutor Execute interface.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/24122 , close https://github.com/pingcap/tidb/issues/30938

### What is changed and how it works?

What's Changed:

1. A retryable error `ErrAllocatedAutoIDInvalid` is added. 
2. When a "key-exists-error" is caught, the error is converted to `ErrAllocatedAutoIDInvalid` in the following 2 cases:
 - For integer handles, if the table `PKIsHandle` and it contains `auto_increment` or `auto_random` column, TiDB finds this duplicated ID in `RetryInfo`.
 - For unique secondary index, if the index only contains 1 column and the column contains `auto_increment`, TiDB finds this duplicated ID in `RetryInfo`.
3. When this special error is caught in `doCommitWithRetry`, at the time before retrying, the `RetryInfo` is marked as `auto_id_conclict`. 
4. This information will be passed to the next round of insertion, causing the allocator invalidate itself.

This PR also refactors the `Table` interface and the `RetryInfo` struct.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

NA

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
