### PR TITLE
planner: forbid BatchPointGet on tables partitioned by compound expressions

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -695,6 +695,7 @@ func (s *partitionTableSuite) TestIssue25527(c *C) {
 	tk.MustExec("set @@tidb_partition_prune_mode = 'dynamic'")
 	tk.MustExec("set @@session.tidb_enable_list_partition = ON")
 
+	// the original case
 	tk.MustExec(`CREATE TABLE t (
 		  col1 tinyint(4) primary key
 		) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PARTITION BY HASH( COL1 DIV 80 )
@@ -703,6 +704,23 @@ func (s *partitionTableSuite) TestIssue25527(c *C) {
 	tk.MustExec(`prepare stmt from 'select col1 from t where col1 in (?, ?, ?)'`)
 	tk.MustExec(`set @a=-128, @b=107, @c=-128`)
 	tk.MustQuery(`execute stmt using @a,@b,@c`).Sort().Check(testkit.Rows("-128", "107"))
+
+	// the minimal reproducible case for hash partitioning
+	tk.MustExec(`CREATE TABLE t0 (a int primary key) PARTITION BY HASH( a DIV 80 ) PARTITIONS 2`)
+	tk.MustExec(`insert into t0 values (1)`)
+	tk.MustQuery(`select a from t0 where a in (1)`).Check(testkit.Rows("1"))
+
+	// the minimal reproducible case for range partitioning
+	tk.MustExec(`create table t1 (a int primary key) partition by range (a+5) (
+		partition p0 values less than(10), partition p1 values less than(20))`)
+	tk.MustExec(`insert into t1 values (5)`)
+	tk.MustQuery(`select a from t1 where a in (5)`).Check(testkit.Rows("5"))
+
+	// the minimal reproducible case for list partitioning
+	tk.MustExec(`create table  t2 (a int primary key) partition by list (a+5) (
+		partition p0 values in (5, 6, 7, 8), partition p1 values in (9, 10, 11, 12))`)
+	tk.MustExec(`insert into t2 values (5)`)
+	tk.MustQuery(`select a from t2 where a in (5)`).Check(testkit.Rows("5"))
 }
 
 func (s *partitionTableSuite) TestBatchGetforRangeandListPartitionTable(c *C) {

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -539,6 +539,13 @@ func newBatchPointGetPlan(
 		if partitionExpr == nil {
 			return nil
 		}
+
+		if partitionExpr.Expr == nil {
+			return nil
+		}
+		if _, ok := partitionExpr.Expr.(*expression.Column); !ok {
+			return nil
+		}
 	}
 	if handleCol != nil {
 		var handles = make([]kv.Handle, len(patternInExpr.List))


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25527 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: forbid BatchPointGet on tables partitioned by compound expressions

### What is changed and how it works?

In this PR #24856, we allow the planner to generate BatchPointGet on partition tables, but BatchPointGet cannot work correctly on tables partitioned by compound expressions like `by hash (col * 2)`, `by range (col + 5)`.
In this PR we forbid these cases and only allow BatchPointGet on tables partitioned by a single column like `by hash (col)`, `by range (col)`.

To solve this problem thoroughly, we should let BatchPointGet apply these partitioning expressions when calculating partition IDs, but it's a little difficult to implement it now, so we forbid these cases in PR as a quick fix.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: forbid BatchPointGet on tables partitioned by compound expressions
