### PR TITLE
test: make TestExtractStartTs stable

### DIFF
--- a/store/tikv/extract_start_ts_test.go
+++ b/store/tikv/extract_start_ts_test.go
@@ -63,41 +63,40 @@ func (s *extractStartTsSuite) SetUpTest(c *C) {
 
 func (s *extractStartTsSuite) TestExtractStartTs(c *C) {
 	i := uint64(100)
-	cases := []kv.TransactionOption{
+	bo := NewBackofferWithVars(context.Background(), tsoMaxBackoff, nil)
+	stalenessTimestamp, _ := s.store.getStalenessTimestamp(bo, oracle.GlobalTxnScope, 100)
+
+	cases := []struct {
+		expectedTS uint64
+		option     kv.TransactionOption
+	}{
 		// StartTS setted
-		{TxnScope: oracle.GlobalTxnScope, StartTS: &i, PrevSec: nil, MinStartTS: nil, MaxPrevSec: nil},
+		{100, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: &i, PrevSec: nil, MinStartTS: nil, MaxPrevSec: nil}},
 		// PrevSec setted
-		{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: &i, MinStartTS: nil, MaxPrevSec: nil},
+		{stalenessTimestamp, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: &i, MinStartTS: nil, MaxPrevSec: nil}},
 		// MinStartTS setted, global
-		{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: &i, MaxPrevSec: nil},
+		{101, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: &i, MaxPrevSec: nil}},
 		// MinStartTS setted, local
-		{TxnScope: oracle.LocalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: &i, MaxPrevSec: nil},
+		{102, kv.TransactionOption{TxnScope: oracle.LocalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: &i, MaxPrevSec: nil}},
 		// MaxPrevSec setted
 		// however we need to add more cases to check the behavior when it fall backs to MinStartTS setted
 		// see `TestMaxPrevSecFallback`
-		{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i},
+		{stalenessTimestamp, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i}},
 		// nothing setted
-		{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: nil},
+		{0, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: nil}},
 	}
-	bo := NewBackofferWithVars(context.Background(), tsoMaxBackoff, nil)
-	stalenessTimestamp, _ := s.store.getStalenessTimestamp(bo, oracle.GlobalTxnScope, 100)
-	expectedTs := []uint64{
-		100,
-		stalenessTimestamp,
-
-		101,
-		102,
-
-		stalenessTimestamp,
-		// it's too hard to figure out the value `getTimestampWithRetry` returns
-		// so we just check whether it is greater than stalenessTimestamp
-		0,
-	}
-	for i, cs := range cases {
-		expected := expectedTs[i]
-		result, _ := extractStartTs(s.store, cs)
+	for _, cs := range cases {
+		expected := cs.expectedTS
+		result, _ := extractStartTs(s.store, cs.option)
 		if expected == 0 {
 			c.Assert(result, Greater, stalenessTimestamp)
+		} else if expected == stalenessTimestamp {
+			// "stalenessTimestamp" fetched by extractStartTs can be later than stalenessTimestamp fetched in this function
+			// because it *is* created in later physical time
+			c.Assert(result, GreaterEqual, expected)
+			// but it should not be late too much
+			maxStalenessTimestamp := oracle.ComposeTS(oracle.ExtractPhysical(stalenessTimestamp)+50, oracle.ExtractLogical(stalenessTimestamp))
+			c.Assert(result, Less, maxStalenessTimestamp)
 		} else {
 			c.Assert(result, Equals, expected)
 		}
@@ -107,16 +106,16 @@ func (s *extractStartTsSuite) TestExtractStartTs(c *C) {
 func (s *extractStartTsSuite) TestMaxPrevSecFallback(c *C) {
 	s.store.setSafeTS(2, 0x8000000000000002)
 	s.store.setSafeTS(3, 0x8000000000000001)
-
 	i := uint64(100)
-	cases := []kv.TransactionOption{
-		{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i},
-		{TxnScope: oracle.LocalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i},
+	cases := []struct {
+		expectedTS uint64
+		option     kv.TransactionOption
+	}{
+		{0x8000000000000001, kv.TransactionOption{TxnScope: oracle.GlobalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i}},
+		{0x8000000000000002, kv.TransactionOption{TxnScope: oracle.LocalTxnScope, StartTS: nil, PrevSec: nil, MinStartTS: nil, MaxPrevSec: &i}},
 	}
-	expectedTs := []uint64{0x8000000000000001, 0x8000000000000002}
-	for i, cs := range cases {
-		expected := expectedTs[i]
-		result, _ := extractStartTs(s.store, cs)
-		c.Assert(result, Equals, expected)
+	for _, cs := range cases {
+		result, _ := extractStartTs(s.store, cs.option)
+		c.Assert(result, Equals, cs.expectedTS)
 	}
 }

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -235,6 +235,13 @@ func (s *KVStore) CurrentTimestamp(txnScope string) (uint64, error) {
 }
 
 func (s *KVStore) getTimestampWithRetry(bo *Backoffer, txnScope string) (uint64, error) {
+	failpoint.Inject("MockCurrentTimestamp", func(val failpoint.Value) {
+		if v, ok := val.(int); ok {
+			failpoint.Return(uint64(v), nil)
+		} else {
+			panic("MockCurrentTimestamp should be a number, try use this failpoint with \"return(ts)\"")
+		}
+	})
 	if span := opentracing.SpanFromContext(bo.ctx); span != nil && span.Tracer() != nil {
 		span1 := span.Tracer().StartSpan("TiKVStore.getTimestampWithRetry", opentracing.ChildOf(span.Context()))
 		defer span1.Finish()
@@ -264,6 +271,13 @@ func (s *KVStore) getTimestampWithRetry(bo *Backoffer, txnScope string) (uint64,
 }
 
 func (s *KVStore) getStalenessTimestamp(bo *Backoffer, txnScope string, prevSec uint64) (uint64, error) {
+	failpoint.Inject("MockStalenessTimestamp", func(val failpoint.Value) {
+		if v, ok := val.(int); ok {
+			failpoint.Return(uint64(v), nil)
+		} else {
+			panic("MockStalenessTimestamp should be a number, try use this failpoint with \"return(ts)\"")
+		}
+	})
 	for {
 		startTS, err := s.oracle.GetStaleTimestamp(bo.ctx, txnScope, prevSec)
 		if err == nil {


### PR DESCRIPTION
### What problem does this PR solve?

Fix #24583 
Fix #24592

Problem Summary:
`TestExtractStartTs` introduced in #23255 is unstable. Because I thought stalenessTimestamp won't change during the test running, which is not ture because it is calulated with **current** physical time, which do can change during the test running.

### What is changed and how it works?

What's Changed:

Make it stable.

How it Works:

Use failpoints to provide all time related values.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- It's a test itself.

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
