### PR TITLE
binlog: DML on temporary tables do not write binlog

### DIFF
--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -1408,6 +1408,9 @@ func shouldWriteBinlog(ctx sessionctx.Context, tblInfo *model.TableInfo) bool {
 	if ctx.GetSessionVars().BinlogClient == nil {
 		return false
 	}
+	if tblInfo.TempTableType != model.TempTableNone {
+		return false
+	}
 	return !ctx.GetSessionVars().InRestrictedSQL
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
DDL writes binlog, but DML do not write binlog, because the data is not written to TiKV.

### What is changed and how it works?

What's Changed:
Do not write binlog for DML when the table is a temporary table.
Test that DDL writes binlog.

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- DML on temporary tables do not write binlog
