### PR TITLE
txn: add http api to change the unique index lock behaviour

### DIFF
--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -249,7 +249,7 @@ func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
 			if !e.ctx.GetSessionVars().IsPessimisticReadConsistency() {
 				if !keyExist {
 					lockIndexKey = true
-				} else if keyExist && enableLockIdxKey {
+				} else if enableLockIdxKey {
 					lockIndexKey = true
 				}
 			} else {

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -718,6 +718,17 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			config.StoreGlobalConfig(cfg)
 			deadlockhistory.GlobalDeadlockHistory.Resize(uint(capacity))
 		}
+		if lockUniqueKey := req.Form.Get("tidb_lock_unique_key"); lockUniqueKey != "" {
+			switch lockUniqueKey {
+			case "0":
+				variable.LockUniqueKeys.Store(false)
+			case "1":
+				variable.LockUniqueKeys.Store(true)
+			default:
+				writeError(w, errors.New("illegal argument, please use 0 or 1 for this"))
+				return
+			}
+		}
 	} else {
 		writeData(w, config.GetGlobalConfig())
 	}

--- a/server/http_handler.go
+++ b/server/http_handler.go
@@ -722,8 +722,10 @@ func (h settingsHandler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 			switch lockUniqueKey {
 			case "0":
 				variable.LockUniqueKeys.Store(false)
+				logutil.BgLogger().Info("tidb_lock_unique_key is disabled")
 			case "1":
 				variable.LockUniqueKeys.Store(true)
+				logutil.BgLogger().Info("tidb_lock_unique_key is enabled")
 			default:
 				writeError(w, errors.New("illegal argument, please use 0 or 1 for this"))
 				return

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -1156,6 +1156,7 @@ func (ts *HTTPHandlerTestSerialSuite) TestPostSettings(c *C) {
 	form.Set("tidb_general_log", "1")
 	form.Set("tidb_enable_async_commit", "1")
 	form.Set("tidb_enable_1pc", "1")
+	form.Set("tidb_lock_unique_key", "1")
 	resp, err := ts.formStatus("/settings", form)
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
@@ -1168,12 +1169,14 @@ func (ts *HTTPHandlerTestSerialSuite) TestPostSettings(c *C) {
 	val, err = variable.GetGlobalSystemVar(se.GetSessionVars(), variable.TiDBEnable1PC)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, variable.On)
+	c.Assert(variable.LockUniqueKeys.Load(), Equals, true)
 
 	form = make(url.Values)
 	form.Set("log_level", "fatal")
 	form.Set("tidb_general_log", "0")
 	form.Set("tidb_enable_async_commit", "0")
 	form.Set("tidb_enable_1pc", "0")
+	form.Set("tidb_lock_unique_key", "0")
 	resp, err = ts.formStatus("/settings", form)
 	c.Assert(err, IsNil)
 	c.Assert(resp.StatusCode, Equals, http.StatusOK)
@@ -1186,6 +1189,7 @@ func (ts *HTTPHandlerTestSerialSuite) TestPostSettings(c *C) {
 	val, err = variable.GetGlobalSystemVar(se.GetSessionVars(), variable.TiDBEnable1PC)
 	c.Assert(err, IsNil)
 	c.Assert(val, Equals, variable.Off)
+	c.Assert(variable.LockUniqueKeys.Load(), Equals, false)
 	form.Set("log_level", os.Getenv("log_level"))
 
 	// test ddl_slow_threshold

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -751,6 +751,7 @@ var (
 		ReportIntervalSeconds: atomic.NewInt64(DefTiDBTopSQLReportIntervalSeconds),
 	}
 	EnableLocalTxn = atomic.NewBool(DefTiDBEnableLocalTxn)
+	LockUniqueKeys = atomic.NewBool(true)
 )
 
 // TopSQL is the variable for control top sql feature.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: 
Related to #25659.

Problem Summary:
Since https://github.com/pingcap/tidb/pull/21229, all the unique index keys will be locked if they are used in the for update read access path. The for update read with point get on non-clusetered unique index keys may leave many `LOCK` records  which affect the performance a lot.
 
### What is changed and how it works?

What's Changed:
Add a http switch to control the behaviour, it's possible to turn off the change introduced by #21229 by setting the variable to `0`.  
This is a temporary solution to workaround the performance issue, to solve it it's still needed to optimize the `LOCK` and `ROLLBACK` records in the tikv-side. It could be used as a hotfix patch if the users encounter such performance issues.

How it Works:

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Manually test
  With the point/batch point get unique index for update read, check the mvcc record.


Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- Add a http switch to control the unique index key lock behaviour for pessimistic transactions.
