### PR TITLE
test: Fix a misusing of testkit that runs two queries concurrently

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -2322,7 +2322,7 @@ func (s *testPessimisticSuite) TestAmendForUniqueIndex(c *C) {
 	err = <-errCh
 	c.Assert(err, Equals, nil)
 	tk.MustExec("commit")
-	tk2.MustExec("admin check table t")
+	tk.MustExec("admin check table t")
 	err = <-errCh
 	c.Assert(err, Equals, nil)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: In the test case `TestAmendForUniqueIndex`, it uses an instance of testkit to run two queries concurrently, which is an incorrect usage and may cause potential race.

### What is changed and how it works?

What's Changed: Uses another tk to do the last query.

### Related changes

-

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
