### PR TITLE
session: fix dml_batch_size doesn't load the global variable

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -2652,6 +2652,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBAllowFallbackToTiKV,
 	variable.TiDBEnableDynamicPrivileges,
 	variable.CTEMaxRecursionDepth,
+	variable.TiDBDMLBatchSize,
 }
 
 // loadCommonGlobalVariablesIfNeeded loads and applies commonly used global variables for the session.

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -4476,3 +4476,13 @@ func (s *testTxnStateSuite) TestRollbacking(c *C) {
 	c.Assert(tk.Se.TxnInfo().State, Equals, txninfo.TxnRollingBack)
 	<-ch
 }
+
+func (s *testSessionSuite) TestReadDMLBatchSize(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("set global tidb_dml_batch_size=1000")
+	se, err := session.CreateSession(s.store)
+	c.Assert(err, IsNil)
+	// `select 1` to load the global variables.
+	_, _ = se.Execute(context.TODO(), "select 1")
+	c.Assert(se.GetSessionVars().DMLBatchSize, Equals, 1000)
+}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24709 <!-- REMOVE this line if no issue to close -->

Problem Summary:
No TiDBDMLBatchSize in builtinGlobalVariable. So when loading the global variable, it misses TiDBDMLBatchSize.

### What is changed and how it works?

Add TiDBDMLBatchSize to builtinGlobalVariable.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- fix dml_batch_size doesn't load the global variable