### PR TITLE
*: infoschema compatibility with prepare

### DIFF
--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -281,7 +281,7 @@ func (e *Execute) OptimizePreparedPlan(ctx context.Context, sctx sessionctx.Cont
 		preparedObj.Executor = nil
 		// If the schema version has changed we need to preprocess it again,
 		// if this time it failed, the real reason for the error is schema changed.
-		ret := &PreprocessorReturn{InfoSchema: is}
+		ret := &PreprocessorReturn{}
 		err := Preprocess(sctx, prepared.Stmt, InPrepare, WithPreprocessorReturn(ret))
 		if err != nil {
 			return ErrSchemaChanged.GenWithStack("Schema change caused error: %s", err.Error())

--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -2510,12 +2510,10 @@ func (s *testPessimisticSuite) TestPlanCacheSchemaChange(c *C) {
 
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk2 := testkit.NewTestKitWithInit(c, s.store)
-	tk3 := testkit.NewTestKitWithInit(c, s.store)
 	ctx := context.Background()
 
 	tk.MustExec("use test")
 	tk2.MustExec("use test")
-	tk3.MustExec("use test")
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (id int primary key, v int, unique index iv (v), vv int)")
@@ -2537,9 +2535,9 @@ func (s *testPessimisticSuite) TestPlanCacheSchemaChange(c *C) {
 	tk.MustExec("begin pessimistic")
 	tk2.MustExec("begin pessimistic")
 
-	tk3.MustExec("alter table t drop index iv")
-	tk3.MustExec("update t set v = 3 where v = 2")
-	tk3.MustExec("update t set v = 5 where v = 4")
+	tk.MustExec("alter table t drop index iv")
+	tk.MustExec("update t set v = 3 where v = 2")
+	tk.MustExec("update t set v = 5 where v = 4")
 
 	tk.MustExec("set @v = 2")
 	tk.MustExec("execute update_stmt using @v")


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve?

Problem Summary: #24613 has one workaround at `planner/core/common_plans.go:L268`. This PR removed it.

### How it works

As the new design in #24613, you should never write:  `ret := &PreprocessorReturn{InfoSchema: is}`, the introduction of this new struct is to return something from `planner.Preprocess()` without touching its API definition, instead of passing down something. But without that, `TestPlanCacheSchemaChange` will fail.

The failure of test is due to the incorrect infoschema. And you could blame the incorrectness to `concurrent DDL leads to stale infoschema in parallel transactions`.

It is so hard to solve that we only workaround the problem for some of the cases. Like `prepare/execute` statements does not choose the correct infoschema for `updateRead`(even if there are no parallel transactions), so it picked up the wrong cached plan. #22381 is a workaround for this problem.

I came up with the solution of returning the latest infoschema for pessimistic transaction, and it is a direct solution for `concurrent DDL and stale infoschema` problem. But it seems a little risky for @jackysp .

So here is another solution, instead of solving the rock hard `concurrent DDL and stale infoschema` problem, the solution of #22381 is refined and `concurrent DDL for tk1 and tk3` in the test is manually removed. The test should be still effective, `tk2` will responsible for the wanted `SchemaChange` cases: there is still `concurrent DDL for tk1 and tk2`.

### Release note

- No release note
