### PR TITLE
store/tikv: use tikv.error.ErrCannotSetNilValue instead of kv error

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -155,6 +155,11 @@ func toTiDBErr(err error) error {
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
+
+	if errors.ErrorEqual(err, tikverr.ErrCannotSetNilValue) {
+		return kv.ErrCannotSetNilValue
+	}
+
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -27,6 +27,8 @@ var (
 	ErrTiDBShuttingDown = errors.New("tidb server shutting down")
 	// ErrNotExist means the related data not exist.
 	ErrNotExist = errors.New("not exist")
+	// ErrCannotSetNilValue is the error when sets an empty value.
+	ErrCannotSetNilValue = errors.New("can not set nil value")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.

--- a/store/tikv/unionstore/memdb.go
+++ b/store/tikv/unionstore/memdb.go
@@ -217,7 +217,7 @@ func (db *MemDB) UpdateFlags(key []byte, ops ...kv.FlagsOp) {
 // v must NOT be nil or empty, otherwise it returns ErrCannotSetNilValue.
 func (db *MemDB) Set(key []byte, value []byte) error {
 	if len(value) == 0 {
-		return tidbkv.ErrCannotSetNilValue
+		return tikverr.ErrCannotSetNilValue
 	}
 	return db.set(key, value)
 }
@@ -225,7 +225,7 @@ func (db *MemDB) Set(key []byte, value []byte) error {
 // SetWithFlags put key-value into the last active staging buffer with the given KeyFlags.
 func (db *MemDB) SetWithFlags(key []byte, value []byte, ops ...kv.FlagsOp) error {
 	if len(value) == 0 {
-		return tidbkv.ErrCannotSetNilValue
+		return tikverr.ErrCannotSetNilValue
 	}
 	return db.set(key, value, ops...)
 }


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR use `tikverr.ErrCannotSetNilValue` instead of `kv.ErrCannotSetNilValue` in tikv-client and convert to kv error in tikv-driver.
Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note