### PR TITLE
expression: fix unstable test TestExprOnlyPushDownToFlash

### DIFF
--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -904,7 +904,6 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
-	c.Skip("unstable, skip it and fix it before 20210705")
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -924,10 +923,6 @@ func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
 	exprs = append(exprs, function)
 
 	function, err = NewFunction(mock.NewContext(), ast.Substring, types.NewFieldType(mysql.TypeString), stringColumn, intColumn)
-	c.Assert(err, IsNil)
-	exprs = append(exprs, function)
-
-	function, err = NewFunction(mock.NewContext(), ast.DateAdd, types.NewFieldType(mysql.TypeDatetime), datetimeColumn, intColumn, stringColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -593,7 +593,7 @@ func (s *testEvaluatorSuite) TestOtherFunc2Pb(c *C) {
 	}
 }
 
-func (s *testEvaluatorSerialSuites) TestExprPushDownToFlash(c *C) {
+func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -903,7 +903,7 @@ func (s *testEvaluatorSerialSuites) TestExprPushDownToFlash(c *C) {
 	c.Assert(len(remained), Equals, len(exprs))
 }
 
-func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToFlash(c *C) {
+func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -960,7 +960,7 @@ func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToFlash(c *C) {
 	c.Assert(len(remained), Equals, len(exprs))
 }
 
-func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToTiKV(c *C) {
+func (s *testEvaluatorSuite) TestExprOnlyPushDownToTiKV(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -593,7 +593,7 @@ func (s *testEvaluatorSuite) TestOtherFunc2Pb(c *C) {
 	}
 }
 
-func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
+func (s *testEvaluatorSerialSuites) TestExprPushDownToFlash(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -903,7 +903,7 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 	c.Assert(len(remained), Equals, len(exprs))
 }
 
-func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
+func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToFlash(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)
@@ -956,7 +956,7 @@ func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
 	c.Assert(len(remained), Equals, len(exprs))
 }
 
-func (s *testEvaluatorSuite) TestExprOnlyPushDownToTiKV(c *C) {
+func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToTiKV(c *C) {
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -926,10 +926,6 @@ func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 
-	function, err = NewFunction(mock.NewContext(), ast.DateAdd, types.NewFieldType(mysql.TypeDatetime), datetimeColumn, intColumn, stringColumn)
-	c.Assert(err, IsNil)
-	exprs = append(exprs, function)
-
 	function, err = NewFunction(mock.NewContext(), ast.TimestampDiff, types.NewFieldType(mysql.TypeLonglong), stringColumn, datetimeColumn, datetimeColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -926,6 +926,10 @@ func (s *testEvaluatorSerialSuites) TestExprOnlyPushDownToFlash(c *C) {
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)
 
+	function, err = NewFunction(mock.NewContext(), ast.DateAdd, types.NewFieldType(mysql.TypeDatetime), datetimeColumn, intColumn, stringColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
 	function, err = NewFunction(mock.NewContext(), ast.TimestampDiff, types.NewFieldType(mysql.TypeLonglong), stringColumn, datetimeColumn, datetimeColumn)
 	c.Assert(err, IsNil)
 	exprs = append(exprs, function)

--- a/expression/flag_simplify_test.go
+++ b/expression/flag_simplify_test.go
@@ -15,10 +15,16 @@ package expression_test
 
 import (
 	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/charset"
+	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/parser/types"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
 )
@@ -66,4 +72,73 @@ func (s *testFlagSimplifySuite) TestSimplifyExpressionByFlag(c *C) {
 		})
 		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
 	}
+}
+
+type dataGen4Expr2PbTest struct {
+}
+
+func (dg *dataGen4Expr2PbTest) genColumn(tp byte, id int64) *expression.Column {
+	return &expression.Column{
+		RetType: types.NewFieldType(tp),
+		ID:      id,
+		Index:   int(id),
+	}
+}
+
+
+func (s *testFlagSimplifySuite) TestExprOnlyPushDownToFlash(c *C) {
+	sc := new(stmtctx.StatementContext)
+	client := new(mock.Client)
+	dg := new(dataGen4Expr2PbTest)
+	exprs := make([]expression.Expression, 0)
+
+	//jsonColumn := dg.genColumn(mysql.TypeJSON, 1)
+	intColumn := dg.genColumn(mysql.TypeLonglong, 2)
+	//realColumn := dg.genColumn(mysql.TypeDouble, 3)
+	decimalColumn := dg.genColumn(mysql.TypeNewDecimal, 4)
+	stringColumn := dg.genColumn(mysql.TypeString, 5)
+	datetimeColumn := dg.genColumn(mysql.TypeDatetime, 6)
+	binaryStringColumn := dg.genColumn(mysql.TypeString, 7)
+	binaryStringColumn.RetType.Collate = charset.CollationBin
+
+	function, err := expression.NewFunction(mock.NewContext(), ast.Substr, types.NewFieldType(mysql.TypeString), stringColumn, intColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = expression.NewFunction(mock.NewContext(), ast.Substring, types.NewFieldType(mysql.TypeString), stringColumn, intColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = expression.NewFunction(mock.NewContext(), ast.DateAdd, types.NewFieldType(mysql.TypeDatetime), datetimeColumn, intColumn, stringColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = expression.NewFunction(mock.NewContext(), ast.TimestampDiff, types.NewFieldType(mysql.TypeLonglong), stringColumn, datetimeColumn, datetimeColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = expression.NewFunction(mock.NewContext(), ast.FromUnixTime, types.NewFieldType(mysql.TypeDatetime), decimalColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	function, err = expression.NewFunction(mock.NewContext(), ast.Extract, types.NewFieldType(mysql.TypeLonglong), stringColumn, datetimeColumn)
+	c.Assert(err, IsNil)
+	exprs = append(exprs, function)
+
+	pushed, remained := expression.PushDownExprs(sc, exprs, client, kv.UnSpecified)
+	c.Assert(len(pushed), Equals, len(exprs))
+	c.Assert(len(remained), Equals, 0)
+
+	canPush := expression.CanExprsPushDown(sc, exprs, client, kv.TiFlash)
+	c.Assert(canPush, Equals, true)
+	canPush = expression.CanExprsPushDown(sc, exprs, client, kv.TiKV)
+	c.Assert(canPush, Equals, false)
+
+	pushed, remained = expression.PushDownExprs(sc, exprs, client, kv.TiFlash)
+	c.Assert(len(pushed), Equals, len(exprs))
+	c.Assert(len(remained), Equals, 0)
+
+	pushed, remained = expression.PushDownExprs(sc, exprs, client, kv.TiKV)
+	c.Assert(len(pushed), Equals, 0)
+	c.Assert(len(remained), Equals, len(exprs))
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25584 <!-- REMOVE this line if no issue to close -->

Problem Summary:  see https://github.com/pingcap/tidb/issues/25584#issuecomment-873951010

### What is changed and how it works?

What's Changed: make these tests serial.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`: no need
- Need to cherry-pick to the release branch: no need

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Integration test
- Manual test (add detailed scripts or steps below)

Side effects

- Performance regression
    - Consumes more CPU
    - Consumes more MEM
- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
