### PR TITLE
*: remove session.GetDomain

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -74,8 +74,7 @@ PARTITION BY RANGE ( a ) (
 		c.Assert(err, IsNil)
 		pi := table.Meta().GetPartitionInfo()
 		c.Assert(pi, NotNil)
-		do, err := session.GetDomain(s.store)
-		c.Assert(err, IsNil)
+		do := domain.GetDomain(tk.Se)
 		handle := do.StatsHandle()
 		for _, def := range pi.Definitions {
 			statsTbl := handle.GetPartitionStats(table.Meta(), def.ID)

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -665,7 +665,7 @@ func (s *seqTestSuite) TestShowStatsHealthy(c *C) {
 	tk.MustExec("analyze table t")
 	tk.MustQuery("show stats_healthy").Check(testkit.Rows("test t  100"))
 	tk.MustExec("insert into t values (1), (2)")
-	do, _ := session.GetDomain(s.store)
+	do := domain.GetDomain(tk.Se)
 	err := do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll)
 	c.Assert(err, IsNil)
 	tk.MustExec("analyze table t")

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -1125,7 +1125,7 @@ func (ts *HTTPHandlerTestSuite) TestAllHistory(c *C) {
 	decoder := json.NewDecoder(resp.Body)
 
 	var jobs []*model.Job
-	s, _ := session.CreateSession(ts.server.newTikvHandlerTool().Store.(kv.Storage))
+	s, _ := session.CreateSession(ts.server.newHandlerHelper().Store.(kv.Storage))
 	defer s.Close()
 	store := domain.GetDomain(s.(sessionctx.Context)).Store()
 	txn, _ := store.Begin()
@@ -1265,10 +1265,8 @@ func (ts *HTTPHandlerTestSuite) TestServerInfo(c *C) {
 	c.Assert(info.Version, Equals, mysql.ServerVersion)
 	c.Assert(info.GitHash, Equals, versioninfo.TiDBGitHash)
 
-	store := ts.server.newTikvHandlerTool().Store.(kv.Storage)
-	do, err := session.GetDomain(store.(kv.Storage))
-	c.Assert(err, IsNil)
-	ddl := do.DDL()
+	helper := ts.server.newHandlerHelper()
+	ddl := helper.do.DDL()
 	c.Assert(info.ID, Equals, ddl.GetID())
 }
 
@@ -1288,10 +1286,8 @@ func (ts *HTTPHandlerTestSerialSuite) TestAllServerInfo(c *C) {
 	c.Assert(clusterInfo.IsAllServerVersionConsistent, IsTrue)
 	c.Assert(clusterInfo.ServersNum, Equals, 1)
 
-	store := ts.server.newTikvHandlerTool().Store.(kv.Storage)
-	do, err := session.GetDomain(store.(kv.Storage))
-	c.Assert(err, IsNil)
-	ddl := do.DDL()
+	helper := ts.server.newHandlerHelper()
+	ddl := helper.do.DDL()
 	c.Assert(clusterInfo.OwnerID, Equals, ddl.GetID())
 	serverInfo, ok := clusterInfo.AllServersInfo[ddl.GetID()]
 	c.Assert(ok, Equals, true)

--- a/server/statistics_handler.go
+++ b/server/statistics_handler.go
@@ -33,16 +33,7 @@ type StatsHandler struct {
 }
 
 func (s *Server) newStatsHandler() *StatsHandler {
-	store, ok := s.driver.(*TiDBDriver)
-	if !ok {
-		panic("Illegal driver")
-	}
-
-	do, err := session.GetDomain(store.store)
-	if err != nil {
-		panic("Failed to get domain")
-	}
-	return &StatsHandler{do}
+	return &StatsHandler{do: s.dom}
 }
 
 func (sh StatsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
@@ -71,16 +62,7 @@ type StatsHistoryHandler struct {
 }
 
 func (s *Server) newStatsHistoryHandler() *StatsHistoryHandler {
-	store, ok := s.driver.(*TiDBDriver)
-	if !ok {
-		panic("Illegal driver")
-	}
-
-	do, err := session.GetDomain(store.store)
-	if err != nil {
-		panic("Failed to get domain")
-	}
-	return &StatsHistoryHandler{do}
+	return &StatsHistoryHandler{do: s.dom}
 }
 
 func (sh StatsHistoryHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {

--- a/server/statistics_handler_test.go
+++ b/server/statistics_handler_test.go
@@ -68,9 +68,7 @@ func (ds *testDumpStatsSuite) startServer(c *C) {
 	}()
 	ds.waitUntilServerOnline()
 
-	do, err := session.GetDomain(ds.store)
-	c.Assert(err, IsNil)
-	ds.sh = &StatsHandler{do}
+	ds.sh = server.newStatsHandler()
 }
 
 func (ds *testDumpStatsSuite) stopServer(c *C) {

--- a/session/session.go
+++ b/session/session.go
@@ -382,13 +382,8 @@ func (s *session) StoreQueryFeedback(feedback interface{}) {
 		return
 	}
 	if s.statsCollector != nil {
-		do, err := GetDomain(s.store)
-		if err != nil {
-			logutil.BgLogger().Debug("domain not found", zap.Error(err))
-			metrics.StoreQueryFeedbackCounter.WithLabelValues(metrics.LblError).Inc()
-			return
-		}
-		err = s.statsCollector.StoreQueryFeedback(feedback, do.StatsHandle())
+		do := domain.GetDomain(s)
+		err := s.statsCollector.StoreQueryFeedback(feedback, do.StatsHandle())
 		if err != nil {
 			logutil.BgLogger().Debug("store query feedback", zap.Error(err))
 			metrics.StoreQueryFeedbackCounter.WithLabelValues(metrics.LblError).Inc()
@@ -2465,11 +2460,6 @@ func BootstrapSession(store kv.Storage) (*domain.Domain, error) {
 	}
 
 	return dom, err
-}
-
-// GetDomain gets the associated domain for store.
-func GetDomain(store kv.Storage) (*domain.Domain, error) {
-	return domap.Get(store)
 }
 
 // runInBootstrapSession create a special session for bootstrap to run.


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve?

Problem Summary: My investigation on how to decouple domain from session is not done yet, but I think this PR could be merged without controversial.

`domap`, the resource management struct of domain, is in session package. So it must be replaced for the decoupling. `domap` is solely used by `createSession` and `session.GetDomain`. And `session.GetDomain` can be removed easily for:

1. If there is `sessionctx.Context`, one can use `domain.GetDomain` instead.
2. Otherwise, we could directly pass domain due to the one-to-one mapping between `domain.Domain <-> kv.Store(driver) <-> server.Server`.

After this PR, `domap` is only used in `createSession`, and it will be much easier to work out a replacement.

### What is changed and how it works?

What's Changed:

1. replace `session.GetDomain` with `domain.GetDomain`
2. `tikvHandlerTool` renamed to `handlerHelper`, with a new field of type `domain.Domain`. So in case of lacking `sessionctx.Context`, one could still get domain.
3. removal of `session.GetDomain`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
