### PR TITLE
store/tikv: remove use of TaskID transaction option in store/tikv

### DIFF
--- a/store/driver/txn/snapshot.go
+++ b/store/driver/txn/snapshot.go
@@ -73,6 +73,8 @@ func (s *tikvSnapshot) SetOption(opt int, val interface{}) {
 		s.KVSnapshot.SetNotFillCache(val.(bool))
 	case tikvstore.SnapshotTS:
 		s.KVSnapshot.SetSnapshotTS(val.(uint64))
+	case tikvstore.TaskID:
+		s.KVSnapshot.SetTaskID(val.(uint64))
 	default:
 		s.KVSnapshot.SetOption(opt, val)
 	}

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -144,6 +144,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.SetPessimistic(val.(bool))
 	case tikvstore.SnapshotTS:
 		txn.KVTxn.GetSnapshot().SetSnapshotTS(val.(uint64))
+	case tikvstore.TaskID:
+		txn.KVTxn.GetSnapshot().SetTaskID(val.(uint64))
 	case tikvstore.CommitHook:
 		txn.SetCommitCallback(val.(func(string, error)))
 	default:

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -570,10 +570,6 @@ func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 		s.mu.Lock()
 		s.mu.replicaRead = val.(kv.ReplicaReadType)
 		s.mu.Unlock()
-	case kv.TaskID:
-		s.mu.Lock()
-		s.mu.taskID = val.(uint64)
-		s.mu.Unlock()
 	case kv.CollectRuntimeStats:
 		s.mu.Lock()
 		s.mu.stats = val.(*SnapshotRuntimeStats)
@@ -626,6 +622,14 @@ func (s *KVSnapshot) SetIsolationLevel(level IsoLevel) {
 // SetPriority sets the priority for tikv to execute commands.
 func (s *KVSnapshot) SetPriority(pri Priority) {
 	s.priority = pri
+}
+
+// SetTaskID marks current task's unique ID to allow TiKV to schedule
+// tasks more fairly.
+func (s *KVSnapshot) SetTaskID(id uint64) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.taskID = id
 }
 
 // SnapCacheHitCount gets the snapshot cache hit count. Only for test.


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `TaskID` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `SetTaskID` method
- Remove option usages.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note