### PR TITLE
store/tikv: clear RPC error only if prewrite succeeds

### DIFF
--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -216,6 +216,9 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 		prewriteResp := resp.Resp.(*pb.PrewriteResponse)
 		keyErrs := prewriteResp.GetErrors()
 		if len(keyErrs) == 0 {
+			// Clear the RPC Error since the request is evaluated successfully.
+			sender.rpcError = nil
+
 			if batch.isPrimary {
 				// After writing the primary key, if the size of the transaction is larger than 32M,
 				// start the ttlManager. The ttlManager will be closed in tikvTxn.Commit().

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -561,8 +561,6 @@ func (s *RegionRequestSender) SendReqCtx(
 				continue
 			}
 		} else {
-			// Clear the RPC Error since the request is evaluated successfully on a store.
-			s.rpcError = nil
 			if s.leaderReplicaSelector != nil {
 				s.leaderReplicaSelector.OnSendSuccess()
 			}

--- a/store/tikv/region_request_test.go
+++ b/store/tikv/region_request_test.go
@@ -218,8 +218,6 @@ func (s *testRegionRequestToSingleStoreSuite) TestOnSendFailedWithStoreRestart(c
 	resp, err = s.regionRequestSender.SendReq(s.bo, req, region.Region, time.Second)
 	c.Assert(err, IsNil)
 	c.Assert(resp.Resp, NotNil)
-	// The RPC error should be nil since it's evaluated successfully.
-	c.Assert(s.regionRequestSender.rpcError, IsNil)
 }
 
 func (s *testRegionRequestToSingleStoreSuite) TestOnSendFailedWithCloseKnownStoreThenUseNewOne(c *C) {

--- a/store/tikv/tests/async_commit_fail_test.go
+++ b/store/tikv/tests/async_commit_fail_test.go
@@ -233,25 +233,3 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitContextCancelCausingUndetermin
 	c.Assert(err, NotNil)
 	c.Assert(txn.GetCommitter().GetUndeterminedErr(), NotNil)
 }
-
-// TestAsyncCommitRPCErrorThenWriteConflict verifies that the determined failure error overwrites undetermined error.
-func (s *testAsyncCommitFailSuite) TestAsyncCommitRPCErrorThenWriteConflict(c *C) {
-	// This test doesn't support tikv mode because it needs setting failpoint in unistore.
-	if *WithTiKV {
-		return
-	}
-
-	txn := s.beginAsyncCommit(c)
-	err := txn.Set([]byte("a"), []byte("va"))
-	c.Assert(err, IsNil)
-
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
-	}()
-
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
-	err = txn.Commit(ctx)
-	c.Assert(err, NotNil)
-	c.Assert(txn.GetCommitter().GetUndeterminedErr(), IsNil)
-}

--- a/store/tikv/tests/async_commit_fail_test.go
+++ b/store/tikv/tests/async_commit_fail_test.go
@@ -255,29 +255,3 @@ func (s *testAsyncCommitFailSuite) TestAsyncCommitRPCErrorThenWriteConflict(c *C
 	c.Assert(err, NotNil)
 	c.Assert(txn.GetCommitter().GetUndeterminedErr(), IsNil)
 }
-
-// TestAsyncCommitRPCErrorThenWriteConflictInChild verifies that the determined failure error in a child recursion
-// overwrites the undetermined error in the parent.
-func (s *testAsyncCommitFailSuite) TestAsyncCommitRPCErrorThenWriteConflictInChild(c *C) {
-	// This test doesn't support tikv mode because it needs setting failpoint in unistore.
-	if *WithTiKV {
-		return
-	}
-
-	txn := s.beginAsyncCommit(c)
-	err := txn.Set([]byte("a"), []byte("va"))
-	c.Assert(err, IsNil)
-
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult", `1*return("timeout")->return("writeConflict")`), IsNil)
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/tikv/forceRecursion", `return`), IsNil)
-
-	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/rpcPrewriteResult"), IsNil)
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/tikv/forceRecursion"), IsNil)
-	}()
-
-	ctx := context.WithValue(context.Background(), util.SessionID, uint64(1))
-	err = txn.Commit(ctx)
-	c.Assert(err, NotNil)
-	c.Assert(txn.GetCommitter().GetUndeterminedErr(), IsNil)
-}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/tikv/tikv/issues/10468

### What is changed and how it works?

First, this PR reverts https://github.com/pingcap/tidb/pull/25120. Receiving a `Write Conflict` does not mean the transaction fails deterministically.

This PR also reverts a change in https://github.com/pingcap/tidb/pull/25040. If there is no region error, the `rpcErr` should not be cleared. Because even if the retry fails, the previous prewrite can still make the transaction succeed. Instead, this PR removes the `rpcErr` only if the prewrite request has no error.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- After removing the optimization, there is higher chance of undetermined errors in an unstable network environment.

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the bug that successful optimistic transactions may report commit errors.
