### PR TITLE
ddl: disallow changing the default value of the primary key column to null

### DIFF
--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -1705,7 +1705,6 @@ func (s *testColumnTypeChangeSuite) TestChangingAttributeOfColumnWithFK(c *C) {
 func (s *testColumnTypeChangeSuite) TestAlterPrimaryKeyToNull(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	// Enable column change variable.
 	tk.Se.GetSessionVars().EnableChangeColumnType = true
 
 	tk.MustExec("drop table if exists t, t1")

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -1707,9 +1707,6 @@ func (s *testColumnTypeChangeSuite) TestAlterPrimaryKeyToNull(c *C) {
 	tk.MustExec("use test")
 	// Enable column change variable.
 	tk.Se.GetSessionVars().EnableChangeColumnType = true
-	defer func() {
-		tk.Se.GetSessionVars().EnableChangeColumnType = false
-	}()
 
 	tk.MustExec("drop table if exists t, t1")
 	tk.MustExec("create table t(a int not null, b int not null, primary key(a, b));")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24265 <!-- REMOVE this line if no issue to close -->

Problem Summary:
Handle the issue of changing the default value of the primary key column to null.

### What is changed and how it works?

What's Changed:

- Add `checkPriKeyConstraint` for `modify/change column`.
- Uniform processing and checking of default values and column properties.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- Disallow the default value of the primary key column to be NULL when using the 'modify/change column' operation.
