### PR TITLE
executor: temporarily skip 2 unstable tests

### DIFF
--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -167,6 +167,7 @@ func (s *testSuite1) TestAnalyzeRestrict(c *C) {
 }
 
 func (s *testSuite1) TestAnalyzeParameters(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210713")
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -685,6 +685,7 @@ func (s *testSuite5) TestSetCollationAndCharset(c *C) {
 }
 
 func (s *testSuite5) TestValidateSetVar(c *C) {
+	c.Skip("unstable, skip it and fix it before 20210713")
 	tk := testkit.NewTestKit(c, s.store)
 
 	_, err := tk.Exec("set global tidb_distsql_scan_concurrency='fff';")


### PR DESCRIPTION
Skip the following test cases because they're not stable.

- testSuite1.TestAnalyzeParameters (#25782)
- testSuite5.TestValidateSetVar (#25781)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
