### PR TITLE
store/tikv: use tikv.error.ErrTxnTooLarge instead of kv.ErrTxnTooLarge

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -155,6 +155,10 @@ func toTiDBErr(err error) error {
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
+
+	if e, ok := err.(*tikverr.ErrTxnTooLarge); ok {
+		return kv.ErrTxnTooLarge.GenWithStackByArgs(e.Size)
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -145,7 +145,7 @@ type ErrTxnTooLarge struct {
 }
 
 func (e *ErrTxnTooLarge) Error() string {
-	return fmt.Sprintf("txn too large, size:%v.", e.Size)
+	return fmt.Sprintf("txn too large, size: %v.", e.Size)
 }
 
 // ErrEntryTooLarge is the error when a key value entry is too large.

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -14,6 +14,8 @@
 package error
 
 import (
+	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/kvproto/pkg/pdpb"
@@ -131,4 +133,13 @@ type ErrRetryable struct {
 
 func (k *ErrRetryable) Error() string {
 	return k.Retryable
+}
+
+// ErrTxnTooLarge is the error when transaction is too large, lock time reached the maximum value.
+type ErrTxnTooLarge struct {
+	Size int
+}
+
+func (e *ErrTxnTooLarge) Error() string {
+	return fmt.Sprintf("txn too large, size:%v.", e.Size)
 }

--- a/store/tikv/unionstore/memdb.go
+++ b/store/tikv/unionstore/memdb.go
@@ -307,7 +307,7 @@ func (db *MemDB) set(key []byte, value []byte, ops ...kv.FlagsOp) error {
 
 	db.setValue(x, value)
 	if uint64(db.Size()) > db.bufferSizeLimit {
-		return tidbkv.ErrTxnTooLarge.GenWithStackByArgs(db.Size())
+		return &tikverr.ErrTxnTooLarge{Size: db.Size()}
 	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR uses `tikverr.ErrTxnTooLarge` instead of `kv.ErrTxnTooLarge` in `tikv` package, and we convert the tikv error to kv error in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note