### PR TITLE
sessionctx/variable: Improve sysvar test coverage, collation normalization

### DIFF
--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -111,10 +111,11 @@ func int32ToBoolStr(i int32) string {
 }
 
 func checkCollation(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
-	if _, err := collate.GetCollationByName(normalizedValue); err != nil {
+	if coll, err := collate.GetCollationByName(normalizedValue); err != nil {
 		return normalizedValue, errors.Trace(err)
+	} else {
+		return coll.Name, nil
 	}
-	return normalizedValue, nil
 }
 
 func checkCharacterSet(normalizedValue string, argName string) (string, error) {


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/24471

Problem Summary:

This improves the test coverage for sysvars, and fixes a small bug where collation values are not normalized in the validation function.

This brings the unit test coverage of sysvars up to 45.5%, which is still low, but the majority of this code is tested in tests for set etc.

### What is changed and how it works?

What's Changed:

Mainly tests + a small improvement.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note