### PR TITLE
types: Fix duplicate warnings for string-to-float truncation

### DIFF
--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -899,7 +899,7 @@ func (s *testTypeConvertSuite) TestGetValidFloat(c *C) {
 	}
 	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
-		prefix, _ := getValidFloatPrefix(sc, tt.origin, false)
+		prefix, _ := getValidFloatPrefix(sc, tt.origin, false, false)
 		c.Assert(prefix, Equals, tt.valid)
 		_, err := strconv.ParseFloat(prefix, 64)
 		c.Assert(err, IsNil)


### PR DESCRIPTION


<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25829

`select 1 in (0, '1a', 2);` results in two warnings instead of one

### What is changed and how it works?

`getValidIntPrefix` now calls `getValidFloatPrefix` with an extra parameter which disabled the call to `HandleTruncate`


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Manual test (add detailed scripts or steps below)




### Release note <!-- bugfixes or new feature need a release note -->

- Fix duplicate warnings for truncation of `DOUBLE`
