### PR TITLE
test: make test TestTopSQLCPUProfile stable

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -1220,6 +1220,7 @@ func (ts *tidbTestTopSQLSuite) TestTopSQLCPUProfile(c *C) {
 	dbt.mustExec("set @@global.tidb_enable_top_sql='On';")
 	dbt.mustExec("set @@tidb_top_sql_agent_address='127.0.0.1:4001';")
 	dbt.mustExec("set @@global.tidb_top_sql_precision_seconds=1;")
+	dbt.mustExec("set @@global.tidb_txn_mode = 'pessimistic'")
 
 	// Test case 1: DML query: insert/update/replace/delete/select
 	cases1 := []struct {
@@ -1278,9 +1279,12 @@ func (ts *tidbTestTopSQLSuite) TestTopSQLCPUProfile(c *C) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cases2[i].cancel = cancel
 		prepare, args := ca.prepare, ca.args
+		var stmt *sql.Stmt
 		go ts.loopExec(ctx, c, func(db *sql.DB) {
-			stmt, err := db.Prepare(prepare)
-			c.Assert(err, IsNil)
+			if stmt == nil {
+				stmt, err = db.Prepare(prepare)
+				c.Assert(err, IsNil)
+			}
 			if strings.HasPrefix(prepare, "select") {
 				rows, err := stmt.Query(args...)
 				c.Assert(err, IsNil)
@@ -1315,9 +1319,13 @@ func (ts *tidbTestTopSQLSuite) TestTopSQLCPUProfile(c *C) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cases3[i].cancel = cancel
 		prepare, args := ca.prepare, ca.args
+		doPrepare := true
 		go ts.loopExec(ctx, c, func(db *sql.DB) {
-			_, err := db.Exec(fmt.Sprintf("prepare stmt from '%v'", prepare))
-			c.Assert(err, IsNil)
+			if doPrepare {
+				doPrepare = false
+				_, err := db.Exec(fmt.Sprintf("prepare stmt from '%v'", prepare))
+				c.Assert(err, IsNil)
+			}
 			sqlBuf := bytes.NewBuffer(nil)
 			sqlBuf.WriteString("execute stmt ")
 			for i := range args {


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```sql
[2021-06-21T22:38:42.220Z] ----------------------------------------------------------------------
[2021-06-21T22:38:42.220Z] FAIL: tidb_test.go:1196: tidbTestTopSQLSuite.TestTopSQLCPUProfile
[2021-06-21T22:38:42.220Z] 
[2021-06-21T22:38:42.220Z] tidb_test.go:1382:
[2021-06-21T22:38:42.220Z]     checkFn(ca.prepare, ca.planRegexp)
[2021-06-21T22:38:42.220Z] tidb_test.go:1356:
[2021-06-21T22:38:42.220Z]     // since 1 sql may has many plan, check `len(stats) > 0` instead of `len(stats) == 1`.
[2021-06-21T22:38:42.220Z]     c.Assert(len(stats) > 0, IsTrue, commentf)
[2021-06-21T22:38:42.220Z] ... obtained bool = false
[2021-06-21T22:38:42.220Z] ... sql: select * from t1 where a in (?,?,?,?
```

### How it work?

* Use pessimistic to avoid write conflict.
* Do prepare only once instead of `prepare stmt` each time.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- No code

Side effects

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

- No release note.