### PR TITLE
store/tikv: make tikv.ErrGCTooEarly as a normal error instead of dberror

### DIFF
--- a/executor/point_get_test.go
+++ b/executor/point_get_test.go
@@ -27,9 +27,9 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	txndriver "github.com/pingcap/tidb/store/driver/txn"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/store/tikv"
-	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
@@ -536,15 +536,15 @@ func (s *testPointGetSuite) TestSelectCheckVisibility(c *C) {
 		c.Assert(expectErr.Equal(err), IsTrue)
 	}
 	// Test point get.
-	checkSelectResultError("select * from t where a='1'", tikverr.ErrGCTooEarly)
+	checkSelectResultError("select * from t where a='1'", txndriver.ErrGCTooEarly)
 	// Test batch point get.
-	checkSelectResultError("select * from t where a in ('1','2')", tikverr.ErrGCTooEarly)
+	checkSelectResultError("select * from t where a in ('1','2')", txndriver.ErrGCTooEarly)
 	// Test Index look up read.
-	checkSelectResultError("select * from t where b > 0 ", tikverr.ErrGCTooEarly)
+	checkSelectResultError("select * from t where b > 0 ", txndriver.ErrGCTooEarly)
 	// Test Index read.
-	checkSelectResultError("select b from t where b > 0 ", tikverr.ErrGCTooEarly)
+	checkSelectResultError("select b from t where b > 0 ", txndriver.ErrGCTooEarly)
 	// Test table read.
