### PR TITLE
executor, meta: Allocate auto id for global temporary tables

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1590,3 +1590,88 @@ func (s *testSuite10) TestBinaryLiteralInsertToSet(c *C) {
 	tk.MustExec("insert into bintest(h) values(0x61)")
 	tk.MustQuery("select * from bintest").Check(testkit.Rows("a"))
 }
+
+var _ = SerialSuites(&testSuite13{&baseTestSuite{}})
+
+type testSuite13 struct {
+	*baseTestSuite
+}
+
+func (s *testSuite13) TestGlobalTempTableAutoInc(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec("drop table if exists temp_test")
+	tk.MustExec("create global temporary table temp_test(id int primary key auto_increment) on commit delete rows")
+
+	// Data is cleared after transaction auto commits.
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select * from temp_test").Check(testkit.Rows())
+
+	// Data is not cleared inside a transaction.
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select * from temp_test").Check(testkit.Rows("1"))
+	tk.MustExec("commit")
+
+	// AutoID allocator is cleared.
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select * from temp_test").Check(testkit.Rows("1"))
+	// Test whether auto-inc is incremental
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select id from temp_test order by id").Check(testkit.Rows("1", "2"))
+	tk.MustExec("commit")
+
+	// multi-value insert
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0), (0)")
+	tk.MustQuery("select id from temp_test order by id").Check(testkit.Rows("1", "2"))
+	tk.MustExec("insert into temp_test(id) values(0), (0)")
+	tk.MustQuery("select id from temp_test order by id").Check(testkit.Rows("1", "2", "3", "4"))
+	tk.MustExec("commit")
+
+	// rebase
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(10)")
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select id from temp_test order by id").Check(testkit.Rows("10", "11"))
+	tk.MustExec("insert into temp_test(id) values(20), (30)")
+	tk.MustExec("insert into temp_test(id) values(0), (0)")
+	tk.MustQuery("select id from temp_test order by id").Check(testkit.Rows("10", "11", "20", "30", "31", "32"))
+	tk.MustExec("commit")
+}
+
+func (s *testSuite13) TestGlobalTempTableRowID(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec(`use test`)
+	tk.MustExec("drop table if exists temp_test")
+
+	tk.MustExec("create global temporary table temp_test(id int) on commit delete rows")
+
+	// Data is cleared after transaction auto commits.
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select _tidb_rowid from temp_test").Check(testkit.Rows())
+
+	// Data is not cleared inside a transaction.
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select _tidb_rowid from temp_test").Check(testkit.Rows("1"))
+	tk.MustExec("commit")
+
+	// AutoID allocator is cleared.
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select _tidb_rowid from temp_test").Check(testkit.Rows("1"))
+	// Test whether row id is incremental
+	tk.MustExec("insert into temp_test(id) values(0)")
+	tk.MustQuery("select _tidb_rowid from temp_test order by _tidb_rowid").Check(testkit.Rows("1", "2"))
+	tk.MustExec("commit")
+
+	// multi-value insert
+	tk.MustExec("begin")
+	tk.MustExec("insert into temp_test(id) values(0), (0)")
+	tk.MustQuery("select _tidb_rowid from temp_test order by _tidb_rowid").Check(testkit.Rows("1", "2"))
+	tk.MustExec("insert into temp_test(id) values(0), (0)")
+	tk.MustQuery("select _tidb_rowid from temp_test order by _tidb_rowid").Check(testkit.Rows("1", "2", "3", "4"))
+	tk.MustExec("commit")
+}

--- a/meta/autoid/autoid.go
+++ b/meta/autoid/autoid.go
@@ -912,6 +912,132 @@ func (alloc *allocator) alloc4Sequence(tableID int64) (min int64, max int64, rou
 	return newBase, newEnd, round, nil
 }
 
