### PR TITLE
store/tikv: change backoff type for missed tiflash peer.

### DIFF
--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -126,8 +126,10 @@ func buildBatchCopTasks(bo *backoffer, cache *tikv.RegionCache, ranges *tikv.Key
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
-			// If the region is not found in cache, it must be out
-			// of date and already be cleaned up. We should retry and generate new tasks.
+			// When rpcCtx is nil, it's not only attributed to the miss region, but also
+			// some TiFlash stores crash and can't be recovered.
+			// That is not an error that can be easily recovered, so we regard this error
+			// same as rpc error.
 			if rpcCtx == nil {
 				needRetry = true
 				logutil.BgLogger().Info("retry for TiFlash peer with region missing", zap.Uint64("region id", task.region.GetID()))
@@ -147,8 +149,10 @@ func buildBatchCopTasks(bo *backoffer, cache *tikv.RegionCache, ranges *tikv.Key
 			}
 		}
 		if needRetry {
-			// Backoff once for each retry.
-			err = bo.Backoff(tikv.BoRegionMiss, errors.New("Cannot find region with TiFlash peer"))
+			// As mentioned above, nil rpcCtx is always attributed to failed stores.
+			// It's equal to long poll the store but get no response. Here we'd better use
+			// TiFlash error to trigger the TiKV fallback mechanism.
+			err = bo.Backoff(tikv.BoTiFlashRPC, errors.New("Cannot find region with TiFlash peer"))
 			if err != nil {
 				return nil, errors.Trace(err)
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: 
After stopping a TiFlash store, we expect the tiflash queries would successfully fallback to TiKV mode. At first it really works, but after a little while (maybe several minutes), the "GetTiFlashRpcContext" function is able to detect the stale TiFlash store and always returns nil RPCContext. In this case, backoff will retry repeatly and raise "region unavailable" error which cannot trigger fallback mechanism.

### What is changed and how it works?

What's Changed:
When tiflash rpc context is nil, it's mostly attributed to the long failed store which cannot be easily recovered. Actually we'd better to add a new backoff type such as "TiFlash peer miss". But for briefness, we work it around by setting it "TiFlash rpc error", which has the same effect.


### Related changes



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)




### Release note <!-- bugfixes or new feature need a release note -->

- store/tikv: change backoff type for missed tiflash peer.
