### PR TITLE
store/tikv: avoid using unistore failpoints

### DIFF
--- a/store/tikv/tests/async_commit_fail_test.go
+++ b/store/tikv/tests/async_commit_fail_test.go
@@ -49,9 +49,9 @@ func (s *testAsyncCommitFailSuite) TestFailAsyncCommitPrewriteRpcErrors(c *C) {
 	}
 
 	c.Assert(failpoint.Enable("tikvclient/noRetryOnRpcError", "return(true)"), IsNil)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout", `return(true)`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcPrewriteTimeout", `return(true)`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteTimeout"), IsNil)
+		c.Assert(failpoint.Disable("tikvclient/rpcPrewriteTimeout"), IsNil)
 		c.Assert(failpoint.Disable("tikvclient/noRetryOnRpcError"), IsNil)
 	}()
 	// The rpc error will be wrapped to ErrResultUndetermined.
@@ -90,9 +90,9 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitPrewriteCancelled(c *C) {
 	s.cluster.Split(loc.Region.GetID(), newRegionID, []byte(splitKey), []uint64{newPeerID}, newPeerID)
 	s.store.GetRegionCache().InvalidateCachedRegion(loc.Region)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("writeConflict")->sleep(50)`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcPrewriteResult", `1*return("writeConflict")->sleep(50)`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
+		c.Assert(failpoint.Disable("tikvclient/rpcPrewriteResult"), IsNil)
 	}()
 
 	t1 := s.beginAsyncCommit(c)
@@ -246,9 +246,9 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitRPCErrorThenWriteConflict(c *C
 	err := txn.Set([]byte("a"), []byte("va"))
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
+		c.Assert(failpoint.Disable("tikvclient/rpcPrewriteResult"), IsNil)
 	}()
 
 	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
@@ -269,11 +269,11 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitRPCErrorThenWriteConflictInChi
 	err := txn.Set([]byte("a"), []byte("va"))
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
 	c.Assert(failpoint.Enable("tikvclient/forceRecursion", `return`), IsNil)
 
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
+		c.Assert(failpoint.Disable("tikvclient/rpcPrewriteResult"), IsNil)
 		c.Assert(failpoint.Disable("tikvclient/forceRecursion"), IsNil)
 	}()
 

--- a/store/tikv/tests/async_commit_test.go
+++ b/store/tikv/tests/async_commit_test.go
@@ -57,7 +57,7 @@ func (s *testAsyncCommitCommon) setUpTest(c *C) {
 	c.Assert(err, IsNil)
 	unistore.BootstrapWithSingleStore(cluster)
 	s.cluster = cluster
-	store, err := tikv.NewTestTiKVStore(client, pdClient, nil, nil, 0)
+	store, err := tikv.NewTestTiKVStore(fpClient{Client: client}, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 
 	s.store = store

--- a/store/tikv/tests/client_fp_test.go
+++ b/store/tikv/tests/client_fp_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tikv/client-go/v2/tikvrpc"
 )
 
+// mock TiKV RPC client that hooks message by failpoint
 type fpClient struct {
 	client.Client
 }

--- a/store/tikv/tests/client_fp_test.go
+++ b/store/tikv/tests/client_fp_test.go
@@ -1,0 +1,96 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tikv_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/kvrpcpb"
+	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/store/tikv/util"
+	"github.com/tikv/client-go/v2/client"
+	"github.com/tikv/client-go/v2/tikvrpc"
+)
+
+type fpClient struct {
+	client.Client
+}
+
+func (c fpClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.Request, timeout time.Duration) (*tikvrpc.Response, error) {
+	switch req.Type {
+	case tikvrpc.CmdPrewrite:
+		if val, err := util.EvalFailpoint("rpcPrewriteResult"); err == nil && val != nil {
+			switch val.(string) {
+			case "timeout":
+				return nil, errors.New("timeout")
+			case "writeConflict":
+				return &tikvrpc.Response{
+					Resp: &kvrpcpb.PrewriteResponse{Errors: []*kvrpcpb.KeyError{{Conflict: &kvrpcpb.WriteConflict{}}}},
+				}, nil
+			}
+		}
+	case tikvrpc.CmdBatchGet:
+		batchGetReq := req.BatchGet()
+		if val, err := util.EvalFailpoint("rpcBatchGetResult"); err == nil {
+			switch val.(string) {
+			case "keyError":
+				return &tikvrpc.Response{
+					Resp: &kvrpcpb.BatchGetResponse{Error: &kvrpcpb.KeyError{
+						Locked: &kvrpcpb.LockInfo{
+							PrimaryLock: batchGetReq.Keys[0],
+							LockVersion: batchGetReq.Version - 1,
+							Key:         batchGetReq.Keys[0],
+							LockTtl:     50,
+							TxnSize:     1,
+							LockType:    kvrpcpb.Op_Put,
+						},
+					}},
+				}, nil
+			}
+		}
+	case tikvrpc.CmdScan:
+		kvScanReq := req.Scan()
+		if val, err := util.EvalFailpoint("rpcScanResult"); err == nil {
+			switch val.(string) {
+			case "keyError":
+				return &tikvrpc.Response{
+					Resp: &kvrpcpb.ScanResponse{Error: &kvrpcpb.KeyError{
+						Locked: &kvrpcpb.LockInfo{
+							PrimaryLock: kvScanReq.StartKey,
+							LockVersion: kvScanReq.Version - 1,
+							Key:         kvScanReq.StartKey,
+							LockTtl:     50,
+							TxnSize:     1,
+							LockType:    kvrpcpb.Op_Put,
+						},
+					}},
+				}, nil
+			}
+		}
+	}
+
+	res, err := c.Client.SendRequest(ctx, addr, req, timeout)
+
+	switch req.Type {
+	case tikvrpc.CmdPrewrite:
+		if val, err := util.EvalFailpoint("rpcPrewriteTimeout"); err == nil {
+			if val.(bool) {
+				return nil, terror.ErrResultUndetermined
+			}
+		}
+	}
+	return res, err
+}

--- a/store/tikv/tests/snapshot_fail_test.go
+++ b/store/tikv/tests/snapshot_fail_test.go
@@ -38,7 +38,7 @@ func (s *testSnapshotFailSuite) SetUpSuite(c *C) {
 	client, pdClient, cluster, err := unistore.New("")
 	c.Assert(err, IsNil)
 	unistore.BootstrapWithSingleStore(cluster)
-	store, err := tikv.NewTestTiKVStore(client, pdClient, nil, nil, 0)
+	store, err := tikv.NewTestTiKVStore(fpClient{Client: client}, pdClient, nil, nil, 0)
 	c.Assert(err, IsNil)
 	s.store = tikv.StoreProbe{KVStore: store}
 }
@@ -78,9 +78,9 @@ func (s *testSnapshotFailSuite) TestBatchGetResponseKeyError(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcBatchGetResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcBatchGetResult", `1*return("keyError")`), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcBatchGetResult"), IsNil)
+		c.Assert(failpoint.Disable("tikvclient/rpcBatchGetResult"), IsNil)
 	}()
 
 	txn, err = s.store.Begin()
@@ -109,7 +109,7 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	err = txn.Commit(context.Background())
 	c.Assert(err, IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcScanResult", `1*return("keyError")`), IsNil)
 	txn, err = s.store.Begin()
 	c.Assert(err, IsNil)
 	iter, err := txn.Iter([]byte("a"), []byte("z"))
@@ -124,9 +124,9 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(iter.Value(), DeepEquals, []byte("v3"))
 	c.Assert(iter.Next(), IsNil)
 	c.Assert(iter.Valid(), IsFalse)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
+	c.Assert(failpoint.Disable("tikvclient/rpcScanResult"), IsNil)
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult", `1*return("keyError")`), IsNil)
+	c.Assert(failpoint.Enable("tikvclient/rpcScanResult", `1*return("keyError")`), IsNil)
 	txn, err = s.store.Begin()
 	c.Assert(err, IsNil)
 	iter, err = txn.Iter([]byte("k2"), []byte("k4"))
@@ -138,7 +138,7 @@ func (s *testSnapshotFailSuite) TestScanResponseKeyError(c *C) {
 	c.Assert(iter.Value(), DeepEquals, []byte("v3"))
 	c.Assert(iter.Next(), IsNil)
 	c.Assert(iter.Valid(), IsFalse)
-	c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcScanResult"), IsNil)
+	c.Assert(failpoint.Disable("tikvclient/rpcScanResult"), IsNil)
 }
 
 func (s *testSnapshotFailSuite) TestRetryMaxTsPointGetSkipLock(c *C) {


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?
tests in `store/tikv/tests` use some failpoints of `unistore`. They cannot work if we move tests to `tikv/client-go`.

Part of https://github.com/pingcap/tidb/issues/22513

### What is changed and how it works?
What's Changed:
- define new failpoints in `tests` to replace

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note