+// NewAllocatorFromTempTblInfo creates an in-memory allocator from a temporary table info.
+func NewAllocatorFromTempTblInfo(tblInfo *model.TableInfo) Allocator {
+	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
+	hasAutoIncID := tblInfo.GetAutoIncrementColInfo() != nil
+	// Temporary tables don't support auto_random and sequence.
+	if hasRowID || hasAutoIncID {
+		return &inMemoryAllocator{
+			isUnsigned: tblInfo.IsAutoIncColUnsigned(),
+			allocType:  RowIDAllocType,
+		}
+	}
+	return nil
+}
+
+// inMemoryAllocator is typically used in temporary tables.
+// Some characteristics:
+// - It allocates IDs from memory.
+// - It's session-wide and thus won't be visited concurrently.
+// - It doesn't support sequence.
+// - The metrics are not reported.
+type inMemoryAllocator struct {
+	base       int64
+	isUnsigned bool
+	allocType  AllocatorType
+}
+
+// Base implements autoid.Allocator Base interface.
+func (alloc *inMemoryAllocator) Base() int64 {
+	return alloc.base
+}
+
+// End implements autoid.Allocator End interface.
+func (alloc *inMemoryAllocator) End() int64 {
+	return math.MaxInt64
+}
+
+func (alloc *inMemoryAllocator) GetType() AllocatorType {
+	return alloc.allocType
+}
+
+// NextGlobalAutoID implements autoid.Allocator NextGlobalAutoID interface.
+func (alloc *inMemoryAllocator) NextGlobalAutoID(tableID int64) (int64, error) {
+	return 0, errNotImplemented.GenWithStackByArgs()
+}
+
+func (alloc *inMemoryAllocator) Alloc(ctx context.Context, tableID int64, n uint64, increment, offset int64) (int64, int64, error) {
+	if n == 0 {
+		return 0, 0, nil
+	}
+	if alloc.allocType == AutoIncrementType || alloc.allocType == RowIDAllocType {
+		if !validIncrementAndOffset(increment, offset) {
+			return 0, 0, errInvalidIncrementAndOffset.GenWithStackByArgs(increment, offset)
+		}
+	}
+	if alloc.isUnsigned {
+		return alloc.alloc4Unsigned(n, increment, offset)
+	}
+	return alloc.alloc4Signed(n, increment, offset)
+}
+
+// Rebase implements autoid.Allocator Rebase interface.
+// The requiredBase is the minimum base value after Rebase.
+// The real base may be greater than the required base.
+func (alloc *inMemoryAllocator) Rebase(tableID, requiredBase int64, allocIDs bool) error {
+	if alloc.isUnsigned {
+		if uint64(requiredBase) > uint64(alloc.base) {
+			alloc.base = requiredBase
+		}
+	}
+	if requiredBase > alloc.base {
+		alloc.base = requiredBase
+	}
+	return nil
+}
+
+func (alloc *inMemoryAllocator) alloc4Signed(n uint64, increment, offset int64) (int64, int64, error) {
+	// Check offset rebase if necessary.
+	if offset-1 > alloc.base {
+		requiredBase := offset - 1
+		if requiredBase > alloc.base {
+			alloc.base = requiredBase
+		}
+	}
+	// CalcNeededBatchSize calculates the total batch size needed.
+	n1 := CalcNeededBatchSize(alloc.base, int64(n), increment, offset, alloc.isUnsigned)
+
+	// Condition alloc.base+N1 > alloc.end will overflow when alloc.base + N1 > MaxInt64. So need this.
+	if math.MaxInt64-alloc.base <= n1 {
+		return 0, 0, ErrAutoincReadFailed
+	}
+
+	min := alloc.base
+	alloc.base += n1
+	return min, alloc.base, nil
+}
+
+func (alloc *inMemoryAllocator) alloc4Unsigned(n uint64, increment, offset int64) (int64, int64, error) {
+	// Check offset rebase if necessary.
+	if uint64(offset-1) > uint64(alloc.base) {
+		requiredBase := uint64(offset - 1)
+		if requiredBase > uint64(alloc.base) {
+			alloc.base = int64(requiredBase)
+		}
+	}
+	// CalcNeededBatchSize calculates the total batch size needed.
+	n1 := CalcNeededBatchSize(alloc.base, int64(n), increment, offset, alloc.isUnsigned)
+
+	// Condition alloc.base+n1 > alloc.end will overflow when alloc.base + n1 > MaxInt64. So need this.
+	if math.MaxUint64-uint64(alloc.base) <= uint64(n1) {
+		return 0, 0, ErrAutoincReadFailed
+	}
+
+	min := alloc.base
+	// Use uint64 n directly.
+	alloc.base = int64(uint64(alloc.base) + uint64(n1))
+	return min, alloc.base, nil
+}
+
+func (alloc *inMemoryAllocator) AllocSeqCache(tableID int64) (int64, int64, int64, error) {
+	return 0, 0, 0, errNotImplemented.GenWithStackByArgs()
+}
+
+func (alloc *inMemoryAllocator) RebaseSeq(tableID, requiredBase int64) (int64, bool, error) {
+	return 0, false, errNotImplemented.GenWithStackByArgs()
+}
+
 // GetAutoID get an auto ID for the given allocator type.
 func GetAutoID(m *meta.Meta, dbID, tableID int64, allocType AllocatorType) (int64, error) {
 	switch allocType {

--- a/meta/autoid/errors.go
+++ b/meta/autoid/errors.go
@@ -22,6 +22,7 @@ import (
 var (
 	errInvalidTableID            = dbterror.ClassAutoid.NewStd(mysql.ErrInvalidTableID)
 	errInvalidIncrementAndOffset = dbterror.ClassAutoid.NewStd(mysql.ErrInvalidIncrementAndOffset)
+	errNotImplemented            = dbterror.ClassAutoid.NewStd(mysql.ErrNotImplemented)
 	ErrAutoincReadFailed         = dbterror.ClassAutoid.NewStd(mysql.ErrAutoincReadFailed)
 	ErrWrongAutoKey              = dbterror.ClassAutoid.NewStd(mysql.ErrWrongAutoKey)
 	ErrInvalidAllocatorType      = dbterror.ClassAutoid.NewStd(mysql.ErrUnknownAllocatorType)

--- a/session/session.go
+++ b/session/session.go
@@ -513,7 +513,10 @@ func (s *session) doCommit(ctx context.Context) error {
 	// Filter out the temporary table key-values.
 	if tables := s.sessionVars.TxnCtx.GlobalTemporaryTables; tables != nil {
 		memBuffer := s.txn.GetMemBuffer()
-		for tid := range tables {
+		for tid, tempTable := range tables {
+			if !tempTable.Modified {
+				continue
+			}
 			seekKey := tablecodec.EncodeTablePrefix(tid)
 			endKey := tablecodec.EncodeTablePrefix(tid + 1)
 			iter, err := memBuffer.Iter(seekKey, endKey)

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -1369,6 +1369,7 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 	if ctx == nil {
 		return t.allocs
 	} else if ctx.GetSessionVars().IDAllocator == nil {
+		// Use an independent allocator for global temporary tables.
 		if t.meta.TempTableType == model.TempTableGlobal {
 			alloc := ctx.GetSessionVars().GetTemporaryTable(t.meta).AutoIdAllocator
 			return autoid.Allocators{alloc}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Since data in global temporary tables are isolated among sessions, the allocator should also be isolated.

### What is changed and how it works?

What's Changed:
- Maintain a `GlobalTemporaryTables` for each transaction, containing an isolated auto-id allocator.
- Define an `inMemoryAllocator`, which allocates auto-id in memory.
- Use the `inMemoryAllocator` for global temporary tables.

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Allocate auto-id in-memory for global temporary tables.
