### PR TITLE
store/tikv: make tikv.ErrResolveLockTimeout as a normal error instead…

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -39,7 +39,8 @@ import (
 // tikv error instance
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
-	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	ErrTiKVServerTimeout  = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	ErrResolveLockTimeout = dbterror.ClassTiKV.NewStd(errno.ErrResolveLockTimeout)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -188,6 +189,9 @@ func toTiDBErr(err error) error {
 		return ErrTiKVServerTimeout
 	}
 
+	if errors.ErrorEqual(err, tikverr.ErrResolveLockTimeout) {
+		return ErrResolveLockTimeout
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -25,11 +25,10 @@ const (
 	CodeLockAcquireFailAndNoWaitSet = 3572
 
 	// TiKV/PD/TiFlash errors.
-	CodePDServerTimeout    = 9001
-	CodeTiKVServerBusy     = 9003
-	CodeResolveLockTimeout = 9004
-	CodeRegionUnavailable  = 9005
-	CodeGCTooEarly         = 9006
+	CodePDServerTimeout   = 9001
+	CodeTiKVServerBusy    = 9003
+	CodeRegionUnavailable = 9005
+	CodeGCTooEarly        = 9006
 
 	CodeTiKVStoreLimit = 9008
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -35,6 +35,8 @@ var (
 	ErrInvalidTxn = errors.New("invalid transaction")
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = errors.New("tikv server timeout")
+	// ErrResolveLockTimeout is the error that resolve lock timeout.
+	ErrResolveLockTimeout = errors.New("resolve lock timeout")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -43,7 +45,6 @@ const MismatchClusterID = "mismatch cluster id"
 // error instances.
 var (
 	ErrTiFlashServerTimeout        = dbterror.ClassTiKV.NewStd(CodeTiFlashServerTimeout)
-	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
 	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
 	ErrRegionUnavailable           = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
 	ErrTiKVServerBusy              = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrResolveLockTimeout` as a normal error instead of a dberror and we convert the tikv error to  dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note