### PR TITLE
expression: fix IN expr critical bug

### DIFF
--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -217,7 +217,7 @@ func (b *builtinInIntSig) evalInt(row chunk.Row) (int64, bool, error) {
 				return 1, false, nil
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -306,7 +306,7 @@ func (b *builtinInStringSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if b.hashSet.Exist(string(collator.Key(arg0))) {
 			return 1, false, nil
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -377,7 +377,7 @@ func (b *builtinInRealSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if b.hashSet.Exist(arg0) {
 			return 1, false, nil
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -457,7 +457,7 @@ func (b *builtinInDecimalSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if b.hashSet.Exist(string(key)) {
 			return 1, false, nil
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -528,7 +528,7 @@ func (b *builtinInTimeSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if _, ok := b.hashSet[arg0.CoreTime()]; ok {
 			return 1, false, nil
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -599,7 +599,7 @@ func (b *builtinInDurationSig) evalInt(row chunk.Row) (int64, bool, error) {
 		if _, ok := b.hashSet[arg0.Duration]; ok {
 			return 1, false, nil
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}

--- a/expression/builtin_other_vec_generated.go
+++ b/expression/builtin_other_vec_generated.go
@@ -72,7 +72,7 @@ func (b *builtinInIntSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 				}
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -170,7 +170,7 @@ func (b *builtinInStringSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column
 				result.SetNull(i, false)
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -255,7 +255,7 @@ func (b *builtinInDecimalSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colum
 				result.SetNull(i, false)
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -341,7 +341,7 @@ func (b *builtinInRealSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 				result.SetNull(i, false)
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -424,7 +424,7 @@ func (b *builtinInTimeSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) 
 				result.SetNull(i, false)
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}
@@ -507,7 +507,7 @@ func (b *builtinInDurationSig) vecEvalInt(input *chunk.Chunk, result *chunk.Colu
 				result.SetNull(i, false)
 			}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}

--- a/expression/generator/other_vec.go
+++ b/expression/generator/other_vec.go
@@ -201,7 +201,7 @@ func (b *{{.SigName}}) vecEvalInt(input *chunk.Chunk, result *chunk.Column) erro
 				{{- end }}
 			{{- end }}
 		}
-		args = args[:0]
+		args = make([]Expression, 0, len(b.nonConstArgsIdx))
 		for _, i := range b.nonConstArgsIdx {
 			args = append(args, b.args[i])
 		}

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -9757,14 +9757,10 @@ func (s *testIntegrationSuite2) TestIssue25591(c *C) {
 
 	tk.MustExec("use test;")
 	tk.MustExec("drop table if exists t1_1, t2_1;")
-	tk.MustExec("CREATE TABLE `t1_1` (`col1` double DEFAULT NULL);")
+	tk.MustExec("CREATE TABLE `t1_1` (`col1` double DEFAULT NULL, `col2` double DEFAULT NULL);")
 	tk.MustExec("CREATE TABLE `t2_1` (`col1` varchar(20) DEFAULT NULL, `col2` double DEFAULT NULL);")
-	tk.MustExec("insert into t1_1 values(12.991);")
+	tk.MustExec("insert into t1_1 values(12.991, null), (12.991, null);")
 	tk.MustExec("insert into t2_1(col2) values(87), (-9.183), (-9.183);")
-
-	// Analyze to make sure this specific plan can recurring problem.
-	tk.MustExec("analyze table t1_1;")
-	tk.MustExec("analyze table t2_1;")
 
 	tk.MustExec("set @@tidb_enable_vectorized_expression  = false;")
 	rows := tk.MustQuery("select t1.col1, t2.col1, t2.col2 from t1_1 t1 inner join  t2_1 t2 on t1.col1 not in (1,t2.col1,t2.col2) order by 1,2,3;")

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -9751,3 +9751,26 @@ func (s *testIntegrationSuite) TestCharsetErr(c *C) {
 	err = tk.ExecToErr("insert into charset_test(c1) values ('aaa\xEF\xBF\xBD')")
 	c.Assert(err.Error(), Equals, "[table:1366]Incorrect string value '\\xEF\\xBF\\xBD' for column 'c1'")
 }
+
+func (s *testIntegrationSuite2) TestIssue25591(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t1_1, t2_1;")
+	tk.MustExec("CREATE TABLE `t1_1` (`col1` double DEFAULT NULL);")
+	tk.MustExec("CREATE TABLE `t2_1` (`col1` varchar(20) DEFAULT NULL, `col2` double DEFAULT NULL);")
+	tk.MustExec("insert into t1_1 values(12.991);")
+	tk.MustExec("insert into t2_1(col2) values(87), (-9.183), (-9.183);")
+
+	// Analyze to make sure this specific plan can recurring problem.
+	tk.MustExec("analyze table t1_1;")
+	tk.MustExec("analyze table t2_1;")
+
+	tk.MustExec("set @@tidb_enable_vectorized_expression  = false;")
+	rows := tk.MustQuery("select t1.col1, t2.col1, t2.col2 from t1_1 t1 inner join  t2_1 t2 on t1.col1 not in (1,t2.col1,t2.col2) order by 1,2,3;")
+	rows.Check(testkit.Rows())
+
+	tk.MustExec("set @@tidb_enable_vectorized_expression  = true;")
+	rows = tk.MustQuery("select t1.col1, t2.col1, t2.col2 from t1_1 t1 inner join  t2_1 t2 on t1.col1 not in (1,t2.col1,t2.col2) order by 1,2,3;")
+	rows.Check(testkit.Rows())
+}


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25591 <!-- REMOVE this line if no issue to close -->

Problem Summary: The implementation of **IN expr** will change its arguments array unexpectedly. For example:

```
t1.c1 IN (1, t2.c1, t2.c2);
original args: (t1.c1, 1, t2.c1, t2.c2)
after: (t1.c1, t2.c1, t2.c2, t2.c2)
```

### What is changed and how it works?
What's Changed: If we need to change local args slice, make a new underlying array instead of changing the expr's(`b.args` should not be changed)


### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Integration test


Side effects: May use extra memory to store local arguments array.

### Release note <!-- bugfixes or new feature need a release note -->

- expression: fix IN expr critical bug
