### PR TITLE
store/tikv: make tikv.ErrLockAcquireFailAndNoWaitSet as a normal error

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -31,6 +31,7 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	txndriver "github.com/pingcap/tidb/store/driver/txn"
 	"github.com/pingcap/tidb/store/tikv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/oracle"
@@ -1131,11 +1132,11 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err := tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 4 for update nowait")
-	c.Check(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 7 for update nowait")
-	c.Check(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 
@@ -1147,9 +1148,9 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err = tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	err = tk1.ExecToErr("select * from t where k = 6 for update nowait")
-	c.Check(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 }
@@ -1282,7 +1283,7 @@ func (s *testPessimisticSuite) TestBatchPointGetLockIndex(c *C) {
 	c.Assert(tikverr.ErrLockWaitTimeout.Equal(err), IsTrue)
 	err = tk2.ExecToErr("select * from t1 where c2 = 3 for update nowait")
 	c.Assert(err, NotNil)
-	c.Assert(tikverr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Assert(txndriver.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
 	tk.MustExec("rollback")
 	tk2.MustExec("rollback")
 }
@@ -1429,12 +1430,12 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk2.MustExec("begin pessimistic")
 		err := tk2.ExecToErr("select * from tu where z = 3 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikverr.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, txndriver.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(2, 2);")
 		err = tk2.ExecToErr("select * from tu where z = 4 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikverr.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, txndriver.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		// test batch point get lock
 		tk.MustExec("begin pessimistic")
@@ -1443,12 +1444,12 @@ func (s *testPessimisticSuite) TestGenerateColPointGet(c *C) {
 		tk2.MustExec("begin pessimistic")
 		err = tk2.ExecToErr("select x from tu where z in (3, 7, 9) for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikverr.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, txndriver.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 		tk.MustExec("begin pessimistic")
 		tk.MustExec("insert into tu(x, y) values(5, 6);")
 		err = tk2.ExecToErr("select * from tu where z = 11 for update nowait")
 		c.Assert(err, NotNil)
-		c.Assert(terror.ErrorEqual(err, tikverr.ErrLockAcquireFailAndNoWaitSet), IsTrue)
+		c.Assert(terror.ErrorEqual(err, txndriver.ErrLockAcquireFailAndNoWaitSet), IsTrue)
 
 		tk.MustExec("commit")
 		tk2.MustExec("commit")

--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -47,7 +47,9 @@ var (
 	ErrTiKVStaleCommand = dbterror.ClassTiKV.NewStd(errno.ErrTiKVStaleCommand)
 	// ErrTiKVMaxTimestampNotSynced is the error that tikv's max timestamp is not synced.
 	ErrTiKVMaxTimestampNotSynced = dbterror.ClassTiKV.NewStd(errno.ErrTiKVMaxTimestampNotSynced)
-	ErrResolveLockTimeout        = dbterror.ClassTiKV.NewStd(errno.ErrResolveLockTimeout)
+	// ErrLockAcquireFailAndNoWaitSet is the error that acquire the lock failed while no wait is setted.
+	ErrLockAcquireFailAndNoWaitSet = dbterror.ClassTiKV.NewStd(errno.ErrLockAcquireFailAndNoWaitSet)
+	ErrResolveLockTimeout          = dbterror.ClassTiKV.NewStd(errno.ErrResolveLockTimeout)
 	// ErrTiKVServerBusy is the error when tikv server is busy.
 	ErrTiKVServerBusy = dbterror.ClassTiKV.NewStd(errno.ErrTiKVServerBusy)
 	// ErrTiFlashServerBusy is the error that tiflash server is busy.
@@ -236,6 +238,10 @@ func ToTiDBErr(err error) error {
 
 	if errors.ErrorEqual(err, tikverr.ErrTiKVMaxTimestampNotSynced) {
 		return ErrTiKVMaxTimestampNotSynced
+	}
+
+	if errors.ErrorEqual(err, tikverr.ErrLockAcquireFailAndNoWaitSet) {
+		return ErrLockAcquireFailAndNoWaitSet
 	}
 
 	if errors.ErrorEqual(err, tikverr.ErrResolveLockTimeout) {

--- a/store/tikv/error/errcode.go
+++ b/store/tikv/error/errcode.go
@@ -16,13 +16,12 @@ package error
 // MySQL error code.
 // This value is numeric. It is not portable to other database systems.
 const (
-	CodeUnknown                     = 1105
-	CodeLockWaitTimeout             = 1205
-	CodeTruncatedWrongValue         = 1292
-	CodeQueryInterrupted            = 1317
-	CodeDivisionByZero              = 1365
-	CodeDataOutOfRange              = 1690
-	CodeLockAcquireFailAndNoWaitSet = 3572
+	CodeUnknown             = 1105
+	CodeLockWaitTimeout     = 1205
+	CodeTruncatedWrongValue = 1292
+	CodeQueryInterrupted    = 1317
+	CodeDivisionByZero      = 1365
+	CodeDataOutOfRange      = 1690
 
 	// TiKV/PD/TiFlash errors.
 	CodeTiKVStoreLimit = 9008

--- a/store/tikv/error/error.go
+++ b/store/tikv/error/error.go
@@ -42,6 +42,8 @@ var (
 	ErrTiKVStaleCommand = errors.New("tikv stale command")
 	// ErrTiKVMaxTimestampNotSynced is the error that tikv's max timestamp is not synced.
 	ErrTiKVMaxTimestampNotSynced = errors.New("tikv max timestamp not synced")
+	// ErrLockAcquireFailAndNoWaitSet is the error that acquire the lock failed while no wait is setted.
+	ErrLockAcquireFailAndNoWaitSet = errors.New("lock acquired failed and no wait is setted")
 	// ErrResolveLockTimeout is the error that resolve lock timeout.
 	ErrResolveLockTimeout = errors.New("resolve lock timeout")
 	// ErrTiKVServerBusy is the error when tikv server is busy.
@@ -57,11 +59,10 @@ const MismatchClusterID = "mismatch cluster id"
 
 // error instances.
 var (
-	ErrQueryInterrupted            = dbterror.ClassTiKV.NewStd(CodeQueryInterrupted)
-	ErrLockAcquireFailAndNoWaitSet = dbterror.ClassTiKV.NewStd(CodeLockAcquireFailAndNoWaitSet)
-	ErrLockWaitTimeout             = dbterror.ClassTiKV.NewStd(CodeLockWaitTimeout)
-	ErrTokenLimit                  = dbterror.ClassTiKV.NewStd(CodeTiKVStoreLimit)
-	ErrUnknown                     = dbterror.ClassTiKV.NewStd(CodeUnknown)
+	ErrQueryInterrupted = dbterror.ClassTiKV.NewStd(CodeQueryInterrupted)
+	ErrLockWaitTimeout  = dbterror.ClassTiKV.NewStd(CodeLockWaitTimeout)
+	ErrTokenLimit       = dbterror.ClassTiKV.NewStd(CodeTiKVStoreLimit)
+	ErrUnknown          = dbterror.ClassTiKV.NewStd(CodeUnknown)
 )
 
 // Registers error returned from TiKV.


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes `tikv.ErrLockAcquireFailAndNoWaitSet` as a normal error instead of a dberror and we convert the tikv error to dberror in the driver.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note