### PR TITLE
*: update client-go and cleanup retry dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,7 +55,7 @@ require (
 	github.com/shirou/gopsutil v3.21.2+incompatible
 	github.com/soheilhy/cmux v0.1.4
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210628064110-666340265aac
+	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210630040115-58b6783d1b56
 	github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber-go/atomic v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -558,8 +558,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210628064110-666340265aac h1:iqrha2f7pXKhgoa3+Lriat13RM2dOtJ6430XpVJ8izk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210628064110-666340265aac/go.mod h1:crzTwbliZf57xC5ZSzmQx4iMZCLCGhA364to+E2JAPU=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210630040115-58b6783d1b56 h1:R1jC5I6wJmmfrYGNxAPR+ABbo1T2KMWcEWPr+UN5Bec=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210630040115-58b6783d1b56/go.mod h1:crzTwbliZf57xC5ZSzmQx4iMZCLCGhA364to+E2JAPU=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d h1:K0XnvsnT6ofLDuM8Rt3PuFQO4p8bNraeHYstspD316g=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d/go.mod h1:Jw9KG11C/23Rr7DW4XWQ7H5xOgGZo6DFL1OKAF4+Igw=
 github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=

--- a/store/copr/batch_request_sender.go
+++ b/store/copr/batch_request_sender.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	tikverr "github.com/tikv/client-go/v2/error"
-	"github.com/tikv/client-go/v2/retry"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	"google.golang.org/grpc/codes"
@@ -95,6 +94,6 @@ func (ss *RegionBatchRequestSender) onSendFailForBatchRegions(bo *Backoffer, ctx
 	// When a store is not available, the leader of related region should be elected quickly.
 	// TODO: the number of retry time should be limited:since region may be unavailable
 	// when some unrecoverable disaster happened.
-	err = bo.Backoff(retry.BoTiFlashRPC, errors.Errorf("send request error: %v, ctx: %v, regionInfos: %v", err, ctx, regionInfos))
+	err = bo.Backoff(tikv.BoTiFlashRPC(), errors.Errorf("send request error: %v, ctx: %v, regionInfos: %v", err, ctx, regionInfos))
 	return errors.Trace(err)
 }

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -42,7 +42,6 @@ import (
 	"github.com/tikv/client-go/v2/mockstore/mocktikv"
 	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/oracle/oracles"
-	"github.com/tikv/client-go/v2/retry"
 	"github.com/tikv/client-go/v2/tikv"
 	"github.com/tikv/client-go/v2/tikvrpc"
 	pd "github.com/tikv/pd/client"
@@ -945,7 +944,7 @@ func (s *testGCWorkerSuite) TestResolveLockRangeMeetRegionEnlargeCausedByRegionM
 			mCluster.Merge(s.initRegion.regionID, region2)
 			regionMeta, _ := mCluster.GetRegion(s.initRegion.regionID)
 			_, err := s.tikvStore.GetRegionCache().OnRegionEpochNotMatch(
-				retry.NewNoopBackoff(context.Background()),
+				tikv.NewNoopBackoff(context.Background()),
 				&tikv.RPCContext{Region: regionID, Store: &tikv.Store{}},
 				[]*metapb.Region{regionMeta})
 			c.Assert(err, IsNil)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>


### What problem does this PR solve?

`retry` is moved to an internal package.

### What is changed and how it works?

- update client-go dependency
- avoid using `retry` package

Tests <!-- At least one of them must be included. -->
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note
