### PR TITLE
store/tikv: move function GetStoreTypeByMeta to sub package tikvrpc

### DIFF
--- a/store/tikv/region_cache.go
+++ b/store/tikv/region_cache.go
@@ -1988,7 +1988,7 @@ func (s *Store) initResolve(bo *Backoffer, c *RegionCache) (addr string, err err
 		}
 		s.addr = addr
 		s.saddr = store.GetStatusAddress()
-		s.storeType = GetStoreTypeByMeta(store)
+		s.storeType = tikvrpc.GetStoreTypeByMeta(store)
 		s.labels = store.GetLabels()
 		// Shouldn't have other one changing its state concurrently, but we still use changeResolveStateTo for safety.
 		s.changeResolveStateTo(unresolved, resolved)
@@ -2030,7 +2030,7 @@ func (s *Store) reResolve(c *RegionCache) (bool, error) {
 		return false, nil
 	}
 
-	storeType := GetStoreTypeByMeta(store)
+	storeType := tikvrpc.GetStoreTypeByMeta(store)
 	addr = store.GetAddress()
 	if s.addr != addr || !s.IsSameLabels(store.GetLabels()) {
 		newStore := &Store{storeID: s.storeID, addr: addr, saddr: store.GetStatusAddress(), storeType: storeType, labels: store.GetLabels(), state: uint64(resolved)}

--- a/store/tikv/store_type.go
+++ b/store/tikv/store_type.go
@@ -43,19 +43,7 @@ func (a AccessMode) String() string {
 	}
 }
 
-// Constants to determine engine type.
-// They should be synced with PD.
-const (
-	engineLabelKey     = "engine"
-	engineLabelTiFlash = "tiflash"
-)
-
 // GetStoreTypeByMeta gets store type by store meta pb.
 func GetStoreTypeByMeta(store *metapb.Store) tikvrpc.EndpointType {
-	for _, label := range store.Labels {
-		if label.Key == engineLabelKey && label.Value == engineLabelTiFlash {
-			return tikvrpc.TiFlash
-		}
-	}
-	return tikvrpc.TiKV
+	return tikvrpc.GetStoreTypeByMeta(store)
 }

--- a/store/tikv/tikvrpc/endpoint.go
+++ b/store/tikv/tikvrpc/endpoint.go
@@ -13,6 +13,8 @@
 
 package tikvrpc
 
+import "github.com/pingcap/kvproto/pkg/metapb"
+
 // EndpointType represents the type of a remote endpoint..
 type EndpointType uint8
 
@@ -34,4 +36,21 @@ func (t EndpointType) Name() string {
 		return "tidb"
 	}
 	return "unspecified"
+}
+
+// Constants to determine engine type.
+// They should be synced with PD.
+const (
+	engineLabelKey     = "engine"
+	engineLabelTiFlash = "tiflash"
+)
+
+// GetStoreTypeByMeta gets store type by store meta pb.
+func GetStoreTypeByMeta(store *metapb.Store) EndpointType {
+	for _, label := range store.Labels {
+		if label.Key == engineLabelKey && label.Value == engineLabelTiFlash {
+			return TiFlash
+		}
+	}
+	return TiKV
 }


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR moves the implementation of the function `GetStoreTypeByMeta` to sub package `tikvrpc` since the data it returns from the `tikvrpc` package. It is preparing for the later PR: create `tikv/region` package https://github.com/pingcap/tidb/pull/25205


Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note