### PR TITLE
store/tikv: make tikv.ErrTiKVServerTimeout as a normal error 

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -25,12 +25,14 @@ import (
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/kv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util/dbterror"
 	"go.uber.org/zap"
 )
 
@@ -167,6 +169,11 @@ func toTiDBErr(err error) error {
 	if errors.ErrorEqual(err, tikverr.ErrInvalidTxn) {
 		return kv.ErrInvalidTxn
 	}
+
+	if errors.ErrorEqual(err, tikverr.ErrTiKVServerTimeout) {
+		return dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	}
+
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -26,7 +26,6 @@ const (
 
 	// TiKV/PD/TiFlash errors.
 	CodePDServerTimeout    = 9001
-	CodeTiKVServerTimeout  = 9002
 	CodeTiKVServerBusy     = 9003
 	CodeResolveLockTimeout = 9004
 	CodeRegionUnavailable  = 9005

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -33,6 +33,8 @@ var (
 	ErrCannotSetNilValue = errors.New("can not set nil value")
 	// ErrInvalidTxn is the error when commits or rollbacks in an invalid transaction.
 	ErrInvalidTxn = errors.New("invalid transaction")
+	// ErrTiKVServerTimeout is the error when tikv server is timeout.
+	ErrTiKVServerTimeout = errors.New("tikv server timeout")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -40,7 +42,6 @@ const MismatchClusterID = "mismatch cluster id"
 
 // error instances.
 var (
-	ErrTiKVServerTimeout           = dbterror.ClassTiKV.NewStd(CodeTiKVServerTimeout)
 	ErrTiFlashServerTimeout        = dbterror.ClassTiKV.NewStd(CodeTiFlashServerTimeout)
 	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
 	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrTiKVServerTimeout` as a normal error instead of a dberror and we convert the tikv error to  dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note