### PR TITLE
planner: avoid unnecessary cartesian product for IN expressions on multi-columns

### DIFF
--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -894,11 +894,13 @@ func (er *expressionRewriter) handleInSubquery(ctx context.Context, v *ast.Patte
 	} else {
 		args := make([]expression.Expression, 0, np.Schema().Len())
 		for i, col := range np.Schema().Columns {
-			larg := expression.GetFuncArg(lexpr, i)
-			if !expression.ExprNotNull(larg) || !expression.ExprNotNull(col) {
-				rarg := *col
-				rarg.InOperand = true
-				col = &rarg
+			if v.Not || asScalar {
+				larg := expression.GetFuncArg(lexpr, i)
+				if !expression.ExprNotNull(larg) || !expression.ExprNotNull(col) {
+					rarg := *col
+					rarg.InOperand = true
+					col = &rarg
+				}
 			}
 			args = append(args, col)
 		}

--- a/planner/core/expression_rewriter_test.go
+++ b/planner/core/expression_rewriter_test.go
@@ -26,6 +26,17 @@ import (
 var _ = Suite(&testExpressionRewriterSuite{})
 
 type testExpressionRewriterSuite struct {
+	testData testutil.TestData
+}
+
+func (s *testExpressionRewriterSuite) SetUpSuite(c *C) {
+	var err error
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "expression_rewriter_suite")
+	c.Assert(err, IsNil)
+}
+
+func (s *testExpressionRewriterSuite) TearDownSuite(c *C) {
+	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
 }
 
 func (s *testExpressionRewriterSuite) TestIfNullEliminateColName(c *C) {
@@ -424,4 +435,39 @@ func (s *testExpressionRewriterSuite) TestIssue24705(c *C) {
 	tk.MustExec("create table t2 (c_int int, c_str varchar(40) character set utf8 collate utf8_unicode_ci);")
 	err = tk.ExecToErr("select * from t1 where c_str < any (select c_str from t2 where c_int between 6 and 9);")
 	c.Assert(err.Error(), Equals, "[expression:1267]Illegal mix of collations (utf8_general_ci,IMPLICIT) and (utf8_unicode_ci,IMPLICIT) for operation '<'")
+}
+
+func (s *testExpressionRewriterSuite) TestMultiColInExpression(c *C) {
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t1, t2")
+	tk.MustExec("create table t1(a int, b int)")
+	tk.MustExec("insert into t1 values(1,1),(2,null),(null,3),(4,4)")
+	tk.MustExec("analyze table t1")
+	tk.MustExec("create table t2(a int, b int)")
+	tk.MustExec("insert into t2 values(1,1),(2,null),(null,3),(5,4)")
+	tk.MustExec("analyze table t2")
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+		Res  []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery("explain format = 'brief' " + tt).Rows())
+			output[i].Res = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Sort().Rows())
+		})
+		tk.MustQuery("explain format = 'brief' " + tt).Check(testkit.Rows(output[i].Plan...))
+		tk.MustQuery(tt).Sort().Check(testkit.Rows(output[i].Res...))
+	}
 }

--- a/planner/core/testdata/expression_rewriter_suite_in.json
+++ b/planner/core/testdata/expression_rewriter_suite_in.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "TestMultiColInExpression",
+    "cases": [
+      "select * from t1 where (t1.a, t1.b) in (select a, b from t2)",
+      "select * from t1 where (t1.a, t1.b) not in (select a, b from t2)",
+      "select t1.a from t1 group by t1.a having (a, count(1)) in (select a, b from t2)",
+      "select t1.a from t1 group by t1.a having (a, count(1)) not in (select a, b from t2)"
+    ]
+  }
+]

