### PR TITLE
sem: add tidbredact log to restricted variables

### DIFF
--- a/util/sem/sem.go
+++ b/util/sem/sem.go
@@ -138,6 +138,7 @@ func IsInvisibleSysVar(varNameInLower string) bool {
 		variable.TiDBCheckMb4ValueInUTF8,
 		variable.TiDBConfig,
 		variable.TiDBEnableSlowLog,
+		variable.TiDBEnableTelemetry,
 		variable.TiDBExpensiveQueryTimeThreshold,
 		variable.TiDBForcePriority,
 		variable.TiDBGeneralLog,
@@ -146,12 +147,13 @@ func IsInvisibleSysVar(varNameInLower string) bool {
 		variable.TiDBOptWriteRowID,
 		variable.TiDBPProfSQLCPU,
 		variable.TiDBRecordPlanInSlowLog,
+		variable.TiDBRowFormatVersion,
 		variable.TiDBSlowQueryFile,
 		variable.TiDBSlowLogThreshold,
 		variable.TiDBEnableCollectExecutionInfo,
 		variable.TiDBMemoryUsageAlarmRatio,
-		variable.TiDBEnableTelemetry,
-		variable.TiDBRowFormatVersion:
+		variable.TiDBRedactLog,
+		variable.TiDBSlowLogMasking:
 		return true
 	}
 	return false

--- a/util/sem/sem_test.go
+++ b/util/sem/sem_test.go
@@ -98,4 +98,6 @@ func (s *testSecurity) TestIsInvisibleSysVar(c *C) {
 	c.Assert(IsInvisibleSysVar(variable.TiDBMemoryUsageAlarmRatio), IsTrue)
 	c.Assert(IsInvisibleSysVar(variable.TiDBEnableTelemetry), IsTrue)
 	c.Assert(IsInvisibleSysVar(variable.TiDBRowFormatVersion), IsTrue)
+	c.Assert(IsInvisibleSysVar(variable.TiDBRedactLog), IsTrue)
+	c.Assert(IsInvisibleSysVar(variable.TiDBSlowLogMasking), IsTrue)
 }


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

When reviewing the [spec for SEM](https://github.com/pingcap/tidb/blob/master/docs/design/2021-03-09-security-enhanced-mode.md#system-variables), I noticed that the redact log variables were not correctly hidden. They are now hidden.

### What is changed and how it works?

What's Changed:

The redact log variable and its alias are now hidden when SEM is enabled.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note