### PR TITLE
executor: Use TableReader directly when accessing TiFlash partition table instead of using PartitionTableExec

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2686,31 +2686,18 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 	}
 	if v.StoreType == kv.TiFlash {
 		sctx.IsTiFlash.Store(true)
-		partsExecutor := make([]Executor, 0, len(partitions))
-		for _, part := range partitions {
-			exec, err := buildNoRangeTableReader(b, v)
-			if err != nil {
-				b.err = err
-				return nil
-			}
-			exec.ranges = ts.Ranges
-			nexec, err := nextPartitionForTableReader{exec: exec}.nextPartition(context.Background(), part)
-			if err != nil {
-				b.err = err
-				return nil
-			}
-			partsExecutor = append(partsExecutor, nexec)
+		exec, err := buildNoRangeTableReader(b, v)
+		if err != nil {
+			b.err = err
+			return nil
 		}
-		if len(partsExecutor) == 0 {
-			return &TableDualExec{baseExecutor: *ret.base()}
+		exec.ranges = ts.Ranges
+		exec.kvRangeBuilder = kvRangeBuilderFromRangeAndPartition{
+			sctx:       b.ctx,
+			partitions: partitions,
+			ranges:     ts.Ranges,
 		}
-		if len(partsExecutor) == 1 {
-			return partsExecutor[0]
-		}
-		return &UnionExec{
-			baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID(), partsExecutor...),
-			concurrency:  b.ctx.GetSessionVars().UnionConcurrency(),
-		}
+		return exec
 	}
 
 	if len(partitions) == 0 {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2686,18 +2686,6 @@ func (b *executorBuilder) buildTableReader(v *plannercore.PhysicalTableReader) E
 	}
 	if v.StoreType == kv.TiFlash {
 		sctx.IsTiFlash.Store(true)
-		exec, err := buildNoRangeTableReader(b, v)
-		if err != nil {
-			b.err = err
-			return nil
-		}
-		exec.ranges = ts.Ranges
-		exec.kvRangeBuilder = kvRangeBuilderFromRangeAndPartition{
-			sctx:       b.ctx,
-			partitions: partitions,
-			ranges:     ts.Ranges,
-		}
-		return exec
 	}
 
 	if len(partitions) == 0 {

--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -40,33 +40,6 @@ type nextPartition interface {
 	nextPartition(context.Context, table.PhysicalTable) (Executor, error)
 }
 
-// nolint:structcheck
-type innerPartitionInfo struct {
-	isFullPartition bool
-}
-
-type nextPartitionForTableReader struct {
-	*innerPartitionInfo
-	rangeBuilders map[int64]kvRangeBuilder
-	exec          *TableReaderExecutor
-}
-
-func (n nextPartitionForTableReader) GetInnerPartitionInfo() *innerPartitionInfo {
-	return n.innerPartitionInfo
-}
-
-func (n nextPartitionForTableReader) nextPartition(ctx context.Context, tbl table.PhysicalTable) (Executor, error) {
-	n.exec.table = tbl
-	n.exec.kvRanges = n.exec.kvRanges[:0]
-	if n.innerPartitionInfo != nil && !n.isFullPartition {
-		n.exec.kvRangeBuilder = n.rangeBuilders[tbl.GetPhysicalID()]
-	}
-	if err := updateDAGRequestTableID(ctx, n.exec.dagPB, tbl.GetPhysicalID()); err != nil {
-		return nil, err
-	}
-	return n.exec, nil
-}
-
 type nextPartitionForUnionScan struct {
 	b     *executorBuilder
 	us    *plannercore.PhysicalUnionScan

--- a/executor/partition_table.go
+++ b/executor/partition_table.go
@@ -69,23 +69,6 @@ func nextPartitionWithTrace(ctx context.Context, n nextPartition, tbl table.Phys
 	return n.nextPartition(ctx, tbl)
 }
 
-// updateDAGRequestTableID update the table ID in the DAG request to partition ID.
-// TiKV only use that table ID for log, but TiFlash use it.
-func updateDAGRequestTableID(ctx context.Context, dag *tipb.DAGRequest, partitionID int64) error {
-	// TiFlash set RootExecutor field and ignore Executors field.
-	if dag.RootExecutor != nil {
-		return updateExecutorTableID(ctx, dag.RootExecutor, partitionID, true)
-	}
-	for i := 0; i < len(dag.Executors); i++ {
-		exec := dag.Executors[i]
-		err := updateExecutorTableID(ctx, exec, partitionID, false)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 func updateExecutorTableID(ctx context.Context, exec *tipb.Executor, partitionID int64, recursive bool) error {
 	var child *tipb.Executor
 	switch exec.Tp {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24343 <!-- REMOVE this line if no issue to close -->

Problem Summary: executor: Use TableReader directly when accessing TiFlash partition table instead of using PartitionTableExec

### What is changed and how it works?

Now TableReader can support reading partition table directly, but when accessing TiFlash, PartitionTableExec is still used.
There is already a test about this(`TestReadPartitionTable` in `tiflash_test.go`), so I didn't introduce any new test case.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- executor: Use TableReader directly when accessing TiFlash partition table instead of using PartitionTableExec
