### PR TITLE
executor: Fix unstable TestTiDBLastTxnInfoCommitMode

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3067,9 +3067,10 @@ func (s *testSerialSuite) TestTiDBLastTxnInfoCommitMode(c *C) {
 	c.Assert(rows[0][1], Equals, "false")
 	c.Assert(rows[0][2], Equals, "false")
 
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TiKVClient.AsyncCommit.SafeWindow = 0
-	})
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/invalidMaxCommitTS", "return"), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/invalidMaxCommitTS"), IsNil)
+	}()
 
 	tk.MustExec("set @@tidb_enable_async_commit = 1")
 	tk.MustExec("set @@tidb_enable_1pc = 0")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24774

Problem Summary:
The test case `TestTiDBLastTxnInfoCommitMode ` is unstable, because in the case it assumes when `AsyncCommit.SafeWindow = 0` the async commit / 1pc will surely fallback, which is incorrect.

### What is changed and how it works?

What's Changed:
Use the failpoint `invalidMaxCommitTS` instead of setting `SafeWindow = 0` to trigger falling back.

### Related changes

- 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- 
### Release note <!-- bugfixes or new feature need a release note -->

- No release note