### PR TITLE
*: update the `golangci-lint` and fix all lint errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ tools/bin/errdoc-gen: tools/check/go.mod
 	$(GO) build -o ../bin/errdoc-gen github.com/pingcap/errors/errdoc-gen
 
 tools/bin/golangci-lint:
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.29.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b ./tools/bin v1.41.1
 
 # Usage:
 #

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -1145,7 +1145,7 @@ func BuildElements(changingCol *model.ColumnInfo, changingIdxs []*model.IndexInf
 
 func (w *worker) updatePhysicalTableRow(t table.PhysicalTable, oldColInfo, colInfo *model.ColumnInfo, reorgInfo *reorgInfo) error {
 	logutil.BgLogger().Info("[ddl] start to update table row", zap.String("job", reorgInfo.Job.String()), zap.String("reorgInfo", reorgInfo.String()))
-	return w.writePhysicalTableRecord(t.(table.PhysicalTable), typeUpdateColumnWorker, nil, oldColInfo, colInfo, reorgInfo)
+	return w.writePhysicalTableRecord(t, typeUpdateColumnWorker, nil, oldColInfo, colInfo, reorgInfo)
 }
 
 // TestReorgGoroutineRunning is only used in test to indicate the reorg goroutine has been started.

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -2992,7 +2992,7 @@ func getPartitionTableRecordsNum(c *C, ctx sessionctx.Context, tbl table.Partiti
 	info := tbl.Meta().GetPartitionInfo()
 	for _, def := range info.Definitions {
 		pid := def.ID
-		partition := tbl.(table.PartitionedTable).GetPartition(pid)
+		partition := tbl.GetPartition(pid)
 		c.Assert(ctx.NewTxn(context.Background()), IsNil)
 		err := tables.IterRecords(partition, ctx, partition.Cols(),
 			func(_ kv.Handle, data []types.Datum, cols []*table.Column) (bool, error) {

--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1167,7 +1167,7 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 
 func (w *worker) addPhysicalTableIndex(t table.PhysicalTable, indexInfo *model.IndexInfo, reorgInfo *reorgInfo) error {
 	logutil.BgLogger().Info("[ddl] start to add table index", zap.String("job", reorgInfo.Job.String()), zap.String("reorgInfo", reorgInfo.String()))
-	return w.writePhysicalTableRecord(t.(table.PhysicalTable), typeAddIndexWorker, indexInfo, nil, nil, reorgInfo)
+	return w.writePhysicalTableRecord(t, typeAddIndexWorker, indexInfo, nil, nil, reorgInfo)
 }
 
 // addTableIndex handles the add index reorganization state for a table.
@@ -1358,7 +1358,7 @@ func (w *cleanUpIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (t
 // cleanupPhysicalTableIndex handles the drop partition reorganization state for a non-partitioned table or a partition.
 func (w *worker) cleanupPhysicalTableIndex(t table.PhysicalTable, reorgInfo *reorgInfo) error {
 	logutil.BgLogger().Info("[ddl] start to clean up index", zap.String("job", reorgInfo.Job.String()), zap.String("reorgInfo", reorgInfo.String()))
-	return w.writePhysicalTableRecord(t.(table.PhysicalTable), typeCleanUpIndexWorker, nil, nil, nil, reorgInfo)
+	return w.writePhysicalTableRecord(t, typeCleanUpIndexWorker, nil, nil, nil, reorgInfo)
 }
 
 // cleanupGlobalIndex handles the drop partition reorganization state to clean up index entries of partitions.

--- a/executor/slow_query.go
+++ b/executor/slow_query.go
@@ -552,10 +552,7 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 				} else {
 					fieldValues := strings.Split(line, " ")
 					for i := 0; i < len(fieldValues)-1; i += 2 {
-						field := fieldValues[i]
-						if strings.HasSuffix(field, ":") {
-							field = field[:len(field)-1]
-						}
+						field := strings.TrimSuffix(fieldValues[i], ":")
 						valid, err := st.setFieldValue(tz, field, fieldValues[i+1], fileLine, e.checker)
 						if err != nil {
 							sctx.GetSessionVars().StmtCtx.AppendWarning(err)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1359,7 +1359,7 @@ func (e *Explain) prepareTaskDot(p PhysicalPlan, taskTp string, buffer *bytes.Bu
 	buffer.WriteString("}\n")
 
 	for _, cop := range copTasks {
-		e.prepareTaskDot(cop.(PhysicalPlan), "cop", buffer)
+		e.prepareTaskDot(cop, "cop", buffer)
 	}
 
 	for i := range pipelines {

--- a/planner/core/encode.go
+++ b/planner/core/encode.go
@@ -112,7 +112,7 @@ func (pn *planEncoder) encodePlan(p Plan, isRoot bool, store kv.StoreType, depth
 		if pn.encodedPlans[child.ID()] {
 			continue
 		}
-		pn.encodePlan(child.(PhysicalPlan), isRoot, store, depth)
+		pn.encodePlan(child, isRoot, store, depth)
 	}
 	switch copPlan := selectPlan.(type) {
 	case *PhysicalTableReader:
@@ -184,7 +184,7 @@ func (d *planDigester) normalizePlan(p PhysicalPlan, isRoot bool, store kv.Store
 		if d.encodedPlans[child.ID()] {
 			continue
 		}
-		d.normalizePlan(child.(PhysicalPlan), isRoot, store, depth)
+		d.normalizePlan(child, isRoot, store, depth)
 	}
 	switch x := p.(type) {
 	case *PhysicalTableReader:

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1410,7 +1410,7 @@ func (s *testPlanSuite) TestUnion(c *C) {
 		}
 		c.Assert(err, IsNil)
 		p := plan.(LogicalPlan)
-		p, err = logicalOptimize(ctx, builder.optFlag, p.(LogicalPlan))
+		p, err = logicalOptimize(ctx, builder.optFlag, p)
 		s.testData.OnRecord(func() {
 			output[i].Best = ToString(p)
 		})

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -1074,7 +1074,7 @@ func (ts *HTTPHandlerTestSuite) TestGetSchema(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(dbtbl.TableInfo.Name.L, Equals, "user")
 	c.Assert(dbtbl.DBInfo.Name.L, Equals, "mysql")
-	se, err := session.CreateSession(ts.store.(kv.Storage))
+	se, err := session.CreateSession(ts.store)
 	c.Assert(err, IsNil)
 	c.Assert(dbtbl.SchemaVersion, Equals, domain.GetDomain(se.(sessionctx.Context)).InfoSchema().SchemaMetaVersion())
 
@@ -1148,7 +1148,7 @@ func (ts *HTTPHandlerTestSerialSuite) TestPostSettings(c *C) {
 	ts.startServer(c)
 	ts.prepareData(c)
 	defer ts.stopServer(c)
-	se, err := session.CreateSession(ts.store.(kv.Storage))
+	se, err := session.CreateSession(ts.store)
 	c.Assert(err, IsNil)
 
 	form := make(url.Values)
@@ -1298,7 +1298,7 @@ func (ts *HTTPHandlerTestSuite) TestServerInfo(c *C) {
 	c.Assert(info.GitHash, Equals, versioninfo.TiDBGitHash)
 
 	store := ts.server.newTikvHandlerTool().Store.(kv.Storage)
-	do, err := session.GetDomain(store.(kv.Storage))
+	do, err := session.GetDomain(store)
 	c.Assert(err, IsNil)
 	ddl := do.DDL()
 	c.Assert(info.ID, Equals, ddl.GetID())
@@ -1321,7 +1321,7 @@ func (ts *HTTPHandlerTestSerialSuite) TestAllServerInfo(c *C) {
 	c.Assert(clusterInfo.ServersNum, Equals, 1)
 
 	store := ts.server.newTikvHandlerTool().Store.(kv.Storage)
-	do, err := session.GetDomain(store.(kv.Storage))
+	do, err := session.GetDomain(store)
 	c.Assert(err, IsNil)
 	ddl := do.DDL()
 	c.Assert(clusterInfo.OwnerID, Equals, ddl.GetID())

--- a/types/time.go
+++ b/types/time.go
@@ -3004,7 +3004,6 @@ func parseSep(input string) (string, parseState) {
 
 func time12Hour(t *CoreTime, input string, ctx map[string]int) (string, bool) {
 	tryParse := func(input string) (string, parseState) {
-		state := parseStateNormal
 		// hh:mm:ss AM
 		/// Note that we should update `t` as soon as possible, or we
 		/// can not get correct result for incomplete input like "12:13"
@@ -3023,6 +3022,7 @@ func time12Hour(t *CoreTime, input string, ctx map[string]int) (string, bool) {
 		t.setHour(uint8(hour))
 
 		// ':'
+		var state parseState
 		if input, state = parseSep(input[length:]); state != parseStateNormal {
 			return input, state
 		}
@@ -3082,7 +3082,6 @@ func time24Hour(t *CoreTime, input string, ctx map[string]int) (string, bool) {
 		/// Note that we should update `t` as soon as possible, or we
 		/// can not get correct result for incomplete input like "12:13"
 		/// that is shorter than "hh:mm:ss"
-		state := parseStateNormal
 		result := oneOrTwoDigitRegex.FindString(input) // 0..23
 		length := len(result)
 		hour, succ := parseDigits(input, length)
@@ -3092,6 +3091,7 @@ func time24Hour(t *CoreTime, input string, ctx map[string]int) (string, bool) {
 		t.setHour(uint8(hour))
 
 		// ':'
+		var state parseState
 		if input, state = parseSep(input[length:]); state != parseStateNormal {
 			return input, state
 		}


### PR DESCRIPTION
Signed-off-by: JmPotato <ghzpotato@gmail.com>

### What problem does this PR solve?

Try to run `make tools/bin/golangci-lint` on M1 macOS.

![图片](https://user-images.githubusercontent.com/1446531/124344811-38289e80-dc07-11eb-9917-31156369cace.png)

It will fail.

### What is changed and how it works?

To make sure the M1 (or go 1.16) is supported, I upgrade the golangci-lint to the latest version. See golangci/golangci-lint#1725 for more details.

![图片](https://user-images.githubusercontent.com/1446531/124344880-c3099900-dc07-11eb-9ca7-75bf48a57a07.png)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test
- Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`.
