### PR TITLE
ddl: restrict the length of column comment

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3659,10 +3659,13 @@ func setColumnComment(ctx sessionctx.Context, col *table.Column, option *ast.Col
 		return errors.Trace(err)
 	}
 	col.Comment, err = value.ToString()
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if utf8.RuneCountInString(col.Comment) > MaxCommentLength {
 		return errTooLongFieldComment.GenWithStackByArgs(col.Name.O, MaxCommentLength)
 	}
-	return errors.Trace(err)
+	return nil
 }
 
 // processColumnOptions is only used in getModifiableColumnJob.

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -79,7 +79,10 @@ var (
 	errJSONUsedAsKey = dbterror.ClassDDL.NewStd(mysql.ErrJSONUsedAsKey)
 	// errBlobCantHaveDefault forbids to give not null default value to TEXT/BLOB/JSON.
 	errBlobCantHaveDefault = dbterror.ClassDDL.NewStd(mysql.ErrBlobCantHaveDefault)
+	// errTooLongIndexComment returns for index comment length greater than MaxCommentLength.
 	errTooLongIndexComment = dbterror.ClassDDL.NewStd(mysql.ErrTooLongIndexComment)
+	// errTooLongFieldComment returns for column comment length greater than MaxCommentLength.
+	errTooLongFieldComment = dbterror.ClassDDL.NewStd(mysql.ErrTooLongFieldComment)
 	// ErrInvalidDefaultValue returns for invalid default value for columns.
 	ErrInvalidDefaultValue = dbterror.ClassDDL.NewStd(mysql.ErrInvalidDefault)
 	// ErrGeneratedColumnRefAutoInc forbids to refer generated columns to auto-increment columns .

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -1557,3 +1557,25 @@ func (s *testSerialSuite) TestCheckEnumLength(c *C) {
 	tk.MustGetErrCode("create table t5 (a set('aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'))", errno.ErrTooLongValueForType)
 	tk.MustExec("drop table if exists t1,t2,t3,t4,t5")
 }
+
+func (s *testSerialSuite) TestColumnCommentLength(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	str := "一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十一二三四五六七八九十" +
+		"一二三四五六七八九十一二三四五六七八九十一二三四"
+	str1 := str + "1"
+	tk.MustExec("drop table if exists t1,t2")
+	tk.MustExec("create table t1 (id int comment '" + str + "')")
+	tk.MustGetErrCode("alter table t1 add (id1 int comment '"+str1+"',id2 int comment '"+str1+"')", errno.ErrTooLongFieldComment)
+	tk.MustGetErrCode("alter table t1 modify column id int comment '"+str1+"'", errno.ErrTooLongFieldComment)
+	tk.MustGetErrCode("create table t2 (id int comment '"+str1+"')", errno.ErrTooLongFieldComment)
+	tk.MustExec("drop table if exists t1,t2")
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24322 <!-- REMOVE this line if no issue to close -->

Problem Summary:To be compatible with MySQL 8 : the column comment should be less than 1024 characters
For more detail, see https://dev.mysql.com/doc/refman/8.0/en/create-table.html

### What is changed and how it works?

What's Changed: 
Check the column comment length in create table or alter table. When column comment length>`MaxCommentLength` , return error.
How it Works:

### Related changes

- N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
