### PR TITLE
planner: update IsCompleteModeAgg to find if any of aggFuncs are CompleteMode, not just compare the first aggFunc

### DIFF
--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -206,4 +207,29 @@ func (s *testUnitTestSuit) TestIndexPathSplitCorColCond(c *C) {
 		c.Assert(fmt.Sprintf("%s", remained), Equals, tt.remained, comment)
 	}
 	collate.SetNewCollationEnabledForTest(false)
+}
+
+func (s *testUnitTestSuit) TestIsCompleteModeAgg(c *C) {
+	defer testleak.AfterTest(c)()
+
+	aggFuncs := make([]*aggregation.AggFuncDesc, 2)
+	aggFuncs[0] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.FinalMode,
+		HasDistinct: true,
+	}
+	aggFuncs[1] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.CompleteMode,
+		HasDistinct: true,
+	}
+
+	newAgg := &LogicalAggregation{
+		AggFuncs: aggFuncs,
+	}
+	c.Assert(newAgg.IsCompleteModeAgg(), Equals, true)
+
+	aggFuncs[1] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.FinalMode,
+		HasDistinct: true,
+	}
+	c.Assert(newAgg.IsCompleteModeAgg(), Equals, false)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #24449 

Problem Summary:  when tidb_opt_distinct_agg_push_down and tidb_enable_cascades_planner are open, if agg are Partially pushed down, the InjectProjectionBelowAgg will not be matched, and the groupExpr will be wrong. this PR will update IsCompleteModeAgg to find if any of aggFuncs are CompleteMode, not just compare the first aggFunc to fix it.

### What is changed and how it works?

Proposal: [planner] update IsCompleteModeAgg to find if any of aggFuncs are CompleteMode, not just compare the first aggFunc

What's Changed: planner/core logical_plans.go


### Check List 

Tests 

- Unit test

### Release note 

- update IsCompleteModeAgg to find if any of aggFuncs are CompleteMode, not just compare the first aggFunc
