### PR TITLE
txn: fix panic on duplicate insert on index column len longer than data len

### DIFF
--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -1526,14 +1526,3 @@ func (s *testRecoverTable) TestRenameMultiTables(c *C) {
 	tk.MustExec("drop database rename2")
 	tk.MustExec("drop database rename3")
 }
-
-// See https://github.com/pingcap/tidb/issues/24582
-func (s *testSuite6) TestDuplicatedEntryErr(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec("drop table if exists t1;")
-	tk.MustExec("create table t1(a int, b varchar(20), primary key(a,b(3)) clustered);")
-	tk.MustExec("insert into t1 values(1,'aaaaa');")
-	_, err := tk.Exec("insert into t1 values(1,'aaaaa');")
-	c.Assert(err.Error(), Equals, "[kv:1062]Duplicate entry '1-aaa' for key 'PRIMARY'")
-}

--- a/store/driver/txn/error.go
+++ b/store/driver/txn/error.go
@@ -94,7 +94,7 @@ func extractKeyExistsErrFromHandle(key kv.Key, value []byte, tblInfo *model.Tabl
 		if err != nil {
 			return genKeyExistsError(name, key.String(), err)
 		}
-		if col.Length > 0 {
+		if col.Length > 0 && len(str) > col.Length {
 			str = str[:col.Length]
 		}
 		valueStr = append(valueStr, str)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25377 <!-- REMOVE this line if no issue to close -->

Problem Summary:

insert 'abc' into index col1 defined as `index(col1(4)`, will make slice by `col1-data[:4]` and paniced

and this is introduced by https://github.com/pingcap/tidb/pull/24831, only affect on master and not-public 5.1 version

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed, How it Works:

substring only data length > index column length

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
