### PR TITLE
planner: fix the risk of integer overflow when locating partitions

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8665,5 +8665,5 @@ func (s *testSuite) TestIssue25506(c *C) {
 	tk.MustExec("insert into tbl_3 values (0xFF)")
 	tk.MustExec("create table tbl_23 (col_15 bit(15))")
 	tk.MustExec("insert into tbl_23 values (0xF)")
-	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update)").Check(testkit.Rows("\x00\x00\x0F", "\x00\xFF\xFF", "\x00\x00\xFF"))
+	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update)").Sort().Check(testkit.Rows("\x00\x00\x0F", "\x00\x00\xFF", "\x00\xFF\xFF"))
 }

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -183,7 +183,7 @@ func (s *partitionProcessor) findUsedPartitions(ctx sessionctx.Context, tbl tabl
 				if r.HighExclude {
 					posHigh--
 				}
-				rangeScalar := float64(posHigh) - float64(posLow)
+				rangeScalar := float64(posHigh) - float64(posLow) // use float64 to avoid integer overflow
 
 				// if range is less than the number of partitions, there will be unused partitions we can prune out.
 				if rangeScalar < float64(numPartitions) && !highIsNull && !lowIsNull {

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -183,10 +183,10 @@ func (s *partitionProcessor) findUsedPartitions(ctx sessionctx.Context, tbl tabl
 				if r.HighExclude {
 					posHigh--
 				}
-				rangeScalar := posHigh - posLow
+				rangeScalar := float64(posHigh) - float64(posLow)
 
 				// if range is less than the number of partitions, there will be unused partitions we can prune out.
-				if rangeScalar < int64(numPartitions) && !highIsNull && !lowIsNull {
+				if rangeScalar < float64(numPartitions) && !highIsNull && !lowIsNull {
 					for i := posLow; i <= posHigh; i++ {
 						idx := math.Abs(i % int64(pi.Num))
 						if len(partitionNames) > 0 && !s.findByName(partitionNames, pi.Definitions[idx].Name.L) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Issue Number: close #25598 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix the risk of integer overflow when locating partitions

When locating partitions for integers, TiDB may subtract an integer's highest and lowest values, where the risk of interger overflow might appear.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: fix the risk of integer overflow when locating partitions
