### PR TITLE
executor: skip unstable test case TestMergeJoinInDisk and TestAnalyzeIndexExtractTopN.

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -238,9 +238,7 @@ func (s *testSuite1) TestAnalyzeTooLongColumns(c *C) {
 }
 
 func (s *testSuite1) TestAnalyzeIndexExtractTopN(c *C) {
-	if israce.RaceEnabled {
-		c.Skip("unstable, skip race test")
-	}
+	c.Skip("unstable, skip it and fix it before 20210618")
 	store, err := mockstore.NewMockStore()
 	c.Assert(err, IsNil)
 	defer func() {

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -279,6 +279,8 @@ func (s *testSerialSuite1) TestShuffleMergeJoinInDisk(c *C) {
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.DiskTracker.MaxConsumed(), Greater, int64(0))
 }
 func (s *testSerialSuite1) TestMergeJoinInDisk(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210618")
+
 	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: related to https://github.com/pingcap/tidb/issues/25157

Problem Summary:

What's Changed: the unstable test cases are skipped temporarily.

How it Works:

### Related changes

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- NA

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
