### PR TITLE
store/tikv: use tikv.error.ErrWriteConflictInLatch instead of kv.ErrW…

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -157,7 +157,7 @@ func toTiDBErr(err error) error {
 	}
 
 	if e, ok := err.(*tikverr.ErrWriteConflictInLatch); ok {
-		return kv.ErrWriteConflictInTiDB.GenWithStackByArgs(e.StartTS)
+		return kv.ErrWriteConflictInTiDB.FastGenByArgs(e.StartTS)
 	}
 	return errors.Trace(err)
 }

--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -155,6 +155,10 @@ func toTiDBErr(err error) error {
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
+
+	if e, ok := err.(*tikverr.ErrWriteConflictInLatch); ok {
+		return kv.ErrWriteConflictInTiDB.GenWithStackByArgs(e.StartTS)
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/config/config.go
+++ b/store/tikv/config/config.go
@@ -36,6 +36,11 @@ const (
 	DefStoresRefreshInterval = 60
 )
 
+func init() {
+	conf := DefaultConfig()
+	StoreGlobalConfig(&conf)
+}
+
 // Config contains configuration options.
 type Config struct {
 	CommitterConcurrency int

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -14,6 +14,8 @@
 package error
 
 import (
+	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -122,6 +124,15 @@ func NewErrWriteConfictWithArgs(startTs, conflictTs, conflictCommitTs uint64, ke
 		ConflictCommitTs: conflictCommitTs,
 	}
 	return &ErrWriteConflict{WriteConflict: &conflict}
+}
+
+// ErrWriteConflictInTiDB is the error when the commit meets an write conflict error when local latch is enabled.
+type ErrWriteConflictInLatch struct {
+	StartTS uint64
+}
+
+func (e *ErrWriteConflictInLatch) Error() string {
+	return fmt.Sprintf("write conflict in latch,startTS:%v", e.StartTS)
 }
 
 // ErrRetryable wraps *kvrpcpb.Retryable to implement the error interface.

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -126,7 +126,7 @@ func NewErrWriteConfictWithArgs(startTs, conflictTs, conflictCommitTs uint64, ke
 	return &ErrWriteConflict{WriteConflict: &conflict}
 }
 
-// ErrWriteConflictInTiDB is the error when the commit meets an write conflict error when local latch is enabled.
+// ErrWriteConflictInLatch is the error when the commit meets an write conflict error when local latch is enabled.
 type ErrWriteConflictInLatch struct {
 	StartTS uint64
 }

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -136,7 +136,7 @@ type ErrWriteConflictInLatch struct {
 }
 
 func (e *ErrWriteConflictInLatch) Error() string {
-	return fmt.Sprintf("write conflict in latch,startTS:%v", e.StartTS)
+	return fmt.Sprintf("write conflict in latch,startTS: %v", e.StartTS)
 }
 
 // ErrRetryable wraps *kvrpcpb.Retryable to implement the error interface.

--- a/store/tikv/tests/2pc_test.go
+++ b/store/tikv/tests/2pc_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
-	tidbkv "github.com/pingcap/tidb/kv"
 	drivertxn "github.com/pingcap/tidb/store/driver/txn"
 	"github.com/pingcap/tidb/store/tikv"
 	"github.com/pingcap/tidb/store/tikv/config"
@@ -307,7 +306,8 @@ func (s *testCommitterSuite) TestContextCancelRetryable(c *C) {
 	c.Assert(err, IsNil)
 	err = txn2.Commit(context.Background())
 	c.Assert(err, NotNil)
-	c.Assert(tidbkv.ErrWriteConflictInTiDB.Equal(err), IsTrue, Commentf("err: %s", err))
+	_, ok := err.(*tikverr.ErrWriteConflictInLatch)
+	c.Assert(ok, IsTrue, Commentf("err: %s", err))
 }
 
 func (s *testCommitterSuite) TestContextCancelCausingUndetermined(c *C) {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -296,7 +296,7 @@ func (txn *KVTxn) Commit(ctx context.Context) error {
 	}
 	defer txn.store.txnLatches.UnLock(lock)
 	if lock.IsStale() {
-		return tidbkv.ErrWriteConflictInTiDB.FastGenByArgs(txn.startTS)
+		return &tikverr.ErrWriteConflictInLatch{StartTS: txn.startTS}
 	}
 	err = committer.execute(ctx)
 	if val == nil || sessionID > 0 {

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -30,7 +30,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
-	tidbkv "github.com/pingcap/tidb/kv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR use `tikverr.ErrWriteConflictInLatch` instead of `kv.ErrWriteConflictInTiDB` in tikv-client and convert to kv error in tikv-driver.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note