### PR TITLE
executor, privileges: Add dynamic privileges to SHOW PRIVILEGES

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -350,7 +350,14 @@ func (s *testSuiteP1) TestShow(c *C) {
 		"Trigger Tables To use triggers",
 		"Create tablespace Server Admin To create/alter/drop tablespaces",
 		"Update Tables To update existing rows",
-		"Usage Server Admin No privileges - allow connect only"))
+		"Usage Server Admin No privileges - allow connect only",
+		"BACKUP_ADMIN Server Admin ",
+		"SYSTEM_VARIABLES_ADMIN Server Admin ",
+		"ROLE_ADMIN Server Admin ",
+		"CONNECTION_ADMIN Server Admin ",
+		"RESTRICTED_TABLES_ADMIN Server Admin ",
+		"RESTRICTED_STATUS_ADMIN Server Admin ",
+	))
 	c.Assert(len(tk.MustQuery("show table status").Rows()), Equals, 1)
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -1412,6 +1412,10 @@ func (e *ShowExec) fetchShowPrivileges() error {
 	e.appendRow([]interface{}{"Create tablespace", "Server Admin", "To create/alter/drop tablespaces"})
 	e.appendRow([]interface{}{"Update", "Tables", "To update existing rows"})
 	e.appendRow([]interface{}{"Usage", "Server Admin", "No privileges - allow connect only"})
+
+	for _, priv := range privileges.GetDynamicPrivileges() {
+		e.appendRow([]interface{}{priv, "Server Admin", ""})
+	}
 	return nil
 }
 

--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -535,3 +535,14 @@ func RegisterDynamicPrivilege(privNameInUpper string) error {
 	dynamicPrivs = append(dynamicPrivs, privNameInUpper)
 	return nil
 }
+
+// GetDynamicPrivileges returns the list of registered DYNAMIC privileges
+// for use in meta data commands (i.e. SHOW PRIVILEGES)
+func GetDynamicPrivileges() []string {
+	dynamicPrivLock.Lock()
+	defer dynamicPrivLock.Unlock()
+
+	privCopy := make([]string, len(dynamicPrivs))
+	copy(privCopy, dynamicPrivs)
+	return privCopy
+}

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -1427,3 +1427,15 @@ func (s *testPrivilegeSuite) TestViewDefiner(c *C) {
 	tk.MustExec("select * from test_view")
 	tk.MustExec("select * from test_view2")
 }
+
+func (s *testPrivilegeSuite) TestDynamicPrivsRegistration(c *C) {
+	se := newSession(c, s.store, s.dbName)
+	pm := privilege.GetPrivilegeManager(se)
+
+	count := len(privileges.GetDynamicPrivileges())
+
+	c.Assert(pm.IsDynamicPrivilege("ACDC_ADMIN"), IsFalse)
+	privileges.RegisterDynamicPrivilege("ACDC_ADMIN")
+	c.Assert(pm.IsDynamicPrivilege("ACDC_ADMIN"), IsTrue)
+	c.Assert(len(privileges.GetDynamicPrivileges()), Equals, count+1)
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/24645

Problem Summary:

Dynamic privileges previously did not show up in the diagnostic command "SHOW PRIVILEGES". Now they do.

### What is changed and how it works?

What's Changed:

Dynamic privileges previously did not show up in the diagnostic command "SHOW PRIVILEGES". Now they do.

### Related changes

None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- The command 'SHOW PRIVILEGES' now includes the list of dynamic privileges registered with the TiDB server.