### PR TITLE
store/tikv: make pub vars related to region to private and add functions to set & get

### DIFF
--- a/store/copr/batch_request_sender.go
+++ b/store/copr/batch_request_sender.go
@@ -15,7 +15,6 @@ package copr
 
 import (
 	"context"
-	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/errors"
@@ -80,7 +79,7 @@ func (ss *RegionBatchRequestSender) onSendFailForBatchRegions(bo *Backoffer, ctx
 	// If it failed because the context is cancelled by ourself, don't retry.
 	if errors.Cause(err) == context.Canceled || status.Code(errors.Cause(err)) == codes.Canceled {
 		return errors.Trace(err)
-	} else if atomic.LoadUint32(&tikv.ShuttingDown) > 0 {
+	} else if tikv.LoadShuttingDown() > 0 {
 		return tikverr.ErrTiDBShuttingDown
 	}
 

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -44,7 +44,18 @@ import (
 // ShuttingDown is a flag to indicate tidb-server is exiting (Ctrl+C signal
 // receved for example). If this flag is set, tikv client should not retry on
 // network error because tidb-server expect tikv client to exit as soon as possible.
+// TODO: make it private when br is ready.
 var ShuttingDown uint32
+
+// StoreShuttingDown atomically stores ShuttingDown into v.
+func StoreShuttingDown(v uint32) {
+	atomic.StoreUint32(&ShuttingDown, v)
+}
+
+// LoadShuttingDown atomically loads ShuttingDown.
+func LoadShuttingDown() uint32 {
+	return atomic.LoadUint32(&ShuttingDown)
+}
 
 // RegionRequestSender sends KV/Cop requests to tikv server. It handles network
 // errors and some region errors internally.
@@ -555,7 +566,7 @@ func (s *RegionRequestSender) onSendFail(bo *Backoffer, ctx *RPCContext, err err
 	// If it failed because the context is cancelled by ourself, don't retry.
 	if errors.Cause(err) == context.Canceled {
 		return errors.Trace(err)
-	} else if atomic.LoadUint32(&ShuttingDown) > 0 {
+	} else if LoadShuttingDown() > 0 {
 		return tikverr.ErrTiDBShuttingDown
 	}
 	if status.Code(errors.Cause(err)) == codes.Canceled {

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -560,7 +560,7 @@ func setGlobalVars() {
 	}
 
 	atomic.StoreUint64(&tikv.CommitMaxBackoff, uint64(parseDuration(cfg.TiKVClient.CommitTimeout).Seconds()*1000))
-	tikv.RegionCacheTTLSec = int64(cfg.TiKVClient.RegionCacheTTL)
+	tikv.SetRegionCacheTTLSec(int64(cfg.TiKVClient.RegionCacheTTL))
 	domainutil.RepairInfo.SetRepairMode(cfg.RepairMode)
 	domainutil.RepairInfo.SetRepairTableList(cfg.RepairTableList)
 	executor.GlobalDiskUsageTracker.SetBytesLimit(cfg.TempStorageQuota)
@@ -577,7 +577,7 @@ func setGlobalVars() {
 		logutil.BgLogger().Fatal("invalid duration value for store-liveness-timeout",
 			zap.String("currentValue", cfg.TiKVClient.StoreLivenessTimeout))
 	}
-	tikv.StoreLivenessTimeout = t
+	tikv.SetStoreLivenessTimeout(t)
 	parsertypes.TiDBStrictIntegerDisplayWidth = cfg.DeprecateIntegerDisplayWidth
 }
 
@@ -647,7 +647,7 @@ func setupTracing() {
 }
 
 func closeDomainAndStorage(storage kv.Storage, dom *domain.Domain) {
-	atomic.StoreUint32(&tikv.ShuttingDown, 1)
+	tikv.StoreShuttingDown(1)
 	dom.Close()
 	err := storage.Close()
 	terror.Log(errors.Trace(err))


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR makes some public vars which is related to the region to private, and add public functions to set and get. By this PR, we could move and rename the vars freely in the `go-client` package and do not need to update the tools which are using these vars, for example br and tidb.


Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note