### PR TITLE
telemetry: change func PreviewUsageData to show telemetry status when telemetry is disabled

### DIFF
--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -81,7 +81,7 @@ func PreviewUsageData(ctx sessionctx.Context, etcdClient *clientv3.Client) (stri
 			s.ErrorMessage = err.Error()
 		} else {
 			s.IsRequestSent = reported
-			// s.IsTelemetryEnabled = enabled
+
 		}
 		err = updateTelemetryStatus(s, etcdClient)
 		return "", err


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24707 <!-- REMOVE this line if no issue to close -->

Problem Summary: no preview telemetry data when telemetry is disabled

### What is changed and how it works?

What's Changed:
change func PreviewUsageData to show telemetry status when telemetry is disabled. If telemetry is banned the preview data will show "telemetry is disabled" in status.




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test


### Release note <!-- bugfixes or new feature need a release note -->
 no release note
