### PR TITLE
domain: fix sysvar cache leak

### DIFF
--- a/domain/sysvar_cache.go
+++ b/domain/sysvar_cache.go
@@ -140,6 +140,7 @@ func (svc *SysVarCache) RebuildSysVarCache(ctx sessionctx.Context) error {
 
 	svc.Lock()
 	defer svc.Unlock()
+	svc.session, svc.global = nil, nil // free old maps
 	svc.session = newSessionCache
 	svc.global = newGlobalCache
 	return nil


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25352

Problem Summary:

There is a leak in `LoadSysVarCacheLoop`. I believe it is caused by the GC not correctly detecting that references to the old cache have been removed. This is my attempt to force free'ing of the old map (under a lock). Reads of the map are under a RLock, so this should be safe.

I appreciate the review / second opinion if you interpret the leak differently.

### What is changed and how it works?

What's Changed:

A potential memory leak when refreshing system variables has been fixed.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Manual test (add detailed scripts or steps below)

I tried to run the leak test to identify this leak but could not reproduce. I tried to run it after, and also couldn't reproduce :-) So this is a best guess.

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- A potential memory leak when refreshing system variables has been fixed.