### PR TITLE
planner: solve an incompatible issue about dynamic-mode and TiFlash and enable dynamic mode by default 

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -3483,6 +3483,22 @@ type kvRangeBuilderFromRangeAndPartition struct {
 	partitions []table.PhysicalTable
 }
 
+func (h kvRangeBuilderFromRangeAndPartition) buildKeyRangeSeparately(ranges []*ranger.Range) ([]int64, [][]kv.KeyRange, error) {
+	var ret [][]kv.KeyRange
+	var pids []int64
+	for _, p := range h.partitions {
+		pid := p.GetPhysicalID()
+		meta := p.Meta()
+		kvRange, err := distsql.TableHandleRangesToKVRanges(h.sctx.GetSessionVars().StmtCtx, []int64{pid}, meta != nil && meta.IsCommonHandle, ranges, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		pids = append(pids, pid)
+		ret = append(ret, kvRange)
+	}
+	return pids, ret, nil
+}
+
 func (h kvRangeBuilderFromRangeAndPartition) buildKeyRange(_ int64, ranges []*ranger.Range) ([]kv.KeyRange, error) {
 	var ret []kv.KeyRange
 	for _, p := range h.partitions {

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -2403,6 +2403,26 @@ func (s *partitionTableSuite) TestDirectReadingWithAgg(c *C) {
 	}
 }
 
+func (s *partitionTableSuite) TestDynamicModeByDefault(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create database test_dynamic_by_default")
+
+	tk.MustExec(`create table trange(a int, b int, primary key(a) clustered, index idx_b(b)) partition by range(a) (
+		partition p0 values less than(300),
+		partition p1 values less than(500),
+		partition p2 values less than(1100));`)
+	tk.MustExec(`create table thash(a int, b int, primary key(a) clustered, index idx_b(b)) partition by hash(a) partitions 4;`)
+
+	for _, q := range []string{
+		"explain select * from trange where a>400",
+		"explain select * from thash where a>=100",
+	} {
+		for _, r := range tk.MustQuery(q).Rows() {
+			c.Assert(strings.Contains(strings.ToLower(r[0].(string)), "partitionunion"), IsFalse)
+		}
+	}
+}
+
 func (s *partitionTableSuite) TestIssue24636(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	tk.MustExec("create database test_issue_24636")

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -276,6 +276,7 @@ func (e *TableReaderExecutor) buildKVReqSeparately(ctx context.Context, ranges [
 	}
 	var kvReqs []*kv.Request
 	for i, kvRange := range kvRanges {
+		e.kvRanges = append(e.kvRanges, kvRange...)
 		if err := updateExecutorTableID(ctx, e.dagPB.RootExecutor, pids[i], true); err != nil {
 			return nil, err
 		}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -247,7 +247,7 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		}
 		var results []distsql.SelectResult
 		for _, kvReq := range kvReqs {
-			result, err := e.SelectResult(ctx, e.ctx, kvReq, retTypes(e),e.feedback, getPhysicalPlanIDs(e.plans), e.id)
+			result, err := e.SelectResult(ctx, e.ctx, kvReq, retTypes(e), e.feedback, getPhysicalPlanIDs(e.plans), e.id)
 			if err != nil {
 				return nil, err
 			}

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -54,6 +54,7 @@ func (sr selectResultHook) SelectResult(ctx context.Context, sctx sessionctx.Con
 
 type kvRangeBuilder interface {
 	buildKeyRange(pid int64, ranges []*ranger.Range) ([]kv.KeyRange, error)
+	buildKeyRangeSeparately(ranges []*ranger.Range) ([]int64, [][]kv.KeyRange, error)
 }
 
 // TableReaderExecutor sends DAG request and reads table data from kv layer.
@@ -238,6 +239,23 @@ func (e *TableReaderExecutor) Close() error {
 // buildResp first builds request and sends it to tikv using distsql.Select. It uses SelectResult returned by the callee
 // to fetch all results.
 func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Range) (distsql.SelectResult, error) {
+	if e.storeType == kv.TiFlash && e.kvRangeBuilder != nil {
+		// TiFlash cannot support to access multiple tables/partitions within one KVReq, so we have to build KVReq for each partition separately.
+		kvReqs, err := e.buildKVReqSeparately(ctx, ranges)
+		if err != nil {
+			return nil, err
+		}
+		var results []distsql.SelectResult
+		for _, kvReq := range kvReqs {
+			result, err := e.SelectResult(ctx, e.ctx, kvReq, retTypes(e),e.feedback, getPhysicalPlanIDs(e.plans), e.id)
+			if err != nil {
+				return nil, err
+			}
+			results = append(results, result)
+		}
+		return distsql.NewSerialSelectResults(results), nil
+	}
+
 	kvReq, err := e.buildKVReq(ctx, ranges)
 	if err != nil {
 		return nil, err
@@ -249,6 +267,37 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 		return nil, err
 	}
 	return result, nil
+}
+
+func (e *TableReaderExecutor) buildKVReqSeparately(ctx context.Context, ranges []*ranger.Range) ([]*kv.Request, error) {
+	pids, kvRanges, err := e.kvRangeBuilder.buildKeyRangeSeparately(ranges)
+	if err != nil {
+		return nil, err
+	}
+	var kvReqs []*kv.Request
+	for i, kvRange := range kvRanges {
+		if err := updateExecutorTableID(ctx, e.dagPB.RootExecutor, pids[i], true); err != nil {
+			return nil, err
+		}
+		var builder distsql.RequestBuilder
+		reqBuilder := builder.SetKeyRanges(kvRange)
+		kvReq, err := reqBuilder.
+			SetDAGRequest(e.dagPB).
+			SetStartTS(e.startTS).
+			SetDesc(e.desc).
+			SetKeepOrder(e.keepOrder).
+			SetStreaming(e.streaming).
+			SetFromSessionVars(e.ctx.GetSessionVars()).
+			SetFromInfoSchema(e.ctx.GetInfoSchema()).
+			SetMemTracker(e.memTracker).
+			SetStoreType(e.storeType).
+			SetAllowBatchCop(e.batchCop).Build()
+		if err != nil {
+			return nil, err
+		}
+		kvReqs = append(kvReqs, kvReq)
+	}
+	return kvReqs, nil
 }
 
 func (e *TableReaderExecutor) buildKVReq(ctx context.Context, ranges []*ranger.Range) (*kv.Request, error) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1610,7 +1610,7 @@ func doDMLWorks(s Session) {
 				vVal = strconv.Itoa(variable.DefTiDBRowFormatV2)
 			}
 			if v.Name == variable.TiDBPartitionPruneMode {
-				vVal = string(variable.Static)
+				vVal = variable.DefTiDBPartitionPruneMode
 				if flag.Lookup("test.v") != nil || flag.Lookup("check.v") != nil || config.CheckTableBeforeDrop {
 					// enable Dynamic Prune by default in test case.
 					vVal = string(variable.Dynamic)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1583,7 +1583,7 @@ var defaultSysVars = []*SysVar{
 		s.EnableClusteredIndex = TiDBOptEnableClustered(val)
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPartitionPruneMode, Value: string(Static), Hidden: true, Type: TypeStr, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBPartitionPruneMode, Value: DefTiDBPartitionPruneMode, Hidden: true, Type: TypeStr, Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
 		mode := PartitionPruneMode(normalizedValue).Update()
 		if !mode.Valid() {
 			return normalizedValue, ErrWrongTypeForVar.GenWithStackByArgs(TiDBPartitionPruneMode)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25252 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: solve an incompatible issue about dynamic-mode and TiFlash and enable dynamic mode by default 

### What is changed and how it works?

planner: solve an incompatible issue about dynamic-mode and TiFlash and enable dynamic mode by default.

The Root cause of this incompatible issue is that if the dynamic mode is enabled, `KVRange` of each partition may be built together into a single `KVReq`, but TiFlash cannot support to access multiple partitions/tables within one single `KVReq` now.
So to be compatible with TiFlash, we make `TableReader` specially handle its `KVReq` that building and sending `KVReq` for each partition separately.

This issue was found by the `tics-test` and cannot be caught by `mockkv`, so I didn't add any unit test case for it and let the `tics-test` to cover it.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: solve an incompatible issue about dynamic-mode and TiFlash and enable dynamic mode by default 
