### PR TITLE
variable: change default for DefDMLBatchSize tidbOptInt64 call

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -904,7 +904,7 @@ var defaultSysVars = []*SysVar{
 		return nil
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBDMLBatchSize, Value: strconv.Itoa(DefDMLBatchSize), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {
-		s.DMLBatchSize = int(tidbOptInt64(val, DefOptCorrelationExpFactor))
+		s.DMLBatchSize = int(tidbOptInt64(val, DefDMLBatchSize))
 		return nil
 	}},
 	{Scope: ScopeSession, Name: TiDBCurrentTS, Value: strconv.Itoa(DefCurretTS), ReadOnly: true},


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

On manual inspection of the code, the "default" value passed to tidbOptInt64 is wrong. It looks like it has been this way for a while (confirmed in 5.0 branch before refactoring occured).

It is unlikely that this bug will surface *because* validation is performed on values prior to calling `DefDMLBatchSize` to ensure they are valid integers. Thus, the fallback path is unused. This makes adding tests hard too, because the API must intentionally be misused.

In future we may update the API to not include the "default" fallback, but for now it makes sense to adjust the incorrect code.

### What is changed and how it works?

What's Changed:

Fix potential bug.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- None

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note