### PR TITLE
store/tikv/retry: make several BackoffType constants private

### DIFF
--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -153,7 +153,7 @@ func buildBatchCopTasks(bo *Backoffer, cache *tikv.RegionCache, ranges *tikv.Key
 			// As mentioned above, nil rpcCtx is always attributed to failed stores.
 			// It's equal to long poll the store but get no response. Here we'd better use
 			// TiFlash error to trigger the TiKV fallback mechanism.
-			err = bo.Backoff(tikv.BoTiFlashRPC, errors.New("Cannot find region with TiFlash peer"))
+			err = bo.BackoffTiFlashRPC(errors.New("Cannot find region with TiFlash peer"))
 			if err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/store/copr/batch_request_sender.go
+++ b/store/copr/batch_request_sender.go
@@ -91,6 +91,6 @@ func (ss *RegionBatchRequestSender) onSendFail(bo *Backoffer, ctxs []copTaskAndR
 	// When a store is not available, the leader of related region should be elected quickly.
 	// TODO: the number of retry time should be limited:since region may be unavailable
 	// when some unrecoverable disaster happened.
-	err = bo.Backoff(tikv.BoTiFlashRPC, errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
+	err = bo.BackoffTiFlashRPC(errors.Errorf("send tikv request error: %v, ctxs: %v, try next peer later", err, ctxs))
 	return errors.Trace(err)
 }

--- a/store/driver/backoff/backoff.go
+++ b/store/driver/backoff/backoff.go
@@ -43,13 +43,6 @@ func (b *Backoffer) TiKVBackoffer() *tikv.Backoffer {
 	return b.b
 }
 
-// Backoff sleeps a while base on the backoffType and records the error message.
-// It returns a retryable error if total sleep time exceeds maxSleep.
-func (b *Backoffer) Backoff(typ tikv.BackoffType, err error) error {
-	e := b.b.Backoff(typ, err)
-	return derr.ToTiDBErr(e)
-}
-
 // BackoffTiKVRPC sleeps a while base on the TiKVRPC and records the error message.
 // It returns a retryable error if total sleep time exceeds maxSleep.
 func (b *Backoffer) BackoffTiKVRPC(err error) error {
@@ -57,10 +50,38 @@ func (b *Backoffer) BackoffTiKVRPC(err error) error {
 	return derr.ToTiDBErr(e)
 }
 
-// BackoffWithMaxSleep sleeps a while base on the backoffType and records the error message
+// BackoffTiFlashRPC sleeps a while base on the TiFlash and records the error message.
+// It returns a retryable error if total sleep time exceeds maxSleep.
+func (b *Backoffer) BackoffTiFlashRPC(err error) error {
+	e := b.b.BackoffTiFlashRPC(err)
+	return derr.ToTiDBErr(e)
+}
+
+// BackoffTxnLock sleeps a while base on the TxnLock and records the error message.
+// It returns a retryable error if total sleep time exceeds maxSleep.
+func (b *Backoffer) BackoffTxnLock(err error) error {
+	e := b.b.BackoffTxnLock(err)
+	return derr.ToTiDBErr(e)
+}
+
+// BackoffPDRPC sleeps a while base on the PDRPC and records the error message.
+// It returns a retryable error if total sleep time exceeds maxSleep.
+func (b *Backoffer) BackoffPDRPC(err error) error {
+	e := b.b.BackoffPDRPC(err)
+	return derr.ToTiDBErr(e)
+}
+
+// BackoffRegionMiss sleeps a while base on the RegionMiss and records the error message.
+// It returns a retryable error if total sleep time exceeds maxSleep.
+func (b *Backoffer) BackoffRegionMiss(err error) error {
+	e := b.b.BackoffRegionMiss(err)
+	return derr.ToTiDBErr(e)
+}
+
+// BackoffWithMaxSleepTxnLockFast sleeps a while base on the TxnLockFast and records the error message
 // and never sleep more than maxSleepMs for each sleep.
-func (b *Backoffer) BackoffWithMaxSleep(typ tikv.BackoffType, maxSleepMs int, err error) error {
-	e := b.b.BackoffWithMaxSleep(typ, maxSleepMs, err)
+func (b *Backoffer) BackoffWithMaxSleepTxnLockFast(maxSleepMs int, err error) error {
+	e := b.b.BackoffWithMaxSleepTxnLockFast(maxSleepMs, err)
 	return derr.ToTiDBErr(e)
 }
 

--- a/store/driver/tikv_driver.go
+++ b/store/driver/tikv_driver.go
@@ -231,7 +231,7 @@ func (s *tikvStore) EtcdAddrs() ([]string, error) {
 	for {
 		members, err := pdClient.GetAllMembers(ctx)
 		if err != nil {
-			err := bo.Backoff(tikv.BoRegionMiss, err)
+			err := bo.BackoffRegionMiss(err)
 			if err != nil {
 				return nil, err
 			}

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -1080,7 +1080,7 @@ retryScanAndResolve:
 			return stat, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(tikv.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return stat, errors.Trace(err)
 			}
@@ -1116,7 +1116,7 @@ retryScanAndResolve:
 				return stat, errors.Trace(err1)
 			}
 			if !ok {
-				err = bo.Backoff(tikv.BoTxnLock, errors.Errorf("remain locks: %d", len(locks)))
+				err = bo.BackoffTxnLock(errors.Errorf("remain locks: %d", len(locks)))
 				if err != nil {
 					return stat, errors.Trace(err)
 				}
@@ -1488,7 +1488,7 @@ func (w *GCWorker) resolveLocksAcrossRegions(ctx context.Context, locks []*tikv.
 			return errors.Trace(err)
 		}
 		if !ok {
-			err = bo.Backoff(tikv.BoTxnLock, errors.Errorf("remain locks: %d", len(locks)))
+			err = bo.BackoffTxnLock(errors.Errorf("remain locks: %d", len(locks)))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1516,7 +1516,7 @@ func (w *GCWorker) uploadSafePointToPD(ctx context.Context, safePoint uint64) er
 			if errors.Cause(err) == context.Canceled {
 				return errors.Trace(err)
 			}
-			err = bo.Backoff(tikv.BoPDRPC, errors.Errorf("failed to upload safe point to PD, err: %v", err))
+			err = bo.BackoffPDRPC(errors.Errorf("failed to upload safe point to PD, err: %v", err))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -1558,7 +1558,7 @@ func (w *GCWorker) doGCForRange(ctx context.Context, startKey []byte, endKey []b
 		// we check regionErr here first, because we know 'regionErr' and 'err' should not return together, to keep it to
 		// make the process correct.
 		if regionErr != nil {
-			err = bo.Backoff(tikv.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err == nil {
 				continue
 			}

--- a/store/tikv/2pc.go
+++ b/store/tikv/2pc.go
@@ -741,7 +741,7 @@ func (tm *ttlManager) keepAlive(c *twoPhaseCommitter) {
 			bo := retry.NewBackofferWithVars(context.Background(), pessimisticLockMaxBackoff, c.txn.vars)
 			now, err := c.store.GetOracle().GetTimestamp(bo.GetCtx(), &oracle.Option{TxnScope: oracle.GlobalTxnScope})
 			if err != nil {
-				err1 := bo.Backoff(retry.BoPDRPC, err)
+				err1 := bo.BackoffPDRPC(err)
 				if err1 != nil {
 					logutil.Logger(bo.GetCtx()).Warn("keepAlive get tso fail",
 						zap.Error(err))
@@ -804,7 +804,7 @@ func sendTxnHeartBeat(bo *Backoffer, store *KVStore, primary []byte, startTS, tt
 			return 0, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return 0, errors.Trace(err)
 			}

--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -26,15 +26,6 @@ type Backoffer = retry.Backoffer
 // BackoffType defines the backoff type.
 type BackoffType = retry.BackoffType
 
-// Back off types.
-const (
-	BoRegionMiss  = retry.BoRegionMiss
-	BoTiFlashRPC  = retry.BoTiFlashRPC
-	BoTxnLockFast = retry.BoTxnLockFast
-	BoTxnLock     = retry.BoTxnLock
-	BoPDRPC       = retry.BoPDRPC
-)
-
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	gcResolveLockMaxBackoff = 100000

--- a/store/tikv/cleanup.go
+++ b/store/tikv/cleanup.go
@@ -18,7 +18,6 @@ import (
 	pb "github.com/pingcap/kvproto/pkg/kvrpcpb"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
-	"github.com/pingcap/tidb/store/tikv/retry"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -50,7 +49,7 @@ func (actionCleanup) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batc
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/store/tikv/commit.go
+++ b/store/tikv/commit.go
@@ -22,7 +22,6 @@ import (
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
-	"github.com/pingcap/tidb/store/tikv/retry"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -68,7 +67,7 @@ func (actionCommit) handleSingleBatch(c *twoPhaseCommitter, bo *Backoffer, batch
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/store/tikv/delete_range.go
+++ b/store/tikv/delete_range.go
@@ -124,7 +124,7 @@ func (t *DeleteRangeTask) sendReqOnRange(ctx context.Context, r kv.KeyRange) (Ra
 			return stat, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return stat, errors.Trace(err)
 			}

--- a/store/tikv/kv.go
+++ b/store/tikv/kv.go
@@ -264,7 +264,7 @@ func (s *KVStore) getTimestampWithRetry(bo *Backoffer, txnScope string) (uint64,
 		if err == nil {
 			return startTS, nil
 		}
-		err = bo.Backoff(retry.BoPDRPC, errors.Errorf("get timestamp failed: %v", err))
+		err = bo.BackoffPDRPC(errors.Errorf("get timestamp failed: %v", err))
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
@@ -284,7 +284,7 @@ func (s *KVStore) getStalenessTimestamp(bo *Backoffer, txnScope string, prevSec 
 		if err == nil {
 			return startTS, nil
 		}
-		err = bo.Backoff(retry.BoPDRPC, errors.Errorf("get staleness timestamp failed: %v", err))
+		err = bo.BackoffPDRPC(errors.Errorf("get staleness timestamp failed: %v", err))
 		if err != nil {
 			return 0, errors.Trace(err)
 		}

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -298,7 +298,7 @@ func (lr *LockResolver) BatchResolveLocks(bo *Backoffer, locks []*Lock, loc Regi
 	}
 
 	if regionErr != nil {
-		err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return false, errors.Trace(err)
 		}
@@ -523,7 +523,7 @@ func (lr *LockResolver) getTxnStatusFromLock(bo *Backoffer, l *Lock, callerStart
 		// getTxnStatus() returns it when the secondary locks exist while the primary lock doesn't.
 		// This is likely to happen in the concurrently prewrite when secondary regions
 		// success before the primary region.
-		if err := bo.Backoff(retry.BoTxnNotFound, err); err != nil {
+		if err := bo.BackoffTxnNotFound(err); err != nil {
 			logutil.Logger(bo.GetCtx()).Warn("getTxnStatusFromLock backoff fail", zap.Error(err))
 		}
 
@@ -600,7 +600,7 @@ func (lr *LockResolver) getTxnStatus(bo *Backoffer, txnID uint64, primary []byte
 			return status, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return status, errors.Trace(err)
 			}
@@ -736,7 +736,7 @@ func (lr *LockResolver) checkSecondaries(bo *Backoffer, txnID uint64, curKeys []
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -867,7 +867,7 @@ func (lr *LockResolver) resolveRegionLocks(bo *Backoffer, l *Lock, region Region
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -935,7 +935,7 @@ func (lr *LockResolver) resolveLock(bo *Backoffer, l *Lock, status TxnStatus, li
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -986,7 +986,7 @@ func (lr *LockResolver) resolvePessimisticLock(bo *Backoffer, l *Lock, cleanRegi
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/store/tikv/pessimistic.go
+++ b/store/tikv/pessimistic.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
-	"github.com/pingcap/tidb/store/tikv/retry"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -131,7 +130,7 @@ func (action actionPessimisticLock) handleSingleBatch(c *twoPhaseCommitter, bo *
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -229,7 +228,7 @@ func (actionPessimisticRollback) handleSingleBatch(c *twoPhaseCommitter, bo *Bac
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -27,7 +27,6 @@ import (
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/logutil"
 	"github.com/pingcap/tidb/store/tikv/metrics"
-	"github.com/pingcap/tidb/store/tikv/retry"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
@@ -176,7 +175,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -269,7 +268,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		}
 		atomic.AddInt64(&c.getDetail().ResolveLockTime, int64(time.Since(start)))
 		if msBeforeExpired > 0 {
-			err = bo.BackoffWithMaxSleep(retry.BoTxnLock, int(msBeforeExpired), errors.Errorf("2PC prewrite lockedKeys: %d", len(locks)))
+			err = bo.BackoffWithMaxSleepTxnLock(int(msBeforeExpired), errors.Errorf("2PC prewrite lockedKeys: %d", len(locks)))
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/store/tikv/rawkv.go
+++ b/store/tikv/rawkv.go
@@ -375,7 +375,7 @@ func (c *RawKVClient) sendReq(key []byte, req *tikvrpc.Request, reverse bool) (*
 			return nil, nil, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
@@ -459,7 +459,7 @@ func (c *RawKVClient) doBatchReq(bo *Backoffer, batch batch, cmdType tikvrpc.Cmd
 		return batchResp
 	}
 	if regionErr != nil {
-		err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			batchResp.err = errors.Trace(err)
 			return batchResp
@@ -520,7 +520,7 @@ func (c *RawKVClient) sendDeleteRangeReq(startKey []byte, endKey []byte) (*tikvr
 			return nil, nil, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
@@ -625,7 +625,7 @@ func (c *RawKVClient) doBatchPut(bo *Backoffer, batch batch) error {
 		return errors.Trace(err)
 	}
 	if regionErr != nil {
-		err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1137,7 +1137,7 @@ func (c *RegionCache) loadRegion(bo *Backoffer, key []byte, isEndKey bool) (*Reg
 	searchPrev := false
 	for {
 		if backoffErr != nil {
-			err := bo.Backoff(retry.BoPDRPC, backoffErr)
+			err := bo.BackoffPDRPC(backoffErr)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -1193,7 +1193,7 @@ func (c *RegionCache) loadRegionByID(bo *Backoffer, regionID uint64) (*Region, e
 	var backoffErr error
 	for {
 		if backoffErr != nil {
-			err := bo.Backoff(retry.BoPDRPC, backoffErr)
+			err := bo.BackoffPDRPC(backoffErr)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -1243,7 +1243,7 @@ func (c *RegionCache) scanRegions(bo *Backoffer, startKey, endKey []byte, limit 
 	var backoffErr error
 	for {
 		if backoffErr != nil {
-			err := bo.Backoff(retry.BoPDRPC, backoffErr)
+			err := bo.BackoffPDRPC(backoffErr)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -1413,7 +1413,7 @@ func (c *RegionCache) OnRegionEpochNotMatch(bo *Backoffer, ctx *RPCContext, curr
 				meta.GetRegionEpoch().GetVersion() < ctx.Region.ver) {
 			err := errors.Errorf("region epoch is ahead of tikv. rpc ctx: %+v, currentRegions: %+v", ctx, currentRegions)
 			logutil.BgLogger().Info("region epoch is ahead of tikv", zap.Error(err))
-			return bo.Backoff(retry.BoRegionMiss, err)
+			return bo.BackoffRegionMiss(err)
 		}
 	}
 
@@ -1788,7 +1788,7 @@ func (s *Store) initResolve(bo *Backoffer, c *RegionCache) (addr string, err err
 				return
 			}
 			err = errors.Errorf("loadStore from PD failed, id: %d, err: %v", s.storeID, err)
-			if err = bo.Backoff(retry.BoPDRPC, err); err != nil {
+			if err = bo.BackoffPDRPC(err); err != nil {
 				return
 			}
 			continue

--- a/store/tikv/retry/backoff_test.go
+++ b/store/tikv/retry/backoff_test.go
@@ -27,7 +27,7 @@ var _ = Suite(&testBackoffSuite{})
 
 func (s *testBackoffSuite) TestBackoffWithMax(c *C) {
 	b := NewBackofferWithVars(context.TODO(), 2000, nil)
-	err := b.BackoffWithMaxSleep(BoTxnLockFast, 30, errors.New("test"))
+	err := b.BackoffWithMaxSleepTxnLockFast(30, errors.New("test"))
 	c.Assert(err, IsNil)
 	c.Assert(b.totalSleep, Equals, 30)
 }

--- a/store/tikv/scan.go
+++ b/store/tikv/scan.go
@@ -226,7 +226,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 		if regionErr != nil {
 			logutil.BgLogger().Debug("scanner getData failed",
 				zap.Stringer("regionErr", regionErr))
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -254,7 +254,7 @@ func (s *Scanner) getData(bo *Backoffer) error {
 				return errors.Trace(err)
 			}
 			if msBeforeExpired > 0 {
-				err = bo.BackoffWithMaxSleep(retry.BoTxnLockFast, int(msBeforeExpired), errors.Errorf("key is locked during scanning"))
+				err = bo.BackoffWithMaxSleepTxnLockFast(int(msBeforeExpired), errors.Errorf("key is locked during scanning"))
 				if err != nil {
 					return errors.Trace(err)
 				}

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -334,7 +334,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, collec
 			return errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -381,7 +381,7 @@ func (s *KVSnapshot) batchGetSingleRegion(bo *Backoffer, batch batchKeys, collec
 				return errors.Trace(err)
 			}
 			if msBeforeExpired > 0 {
-				err = bo.BackoffWithMaxSleep(retry.BoTxnLockFast, int(msBeforeExpired), errors.Errorf("batchGet lockedKeys: %d", len(lockedKeys)))
+				err = bo.BackoffWithMaxSleepTxnLockFast(int(msBeforeExpired), errors.Errorf("batchGet lockedKeys: %d", len(lockedKeys)))
 				if err != nil {
 					return errors.Trace(err)
 				}
@@ -493,7 +493,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 			return nil, errors.Trace(err)
 		}
 		if regionErr != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+			err = bo.BackoffRegionMiss(errors.New(regionErr.String()))
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -527,7 +527,7 @@ func (s *KVSnapshot) get(ctx context.Context, bo *Backoffer, k []byte) ([]byte, 
 				return nil, errors.Trace(err)
 			}
 			if msBeforeExpired > 0 {
-				err = bo.BackoffWithMaxSleep(retry.BoTxnLockFast, int(msBeforeExpired), errors.New(keyErr.String()))
+				err = bo.BackoffWithMaxSleepTxnLockFast(int(msBeforeExpired), errors.New(keyErr.String()))
 				if err != nil {
 					return nil, errors.Trace(err)
 				}

--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -137,7 +137,7 @@ func (s *KVStore) batchSendSingleRegion(bo *Backoffer, batch batch, scatter bool
 		return batchResp
 	}
 	if regionErr != nil {
-		err := bo.Backoff(retry.BoRegionMiss, errors.New(regionErr.String()))
+		err := bo.BackoffRegionMiss(errors.New(regionErr.String()))
 		if err != nil {
 			batchResp.err = errors.Trace(err)
 			return batchResp
@@ -232,7 +232,7 @@ func (s *KVStore) scatterRegion(bo *Backoffer, regionID uint64, tableID *int64) 
 		if err == nil {
 			break
 		}
-		err = bo.Backoff(retry.BoPDRPC, errors.New(err.Error()))
+		err = bo.BackoffPDRPC(errors.New(err.Error()))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -318,9 +318,9 @@ func (s *KVStore) WaitScatterRegionFinish(ctx context.Context, regionID uint64, 
 			logFreq++
 		}
 		if err != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(err.Error()))
+			err = bo.BackoffRegionMiss(errors.New(err.Error()))
 		} else {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New("wait scatter region timeout"))
+			err = bo.BackoffRegionMiss(errors.New("wait scatter region timeout"))
 		}
 		if err != nil {
 			return errors.Trace(err)
@@ -339,7 +339,7 @@ func (s *KVStore) CheckRegionInScattering(regionID uint64) (bool, error) {
 			}
 		}
 		if err != nil {
-			err = bo.Backoff(retry.BoRegionMiss, errors.New(err.Error()))
+			err = bo.BackoffRegionMiss(errors.New(err.Error()))
 		} else {
 			return true, nil
 		}

--- a/store/tikv/tests/snapshot_test.go
+++ b/store/tikv/tests/snapshot_test.go
@@ -273,7 +273,7 @@ func (s *testSnapshotSuite) TestSnapshotRuntimeStats(c *C) {
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	snapshot.MergeRegionRequestStats(reqStats.Stats)
 	bo := tikv.NewBackofferWithVars(context.Background(), 2000, nil)
-	err := bo.BackoffWithMaxSleep(tikv.BoTxnLockFast, 30, errors.New("test"))
+	err := bo.BackoffWithMaxSleepTxnLockFast(30, errors.New("test"))
 	c.Assert(err, IsNil)
 	snapshot.RecordBackoffInfo(bo)
 	snapshot.RecordBackoffInfo(bo)

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/store/tikv"
+	"github.com/pingcap/tidb/store/tikv/retry"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/execdetails"
@@ -192,7 +192,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 					sync.Mutex
 					BackoffTypes []fmt.Stringer
 				}{
-					BackoffTypes: []fmt.Stringer{tikv.BoTxnLock},
+					BackoffTypes: []fmt.Stringer{retry.BoTxnLock},
 				},
 				ResolveLockTime:   10000,
 				WriteKeys:         100000,
@@ -268,7 +268,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 	expectedSummaryElement.sumTxnRetry += int64(stmtExecInfo2.ExecDetail.CommitDetail.TxnRetry)
 	expectedSummaryElement.maxTxnRetry = stmtExecInfo2.ExecDetail.CommitDetail.TxnRetry
 	expectedSummaryElement.sumBackoffTimes += 1
-	expectedSummaryElement.backoffTypes[tikv.BoTxnLock] = 1
+	expectedSummaryElement.backoffTypes[retry.BoTxnLock] = 1
 	expectedSummaryElement.sumMem += stmtExecInfo2.MemMax
 	expectedSummaryElement.maxMem = stmtExecInfo2.MemMax
 	expectedSummaryElement.sumDisk += stmtExecInfo2.DiskMax
@@ -319,7 +319,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 					sync.Mutex
 					BackoffTypes []fmt.Stringer
 				}{
-					BackoffTypes: []fmt.Stringer{tikv.BoTxnLock},
+					BackoffTypes: []fmt.Stringer{retry.BoTxnLock},
 				},
 				ResolveLockTime:   1000,
 				WriteKeys:         10000,
@@ -374,7 +374,7 @@ func (s *testStmtSummarySuite) TestAddStatement(c *C) {
 	expectedSummaryElement.sumPrewriteRegionNum += int64(stmtExecInfo3.ExecDetail.CommitDetail.PrewriteRegionNum)
 	expectedSummaryElement.sumTxnRetry += int64(stmtExecInfo3.ExecDetail.CommitDetail.TxnRetry)
 	expectedSummaryElement.sumBackoffTimes += 1
-	expectedSummaryElement.backoffTypes[tikv.BoTxnLock] = 2
+	expectedSummaryElement.backoffTypes[retry.BoTxnLock] = 2
 	expectedSummaryElement.sumMem += stmtExecInfo3.MemMax
 	expectedSummaryElement.sumDisk += stmtExecInfo3.DiskMax
 	expectedSummaryElement.sumAffectedRows += stmtExecInfo3.StmtCtx.AffectedRows()
@@ -575,7 +575,7 @@ func generateAnyExecInfo() *StmtExecInfo {
 					sync.Mutex
 					BackoffTypes []fmt.Stringer
 				}{
-					BackoffTypes: []fmt.Stringer{tikv.BoTxnLock},
+					BackoffTypes: []fmt.Stringer{retry.BoTxnLock},
 				},
 				ResolveLockTime:   2000,
 				WriteKeys:         20000,
@@ -960,10 +960,10 @@ func (s *testStmtSummarySuite) TestFormatBackoffTypes(c *C) {
 	backoffMap := make(map[fmt.Stringer]int)
 	c.Assert(formatBackoffTypes(backoffMap), IsNil)
 
-	backoffMap[tikv.BoPDRPC] = 1
+	backoffMap[retry.BoPDRPC] = 1
 	c.Assert(formatBackoffTypes(backoffMap), Equals, "pdRPC:1")
 
-	backoffMap[tikv.BoTxnLock] = 2
+	backoffMap[retry.BoTxnLock] = 2
 	c.Assert(formatBackoffTypes(backoffMap), Equals, "txnLock:2,pdRPC:1")
 }
 


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes several constants `BackOffType` private, so the caller needn't learn about the `BackoffType`, and also the `BackoffType` should be an enum while `golang` doesn't support, with this PR we can protect the new `BackoffType` created by caller too.

Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note