### PR TITLE
*: change SHOW CONFIG to require CONFIG privilege

### DIFF
--- a/docs/design/2021-03-09-security-enhanced-mode.md
+++ b/docs/design/2021-03-09-security-enhanced-mode.md
@@ -145,7 +145,7 @@ All tables will be hidden, including the schema itself unless the user has the `
 
 ### Commands
 
-* `SHOW CONFIG` is disabled.
+* `SHOW CONFIG` is changed to require the `CONFIG` privilege (with or without SEM enabled).
 * `SET CONFIG` is disabled by the `CONFIG` Privilege (no change necessary)
 * The `BACKUP` and `RESTORE` commands prevent local backups and restores.
 * The statement `SELECT .. INTO OUTFILE` is disabled (this is the only current usage of the `FILE` privilege, effectively disabling `FILE`. For compatibility `GRANT` and `REVOKE` of `FILE` will not be affected.)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -9430,12 +9430,8 @@ func (s *testIntegrationSuite) TestSecurityEnhancedMode(c *C) {
 
 	// When SEM is enabled these features are restricted to all users
 	// regardless of what privileges they have available.
-
-	_, err := tk.Exec("SHOW CONFIG")
-	c.Assert(err.Error(), Equals, "[planner:8132]Feature 'SHOW CONFIG' is not supported when security enhanced mode is enabled")
-	_, err = tk.Exec("SELECT 1 INTO OUTFILE '/tmp/aaaa'")
+	_, err := tk.Exec("SELECT 1 INTO OUTFILE '/tmp/aaaa'")
 	c.Assert(err.Error(), Equals, "[planner:8132]Feature 'SELECT INTO' is not supported when security enhanced mode is enabled")
-
 }
 
 func (s *testIntegrationSuite) TestIssue23925(c *C) {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1302,6 +1302,12 @@ func (s *testPlanSuite) TestVisitInfo(c *C) {
 				{mysql.CreateUserPriv, "", "", "", ErrSpecificAccessDenied, false, "", false},
 			},
 		},
+		{
+			sql: "SHOW CONFIG",
+			ans: []visitInfo{
+				{mysql.ConfigPriv, "", "", "", ErrSpecificAccessDenied, false, "", false},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2252,6 +2252,9 @@ func (b *PlanBuilder) buildShow(ctx context.Context, show *ast.ShowStmt) (Plan, 
 			isView = table.Meta().IsView()
 			isSequence = table.Meta().IsSequence()
 		}
+	case ast.ShowConfig:
+		privErr := ErrSpecificAccessDenied.GenWithStackByArgs("CONFIG")
+		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ConfigPriv, "", "", "", privErr)
 	case ast.ShowCreateView:
 		err := ErrSpecificAccessDenied.GenWithStackByArgs("SHOW VIEW")
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShowViewPriv, show.Table.Schema.L, show.Table.Name.L, "", err)

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -36,7 +36,6 @@ import (
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/domainutil"
 	utilparser "github.com/pingcap/tidb/util/parser"
-	"github.com/pingcap/tidb/util/sem"
 )
 
 // PreprocessOpt presents optional parameters to `Preprocess` method.
@@ -1335,9 +1334,6 @@ func (p *preprocessor) handleRepairName(tn *ast.TableName) {
 }
 
 func (p *preprocessor) resolveShowStmt(node *ast.ShowStmt) {
-	if sem.IsEnabled() && node.Tp == ast.ShowConfig {
-		p.err = ErrNotSupportedWithSem.GenWithStackByArgs("SHOW CONFIG")
-	}
 	if node.DBName == "" {
 		if node.Table != nil && node.Table.Schema.L != "" {
 			node.DBName = node.Table.Schema.O

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -924,9 +924,12 @@ func (s *testPrivilegeSuite) TestConfigPrivilege(c *C) {
 	mustExec(c, se, `REVOKE CONFIG ON *.* FROM tcd2`)
 
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "tcd1", Hostname: "localhost", AuthHostname: "tcd1", AuthUsername: "%"}, nil, nil), IsTrue)
+	mustExec(c, se, `SHOW CONFIG`)
 	mustExec(c, se, `SET CONFIG TIKV testkey="testval"`)
 	c.Assert(se.Auth(&auth.UserIdentity{Username: "tcd2", Hostname: "localhost", AuthHostname: "tcd2", AuthUsername: "%"}, nil, nil), IsTrue)
-	_, err := se.ExecuteInternal(context.Background(), `SET CONFIG TIKV testkey="testval"`)
+	_, err := se.ExecuteInternal(context.Background(), `SHOW CONFIG`)
+	c.Assert(err, ErrorMatches, ".*you need \\(at least one of\\) the CONFIG privilege\\(s\\) for this operation")
+	_, err = se.ExecuteInternal(context.Background(), `SET CONFIG TIKV testkey="testval"`)
 	c.Assert(err, ErrorMatches, ".*you need \\(at least one of\\) the CONFIG privilege\\(s\\) for this operation")
 	mustExec(c, se, `DROP USER tcd1, tcd2`)
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

The original design document for SEM specified that `SHOW CONFIG` would be disabled, but `SET CONFIG` is still permitted with the config privilege. From further discussion, this is a weird behavior, since `SET CONFIG` is not useful when `SHOW CONFIG` is disabled.

Since it is desired that `SHOW CONFIG` is hidden from lower privileged users, the next discussion topic is what permission should it require? Since `SET CONFIG` requires the `CONFIG` privilege, the natural conclusion is that `SHOW CONFIG` should also.

This PR makes this change to the privileges, and updates the original proposal.

### What is changed and how it works?

What's Changed:

The `SHOW CONFIG` statement now requires the `CONFIG` privileges to be assigned.

### Related changes

- None

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

Side effects

- Breaking backward compatibility (not expected to be a major use-case broken, but it is still a compatibility change)

### Release note <!-- bugfixes or new feature need a release note -->

- The `SHOW CONFIG` statement now requires the `CONFIG` privileges to be assigned.