### PR TITLE
executor: add limit implementation for CTEExec

### DIFF
--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -7,19 +7,19 @@ insert into t2 values(1, 0), (2, 1);
 explain with cte(a) as (select 1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_8	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─Projection_6(Seed Part)	1.00	root		1->Column#1
   └─TableDual_7	1.00	root		rows:1
 explain with cte(a) as (select c1 from t1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_11	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─TableReader_8(Seed Part)	10000.00	root		data:TableFullScan_7
   └─TableFullScan_7	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain with cte(a,b,c,d) as (select * from t1, t2) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_18	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─HashJoin_10(Seed Part)	100000000.00	root		CARTESIAN inner join
   ├─TableReader_17(Build)	10000.00	root		data:TableFullScan_16
   │ └─TableFullScan_16	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
@@ -46,7 +46,7 @@ CTE_0	1.00	root		Recursive CTE
 explain with cte(a) as (with recursive cte1(a) as (select 1 union select a + 1 from cte1 where a < 10) select * from cte1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_21	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─CTEFullScan_20(Seed Part)	1.00	root	CTE:cte1	data:CTE_1
 CTE_1	1.00	root		Recursive CTE
 ├─Projection_15(Seed Part)	1.00	root		1->Column#2
@@ -70,7 +70,7 @@ id	estRows	task	access object	operator info
 HashJoin_17	1.00	root		CARTESIAN inner join
 ├─CTEFullScan_27(Build)	1.00	root	CTE:t2	data:CTE_0
 └─CTEFullScan_26(Probe)	1.00	root	CTE:t1	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─CTEFullScan_25(Seed Part)	1.00	root	CTE:cte1	data:CTE_1
 CTE_1	1.00	root		Recursive CTE
 ├─Projection_20(Seed Part)	1.00	root		1->Column#2
@@ -102,7 +102,7 @@ HashJoin_12	0.64	root		CARTESIAN inner join
 │ └─CTEFullScan_22	1.00	root	CTE:q1	data:CTE_0
 └─Selection_14(Probe)	0.80	root		eq(test.t1.c1, 1)
   └─CTEFullScan_20	1.00	root	CTE:q	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─TableReader_17(Seed Part)	10000.00	root		data:TableFullScan_16
   └─TableFullScan_16	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain with recursive cte(a,b) as (select 1, concat('a', 1) union select a+1, concat(b, 1) from cte where a < 5) select * from cte;
@@ -178,7 +178,7 @@ CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:0)
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 1) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─Limit_21(Seed Part)	1.00	root		offset:0, count:1
   └─HashAgg_22	1.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
     └─Union_23	20000.00	root		
@@ -189,7 +189,7 @@ CTE_0	1.00	root		Non Recursive CTE
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 100 offset 100) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─Limit_21(Seed Part)	100.00	root		offset:100, count:100
   └─HashAgg_22	200.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
     └─Union_23	20000.00	root		
@@ -200,5 +200,5 @@ CTE_0	1.00	root		Non Recursive CTE
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 0 offset 0) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_18	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		Non Recursive CTE
+CTE_0	1.00	root		Non-Recursive CTE
 └─TableDual_17(Seed Part)	0.00	root		rows:0

--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -127,3 +127,78 @@ CTE_0	1.00	root		Recursive CTE
 └─Projection_27(Recursive Part)	0.80	root		plus(Column#5, 1)->Column#7
   └─Selection_28	0.80	root		eq(Column#5, 0)
     └─CTETable_29	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 1) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_19	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:1)
