### PR TITLE
tables: fix handle changed insert ignore on dup on partition table

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -806,6 +806,12 @@ func (s *testSuite4) TestInsertIgnoreOnDup(c *C) {
 	tk.MustQuery("select * from t6").Check(testkit.Rows("100 10 20"))
 	tk.MustExec("insert ignore into t6 set a = 200, b= 10 on duplicate key update c = 1000")
 	tk.MustQuery("select * from t6").Check(testkit.Rows("100 10 1000"))
+
+	tk.MustExec("drop table if exists t7")
+	tk.MustExec("CREATE TABLE t7 (`col_334` mediumint(9) NOT NULL DEFAULT '-3217641',  `col_335` mediumint(8) unsigned NOT NULL DEFAULT '2002468',  `col_336` enum('alice','bob','charlie','david') COLLATE utf8_general_ci NOT NULL DEFAULT 'alice',  PRIMARY KEY (`col_334`,`col_336`,`col_335`) CLUSTERED,  UNIQUE KEY `idx_116` (`col_334`,`col_335`),  UNIQUE KEY `idx_117` (`col_336`,`col_334`),  KEY `idx_118` (`col_336`)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci PARTITION BY HASH( `col_334` ) PARTITIONS 6;")
+	tk.MustExec("insert into t7(col_335, col_336) values(7685969, 'alice'),(2002468, 'bob')")
+	tk.MustExec("insert ignore into t7(col_335, col_336) values(2002468, 'david') on duplicate key update col_335 = 7685969")
+	tk.MustQuery("select * from t7").Check(testkit.Rows("-3217641 7685969 alice", "-3217641 2002468 bob"))
 }
 
 func (s *testSuite4) TestInsertSetWithDefault(c *C) {

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -1451,6 +1451,7 @@ func FindIndexByColName(t table.Table, name string) table.Index {
 // otherwise return kv.ErrKeyExists error.
 func CheckHandleOrUniqueKeyExistForUpdateIgnoreOrInsertOnDupIgnore(ctx context.Context, sctx sessionctx.Context, t table.Table, recordID kv.Handle, newRow []types.Datum, modified []bool) error {
 	physicalTableID := t.Meta().ID
+	idxs := t.Indices()
 	if pt, ok := t.(*partitionedTable); ok {
 		info := t.Meta().GetPartitionInfo()
 		pid, err := pt.locatePartition(sctx, info, newRow)
@@ -1459,6 +1460,7 @@ func CheckHandleOrUniqueKeyExistForUpdateIgnoreOrInsertOnDupIgnore(ctx context.C
 		}
 		partition := pt.GetPartition(pid)
 		physicalTableID = partition.GetPhysicalID()
+		idxs = partition.Indices()
 	}
 	txn, err := sctx.Txn(true)
 	if err != nil {
@@ -1492,7 +1494,7 @@ func CheckHandleOrUniqueKeyExistForUpdateIgnoreOrInsertOnDupIgnore(ctx context.C
 			return true
 		}
 
-		for _, idx := range t.Indices() {
+		for _, idx := range idxs {
 			if shouldSkipIgnoreCheck(idx) {
 				continue
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25846 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`CheckHandleOrUniqueKeyExistForUpdateIgnoreOrInsertOnDupIgnore` use table id instead of partition id to check index dup.

5.1 or master doesn't has this problem due to it use new memdb's stagehandle feature

### What is changed and how it works?


What's Changed, How it Works:

use partition's index when its partition

### Related changes

- Need to cherry-pick to the release branch 4.0, 3.0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the wrong result for "insert ignore duplicate up" on partition table when handle changed and duplicated on secondary index  <!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
