### PR TITLE
store/tikv: use tikv.error.ErrEntryTooLarge instead of kv error

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -155,6 +155,11 @@ func toTiDBErr(err error) error {
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
+
+	if e, ok := err.(*tikverr.ErrEntryTooLarge); ok {
+		return kv.ErrEntryTooLarge.GenWithStackByArgs(e.Limit, e.Size)
+	}
+
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -14,6 +14,8 @@
 package error
 
 import (
+	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -131,4 +133,14 @@ type ErrRetryable struct {
 
 func (k *ErrRetryable) Error() string {
 	return k.Retryable
+}
+
+// ErrEntryTooLarge is the error when a key value entry is too large.
+type ErrEntryTooLarge struct {
+	Limit uint64
+	Size  uint64
+}
+
+func (e *ErrEntryTooLarge) Error() string {
+	return fmt.Sprintf("entry size too large, size:%v,limit:%v.", e.Size, e.Limit)
 }

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -142,5 +142,5 @@ type ErrEntryTooLarge struct {
 }
 
 func (e *ErrEntryTooLarge) Error() string {
-	return fmt.Sprintf("entry size too large, size:%v,limit:%v.", e.Size, e.Limit)
+	return fmt.Sprintf("entry size too large, size: %v,limit: %v.", e.Size, e.Limit)
 }

--- a/store/tikv/unionstore/memdb.go
+++ b/store/tikv/unionstore/memdb.go
@@ -281,7 +281,10 @@ func (db *MemDB) set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 
 	if value != nil {
 		if size := uint64(len(key) + len(value)); size > db.entrySizeLimit {
-			return tidbkv.ErrEntryTooLarge.GenWithStackByArgs(db.entrySizeLimit, size)
+			return &tikverr.ErrEntryTooLarge{
+				Limit: db.entrySizeLimit,
+				Size:  size,
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR uses `tikverr.ErrEntryTooLarge` instead of `kv.ErrEntryTooLarge` in `tikv` package, and we convert the tikv error to kv error in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note