+├─TableReader_14(Seed Part)	10000.00	root		data:TableFullScan_13
+│ └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_17(Recursive Part)	1.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+  └─CTETable_18	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 100 offset 100) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_19	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		Recursive CTE, limit(offset:100, count:100)
+├─TableReader_14(Seed Part)	10000.00	root		data:TableFullScan_13
+│ └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_17(Recursive Part)	1.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+  └─CTETable_18	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_19	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:0)
+├─TableReader_14(Seed Part)	10000.00	root		data:TableFullScan_13
+│ └─TableFullScan_13	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_17(Recursive Part)	1.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+  └─CTETable_18	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 1) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
+id	estRows	task	access object	operator info
+HashJoin_18	0.64	root		inner join, equal:[eq(test.t1.c1, test.t1.c1)]
+├─Selection_29(Build)	0.80	root		not(isnull(test.t1.c1))
+│ └─CTEFullScan_30	1.00	root	CTE:dt2	data:CTE_0
+└─Selection_20(Probe)	0.80	root		not(isnull(test.t1.c1))
+  └─CTEFullScan_28	1.00	root	CTE:dt1	data:CTE_0
+CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:1)
+├─TableReader_23(Seed Part)	10000.00	root		data:TableFullScan_22
+│ └─TableFullScan_22	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_26(Recursive Part)	1.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+  └─CTETable_27	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
+id	estRows	task	access object	operator info
+HashJoin_18	0.64	root		inner join, equal:[eq(test.t1.c1, test.t1.c1)]
+├─Selection_29(Build)	0.80	root		not(isnull(test.t1.c1))
+│ └─CTEFullScan_30	1.00	root	CTE:dt2	data:CTE_0
+└─Selection_20(Probe)	0.80	root		not(isnull(test.t1.c1))
+  └─CTEFullScan_28	1.00	root	CTE:dt1	data:CTE_0
+CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:0)
+├─TableReader_23(Seed Part)	10000.00	root		data:TableFullScan_22
+│ └─TableFullScan_22	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Projection_26(Recursive Part)	1.00	root		cast(plus(test.t1.c1, 1), int(11))->test.t1.c1
+  └─CTETable_27	1.00	root		Scan on CTE_0
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 1) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		None Recursive CTE
+└─Limit_21(Seed Part)	1.00	root		offset:0, count:1
+  └─HashAgg_22	1.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
+    └─Union_23	20000.00	root		
+      ├─TableReader_26	10000.00	root		data:TableFullScan_25
+      │ └─TableFullScan_25	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+      └─IndexReader_33	10000.00	root		index:IndexFullScan_32
+        └─IndexFullScan_32	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:false, stats:pseudo
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 100 offset 100) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		None Recursive CTE
+└─Limit_21(Seed Part)	100.00	root		offset:100, count:100
+  └─HashAgg_22	200.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
+    └─Union_23	20000.00	root		
+      ├─TableReader_26	10000.00	root		data:TableFullScan_25
+      │ └─TableFullScan_25	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+      └─IndexReader_33	10000.00	root		index:IndexFullScan_32
+        └─IndexFullScan_32	10000.00	cop[tikv]	table:t2, index:c1(c1)	keep order:false, stats:pseudo
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 0 offset 0) select * from cte1;
+id	estRows	task	access object	operator info
+CTEFullScan_18	1.00	root	CTE:cte1	data:CTE_0
+CTE_0	1.00	root		None Recursive CTE
+└─TableDual_17(Seed Part)	0.00	root		rows:0

