### PR TITLE
plugin: fix audit plugin will cause tidb panic

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -382,13 +382,13 @@ func (s *Server) onConn(conn *clientConn) {
 	s.rwlock.Unlock()
 	metrics.ConnGauge.Set(float64(connections))
 
+	sessionVars := conn.ctx.GetSessionVars()
 	if plugin.IsEnable(plugin.Audit) {
-		conn.ctx.GetSessionVars().ConnectionInfo = conn.connectInfo()
+		sessionVars.ConnectionInfo = conn.connectInfo()
 	}
 	err := plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
 		authPlugin := plugin.DeclareAuditManifest(p.Manifest)
 		if authPlugin.OnConnectionEvent != nil {
-			sessionVars := conn.ctx.GetSessionVars()
 			return authPlugin.OnConnectionEvent(context.Background(), plugin.Connected, sessionVars.ConnectionInfo)
 		}
 		return nil
@@ -401,9 +401,12 @@ func (s *Server) onConn(conn *clientConn) {
 	conn.Run(ctx)
 
 	err = plugin.ForeachPlugin(plugin.Audit, func(p *plugin.Plugin) error {
+		// Audit plugin may be disabled before a conn is created, leading no connectionInfo in sessionVars.
+		if sessionVars.ConnectionInfo == nil {
+			sessionVars.ConnectionInfo = conn.connectInfo()
+		}
 		authPlugin := plugin.DeclareAuditManifest(p.Manifest)
 		if authPlugin.OnConnectionEvent != nil {
-			sessionVars := conn.ctx.GetSessionVars()
 			sessionVars.ConnectionInfo.Duration = float64(time.Since(connectedTime)) / float64(time.Millisecond)
 			err := authPlugin.OnConnectionEvent(context.Background(), plugin.Disconnect, sessionVars.ConnectionInfo)
 			if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/23786

### What is changed and how it works?

What's Changed: fix the sessionVars.connectionInfo may be nil when exit a conn.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)
```
1: tiup playground nightly --tiflash 0  
2: substitute the tidb bin with the ours
3: open a leading conn1 and set the audit plugin as false ( admin plugins disable audit;)
5: open a test conn2
6: enable the audit plugin in the leading con1 ( admin plugins enable audit;)
7: exit the test conn2
```

##### before this pr: tidb panic 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x58 pc=0x2f5de34]
goroutine 809 [running]:
github.com/pingcap/tidb/server.(*Server).onConn.func4(0xc0006d3590, 0xc0006d3380, 0xc00155ddee)
        /home/arenatlx/go/src/github.com/pingcap/tidb/server/server.go:486 +0xb4
github.com/pingcap/tidb/plugin.ForeachPlugin(0xc0011e6d01, 0xc00155df00, 0xc00141ba10, 0x0)
        /home/arenatlx/go/src/github.com/pingcap/tidb/plugin/plugin.go:419 +0x137
github.com/pingcap/tidb/server.(*Server).onConn(0xc0012c2dd0, 0xc0011e6d00)
        /home/arenatlx/go/src/github.com/pingcap/tidb/server/server.go:482 +0xaf9
created by github.com/pingcap/tidb/server.(*Server).Run
        /home/arenatlx/go/src/github.com/pingcap/tidb/server/server.go:383 +0x8d5


##### this pr
HAPPY

### Release note <!-- bugfixes or new feature need a release note -->

- plugin: fix audit plugin will cause tidb panic