### PR TITLE
store/tikv: make tikv.ErrTiFlashServerBusy as a normal error instead …

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -40,6 +40,8 @@ import (
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	// ErrTiFlashServerBusy is the error that tiflash server is busy.
+	ErrTiFlashServerBusy = dbterror.ClassTiKV.NewStd(errno.ErrTiFlashServerBusy)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -186,6 +188,10 @@ func toTiDBErr(err error) error {
 
 	if errors.ErrorEqual(err, tikverr.ErrTiKVServerTimeout) {
 		return ErrTiKVServerTimeout
+	}
+
+	if errors.ErrorEqual(err, tikverr.ErrTiFlashServerBusy) {
+		return ErrTiFlashServerBusy
 	}
 
 	return errors.Trace(err)

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -36,5 +36,4 @@ const (
 	CodeTiKVStaleCommand          = 9010
 	CodeTiKVMaxTimestampNotSynced = 9011
 	CodeTiFlashServerTimeout      = 9012
-	CodeTiFlashServerBusy         = 9013
 )

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -35,6 +35,8 @@ var (
 	ErrInvalidTxn = errors.New("invalid transaction")
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = errors.New("tikv server timeout")
+	// ErrTiFlashServerBusy is the error that tiflash server is busy.
+	ErrTiFlashServerBusy = errors.New("tiflash server busy")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -47,7 +49,6 @@ var (
 	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
 	ErrRegionUnavailable           = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
 	ErrTiKVServerBusy              = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)
-	ErrTiFlashServerBusy           = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
 	ErrTiKVStaleCommand            = dbterror.ClassTiKV.NewStd(CodeTiKVStaleCommand)
 	ErrTiKVMaxTimestampNotSynced   = dbterror.ClassTiKV.NewStd(CodeTiKVMaxTimestampNotSynced)
 	ErrGCTooEarly                  = dbterror.ClassTiKV.NewStd(CodeGCTooEarly)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrTiFlashServerBusy` as a normal error instead of a dberror and we convert the tikv error to  dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note