--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -7,19 +7,19 @@ insert into t2 values(1, 0), (2, 1);
 explain with cte(a) as (select 1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_8	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─Projection_6(Seed Part)	1.00	root		1->Column#1
   └─TableDual_7	1.00	root		rows:1
 explain with cte(a) as (select c1 from t1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_11	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─TableReader_8(Seed Part)	10000.00	root		data:TableFullScan_7
   └─TableFullScan_7	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain with cte(a,b,c,d) as (select * from t1, t2) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_18	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─HashJoin_10(Seed Part)	100000000.00	root		CARTESIAN inner join
   ├─TableReader_17(Build)	10000.00	root		data:TableFullScan_16
   │ └─TableFullScan_16	10000.00	cop[tikv]	table:t2	keep order:false, stats:pseudo
@@ -46,7 +46,7 @@ CTE_0	1.00	root		Recursive CTE
 explain with cte(a) as (with recursive cte1(a) as (select 1 union select a + 1 from cte1 where a < 10) select * from cte1) select * from cte;
 id	estRows	task	access object	operator info
 CTEFullScan_21	1.00	root	CTE:cte	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─CTEFullScan_20(Seed Part)	1.00	root	CTE:cte1	data:CTE_1
 CTE_1	1.00	root		Recursive CTE
 ├─Projection_15(Seed Part)	1.00	root		1->Column#2
@@ -70,7 +70,7 @@ id	estRows	task	access object	operator info
 HashJoin_17	1.00	root		CARTESIAN inner join
 ├─CTEFullScan_27(Build)	1.00	root	CTE:t2	data:CTE_0
 └─CTEFullScan_26(Probe)	1.00	root	CTE:t1	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─CTEFullScan_25(Seed Part)	1.00	root	CTE:cte1	data:CTE_1
 CTE_1	1.00	root		Recursive CTE
 ├─Projection_20(Seed Part)	1.00	root		1->Column#2
@@ -102,7 +102,7 @@ HashJoin_12	0.64	root		CARTESIAN inner join
 │ └─CTEFullScan_22	1.00	root	CTE:q1	data:CTE_0
 └─Selection_14(Probe)	0.80	root		eq(test.t1.c1, 1)
   └─CTEFullScan_20	1.00	root	CTE:q	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─TableReader_17(Seed Part)	10000.00	root		data:TableFullScan_16
   └─TableFullScan_16	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
 explain with recursive cte(a,b) as (select 1, concat('a', 1) union select a+1, concat(b, 1) from cte where a < 5) select * from cte;
@@ -178,7 +178,7 @@ CTE_0	1.00	root		Recursive CTE, limit(offset:0, count:0)
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 1) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─Limit_21(Seed Part)	1.00	root		offset:0, count:1
   └─HashAgg_22	1.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
     └─Union_23	20000.00	root		
@@ -189,7 +189,7 @@ CTE_0	1.00	root		None Recursive CTE
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 100 offset 100) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_34	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─Limit_21(Seed Part)	100.00	root		offset:100, count:100
   └─HashAgg_22	200.00	root		group by:Column#11, funcs:firstrow(Column#11)->Column#11
     └─Union_23	20000.00	root		
@@ -200,5 +200,5 @@ CTE_0	1.00	root		None Recursive CTE
 explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 0 offset 0) select * from cte1;
 id	estRows	task	access object	operator info
 CTEFullScan_18	1.00	root	CTE:cte1	data:CTE_0
-CTE_0	1.00	root		None Recursive CTE
+CTE_0	1.00	root		Non Recursive CTE
 └─TableDual_17(Seed Part)	0.00	root		rows:0

--- a/cmd/explaintest/t/explain_cte.test
+++ b/cmd/explaintest/t/explain_cte.test
@@ -29,3 +29,16 @@ explain with q(a,b) as (select * from t1) select /*+ merge(q) no_merge(q1) */ * 
 # explain with cte(a,b) as (select * from t1) select (select 1 from cte limit 1) from cte;
 explain with recursive cte(a,b) as (select 1, concat('a', 1) union select a+1, concat(b, 1) from cte where a < 5) select * from cte;
 explain select * from t1 dt where exists(with recursive qn as (select c1*0+1 as b union all select b+1 from qn where b=0) select * from qn where b=1);
+
+# recursive limit
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 1) select * from cte1;
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 100 offset 100) select * from cte1;
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1;
+
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 1) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 0 offset 0) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1;
+
+# non-recursive limit
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 1) select * from cte1;
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 100 offset 100) select * from cte1;
+explain with recursive cte1(c1) as (select c1 from t1 union select c1 from t2 limit 0 offset 0) select * from cte1;

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4152,6 +4152,9 @@ func (b *executorBuilder) buildCTE(v *plannercore.PhysicalCTE) Executor {
 		chkIdx:        0,
 		isDistinct:    v.CTE.IsDistinct,
 		sel:           sel,
+		hasLimit:      v.CTE.HasLimit,
+		limitBeg:      v.CTE.LimitBeg,
+		limitEnd:      v.CTE.LimitEnd,
 	}
 }
 

