### PR TITLE
lock_resolver: avoid pessimistic transactions using resolveLocksForWrite

### DIFF
--- a/store/tikv/async_commit_test.go
+++ b/store/tikv/async_commit_test.go
@@ -168,6 +168,7 @@ func (s *testAsyncCommitSuite) lockKeysWithAsyncCommit(c *C, keys, values [][]by
 	tpc, err := newTwoPhaseCommitterWithInit(txn, 0)
 	c.Assert(err, IsNil)
 	tpc.primaryKey = primaryKey
+	tpc.setAsyncCommit(true)
 
 	ctx := context.Background()
 	err = tpc.prewriteMutations(NewBackofferWithVars(ctx, PrewriteMaxBackoff, nil), tpc.mutations)
@@ -528,4 +529,25 @@ func (m *mockResolveClient) SendRequest(ctx context.Context, addr string, req *t
 
 func (m *mockResolveClient) Close() error {
 	return m.inner.Close()
+}
+
+// TestPessimisticTxnResolveAsyncCommitLock tests that pessimistic transactions resolve non-expired async-commit locks during the prewrite phase.
+// Pessimistic transactions will resolve locks immediately during the prewrite phase because of the special logic for handling non-pessimistic lock conflict.
+// However, async-commit locks can't be resolved until they expire. This test covers it.
+func (s *testAsyncCommitSuite) TestPessimisticTxnResolveAsyncCommitLock(c *C) {
+	ctx := context.Background()
+	k := []byte("k")
+
+	txn, err := s.store.Begin()
+	c.Assert(err, IsNil)
+	txn.SetOption(kv.Pessimistic, true)
+	err = txn.LockKeys(ctx, &kv.LockCtx{ForUpdateTS: txn.StartTS()}, []byte("k1"))
+	c.Assert(err, IsNil)
+
+	// Lock the key with a async-commit lock.
+	s.lockKeysWithAsyncCommit(c, [][]byte{}, [][]byte{}, k, k, false)
+
+	txn.Set(k, k)
+	err = txn.Commit(context.Background())
+	c.Assert(err, IsNil)
 }

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -430,8 +430,10 @@ func (lr *LockResolver) resolveLocks(bo *Backoffer, callerStartTS uint64, locks 
 	return msBeforeTxnExpired.value(), pushed, nil
 }
 
-func (lr *LockResolver) resolveLocksForWrite(bo *Backoffer, callerStartTS uint64, locks []*Lock) (int64, error) {
-	msBeforeTxnExpired, _, err := lr.resolveLocks(bo, callerStartTS, locks, true, false)
+func (lr *LockResolver) resolveLocksForWrite(bo *Backoffer, callerStartTS, callerForUpdateTS uint64, locks []*Lock) (int64, error) {
+	// The forWrite parameter is only useful for optimistic transactions which can avoid deadlock between large transactions,
+	// so only use forWrite if the callerForUpdateTS is zero.
+	msBeforeTxnExpired, _, err := lr.resolveLocks(bo, callerStartTS, locks, callerForUpdateTS == 0, false)
 	return msBeforeTxnExpired, err
 }
 

--- a/store/tikv/prewrite.go
+++ b/store/tikv/prewrite.go
@@ -261,7 +261,7 @@ func (action actionPrewrite) handleSingleBatch(c *twoPhaseCommitter, bo *Backoff
 			locks = append(locks, lock)
 		}
 		start := time.Now()
-		msBeforeExpired, err := c.store.lockResolver.resolveLocksForWrite(bo, c.startTS, locks)
+		msBeforeExpired, err := c.store.lockResolver.resolveLocksForWrite(bo, c.startTS, c.forUpdateTS, locks)
 		if err != nil {
 			return errors.Trace(err)
 		}


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

Fix https://github.com/pingcap/tidb/issues/25964 in v5.0.

### What is changed and how it works?

What's Changed:

Avoid pessimistic transactions using resolveLocksForWrite which is only useful for optimistic transactions.

### Related changes


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects


### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that committing pessimistic transactions may report write-conflict errors.