### PR TITLE
store/tikv: remove use of InfoSchema transaction option in store/tikv

### DIFF
--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -136,6 +136,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.KVTxn.GetSnapshot().SetIsolationLevel(level)
 	case tikvstore.Pessimistic:
 		txn.SetPessimistic(val.(bool))
+	case tikvstore.InfoSchema:
+		txn.SetTxnInfoSchema(val.(tikv.SchemaVer))
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -137,7 +137,7 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 	case tikvstore.Pessimistic:
 		txn.SetPessimistic(val.(bool))
 	case tikvstore.InfoSchema:
-		txn.SetTxnInfoSchema(val.(tikv.SchemaVer))
+		txn.SetSchemaVer(val.(tikv.SchemaVer))
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -1114,12 +1114,12 @@ func (c *twoPhaseCommitter) execute(ctx context.Context) (err error) {
 	if !c.isAsyncCommit() {
 		tryAmend := c.isPessimistic && c.sessionID > 0 && c.txn.schemaAmender != nil
 		if !tryAmend {
-			_, _, err = c.checkSchemaValid(ctx, commitTS, c.txn.txnInfoSchema, false)
+			_, _, err = c.checkSchemaValid(ctx, commitTS, c.txn.schemaVer, false)
 			if err != nil {
 				return errors.Trace(err)
 			}
 		} else {
-			relatedSchemaChange, memAmended, err := c.checkSchemaValid(ctx, commitTS, c.txn.txnInfoSchema, true)
+			relatedSchemaChange, memAmended, err := c.checkSchemaValid(ctx, commitTS, c.txn.schemaVer, true)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1431,7 +1431,7 @@ func (c *twoPhaseCommitter) checkSchemaValid(ctx context.Context, checkTS uint64
 func (c *twoPhaseCommitter) calculateMaxCommitTS(ctx context.Context) error {
 	// Amend txn with current time first, then we can make sure we have another SafeWindow time to commit
 	currentTS := oracle.EncodeTSO(int64(time.Since(c.txn.startTime)/time.Millisecond)) + c.startTS
-	_, _, err := c.checkSchemaValid(ctx, currentTS, c.txn.txnInfoSchema, true)
+	_, _, err := c.checkSchemaValid(ctx, currentTS, c.txn.schemaVer, true)
 	if err != nil {
 		logutil.Logger(ctx).Info("Schema changed for async commit txn",
 			zap.Error(err),

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -182,8 +182,6 @@ func (txn *KVTxn) SetOption(opt int, val interface{}) {
 	txn.us.SetOption(opt, val)
 	txn.snapshot.SetOption(opt, val)
 	switch opt {
-	case kv.InfoSchema:
-		txn.txnInfoSchema = val.(SchemaVer)
 	case kv.SchemaAmender:
 		txn.schemaAmender = val.(SchemaAmender)
 	case kv.CommitHook:
@@ -209,6 +207,11 @@ func (txn *KVTxn) SetSchemaLeaseChecker(checker SchemaLeaseChecker) {
 // SetPessimistic indicates if the transaction should use pessimictic lock.
 func (txn *KVTxn) SetPessimistic(b bool) {
 	txn.isPessimistic = b
+}
+
+// SetTxnInfoSchema updates schema version to validate transaction.
+func (txn *KVTxn) SetTxnInfoSchema(schemaVer SchemaVer) {
+	txn.txnInfoSchema = schemaVer
 }
 
 // SetKVFilter sets the filter to ignore key-values in memory buffer.

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -67,8 +67,8 @@ type KVTxn struct {
 
 	valid bool
 
-	// txnInfoSchema is the infoSchema fetched at startTS.
-	txnInfoSchema SchemaVer
+	// schemaVer is the infoSchema fetched at startTS.
+	schemaVer SchemaVer
 	// SchemaAmender is used amend pessimistic txn commit mutations for schema change
 	schemaAmender SchemaAmender
 	// commitCallback is called after current transaction gets committed
@@ -209,9 +209,9 @@ func (txn *KVTxn) SetPessimistic(b bool) {
 	txn.isPessimistic = b
 }
 
-// SetTxnInfoSchema updates schema version to validate transaction.
-func (txn *KVTxn) SetTxnInfoSchema(schemaVer SchemaVer) {
-	txn.txnInfoSchema = schemaVer
+// SetSchemaVer updates schema version to validate transaction.
+func (txn *KVTxn) SetSchemaVer(schemaVer SchemaVer) {
+	txn.schemaVer = schemaVer
 }
 
 // SetKVFilter sets the filter to ignore key-values in memory buffer.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `InfoSchema` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `SetSchemaVer` method to update
- Adapt option in txn\_driver

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note