--- a/executor/cte.go
+++ b/executor/cte.go
@@ -138,8 +138,8 @@ func (e *CTEExec) Open(ctx context.Context) (err error) {
 func (e *CTEExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 	req.Reset()
 	e.resTbl.Lock()
+	defer e.resTbl.Unlock()
 	if !e.resTbl.Done() {
-		defer e.resTbl.Unlock()
 		resAction := setupCTEStorageTracker(e.resTbl, e.ctx, e.memTracker, e.diskTracker)
 		iterInAction := setupCTEStorageTracker(e.iterInTbl, e.ctx, e.memTracker, e.diskTracker)
 		iterOutAction := setupCTEStorageTracker(e.iterOutTbl, e.ctx, e.memTracker, e.diskTracker)
@@ -167,8 +167,6 @@ func (e *CTEExec) Next(ctx context.Context, req *chunk.Chunk) (err error) {
 			return err
 		}
 		e.resTbl.SetDone()
-	} else {
-		e.resTbl.Unlock()
 	}
 
 	if e.hasLimit {

--- a/executor/cte_test.go
+++ b/executor/cte_test.go
@@ -254,8 +254,53 @@ func (test *CTETestSuite) TestCTEWithLimit(c *check.C) {
 	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 5 offset 1) select * from cte1")
 	rows.Check(testkit.Rows("2", "3", "4", "5", "6"))
 
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 5 offset 10) select * from cte1")
+	rows.Check(testkit.Rows("11", "12", "13", "14", "15"))
+
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 5 offset 995) select * from cte1")
+	rows.Check(testkit.Rows("996", "997", "998", "999", "1000"))
+
+	// Test with cte_max_recursion_depth
+	tk.MustExec("set cte_max_recursion_depth=2;")
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 0 union select c1 + 1 from cte1 limit 1 offset 2) select * from cte1;")
+	rows.Check(testkit.Rows("2"))
+
+	err := tk.QueryToErr("with recursive cte1(c1) as (select 0 union select c1 + 1 from cte1 limit 1 offset 3) select * from cte1;")
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "[executor:3636]Recursive query aborted after 3 iterations. Try increasing @@cte_max_recursion_depth to a larger value")
+
+	tk.MustExec("set cte_max_recursion_depth=1000;")
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 0 union select c1 + 1 from cte1 limit 5 offset 996) select * from cte1;")
+	rows.Check(testkit.Rows("996", "997", "998", "999", "1000"))
+
+	err = tk.QueryToErr("with recursive cte1(c1) as (select 0 union select c1 + 1 from cte1 limit 5 offset 997) select * from cte1;")
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "[executor:3636]Recursive query aborted after 1001 iterations. Try increasing @@cte_max_recursion_depth to a larger value")
+
 	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 0 offset 1) select * from cte1")
 	rows.Check(testkit.Rows())
+
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 0 offset 10) select * from cte1")
+	rows.Check(testkit.Rows())
+
+	// Test join.
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 2 offset 1) select * from cte1 dt1 join cte1 dt2 order by dt1.c1, dt2.c1;")
+	rows.Check(testkit.Rows("2 2", "2 3", "3 2", "3 3"))
+
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 2 offset 1) select * from cte1 dt1 join cte1 dt2 on dt1.c1 = dt2.c1 order by dt1.c1, dt1.c1;")
+	rows.Check(testkit.Rows("2 2", "3 3"))
+
+	// Test subquery.
+	// Different with mysql, maybe it's mysql bug?(https://bugs.mysql.com/bug.php?id=103890&thanks=4)
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 2 offset 1) select c1 from cte1 where c1 in (select 2);")
+	rows.Check(testkit.Rows("2"))
+
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 2 offset 1) select c1 from cte1 dt where c1 in (select c1 from cte1 where 1 = dt.c1 - 1);")
+	rows.Check(testkit.Rows("2"))
+
+	// Test Apply.
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 2 offset 1) select c1 from cte1 where cte1.c1 = (select dt1.c1 from cte1 dt1 where dt1.c1 = cte1.c1);")
+	rows.Check(testkit.Rows("2", "3"))
 
 	// Recursive tests with table.
 	tk.MustExec("drop table if exists t1;")
