### PR TITLE
variable: set max duration of gc interval/lifetime to 365 days

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1675,8 +1675,8 @@ var defaultSysVars = []*SysVar{
 
 	/* tikv gc metrics */
 	{Scope: ScopeGlobal, Name: TiDBGCEnable, Value: On, Type: TypeBool},
-	{Scope: ScopeGlobal, Name: TiDBGCRunInterval, Value: "10m0s", Type: TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: math.MaxInt64},
-	{Scope: ScopeGlobal, Name: TiDBGCLifetime, Value: "10m0s", Type: TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: math.MaxInt64},
+	{Scope: ScopeGlobal, Name: TiDBGCRunInterval, Value: "10m0s", Type: TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: uint64(time.Hour * 24 * 365)},
+	{Scope: ScopeGlobal, Name: TiDBGCLifetime, Value: "10m0s", Type: TypeDuration, MinValue: int64(time.Minute * 10), MaxValue: uint64(time.Hour * 24 * 365)},
 	{Scope: ScopeGlobal, Name: TiDBGCConcurrency, Value: "-1", Type: TypeInt, MinValue: 1, MaxValue: 128, AllowAutoValue: true},
 	{Scope: ScopeGlobal, Name: TiDBGCScanLockMode, Value: "PHYSICAL", Type: TypeEnum, PossibleValues: []string{"PHYSICAL", "LEGACY"}},
 	{Scope: ScopeGlobal, Name: TiDBGCScanLockMode, Value: "LEGACY", Type: TypeEnum, PossibleValues: []string{"PHYSICAL", "LEGACY"}},


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

In https://github.com/pingcap/docs/pull/5752 I am working through a PR to document min/max, scope etc of system variables by generating it from the TiDB server source. This has revealed that the max values for gc interval/lifetime are quite large (292 years).

It is a very minor issue, but in this PR I propose we change it to 365 days. It is inspired by similar "time based" values in MySQL such as https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_lock_wait_timeout (1 year). The rationale for the change is that Golang doesn't print 292 years in a user-friendly way.

### What is changed and how it works?

What's Changed:

The maximum duration for gc interval/lifetime changes from 292 years to 365 days. This is not expected to cause issues for users, since the typical range is specified in minutes to hours.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test (covered by existing tests)

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- The maximum duration for gc interval/lifetime changes from 292 years to 365 days. This is not expected to cause issues for users, since the typical range is specified in minutes to hours.