### PR TITLE
*: temporarily skip some unstable test cases

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -293,6 +293,7 @@ func backgroundExec(s kv.Storage, sql string, done chan error) {
 
 // TestAddPrimaryKeyRollback1 is used to test scenarios that will roll back when a duplicate primary key is encountered.
 func (s *testDBSuite8) TestAddPrimaryKeyRollback1(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210705")
 	hasNullValsInKey := false
 	idxName := "PRIMARY"
 	addIdxSQL := "alter table t1 add primary key c3_index (c3);"

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -904,6 +904,7 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210705")
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -254,6 +254,7 @@ func (s *testPrepareSerialSuite) TestPrepareCacheNow(c *C) {
 }
 
 func (s *testPrepareSerialSuite) TestPrepareOverMaxPreparedStmtCount(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210705")
 	defer testleak.AfterTest(c)()
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)
@@ -813,6 +814,7 @@ func (s *testPlanSerialSuite) TestPlanCacheUnionScan(c *C) {
 }
 
 func (s *testPlanSerialSuite) TestPlanCacheHitInfo(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210705")
 	defer testleak.AfterTest(c)()
 	store, dom, err := newStoreWithBootstrap()
 	c.Assert(err, IsNil)


### PR DESCRIPTION
Skip the following test cases because they're not stable.

- testDBSuite8.TestAddPrimaryKeyRollback1 (#25586)
- testPlanSerialSuite.TestPlanCacheHitInfo (#25585)
- testEvaluatorSuite.TestExprOnlyPushDownToFlash (#25584)
- testPrepareSerialSuite.TestPrepareOverMaxPreparedStmtCount (#25589)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
