### PR TITLE
planner: fix begin statement consumed read_ts wrongly

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -470,6 +470,7 @@ func (s *testStaleTxnSerialSuite) TestSetTransactionReadOnlyAsOf(c *C) {
 	c.Assert(err.Error(), Equals, "start transaction read only as of is forbidden after set transaction read only as of")
 
 	tk.MustExec("begin")
+	c.Assert(tk.Se.GetSessionVars().TxnReadTS.PeakTxnReadTS(), Equals, uint64(424394603102208000))
 	tk.MustExec("commit")
 	tk.MustExec(`START TRANSACTION READ ONLY AS OF TIMESTAMP '2020-09-06 00:00:00'`)
 }

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -465,6 +465,13 @@ func (s *testStaleTxnSerialSuite) TestSetTransactionReadOnlyAsOf(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "start transaction read only as of is forbidden after set transaction read only as of")
 	tk.MustExec(`SET TRANSACTION READ ONLY as of timestamp '2021-04-21 00:42:12'`)
+	err = tk.ExecToErr(`START TRANSACTION READ ONLY AS OF TIMESTAMP '2020-09-06 00:00:00'`)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "start transaction read only as of is forbidden after set transaction read only as of")
+
+	tk.MustExec("begin")
+	tk.MustExec("commit")
+	tk.MustExec(`START TRANSACTION READ ONLY AS OF TIMESTAMP '2020-09-06 00:00:00'`)
 }
 
 func (s *testStaleTxnSerialSuite) TestValidateReadOnlyInStalenessTransaction(c *C) {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2414,7 +2414,7 @@ func (b *PlanBuilder) buildSimple(ctx context.Context, node ast.StmtNode) (Plan,
 	case *ast.ShutdownStmt:
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShutdownPriv, "", "", "", nil)
 	case *ast.BeginStmt:
-		readTS := b.ctx.GetSessionVars().TxnReadTS.UseTxnReadTS()
+		readTS := b.ctx.GetSessionVars().TxnReadTS.PeakTxnReadTS()
 		if raw.AsOf != nil {
 			startTS, err := calculateTsExpr(b.ctx, raw.AsOf)
 			if err != nil {
@@ -2423,6 +2423,8 @@ func (b *PlanBuilder) buildSimple(ctx context.Context, node ast.StmtNode) (Plan,
 			p.StaleTxnStartTS = startTS
 		} else if readTS > 0 {
 			p.StaleTxnStartTS = readTS
+			// consume read ts here
+			b.ctx.GetSessionVars().TxnReadTS.UseTxnReadTS()
 		}
 	}
 	return p, nil


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
The following behavior is not expected.
```sql
mysql> set transaction read only as of timestamp '2021-06-16 11:20:00';
Query OK, 0 rows affected (0.05 sec)

mysql> delete from t1 where id=3;
ERROR 1105 (HY000): only support read-only statement during read-only staleness transactions
mysql> commit;
Query OK, 0 rows affected (0.05 sec)

mysql> start transaction read only as of timestamp now()-interval 1 minute;
ERROR 1105 (HY000): start transaction read only as of is forbidden after set transaction read only as of
mysql> start transaction read only as of timestamp now()-interval 1 minute;
Query OK, 0 rows affected (0.05 sec)
```


### What is changed and how it works?

Fix that the read_ts would be consumed wrongly.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

* No release note
