### PR TITLE
store/tikv: remove unused function and private the variable shuttingDown

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -29,7 +29,6 @@ type BackoffConfig = retry.Config
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
 	gcResolveLockMaxBackoff = 100000
-	pdRPCMaxBackoff         = 20000
 	// CommitSecondaryMaxBackoff is max sleep time of the 'commit' command
 	CommitSecondaryMaxBackoff = 41000
 )

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -43,20 +43,19 @@ import (
 	"github.com/pingcap/tidb/store/tikv/util"
 )
 
-// ShuttingDown is a flag to indicate tidb-server is exiting (Ctrl+C signal
+// shuttingDown is a flag to indicate tidb-server is exiting (Ctrl+C signal
 // receved for example). If this flag is set, tikv client should not retry on
 // network error because tidb-server expect tikv client to exit as soon as possible.
-// TODO: make it private when br is ready.
-var ShuttingDown uint32
+var shuttingDown uint32
 
 // StoreShuttingDown atomically stores ShuttingDown into v.
 func StoreShuttingDown(v uint32) {
-	atomic.StoreUint32(&ShuttingDown, v)
+	atomic.StoreUint32(&shuttingDown, v)
 }
 
 // LoadShuttingDown atomically loads ShuttingDown.
 func LoadShuttingDown() uint32 {
-	return atomic.LoadUint32(&ShuttingDown)
+	return atomic.LoadUint32(&shuttingDown)
 }
 
 // RegionRequestSender sends KV/Cop requests to tikv server. It handles network

--- a/store/tikv/retry/backoff.go
+++ b/store/tikv/retry/backoff.go
@@ -27,7 +27,6 @@ import (
 	tikverr "github.com/pingcap/tidb/store/tikv/error"
 	"github.com/pingcap/tidb/store/tikv/kv"
 	"github.com/pingcap/tidb/store/tikv/logutil"
-	"github.com/pingcap/tidb/store/tikv/metrics"
 	"github.com/pingcap/tidb/store/tikv/util"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -102,50 +101,6 @@ func (b *Backoffer) Backoff(cfg *Config, err error) error {
 // and never sleep more than maxSleepMs for each sleep.
 func (b *Backoffer) BackoffWithMaxSleepTxnLockFast(maxSleepMs int, err error) error {
 	cfg := BoTxnLockFast
-	return b.BackoffWithCfgAndMaxSleep(cfg, maxSleepMs, err)
-}
-
-// BackoffWithMaxSleep is deprecated, please use BackoffWithCfgAndMaxSleep instead. TODO: remove it when br is ready.
-func (b *Backoffer) BackoffWithMaxSleep(typ int, maxSleepMs int, err error) error {
-	// Back off types.
-	const (
-		boTiKVRPC int = iota
-		boTiFlashRPC
-		boTxnLock
-		boTxnLockFast
-		boPDRPC
-		boRegionMiss
-		boTiKVServerBusy
-		boTiFlashServerBusy
-		boTxnNotFound
-		boStaleCmd
-		boMaxTsNotSynced
-	)
-	switch typ {
-	case boTiKVRPC:
-		return b.BackoffWithCfgAndMaxSleep(BoTiKVRPC, maxSleepMs, err)
-	case boTiFlashRPC:
-		return b.BackoffWithCfgAndMaxSleep(BoTiFlashRPC, maxSleepMs, err)
-	case boTxnLock:
-		return b.BackoffWithCfgAndMaxSleep(BoTxnLock, maxSleepMs, err)
-	case boTxnLockFast:
-		return b.BackoffWithCfgAndMaxSleep(BoTxnLockFast, maxSleepMs, err)
-	case boPDRPC:
-		return b.BackoffWithCfgAndMaxSleep(BoPDRPC, maxSleepMs, err)
-	case boRegionMiss:
-		return b.BackoffWithCfgAndMaxSleep(BoRegionMiss, maxSleepMs, err)
-	case boTiKVServerBusy:
-		return b.BackoffWithCfgAndMaxSleep(BoTiKVServerBusy, maxSleepMs, err)
-	case boTiFlashServerBusy:
-		return b.BackoffWithCfgAndMaxSleep(BoTiFlashServerBusy, maxSleepMs, err)
-	case boTxnNotFound:
-		return b.BackoffWithCfgAndMaxSleep(BoTxnNotFound, maxSleepMs, err)
-	case boStaleCmd:
-		return b.BackoffWithCfgAndMaxSleep(BoStaleCmd, maxSleepMs, err)
-	case boMaxTsNotSynced:
-		return b.BackoffWithCfgAndMaxSleep(BoMaxTsNotSynced, maxSleepMs, err)
-	}
-	cfg := NewConfig("", &metrics.BackoffHistogramEmpty, nil, tikverr.ErrUnknown)
 	return b.BackoffWithCfgAndMaxSleep(cfg, maxSleepMs, err)
 }
 


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR removes unused function in tikv and private the variable ShuttingDown since the set/get function already exists.


Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note