### PR TITLE
store/tikv: make tikv.ErrTiKV* as normal errors instead of dberror

### DIFF
--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -40,6 +40,10 @@ import (
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	// ErrTiKVStaleCommand is the error that the command is stale in tikv.
+	ErrTiKVStaleCommand = dbterror.ClassTiKV.NewStd(errno.ErrTiKVStaleCommand)
+	// ErrTiKVMaxTimestampNotSynced is the error that tikv's max timestamp is not synced.
+	ErrTiKVMaxTimestampNotSynced = dbterror.ClassTiKV.NewStd(errno.ErrTiKVMaxTimestampNotSynced)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -186,6 +190,14 @@ func toTiDBErr(err error) error {
 
 	if errors.ErrorEqual(err, tikverr.ErrTiKVServerTimeout) {
 		return ErrTiKVServerTimeout
+	}
+
+	if errors.ErrorEqual(err, tikverr.ErrTiKVStaleCommand) {
+		return ErrTiKVStaleCommand
+	}
+
+	if errors.ErrorEqual(err, tikverr.ErrTiKVMaxTimestampNotSynced) {
+		return ErrTiKVMaxTimestampNotSynced
 	}
 
 	return errors.Trace(err)

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -33,8 +33,6 @@ const (
 
 	CodeTiKVStoreLimit = 9008
 
-	CodeTiKVStaleCommand          = 9010
-	CodeTiKVMaxTimestampNotSynced = 9011
-	CodeTiFlashServerTimeout      = 9012
-	CodeTiFlashServerBusy         = 9013
+	CodeTiFlashServerTimeout = 9012
+	CodeTiFlashServerBusy    = 9013
 )

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -35,6 +35,10 @@ var (
 	ErrInvalidTxn = errors.New("invalid transaction")
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = errors.New("tikv server timeout")
+	// ErrTiKVStaleCommand is the error that the command is stale in tikv.
+	ErrTiKVStaleCommand = errors.New("tikv stale command")
+	// ErrTiKVMaxTimestampNotSynced is the error that tikv's max timestamp is not synced.
+	ErrTiKVMaxTimestampNotSynced = errors.New("tikv max timestamp not synced")
 )
 
 // MismatchClusterID represents the message that the cluster ID of the PD client does not match the PD.
@@ -42,14 +46,13 @@ const MismatchClusterID = "mismatch cluster id"
 
 // error instances.
 var (
-	ErrTiFlashServerTimeout        = dbterror.ClassTiKV.NewStd(CodeTiFlashServerTimeout)
-	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
-	ErrPDServerTimeout             = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
-	ErrRegionUnavailable           = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
-	ErrTiKVServerBusy              = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)
-	ErrTiFlashServerBusy           = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
-	ErrTiKVStaleCommand            = dbterror.ClassTiKV.NewStd(CodeTiKVStaleCommand)
-	ErrTiKVMaxTimestampNotSynced   = dbterror.ClassTiKV.NewStd(CodeTiKVMaxTimestampNotSynced)
+	ErrTiFlashServerTimeout = dbterror.ClassTiKV.NewStd(CodeTiFlashServerTimeout)
+	ErrResolveLockTimeout   = dbterror.ClassTiKV.NewStd(CodeResolveLockTimeout)
+	ErrPDServerTimeout      = dbterror.ClassTiKV.NewStd(CodePDServerTimeout)
+	ErrRegionUnavailable    = dbterror.ClassTiKV.NewStd(CodeRegionUnavailable)
+	ErrTiKVServerBusy       = dbterror.ClassTiKV.NewStd(CodeTiKVServerBusy)
+	ErrTiFlashServerBusy    = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
+
 	ErrGCTooEarly                  = dbterror.ClassTiKV.NewStd(CodeGCTooEarly)
 	ErrQueryInterrupted            = dbterror.ClassTiKV.NewStd(CodeQueryInterrupted)
 	ErrLockAcquireFailAndNoWaitSet = dbterror.ClassTiKV.NewStd(CodeLockAcquireFailAndNoWaitSet)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrTiKV*` as normal errors instead of a dberror and we convert the tikv error to dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note