### PR TITLE
store/tikv: interate all keys in relocate of batch-get

### DIFF
--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -21,7 +21,6 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
-	"unsafe"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -151,6 +150,7 @@ func (s *KVSnapshot) SetSnapshotTS(ts uint64) {
 
 // BatchGet gets all the keys' value from kv-server and returns a map contains key/value pairs.
 // The map will not contain nonexistent keys.
+// NOTE: Don't modify keys. Some codes rely on the order of keys.
 func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]byte, error) {
 	// Check the cached value first.
 	m := make(map[string][]byte)
@@ -175,14 +175,12 @@ func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]
 		return m, nil
 	}
 
-	// We want [][]byte instead of []kv.Key, use some magic to save memory.
-	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
 	ctx = context.WithValue(ctx, retry.TxnStartKey, s.version)
 	bo := retry.NewBackofferWithVars(ctx, batchGetMaxBackoff, s.vars)
 
 	// Create a map to collect key-values from region servers.
 	var mu sync.Mutex
-	err := s.batchGetKeysByRegions(bo, bytesKeys, func(k, v []byte) {
+	err := s.batchGetKeysByRegions(bo, keys, func(k, v []byte) {
 		if len(v) == 0 {
 			return
 		}
@@ -236,13 +234,15 @@ type batchKeys struct {
 }
 
 func (b *batchKeys) relocate(bo *Backoffer, c *RegionCache) (bool, error) {
-	begin, end := b.keys[0], b.keys[len(b.keys)-1]
-	loc, err := c.LocateKey(bo, begin)
+	loc, err := c.LocateKey(bo, b.keys[0])
 	if err != nil {
 		return false, errors.Trace(err)
 	}
-	if !loc.Contains(end) {
-		return false, nil
+	// keys is not in order, so we have to iterate all keys.
+	for i := 1; i < len(b.keys); i++ {
+		if !loc.Contains(b.keys[i]) {
+			return false, nil
+		}
 	}
 	b.region = loc.Region
 	return true, nil

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
@@ -175,12 +175,14 @@ func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]
 		return m, nil
 	}
 
+	// We want [][]byte instead of []kv.Key, use some magic to save memory.
+	bytesKeys := *(*[][]byte)(unsafe.Pointer(&keys))
 	ctx = context.WithValue(ctx, retry.TxnStartKey, s.version)
 	bo := retry.NewBackofferWithVars(ctx, batchGetMaxBackoff, s.vars)
 
 	// Create a map to collect key-values from region servers.
 	var mu sync.Mutex
-	err := s.batchGetKeysByRegions(bo, keys, func(k, v []byte) {
+	err := s.batchGetKeysByRegions(bo, bytesKeys, func(k, v []byte) {
 		if len(v) == 0 {
 			return
 		}
@@ -230,8 +232,7 @@ func (s *KVSnapshot) BatchGet(ctx context.Context, keys [][]byte) (map[string][]
 
 type batchKeys struct {
 	region locate.RegionVerID
-	// keys are in ascending order.
-	keys [][]byte
+	keys   [][]byte
 }
 
 func (b *batchKeys) relocate(bo *Backoffer, c *RegionCache) (bool, error) {
@@ -268,8 +269,6 @@ func (s *KVSnapshot) batchGetKeysByRegions(bo *Backoffer, keys [][]byte, collect
 	defer func(start time.Time) {
 		metrics.TxnCmdHistogramWithBatchGet.Observe(time.Since(start).Seconds())
 	}(time.Now())
-	// Sort keys so that keys located in the same region only require 1 request.
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
 	groups, _, err := s.store.regionCache.GroupKeysByRegion(bo, keys, nil)
 	if err != nil {
 		return errors.Trace(err)

--- a/store/tikv/test_probe.go
+++ b/store/tikv/test_probe.go
@@ -16,7 +16,6 @@ package tikv
 import (
 	"bytes"
 	"context"
-	"sort"
 	"sync/atomic"
 	"time"
 
@@ -143,7 +142,6 @@ func (txn TxnProbe) CollectLockedKeys() [][]byte {
 // BatchGetSingleRegion gets a batch of keys from a region.
 func (txn TxnProbe) BatchGetSingleRegion(bo *Backoffer, region locate.RegionVerID, keys [][]byte, collect func([]byte, []byte)) error {
 	snapshot := txn.GetSnapshot()
-	sort.Slice(keys, func(i, j int) bool { return bytes.Compare(keys[i], keys[j]) < 0 })
 	return snapshot.batchGetSingleRegion(bo, batchKeys{region: region, keys: keys}, collect)
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

https://github.com/pingcap/tidb/pull/25416 changes the order of keys in batch-get, but some codes rely on the order of keys. 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

Instead of sorting, iterate all keys in relocate.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects
### Release note <!-- bugfixes or new feature need a release note -->

- No release note.