### PR TITLE
store/tikv: remove unused failpoints

### DIFF
--- a/store/tikv/client/client_batch.go
+++ b/store/tikv/client/client_batch.go
@@ -295,13 +295,6 @@ func (a *batchConn) batchSendLoop(cfg config.TiKVClient) {
 		a.pendingRequests.Observe(float64(len(a.batchCommandsCh)))
 		a.batchSize.Observe(float64(a.reqBuilder.len()))
 
-		// curl -XPUT -d 'return(true)' http://0.0.0.0:10080/fail/github.com/pingcap/tidb/store/tikv/mockBlockOnBatchClient
-		failpoint.Inject("mockBlockOnBatchClient", func(val failpoint.Value) {
-			if val.(bool) {
-				time.Sleep(1 * time.Hour)
-			}
-		})
-
 		if a.reqBuilder.len() < int(cfg.MaxBatchSize) && cfg.MaxBatchWaitTime > 0 {
 			// If the target TiKV is overload, wait a while to collect more requests.
 			if atomic.LoadUint64(&a.tikvTransportLayerLoad) >= uint64(cfg.OverloadThreshold) {

--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -258,10 +258,6 @@ func (r *Region) compareAndSwapStore(oldStore, newStore *RegionStore) bool {
 }
 
 func (r *Region) checkRegionCacheTTL(ts int64) bool {
-	// Only consider use percentage on this failpoint, for example, "2%return"
-	failpoint.Inject("invalidateRegionCache", func() {
-		r.invalidate(Other)
-	})
 	for {
 		lastAccess := atomic.LoadInt64(&r.lastAccess)
 		if ts-lastAccess > regionCacheTTLSec {
@@ -523,12 +519,6 @@ func (c *RegionCache) GetTiKVRPCContext(bo *Backoffer, id RegionVerID, replicaRe
 	if err != nil {
 		return nil, err
 	}
-	// enable by `curl -XPUT -d '1*return("[some-addr]")->return("")' http://host:port/github.com/pingcap/tidb/store/tikv/injectWrongStoreAddr`
-	failpoint.Inject("injectWrongStoreAddr", func(val failpoint.Value) {
-		if a, ok := val.(string); ok && len(a) > 0 {
-			addr = a
-		}
-	})
 	if store == nil || len(addr) == 0 {
 		// Store not found, region must be out of date.
 		cachedRegion.invalidate(StoreNotFound)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
Some failpoints in `store/tikv` are not used.

### What is changed and how it works?

Remove them.

Note: There are some failpoints that are not used in the code that are marked as being able to be set via HTTP, but I have not found a place to use them and all the tests can pass. I'll delete them here and add them back if something goes wrong.

### Check List <!--REMOVE the items that are not applicable-->

Tests 
- Unit test


### Release note <!-- bugfixes or new feature need a release note -->
- No release note
