### PR TITLE
tikv-client: Optimize batch commands

### DIFF
--- a/store/tikv/config/client.go
+++ b/store/tikv/config/client.go
@@ -111,7 +111,7 @@ func DefaultTiKVClient() TiKVClient {
 
 		MaxBatchSize:      128,
 		OverloadThreshold: 200,
-		MaxBatchWaitTime:  0,
+		MaxBatchWaitTime:  time.Millisecond,
 		BatchWaitSize:     8,
 
 		EnableChunkRPC: true,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
The performance of `Timer` is bad because it will add an event to global event manager,  which is a binary tree. When the timeout point reaches, it will wake up the original goroutine but it can not guarantee the goroutine will be scheduled at once.  If the tidb process is busy with many request and there are too many goroutine, the wake-up time will be too long and make tidb sql too slow.

### What is changed and how it works?

We do not need `Timer` to wake up send goroutine. We only need the send goroutine is busy and it can be waked up when some error ocurrs. If there are some requests which have not return response, we can make up by it because We know that the response must return in a short time, or some error may happen to the connection. If all of the responses return in a long time, it means that the tikv is busy,  so we allow the current requests which still keep in `BatchRequestBuilder` are delay to send.

This PR can reduce the p999 latency of point-select by **70%** and reduce the p99 latency by **50%**.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

m5.xlarge |  PD
-- | --
m5.xlarge | PD
m5.xlarge | PD


c6g.4xlarge |  TiDB
--  | --
c6g.4xlarge |  TiDB
c6g.4xlarge |  TiDB


i3.4xlarge  | TiKV
-- | --
i3.4xlarge  | TiKV
i3.4xlarge  | TiKV


![image](https://user-images.githubusercontent.com/16376959/116211111-14b02600-a776-11eb-8664-b3099c06f6a4.png)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->
- No release note.
