### PR TITLE
store/tikv: remove use of NotFillCache transaction option in store/tikv

### DIFF
--- a/store/driver/txn/snapshot.go
+++ b/store/driver/txn/snapshot.go
@@ -67,6 +67,8 @@ func (s *tikvSnapshot) SetOption(opt int, val interface{}) {
 	case tikvstore.IsolationLevel:
 		level := getTiKVIsolationLevel(val.(kv.IsoLevel))
 		s.KVSnapshot.SetIsolationLevel(level)
+	case tikvstore.NotFillCache:
+		s.KVSnapshot.SetNotFillCache(val.(bool))
 	default:
 		s.KVSnapshot.SetOption(opt, val)
 	}

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -134,6 +134,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 	case tikvstore.IsolationLevel:
 		level := getTiKVIsolationLevel(val.(kv.IsoLevel))
 		txn.KVTxn.GetSnapshot().SetIsolationLevel(level)
+	case tikvstore.NotFillCache:
+		txn.KVTxn.GetSnapshot().SetNotFillCache(val.(bool))
 	case tikvstore.Pessimistic:
 		txn.SetPessimistic(val.(bool))
 	default:

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -553,8 +553,6 @@ func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 	switch opt {
 	case kv.Priority:
 		s.priority = PriorityToPB(val.(int))
-	case kv.NotFillCache:
-		s.notFillCache = val.(bool)
 	case kv.SyncLog:
 		s.syncLog = val.(bool)
 	case kv.KeyOnly:
@@ -600,6 +598,12 @@ func (s *KVSnapshot) DelOption(opt int) {
 		s.mu.stats = nil
 		s.mu.Unlock()
 	}
+}
+
+// SetNotFillCache indicates whether tikv should skip filling cache when
+// loading data.
+func (s *KVSnapshot) SetNotFillCache(b bool) {
+	s.notFillCache = b
 }
 
 // SetIsolationLevel sets the isolation level used to scan data from tikv.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `Priority` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `KVSnapshot` method to update `notFillCache` flag
- Adapt option in txn\_driver

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note