@@ -271,7 +316,7 @@ func (test *CTETestSuite) TestCTEWithLimit(c *check.C) {
 
 	// Error: ERROR 1221 (HY000): Incorrect usage of UNION and LIMIT.
 	// Limit can only be at the end of SQL stmt.
-	err := tk.ExecToErr("with recursive cte1(c1) as (select c1 from t1 limit 1 offset 1 union select c1 + 1 from cte1 limit 0 offset 1) select * from cte1")
+	err = tk.ExecToErr("with recursive cte1(c1) as (select c1 from t1 limit 1 offset 1 union select c1 + 1 from cte1 limit 0 offset 1) select * from cte1")
 	c.Assert(err.Error(), check.Equals, "[planner:1221]Incorrect usage of UNION and LIMIT")
 
 	// Basic non-recusive tests.
@@ -303,4 +348,16 @@ func (test *CTETestSuite) TestCTEWithLimit(c *check.C) {
 
 	rows = tk.MustQuery("with recursive cte1(c1) as (select c1 from t1 union select c1 + 1 c1 from cte1 limit 5 offset 100) select * from cte1")
 	rows.Check(testkit.Rows("100", "101", "102", "103", "104"))
+
+	// Test limit 0.
+	tk.MustExec("set cte_max_recursion_depth = 0;")
+	tk.MustExec("drop table if exists t1;")
+	tk.MustExec("create table t1(c1 int);")
+	tk.MustExec("insert into t1 values(0);")
+	rows = tk.MustQuery("with recursive cte1 as (select 1/c1 c1 from t1 union select c1 + 1 c1 from cte1 where c1 < 2 limit 0) select * from cte1;")
+	rows.Check(testkit.Rows())
+	// MySQL err: ERROR 1365 (22012): Division by 0. Because it gives error when computing 1/c1.
+	err = tk.QueryToErr("with recursive cte1 as (select 1/c1 c1 from t1 union select c1 + 1 c1 from cte1 where c1 < 2 limit 1) select * from cte1;")
+	c.Assert(err, check.NotNil)
+	c.Assert(err.Error(), check.Equals, "[executor:3636]Recursive query aborted after 1 iterations. Try increasing @@cte_max_recursion_depth to a larger value")
 }

--- a/executor/cte_test.go
+++ b/executor/cte_test.go
@@ -260,6 +260,9 @@ func (test *CTETestSuite) TestCTEWithLimit(c *check.C) {
 	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 5 offset 995) select * from cte1")
 	rows.Check(testkit.Rows("996", "997", "998", "999", "1000"))
 
+	rows = tk.MustQuery("with recursive cte1(c1) as (select 1 union select c1 + 1 from cte1 limit 5 offset 6) select * from cte1;")
+	rows.Check(testkit.Rows("7", "8", "9", "10", "11"))
+
 	// Test with cte_max_recursion_depth
 	tk.MustExec("set cte_max_recursion_depth=2;")
 	rows = tk.MustQuery("with recursive cte1(c1) as (select 0 union select c1 + 1 from cte1 limit 1 offset 2) select * from cte1;")

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3671,8 +3671,28 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 			}
 
 			b.handleHelper.pushMap(nil)
+
+			hasLimit := false
+			limitBeg := uint64(0)
+			limitEnd := uint64(0)
+			if cte.limitLP != nil {
+				hasLimit = true
+				switch x := cte.limitLP.(type) {
+				case *LogicalLimit:
+					limitBeg = x.Offset
+					limitEnd = x.Offset + x.Count
+				case *LogicalTableDual:
+					return x, nil
+				default:
+					return nil, errors.Errorf("invalid type for limit plan: %v", cte.limitLP)
+				}
+			}
+
 			var p LogicalPlan
