### PR TITLE
ddl: make DDLJob.Query using "show create table" sql when create clustered table with session vars

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -533,7 +533,9 @@ func updateTickerInterval(ticker *time.Ticker, lease time.Duration, job *model.J
 // - other: found in history DDL job and return that job error
 func (d *ddl) doDDLJob(ctx sessionctx.Context, job *model.Job) error {
 	// Get a global job ID and put the DDL job in the queue.
-	job.Query, _ = ctx.Value(sessionctx.QueryString).(string)
+	if job.Query == "" {
+		job.Query, _ = ctx.Value(sessionctx.QueryString).(string)
+	}
 	task := &limitJobTask{job, make(chan error)}
 	d.limitJobCh <- task
 	// worker should restart to continue handling tasks in limitJobCh, and send back through task.err

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1889,8 +1889,8 @@ func (d *ddl) CreateTableWithInfo(
 		actionType = model.ActionCreateTable
 	}
 
-	createTableQuery := ctx.Value(sessionctx.QueryString).(string)
-	if ctx.GetSessionVars().StmtCtx.UseShowCreateInDDLJob {
+	createTableQuery, _ := ctx.Value(sessionctx.QueryString).(string)
+	if createTableQuery != "" && ctx.GetSessionVars().StmtCtx.UseShowCreateInDDLJob {
 		var buf bytes.Buffer
 		err = CtorShowCreateTableHook(ctx, tbInfo, nil, &buf)
 		if err != nil {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -162,6 +162,7 @@ type StatementContext struct {
 	TblInfo2UnionScan     map[*model.TableInfo]bool
 	TaskID                uint64 // unique ID for an execution of a statement
 	TaskMapBakTS          uint64 // counter for
+	UseShowCreateInDDLJob bool   // indicate whether use `show create table` sql in ddl job
 
 	// stmtCache is used to store some statement-related values.
 	stmtCache map[StmtCacheKey]interface{}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24796 <!-- REMOVE this line if no issue to close -->

Problem Summary:

first, simple introduce how tidb/cdc/binlog works with create table with clustered

1. TiDB setup a tableInfo with `IsCommonHandle = true`
2. TiDB enqueue DDLJob with origin query --- `create table t (a char(1) primary key)` 
3. For Binlog,  tidb will replace ddlJob.Query's keyword as hint in https://github.com/pingcap/tidb/blob/18cbfaac15f8478902726e1e64971aa96b862462/sessionctx/binloginfo/binloginfo.go#L285, then output hinted-query in binlogInfo
4. For CDC,  cdc will subscribe tidb's ddlJob and replace ddlJob.Query to hinted query in  https://github.com/pingcap/ticdc/blob/7346b76d427dfa6717eb2b56e3872a7c1e53bdf8/cdc/changefeed.go#L706.

so, for `set tidb_enable_clustered_index=1` + `create table t (a char(1) primary key)` can not be hinted in step3 or step4, because it's not keyword, only a session vars.

### What is changed and how it works?

What's Changed, How it Works:

choose use `show create table` result in step2's ddlJob.Query

`StatementContext.UseShowCreateInDDLJob` and `CtorShowCreateTableHook` is very dirty, but it seems the cheapest way - 

> maybe we also can choose rewrite query like `AddSpecialComment` but use regexp to replace a SQL is very dangerous(e.g. `create table t5(`AUTO_RANDOM_BASE=3` int auto_increment key)` should cause downstream use different column name)

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: will do it with clustered binlog support
- Need to cherry-pick to the release branch 5.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

```
setup two clusters with  cdc or binlog, create a clustered index table in upstream and check it in downstream
```

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Will do it with clustered binlog support release item <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
