### PR TITLE
planner: generate wrong plan when update has subquery (#25660)

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1280,6 +1280,12 @@ func findInPairs(colName string, pairs []nameValuePair) int {
 }
 
 func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan {
+	// avoid using the point_get when assignment_list contains the subquery in the UPDATE.
+	for _, list := range updateStmt.List {
+		if _, ok := list.Expr.(*ast.SubqueryExpr); ok {
+			return nil
+		}
+	}
 	selStmt := &ast.SelectStmt{
 		Fields:  &ast.FieldList{},
 		From:    updateStmt.TableRefs,


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25658  

Problem Summary:

### What is changed and how it works?

if finding the subquery in the UPDATE's assignment list, the point_get return null.

What's Changed:

How it Works:

it change plan. the plan is shown below.
![image](https://user-images.githubusercontent.com/3427324/122892974-76f16580-d378-11eb-9161-35cfb2d0b8d9.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- add integration test

Release note
- No release note
