### PR TITLE
*: avoid pass session ID by context & fix no schemaChecker error log

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -306,7 +306,6 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 	}()
 
 	sctx := a.Ctx
-	ctx = util.SetSessionID(ctx, sctx.GetSessionVars().ConnectionID)
 	if _, ok := a.Plan.(*plannercore.Analyze); ok && sctx.GetSessionVars().InRestrictedSQL {
 		oriStats, _ := sctx.GetSessionVars().GetSystemVar(variable.TiDBBuildStatsConcurrency)
 		oriScan := sctx.GetSessionVars().DistSQLScanConcurrency()
@@ -582,6 +581,7 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 		var lockKeyStats *util.LockKeysDetails
 		ctx = context.WithValue(ctx, util.LockKeysDetailCtxKey, &lockKeyStats)
 		startLocking := time.Now()
+		txn.SetOption(kv.SessionID, seVars.ConnectionID)
 		err = txn.LockKeys(ctx, lockCtx, keys...)
 		if lockKeyStats != nil {
 			seVars.StmtCtx.MergeLockKeysExecDetails(lockKeyStats)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1002,7 +1002,8 @@ func doLockKeys(ctx context.Context, se sessionctx.Context, lockCtx *tikvstore.L
 	}
 	var lockKeyStats *tikvutil.LockKeysDetails
 	ctx = context.WithValue(ctx, tikvutil.LockKeysDetailCtxKey, &lockKeyStats)
-	err = txn.LockKeys(tikvutil.SetSessionID(ctx, se.GetSessionVars().ConnectionID), lockCtx, keys...)
+	txn.SetOption(kv.SessionID, se.GetSessionVars().ConnectionID)
+	err = txn.LockKeys(ctx, lockCtx, keys...)
 	if lockKeyStats != nil {
 		sctx.MergeLockKeysExecDetails(lockKeyStats)
 	}

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -41,7 +41,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/tikv/oracle"
-	tikvutil "github.com/pingcap/tidb/store/tikv/util"
 	"github.com/pingcap/tidb/types"
 	driver "github.com/pingcap/tidb/types/parser_driver"
 	"github.com/pingcap/tidb/util"
@@ -970,7 +969,8 @@ func (e *SimpleExec) executeAlterUser(s *ast.AlterUserStmt) error {
 		if err != nil {
 			return err
 		}
-		err = txn.Commit(tikvutil.SetSessionID(context.TODO(), e.ctx.GetSessionVars().ConnectionID))
+		txn.SetOption(kv.SessionID, e.ctx.GetSessionVars().ConnectionID)
+		err = txn.Commit(context.TODO())
 		if err != nil {
 			return err
 		}

--- a/go.sum
+++ b/go.sum
@@ -500,6 +500,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/sasha-s/go-deadlock v0.2.0/go.mod h1:StQn567HiB1fF2yJ44N9au7wOhrPS3iZqiDbRupzT10=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sergi/go-diff v1.0.1-0.20180205163309-da645544ed44/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shirou/gopsutil v2.19.10+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v3.21.2+incompatible h1:U+YvJfjCh6MslYlIAXvPtzhW3YZEtc9uncueUNpD/0A=

--- a/kv/option.go
+++ b/kv/option.go
@@ -59,4 +59,6 @@ const (
 	IsStalenessReadOnly
 	// MatchStoreLabels indicates the labels the store should be matched
 	MatchStoreLabels
+	// SessionID store the session (connection) ID to the transaction.
+	SessionID
 )

--- a/session/session.go
+++ b/session/session.go
@@ -516,6 +516,7 @@ func (s *session) doCommit(ctx context.Context) error {
 	}
 	s.txn.SetOption(kv.EnableAsyncCommit, s.GetSessionVars().EnableAsyncCommit)
 	s.txn.SetOption(kv.Enable1PC, s.GetSessionVars().Enable1PC)
+	s.txn.SetOption(kv.SessionID, s.GetSessionVars().ConnectionID)
 	// priority of the sysvar is lower than `start transaction with causal consistency only`
 	if val := s.txn.GetOption(kv.GuaranteeLinearizability); val == nil || val.(bool) {
 		// We needn't ask the TiKV client to guarantee linearizability for auto-commit transactions
@@ -549,7 +550,7 @@ func (s *session) doCommit(ctx context.Context) error {
 		}
 	}
 
-	return s.txn.Commit(tikvutil.SetSessionID(ctx, s.GetSessionVars().ConnectionID))
+	return s.txn.Commit(ctx)
 }
 
 // errIsNoisy is used to filter DUPLCATE KEY errors.

--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -168,6 +168,8 @@ func (txn *tikvTxn) SetOption(opt int, val interface{}) {
 		txn.KVTxn.GetSnapshot().SetIsStatenessReadOnly(val.(bool))
 	case kv.MatchStoreLabels:
 		txn.KVTxn.GetSnapshot().SetMatchStoreLabels(val.([]*metapb.StoreLabel))
+	case kv.SessionID:
+		txn.KVTxn.SetSessionID(val.(uint64))
 	}
 }
 

--- a/store/tikv/tests/async_commit_fail_test.go
+++ b/store/tikv/tests/async_commit_fail_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/tidb/store/tikv"
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
-	"github.com/pingcap/tidb/store/tikv/util"
 )
 
 type testAsyncCommitFailSuite struct {
@@ -57,7 +56,7 @@ func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
 	t1 := s.beginAsyncCommit(c)
 	err := t1.Set([]byte("a"), []byte("a1"))
 	c.Assert(err, IsNil)
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
+	ctx := context.Background()
 	err = t1.Commit(ctx)
 	c.Assert(err, NotNil)
 	c.Assert(terror.ErrorEqual(err, terror.ErrResultUndetermined), IsTrue, Commentf("%s", errors.ErrorStack(err)))
@@ -99,7 +98,7 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitPrewriteCancelled(c *C) {
 	c.Assert(err, IsNil)
 	err = t1.Set([]byte("z"), []byte("z"))
 	c.Assert(err, IsNil)
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
+	ctx := context.Background()
 	err = t1.Commit(ctx)
 	c.Assert(err, NotNil)
 	_, ok := errors.Cause(err).(*tikverr.ErrWriteConflict)
@@ -117,7 +116,7 @@ func (s *testAsyncCommitFailSuite) TestPointGetWithAsyncCommit(c *C) {
 
 	// PointGet cannot ignore async commit transactions' locks.
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/asyncCommitDoNothing", "return"), IsNil)
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
+	ctx := context.Background()
 	err := txn.Commit(ctx)
 	c.Assert(err, IsNil)
 	c.Assert(txn.GetCommitter().IsAsyncCommit(), IsTrue)
@@ -167,9 +166,10 @@ func (s *testAsyncCommitFailSuite) TestSecondaryListInPrimaryLock(c *C) {
 	var sessionID uint64 = 0
 	test := func(keys []string, values []string) {
 		sessionID++
-		ctx := context.WithValue(context.Background(), util.SessionID, sessionID)
+		ctx := context.Background()
 
 		txn := s.beginAsyncCommit(c)
+		txn.SetSessionID(sessionID)
 		for i := range keys {
 			txn.Set([]byte(keys[i]), []byte(values[i]))
 		}
@@ -228,7 +228,8 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitContextCancelCausingUndetermin
 		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/rpcContextCancelErr"), IsNil)
 	}()
 
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
+	ctx := context.Background()
+	txn.SetSessionID(1)
 	err = txn.Commit(ctx)
 	c.Assert(err, NotNil)
 	c.Assert(txn.GetCommitter().GetUndeterminedErr(), NotNil)

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -134,6 +134,7 @@ func (s *testAsyncCommitCommon) beginAsyncCommit(c *C) tikv.TxnProbe {
 	txn, err := s.store.Begin()
 	c.Assert(err, IsNil)
 	txn.SetEnableAsyncCommit(true)
+	txn.SetSessionID(1)
 	return tikv.TxnProbe{KVTxn: txn}
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #22783

Problem Summary:

Pass important argument by `context.WithValue` is a bad idea.

The callee need the data in the `context.Context`, but the caller maybe passing a `context.Bacground()`
#22783  is caused by such kind of refactoring.

In the beginning, we just use the session ID for logging.
Now I review the code and find we're using `sessionID == 0` to check whether it's an internal transaction or a user's transaction.

### What is changed and how it works?

Introduce a `txn.SetOption(kv.SessionID, id)` to replace the old way of passing session ID by `context.Context`.

What's Changed:

Use `txn.SetOption(kv.SessionID, id)` instead of `txn.Commit(tikvutil.SetSessionID(ctx, s.GetSessionVars().ConnectionID))` to pass the session ID.

How it Works:


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
