### PR TITLE
store/tikv: remove use of KeyOnly transaction option in store/tikv

### DIFF
--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -544,8 +544,6 @@ func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 		s.notFillCache = val.(bool)
 	case kv.SyncLog:
 		s.syncLog = val.(bool)
-	case kv.KeyOnly:
-		s.keyOnly = val.(bool)
 	case kv.SnapshotTS:
 		s.setSnapshotTS(val.(uint64))
 	case kv.ReplicaRead:
@@ -587,6 +585,11 @@ func (s *KVSnapshot) DelOption(opt int) {
 		s.mu.stats = nil
 		s.mu.Unlock()
 	}
+}
+
+// SetKeyOnly updates option to scan only keys.
+func (s *KVSnapshot) SetKeyOnly(b bool) {
+	s.keyOnly = b
 }
 
 // SnapCacheHitCount gets the snapshot cache hit count. Only for test.

--- a/store/tikv/tests/lock_test.go
+++ b/store/tikv/tests/lock_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
-	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 )
@@ -142,7 +141,7 @@ func (s *testLockSuite) TestScanLockResolveWithSeekKeyOnly(c *C) {
 
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	txn.SetOption(kv.KeyOnly, true)
+	txn.GetSnapshot().SetKeyOnly(true)
 	iter, err := txn.Iter([]byte("a"), nil)
 	c.Assert(err, IsNil)
 	for ch := byte('a'); ch <= byte('z'); ch++ {

--- a/store/tikv/tests/scan_test.go
+++ b/store/tikv/tests/scan_test.go
@@ -146,7 +146,7 @@ func (s *testScanSuite) TestScan(c *C) {
 		check(c, scan, upperBound, false)
 
 		txn3 := s.beginTxn(c)
-		txn3.SetOption(kv.KeyOnly, true)
+		txn3.GetSnapshot().SetKeyOnly(true)
 		// Test scan without upper bound
 		scan, err = txn3.Iter(s.recordPrefix, nil)
 		c.Assert(err, IsNil)
@@ -157,7 +157,7 @@ func (s *testScanSuite) TestScan(c *C) {
 		check(c, scan, upperBound, true)
 
 		// Restore KeyOnly to false
-		txn3.SetOption(kv.KeyOnly, false)
+		txn3.GetSnapshot().SetKeyOnly(false)
 		scan, err = txn3.Iter(s.recordPrefix, nil)
 		c.Assert(err, IsNil)
 		check(c, scan, rowNum, true)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `KeyOnly` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- add method `SetKeyOnly` to set up the checker
- replaces usages of options
- (no need to update driver because TiDB does not use this option)

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note