### PR TITLE
executor: fix a concurrent-access problem caused by accessing a single parser object in session concurrently 

### DIFF
--- a/executor/distsql_test.go
+++ b/executor/distsql_test.go
@@ -360,7 +360,7 @@ func (s *testSuite3) TestPartitionTableIndexJoinIndexLookUp(c *C) {
 	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
 	tk.MustExec(`create table t (a int, b int, key(a)) partition by hash(a) partitions 4`)
 	tk.MustExec("create table tnormal (a int, b int, key(a), key(b))")
-	nRows := 64
+	nRows := 512
 	values := make([]string, 0, nRows)
 	for i := 0; i < nRows; i++ {
 		values = append(values, fmt.Sprintf("(%v, %v)", rand.Intn(nRows), rand.Intn(nRows)))

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -344,7 +344,7 @@ func (s *testSuite5) TestPartitionTableIndexJoinAndIndexReader(c *C) {
 	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
 	tk.MustExec(`create table t (a int, b int, key(a)) partition by hash(a) partitions 4`)
 	tk.MustExec("create table tnormal (a int, b int, key(a), key(b))")
-	nRows := 64
+	nRows := 512
 	values := make([]string, 0, nRows)
 	for i := 0; i < nRows; i++ {
 		values = append(values, fmt.Sprintf("(%v, %v)", rand.Intn(nRows), rand.Intn(nRows)))

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -16,6 +16,7 @@ package session
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser"
@@ -118,7 +119,7 @@ func globalVarsCount() int64 {
 func (s *testBootstrapSuite) bootstrapWithOnlyDDLWork(store kv.Storage, c *C) {
 	ss := &session{
 		store:       store,
-		parser:      parser.New(),
+		parserPool:  &sync.Pool{New: func() interface{} { return parser.New() }},
 		sessionVars: variable.NewSessionVars(),
 	}
 	ss.txn.init()

--- a/session/schema_amender_test.go
+++ b/session/schema_amender_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"sort"
 	"strconv"
+	"sync"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -255,7 +256,7 @@ func (s *testSchemaAmenderSuite) TestAmendCollectAndGenMutations(c *C) {
 	defer store.Close()
 	se := &session{
 		store:       store,
-		parser:      parser.New(),
+		parserPool:  &sync.Pool{New: func() interface{} { return parser.New() }},
 		sessionVars: variable.NewSessionVars(),
 	}
 	startStates := []model.SchemaState{model.StateNone, model.StateDeleteOnly, model.StateWriteOnly, model.StateWriteReorganization}

--- a/session/session.go
+++ b/session/session.go
@@ -194,8 +194,6 @@ type session struct {
 
 	store kv.Storage
 
-	parser *parser.Parser
-
 	preparedPlanCache *kvcache.SimpleLRUCache
 
 	sessionVars    *variable.SessionVars
@@ -1089,9 +1087,14 @@ func (s *session) ParseSQL(ctx context.Context, sql, charset, collation string) 
 		defer span1.Finish()
 	}
 	defer trace.StartRegion(ctx, "ParseSQL").End()
-	s.parser.SetSQLMode(s.sessionVars.SQLMode)
-	s.parser.SetParserConfig(s.sessionVars.BuildParserConfig())
-	return s.parser.Parse(sql, charset, collation)
+	return s.newParser().Parse(sql, charset, collation)
+}
+
+func (s *session) newParser() *parser.Parser {
+	p := parser.New()
+	p.SetSQLMode(s.sessionVars.SQLMode)
+	p.SetParserConfig(s.sessionVars.BuildParserConfig())
+	return p
 }
 
 func (s *session) SetProcessInfo(sql string, t time.Time, command byte, maxExecutionTime uint64) {
@@ -2102,7 +2105,7 @@ func CreateSessionWithOpt(store kv.Storage, opt *Opt) (Session, error) {
 	}
 	privilege.BindPrivilegeManager(s, pm)
 
-	sessionBindHandle := bindinfo.NewSessionBindHandle(s.parser)
+	sessionBindHandle := bindinfo.NewSessionBindHandle(s.newParser())
 	s.SetValue(bindinfo.SessionBindInfoKeyType, sessionBindHandle)
 	// Add stats collector, and it will be freed by background stats worker
 	// which periodically updates stats using the collected data.
@@ -2341,7 +2344,6 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 	}
 	s := &session{
 		store:           store,
-		parser:          parser.New(),
 		sessionVars:     variable.NewSessionVars(),
 		ddlOwnerChecker: dom.DDL().OwnerManager(),
 		client:          store.GetClient(),
@@ -2363,7 +2365,7 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 	s.sessionVars.BinlogClient = binloginfo.GetPumpsClient()
 	s.txn.init()
 
-	sessionBindHandle := bindinfo.NewSessionBindHandle(s.parser)
+	sessionBindHandle := bindinfo.NewSessionBindHandle(s.newParser())
 	s.SetValue(bindinfo.SessionBindInfoKeyType, sessionBindHandle)
 	return s, nil
 }
@@ -2375,7 +2377,6 @@ func createSessionWithOpt(store kv.Storage, opt *Opt) (*session, error) {
 func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, error) {
 	s := &session{
 		store:       store,
-		parser:      parser.New(),
 		sessionVars: variable.NewSessionVars(),
 		client:      store.GetClient(),
 		mppClient:   store.GetMPPClient(),


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24259, close #24307 <!-- REMOVE this line if no issue to close -->

Problem Summary: executor: fix a concurrent-access problem caused by accessing a single parser in session concurrently 

### What is changed and how it works?

The parser object in `session` may be accessed concurrently by `rule_partition_processor` when there is a `DataSource` accessing a partition table in the inner side of an IndexJoin since the `IndexJoin` may create multiple `DataSource`.

After discussing this problem with @tiancaiamao , we decided to introduce a parser pool to solve it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- executor: fix a concurrent-access problem caused by accessing a single parser in session concurrently 
