### PR TITLE
server: add gzip compressor in tidb grpc server

### DIFF
--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -36,6 +36,7 @@ import (
 	"github.com/tikv/client-go/v2/tikv"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	_ "google.golang.org/grpc/encoding/gzip"
 	"google.golang.org/grpc/peer"
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
If the `gzip` config is used, the tidb grpc server side may not have the corresponding compressor and the query on the `cluster_xxx` table may fail.

### What is changed and how it works?

What's Changed:
Try to registe the compressor.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


Side effects



### Release note <!-- bugfixes or new feature need a release note -->

- Registe the comprassor in tidb grpc server side.
