### PR TITLE
planner: convert Sequence as DataSource to TableDual

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3555,3 +3555,27 @@ func (s *testIntegrationSuite) TestConflictReadFromStorage(c *C) {
 	tk.MustQuery(`explain select /*+ read_from_storage(tikv[t], tiflash[t]) */ * from t`)
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1815 Storage hints are conflict, you can only specify one storage type of table test.t"))
 }
+
+// TestSequenceAsDataSource is used to test https://github.com/pingcap/tidb/issues/24383.
+func (s *testIntegrationSuite) TestSequenceAsDataSource(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop sequence if exists s1, s2")
+	tk.MustExec("create sequence s1")
+	tk.MustExec("create sequence s2")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery("explain format = 'brief' " + tt).Rows())
+		})
+		tk.MustQuery("explain format = 'brief' " + tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3592,6 +3592,14 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		return b.BuildDataSourceFromView(ctx, dbName, tableInfo)
 	}
 
+	if tableInfo.IsSequence() {
+		if tn.TableSample != nil {
+			return nil, expression.ErrInvalidTableSample.GenWithStackByArgs("Unsupported TABLESAMPLE in sequences")
+		}
+		// When the source is a Sequence, we convert it to a TableDual, as what most databases do.
+		return b.buildTableDual(), nil
+	}
+
 	if tableInfo.GetPartitionInfo() != nil {
 		// Use the new partition implementation, clean up the code here when it's full implemented.
 		if !b.ctx.GetSessionVars().UseDynamicPartitionPrune() {

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -284,5 +284,15 @@
     "cases": [
       "select count(*) from t join (select t.id, t.value v1 from t join t t1 on t.id = t1.id order by t.value limit 1) v on v.id = t.id and v.v1 = t.value;"
     ]
+  },
+  {
+    "name": "TestSequenceAsDataSource",
+    "cases": [
+      "select 1 from s1",
+      "select count(1) from s1",
+      "select count(*) from s1",
+      "select sum(1) from s1",
+      "select count(1) as cnt from s1 union select count(1) as cnt from s2"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -1520,5 +1520,49 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestSequenceAsDataSource",
+    "Cases": [
+      {
+        "SQL": "select 1 from s1",
+        "Plan": [
+			"Projection 1.00 root  1->Column#1",
+			"└─TableDual 1.00 root  rows:1"
+        ]
+	  },
+	  {
+        "SQL": "select count(1) from s1",
+        "Plan": [
+			"StreamAgg 1.00 root  funcs:count(1)->Column#1",
+			"└─TableDual 1.00 root  rows:1"
+        ]
+	  },
+	  {
+        "SQL": "select count(*) from s1",
+        "Plan": [
+			"StreamAgg 1.00 root  funcs:count(1)->Column#1",
+			"└─TableDual 1.00 root  rows:1"
+        ]
+	  },
+	  {
+        "SQL": "select sum(1) from s1",
+        "Plan": [
+			"StreamAgg 1.00 root  funcs:sum(1)->Column#1",
+			"└─TableDual 1.00 root  rows:1"
+        ]
+	  },
+	  {
+        "SQL": "select count(1) as cnt from s1 union select count(1) as cnt from s2",
+        "Plan": [
+			"HashAgg 2.00 root  group by:Column#3, funcs:firstrow(Column#3)->Column#3",
+			"└─Union 2.00 root  ",
+			"  ├─StreamAgg 1.00 root  funcs:count(1)->Column#1",
+			"  │ └─TableDual 1.00 root  rows:1",
+			"  └─StreamAgg 1.00 root  funcs:count(1)->Column#2",
+			"    └─TableDual 1.00 root  rows:1"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24383 

### What is changed and how it works?

What's Changed: make `SELECT COUNT(1) FROM $SEQ_NAME` returns 1 by converting sequences as tableduals.

How it Works: please check the code, it's simple enough. 

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: TBD

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below):
```
tidb> create sequence s;
Query OK, 0 rows affected (0.01 sec)

tidb> select count(*) from s;
+----------+
| count(*) |
+----------+
|        1 |
+----------+
1 row in set (0.00 sec)
```

Side effects

- Breaking backward compatibility(but I believe it is tiny enough to be ignored).

### Release note <!-- bugfixes or new feature need a release note -->

- make `SELECT COUNT(1) FROM $SEQQUENCE` returns 1, which follows the behavior of most databases that support Sequence.
