### PR TITLE
executor: temporarily skip some unstable test cases.

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -559,6 +559,7 @@ func (s *testSuite1) TestIssue15752(c *C) {
 }
 
 func (s *testSuite1) TestAnalyzeIndex(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210622")
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t1")
@@ -582,6 +583,7 @@ func (s *testSuite1) TestAnalyzeIndex(c *C) {
 }
 
 func (s *testSuite1) TestAnalyzeIncremental(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210622")
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_analyze_version = 1")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -73,6 +73,7 @@ import (
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/deadlockhistory"
 	"github.com/pingcap/tidb/util/gcutil"
+	"github.com/pingcap/tidb/util/israce"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
@@ -8413,6 +8414,9 @@ func (s testSerialSuite) TestTemporaryTableNoNetwork(c *C) {
 }
 
 func (s *testResourceTagSuite) TestResourceGroupTag(c *C) {
+	if israce.RaceEnabled {
+		c.Skip("unstable, skip it and fix it before 20210622")
+	}
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t;")

--- a/executor/join_test.go
+++ b/executor/join_test.go
@@ -1182,6 +1182,7 @@ func (s *testSuiteJoin1) TestIssue15850JoinNullValue(c *C) {
 }
 
 func (s *testSuiteJoin1) TestIndexLookupJoin(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210622")
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("set @@tidb_init_chunk_size=2")


### PR DESCRIPTION
Skip the following test cases because they're not stable.

- testResourceTagSuite.TestResourceGroupTag (#25189)
- testSuiteJoin1.TestIndexLookupJoin (#25191)
- testSuite1.TestAnalyzeIndex (#25188)
- testSuite1.TestAnalyzeIncremental (#25187)
- testVectorizeSuite2.TestVectorizedBuiltinTimeEvalOneVec (#25169)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
