### PR TITLE
infoschema, executor, txn: implement (CLUSTER_)TRX_SQL table

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1583,6 +1583,7 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			strings.ToLower(infoschema.TableClientErrorsSummaryByUser),
 			strings.ToLower(infoschema.TableClientErrorsSummaryByHost),
 			strings.ToLower(infoschema.TableTiDBTrx),
+			strings.ToLower(infoschema.TableTrxSQL),
 			strings.ToLower(infoschema.ClusterTableTiDBTrx),
 			strings.ToLower(infoschema.TableDeadlocks),
 			strings.ToLower(infoschema.ClusterTableDeadlocks),

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -171,6 +171,8 @@ const (
 	TableDeadlocks = "DEADLOCKS"
 	// TableDataLockWaits is current lock waiting status table.
 	TableDataLockWaits = "DATA_LOCK_WAITS"
+	// TableTrxSQL is a table which contains all SQL in current running transaction.
+	TableTrxSQL = "TRX_SQL"
 )
 
 var tableIDMap = map[string]int64{
@@ -250,6 +252,7 @@ var tableIDMap = map[string]int64{
 	TableDataLockWaits:                      autoid.InformationSchemaDBID + 74,
 	TableStatementsSummaryEvicted:           autoid.InformationSchemaDBID + 75,
 	ClusterTableStatementsSummaryEvicted:    autoid.InformationSchemaDBID + 76,
+	TableTrxSQL:                             autoid.InformationSchemaDBID + 77,
 }
 
 type columnInfo struct {
@@ -1371,6 +1374,12 @@ var tableTiDBTrxCols = []columnInfo{
 	{name: "ALL_SQL_DIGESTS", tp: mysql.TypeBlob, size: types.UnspecifiedLength, comment: "A list of the digests of SQL statements that the transaction has executed"},
 }
 
+var tableTrxSQLCols = []columnInfo{
+	{name: "TRX_ID", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag | mysql.UnsignedFlag, comment: "ID of the transaction"},
+	{name: "DIGEST", tp: mysql.TypeVarchar, size: 64, comment: "Digest of the SQL"},
+	{name: "INDEX", tp: mysql.TypeLonglong, size: 64, comment: "INDEX of the statement in this transaction"},
+}
+
 var tableDeadlocksCols = []columnInfo{
 	{name: "DEADLOCK_ID", tp: mysql.TypeLonglong, size: 21, flag: mysql.NotNullFlag, comment: "The ID to distinguish different deadlock events"},
 	{name: "OCCUR_TIME", tp: mysql.TypeTimestamp, decimal: 6, size: 26, comment: "The physical time when the deadlock occurs"},
@@ -1778,6 +1787,7 @@ var tableNameToColumns = map[string][]columnInfo{
 	TableTiDBTrx:                            tableTiDBTrxCols,
 	TableDeadlocks:                          tableDeadlocksCols,
 	TableDataLockWaits:                      tableDataLockWaitsCols,
+	TableTrxSQL:                             tableTrxSQLCols,
 }
 
 func createInfoSchemaTable(_ autoid.Allocators, meta *model.TableInfo) (table.Table, error) {

--- a/session/txninfo/txn_info.go
+++ b/session/txninfo/txn_info.go
@@ -67,8 +67,6 @@ type TxnInfo struct {
 	// MemDB used memory
 	EntriesSize uint64
 
-	// The following fields will be filled in `session` instead of `LazyTxn`
-
 	// Which session this transaction belongs to
 	ConnectionID uint64
 	// The user who open this session
@@ -135,4 +133,17 @@ func (info *TxnInfo) ToDatum() []types.Datum {
 		info.CurrentDB,
 		allSQLs)...)
 	return datums
+}
+
+// AllSQLDatum dumps AllSQLDigests field to `Datum`s to show in the `TRX_SQL` table.
+func (info *TxnInfo) AllSQLDatum() [][]types.Datum {
+	var result [][]types.Datum
+	for index, digest := range info.AllSQLDigests {
+		result = append(result, types.MakeDatums(
+			info.StartTS,
+			digest,
+			index,
+		))
+	}
+	return result
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
According to some custome response, it is inconvinet to use `TRX_SQL.ALL_SQL_DIGESTS` because it is a "list". We cannot do joins with other tables (eg. `STATEMENTS_SUMMARY`) to get SQL text. 

### What is changed and how it works?

Proposal: [TiDB Transaction related views (sprint 4 plan)](https://docs.google.com/document/d/1smM_L0vZHcYVAUNlFgjS8USJsbGQjT7bBru0H1Md4wI/edit) <!-- REMOVE this line if not applicable -->

⚠️：This plan is still open for discussion.

What's Changed:

- [ ] Add a `TRX_SQL` table.
- [ ] Add a `CLUSTER_TRX_SQL` table.
- [ ] Design doc.
- [ ] Tests.

How it Works:

Just read the sql digests fields on `txnInfo`s when got queried.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

(TBA)

- Unit test
- Integration test

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`.
