### PR TITLE
*: introduce snapshot into analyze

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -88,10 +88,10 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		return err
 	}
 	taskCh := make(chan *analyzeTask, len(e.tasks))
-	resultCh := make(chan analyzeResult, len(e.tasks))
+	resultsCh := make(chan *statistics.AnalyzeResults, len(e.tasks))
 	e.wg.Add(concurrency)
 	for i := 0; i < concurrency; i++ {
-		go e.analyzeWorker(taskCh, resultCh, i == 0)
+		go e.analyzeWorker(taskCh, resultsCh, i == 0)
 	}
 	for _, task := range e.tasks {
 		statistics.AddNewAnalyzeJob(task.job)
@@ -133,56 +133,45 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		}
 	}
 	for panicCnt < concurrency {
-		result, ok := <-resultCh
+		results, ok := <-resultsCh
 		if !ok {
 			break
 		}
-		if result.Err != nil {
-			err = result.Err
+		if results.Err != nil {
+			err = results.Err
 			if err == errAnalyzeWorkerPanic {
 				panicCnt++
 			} else {
 				logutil.Logger(ctx).Error("analyze failed", zap.Error(err))
 			}
-			finishJobWithLogFn(ctx, result.job, true)
+			finishJobWithLogFn(ctx, results.Job, true)
 			continue
 		}
-		statisticsID := result.TableID.GetStatisticsID()
-		for i, hg := range result.Hist {
-			// It's normal virtual column, skip.
-			if hg == nil {
-				continue
-			}
-			if result.TableID.IsPartitionTable() && needGlobalStats {
-				// If it does not belong to the statistics of index, we need to set it to -1 to distinguish.
-				idxID := int64(-1)
-				if result.IsIndex != 0 {
-					idxID = hg.ID
+		if results.TableID.IsPartitionTable() && needGlobalStats {
+			for _, result := range results.Ars {
+				for _, hg := range result.Hist {
+					// It's normal virtual column, skip.
+					if hg == nil {
+						continue
+					}
+					// If it does not belong to the statistics of index, we need to set it to -1 to distinguish.
+					idxID := int64(-1)
+					if result.IsIndex != 0 {
+						idxID = hg.ID
+					}
+					globalStatsID := globalStatsKey{results.TableID.TableID, idxID}
+					if _, ok := globalStatsMap[globalStatsID]; !ok {
+						globalStatsMap[globalStatsID] = globalStatsInfo{result.IsIndex, hg.ID, results.StatsVer}
+					}
 				}
-				globalStatsID := globalStatsKey{result.TableID.TableID, idxID}
-				if _, ok := globalStatsMap[globalStatsID]; !ok {
-					globalStatsMap[globalStatsID] = globalStatsInfo{result.IsIndex, hg.ID, result.StatsVer}
-				}
-			}
-			var err1 error
-			if result.StatsVer == statistics.Version2 {
-				err1 = statsHandle.SaveStatsToStorage(statisticsID, result.Count, result.IsIndex, hg, nil, result.TopNs[i], result.Fms[i], result.StatsVer, 1, result.TableID.IsPartitionTable() && needGlobalStats)
-			} else {
-				err1 = statsHandle.SaveStatsToStorage(statisticsID, result.Count, result.IsIndex, hg, result.Cms[i], result.TopNs[i], result.Fms[i], result.StatsVer, 1, result.TableID.IsPartitionTable() && needGlobalStats)
-			}
-			if err1 != nil {
-				err = err1
-				logutil.Logger(ctx).Error("save stats to storage failed", zap.Error(err))
-				finishJobWithLogFn(ctx, result.job, true)
-				continue
 			}
 		}
-		if err1 := statsHandle.SaveExtendedStatsToStorage(statisticsID, result.ExtStats, false); err1 != nil {
+		if err1 := statsHandle.SaveTableStatsToStorage(results, results.TableID.IsPartitionTable() && needGlobalStats); err1 != nil {
 			err = err1
-			logutil.Logger(ctx).Error("save extended stats to storage failed", zap.Error(err))
-			finishJobWithLogFn(ctx, result.job, true)
+			logutil.Logger(ctx).Error("save table stats to storage failed", zap.Error(err))
+			finishJobWithLogFn(ctx, results.Job, true)
 		} else {
-			finishJobWithLogFn(ctx, result.job, false)
+			finishJobWithLogFn(ctx, results.Job, false)
 		}
 	}
 	for _, task := range e.tasks {
@@ -247,7 +236,7 @@ type analyzeTask struct {
 
 var errAnalyzeWorkerPanic = errors.New("analyze worker panic")
 
-func (e *AnalyzeExec) analyzeWorker(taskCh <-chan *analyzeTask, resultCh chan<- analyzeResult, isCloseChanThread bool) {
+func (e *AnalyzeExec) analyzeWorker(taskCh <-chan *analyzeTask, resultsCh chan<- *statistics.AnalyzeResults, isCloseChanThread bool) {
 	var task *analyzeTask
 	defer func() {
 		if r := recover(); r != nil {
@@ -256,15 +245,15 @@ func (e *AnalyzeExec) analyzeWorker(taskCh <-chan *analyzeTask, resultCh chan<- 
 			buf = buf[:stackSize]
 			logutil.BgLogger().Error("analyze worker panicked", zap.String("stack", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelAnalyze).Inc()
-			resultCh <- analyzeResult{
+			resultsCh <- &statistics.AnalyzeResults{
 				Err: errAnalyzeWorkerPanic,
-				job: task.job,
+				Job: task.job,
 			}
 		}
 		e.wg.Done()
 		if isCloseChanThread {
 			e.wg.Wait()
-			close(resultCh)
+			close(resultsCh)
 		}
 	}()
 	for {
@@ -276,30 +265,20 @@ func (e *AnalyzeExec) analyzeWorker(taskCh <-chan *analyzeTask, resultCh chan<- 
 		task.job.Start()
 		switch task.taskType {
 		case colTask:
-			task.colExec.job = task.job
-			for _, result := range analyzeColumnsPushdown(task.colExec) {
-				resultCh <- result
-			}
+			resultsCh <- analyzeColumnsPushdown(task.colExec)
 		case idxTask:
-			task.idxExec.job = task.job
-			resultCh <- analyzeIndexPushdown(task.idxExec)
+			resultsCh <- analyzeIndexPushdown(task.idxExec)
 		case fastTask:
-			task.fastExec.job = task.job
-			task.job.Start()
-			for _, result := range analyzeFastExec(task.fastExec) {
-				resultCh <- result
-			}
+			resultsCh <- analyzeFastExec(task.fastExec)
 		case pkIncrementalTask:
-			task.colIncrementalExec.job = task.job
-			resultCh <- analyzePKIncremental(task.colIncrementalExec)
+			resultsCh <- analyzePKIncremental(task.colIncrementalExec)
 		case idxIncrementalTask:
-			task.idxIncrementalExec.job = task.job
-			resultCh <- analyzeIndexIncremental(task.idxIncrementalExec)
+			resultsCh <- analyzeIndexIncremental(task.idxIncrementalExec)
 		}
 	}
 }
 
-func analyzeIndexPushdown(idxExec *AnalyzeIndexExec) analyzeResult {
+func analyzeIndexPushdown(idxExec *AnalyzeIndexExec) *statistics.AnalyzeResults {
 	ranges := ranger.FullRange()
 	// For single-column index, we do not load null rows from TiKV, so the built histogram would not include
 	// null values, and its `NullCount` would be set by result of another distsql call to get null rows.
@@ -311,33 +290,47 @@ func analyzeIndexPushdown(idxExec *AnalyzeIndexExec) analyzeResult {
 	}
 	hist, cms, fms, topN, err := idxExec.buildStats(ranges, true)
 	if err != nil {
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
 	var statsVer = statistics.Version1
 	if idxExec.analyzePB.IdxReq.Version != nil {
 		statsVer = int(*idxExec.analyzePB.IdxReq.Version)
 	}
-	result := analyzeResult{
-		TableID:  idxExec.tableID,
-		Hist:     []*statistics.Histogram{hist},
-		Cms:      []*statistics.CMSketch{cms},
-		TopNs:    []*statistics.TopN{topN},
-		Fms:      []*statistics.FMSketch{fms},
-		IsIndex:  1,
-		job:      idxExec.job,
-		StatsVer: statsVer,
+	result := &statistics.AnalyzeResult{
+		Hist:    []*statistics.Histogram{hist},
+		Cms:     []*statistics.CMSketch{cms},
+		TopNs:   []*statistics.TopN{topN},
+		Fms:     []*statistics.FMSketch{fms},
+		IsIndex: 1,
 	}
-	result.Count = hist.NullCount
+	cnt := hist.NullCount
 	if hist.Len() > 0 {
-		result.Count += hist.Buckets[hist.Len()-1].Count
+		cnt += hist.Buckets[hist.Len()-1].Count
 	}
 	if topN.TotalCount() > 0 {
-		result.Count += int64(topN.TotalCount())
+		cnt += int64(topN.TotalCount())
 	}
-	return result
+	return &statistics.AnalyzeResults{
+		TableID:  idxExec.tableID,
+		Ars:      []*statistics.AnalyzeResult{result},
+		Job:      idxExec.job,
+		StatsVer: statsVer,
+		Count:    cnt,
+		Snapshot: idxExec.snapshot,
+	}
 }
 
-func analyzeIndexNDVPushDown(idxExec *AnalyzeIndexExec) analyzeResult {
+type baseAnalyzeExec struct {
+	ctx         sessionctx.Context
+	tableID     statistics.AnalyzeTableID
+	concurrency int
+	analyzePB   *tipb.AnalyzeReq
+	opts        map[ast.AnalyzeOptionType]uint64
+	job         *statistics.AnalyzeJob
+	snapshot    uint64
+}
+
+func analyzeIndexNDVPushDown(idxExec *AnalyzeIndexExec) *statistics.AnalyzeResults {
 	ranges := ranger.FullRange()
 	// For single-column index, we do not load null rows from TiKV, so the built histogram would not include
 	// null values, and its `NullCount` would be set by result of another distsql call to get null rows.
@@ -349,36 +342,35 @@ func analyzeIndexNDVPushDown(idxExec *AnalyzeIndexExec) analyzeResult {
 	}
 	fms, nullHist, err := idxExec.buildSimpleStats(ranges, len(idxExec.idxInfo.Columns) == 1)
 	if err != nil {
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
-	result := analyzeResult{
-		TableID: idxExec.tableID,
-		Fms:     []*statistics.FMSketch{fms},
+	result := &statistics.AnalyzeResult{
+		Fms: []*statistics.FMSketch{fms},
 		// We use histogram to get the Index's ID.
 		Hist:    []*statistics.Histogram{statistics.NewHistogram(idxExec.idxInfo.ID, 0, 0, statistics.Version1, types.NewFieldType(mysql.TypeBlob), 0, 0)},
 		IsIndex: 1,
-		job:     idxExec.job,
+	}
+	r := &statistics.AnalyzeResults{
+		TableID: idxExec.tableID,
+		Ars:     []*statistics.AnalyzeResult{result},
+		Job:     idxExec.job,
 		// TODO: avoid reusing Version1.
 		StatsVer: statistics.Version1,
 	}
 	if nullHist != nil && nullHist.Len() > 0 {
-		result.Count = nullHist.Buckets[nullHist.Len()-1].Count
+		r.Count = nullHist.Buckets[nullHist.Len()-1].Count
 	}
-	return result
+	return r
 }
 
 // AnalyzeIndexExec represents analyze index push down executor.
 type AnalyzeIndexExec struct {
-	ctx            sessionctx.Context
-	tableID        core.AnalyzeTableID
+	baseAnalyzeExec
+
 	idxInfo        *model.IndexInfo
 	isCommonHandle bool
-	concurrency    int
-	analyzePB      *tipb.AnalyzeReq
 	result         distsql.SelectResult
 	countNullRes   distsql.SelectResult
-	opts           map[ast.AnalyzeOptionType]uint64
-	job            *statistics.AnalyzeJob
 }
 
 // fetchAnalyzeResult builds and dispatches the `kv.Request` from given ranges, and stores the `SelectResult`
@@ -395,7 +387,7 @@ func (e *AnalyzeIndexExec) fetchAnalyzeResult(ranges []*ranger.Range, isNullRang
 	kvReqBuilder.SetResourceGroupTag(e.ctx.GetSessionVars().StmtCtx)
 	kvReq, err := kvReqBuilder.
 		SetAnalyzeRequest(e.analyzePB).
-		SetStartTS(math.MaxUint64).
+		SetStartTS(e.snapshot).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
 		Build()
@@ -572,7 +564,7 @@ func (e *AnalyzeIndexExec) buildSimpleStats(ranges []*ranger.Range, considerNull
 	return fms, nil, nil
 }
 
-func analyzeColumnsPushdown(colExec *AnalyzeColumnsExec) []analyzeResult {
+func analyzeColumnsPushdown(colExec *AnalyzeColumnsExec) *statistics.AnalyzeResults {
 	var ranges []*ranger.Range
 	if hc := colExec.handleCols; hc != nil {
 		if hc.IsInt() {
@@ -607,18 +599,14 @@ func analyzeColumnsPushdown(colExec *AnalyzeColumnsExec) []analyzeResult {
 		go colExec.handleNDVForSpecialIndexes(specialIndexes, idxNDVPushDownCh)
 		count, hists, topns, fmSketches, extStats, err := colExec.buildSamplingStats(ranges, collExtStats, specialIndexesOffsets, idxNDVPushDownCh)
 		if err != nil {
-			return []analyzeResult{{Err: err, job: colExec.job}}
+			return &statistics.AnalyzeResults{Err: err, Job: colExec.job}
 		}
 		cLen := len(colExec.analyzePB.ColReq.ColumnsInfo)
-		colGroupResult := analyzeResult{
-			TableID:  colExec.TableID,
-			Hist:     hists[cLen:],
-			TopNs:    topns[cLen:],
-			Fms:      fmSketches[cLen:],
-			job:      colExec.job,
-			StatsVer: colExec.StatsVersion,
-			Count:    count,
-			IsIndex:  1,
+		colGroupResult := &statistics.AnalyzeResult{
+			Hist:    hists[cLen:],
+			TopNs:   topns[cLen:],
+			Fms:     fmSketches[cLen:],
+			IsIndex: 1,
 		}
 		// Discard stats of _tidb_rowid.
 		// Because the process of analyzing will keep the order of results be the same as the colsInfo in the analyze task,
@@ -628,94 +616,93 @@ func analyzeColumnsPushdown(colExec *AnalyzeColumnsExec) []analyzeResult {
 		if hists[cLen-1] != nil && hists[cLen-1].ID == -1 {
 			cLen -= 1
 		}
-		colResult := analyzeResult{
-			TableID:  colExec.TableID,
-			Hist:     hists[:cLen],
-			TopNs:    topns[:cLen],
-			Fms:      fmSketches[:cLen],
-			ExtStats: extStats,
-			job:      colExec.job,
+		colResult := &statistics.AnalyzeResult{
+			Hist:  hists[:cLen],
+			TopNs: topns[:cLen],
+			Fms:   fmSketches[:cLen],
+		}
+		return &statistics.AnalyzeResults{
+			TableID:  colExec.tableID,
+			Ars:      []*statistics.AnalyzeResult{colResult, colGroupResult},
+			Job:      colExec.job,
 			StatsVer: colExec.StatsVersion,
 			Count:    count,
+			Snapshot: colExec.snapshot,
+			ExtStats: extStats,
 		}
-
-		return []analyzeResult{colResult, colGroupResult}
 	}
 	hists, cms, topNs, fms, extStats, err := colExec.buildStats(ranges, collExtStats)
 	if err != nil {
-		return []analyzeResult{{Err: err, job: colExec.job}}
+		return &statistics.AnalyzeResults{Err: err, Job: colExec.job}
 	}
 
 	if hasPkHist(colExec.handleCols) {
-		PKresult := analyzeResult{
-			TableID:  colExec.TableID,
-			Hist:     hists[:1],
-			Cms:      cms[:1],
-			TopNs:    topNs[:1],
-			Fms:      fms[:1],
-			ExtStats: nil,
-			job:      nil,
-			StatsVer: statistics.Version1,
+		PKresult := &statistics.AnalyzeResult{
+			Hist:  hists[:1],
+			Cms:   cms[:1],
+			TopNs: topNs[:1],
+			Fms:   fms[:1],
 		}
-		PKresult.Count = int64(PKresult.Hist[0].TotalRowCount())
-		restResult := analyzeResult{
-			TableID:  colExec.TableID,
-			Hist:     hists[1:],
-			Cms:      cms[1:],
-			TopNs:    topNs[1:],
-			Fms:      fms[1:],
+		restResult := &statistics.AnalyzeResult{
+			Hist:  hists[1:],
+			Cms:   cms[1:],
+			TopNs: topNs[1:],
+			Fms:   fms[1:],
+		}
+		return &statistics.AnalyzeResults{
+			TableID:  colExec.tableID,
+			Ars:      []*statistics.AnalyzeResult{PKresult, restResult},
 			ExtStats: extStats,
-			job:      colExec.job,
+			Job:      colExec.job,
 			StatsVer: colExec.StatsVersion,
+			Count:    int64(PKresult.Hist[0].TotalRowCount()),
+			Snapshot: colExec.snapshot,
 		}
-		restResult.Count = PKresult.Count
-		return []analyzeResult{PKresult, restResult}
 	}
-	var result []analyzeResult
+	var ars []*statistics.AnalyzeResult
 	if colExec.analyzePB.Tp == tipb.AnalyzeType_TypeMixed {
-		result = append(result, analyzeResult{
-			TableID:  colExec.TableID,
-			Hist:     []*statistics.Histogram{hists[0]},
-			Cms:      []*statistics.CMSketch{cms[0]},
-			TopNs:    []*statistics.TopN{topNs[0]},
-			Fms:      []*statistics.FMSketch{nil},
-			IsIndex:  1,
-			job:      colExec.job,
-			StatsVer: colExec.StatsVersion,
+		ars = append(ars, &statistics.AnalyzeResult{
+			Hist:    []*statistics.Histogram{hists[0]},
+			Cms:     []*statistics.CMSketch{cms[0]},
+			TopNs:   []*statistics.TopN{topNs[0]},
+			Fms:     []*statistics.FMSketch{nil},
+			IsIndex: 1,
 		})
 		hists = hists[1:]
 		cms = cms[1:]
 		topNs = topNs[1:]
 	}
-	colResult := analyzeResult{
-		TableID:  colExec.TableID,
-		Hist:     hists,
-		Cms:      cms,
-		TopNs:    topNs,
-		Fms:      fms,
-		ExtStats: extStats,
-		job:      colExec.job,
+	colResult := &statistics.AnalyzeResult{
+		Hist:  hists,
+		Cms:   cms,
+		TopNs: topNs,
+		Fms:   fms,
+	}
+	ars = append(ars, colResult)
+	cnt := int64(hists[0].TotalRowCount())
+	if colExec.StatsVersion >= statistics.Version2 {
+		cnt += int64(topNs[0].TotalCount())
+	}
+	return &statistics.AnalyzeResults{
+		TableID:  colExec.tableID,
+		Ars:      ars,
+		Job:      colExec.job,
 		StatsVer: colExec.StatsVersion,
+		ExtStats: extStats,
+		Count:    cnt,
+		Snapshot: colExec.snapshot,
 	}
-	colResult.Count = int64(colResult.Hist[0].TotalRowCount())
-	if colResult.StatsVer >= statistics.Version2 {
-		colResult.Count += int64(topNs[0].TotalCount())
-	}
-	return append(result, colResult)
 }
 
 // AnalyzeColumnsExec represents Analyze columns push down executor.
 type AnalyzeColumnsExec struct {
-	ctx           sessionctx.Context
+	baseAnalyzeExec
+
 	tableInfo     *model.TableInfo
 	colsInfo      []*model.ColumnInfo
 	handleCols    core.HandleCols
-	concurrency   int
-	analyzePB     *tipb.AnalyzeReq
 	commonHandle  *model.IndexInfo
 	resultHandler *tableResultHandler
-	opts          map[ast.AnalyzeOptionType]uint64
-	job           *statistics.AnalyzeJob
 	indexes       []*model.IndexInfo
 	core.AnalyzeInfo
 
@@ -755,7 +742,7 @@ func (e *AnalyzeColumnsExec) buildResp(ranges []*ranger.Range) (distsql.SelectRe
 	// correct `correlation` of columns.
 	kvReq, err := reqBuilder.
 		SetAnalyzeRequest(e.analyzePB).
-		SetStartTS(math.MaxUint64).
+		SetStartTS(e.snapshot).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).
 		Build()
@@ -952,7 +939,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 	for _, offset := range indexesWithVirtualColOffsets {
 		ret := indexPushedDownResult.results[e.indexes[offset].ID]
 		rootRowCollector.NullCount[colLen+offset] = ret.Count
-		rootRowCollector.FMSketches[colLen+offset] = ret.Fms[0]
+		rootRowCollector.FMSketches[colLen+offset] = ret.Ars[0].Fms[0]
 	}
 
 	// build index stats
@@ -996,7 +983,7 @@ func (e *AnalyzeColumnsExec) buildSamplingStats(
 }
 
 type analyzeIndexNDVTotalResult struct {
-	results map[int64]analyzeResult
+	results map[int64]*statistics.AnalyzeResults
 	err     error
 }
 
@@ -1020,11 +1007,11 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(indexInfos []*model.Inde
 	for _, task := range tasks {
 		statistics.AddNewAnalyzeJob(task.job)
 	}
-	resultCh := make(chan analyzeResult, len(tasks))
+	resultsCh := make(chan *statistics.AnalyzeResults, len(tasks))
 	e.subIndexWorkerWg = &sync.WaitGroup{}
 	e.subIndexWorkerWg.Add(statsConcurrncy)
 	for i := 0; i < statsConcurrncy; i++ {
-		go e.subIndexWorkerForNDV(taskCh, resultCh, i == 0)
+		go e.subIndexWorkerForNDV(taskCh, resultsCh, i == 0)
 	}
 	for _, task := range tasks {
 		taskCh <- task
@@ -1032,24 +1019,24 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(indexInfos []*model.Inde
 	close(taskCh)
 	panicCnt := 0
 	totalResult := analyzeIndexNDVTotalResult{
-		results: make(map[int64]analyzeResult, len(indexInfos)),
+		results: make(map[int64]*statistics.AnalyzeResults, len(indexInfos)),
 	}
 	for panicCnt < statsConcurrncy {
-		result, ok := <-resultCh
+		results, ok := <-resultsCh
 		if !ok {
 			break
 		}
-		if result.Err != nil {
-			result.job.Finish(true)
-			err = result.Err
+		if results.Err != nil {
+			results.Job.Finish(true)
+			err = results.Err
 			if err == errAnalyzeWorkerPanic {
 				panicCnt++
 			}
 			continue
 		}
-		result.job.Finish(false)
-		statistics.MoveToHistory(result.job)
-		totalResult.results[result.Hist[0].ID] = result
+		results.Job.Finish(false)
+		statistics.MoveToHistory(results.Job)
+		totalResult.results[results.Ars[0].Hist[0].ID] = results
 	}
 	if err != nil {
 		totalResult.err = err
@@ -1058,7 +1045,7 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(indexInfos []*model.Inde
 }
 
 // subIndexWorker receive the task for each index and return the result for them.
-func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(taskCh chan *analyzeTask, resultCh chan analyzeResult, isFirstToCloseCh bool) {
+func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(taskCh chan *analyzeTask, resultsCh chan *statistics.AnalyzeResults, isFirstToCloseCh bool) {
 	var task *analyzeTask
 	defer func() {
 		if r := recover(); r != nil {
@@ -1067,15 +1054,15 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(taskCh chan *analyzeTask, resu
 			buf = buf[:stackSize]
 			logutil.BgLogger().Error("analyze worker panicked", zap.String("stack", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelAnalyze).Inc()
-			resultCh <- analyzeResult{
+			resultsCh <- &statistics.AnalyzeResults{
 				Err: errAnalyzeWorkerPanic,
-				job: task.job,
+				Job: task.job,
 			}
 		}
 		e.subIndexWorkerWg.Done()
 		if isFirstToCloseCh {
 			e.subIndexWorkerWg.Wait()
-			close(resultCh)
+			close(resultsCh)
 		}
 	}()
 	for {
@@ -1086,14 +1073,14 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(taskCh chan *analyzeTask, resu
 		}
 		task.job.Start()
 		if task.taskType != idxTask {
-			resultCh <- analyzeResult{
+			resultsCh <- &statistics.AnalyzeResults{
 				Err: errors.Errorf("incorrect analyze type"),
-				job: task.job,
+				Job: task.job,
 			}
 			continue
 		}
 		task.idxExec.job = task.job
-		resultCh <- analyzeIndexNDVPushDown(task.idxExec)
+		resultsCh <- analyzeIndexNDVPushDown(task.idxExec)
 	}
 }
 
@@ -1104,17 +1091,21 @@ func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(indexInfos []*model
 	tasks := make([]*analyzeTask, 0, len(indexInfos))
 	sc := e.ctx.GetSessionVars().StmtCtx
 	for _, indexInfo := range indexInfos {
-		idxExec := &AnalyzeIndexExec{
-			ctx:            e.ctx,
-			tableID:        e.TableID,
-			isCommonHandle: e.tableInfo.IsCommonHandle,
-			idxInfo:        indexInfo,
-			concurrency:    e.ctx.GetSessionVars().IndexSerialScanConcurrency(),
+		base := baseAnalyzeExec{
+			ctx:         e.ctx,
+			tableID:     e.TableID,
+			concurrency: e.ctx.GetSessionVars().IndexSerialScanConcurrency(),
 			analyzePB: &tipb.AnalyzeReq{
 				Tp:             tipb.AnalyzeType_TypeIndex,
 				Flags:          sc.PushDownFlags(),
 				TimeZoneOffset: offset,
 			},
+			snapshot: e.snapshot,
+		}
+		idxExec := &AnalyzeIndexExec{
+			baseAnalyzeExec: base,
+			isCommonHandle:  e.tableInfo.IsCommonHandle,
+			idxInfo:         indexInfo,
 		}
 		idxExec.opts = make(map[ast.AnalyzeOptionType]uint64, len(ast.AnalyzeOptionString))
 		idxExec.opts[ast.AnalyzeOptNumTopN] = 0
@@ -1147,6 +1138,7 @@ func (e *AnalyzeColumnsExec) buildSubIndexJobForSpecialIndex(indexInfos []*model
 			autoAnalyze = "auto "
 		}
 		job := &statistics.AnalyzeJob{DBName: e.job.DBName, TableName: e.job.TableName, PartitionName: e.job.PartitionName, JobInfo: autoAnalyze + "analyze ndv for index " + indexInfo.Name.O}
+		idxExec.job = job
 		tasks = append(tasks, &analyzeTask{
 			taskType: idxTask,
 			idxExec:  idxExec,
@@ -1509,65 +1501,54 @@ var (
 	fastAnalyzeHistogramScanKeys      = metrics.FastAnalyzeHistogram.WithLabelValues(metrics.LblGeneral, "scan_keys")
 )
 
-func analyzeFastExec(exec *AnalyzeFastExec) []analyzeResult {
+func analyzeFastExec(exec *AnalyzeFastExec) *statistics.AnalyzeResults {
 	hists, cms, topNs, fms, err := exec.buildStats()
 	if err != nil {
-		return []analyzeResult{{Err: err, job: exec.job}}
+		return &statistics.AnalyzeResults{Err: err, Job: exec.job}
 	}
-	var results []analyzeResult
+	var results []*statistics.AnalyzeResult
 	pkColCount := pkColsCount(exec.handleCols)
 	if len(exec.idxsInfo) > 0 {
-		for i := pkColCount + len(exec.colsInfo); i < len(hists); i++ {
-			idxResult := analyzeResult{
-				TableID:  exec.tableID,
-				Hist:     []*statistics.Histogram{hists[i]},
-				Cms:      []*statistics.CMSketch{cms[i]},
-				TopNs:    []*statistics.TopN{topNs[i]},
-				Fms:      []*statistics.FMSketch{nil},
-				IsIndex:  1,
-				Count:    hists[i].NullCount,
-				job:      exec.job,
-				StatsVer: statistics.Version1,
-			}
-			if hists[i].Len() > 0 {
-				idxResult.Count += hists[i].Buckets[hists[i].Len()-1].Count
-			}
-			if exec.rowCount != 0 {
-				idxResult.Count = exec.rowCount
-			}
-			results = append(results, idxResult)
+		idxResult := &statistics.AnalyzeResult{
+			Hist:    hists[pkColCount+len(exec.colsInfo):],
+			Cms:     cms[pkColCount+len(exec.colsInfo):],
+			TopNs:   topNs[pkColCount+len(exec.colsInfo):],
+			Fms:     fms[pkColCount+len(exec.colsInfo):],
+			IsIndex: 1,
 		}
+		results = append(results, idxResult)
 	}
-	hist := hists[0]
-	colResult := analyzeResult{
-		TableID:  exec.tableID,
-		Hist:     hists[:pkColCount+len(exec.colsInfo)],
-		Cms:      cms[:pkColCount+len(exec.colsInfo)],
-		TopNs:    topNs[:pkColCount+len(exec.colsInfo)],
-		Fms:      fms[:pkColCount+len(exec.colsInfo)],
-		Count:    hist.NullCount,
-		job:      exec.job,
-		StatsVer: statistics.Version1,
-	}
-	if hist.Len() > 0 {
-		colResult.Count += hist.Buckets[hist.Len()-1].Count
-	}
-	if exec.rowCount != 0 {
-		colResult.Count = exec.rowCount
+	colResult := &statistics.AnalyzeResult{
+		Hist:  hists[:pkColCount+len(exec.colsInfo)],
+		Cms:   cms[:pkColCount+len(exec.colsInfo)],
+		TopNs: topNs[:pkColCount+len(exec.colsInfo)],
+		Fms:   fms[:pkColCount+len(exec.colsInfo)],
 	}
 	results = append(results, colResult)
-	return results
+	hist := hists[0]
+	cnt := hist.NullCount
+	if hist.Len() > 0 {
+		cnt += hist.Buckets[hist.Len()-1].Count
+	}
+	if exec.rowCount != 0 {
+		cnt = exec.rowCount
+	}
+	return &statistics.AnalyzeResults{
+		TableID:  exec.tableID,
+		Ars:      results,
+		Job:      exec.job,
+		StatsVer: statistics.Version1,
+		Count:    cnt,
+		Snapshot: exec.snapshot,
+	}
 }
 
 // AnalyzeFastExec represents Fast Analyze executor.
 type AnalyzeFastExec struct {
-	ctx         sessionctx.Context
-	tableID     core.AnalyzeTableID
+	baseAnalyzeExec
 	handleCols  core.HandleCols
 	colsInfo    []*model.ColumnInfo
 	idxsInfo    []*model.IndexInfo
-	concurrency int
-	opts        map[ast.AnalyzeOptionType]uint64
 	tblInfo     *model.TableInfo
 	cache       *tikv.RegionCache
 	wg          *sync.WaitGroup
@@ -1577,7 +1558,6 @@ type AnalyzeFastExec struct {
 	scanTasks   []*tikv.KeyLocation
 	collectors  []*statistics.SampleCollector
 	randSeed    int64
-	job         *statistics.AnalyzeJob
 	estSampStep uint32
 }
 
@@ -1664,7 +1644,7 @@ func (e *AnalyzeFastExec) activateTxnForRowCount() (rollbackFn func() error, err
 		}
 	}
 	txn.SetOption(kv.Priority, kv.PriorityLow)
-	txn.SetOption(kv.IsolationLevel, kv.RC)
+	txn.SetOption(kv.IsolationLevel, kv.SI)
 	txn.SetOption(kv.NotFillCache, true)
 	return rollbackFn, nil
 }
@@ -1862,7 +1842,8 @@ func (e *AnalyzeFastExec) handleScanIter(iter kv.Iterator) (scanKeysSize int, er
 }
 
 func (e *AnalyzeFastExec) handleScanTasks(bo *tikv.Backoffer) (keysSize int, err error) {
-	snapshot := e.ctx.GetStore().GetSnapshot(kv.MaxVersion)
+	snapshot := e.ctx.GetStore().GetSnapshot(kv.NewVersion(e.snapshot))
+	snapshot.SetOption(kv.IsolationLevel, kv.SI)
 	if e.ctx.GetSessionVars().GetReplicaRead().IsFollowerRead() {
 		snapshot.SetOption(kv.ReplicaRead, kv.ReplicaReadFollower)
 	}
@@ -1883,9 +1864,9 @@ func (e *AnalyzeFastExec) handleScanTasks(bo *tikv.Backoffer) (keysSize int, err
 
 func (e *AnalyzeFastExec) handleSampTasks(workID int, step uint32, err *error) {
 	defer e.wg.Done()
-	snapshot := e.ctx.GetStore().GetSnapshot(kv.MaxVersion)
+	snapshot := e.ctx.GetStore().GetSnapshot(kv.NewVersion(e.snapshot))
 	snapshot.SetOption(kv.NotFillCache, true)
-	snapshot.SetOption(kv.IsolationLevel, kv.RC)
+	snapshot.SetOption(kv.IsolationLevel, kv.SI)
 	snapshot.SetOption(kv.Priority, kv.PriorityLow)
 	setResourceGroupTagForTxn(e.ctx.GetSessionVars().StmtCtx, snapshot)
 	if e.ctx.GetSessionVars().GetReplicaRead().IsFollowerRead() {
@@ -2078,7 +2059,7 @@ func (e *AnalyzeFastExec) buildStats() (hists []*statistics.Histogram, cms []*st
 type AnalyzeTestFastExec struct {
 	AnalyzeFastExec
 	Ctx         sessionctx.Context
-	TableID     core.AnalyzeTableID
+	TableID     statistics.AnalyzeTableID
 	HandleCols  core.HandleCols
 	ColsInfo    []*model.ColumnInfo
 	IdxsInfo    []*model.IndexInfo
@@ -2086,6 +2067,7 @@ type AnalyzeTestFastExec struct {
 	Collectors  []*statistics.SampleCollector
 	TblInfo     *model.TableInfo
 	Opts        map[ast.AnalyzeOptionType]uint64
+	Snapshot    uint64
 }
 
 // TestFastSample only test the fast sample in unit test.
@@ -2100,6 +2082,7 @@ func (e *AnalyzeTestFastExec) TestFastSample() error {
 	e.job = &statistics.AnalyzeJob{}
 	e.tblInfo = e.TblInfo
 	e.opts = e.Opts
+	e.snapshot = e.Snapshot
 	_, _, _, _, err := e.buildStats()
 	e.Collectors = e.collectors
 	return err
@@ -2112,7 +2095,7 @@ type analyzeIndexIncrementalExec struct {
 	oldTopN *statistics.TopN
 }
 
-func analyzeIndexIncremental(idxExec *analyzeIndexIncrementalExec) analyzeResult {
+func analyzeIndexIncremental(idxExec *analyzeIndexIncrementalExec) *statistics.AnalyzeResults {
 	var statsVer = statistics.Version1
 	if idxExec.analyzePB.IdxReq.Version != nil {
 		statsVer = int(*idxExec.analyzePB.IdxReq.Version)
@@ -2120,26 +2103,26 @@ func analyzeIndexIncremental(idxExec *analyzeIndexIncrementalExec) analyzeResult
 	pruneMode := variable.PartitionPruneMode(idxExec.ctx.GetSessionVars().PartitionPruneMode.Load())
 	if idxExec.tableID.IsPartitionTable() && pruneMode == variable.Dynamic {
 		err := errors.Errorf("[stats]: global statistics for partitioned tables unavailable in ANALYZE INCREMENTAL")
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
 	startPos := idxExec.oldHist.GetUpper(idxExec.oldHist.Len() - 1)
 	values, _, err := codec.DecodeRange(startPos.GetBytes(), len(idxExec.idxInfo.Columns), nil, nil)
 	if err != nil {
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
 	ran := ranger.Range{LowVal: values, HighVal: []types.Datum{types.MaxValueDatum()}}
 	hist, cms, fms, topN, err := idxExec.buildStats([]*ranger.Range{&ran}, false)
 	if err != nil {
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
 	hist, err = statistics.MergeHistograms(idxExec.ctx.GetSessionVars().StmtCtx, idxExec.oldHist, hist, int(idxExec.opts[ast.AnalyzeOptNumBuckets]), statsVer)
 	if err != nil {
-		return analyzeResult{Err: err, job: idxExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 	}
 	if idxExec.oldCMS != nil && cms != nil {
 		err = cms.MergeCMSketch4IncrementalAnalyze(idxExec.oldCMS, uint32(idxExec.opts[ast.AnalyzeOptNumTopN]))
 		if err != nil {
-			return analyzeResult{Err: err, job: idxExec.job}
+			return &statistics.AnalyzeResults{Err: err, Job: idxExec.job}
 		}
 		cms.CalcDefaultValForAnalyze(uint64(hist.NDV))
 	}
@@ -2147,21 +2130,25 @@ func analyzeIndexIncremental(idxExec *analyzeIndexIncrementalExec) analyzeResult
 		poped := statistics.MergeTopNAndUpdateCMSketch(topN, idxExec.oldTopN, cms, uint32(idxExec.opts[ast.AnalyzeOptNumTopN]))
 		hist.AddIdxVals(poped)
 	}
-	result := analyzeResult{
-		TableID:  idxExec.tableID,
-		Hist:     []*statistics.Histogram{hist},
-		Cms:      []*statistics.CMSketch{cms},
-		TopNs:    []*statistics.TopN{topN},
-		Fms:      []*statistics.FMSketch{fms},
-		IsIndex:  1,
-		job:      idxExec.job,
-		StatsVer: statsVer,
+	result := &statistics.AnalyzeResult{
+		Hist:    []*statistics.Histogram{hist},
+		Cms:     []*statistics.CMSketch{cms},
+		TopNs:   []*statistics.TopN{topN},
+		Fms:     []*statistics.FMSketch{fms},
+		IsIndex: 1,
 	}
-	result.Count = hist.NullCount
+	cnt := hist.NullCount
 	if hist.Len() > 0 {
-		result.Count += hist.Buckets[hist.Len()-1].Count
+		cnt += hist.Buckets[hist.Len()-1].Count
 	}
-	return result
+	return &statistics.AnalyzeResults{
+		TableID:  idxExec.tableID,
+		Ars:      []*statistics.AnalyzeResult{result},
+		Job:      idxExec.job,
+		StatsVer: statsVer,
+		Count:    cnt,
+		Snapshot: idxExec.snapshot,
+	}
 }
 
 type analyzePKIncrementalExec struct {
@@ -2169,7 +2156,7 @@ type analyzePKIncrementalExec struct {
 	oldHist *statistics.Histogram
 }
 
-func analyzePKIncremental(colExec *analyzePKIncrementalExec) analyzeResult {
+func analyzePKIncremental(colExec *analyzePKIncrementalExec) *statistics.AnalyzeResults {
 	var maxVal types.Datum
 	pkInfo := colExec.handleCols.GetCol(0)
 	if mysql.HasUnsignedFlag(pkInfo.RetType.Flag) {
@@ -2181,39 +2168,29 @@ func analyzePKIncremental(colExec *analyzePKIncrementalExec) analyzeResult {
 	ran := ranger.Range{LowVal: []types.Datum{startPos}, LowExclude: true, HighVal: []types.Datum{maxVal}}
 	hists, _, _, _, _, err := colExec.buildStats([]*ranger.Range{&ran}, false)
 	if err != nil {
-		return analyzeResult{Err: err, job: colExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: colExec.job}
 	}
 	hist := hists[0]
 	hist, err = statistics.MergeHistograms(colExec.ctx.GetSessionVars().StmtCtx, colExec.oldHist, hist, int(colExec.opts[ast.AnalyzeOptNumBuckets]), statistics.Version1)
 	if err != nil {
-		return analyzeResult{Err: err, job: colExec.job}
+		return &statistics.AnalyzeResults{Err: err, Job: colExec.job}
 	}
-	result := analyzeResult{
-		TableID:  colExec.TableID,
-		Hist:     []*statistics.Histogram{hist},
-		Cms:      []*statistics.CMSketch{nil},
-		TopNs:    []*statistics.TopN{nil},
-		Fms:      []*statistics.FMSketch{nil},
-		job:      colExec.job,
-		StatsVer: statistics.Version1,
+	result := &statistics.AnalyzeResult{
+		Hist:  []*statistics.Histogram{hist},
+		Cms:   []*statistics.CMSketch{nil},
+		TopNs: []*statistics.TopN{nil},
+		Fms:   []*statistics.FMSketch{nil},
 	}
+	var cnt int64
 	if hist.Len() > 0 {
-		result.Count += hist.Buckets[hist.Len()-1].Count
+		cnt = hist.Buckets[hist.Len()-1].Count
 	}
-	return result
-}
-
-// analyzeResult is used to represent analyze result.
-type analyzeResult struct {
-	TableID  core.AnalyzeTableID
-	Hist     []*statistics.Histogram
-	Cms      []*statistics.CMSketch
-	TopNs    []*statistics.TopN
-	Fms      []*statistics.FMSketch
-	ExtStats *statistics.ExtendedStatsColl
-	Count    int64
-	IsIndex  int
-	Err      error
-	job      *statistics.AnalyzeJob
-	StatsVer int
+	return &statistics.AnalyzeResults{
+		TableID:  colExec.tableID,
+		Ars:      []*statistics.AnalyzeResult{result},
+		Job:      colExec.job,
+		StatsVer: statistics.Version1,
+		Count:    cnt,
+		Snapshot: colExec.snapshot,
+	}
 }

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -341,13 +341,20 @@ func (s *testFastAnalyze) TestAnalyzeFastSample(c *C) {
 	}
 	opts := make(map[ast.AnalyzeOptionType]uint64)
 	opts[ast.AnalyzeOptNumSamples] = 20
+	// Get a start_ts later than the above inserts.
+	tk.MustExec("begin")
+	txn, err := tk.Se.Txn(false)
+	c.Assert(err, IsNil)
+	ts := txn.StartTS()
+	tk.MustExec("commit")
 	mockExec := &executor.AnalyzeTestFastExec{
 		Ctx:         tk.Se.(sessionctx.Context),
 		HandleCols:  handleCols,
 		ColsInfo:    colsInfo,
 		IdxsInfo:    indicesInfo,
 		Concurrency: 1,
-		TableID: core.AnalyzeTableID{
+		Snapshot:    ts,
+		TableID: statistics.AnalyzeTableID{
 			PartitionID: -1,
 			TableID:     tbl.(table.PhysicalTable).GetPhysicalID(),
 		},
@@ -1055,4 +1062,50 @@ func (s *testSerialSuite2) TestAnalyzeSamplingWorkPanic(c *C) {
 	err = tk.ExecToErr("analyze table t")
 	c.Assert(err, NotNil)
 	c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/mockAnalyzeSamplingMergeWorkerPanic"), IsNil)
+}
+
+func (s *testSuite10) TestSnapshotAnalyze(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, index index_a(a))")
+	is := tk.Se.(sessionctx.Context).GetInfoSchema().(infoschema.InfoSchema)
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	tblInfo := tbl.Meta()
+	tid := tblInfo.ID
+	tk.MustExec("insert into t values(1),(1),(1)")
+	tk.MustExec("begin")
+	txn, err := tk.Se.Txn(false)
+	c.Assert(err, IsNil)
+	startTS1 := txn.StartTS()
+	tk.MustExec("commit")
+	tk.MustExec("insert into t values(2),(2),(2)")
+	tk.MustExec("begin")
+	txn, err = tk.Se.Txn(false)
+	c.Assert(err, IsNil)
+	startTS2 := txn.StartTS()
+	tk.MustExec("commit")
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/injectAnalyzeSnapshot", fmt.Sprintf("return(%d)", startTS1)), IsNil)
+	tk.MustExec("analyze table t")
+	rows := tk.MustQuery(fmt.Sprintf("select count, snapshot from mysql.stats_meta where table_id = %d", tid)).Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "3")
+	s1Str := rows[0][1].(string)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/injectAnalyzeSnapshot", fmt.Sprintf("return(%d)", startTS2)), IsNil)
+	tk.MustExec("analyze table t")
+	rows = tk.MustQuery(fmt.Sprintf("select count, snapshot from mysql.stats_meta where table_id = %d", tid)).Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "6")
+	s2Str := rows[0][1].(string)
+	c.Assert(s1Str != s2Str, IsTrue)
+	tk.MustExec("set @@session.tidb_analyze_version = 2")
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/executor/injectAnalyzeSnapshot", fmt.Sprintf("return(%d)", startTS1)), IsNil)
+	tk.MustExec("analyze table t")
+	rows = tk.MustQuery(fmt.Sprintf("select count, snapshot from mysql.stats_meta where table_id = %d", tid)).Rows()
+	c.Assert(len(rows), Equals, 1)
+	c.Assert(rows[0][0], Equals, "6")
+	s3Str := rows[0][1].(string)
+	c.Assert(s3Str, Equals, s2Str)
+	c.Assert(failpoint.Disable("github.com/pingcap/tidb/executor/injectAnalyzeSnapshot"), IsNil)
 }

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -32,6 +32,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/types"
@@ -814,51 +815,12 @@ type Delete struct {
 	TblColPosInfos TblColPosInfoSlice
 }
 
-// AnalyzeTableID is hybrid table id used to analyze table.
-type AnalyzeTableID struct {
-	TableID int64
-	// PartitionID is used for the construction of partition table statistics. It indicate the ID of the partition.
-	// If the table is not the partition table, the PartitionID will be equal to -1.
-	PartitionID int64
-}
-
-// GetStatisticsID is used to obtain the table ID to build statistics.
-// If the 'PartitionID == -1', we use the TableID to build the statistics for non-partition tables.
-// Otherwise, we use the PartitionID to build the statistics of the partitions in the partition tables.
-func (h *AnalyzeTableID) GetStatisticsID() int64 {
-	statisticsID := h.TableID
-	if h.PartitionID != -1 {
-		statisticsID = h.PartitionID
-	}
-	return statisticsID
-}
-
-// IsPartitionTable indicates whether the table is partition table.
-func (h *AnalyzeTableID) IsPartitionTable() bool {
-	return h.PartitionID != -1
-}
-
-func (h *AnalyzeTableID) String() string {
-	return fmt.Sprintf("%d => %v", h.PartitionID, h.TableID)
-}
-
-// Equals indicates whether two table id is equal.
-func (h *AnalyzeTableID) Equals(t *AnalyzeTableID) bool {
-	if h == t {
-		return true
-	}
-	if h == nil || t == nil {
-		return false
-	}
-	return h.TableID == t.TableID && h.PartitionID == t.PartitionID
-}
-
 // AnalyzeInfo is used to store the database name, table name and partition name of analyze task.
 type AnalyzeInfo struct {
 	DBName        string
 	TableName     string
 	PartitionName string
-	TableID       AnalyzeTableID
+	TableID       statistics.AnalyzeTableID
 	Incremental   bool
 	StatsVersion  int
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -1738,7 +1738,7 @@ func (b *PlanBuilder) buildAnalyzeFullSamplingTask(
 			DBName:        tbl.Schema.O,
 			TableName:     tbl.Name.O,
 			PartitionName: names[i],
-			TableID:       AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
+			TableID:       statistics.AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
 			Incremental:   false,
 			StatsVersion:  version,
 		}
@@ -1805,7 +1805,7 @@ func (b *PlanBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt, opts map[ast.A
 					DBName:        tbl.Schema.O,
 					TableName:     tbl.Name.O,
 					PartitionName: names[i],
-					TableID:       AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
+					TableID:       statistics.AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
 					Incremental:   as.Incremental,
 					StatsVersion:  version,
 				}
@@ -1826,7 +1826,7 @@ func (b *PlanBuilder) buildAnalyzeTable(as *ast.AnalyzeTableStmt, opts map[ast.A
 					DBName:        tbl.Schema.O,
 					TableName:     tbl.Name.O,
 					PartitionName: names[i],
-					TableID:       AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
+					TableID:       statistics.AnalyzeTableID{TableID: tbl.TableInfo.ID, PartitionID: id},
 					Incremental:   as.Incremental,
 					StatsVersion:  version,
 				}
@@ -1877,7 +1877,7 @@ func (b *PlanBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt, opts map[ast.A
 					info := AnalyzeInfo{
 						DBName:        as.TableNames[0].Schema.O,
 						TableName:     as.TableNames[0].Name.O,
-						PartitionName: names[i], TableID: AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
+						PartitionName: names[i], TableID: statistics.AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
 						Incremental:  as.Incremental,
 						StatsVersion: version,
 					}
@@ -1898,7 +1898,7 @@ func (b *PlanBuilder) buildAnalyzeIndex(as *ast.AnalyzeTableStmt, opts map[ast.A
 				DBName:        as.TableNames[0].Schema.O,
 				TableName:     as.TableNames[0].Name.O,
 				PartitionName: names[i],
-				TableID:       AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
+				TableID:       statistics.AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
 				Incremental:   as.Incremental,
 				StatsVersion:  version,
 			}
@@ -1940,7 +1940,7 @@ func (b *PlanBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt, opts map[as
 					DBName:        as.TableNames[0].Schema.O,
 					TableName:     as.TableNames[0].Name.O,
 					PartitionName: names[i],
-					TableID:       AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
+					TableID:       statistics.AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
 					Incremental:   as.Incremental,
 					StatsVersion:  version,
 				}
@@ -1958,7 +1958,7 @@ func (b *PlanBuilder) buildAnalyzeAllIndex(as *ast.AnalyzeTableStmt, opts map[as
 				DBName:        as.TableNames[0].Schema.O,
 				TableName:     as.TableNames[0].Name.O,
 				PartitionName: names[i],
-				TableID:       AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
+				TableID:       statistics.AnalyzeTableID{TableID: tblInfo.ID, PartitionID: id},
 				Incremental:   as.Incremental,
 				StatsVersion:  version,
 			}

--- a/statistics/analyze.go
+++ b/statistics/analyze.go
@@ -1,0 +1,78 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"fmt"
+)
+
+// AnalyzeTableID is hybrid table id used to analyze table.
+type AnalyzeTableID struct {
+	TableID int64
+	// PartitionID is used for the construction of partition table statistics. It indicate the ID of the partition.
+	// If the table is not the partition table, the PartitionID will be equal to -1.
+	PartitionID int64
+}
+
+// GetStatisticsID is used to obtain the table ID to build statistics.
+// If the 'PartitionID == -1', we use the TableID to build the statistics for non-partition tables.
+// Otherwise, we use the PartitionID to build the statistics of the partitions in the partition tables.
+func (h *AnalyzeTableID) GetStatisticsID() int64 {
+	statisticsID := h.TableID
+	if h.PartitionID != -1 {
+		statisticsID = h.PartitionID
+	}
+	return statisticsID
+}
+
+// IsPartitionTable indicates whether the table is partition table.
+func (h *AnalyzeTableID) IsPartitionTable() bool {
+	return h.PartitionID != -1
+}
+
+func (h *AnalyzeTableID) String() string {
+	return fmt.Sprintf("%d => %v", h.PartitionID, h.TableID)
+}
+
+// Equals indicates whether two table id is equal.
+func (h *AnalyzeTableID) Equals(t *AnalyzeTableID) bool {
+	if h == t {
+		return true
+	}
+	if h == nil || t == nil {
+		return false
+	}
+	return h.TableID == t.TableID && h.PartitionID == t.PartitionID
+}
+
+// AnalyzeResult is used to represent analyze result.
+type AnalyzeResult struct {
+	Hist    []*Histogram
+	Cms     []*CMSketch
+	TopNs   []*TopN
+	Fms     []*FMSketch
+	IsIndex int
+}
+
+// AnalyzeResults represents the analyze results of a task.
+type AnalyzeResults struct {
+	TableID  AnalyzeTableID
+	Ars      []*AnalyzeResult
+	Count    int64
+	ExtStats *ExtendedStatsColl
+	Err      error
+	Job      *AnalyzeJob
+	StatsVer int
+	Snapshot uint64
+}

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -955,6 +955,147 @@ func (h *Handle) extendedStatsFromStorage(reader *statsReader, table *statistics
 	return table, nil
 }
 
+// SaveTableStatsToStorage saves the stats of a table to storage.
+func (h *Handle) SaveTableStatsToStorage(results *statistics.AnalyzeResults, needDumpFMS bool) (err error) {
+	tableID := results.TableID.GetStatisticsID()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	ctx := context.TODO()
+	exec := h.mu.ctx.(sqlexec.SQLExecutor)
+	_, err = exec.ExecuteInternal(ctx, "begin pessimistic")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = finishTransaction(context.Background(), exec, err)
+	}()
+	txn, err := h.mu.ctx.Txn(true)
+	if err != nil {
+		return err
+	}
+	version := txn.StartTS()
+	// 1. Save mysql.stats_meta.
+	var rs sqlexec.RecordSet
+	// Lock this row to prevent writing of concurrent analyze.
+	rs, err = exec.ExecuteInternal(ctx, "select snapshot from mysql.stats_meta where table_id = %? for update", tableID)
+	if err != nil {
+		return err
+	}
+	var rows []chunk.Row
+	rows, err = sqlexec.DrainRecordSet(ctx, rs, h.mu.ctx.GetSessionVars().MaxChunkSize)
+	if err != nil {
+		return err
+	}
+	if len(rows) > 0 {
+		snapshot := rows[0].GetUint64(0)
+		// A newer version analyze result has been written, so skip this writing.
+		if snapshot >= results.Snapshot && results.StatsVer == statistics.Version2 {
+			return nil
+		}
+	}
+	// This `replace` would reset modify_count to 0.
+	// TODO: subtract original modify_count from the current modify_count.
+	if _, err = exec.ExecuteInternal(ctx, "replace into mysql.stats_meta (version, table_id, count, snapshot) values (%?, %?, %?, %?)", version, tableID, results.Count, results.Snapshot); err != nil {
+		return err
+	}
+	// 2. Save histograms.
+	for _, result := range results.Ars {
+		for i, hg := range result.Hist {
+			var cms *statistics.CMSketch
+			if results.StatsVer != statistics.Version2 {
+				cms = result.Cms[i]
+			}
+			cmSketch, err := statistics.EncodeCMSketchWithoutTopN(cms)
+			if err != nil {
+				return err
+			}
+			fmSketch, err := statistics.EncodeFMSketch(result.Fms[i])
+			if err != nil {
+				return err
+			}
+			// Delete outdated data
+			if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_top_n where table_id = %? and is_index = %? and hist_id = %?", tableID, result.IsIndex, hg.ID); err != nil {
+				return err
+			}
+			if topN := result.TopNs[i]; topN != nil {
+				for _, meta := range topN.TopN {
+					if _, err = exec.ExecuteInternal(ctx, "insert into mysql.stats_top_n (table_id, is_index, hist_id, value, count) values (%?, %?, %?, %?, %?)", tableID, result.IsIndex, hg.ID, meta.Encoded, meta.Count); err != nil {
+						return err
+					}
+				}
+			}
+			if _, err := exec.ExecuteInternal(ctx, "delete from mysql.stats_fm_sketch where table_id = %? and is_index = %? and hist_id = %?", tableID, result.IsIndex, hg.ID); err != nil {
+				return err
+			}
+			if fmSketch != nil && needDumpFMS {
+				if _, err = exec.ExecuteInternal(ctx, "insert into mysql.stats_fm_sketch (table_id, is_index, hist_id, value) values (%?, %?, %?, %?)", tableID, result.IsIndex, hg.ID, fmSketch); err != nil {
+					return err
+				}
+			}
+			if _, err = exec.ExecuteInternal(ctx, "replace into mysql.stats_histograms (table_id, is_index, hist_id, distinct_count, version, null_count, cm_sketch, tot_col_size, stats_ver, flag, correlation) values (%?, %?, %?, %?, %?, %?, %?, %?, %?, %?, %?)",
+				tableID, result.IsIndex, hg.ID, hg.NDV, version, hg.NullCount, cmSketch, hg.TotColSize, results.StatsVer, statistics.AnalyzeFlag, hg.Correlation); err != nil {
+				return err
+			}
+			if _, err = exec.ExecuteInternal(ctx, "delete from mysql.stats_buckets where table_id = %? and is_index = %? and hist_id = %?", tableID, result.IsIndex, hg.ID); err != nil {
+				return err
+			}
+			sc := h.mu.ctx.GetSessionVars().StmtCtx
+			var lastAnalyzePos []byte
+			for j := range hg.Buckets {
+				count := hg.Buckets[j].Count
+				if j > 0 {
+					count -= hg.Buckets[j-1].Count
+				}
+				var upperBound types.Datum
+				upperBound, err = hg.GetUpper(j).ConvertTo(sc, types.NewFieldType(mysql.TypeBlob))
+				if err != nil {
+					return err
+				}
+				if j == len(hg.Buckets)-1 {
+					lastAnalyzePos = upperBound.GetBytes()
+				}
+				var lowerBound types.Datum
+				lowerBound, err = hg.GetLower(j).ConvertTo(sc, types.NewFieldType(mysql.TypeBlob))
+				if err != nil {
+					return err
+				}
+				if _, err = exec.ExecuteInternal(ctx, "insert into mysql.stats_buckets(table_id, is_index, hist_id, bucket_id, count, repeats, lower_bound, upper_bound, ndv) values(%?, %?, %?, %?, %?, %?, %?, %?, %?)", tableID, result.IsIndex, hg.ID, j, count, hg.Buckets[j].Repeat, lowerBound.GetBytes(), upperBound.GetBytes(), hg.Buckets[j].NDV); err != nil {
+					return err
+				}
+			}
+			if len(lastAnalyzePos) > 0 {
+				if _, err = exec.ExecuteInternal(ctx, "update mysql.stats_histograms set last_analyze_pos = %? where table_id = %? and is_index = %? and hist_id = %?", lastAnalyzePos, tableID, result.IsIndex, hg.ID); err != nil {
+					return err
+				}
+			}
+		}
+	}
+	// 3. Save extended statistics.
+	extStats := results.ExtStats
+	if extStats == nil || len(extStats.Stats) == 0 {
+		return nil
+	}
+	var bytes []byte
+	var statsStr string
+	for name, item := range extStats.Stats {
+		bytes, err = json.Marshal(item.ColIDs)
+		if err != nil {
+			return err
+		}
+		strColIDs := string(bytes)
+		switch item.Tp {
+		case ast.StatsTypeCardinality, ast.StatsTypeCorrelation:
+			statsStr = fmt.Sprintf("%f", item.ScalarVals)
+		case ast.StatsTypeDependency:
+			statsStr = item.StringVals
+		}
+		if _, err = exec.ExecuteInternal(ctx, "replace into mysql.stats_extended values (%?, %?, %?, %?, %?, %?, %?)", name, item.Tp, tableID, strColIDs, statsStr, version, StatsStatusAnalyzed); err != nil {
+			return err
+		}
+	}
+	return
+}
+
 // SaveStatsToStorage saves the stats to storage.
 func (h *Handle) SaveStatsToStorage(tableID int64, count int64, isIndex int, hg *statistics.Histogram, cms *statistics.CMSketch, topN *statistics.TopN, fms *statistics.FMSketch, statsVersion int, isAnalyzed int64, needDumpFMS bool) (err error) {
 	h.mu.Lock()

--- a/util/sqlexec/restricted_sql_executor.go
+++ b/util/sqlexec/restricted_sql_executor.go
@@ -153,3 +153,20 @@ type MultiQueryNoDelayResult interface {
 	// LastInsertID return last insert id for one statement in multi-queries.
 	LastInsertID() uint64
 }
+
+// DrainRecordSet fetches the rows in the RecordSet.
+func DrainRecordSet(ctx context.Context, rs RecordSet, maxChunkSize int) ([]chunk.Row, error) {
+	var rows []chunk.Row
+	req := rs.NewChunk()
+	for {
+		err := rs.Next(ctx, req)
+		if err != nil || req.NumRows() == 0 {
+			return rows, err
+		}
+		iter := chunk.NewIterator4Chunk(req)
+		for r := iter.Begin(); r != iter.End(); r = iter.Next() {
+			rows = append(rows, r)
+		}
+		req = chunk.Renew(req, maxChunkSize)
+	}
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

First PR to fix https://github.com/pingcap/tidb/issues/23453

Problem Summary:

modify_count is not as expected.

### What is changed and how it works?

Proposal: [RFC for a More Accurate ModifyCount](https://docs.google.com/document/d/1VjJjAkp_EzUBroOzkZHq9OszrrY-1gnMxT1N_KYFpZs/edit#) <!-- REMOVE this line if not applicable -->

What's Changed:

- add a column `snapshot` into `mysql.stats_meta`
- use a snapshot to scan the table for analyze
- introduce `AnalyzeResults` to wrap `AnalyzeResult` of a same table
- combine dumping of histograms for a task(i.e, histograms of a table in version 2 analyze) into a single transaction, and only update `mysql.stats_meta` once in the analyze
- check if newer version of stats already exists before dumping current snapshot analyze results

How it Works:
- snapshot check when dumping analyze results would be used in later PRs to solve concurrent analyze problems

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Introduce snapshot into analyze