### PR TITLE
executor: check the length of lookUpContent in prunePartitionForInnerExecutor

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2842,6 +2842,9 @@ func prunePartitionForInnerExecutor(ctx sessionctx.Context, tbl table.Table, sch
 	}
 
 	// recalculate key column offsets
+	if len(lookUpContent) == 0 {
+		return nil, false, nil, nil
+	}
 	if lookUpContent[0].keyColIDs == nil {
 		return nil, false, nil,
 			dbterror.ClassOptimizer.NewStd(mysql.ErrInternal).GenWithStack("cannot get column IDs when dynamic pruning")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25309 <!-- REMOVE this line if no issue to close -->

Problem Summary:

Use `lookUpContent[0]` without checking the length of it. And then cause panic here.

### What is changed and how it works?

What's Changed:

How it Works:

Check the length of `lookUpContent` before using it.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- executor: check the length of lookUpContent in prunePartitionForInnerExecutor