-			lp := LogicalCTE{cteAsName: tn.Name, cte: &CTEClass{IsDistinct: cte.isDistinct, seedPartLogicalPlan: cte.seedLP, recursivePartLogicalPlan: cte.recurLP, IDForStorage: cte.storageID, optFlag: cte.optFlag}}.Init(b.ctx, b.getSelectOffset())
+			lp := LogicalCTE{cteAsName: tn.Name, cte: &CTEClass{IsDistinct: cte.isDistinct, seedPartLogicalPlan: cte.seedLP,
+				recursivePartLogicalPlan: cte.recurLP, IDForStorage: cte.storageID,
+				optFlag: cte.optFlag, HasLimit: hasLimit, LimitBeg: limitBeg,
+				LimitEnd: limitEnd}}.Init(b.ctx, b.getSelectOffset())
 			lp.SetSchema(getResultCTESchema(cte.seedLP.Schema(), b.ctx.GetSessionVars()))
 			p = lp
 			p.SetOutputNames(cte.seedLP.OutputNames())
@@ -5820,6 +5840,9 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 					if x.OrderBy != nil {
 						return ErrNotSupportedYet.GenWithStackByArgs("ORDER BY over UNION in recursive Common Table Expression")
 					}
+					// Limit clause is for the whole CTE instead of only for the seed part.
+					oriLimit := x.Limit
+					x.Limit = nil
 
 					// Check union type.
 					if afterOpr != nil {
@@ -5849,6 +5872,7 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 					// Rebuild the plan.
 					i--
 					b.buildingRecursivePartForCTE = true
+					x.Limit = oriLimit
 					continue
 				}
 				if err != nil {
@@ -5897,6 +5921,15 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 		}
 		// 4. Finally, we get the seed part plan and recursive part plan.
 		cInfo.recurLP = recurPart
+		// Only need to handle limit if x is SetOprStmt.
+		if x.Limit != nil {
+			limit, err := b.buildLimit(cInfo.seedLP, x.Limit)
+			if err != nil {
+				return err
+			}
+			limit.SetChildren(nil)
+			cInfo.limitLP = limit
+		}
 		return nil
 	default:
 		p, err := b.buildResultSetNode(ctx, x)
@@ -5976,7 +6009,7 @@ func (b *PlanBuilder) buildWith(ctx context.Context, w *ast.WithClause) error {
 		nameMap[cte.Name.L] = struct{}{}
 	}
 	for _, cte := range w.CTEs {
-		b.outerCTEs = append(b.outerCTEs, &cteInfo{def: cte, nonRecursive: !w.IsRecursive, isBuilding: true, storageID: b.allocIDForCTEStorage})
+		b.outerCTEs = append(b.outerCTEs, &cteInfo{cte, !w.IsRecursive, false, true, false, nil, nil, b.allocIDForCTEStorage, 0, false, false, nil})
 		b.allocIDForCTEStorage++
 		saveFlag := b.optFlag
 		// Init the flag to flagPrunColumns, otherwise it's missing.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -6009,7 +6009,7 @@ func (b *PlanBuilder) buildWith(ctx context.Context, w *ast.WithClause) error {
 		nameMap[cte.Name.L] = struct{}{}
 	}
 	for _, cte := range w.CTEs {
-		b.outerCTEs = append(b.outerCTEs, &cteInfo{cte, !w.IsRecursive, false, true, false, nil, nil, b.allocIDForCTEStorage, 0, false, false, nil})
+		b.outerCTEs = append(b.outerCTEs, &cteInfo{def: cte, nonRecursive: !w.IsRecursive, isBuilding: true, storageID: b.allocIDForCTEStorage})
 		b.allocIDForCTEStorage++
 		saveFlag := b.optFlag
 		// Init the flag to flagPrunColumns, otherwise it's missing.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3682,7 +3682,7 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 					limitBeg = x.Offset
 					limitEnd = x.Offset + x.Count
 				case *LogicalTableDual:
-					return x, nil
+					// Beg and End will both be 0.
 				default:
 					return nil, errors.Errorf("invalid type for limit plan: %v", cte.limitLP)
 				}
