### PR TITLE
planner: generate wrong plan when update has subquery

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1280,6 +1280,11 @@ func findInPairs(colName string, pairs []nameValuePair) int {
 }
 
 func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan {
+	for _, list := range updateStmt.List {
+		if _, ok := list.Expr.(*ast.SubqueryExpr); ok {
+			return nil
+		}
+	}
 	selStmt := &ast.SelectStmt{
 		Fields:  &ast.FieldList{},
 		From:    updateStmt.TableRefs,

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1280,6 +1280,7 @@ func findInPairs(colName string, pairs []nameValuePair) int {
 }
 
 func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan {
+	// avoid using the point_get when assignment_list contains the subquery in the UPDATE.
 	for _, list := range updateStmt.List {
 		if _, ok := list.Expr.(*ast.SubqueryExpr); ok {
 			return nil


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25658  

Problem Summary:

### What is changed and how it works?

if finding the subquery in the UPDATE's assignment list, the point_get return null.

What's Changed:

How it Works:

it change plan. the plan is shown below.
![image](https://user-images.githubusercontent.com/3427324/122892974-76f16580-d378-11eb-9161-35cfb2d0b8d9.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- Manual test 

```
CREATE TABLE `users` (
  `id` bigint(20) unsigned NOT NULL,
  `name` longtext DEFAULT NULL,
  `age` bigint(20) unsigned DEFAULT NULL,
  `company_id` bigint(20) DEFAULT NULL,
  `manager_id` bigint(20) unsigned DEFAULT NULL,
  `active` tinyint(1) DEFAULT NULL,
  `created_at` datetime(3) DEFAULT NULL,
  `updated_at` datetime(3) DEFAULT NULL,
  `deleted_at` datetime(3) DEFAULT NULL,
  PRIMARY KEY (`id`),
  KEY `idx_users_deleted_at` (`deleted_at`)
);
insert into users(id, company_id, name, updated_at) values(239, 15, 'Company 2 id 15', '2021-03-01 12:12:12.987');
create table companies(id bigint primary key, name longtext default null);
insert into companies values(14, 'Company 1 id 14');
insert into companies values(15, 'Company 2 id 15');
UPDATE `users` SET `company_id`=14,`name`=(SELECT `name` FROM `companies` WHERE companies.id = users.company_id),`updated_at`='2021-04-27 10:28:31.459' WHERE `id` = 239;

```
Release note
- No release note
