### PR TITLE
*: fix ci lint

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1668,7 +1668,7 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 			pprof.SetGoroutineLabels(goCtx)
 		}
 		if variable.TopSQLEnabled() && prepareStmt.SQLDigest != nil {
-			goCtx = topsql.AttachSQLInfo(goCtx, prepareStmt.NormalizedSQL, prepareStmt.SQLDigest, "", nil)
+			topsql.AttachSQLInfo(goCtx, prepareStmt.NormalizedSQL, prepareStmt.SQLDigest, "", nil)
 		}
 	}
 	// execute missed stmtID uses empty sql

--- a/session/session.go
+++ b/session/session.go
@@ -1391,7 +1391,7 @@ func (s *session) ParseWithParams(ctx context.Context, sql string, args ...inter
 		normalized, digest := parser.NormalizeDigest(sql)
 		if digest != nil {
 			// Fixme: reset/clean the label when internal sql execute finish.
-			ctx = topsql.AttachSQLInfo(ctx, normalized, digest, "", nil)
+			topsql.AttachSQLInfo(ctx, normalized, digest, "", nil)
 		}
 	}
 	return stmts[0], nil

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -735,7 +735,6 @@ func (e *RuntimeStatsWithConcurrencyInfo) String() string {
 
 // Merge implements the RuntimeStats interface.
 func (e *RuntimeStatsWithConcurrencyInfo) Merge(_ RuntimeStats) {
-	return
 }
 
 // RuntimeStatsWithCommit is the RuntimeStats with commit detail.


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```go
executor/executor.go:1671:4: ineffectual assignment to `goCtx` (ineffassign)
                        goCtx = topsql.AttachSQLInfo(goCtx, prepareStmt.NormalizedSQL, prepareStmt.SQLDigest, "", nil)
                        ^
session/session.go:1394:4: ineffectual assignment to `ctx` (ineffassign)
                        ctx = topsql.AttachSQLInfo(ctx, normalized, digest, "", nil)
                        ^
util/execdetails/execdetails.go:738:2: S1023: redundant `return` statement (gosimple)
        return
        ^

```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