@@ -5927,7 +5927,7 @@ func (b *PlanBuilder) buildRecursiveCTE(ctx context.Context, cte ast.ResultSetNo
 			if err != nil {
 				return err
 			}
-			limit.SetChildren(nil)
+			limit.SetChildren(limit.Children()[:0]...)
 			cInfo.limitLP = limit
 		}
 		return nil

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1183,7 +1183,10 @@ type CTEClass struct {
 	// storageID for this CTE.
 	IDForStorage int
 	// optFlag is the optFlag for the whole CTE.
-	optFlag uint64
+	optFlag  uint64
+	HasLimit bool
+	LimitBeg uint64
+	LimitEnd uint64
 }
 
 // LogicalCTE is for CTE.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1463,10 +1463,16 @@ type CTEDefinition PhysicalCTE
 
 // ExplainInfo overrides the ExplainInfo
 func (p *CTEDefinition) ExplainInfo() string {
+	var res string
 	if p.RecurPlan != nil {
-		return "Recursive CTE"
+		res = "Recursive CTE"
+	} else {
+		res = "None Recursive CTE"
 	}
-	return "None Recursive CTE"
+	if p.CTE.HasLimit {
+		res += fmt.Sprintf(", limit(offset:%v, count:%v)", p.CTE.LimitBeg, p.CTE.LimitEnd-p.CTE.LimitBeg)
+	}
+	return res
 }
 
 // ExplainID overrides the ExplainID.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1467,7 +1467,7 @@ func (p *CTEDefinition) ExplainInfo() string {
 	if p.RecurPlan != nil {
 		res = "Recursive CTE"
 	} else {
-		res = "None Recursive CTE"
+		res = "Non Recursive CTE"
 	}
 	if p.CTE.HasLimit {
 		res += fmt.Sprintf(", limit(offset:%v, count:%v)", p.CTE.LimitBeg, p.CTE.LimitEnd-p.CTE.LimitBeg)

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1467,7 +1467,7 @@ func (p *CTEDefinition) ExplainInfo() string {
 	if p.RecurPlan != nil {
 		res = "Recursive CTE"
 	} else {
-		res = "Non Recursive CTE"
+		res = "Non-Recursive CTE"
 	}
 	if p.CTE.HasLimit {
 		res += fmt.Sprintf(", limit(offset:%v, count:%v)", p.CTE.LimitBeg, p.CTE.LimitEnd-p.CTE.LimitBeg)

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -432,6 +432,7 @@ type cteInfo struct {
 	// enterSubquery and recursiveRef are used to check "recursive table must be referenced only once, and not in any subquery".
 	enterSubquery bool
 	recursiveRef  bool
+	limitLP       LogicalPlan
 }
 
 // PlanBuilder builds Plan from an ast.Node.

--- a/util/cteutil/storage.go
+++ b/util/cteutil/storage.go
@@ -63,6 +63,9 @@ type Storage interface {
 	// NumChunks return chunk number of the underlying storage.
 	NumChunks() int
 
+	// NumRows return row number of the underlying storage.
+	NumRows() int
+
 	// Storage is not thread-safe.
 	// By using Lock(), users can achieve the purpose of ensuring thread safety.
 	Lock()
@@ -198,6 +201,11 @@ func (s *StorageRC) GetRow(ptr chunk.RowPtr) (chunk.Row, error) {
 // NumChunks impls Storage NumChunks interface.
 func (s *StorageRC) NumChunks() int {
 	return s.rc.NumChunks()
+}
+
+// NumRows impls Storage NumRows interface.
+func (s *StorageRC) NumRows() int {
+	return s.rc.NumRow()
 }
 
 // Lock impls Storage Lock interface.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24869 <!-- REMOVE this line if no issue to close -->

Problem Summary: 
1. This PR add `limit` implementation in `CTEExec`. The logic is basically same as `LimitExec`.
2. Why add `limit`: in recursive CTE, we can use limit to prevent infinite recursion. Just add limit, the execution will be terminated when it reachs the limitation.
3. Why don't just use `LimitExec`: Because CTEExex is a blocking operator, all data if computed in the first called Next().

### What is changed and how it works?


What's Changed: 
1. Also build limit when building recursive CTE.
2. Add begin info and end info into CTEExec.
3. Add more logic in CTEExec. Basically same as `LimitExec`.

How it Works:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Integration test: TestCTEWithLimit


Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- executor: add limit implementation for CTEExec
