### PR TITLE
planner,executor: fix batch point get for update read panic on partition table

### DIFF
--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -3027,4 +3027,9 @@ func (s *partitionTableSuite) TestIssue25528(c *C) {
 	tk.MustExec("insert into issue25528 (id, balance, created_at) values(1, 100, '2021-06-17 22:35:20')")
 	tk.MustExec("begin pessimistic")
 	tk.MustQuery("select * from issue25528 where id = 1 for update").Check(testkit.Rows("1 100.00 -100.00 2021-06-17 22:35:20"))
+
+	tk.MustExec("drop table if exists issue25528")
+	tk.MustExec("CREATE TABLE `issue25528` ( `c1` int(11) NOT NULL, `c2` int(11) DEFAULT NULL, `c3` int(11) DEFAULT NULL, `c4` int(11) DEFAULT NULL, PRIMARY KEY (`c1`) /*T![clustered_index] CLUSTERED */, KEY `k2` (`c2`), KEY `k3` (`c3`) ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin PARTITION BY HASH( `c1` ) PARTITIONS 10;")
+	tk.MustExec("INSERT INTO issue25528 (`c1`, `c2`, `c3`, `c4`) VALUES (1, 1, 1, 1) , (3, 3, 3, 3) , (2, 2, 2, 2) , (4, 4, 4, 4);")
+	tk.MustQuery("select * from issue25528 where c1 in (3, 4) order by c2 for update;").Check(testkit.Rows("3 3 3 3", "4 4 4 4"))
 }

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -723,7 +723,8 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 			// We do not build [batch] point get for dynamic table partitions now. This can be optimized.
 			if ds.ctx.GetSessionVars().UseDynamicPartitionPrune() {
 				canConvertPointGet = false
-			} else if len(path.Ranges) > 1 {
+			}
+			if canConvertPointGet && len(path.Ranges) > 1 {
 				// We can only build batch point get for hash partitions on a simple column now. This is
 				// decided by the current implementation of `BatchPointGetExec::initialize()`, specifically,
 				// the `getPhysID()` function. Once we optimize that part, we can come back and enable
@@ -732,7 +733,8 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 				if hashPartColName == nil {
 					canConvertPointGet = false
 				}
-			} else {
+			}
+			if canConvertPointGet {
 				// If the schema contains ExtraPidColID, do not convert to point get.
 				// Because the point get executor can not handle the extra partition ID column now.
 				for _, col := range ds.schema.Columns {


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25528

Problem Summary:

### What is changed and how it works?

Fix a error logic

What's Changed:

How it Works:

This logic is incorrect:

```
if xxx {
	canConvertPointGet = false
} else if yyy {
	canConvertPointGet = false
} else {
	canConvertPointGet = false
}
```
The correct one should be:

```
if canConvertPointGet && xxx {
	canConvertPointGet = false
}
if canConvertPointGet && yyy {
	canConvertPointGet = false
}
if canConvertPointGet && zzz {
	canConvertPointGet = false
}
```

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note