### PR TITLE
store/tikv: remove use of SyncLog transaction option in store/tikv

### DIFF
--- a/meta/meta.go
+++ b/meta/meta.go
@@ -95,7 +95,7 @@ type Meta struct {
 // If the current Meta needs to handle a job, jobListKey is the type of the job's list.
 func NewMeta(txn kv.Transaction, jobListKeys ...JobListKeyType) *Meta {
 	txn.SetOption(tikvstore.Priority, tikvstore.PriorityHigh)
-	txn.SetOption(tikvstore.SyncLog, true)
+	txn.SetOption(tikvstore.SyncLog, struct{}{})
 	t := structure.NewStructure(txn, txn, mMetaPrefix)
 	listKey := DefaultJobListKey
 	if len(jobListKeys) != 0 {

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -126,6 +126,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 			txn:     txn.KVTxn,
 			binInfo: val.(*binloginfo.BinlogInfo), // val cannot be other type.
 		})
+	case tikvstore.SyncLog:
+		txn.SetSyncLog()
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -426,7 +426,7 @@ func (c *twoPhaseCommitter) initKeysAndMutations() error {
 	c.hasNoNeedCommitKeys = checkCnt > 0
 	c.lockTTL = txnLockTTL(txn.startTime, size)
 	c.priority = getTxnPriority(txn)
-	c.syncLog = getTxnSyncLog(txn)
+	c.syncLog = txn.synclog
 	c.setDetail(commitDetail)
 	return nil
 }
@@ -1654,13 +1654,6 @@ func getTxnPriority(txn *KVTxn) pb.CommandPri {
 		return PriorityToPB(pri.(int))
 	}
 	return pb.CommandPri_Normal
-}
-
-func getTxnSyncLog(txn *KVTxn) bool {
-	if syncOption := txn.us.GetOption(kv.SyncLog); syncOption != nil {
-		return syncOption.(bool)
-	}
-	return false
 }
 
 // PriorityToPB converts priority type to wire type.

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -52,7 +52,6 @@ type KVSnapshot struct {
 	isolationLevel  kv.IsoLevel
 	priority        pb.CommandPri
 	notFillCache    bool
-	syncLog         bool
 	keyOnly         bool
 	vars            *kv.Variables
 	replicaReadSeed uint32
@@ -542,8 +541,6 @@ func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 		s.priority = PriorityToPB(val.(int))
 	case kv.NotFillCache:
 		s.notFillCache = val.(bool)
-	case kv.SyncLog:
-		s.syncLog = val.(bool)
 	case kv.KeyOnly:
 		s.keyOnly = val.(bool)
 	case kv.SnapshotTS:

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -74,7 +74,8 @@ type KVTxn struct {
 	// commitCallback is called after current transaction gets committed
 	commitCallback func(info string, err error)
 
-	binlog BinlogExecutor
+	binlog  BinlogExecutor
+	synclog bool
 }
 
 func newTiKVTxn(store *KVStore, txnScope string) (*KVTxn, error) {
@@ -196,6 +197,11 @@ func (txn *KVTxn) GetOption(opt int) interface{} {
 // DelOption deletes an option.
 func (txn *KVTxn) DelOption(opt int) {
 	txn.us.DelOption(opt)
+}
+
+// SetSyncLog indicates tikv to always sync log for the transaction.
+func (txn *KVTxn) SetSyncLog() {
+	txn.synclog = true
 }
 
 // IsPessimistic returns true if it is pessimistic.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `Sync` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- add `syncLog` in `KVTxn`
- remove `syncLog` of `KVSnapshot` (not used)
- add method `SetSyncLog` to set up the checker
- update `driver.tikvTxn` to adapt.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note