### PR TITLE
table: improve error message for incorrect utf8 value

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -9740,3 +9740,14 @@ OR Variable_name = 'sql_mode' OR Variable_name = 'query_cache_type'  OR Variable
 OR Variable_name = 'license' OR Variable_name = 'init_connect'`).Rows(), HasLen, 19)
 
 }
+
+func (s *testIntegrationSuite) TestCharsetErr(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table charset_test(id int auto_increment primary key, c1 varchar(255) character set ascii)")
+	err := tk.ExecToErr("insert into charset_test(c1) values ('aaa\xEF\xBF\xBDabcdef')")
+	c.Assert(err.Error(), Equals, "[table:1366]Incorrect string value '\\xEF\\xBF\\xBDabc...' for column 'c1'")
+
+	err = tk.ExecToErr("insert into charset_test(c1) values ('aaa\xEF\xBF\xBD')")
+	c.Assert(err.Error(), Equals, "[table:1366]Incorrect string value '\\xEF\\xBF\\xBD' for column 'c1'")
+}

--- a/table/column.go
+++ b/table/column.go
@@ -139,19 +139,26 @@ func truncateTrailingSpaces(v *types.Datum) {
 	v.SetString(str, v.Collation())
 }
 
-func handleWrongASCIIValue(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
+func handleWrongCharsetValue(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
 	sc := ctx.GetSessionVars().StmtCtx
-	err := ErrTruncatedWrongValueForField.FastGen("incorrect ascii value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
-	logutil.BgLogger().Error("incorrect ASCII value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
-	truncateVal := types.NewStringDatum(str[:i])
-	err = sc.HandleTruncate(err)
-	return truncateVal, err
-}
 
-func handleWrongUtf8Value(ctx sessionctx.Context, col *model.ColumnInfo, casted *types.Datum, str string, i int) (types.Datum, error) {
-	sc := ctx.GetSessionVars().StmtCtx
-	err := ErrTruncatedWrongValueForField.FastGen("incorrect utf8 value %x(%s) for column %s", casted.GetBytes(), str, col.Name)
-	logutil.BgLogger().Error("incorrect UTF-8 value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
+	var strval strings.Builder
+	for j := 0; j < 6; j++ {
+		if len(str) > (i + j) {
+			if str[i+j] > unicode.MaxASCII {
+				fmt.Fprintf(&strval, "\\x%X", str[i+j])
+			} else {
+				strval.WriteRune(rune(str[i+j]))
+			}
+		}
+	}
+	if len(str) > i+6 {
+		strval.WriteString(`...`)
+	}
+
+	// TODO: Add 'at row %d'
+	err := ErrTruncatedWrongValueForField.FastGen("Incorrect string value '%s' for column '%s'", strval.String(), col.Name)
+	logutil.BgLogger().Error("incorrect string value", zap.Uint64("conn", ctx.GetSessionVars().ConnectionID), zap.Error(err))
 	// Truncate to valid utf8 string.
 	truncateVal := types.NewStringDatum(str[:i])
 	err = sc.HandleTruncate(err)
@@ -280,7 +287,7 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 		str := casted.GetString()
 		for i := 0; i < len(str); i++ {
 			if str[i] > unicode.MaxASCII {
-				casted, err = handleWrongASCIIValue(ctx, col, &casted, str, i)
+				casted, err = handleWrongCharsetValue(ctx, col, &casted, str, i)
 				break
 			}
 		}
@@ -307,11 +314,11 @@ func CastValue(ctx sessionctx.Context, val types.Datum, col *model.ColumnInfo, r
 				w = width
 				continue
 			}
-			casted, err = handleWrongUtf8Value(ctx, col, &casted, str, i)
+			casted, err = handleWrongCharsetValue(ctx, col, &casted, str, i)
 			break
 		} else if width > 3 && doMB4CharCheck {
 			// Handle non-BMP characters.
-			casted, err = handleWrongUtf8Value(ctx, col, &casted, str, i)
+			casted, err = handleWrongCharsetValue(ctx, col, &casted, str, i)
 			break
 		}
 		w = width


### PR DESCRIPTION

### What problem does this PR solve?

While working on https://github.com/pingcap/tidb/pull/24991 I hit a
`incorrect utf8 value` error. As the HEX and string representation of
the string are concaternated it looked like a single value while it was
not. This more clearly splits and labels the two.

```
[2021/06/02 17:04:33.488 +02:00] [ERROR] [column.go:154] ["incorrect UTF-8 value"] [conn=0] [error="[table:1366]incorrect utf8 value 24412430303524215011f542e7a2aca97fd5ab71aae07dd06f6157662e6a522f72506e5862584e4f475057774f392e38506e73776d2e6d6f5450454a46686a6d334758686d31($A$005$!P\u0011\ufffdB碬\ufffdիq\ufffd\ufffd}\ufffdoaWf.jR/rPnXbXNOGPWwO9.8Pnswm.moTPEJFhjm3GXhm1) for column authentication_string"]
```

```
[2021/06/02 17:04:33.488 +02:00] [ERROR] [column.go:154] ["incorrect UTF-8 value"] [conn=0] [error="[table:1366]incorrect utf8 value hex=24412430303524215011f542e7a2aca97fd5ab71aae07dd06f6157662e6a522f72506e5862584e4f475057774f392e38506e73776d2e6d6f5450454a46686a6d334758686d31 string=$A$005$!P\u0011\ufffdB碬\ufffdիq\ufffd\ufffd}\ufffdoaWf.jR/rPnXbXNOGPWwO9.8Pnswm.moTPEJFhjm3GXhm1 for column authentication_string"]
```

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)


### Release note <!-- bugfixes or new feature need a release note -->

- No release note


Some thoughts/questions related to this:
- The error has `incorrect utf8 value` event if the column is `utf8mb4` intead of `utf8`. Should we use `col.Charset` here? Or change `utf8` to `UTF-8`? I think the latter would be the best option.
- Should the error message include the charset and collation?