### PR TITLE
store/tikv: remove use of Enable1PC transaction option in store/tikv

### DIFF
--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -136,6 +136,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.KVTxn.GetSnapshot().SetIsolationLevel(level)
 	case tikvstore.Pessimistic:
 		txn.SetPessimistic(val.(bool))
+	case tikvstore.Enable1PC:
+		txn.SetEnable1PC(val.(bool))
 	default:
 		txn.KVTxn.SetOption(opt, val)
 	}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -854,8 +854,7 @@ func (c *twoPhaseCommitter) checkOnePC() bool {
 		return false
 	}
 
-	enable1PCOption := c.txn.us.GetOption(kv.Enable1PC)
-	return c.sessionID > 0 && !c.shouldWriteBinlog() && enable1PCOption != nil && enable1PCOption.(bool)
+	return c.sessionID > 0 && !c.shouldWriteBinlog() && c.txn.enable1PC
 }
 
 func (c *twoPhaseCommitter) needLinearizability() bool {

--- a/store/tikv/tests/1pc_test.go
+++ b/store/tikv/tests/1pc_test.go
@@ -18,7 +18,6 @@ import (
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/store/tikv"
-	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/util"

--- a/store/tikv/tests/1pc_test.go
+++ b/store/tikv/tests/1pc_test.go
@@ -27,7 +27,7 @@ import (
 func (s *testAsyncCommitCommon) begin1PC(c *C) tikv.TxnProbe {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
-	txn.SetOption(kv.Enable1PC, true)
+	txn.SetEnable1PC(true)
 	return tikv.TxnProbe{KVTxn: txn}
 }
 

--- a/store/tikv/tests/snapshot_fail_test.go
+++ b/store/tikv/tests/snapshot_fail_test.go
@@ -211,7 +211,7 @@ func (s *testSnapshotFailSuite) TestRetryPointGetResolveTS(c *C) {
 	err = txn.Set([]byte("k2"), []byte("v2"))
 	c.Assert(err, IsNil)
 	txn.SetOption(kv.EnableAsyncCommit, false)
-	txn.SetOption(kv.Enable1PC, false)
+	txn.SetEnable1PC(false)
 	txn.SetOption(kv.GuaranteeLinearizability, false)
 
 	// Prewrite the lock without committing it

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -77,6 +77,7 @@ type KVTxn struct {
 	binlog             BinlogExecutor
 	schemaLeaseChecker SchemaLeaseChecker
 	isPessimistic      bool
+	enable1PC          bool
 	kvFilter           KVFilter
 }
 
@@ -209,6 +210,11 @@ func (txn *KVTxn) SetSchemaLeaseChecker(checker SchemaLeaseChecker) {
 // SetPessimistic indicates if the transaction should use pessimictic lock.
 func (txn *KVTxn) SetPessimistic(b bool) {
 	txn.isPessimistic = b
+}
+
+// SetEnable1PC indicates if the transaction will try to use 1 phase commit.
+func (txn *KVTxn) SetEnable1PC(b bool) {
+	txn.enable1PC = b
 }
 
 // SetKVFilter sets the filter to ignore key-values in memory buffer.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `Enable1PC` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `enable1PC` field to `KVTxn`.
- Add `SetEnable1PC` method
- Adapt option in txn\_driver

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note