### PR TITLE
planner: forbid prepared stale select in txn

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1005,6 +1005,7 @@ const (
 	ErrNotSupportedWithSem                 = 8132
 	ErrDataInConsistentExtraIndex          = 8133
 	ErrDataInConsistentMisMatchIndex       = 8134
+	ErrAsOf                                = 8135
 
 	// Error codes used by TiDB ddl package
 	ErrUnsupportedDDLOperation            = 8200

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1051,6 +1051,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrInvalidPlacementSpec:   mysql.Message("Invalid placement policy '%s': %s", nil),
 	ErrPlacementPolicyCheck:   mysql.Message("Placement policy didn't meet the constraint, reason: %s", nil),
 	ErrMultiStatementDisabled: mysql.Message("client has multi-statement capability disabled. Run SET GLOBAL tidb_multi_statement_mode='ON' after you understand the security risk", nil),
+	ErrAsOf:                   mysql.Message("invalid as of timestamp: %s", nil),
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:           mysql.Message("PD server timeout", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -1211,6 +1211,11 @@ error = '''
 Feature '%s' is not supported when security enhanced mode is enabled
 '''
 
+["planner:8135"]
+error = '''
+invalid as of timestamp: %s
+'''
+
 ["privilege:1141"]
 error = '''
 There is no such grant defined for user '%-.48s' on host '%-.64s'

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -810,7 +810,7 @@ func (s *testStaleTxnSuite) TestStaleSelect(c *C) {
 
 	// test prepared stale select in txn
 	tk.MustExec("begin")
-	tk.MustQuery("execute s").Check(staleRows)
+	c.Assert(tk.ExecToErr(staleSQL), NotNil)
 	tk.MustExec("commit")
 
 	// test stale select in stale txn
@@ -820,7 +820,7 @@ func (s *testStaleTxnSuite) TestStaleSelect(c *C) {
 
 	// test prepared stale select in stale txn
 	tk.MustExec(fmt.Sprintf(`start transaction read only as of timestamp '%s'`, time2.Format("2006-1-2 15:04:05.000")))
-	tk.MustQuery("execute s").Check(staleRows)
+	c.Assert(tk.ExecToErr(staleSQL), NotNil)
 	tk.MustExec("commit")
 
 	// test prepared stale select with schema change

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -260,6 +260,9 @@ func (e *Execute) OptimizePreparedPlan(ctx context.Context, sctx sessionctx.Cont
 
 	var snapshotTS uint64
 	if preparedObj.SnapshotTSEvaluator != nil {
+		if vars.InTxn() {
+			return ErrAsOf.FastGenWithCause("as of timestamp can't be set in transaction.")
+		}
 		// if preparedObj.SnapshotTSEvaluator != nil, it is a stale read SQL:
 		// which means its infoschema is specified by the SQL, not the current/latest infoschema
 		var err error

--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -97,8 +97,7 @@ var (
 	ErrAccessDenied        = dbterror.ClassOptimizer.NewStdErr(mysql.ErrAccessDenied, mysql.MySQLErrName[mysql.ErrAccessDeniedNoPassword])
 	ErrBadNull             = dbterror.ClassOptimizer.NewStd(mysql.ErrBadNull)
 	ErrNotSupportedWithSem = dbterror.ClassOptimizer.NewStd(mysql.ErrNotSupportedWithSem)
-	ErrDifferentAsOf       = dbterror.ClassOptimizer.NewStd(mysql.ErrUnknown)
-	ErrAsOf                = dbterror.ClassOptimizer.NewStd(mysql.ErrUnknown)
+	ErrAsOf                = dbterror.ClassOptimizer.NewStd(mysql.ErrAsOf)
 	ErrOptOnTemporaryTable = dbterror.ClassOptimizer.NewStd(mysql.ErrOptOnTemporaryTable)
 	// ErrPartitionNoTemporary returns when partition at temporary mode
 	ErrPartitionNoTemporary = dbterror.ClassOptimizer.NewStd(mysql.ErrPartitionNoTemporary)

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -1454,7 +1454,7 @@ func (p *preprocessor) handleAsOfAndReadTS(node *ast.AsOfClause) {
 		}
 	}
 	if p.LastSnapshotTS != ts {
-		p.err = ErrDifferentAsOf.GenWithStack("can not set different time in the as of")
+		p.err = ErrAsOf.GenWithStack("can not set different time in the as of")
 		return
 	}
 	if p.LastSnapshotTS != 0 {


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

### What problem does this PR solve?

Problem Summary: https://github.com/pingcap/tidb/pull/25156#discussion_r649929163. Forbid prepared stale select in all txns.

### What is changed and how it works?

What's Changed:

1. Prepared stale select is forbidden in all txn.
2. Error is refined. `Unknown error!%(Extra string...`, the original error is like so. It is so ugly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- Forbid prepared stale select in transactions
