### PR TITLE
store/tikv: make tikv.PDServerTimeout as a normal error instead of db…

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -40,6 +40,8 @@ import (
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	// ErrPDServerTimeout is the error when pd server is timeout.
+	ErrPDServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrPDServerTimeout)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -188,6 +190,12 @@ func toTiDBErr(err error) error {
 		return ErrTiKVServerTimeout
 	}
 
+	if e, ok := err.(*tikverr.ErrPDServerTimeout); ok {
+		if len(e.Error()) == 0 {
+			return ErrPDServerTimeout
+		}
+		return ErrPDServerTimeout.GenWithStackByArgs(e.Error())
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -200,7 +200,7 @@ func (t BackoffType) TError() error {
 	case BoTxnLock, BoTxnLockFast, boTxnNotFound:
 		return tikverr.ErrResolveLockTimeout
 	case BoPDRPC:
-		return tikverr.ErrPDServerTimeout
+		return tikverr.NewErrPDServerTimeout("")
 	case BoRegionMiss:
 		return tikverr.ErrRegionUnavailable
 	case boTiKVServerBusy:

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -25,7 +25,6 @@ const (
 	CodeLockAcquireFailAndNoWaitSet = 3572
 
 	// TiKV/PD/TiFlash errors.
-	CodePDServerTimeout    = 9001
 	CodeTiKVServerBusy     = 9003
 	CodeResolveLockTimeout = 9004
 	CodeRegionUnavailable  = 9005

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -44,7 +44,6 @@ const MismatchClusterID = "mismatch cluster id"
 var (
 	ErrTiFlashServerTimeout        = dbterror.ClassTiKV.NewStd(CodeTiFlashServerTimeout)
 	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
-	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
 	ErrRegionUnavailable           = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
 	ErrTiKVServerBusy              = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)
 	ErrTiFlashServerBusy           = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
@@ -166,4 +165,18 @@ type ErrEntryTooLarge struct {
 
 func (e *ErrEntryTooLarge) Error() string {
 	return fmt.Sprintf("entry size too large, size: %v,limit: %v.", e.Size, e.Limit)
+}
+
+// ErrPDServerTimeout is the error when pd server is timeout.
+type ErrPDServerTimeout struct {
+	msg string
+}
+
+// NewErrPDServerTimeout creates an ErrPDServerTimeout.
+func NewErrPDServerTimeout(msg string) error {
+	return &ErrPDServerTimeout{msg}
+}
+
+func (e *ErrPDServerTimeout) Error() string {
+	return e.msg
 }

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -107,7 +107,7 @@ func (s *KVStore) CheckVisibility(startTime uint64) error {
 	diff := time.Since(cachedTime)
 
 	if diff > (GcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
-		return tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point")
+		return tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point")
 	}
 
 	if startTime < cachedSafePoint {
@@ -307,7 +307,7 @@ func (s *KVStore) getTimestampWithRetry(bo *Backoffer, txnScope string) (uint64,
 		// This may cause duplicate data to be written.
 		failpoint.Inject("mockGetTSErrorInRetry", func(val failpoint.Value) {
 			if val.(bool) && !IsMockCommitErrorEnable() {
-				err = tikverr.ErrPDServerTimeout.GenWithStackByArgs("mock PD timeout")
+				err = tikverr.NewErrPDServerTimeout("mock PD timeout")
 			}
 		})
 

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -185,7 +185,7 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bool
 		if batchResp.err == nil {
 			batchResp.err = err
 		}
-		if tikverr.ErrPDServerTimeout.Equal(err) {
+		if _, ok := err.(*tikverr.ErrPDServerTimeout); ok {
 			break
 		}
 	}
@@ -219,7 +219,7 @@ func (s *KVStore) scatterRegion(bo *Backoffer, regionID uint64, tableID *int64) 
 
 		if val, err2 := util.MockScatterRegionTimeout.Eval(); err2 == nil {
 			if val.(bool) {
-				err = tikverr.ErrPDServerTimeout
+				err = tikverr.NewErrPDServerTimeout("")
 			}
 		}
 

--- a/store/tikv/tests/safepoint_test.go
+++ b/store/tikv/tests/safepoint_test.go
@@ -92,7 +92,7 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 	_, geterr2 := txn2.Get(context.TODO(), encodeKey(s.prefix, s08d("key", 0)))
 	c.Assert(geterr2, NotNil)
 	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
-	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point"))
 	isBehind := isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -104,7 +104,7 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 	_, seekerr := txn3.Iter(encodeKey(s.prefix, ""), nil)
 	c.Assert(seekerr, NotNil)
 	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 
@@ -117,7 +117,7 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 	_, batchgeterr := toTiDBTxn(&txn4).BatchGet(context.Background(), toTiDBKeys(keys))
 	c.Assert(batchgeterr, NotNil)
 	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
-	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
+	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
 }


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.PDServerTimeout` as a normal error instead of a dberror and we convert the tikv error to  dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note