### PR TITLE
test: make test TestIssue25506 stable

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8665,5 +8665,5 @@ func (s *testSuite) TestIssue25506(c *C) {
 	tk.MustExec("insert into tbl_3 values (0xFF)")
 	tk.MustExec("create table tbl_23 (col_15 bit(15))")
 	tk.MustExec("insert into tbl_23 values (0xF)")
-	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update)").Check(testkit.Rows("\x00\x00\x0F", "\x00\xFF\xFF", "\x00\x00\xFF"))
+	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update) order by col_15").Check(testkit.Rows("\x00\x00\x0F", "\x00\x00\xFF", "\x00\xFF\xFF"))
 }


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

As the title said.

```go
[2021-06-21T13:13:11.256Z] ----------------------------------------------------------------------
[2021-06-21T13:13:11.256Z] FAIL: executor_test.go:8659: testSuite.TestIssue25506
[2021-06-21T13:13:11.256Z] 
[2021-06-21T13:13:11.256Z] executor_test.go:8668:
[2021-06-21T13:13:11.256Z]     tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update)").Check(testkit.Rows("\x00\x00\x0F", "\x00\xFF\xFF", "\x00\x00\xFF"))
[2021-06-21T13:13:11.256Z] /home/jenkins/agent/workspace/tidb_ghpr_check_2/go/src/github.com/pingcap/tidb/util/testkit/testkit.go:63:
[2021-06-21T13:13:11.256Z]     res.c.Assert(resBuff.String(), check.Equals, needBuff.String(), res.comment)
[2021-06-21T13:13:11.256Z] ... obtained string = "" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\xff\xff]\n" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\x00\xff]\n" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\x00\x0f]\n"
[2021-06-21T13:13:11.256Z] ... expected string = "" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\x00\x0f]\n" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\xff\xff]\n" +
[2021-06-21T13:13:11.256Z] ...     "[\x00\x00\xff]\n"
[2021-06-21T13:13:11.256Z] ... sql:(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update), args:[]
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- No code

Side effects

- N/A
### Release note <!-- bugfixes or new feature need a release note -->

- No release note.