### PR TITLE
store/tikv: remove use of CollectRuntimeStats option in store/tikv

### DIFF
--- a/store/driver/txn/snapshot.go
+++ b/store/driver/txn/snapshot.go
@@ -75,8 +75,19 @@ func (s *tikvSnapshot) SetOption(opt int, val interface{}) {
 		s.KVSnapshot.SetSnapshotTS(val.(uint64))
 	case tikvstore.TaskID:
 		s.KVSnapshot.SetTaskID(val.(uint64))
+	case tikvstore.CollectRuntimeStats:
+		s.KVSnapshot.SetRuntimeStats(val.(*tikv.SnapshotRuntimeStats))
 	default:
 		s.KVSnapshot.SetOption(opt, val)
+	}
+}
+
+func (s *tikvSnapshot) DelOption(opt int) {
+	switch opt {
+	case tikvstore.CollectRuntimeStats:
+		s.KVSnapshot.SetRuntimeStats(nil)
+	default:
+		s.KVSnapshot.DelOption(opt)
 	}
 }
 

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -148,6 +148,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.KVTxn.GetSnapshot().SetTaskID(val.(uint64))
 	case tikvstore.InfoSchema:
 		txn.SetSchemaVer(val.(tikv.SchemaVer))
+	case tikvstore.CollectRuntimeStats:
+		txn.KVTxn.GetSnapshot().SetRuntimeStats(val.(*tikv.SnapshotRuntimeStats))
 	case tikvstore.CommitHook:
 		txn.SetCommitCallback(val.(func(string, error)))
 	case tikvstore.Enable1PC:
@@ -165,6 +167,15 @@ func (txn *tikvTxn) GetOption(opt int) interface{} {
 		return txn.KVTxn.GetScope()
 	default:
 		return txn.KVTxn.GetOption(opt)
+	}
+}
+
+func (txn *tikvTxn) DelOption(opt int) {
+	switch opt {
+	case tikvstore.CollectRuntimeStats:
+		txn.KVTxn.GetSnapshot().SetRuntimeStats(nil)
+	default:
+		txn.KVTxn.DelOption(opt)
 	}
 }
 

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -569,10 +569,6 @@ func (s *KVSnapshot) SetOption(opt int, val interface{}) {
 		s.mu.Lock()
 		s.mu.replicaRead = val.(kv.ReplicaReadType)
 		s.mu.Unlock()
-	case kv.CollectRuntimeStats:
-		s.mu.Lock()
-		s.mu.stats = val.(*SnapshotRuntimeStats)
-		s.mu.Unlock()
 	case kv.SampleStep:
 		s.sampleStep = val.(uint32)
 	case kv.IsStalenessReadOnly:
@@ -592,10 +588,6 @@ func (s *KVSnapshot) DelOption(opt int) {
 	case kv.ReplicaRead:
 		s.mu.Lock()
 		s.mu.replicaRead = kv.ReplicaReadLeader
-		s.mu.Unlock()
-	case kv.CollectRuntimeStats:
-		s.mu.Lock()
-		s.mu.stats = nil
 		s.mu.Unlock()
 	}
 }
@@ -627,6 +619,14 @@ func (s *KVSnapshot) SetTaskID(id uint64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.mu.taskID = id
+}
+
+// SetRuntimeStats sets the stats to collect runtime statistics.
+// Set it to nil to clear stored stats.
+func (s *KVSnapshot) SetRuntimeStats(stats *SnapshotRuntimeStats) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.stats = stats
 }
 
 // SnapCacheHitCount gets the snapshot cache hit count. Only for test.

--- a/store/tikv/tests/snapshot_test.go
+++ b/store/tikv/tests/snapshot_test.go
@@ -26,7 +26,6 @@ import (
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
-	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"go.uber.org/zap"
@@ -270,7 +269,7 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats(c *C) {
 	tikv.RecordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Second)
 	tikv.RecordRegionRequestRuntimeStats(reqStats.Stats, tikvrpc.CmdGet, time.Millisecond)
 	snapshot := s.store.GetSnapshot(0)
-	snapshot.SetOption(kv.CollectRuntimeStats, &tikv.SnapshotRuntimeStats{})
+	snapshot.SetRuntimeStats(&tikv.SnapshotRuntimeStats{})
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	bo := tikv.NewBackofferWithVars(context.Background(), 2000, nil)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -223,7 +223,6 @@ func (txn *KVTxn) Delete(k []byte) error {
 // value of this option.
 func (txn *KVTxn) SetOption(opt int, val interface{}) {
 	txn.us.SetOption(opt, val)
-	txn.snapshot.SetOption(opt, val)
 }
 
 // GetOption returns the option


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `CollectRuntimeStats` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `SetRuntimeStats` method
- Remove option usages.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note