### PR TITLE
store/tikv: sort keys in batch get

### DIFF
--- a/store/tikv/test_probe.go
+++ b/store/tikv/test_probe.go
@@ -16,6 +16,7 @@ package tikv
 import (
 	"bytes"
 	"context"
+	"sort"
 	"sync/atomic"
 	"time"
 
@@ -142,6 +143,7 @@ func (txn TxnProbe) CollectLockedKeys() [][]byte {
 // BatchGetSingleRegion gets a batch of keys from a region.
 func (txn TxnProbe) BatchGetSingleRegion(bo *Backoffer, region locate.RegionVerID, keys [][]byte, collect func([]byte, []byte)) error {
 	snapshot := txn.GetSnapshot()
+	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
 	return snapshot.batchGetSingleRegion(bo, batchKeys{region: region, keys: keys}, collect)
 }
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #https://github.com/pingcap/tidb/issues/25412
Problem Summary:

Batch-get assumes `batchKeys` is in order which is wrong.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Make keys in order.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- No code

Side effects

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.
