### PR TITLE
store/tikv: remove use of GuaranteeLinearizability option in store/tikv

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -500,7 +500,7 @@ func (s *session) doCommit(ctx context.Context) error {
 	s.txn.SetOption(tikvstore.EnableAsyncCommit, s.GetSessionVars().EnableAsyncCommit)
 	s.txn.SetOption(tikvstore.Enable1PC, s.GetSessionVars().Enable1PC)
 	// priority of the sysvar is lower than `start transaction with causal consistency only`
-	if s.txn.GetOption(tikvstore.GuaranteeLinearizability) == nil {
+	if val := s.txn.GetOption(tikvstore.GuaranteeLinearizability); val == nil || val.(bool) {
 		// We needn't ask the TiKV client to guarantee linearizability for auto-commit transactions
 		// because the property is naturally holds:
 		// We guarantee the commitTS of any transaction must not exceed the next timestamp from the TSO.

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -152,6 +152,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.SetCommitCallback(val.(func(string, error)))
 	case tikvstore.Enable1PC:
 		txn.SetEnable1PC(val.(bool))
+	case tikvstore.GuaranteeLinearizability:
+		txn.SetCasualConsistency(!val.(bool))
 	case tikvstore.TxnScope:
 		txn.SetScope(val.(string))
 	default:
@@ -161,6 +163,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 
 func (txn *tikvTxn) GetOption(opt int) interface{} {
 	switch opt {
+	case tikvstore.GuaranteeLinearizability:
+		return !txn.KVTxn.IsCasualConsistency()
 	case tikvstore.TxnScope:
 		return txn.KVTxn.GetScope()
 	default:

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -163,7 +163,7 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 	case tikvstore.Enable1PC:
 		txn.SetEnable1PC(val.(bool))
 	case tikvstore.GuaranteeLinearizability:
-		txn.SetCasualConsistency(!val.(bool))
+		txn.SetCausalConsistency(!val.(bool))
 	case tikvstore.TxnScope:
 		txn.SetScope(val.(string))
 	case tikvstore.IsStalenessReadOnly:

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -856,9 +856,7 @@ func (c *twoPhaseCommitter) checkOnePC() bool {
 }
 
 func (c *twoPhaseCommitter) needLinearizability() bool {
-	GuaranteeLinearizabilityOption := c.txn.us.GetOption(kv.GuaranteeLinearizability)
-	// by default, guarantee
-	return GuaranteeLinearizabilityOption == nil || GuaranteeLinearizabilityOption.(bool)
+	return !c.txn.causalConsistency
 }
 
 func (c *twoPhaseCommitter) isAsyncCommit() bool {

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -126,7 +126,7 @@ func (s *testAsyncCommitCommon) mustGetNoneFromSnapshot(c *C, version uint64, ke
 
 func (s *testAsyncCommitCommon) beginAsyncCommitWithLinearizability(c *C) tikv.TxnProbe {
 	txn := s.beginAsyncCommit(c)
-	txn.SetCasualConsistency(false)
+	txn.SetCausalConsistency(false)
 	return txn
 }
 

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -127,7 +127,7 @@ func (s *testAsyncCommitCommon) mustGetNoneFromSnapshot(c *C, version uint64, ke
 
 func (s *testAsyncCommitCommon) beginAsyncCommitWithLinearizability(c *C) tikv.TxnProbe {
 	txn := s.beginAsyncCommit(c)
-	txn.SetOption(kv.GuaranteeLinearizability, true)
+	txn.SetCasualConsistency(false)
 	return txn
 }
 

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/store/mockstore/unistore"
 	"github.com/pingcap/tidb/store/tikv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
-	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/mockstore/cluster"
 	"github.com/pingcap/tidb/store/tikv/oracle"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"

--- a/store/tikv/tests/snapshot_fail_test.go
+++ b/store/tikv/tests/snapshot_fail_test.go
@@ -213,7 +213,7 @@ func (s *testSnapshotFailSuite) TestRetryPointGetResolveTS(c *C) {
 	c.Assert(err, IsNil)
 	txn.SetEnableAsyncCommit(false)
 	txn.SetEnable1PC(false)
-	txn.SetCasualConsistency(true)
+	txn.SetCausalConsistency(true)
 
 	// Prewrite the lock without committing it
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/beforeCommit", `pause`), IsNil)

--- a/store/tikv/tests/snapshot_fail_test.go
+++ b/store/tikv/tests/snapshot_fail_test.go
@@ -212,7 +212,7 @@ func (s *testSnapshotFailSuite) TestRetryPointGetResolveTS(c *C) {
 	c.Assert(err, IsNil)
 	txn.SetOption(kv.EnableAsyncCommit, false)
 	txn.SetEnable1PC(false)
-	txn.SetOption(kv.GuaranteeLinearizability, false)
+	txn.SetCasualConsistency(true)
 
 	// Prewrite the lock without committing it
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/beforeCommit", `pause`), IsNil)

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -83,6 +83,7 @@ type KVTxn struct {
 	priority           Priority
 	isPessimistic      bool
 	enable1PC          bool
+	causalConsistency  bool
 	scope              string
 	kvFilter           KVFilter
 }
@@ -276,6 +277,13 @@ func (txn *KVTxn) SetEnable1PC(b bool) {
 	txn.enable1PC = b
 }
 
+// SetCasualConsistency indicates if the transaction does not need to
+// guarantee linearizability. Default value is false which means
+// linearizability is guaranteed.
+func (txn *KVTxn) SetCasualConsistency(b bool) {
+	txn.causalConsistency = b
+}
+
 // SetScope sets the geographical scope of the transaction.
 func (txn *KVTxn) SetScope(scope string) {
 	txn.scope = scope
@@ -289,6 +297,12 @@ func (txn *KVTxn) SetKVFilter(filter KVFilter) {
 // IsPessimistic returns true if it is pessimistic.
 func (txn *KVTxn) IsPessimistic() bool {
 	return txn.isPessimistic
+}
+
+// IsCasualConsistency returns if the transaction allows linearizability
+// inconsistency.
+func (txn *KVTxn) IsCasualConsistency() bool {
+	return txn.causalConsistency
 }
 
 // GetScope returns the geographical scope of the transaction.

--- a/store/tikv/txn.go
+++ b/store/tikv/txn.go
@@ -284,10 +284,10 @@ func (txn *KVTxn) SetEnable1PC(b bool) {
 	txn.enable1PC = b
 }
 
-// SetCasualConsistency indicates if the transaction does not need to
+// SetCausalConsistency indicates if the transaction does not need to
 // guarantee linearizability. Default value is false which means
 // linearizability is guaranteed.
-func (txn *KVTxn) SetCasualConsistency(b bool) {
+func (txn *KVTxn) SetCausalConsistency(b bool) {
 	txn.causalConsistency = b
 }
 


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Usage of `GuaranteeLinearbility` option in `store/tikv` can be removed.

Part of https://github.com/pingcap/tidb/issues/24302

### What is changed and how it works?
What's Changed:
- Add `SetCasualConsistency` method
- Remove option usages.

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note