### PR TITLE
expression: Support push fucntion unix_timestamp, concat down to TiFlash.

### DIFF
--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -729,12 +729,39 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 
+	// ScalarFuncSig_RoundReal
 	function, err = NewFunction(mock.NewContext(), ast.Round, types.NewFieldType(mysql.TypeDouble), realColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 
+	// ScalarFuncSig_RoundInt
 	function, err = NewFunction(mock.NewContext(), ast.Round, types.NewFieldType(mysql.TypeLonglong), intColumn)
 	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	// concat
+	function, err = NewFunction(mock.NewContext(), ast.Concat, types.NewFieldType(mysql.TypeString), stringColumn, intColumn, realColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	// UnixTimestampCurrent
+	function, err = NewFunction(mock.NewContext(), ast.UnixTimestamp, types.NewFieldType(mysql.TypeLonglong))
+	c.Assert(err, IsNil)
+	_, ok := function.(*Constant)
+	c.Assert(ok, IsTrue)
+
+	// UnixTimestampInt
+	datetimeColumn.RetType.Decimal = 0
+	function, err = NewFunction(mock.NewContext(), ast.UnixTimestamp, types.NewFieldType(mysql.TypeLonglong), datetimeColumn)
+	c.Assert(err, IsNil)
+	c.Assert(function.(*ScalarFunction).Function.PbCode(), Equals, tipb.ScalarFuncSig_UnixTimestampInt)
+	exprs = append(exprs, function)
+
+	// UnixTimestampDecimal
+	datetimeColumn.RetType.Decimal = types.UnspecifiedLength
+	function, err = NewFunction(mock.NewContext(), ast.UnixTimestamp, types.NewFieldType(mysql.TypeNewDecimal), datetimeColumn)
+	c.Assert(err, IsNil)
+	c.Assert(function.(*ScalarFunction).Function.PbCode(), Equals, tipb.ScalarFuncSig_UnixTimestampDec)
 	exprs = append(exprs, function)
 
 	canPush := CanExprsPushDown(sc, exprs, client, kv.TiFlash)

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1003,7 +1003,7 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.If, ast.Ifnull, ast.Case,
 		ast.Concat,
 		ast.Month,
-		ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime, ast.UnixTimestamp,
+		ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime,
 		ast.JSONLength:
 		return true
 	case ast.Substr, ast.Substring:
@@ -1025,6 +1025,11 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 	case ast.DateAdd:
 		switch function.Function.PbCode() {
 		case tipb.ScalarFuncSig_AddDateDatetimeInt, tipb.ScalarFuncSig_AddDateStringInt:
+			return true
+		}
+	case ast.UnixTimestamp:
+		switch function.Function.PbCode() {
+		case tipb.ScalarFuncSig_UnixTimestampInt, tipb.ScalarFuncSig_UnixTimestampDec:
 			return true
 		}
 	case ast.Round:

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1001,8 +1001,9 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.GE, ast.LE, ast.EQ, ast.NE, ast.LT, ast.GT, ast.In, ast.IsNull, ast.Like,
 		ast.Plus, ast.Minus, ast.Div, ast.Mul, /*ast.Mod,*/
 		ast.If, ast.Ifnull, ast.Case,
+		ast.Concat,
 		ast.Month,
-		ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime,
+		ast.TimestampDiff, ast.DateFormat, ast.FromUnixTime, ast.UnixTimestamp,
 		ast.JSONLength:
 		return true
 	case ast.Substr, ast.Substring:


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/pingcap/tics/issues/1940, https://github.com/pingcap/tics/issues/1939 <!-- REMOVE this line if no issue to close -->

Problem Summary:

Function: push unix_timestamp, concat to TiFlash.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: 
- Need to cherry-pick to the release branch: no need

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

<!--
- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility
-->

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.