### PR TITLE
store/tikv: remove IsolationLevel option

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -145,7 +145,7 @@ func (builder *RequestBuilder) SetAnalyzeRequest(ana *tipb.AnalyzeReq) *RequestB
 		builder.Request.Tp = kv.ReqTypeAnalyze
 		builder.Request.Data, builder.err = ana.Marshal()
 		builder.Request.NotFillCache = true
-		builder.Request.IsolationLevel = tikvstore.RC
+		builder.Request.IsolationLevel = kv.RC
 		builder.Request.Priority = tikvstore.PriorityLow
 	}
 
@@ -199,12 +199,12 @@ func (builder *RequestBuilder) SetAllowBatchCop(batchCop bool) *RequestBuilder {
 	return builder
 }
 
-func (builder *RequestBuilder) getIsolationLevel() tikvstore.IsoLevel {
+func (builder *RequestBuilder) getIsolationLevel() kv.IsoLevel {
 	switch builder.Tp {
 	case kv.ReqTypeAnalyze:
-		return tikvstore.RC
+		return kv.RC
 	}
-	return tikvstore.SI
+	return kv.SI
 }
 
 func (builder *RequestBuilder) getKVPriority(sv *variable.SessionVars) int {

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -533,7 +533,7 @@ func (s *testSuite) TestRequestBuilder5(c *C) {
 		KeepOrder:      true,
 		Desc:           false,
 		Concurrency:    15,
-		IsolationLevel: tikvstore.RC,
+		IsolationLevel: kv.RC,
 		Priority:       1,
 		NotFillCache:   true,
 		SyncLog:        false,

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -965,7 +965,7 @@ func (e *AnalyzeFastExec) activateTxnForRowCount() (rollbackFn func() error, err
 		}
 	}
 	txn.SetOption(tikvstore.Priority, tikvstore.PriorityLow)
-	txn.SetOption(tikvstore.IsolationLevel, tikvstore.RC)
+	txn.SetOption(tikvstore.IsolationLevel, kv.RC)
 	txn.SetOption(tikvstore.NotFillCache, true)
 	return rollbackFn, nil
 }
@@ -1185,7 +1185,7 @@ func (e *AnalyzeFastExec) handleSampTasks(workID int, step uint32, err *error) {
 	defer e.wg.Done()
 	snapshot := e.ctx.GetStore().GetSnapshot(kv.MaxVersion)
 	snapshot.SetOption(tikvstore.NotFillCache, true)
-	snapshot.SetOption(tikvstore.IsolationLevel, tikvstore.RC)
+	snapshot.SetOption(tikvstore.IsolationLevel, kv.RC)
 	snapshot.SetOption(tikvstore.Priority, tikvstore.PriorityLow)
 	if e.ctx.GetSessionVars().GetReplicaRead().IsFollowerRead() {
 		snapshot.SetOption(tikvstore.ReplicaRead, tikvstore.ReplicaReadFollower)

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -257,7 +257,7 @@ type Request struct {
 	// sent to multiple storage units concurrently.
 	Concurrency int
 	// IsolationLevel is the isolation level, default is SI.
-	IsolationLevel tikvstore.IsoLevel
+	IsolationLevel IsoLevel
 	// Priority is the priority of this KV request, its value may be PriorityNormal/PriorityLow/PriorityHigh.
 	Priority int
 	// memTracker is used to trace and control memory usage in co-processor layer.
@@ -438,3 +438,13 @@ type SplittableStore interface {
 	WaitScatterRegionFinish(ctx context.Context, regionID uint64, backOff int) error
 	CheckRegionInScattering(regionID uint64) (bool, error)
 }
+
+// IsoLevel is the transaction's isolation level.
+type IsoLevel int
+
+const (
+	// SI stands for 'snapshot isolation'.
+	SI IsoLevel = iota
+	// RC stands for 'read committed'.
+	RC
+)

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -2624,13 +2624,13 @@ func (s *testSessionSuite3) TestSetTransactionIsolationOneShot(c *C) {
 
 	// Check isolation level is set to read committed.
 	ctx := context.WithValue(context.Background(), "CheckSelectRequestHook", func(req *kv.Request) {
-		c.Assert(req.IsolationLevel, Equals, tikvstore.SI)
+		c.Assert(req.IsolationLevel, Equals, kv.SI)
 	})
 	tk.Se.Execute(ctx, "select * from t where k = 1")
 
 	// Check it just take effect for one time.
 	ctx = context.WithValue(context.Background(), "CheckSelectRequestHook", func(req *kv.Request) {
-		c.Assert(req.IsolationLevel, Equals, tikvstore.SI)
+		c.Assert(req.IsolationLevel, Equals, kv.SI)
 	})
 	tk.Se.Execute(ctx, "select * from t where k = 1")
 

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -345,7 +345,7 @@ func (b *batchCopIterator) handleTaskOnce(ctx context.Context, bo *tikv.Backoffe
 	}
 
 	req := tikvrpc.NewRequest(task.cmdType, &copReq, kvrpcpb.Context{
-		IsolationLevel: tikv.IsolationLevelToPB(b.req.IsolationLevel),
+		IsolationLevel: isolationLevelToPB(b.req.IsolationLevel),
 		Priority:       tikv.PriorityToPB(b.req.Priority),
 		NotFillCache:   b.req.NotFillCache,
 		RecordTimeStat: true,

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -697,7 +697,7 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *tikv.Backoffer, task *copTas
 	}
 
 	req := tikvrpc.NewReplicaReadRequest(task.cmdType, &copReq, worker.req.ReplicaRead, &worker.replicaReadSeed, kvrpcpb.Context{
-		IsolationLevel: tikv.IsolationLevelToPB(worker.req.IsolationLevel),
+		IsolationLevel: isolationLevelToPB(worker.req.IsolationLevel),
 		Priority:       tikv.PriorityToPB(worker.req.Priority),
 		NotFillCache:   worker.req.NotFillCache,
 		RecordTimeStat: true,
@@ -1190,4 +1190,15 @@ func (e *rateLimitAction) setEnabled(enabled bool) {
 
 func (e *rateLimitAction) isEnabled() bool {
 	return atomic.LoadUint32(&e.enabled) > 0
+}
+
+func isolationLevelToPB(level kv.IsoLevel) kvrpcpb.IsolationLevel {
+	switch level {
+	case kv.RC:
+		return kvrpcpb.IsolationLevel_RC
+	case kv.SI:
+		return kvrpcpb.IsolationLevel_SI
+	default:
+		return kvrpcpb.IsolationLevel_SI
+	}
 }

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -126,6 +126,15 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 			txn:     txn.KVTxn,
 			binInfo: val.(*binloginfo.BinlogInfo), // val cannot be other type.
 		})
+	case tikvstore.IsolationLevel:
+		switch val.(kv.IsoLevel) {
+		case kv.SI:
+			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.SI)
+		case kv.RC:
+			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.RC)
+		default:
+			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.SI)
+		}
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -127,14 +127,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 			binInfo: val.(*binloginfo.BinlogInfo), // val cannot be other type.
 		})
 	case tikvstore.IsolationLevel:
-		switch val.(kv.IsoLevel) {
-		case kv.SI:
-			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.SI)
-		case kv.RC:
-			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.RC)
-		default:
-			txn.KVTxn.GetSnapshot().SetIsolationLevel(tikv.SI)
-		}
+		level := getTiKVIsolationLevel(val.(kv.IsoLevel))
+		txn.KVTxn.GetSnapshot().SetIsolationLevel(level)
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/tikv/kv/kv.go
+++ b/store/tikv/kv/kv.go
@@ -7,16 +7,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/util"
 )
 
