### PR TITLE
planner: generate wrong plan when update has subquery (#25660)

### DIFF
--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1129,6 +1129,12 @@ func findInPairs(colName string, pairs []nameValuePair) int {
 }
 
 func tryUpdatePointPlan(ctx sessionctx.Context, updateStmt *ast.UpdateStmt) Plan {
+	// avoid using the point_get when assignment_list contains the subquery in the UPDATE.
+	for _, list := range updateStmt.List {
+		if _, ok := list.Expr.(*ast.SubqueryExpr); ok {
+			return nil
+		}
+	}
 	selStmt := &ast.SelectStmt{
 		Fields:  &ast.FieldList{},
 		From:    updateStmt.TableRefs,

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -195,6 +195,19 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	tk.MustExec("rollback")
 }
 
+func (s *testPointGetSuite) TestPointGetForUpdateWithSubquery(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("CREATE TABLE users (id bigint(20) unsigned NOT NULL primary key, name longtext DEFAULT NULL, company_id bigint(20) DEFAULT NULL)")
+	tk.MustExec("create table companies(id bigint primary key, name longtext default null)")
+	tk.MustExec("insert into companies values(14, 'Company14')")
+	tk.MustExec("insert into companies values(15, 'Company15')")
+	tk.MustExec("insert into users(id, company_id, name) values(239, 15, 'xxxx')")
+	tk.MustExec("UPDATE users SET name=(SELECT name FROM companies WHERE companies.id = users.company_id)  WHERE id = 239")
+
+	tk.MustQuery("select * from users").Check(testkit.Rows("239 Company15 15"))
+}
+
 func checkUseForUpdate(tk *testkit.TestKit, c *C, expectLock bool) {
 	res := tk.MustQuery("explain select * from fu where id = 6 for update")
 	// Point_Get_1	1.00	root	table:fu, handle:6


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25658  

Problem Summary:

### What is changed and how it works?

if finding the subquery in the UPDATE's assignment list, the point_get return null.

What's Changed:

How it Works:

it change plan. the plan is shown below.
![image](https://user-images.githubusercontent.com/3427324/122892974-76f16580-d378-11eb-9161-35cfb2d0b8d9.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->
- add integration test

Release note
- No release note
