### PR TITLE
store: refine the backoff for DataIsNotReady region error

### DIFF
--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -636,7 +636,7 @@ func (s *testRegionRequestToSingleStoreSuite) TestNoReloadRegionForGrpcWhenCtxCa
 	wg.Wait()
 }
 
-func (s *testRegionRequestToSingleStoreSuite) TestOnDataIsNotReadyErrorBackoff(c *C) {
+func (s *testRegionRequestToSingleStoreSuite) TestBackoffOnDataIsNotReadyError(c *C) {
 	var seed uint32 = 0
 	req := tikvrpc.NewReplicaReadRequest(tikvrpc.CmdGet, &kvrpcpb.GetRequest{}, kv.ReplicaReadMixed, &seed)
 	region, err := s.cache.LocateRegionByID(s.bo, s.region)


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

A request may be sent to a peer which the data is not ready yet because the region is merging or splitting, we should back off and retry in this case.

### What is changed and how it works?

Add backoff for both reading and writing requests during the `DataIsNotReady` error handling.

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