-	checkSelectResultError("select * from t", tikverr.ErrGCTooEarly)
+	checkSelectResultError("select * from t", txndriver.ErrGCTooEarly)
 }
 
 func (s *testPointGetSuite) TestReturnValues(c *C) {

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -183,12 +183,12 @@ func (c *CopClient) sendBatch(ctx context.Context, req *kv.Request, vars *tikv.V
 		return copErrorResponse{err}
 	}
 	it := &batchCopIterator{
-		store:        c.store.KVStore,
+		store:        c.store.kvStoreDriver,
 		req:          req,
 		finishCh:     make(chan struct{}),
 		vars:         vars,
 		memTracker:   req.MemTracker,
-		ClientHelper: tikv.NewClientHelper(c.store.KVStore, util.NewTSSet(5)),
+		ClientHelper: tikv.NewClientHelper(c.store.kvStoreDriver.store, util.NewTSSet(5)),
 		rpcCancel:    tikv.NewRPCanceller(),
 	}
 	ctx = context.WithValue(ctx, tikv.RPCCancellerCtxKey{}, it.rpcCancel)
@@ -201,7 +201,7 @@ func (c *CopClient) sendBatch(ctx context.Context, req *kv.Request, vars *tikv.V
 type batchCopIterator struct {
 	*tikv.ClientHelper
 
-	store    *tikv.KVStore
+	store    *kvStoreDriver
 	req      *kv.Request
 	finishCh chan struct{}
 

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -183,12 +183,12 @@ func (c *CopClient) sendBatch(ctx context.Context, req *kv.Request, vars *tikv.V
 		return copErrorResponse{err}
 	}
 	it := &batchCopIterator{
-		store:        c.store.kvStoreDriver,
+		store:        c.store.kvStore,
 		req:          req,
 		finishCh:     make(chan struct{}),
 		vars:         vars,
 		memTracker:   req.MemTracker,
-		ClientHelper: tikv.NewClientHelper(c.store.kvStoreDriver.store, util.NewTSSet(5)),
+		ClientHelper: tikv.NewClientHelper(c.store.kvStore.store, util.NewTSSet(5)),
 		rpcCancel:    tikv.NewRPCanceller(),
 	}
 	ctx = context.WithValue(ctx, tikv.RPCCancellerCtxKey{}, it.rpcCancel)
@@ -201,7 +201,7 @@ func (c *CopClient) sendBatch(ctx context.Context, req *kv.Request, vars *tikv.V
 type batchCopIterator struct {
 	*tikv.ClientHelper
 
-	store    *kvStoreDriver
+	store    *kvStore
 	req      *kv.Request
 	finishCh chan struct{}
 

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -402,7 +402,7 @@ func (it *copIterator) open(ctx context.Context, enabledRateLimitAction bool) {
 			respChan:        it.respChan,
 			finishCh:        it.finishCh,
 			vars:            it.vars,
-			ClientHelper:    tikv.NewClientHelper(it.store.KVStore, it.resolvedLocks),
+			ClientHelper:    tikv.NewClientHelper(it.store.store, it.resolvedLocks),
 			memTracker:      it.memTracker,
 			replicaReadSeed: it.replicaReadSeed,
 			actionOnExceed:  it.actionOnExceed,

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -36,7 +36,7 @@ import (
 
 // MPPClient servers MPP requests.
 type MPPClient struct {
-	store *tikv.KVStore
+	store *kvStoreDriver
 }
 
 // GetAddress returns the network address.
@@ -117,7 +117,7 @@ func (m *mppResponse) RespTime() time.Duration {
 }
 
 type mppIterator struct {
-	store *tikv.KVStore
+	store *kvStoreDriver
 
 	tasks    []*kv.MPPDispatchRequest
 	finishCh chan struct{}

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -36,7 +36,7 @@ import (
 
 // MPPClient servers MPP requests.
 type MPPClient struct {
-	store *kvStoreDriver
+	store *kvStore
 }
 
 // GetAddress returns the network address.
@@ -117,7 +117,7 @@ func (m *mppResponse) RespTime() time.Duration {
 }
 
 type mppIterator struct {
-	store *kvStoreDriver
+	store *kvStore
 
 	tasks    []*kv.MPPDispatchRequest
 	finishCh chan struct{}

--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -262,7 +262,7 @@ func (s *tikvStore) StartGCWorker() error {
 
 	gcWorker, err := gcworker.NewGCWorker(s, s.pdClient)
 	if err != nil {
-		return errors.Trace(err)
+		return txn_driver.ToTiDBErr(err)
 	}
 	gcWorker.Start()
 	s.gcWorker = gcWorker
@@ -286,7 +286,8 @@ func (s *tikvStore) Close() error {
 		s.gcWorker.Close()
 	}
 	s.coprStore.Close()
-	return s.KVStore.Close()
+	err := s.KVStore.Close()
+	return txn_driver.ToTiDBErr(err)
 }
 
 // GetMemCache return memory manager of the storage
@@ -298,7 +299,7 @@ func (s *tikvStore) GetMemCache() kv.MemManager {
 func (s *tikvStore) Begin() (kv.Transaction, error) {
 	txn, err := s.KVStore.Begin()
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, txn_driver.ToTiDBErr(err)
 	}
 	return txn_driver.NewTiKVTxn(txn), err
 }
@@ -323,7 +324,7 @@ func (s *tikvStore) BeginWithOption(option kv.TransactionOption) (kv.Transaction
 		txn, err = s.BeginWithTxnScope(txnScope)
 	}
 	if err != nil {
-		return nil, errors.Trace(err)
+		return nil, txn_driver.ToTiDBErr(err)
 	}
 
 	return txn_driver.NewTiKVTxn(txn), err
@@ -338,7 +339,7 @@ func (s *tikvStore) GetSnapshot(ver kv.Version) kv.Snapshot {
 // CurrentVersion returns current max committed version with the given txnScope (local or global).
 func (s *tikvStore) CurrentVersion(txnScope string) (kv.Version, error) {
 	ver, err := s.KVStore.CurrentTimestamp(txnScope)
-	return kv.NewVersion(ver), err
+	return kv.NewVersion(ver), txn_driver.ToTiDBErr(err)
 }
 
 // ShowStatus returns the specified status of the storage

--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -40,6 +40,8 @@ import (
 var (
 	// ErrTiKVServerTimeout is the error when tikv server is timeout.
 	ErrTiKVServerTimeout = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerTimeout)
+	// ErrGCTooEarly is the error that GC life time is shorter than transaction duration
+	ErrGCTooEarly = dbterror.ClassTiKV.NewStd(errno.ErrGCTooEarly)
 )
 
 func genKeyExistsError(name string, value string, err error) error {
@@ -153,13 +155,16 @@ func extractKeyErr(err error) error {
 		notFoundDetail := prettyLockNotFoundKey(e.Retryable)
 		return kv.ErrTxnRetryable.GenWithStackByArgs(e.Retryable + " " + notFoundDetail)
 	}
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
-func toTiDBErr(err error) error {
+// ToTiDBErr checks and converts a tikv error to a tidb error.
+func ToTiDBErr(err error) error {
+	originErr := err
 	if err == nil {
 		return nil
 	}
+	err = errors.Cause(err)
 	if tikverr.IsErrNotFound(err) {
 		return kv.ErrNotExist
 	}
@@ -188,7 +193,11 @@ func toTiDBErr(err error) error {
 		return ErrTiKVServerTimeout
 	}
 
-	return errors.Trace(err)
+	if e, ok := err.(*tikverr.ErrGCTooEarly); ok {
+		return ErrGCTooEarly.GenWithStackByArgs(e.TxnStartTS, e.GCSafePoint)
+	}
+
+	return errors.Trace(originErr)
 }
 
 func newWriteConflictError(conflict *kvrpcpb.WriteConflict) error {

--- a/store/driver/txn/snapshot.go
+++ b/store/driver/txn/snapshot.go
@@ -48,7 +48,7 @@ func (s *tikvSnapshot) Get(ctx context.Context, k kv.Key) ([]byte, error) {
 func (s *tikvSnapshot) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 	scanner, err := s.KVSnapshot.Iter(k, upperBound)
 	if err != nil {
-		return nil, toTiDBErr(err)
+		return nil, ToTiDBErr(err)
 	}
 	return &tikvScanner{scanner.(*tikv.Scanner)}, err
 }
@@ -57,7 +57,7 @@ func (s *tikvSnapshot) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 func (s *tikvSnapshot) IterReverse(k kv.Key) (kv.Iterator, error) {
 	scanner, err := s.KVSnapshot.IterReverse(k)
 	if err != nil {
-		return nil, toTiDBErr(err)
+		return nil, ToTiDBErr(err)
 	}
 	return &tikvScanner{scanner.(*tikv.Scanner)}, err
 }

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -75,7 +75,7 @@ func (txn *tikvTxn) GetSnapshot() kv.Snapshot {
 // The Iterator must be Closed after use.
 func (txn *tikvTxn) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 	it, err := txn.KVTxn.Iter(k, upperBound)
-	return newKVIterator(it), toTiDBErr(err)
+	return newKVIterator(it), ToTiDBErr(err)
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
@@ -84,7 +84,7 @@ func (txn *tikvTxn) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 // TODO: Add lower bound limit
 func (txn *tikvTxn) IterReverse(k kv.Key) (kv.Iterator, error) {
 	it, err := txn.KVTxn.IterReverse(k)
-	return newKVIterator(it), toTiDBErr(err)
+	return newKVIterator(it), ToTiDBErr(err)
 }
 
 // BatchGet gets kv from the memory buffer of statement and transaction, and the kv storage.
@@ -101,17 +101,17 @@ func (txn *tikvTxn) BatchGet(ctx context.Context, keys []kv.Key) (map[string][]b
 
 func (txn *tikvTxn) Delete(k kv.Key) error {
 	err := txn.KVTxn.Delete(k)
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
 func (txn *tikvTxn) Get(ctx context.Context, k kv.Key) ([]byte, error) {
 	data, err := txn.KVTxn.Get(ctx, k)
-	return data, toTiDBErr(err)
+	return data, ToTiDBErr(err)
 }
 
 func (txn *tikvTxn) Set(k kv.Key, v []byte) error {
 	err := txn.KVTxn.Set(k, v)
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
 func (txn *tikvTxn) GetMemBuffer() kv.MemBuffer {

--- a/store/driver/txn/unionstore_driver.go
+++ b/store/driver/txn/unionstore_driver.go
@@ -39,17 +39,17 @@ func (m *memBuffer) Delete(k kv.Key) error {
 
 func (m *memBuffer) DeleteWithFlags(k kv.Key, ops ...tikvstore.FlagsOp) error {
 	err := m.MemDB.DeleteWithFlags(k, ops...)
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
 func (m *memBuffer) Get(_ context.Context, key kv.Key) ([]byte, error) {
 	data, err := m.MemDB.Get(key)
-	return data, toTiDBErr(err)
+	return data, ToTiDBErr(err)
 }
 
 func (m *memBuffer) GetFlags(key kv.Key) (tikvstore.KeyFlags, error) {
 	data, err := m.MemDB.GetFlags(key)
-	return data, toTiDBErr(err)
+	return data, ToTiDBErr(err)
 }
 
 func (m *memBuffer) Staging() kv.StagingHandle {
@@ -73,12 +73,12 @@ func (m *memBuffer) InspectStage(handle kv.StagingHandle, f func(kv.Key, tikvsto
 
 func (m *memBuffer) Set(key kv.Key, value []byte) error {
 	err := m.MemDB.Set(key, value)
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
 func (m *memBuffer) SetWithFlags(key kv.Key, value []byte, ops ...kv.FlagsOp) error {
 	err := m.MemDB.SetWithFlags(key, value, ops...)
-	return toTiDBErr(err)
+	return ToTiDBErr(err)
 }
 
 // Iter creates an Iterator positioned on the first entry that k <= entry's key.
@@ -87,7 +87,7 @@ func (m *memBuffer) SetWithFlags(key kv.Key, value []byte, ops ...kv.FlagsOp) er
 // The Iterator must be Closed after use.
 func (m *memBuffer) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 	it, err := m.MemDB.Iter(k, upperBound)
-	return &tikvIterator{Iterator: it}, toTiDBErr(err)
+	return &tikvIterator{Iterator: it}, ToTiDBErr(err)
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
@@ -96,7 +96,7 @@ func (m *memBuffer) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 // TODO: Add lower bound limit
 func (m *memBuffer) IterReverse(k kv.Key) (kv.Iterator, error) {
 	it, err := m.MemDB.IterReverse(k)
-	return &tikvIterator{Iterator: it}, toTiDBErr(err)
+	return &tikvIterator{Iterator: it}, ToTiDBErr(err)
 }
 
 // SnapshotIter returns a Iterator for a snapshot of MemBuffer.
@@ -121,7 +121,7 @@ func (u *tikvUnionStore) GetMemBuffer() kv.MemBuffer {
 
 func (u *tikvUnionStore) Get(ctx context.Context, k kv.Key) ([]byte, error) {
 	data, err := u.KVUnionStore.Get(ctx, k)
-	return data, toTiDBErr(err)
+	return data, ToTiDBErr(err)
 }
 
 func (u *tikvUnionStore) HasPresumeKeyNotExists(k kv.Key) bool {
@@ -134,7 +134,7 @@ func (u *tikvUnionStore) UnmarkPresumeKeyNotExists(k kv.Key) {
 
 func (u *tikvUnionStore) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) {
 	it, err := u.KVUnionStore.Iter(k, upperBound)
-	return newKVIterator(it), toTiDBErr(err)
+	return newKVIterator(it), ToTiDBErr(err)
 }
 
 // IterReverse creates a reversed Iterator positioned on the first entry which key is less than k.
@@ -143,7 +143,7 @@ func (u *tikvUnionStore) Iter(k kv.Key, upperBound kv.Key) (kv.Iterator, error) 
 // TODO: Add lower bound limit
 func (u *tikvUnionStore) IterReverse(k kv.Key) (kv.Iterator, error) {
 	it, err := u.KVUnionStore.IterReverse(k)
-	return newKVIterator(it), toTiDBErr(err)
+	return newKVIterator(it), ToTiDBErr(err)
 }
 
 type tikvGetter struct {
@@ -156,7 +156,7 @@ func newKVGetter(getter unionstore.Getter) kv.Getter {
 
 func (g *tikvGetter) Get(_ context.Context, k kv.Key) ([]byte, error) {
 	data, err := g.Getter.Get(k)
-	return data, toTiDBErr(err)
+	return data, ToTiDBErr(err)
 }
 
 // tikvIterator wraps unionstore.Iterator as kv.Iterator

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -29,7 +29,6 @@ const (
 	CodeTiKVServerBusy     = 9003
 	CodeResolveLockTimeout = 9004
 	CodeRegionUnavailable  = 9005
-	CodeGCTooEarly         = 9006
 
 	CodeTiKVStoreLimit = 9008
 

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -15,6 +15,7 @@ package error
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/kvrpcpb"
@@ -50,7 +51,6 @@ var (
 	ErrTiFlashServerBusy           = dbterror.ClassTiKV.NewStd(CodeTiFlashServerBusy)
 	ErrTiKVStaleCommand            = dbterror.ClassTiKV.NewStd(CodeTiKVStaleCommand)
 	ErrTiKVMaxTimestampNotSynced   = dbterror.ClassTiKV.NewStd(CodeTiKVMaxTimestampNotSynced)
-	ErrGCTooEarly                  = dbterror.ClassTiKV.NewStd(CodeGCTooEarly)
 	ErrQueryInterrupted            = dbterror.ClassTiKV.NewStd(CodeQueryInterrupted)
 	ErrLockAcquireFailAndNoWaitSet = dbterror.ClassTiKV.NewStd(CodeLockAcquireFailAndNoWaitSet)
 	ErrLockWaitTimeout             = dbterror.ClassTiKV.NewStd(CodeLockWaitTimeout)
@@ -166,4 +166,14 @@ type ErrEntryTooLarge struct {
 
 func (e *ErrEntryTooLarge) Error() string {
 	return fmt.Sprintf("entry size too large, size: %v,limit: %v.", e.Size, e.Limit)
+}
+
+// ErrGCTooEarly is the error that GC life time is shorter than transaction duration
+type ErrGCTooEarly struct {
+	TxnStartTS  time.Time
+	GCSafePoint time.Time
+}
+
+func (e *ErrGCTooEarly) Error() string {
+	return fmt.Sprintf("GC life time is shorter than transaction duration, transaction starts at %v, GC safe point is %v", e.TxnStartTS, e.GCSafePoint)
 }

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -113,7 +113,10 @@ func (s *KVStore) CheckVisibility(startTime uint64) error {
 	if startTime < cachedSafePoint {
 		t1 := oracle.GetTimeFromTS(startTime)
 		t2 := oracle.GetTimeFromTS(cachedSafePoint)
-		return tikverr.ErrGCTooEarly.GenWithStackByArgs(t1, t2)
+		return &tikverr.ErrGCTooEarly{
+			TxnStartTS:  t1,
+			GCSafePoint: t2,
+		}
 	}
 
 	return nil

--- a/store/tikv/tests/safepoint_test.go
+++ b/store/tikv/tests/safepoint_test.go
@@ -91,7 +91,8 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, geterr2 := txn2.Get(context.TODO(), encodeKey(s.prefix, s08d("key", 0)))
 	c.Assert(geterr2, NotNil)
-	isFallBehind := terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
+
+	_, isFallBehind := errors.Cause(geterr2).(*tikverr.ErrGCTooEarly)
 	isMayFallBehind := terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind := isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
@@ -103,7 +104,7 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, seekerr := txn3.Iter(encodeKey(s.prefix, ""), nil)
 	c.Assert(seekerr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
+	_, isFallBehind = errors.Cause(geterr2).(*tikverr.ErrGCTooEarly)
 	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)
@@ -116,7 +117,7 @@ func (s *testSafePointSuite) TestSafePoint(c *C) {
 
 	_, batchgeterr := toTiDBTxn(&txn4).BatchGet(context.Background(), toTiDBKeys(keys))
 	c.Assert(batchgeterr, NotNil)
-	isFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrGCTooEarly)
+	_, isFallBehind = errors.Cause(geterr2).(*tikverr.ErrGCTooEarly)
 	isMayFallBehind = terror.ErrorEqual(errors.Cause(geterr2), tikverr.ErrPDServerTimeout.GenWithStackByArgs("start timestamp may fall behind safe point"))
 	isBehind = isFallBehind || isMayFallBehind
 	c.Assert(isBehind, IsTrue)


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrGCTooEarly` as normal errors instead of a dberror and we convert the tikv error to dberror in driver.

Part of https://github.com/pingcap/tidb/issues/22513

What's Changed:

- create a new ErrGCTooEarly in tikv
- convert to db error in tikv driver
- new driver in `copr` package since we need to convert the tikv error to tidb error 
### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note