--- a/planner/core/testdata/expression_rewriter_suite_out.json
+++ b/planner/core/testdata/expression_rewriter_suite_out.json
@@ -1,0 +1,67 @@
+[
+  {
+    "Name": "TestMultiColInExpression",
+    "Cases": [
+      {
+        "SQL": "select * from t1 where (t1.a, t1.b) in (select a, b from t2)",
+        "Plan": [
+          "HashJoin 2.25 root  inner join, equal:[eq(test.t1.a, test.t2.a) eq(test.t1.b, test.t2.b)]",
+          "├─HashAgg(Build) 1.69 root  group by:test.t2.a, test.t2.b, funcs:firstrow(test.t2.a)->test.t2.a, funcs:firstrow(test.t2.b)->test.t2.b",
+          "│ └─TableReader 2.25 root  data:Selection",
+          "│   └─Selection 2.25 cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "│     └─TableFullScan 4.00 cop[tikv] table:t2 keep order:false",
+          "└─TableReader(Probe) 2.25 root  data:Selection",
+          "  └─Selection 2.25 cop[tikv]  not(isnull(test.t1.a)), not(isnull(test.t1.b))",
+          "    └─TableFullScan 4.00 cop[tikv] table:t1 keep order:false"
+        ],
+        "Res": [
+          "1 1"
+        ]
+      },
+      {
+        "SQL": "select * from t1 where (t1.a, t1.b) not in (select a, b from t2)",
+        "Plan": [
+          "HashJoin 3.20 root  CARTESIAN anti semi join, other cond:eq(test.t1.a, test.t2.a), eq(test.t1.b, test.t2.b)",
+          "├─TableReader(Build) 4.00 root  data:TableFullScan",
+          "│ └─TableFullScan 4.00 cop[tikv] table:t2 keep order:false",
+          "└─TableReader(Probe) 4.00 root  data:TableFullScan",
+          "  └─TableFullScan 4.00 cop[tikv] table:t1 keep order:false"
+        ],
+        "Res": [
+          "4 4"
+        ]
+      },
+      {
+        "SQL": "select t1.a from t1 group by t1.a having (a, count(1)) in (select a, b from t2)",
+        "Plan": [
+          "HashJoin 1.69 root  inner join, equal:[eq(test.t2.a, test.t1.a) eq(test.t2.b, Column#7)]",
+          "├─HashAgg(Build) 1.69 root  group by:test.t2.a, test.t2.b, funcs:firstrow(test.t2.a)->test.t2.a, funcs:firstrow(test.t2.b)->test.t2.b",
+          "│ └─TableReader 2.25 root  data:Selection",
+          "│   └─Selection 2.25 cop[tikv]  not(isnull(test.t2.a)), not(isnull(test.t2.b))",
+          "│     └─TableFullScan 4.00 cop[tikv] table:t2 keep order:false",
+          "└─HashAgg(Probe) 2.25 root  group by:test.t1.a, funcs:count(1)->Column#7, funcs:firstrow(test.t1.a)->test.t1.a",
+          "  └─TableReader 3.00 root  data:Selection",
+          "    └─Selection 3.00 cop[tikv]  not(isnull(test.t1.a))",
+          "      └─TableFullScan 4.00 cop[tikv] table:t1 keep order:false"
+        ],
+        "Res": [
+          "1"
+        ]
+      },
+      {
+        "SQL": "select t1.a from t1 group by t1.a having (a, count(1)) not in (select a, b from t2)",
+        "Plan": [
+          "HashJoin 2.40 root  CARTESIAN anti semi join, other cond:eq(Column#7, test.t2.b), eq(test.t1.a, test.t2.a)",
+          "├─TableReader(Build) 4.00 root  data:TableFullScan",
+          "│ └─TableFullScan 4.00 cop[tikv] table:t2 keep order:false",
+          "└─HashAgg(Probe) 3.00 root  group by:test.t1.a, funcs:count(1)->Column#7, funcs:firstrow(test.t1.a)->test.t1.a",
+          "  └─TableReader 4.00 root  data:TableFullScan",
+          "    └─TableFullScan 4.00 cop[tikv] table:t1 keep order:false"
+        ],
+        "Res": [
+          "4"
+        ]
+      }
+    ]
+  }
+]


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/24743

Problem Summary:

Plan is not optimal for queries containing multi-column IN expression.

### What is changed and how it works?

What's Changed:

Only mark `InOperand` for AntiSemiJoin / AntiLeftOuterSemiJoin / LeftOuterSemiJoin, for SemiJoin, treat the IN expression as normal column equal conditions.

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Avoid unnecessary cartesian product for IN expressions on multi-columns