### PR TITLE
docs: Rename some tables' column names in Lock View to reduce confusion

### DIFF
--- a/docs/design/2021-04-26-lock-view.md
+++ b/docs/design/2021-04-26-lock-view.md
@@ -37,8 +37,8 @@ Several tables will be provided in `information_schema`. Some tables has both lo
 |------------|------------|---------|
 | `TRX_ID`    | `unsigned bigint`   | The transaction ID (aka. start ts) |
 | `TRX_STARTED`|`time`| Human readable start time of the transaction |
-| `DIGEST`|`text`| The digest of the current executing SQL statement |
-| `ALL_SQLS` | `text` | A list of all executed SQL statements' digests |
+| `CURRENT_SQL_DIGEST`|`text`| The digest of the current executing SQL statement |
+| `ALL_SQL_DIGESTS` | `text` | A list of all executed SQL statements' digests |
 | `STATE`| `enum('Running', 'Lock waiting', 'Committing', 'RollingBack')`| The state of the transaction |
 | `WAITING_START_TIME` | `time` | The elapsed time since the start of the current lock waiting (if any) |
 | `SCOPE` | `enum('Global', 'Local')` | The scope of the transaction |
@@ -89,7 +89,7 @@ Several tables will be provided in `information_schema`. Some tables has both lo
 | `TRY_LOCK_TRX_ID` | `unsigned bigint` | The transaction ID (start ts) of the transaction that's trying to acquire the lock |
 | `CURRENT_SQL_DIGEST` | `text` | The SQL that's being blocked |
 | `KEY` | `varchar` | The key that's being locked, but locked by another transaction in the deadlock event |
-| `ALL_SQLS` | `text` | A list of the digest of SQL statements that the transaction has executed |
+| `ALL_SQL_DIGESTS` | `text` | A list of the digest of SQL statements that the transaction has executed |
 | `TRX_HOLDING_LOCK` | `unsigned bigint` | The transaction that's currently holding the lock. There will be another record in the table with the same `DEADLOCK_ID` for that transaction. |
 
 * Life span of rows:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: As stated in [the feedback about Lock View](https://github.com/pingcap/tidb/issues/24199#issuecomment-847406462) , some column names are still confusing. This PR is to patch the design doc again to rename the tables' columns.

### What is changed and how it works?

What's Changed: Updated the design doc of lock view.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
