### PR TITLE
cmd: ddl_test modify retryCnt from 5 to 20

### DIFF
--- a/cmd/ddltest/ddl_test.go
+++ b/cmd/ddltest/ddl_test.go
@@ -143,7 +143,7 @@ func (s *TestDDLSuite) SetUpSuite(c *C) {
 	s.procs = make([]*server, *serverNum)
 
 	// Set server restart retry count.
-	s.retryCount = 5
+	s.retryCount = 20
 
 	createLogFiles(c, *serverNum)
 	err = s.startServers()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
When the CI is unstable, tidb-server may take a long time to start. This will cause the ping to fail.
When reaching the `retryCnt` the integration-dll-test will fatal.

This commit increases the `retryCnt` to 20 to reduce the impact of the unstable CI.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- Performance regression
    - Consumes more CPU


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
