### PR TITLE
statistics: skip dumping nil histograms for virtual columns in analyze

### DIFF
--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -1001,6 +1001,10 @@ func (h *Handle) SaveTableStatsToStorage(results *statistics.AnalyzeResults, nee
 	// 2. Save histograms.
 	for _, result := range results.Ars {
 		for i, hg := range result.Hist {
+			// It's normal virtual column, skip it.
+			if hg == nil {
+				continue
+			}
 			var cms *statistics.CMSketch
 			if results.StatsVer != statistics.Version2 {
 				cms = result.Cms[i]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25788

Problem Summary:

Panic when analyzing tables with virtual columns.

### What is changed and how it works?

What's Changed:

Skip dumping nil histograms for virtual columns in analyze.

How it Works:

The problem was incurred by https://github.com/pingcap/tidb/pull/24575 when refactoring the `SaveTableStatsToStorage` function, the nil check for histograms was missing. 

### Related changes

N/A

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Skip dumping nil histograms for virtual columns in analyze