### PR TITLE
executor: avoid panic in the test

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -522,7 +522,7 @@ func (s *testSerialSuite2) TestFastAnalyze4GlobalStats(c *C) {
 	tk.MustExec("create table test_fast_gstats(a int, b int) PARTITION BY HASH(a) PARTITIONS 2;")
 	tk.MustExec("insert into test_fast_gstats values(1,1),(3,3),(4,4),(2,2),(5,5);")
 	err := tk.ExecToErr("analyze table test_fast_gstats;")
-	c.Assert(err.Error(), Equals, "Fast analyze hasn't reached General Availability and only support analyze version 1 currently.")
+	c.Assert(err, ErrorMatches, ".*Fast analyze hasn't reached General Availability and only support analyze version 1 currently.*")
 }
 
 func (s *testSuite1) TestIssue15993(c *C) {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: Not a fix for unstable tests. FYI, check [CI log](https://ci.pingcap.net/blue/rest/organizations/jenkins/pipelines/tidb_ghpr_check_2/runs/8220/nodes/62/steps/73/log/?start=0). `err` may be nil, which leads to a panic. However, I would appreciate if gocheck tell me it is nil and unexpected, instead of panic.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note