-// IsoLevel is the transaction's isolation level.
-type IsoLevel int
-
-const (
-	// SI stands for 'snapshot isolation'.
-	SI IsoLevel = iota
-	// RC stands for 'read committed'.
-	RC
-)
-
 // ReturnedValue pairs the Value and AlreadyLocked flag for PessimisticLock return values result.
 type ReturnedValue struct {
 	Value         []byte

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -737,15 +737,3 @@ func (s *RegionRequestSender) onRegionError(bo *Backoffer, ctx *RPCContext, seed
 	}
 	return false, nil
 }
-
-// IsolationLevelToPB converts isolation level to wire type.
-func IsolationLevelToPB(level kv.IsoLevel) kvrpcpb.IsolationLevel {
-	switch level {
-	case kv.RC:
-		return kvrpcpb.IsolationLevel_RC
-	case kv.SI:
-		return kvrpcpb.IsolationLevel_SI
-	default:
-		return kvrpcpb.IsolationLevel_SI
-	}
-}

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -192,7 +192,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 			Context: &pb.Context{
 				Priority:       s.snapshot.priority,
 				NotFillCache:   s.snapshot.notFillCache,
-				IsolationLevel: IsolationLevelToPB(s.snapshot.isolationLevel),
+				IsolationLevel: s.snapshot.isolationLevel.ToPB(),
 			},
 			StartKey:   s.nextStartKey,
 			EndKey:     reqEndKey,

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -26,6 +26,7 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	tidbkv "github.com/pingcap/tidb/kv"
@@ -45,11 +46,26 @@ const (
 	maxTimestamp  = math.MaxUint64
 )
 
+// IsoLevel is the transaction's isolation level.
+type IsoLevel kvrpcpb.IsolationLevel
+
+const (
+	// SI stands for 'snapshot isolation'.
+	SI IsoLevel = IsoLevel(kvrpcpb.IsolationLevel_SI)
+	// RC stands for 'read committed'.
+	RC IsoLevel = IsoLevel(kvrpcpb.IsolationLevel_RC)
+)
+
+// ToPB converts isolation level to wire type.
+func (l IsoLevel) ToPB() kvrpcpb.IsolationLevel {
+	return kvrpcpb.IsolationLevel(l)
+}
+
 // KVSnapshot implements the tidbkv.Snapshot interface.
 type KVSnapshot struct {
 	store           *KVStore
 	version         uint64
-	isolationLevel  kv.IsoLevel
+	isolationLevel  IsoLevel
 	priority        pb.CommandPri
 	notFillCache    bool
 	syncLog         bool
@@ -536,8 +552,6 @@ func (s *KVSnapshot) IterReverse(k []byte) (unionstore.Iterator, error) {
 // value of this option. Only ReplicaRead is supported for snapshot
 func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 	switch opt {
-	case kv.IsolationLevel:
-		s.isolationLevel = val.(kv.IsoLevel)
 	case kv.Priority:
 		s.priority = PriorityToPB(val.(int))
 	case kv.NotFillCache:
@@ -587,6 +601,11 @@ func (s *KVSnapshot) DelOption(opt int) {
 		s.mu.stats = nil
 		s.mu.Unlock()
 	}
+}
+
+// SetIsolationLevel sets the isolation level used to scan data from tikv.
+func (s *KVSnapshot) SetIsolationLevel(level IsoLevel) {
+	s.isolationLevel = level
 }
 
 // SnapCacheHitCount gets the snapshot cache hit count. Only for test.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `IsolationLevel` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- move `store/tikv/kv.IsoLevel` back to `kv.IsoLevel`
- packages of TiDB use `kv.IsoLevel`
- define new `tikv.IsoLevel` for client API
- adapt types in driver

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note