### PR TITLE
store/tikv: refine the error message when safepoint cache expired

### DIFF
--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -108,7 +108,7 @@ func (s *KVStore) CheckVisibility(startTime uint64) error {
 	diff := time.Since(cachedTime)
 
 	if diff > (GcSafePointCacheInterval - gcCPUTimeInaccuracyBound) {
-		return tikverr.NewErrPDServerTimeout("start timestamp may fall behind safe point")
+		return tikverr.NewErrPDServerTimeout("safe point cache is expired, can't check start-ts")
 	}
 
 	if startTime < cachedSafePoint {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: Fix a confused error found in https://github.com/pingcap/ticdc/issues/1696

Problem Summary:

Note #24400 has fixed the `EXTRA string placeholder` in error message, but the error message is still confused to user, the logic should be

`pd server timeout` causes -> `update safepoint cache failed, and cache expired` causes -> `start timestamp may fall behind safe point`

### What is changed and how it works?

What's Changed:

- update error messages
- also fix some test cases

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
