### PR TITLE
store/tikv: use tikv.error.ErrInvalidTxn instead of kv.ErrInvalidTxn

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -155,6 +155,10 @@ func toTiDBErr(err error) error {
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
+
+	if errors.ErrorEqual(err, tikverr.ErrInvalidTxn) {
+		return kv.ErrInvalidTxn
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -27,6 +27,8 @@ var (
 	ErrTiDBShuttingDown = errors.New("tidb server shutting down")
 	// ErrNotExist means the related data not exist.
 	ErrNotExist = errors.New("not exist")
+	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.
+	ErrInvalidTxn = errors.New("invalid transaction")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.

--- a/store/tikv/tests/2pc_fail_test.go
+++ b/store/tikv/tests/2pc_fail_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/tidb/kv"
+	tikverr "github.com/pingcap/tidb/store/tikv/error"
 )
 
 // TestFailCommitPrimaryRpcErrors tests rpc errors are handled properly when
@@ -40,7 +40,7 @@ func (s *testCommitterSuite) TestFailCommitPrimaryRpcErrors(c *C) {
 
 	// We don't need to call "Rollback" after "Commit" fails.
 	err = t1.Rollback()
-	c.Assert(err, Equals, kv.ErrInvalidTxn)
+	c.Assert(err, Equals, tikverr.ErrInvalidTxn)
 }
 
 // TestFailCommitPrimaryRegionError tests RegionError is handled properly when

--- a/store/tikv/tests/async_commit_fail_test.go
+++ b/store/tikv/tests/async_commit_fail_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/terror"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/tikv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/util"
@@ -65,7 +64,7 @@ func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
 
 	// We don't need to call "Rollback" after "Commit" fails.
 	err = t1.Rollback()
-	c.Assert(err, Equals, kv.ErrInvalidTxn)
+	c.Assert(err, Equals, tikverr.ErrInvalidTxn)
 
 	// Create a new transaction to check. The previous transaction should actually commit.
 	t2 := s.beginAsyncCommit(c)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -220,7 +220,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	defer trace.StartRegion(ctx, "CommitTxn").End()
 
 	if !txn.valid {
-		return tidbkv.ErrInvalidTxn
+		return tikverr.ErrInvalidTxn
 	}
 	defer txn.close()
 
@@ -316,7 +316,7 @@ func (txn *KVTxn) close() {
 // Rollback undoes the transaction operations to KV store.
 func (txn *KVTxn) Rollback() error {
 	if !txn.valid {
-		return tidbkv.ErrInvalidTxn
+		return tikverr.ErrInvalidTxn
 	}
 	start := time.Now()
 	// Clean up pessimistic lock.


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR use `tikverr.ErrInvalidTxn` instead of `kv.ErrInvalidTxn` in tikv-client and convert to kv error in tikv-driver.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note