### PR TITLE
executor: fix a stupid mistake in `filterTemporaryTableKeys()` function

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1026,7 +1026,7 @@ func filterTemporaryTableKeys(vars *variable.SessionVars, keys []kv.Key) []kv.Ke
 		return keys
 	}
 
-	newKeys := keys[:]
+	newKeys := keys[:0:len(keys)]
 	for _, key := range keys {
 		tblID := tablecodec.DecodeTableID(key)
 		if _, ok := txnCtx.GlobalTemporaryTables[tblID]; !ok {

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -29,15 +29,18 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/kv"
 	plannerutil "github.com/pingcap/tidb/planner/util"
 	txninfo "github.com/pingcap/tidb/session/txninfo"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/ranger"
+	"github.com/pingcap/tidb/util/tableutil"
 )
 
 var _ = Suite(&testExecSuite{})
@@ -548,4 +551,15 @@ func getGrowing(m aggPartialResultMapper) bool {
 	point := (**hmap)(unsafe.Pointer(&m))
 	value := *point
 	return value.oldbuckets != nil
+}
+
+func (s *pkgTestSuite) TestFilterTemporaryTableKeys(c *C) {
+	vars := variable.NewSessionVars()
+	const tableID int64 = 3
+	vars.TxnCtx = &variable.TransactionContext{
+		GlobalTemporaryTables: map[int64]tableutil.TempTable{tableID: nil},
+	}
+
+	res := filterTemporaryTableKeys(vars, []kv.Key{tablecodec.EncodeTablePrefix(tableID), tablecodec.EncodeTablePrefix(42)})
+	c.Assert(res, HasLen, 1)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

What's Changed:

A silly mistake in https://github.com/pingcap/tidb/pull/24737/files#diff-4c9a4c1e9a402d07a0a78f4db9f766d23f1ff57ceda1e75c4e83b579488ad301R1037

Should use `[:0]`, but use `[:]`

How it Works:

Fix bug

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)
- No code


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
