### PR TITLE
store/tikv: make tikv.ErrTiKVServerBusy as a normal error instead of …

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -40,6 +40,8 @@ import (
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	// ErrTiKVServerBusy is the error when tikv server is busy.
+	ErrTiKVServerBusy = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerBusy)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -188,6 +190,9 @@ func toTiDBErr(err error) error {
 		return ErrTiKVServerTimeout
 	}
 
+	if errors.ErrorEqual(err, tikverr.ErrTiKVServerBusy) {
+		return ErrTiKVServerBusy
+	}
 	return errors.Trace(err)
 }
 

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -26,7 +26,6 @@ const (
 
 	// TiKV/PD/TiFlash errors.
 	CodePDServerTimeout    = 9001
-	CodeTiKVServerBusy     = 9003
 	CodeResolveLockTimeout = 9004
 	CodeRegionUnavailable  = 9005
 	CodeGCTooEarly         = 9006

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -35,6 +35,8 @@ var (
 	ErrInvalidTxn = errors.New("invalid transaction")
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = errors.New("tikv server timeout")
+	// ErrTiKVServerBusy is the error when tikv server is busy.
+	ErrTiKVServerBusy = errors.New("tikv server busy")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -46,7 +48,6 @@ var (
 	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
 	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
 	ErrRegionUnavailable           = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
-	ErrTiKVServerBusy              = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)
 	ErrTiFlashServerBusy           = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
 	ErrTiKVStaleCommand            = dbterror.ClassTiKV.NewStd(CodeTiKVStaleCommand)
 	ErrTiKVMaxTimestampNotSynced   = dbterror.ClassTiKV.NewStd(CodeTiKVMaxTimestampNotSynced)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrTiKVServerBusy` as a normal error instead of a dberror and we convert the tikv error to  dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note