### PR TITLE
planner,executor: fix point get for update read panic on partition table

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -3023,8 +3023,8 @@ func (s *partitionTableSuite) TestIssue25528(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("set @@tidb_partition_prune_mode = 'static'")
 	tk.MustExec("use test")
-	tk.MustExec("create table t1(id int primary key, balance DECIMAL(10, 2), balance2 DECIMAL(10, 2) GENERATED ALWAYS AS (-balance) VIRTUAL, created_at TIMESTAMP) PARTITION BY HASH(id) PARTITIONS 8")
-	tk.MustExec("insert into t1(id, balance, created_at) values(1, 100, '2021-06-17 22:35:20')")
+	tk.MustExec("create table issue25528 (id int primary key, balance DECIMAL(10, 2), balance2 DECIMAL(10, 2) GENERATED ALWAYS AS (-balance) VIRTUAL, created_at TIMESTAMP) PARTITION BY HASH(id) PARTITIONS 8")
+	tk.MustExec("insert into issue25528 (id, balance, created_at) values(1, 100, '2021-06-17 22:35:20')")
 	tk.MustExec("begin pessimistic")
-	tk.MustQuery("select * from t1 where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
+	tk.MustQuery("select * from issue25528 where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
 }

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -732,6 +732,15 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 				if hashPartColName == nil {
 					canConvertPointGet = false
 				}
+			} else {
+				// If the schema contains ExtraPidColID, do not convert to point get.
+				// Because the point get executor can not handle the extra partition ID column now.
+				for _, col := range ds.schema.Columns {
+					if col.ID == model.ExtraPidColID {
+						canConvertPointGet = false
+						break
+					}
+				}
 			}
 		}
 		if canConvertPointGet {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25528

Problem Summary:

https://github.com/pingcap/tidb/pull/21148 add an extra partition ID column for the select lock executor, the table reader can handle it, but I forget the point / batch point get executor.

### What is changed and how it works?

What's Changed:

Do not convert to point get executor for that case.
I see #21148 is already cherry picked to 5.1 and it introduce this bug, so it's better to fix the bug quickly.
This fix is simplest.

How it Works:

Avoid generate point get executor for that case.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression
    - Consumes more CPU

### Release note <!-- bugfixes or new feature need a release note -->

Fix a bug which is caused by prior bug fix PR

- No release note
