### PR TITLE
domain: fix the `@@tidb_enable_local_txn` sync bug

### DIFF
--- a/domain/sysvar_cache.go
+++ b/domain/sysvar_cache.go
@@ -153,6 +153,8 @@ func (svc *SysVarCache) RebuildSysVarCache(ctx sessionctx.Context) error {
 func checkEnableServerGlobalVar(name, sVal string) {
 	var err error
 	switch name {
+	case variable.TiDBEnableLocalTxn:
+		variable.EnableLocalTxn.Store(variable.TiDBOptOn(sVal))
 	case variable.TiDBEnableStmtSummary:
 		err = stmtsummary.StmtSummaryByDigestMap.SetEnabled(sVal, false)
 	case variable.TiDBStmtSummaryInternalQuery:


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Make `@@tidb_enable_local_txn` sync between TiDB instances globally.

### What is changed and how it works?

Add `TiDBEnableLocalTxn` variable to the `checkEnableServerGlobalVar` function.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test
- Manual test (add detailed scripts or steps below)

First on both TiDB-0 and TiDB-1:

<img width="726" alt="image" src="https://user-images.githubusercontent.com/1446531/122965737-20594b00-d3bb-11eb-883f-63d55d759cc6.png">

<img width="727" alt="image" src="https://user-images.githubusercontent.com/1446531/122965763-28b18600-d3bb-11eb-900b-91ff8d71c444.png">

On TiDB-0:

<img width="725" alt="image" src="https://user-images.githubusercontent.com/1446531/122965186-84c7da80-d3ba-11eb-8cc8-117174d2f24b.png">

Then on TiDB-1:

<img width="322" alt="image" src="https://user-images.githubusercontent.com/1446531/122965353-ae810180-d3ba-11eb-8536-53ee8331fa13.png">

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`.
