### PR TITLE
ddl: wait 1pc only once for ddl reorg job

### DIFF
--- a/ddl/reorg.go
+++ b/ddl/reorg.go
@@ -156,11 +156,6 @@ func (rc *reorgCtx) clean() {
 }
 
 func (w *worker) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, tblInfo *model.TableInfo, lease time.Duration, f func() error) error {
-	// lease = 0 means it's in an integration test. In this case we don't delay so the test won't run too slowly.
-	if lease > 0 {
-		delayForAsyncCommit()
-	}
-
 	job := reorgInfo.Job
 	// This is for tests compatible, because most of the early tests try to build the reorg job manually
 	// without reorg meta info, which will cause nil pointer in here.
@@ -172,6 +167,12 @@ func (w *worker) runReorgJob(t *meta.Meta, reorgInfo *reorgInfo, tblInfo *model.
 		}
 	}
 	if w.reorgCtx.doneCh == nil {
+		// Since reorg job will be interrupted for polling the cancel action outside. we don't need to wait for 2.5s
+		// for the later entrances.
+		// lease = 0 means it's in an integration test. In this case we don't delay so the test won't run too slowly.
+		if lease > 0 {
+			delayForAsyncCommit()
+		}
 		// start a reorganization job
 		w.wg.Add(1)
 		w.reorgCtx.doneCh = make(chan error, 1)


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

1: For now, for a reorg job, when it steps into the reorg portal, DDL will be hung for 2.5s to guarantee 1pc safe.
2: Since the reorg job will be interrupted for polling the cancel action outside every `ReorgInterval` seconds. we don't need to wait for 2.5s for every later entrance.

### What is changed and how it works?

Just wait for 2.5s in the first entrance of DDL reorg job.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```
create table t (a int);
insert into t values(1);
insert into t select * from t   //  * 16 times   =  2 ^ 16 records
alter table t add index(a);
check for wait 1pc log make sure it occurs only once.
``` 

### Release note <!-- bugfixes or new feature need a release note -->

- ddl: wait 1pc once for ddl reorg job
