### PR TITLE
store/cop: reload region every time when meeting io error

### DIFF
--- a/store/copr/batch_request_sender.go
+++ b/store/copr/batch_request_sender.go
@@ -78,7 +78,12 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *tikv.Backoffer, ctxs []copTas
 	for _, failedCtx := range ctxs {
 		ctx := failedCtx.ctx
 		if ctx.Meta != nil {
-			ss.GetRegionCache().OnSendFail(bo, ctx, ss.NeedReloadRegion(ctx), err)
+			// The reload region param is always true. Because that every time we try, we must
+			// re-build the range then re-create the batch sender. As a result, the len of "failStores"
+			// will change. If tiflash's replica is more than two, the "reload region" will always be false.
+			// Now that the batch cop and mpp has a relative low qps, it's reasonable to reload every time
+			// when meeting io error.
+			ss.GetRegionCache().OnSendFail(bo, ctx, true, err)
 		}
 	}
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
When tiflash replica is more than 1 and meets an io error, region cache will not reload.
That's because RequestSender maintains the "failStores" by itself. but for mpp and batch requests, they will re-create the sender when retrying. 

### What is changed and how it works?

What's Changed:
After discussion, the best solution for now is to always reload regions when batch/ mpp request meets io errors. Because of the low qps of batch/mpp requests (for every query, we only access every store **once**), reload everytime will not be a problem.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test 


### Release note <!-- bugfixes or new feature need a release note -->

- store/cop: reload region every time when meeting io error