### PR TITLE
config: add a config of resolve lock lite threshold

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -138,8 +138,9 @@ type Config struct {
 	SplitRegionMaxNum   uint64      `toml:"split-region-max-num" json:"split-region-max-num"`
 	StmtSummary         StmtSummary `toml:"stmt-summary" json:"stmt-summary"`
 	// RepairMode indicates that the TiDB is in the repair mode for table meta.
-	RepairMode      bool     `toml:"repair-mode" json:"repair-mode"`
-	RepairTableList []string `toml:"repair-table-list" json:"repair-table-list"`
+	RepairMode               bool     `toml:"repair-mode" json:"repair-mode"`
+	RepairTableList          []string `toml:"repair-table-list" json:"repair-table-list"`
+	ResolveLockLiteThreshold uint64   `toml:"resolve-lock-lite-threshold" json:"resolve-lock-lite-threshold"`
 	// IsolationRead indicates that the TiDB reads data from which isolation level(engine and label).
 	IsolationRead IsolationRead `toml:"isolation-read" json:"isolation-read"`
 	// MaxServerConnections is the maximum permitted number of simultaneous client connections.
@@ -566,6 +567,7 @@ var defaultConf = Config{
 	EnableTableLock:              false,
 	DelayCleanTableLock:          0,
 	SplitRegionMaxNum:            1000,
+	ResolveLockLiteThreshold:     128,
 	RepairMode:                   false,
 	RepairTableList:              []string{},
 	MaxServerConnections:         0,

--- a/config/config.go
+++ b/config/config.go
@@ -567,7 +567,7 @@ var defaultConf = Config{
 	EnableTableLock:              false,
 	DelayCleanTableLock:          0,
 	SplitRegionMaxNum:            1000,
-	ResolveLockLiteThreshold:     128,
+	ResolveLockLiteThreshold:     16,
 	RepairMode:                   false,
 	RepairTableList:              []string{},
 	MaxServerConnections:         0,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -105,6 +105,9 @@ repair-mode = false
 # In repair mode, repairing table which is not in repair list will get wrong database or wrong table error.
 repair-table-list = []
 
+# If the number of keys that one prewrite request of one region involves exceed this threshold, it will use `ResolveLock` instead of `ResolveLockLite`.
+resolve-lock-lite-threshold = 128
+
 # The maximum permitted number of simultaneous client connections. When the value is 0, the number of connections is unlimited.
 max-server-connections = 0
 

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -106,7 +106,7 @@ repair-mode = false
 repair-table-list = []
 
 # If the number of keys that one prewrite request of one region involves exceed this threshold, it will use `ResolveLock` instead of `ResolveLockLite`.
-resolve-lock-lite-threshold = 128
+resolve-lock-lite-threshold = 16
 
 # The maximum permitted number of simultaneous client connections. When the value is 0, the number of connections is unlimited.
 max-server-connections = 0

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -265,7 +265,7 @@ spilled-file-encryption-method = "plaintext"
 	c.Assert(conf.StmtSummary.HistorySize, Equals, 100)
 	c.Assert(conf.EnableBatchDML, Equals, true)
 	c.Assert(conf.RepairMode, Equals, true)
-	c.Assert(conf.ResolveLockLiteThreshold, Equals, 16)
+	c.Assert(conf.ResolveLockLiteThreshold, Equals, uint64(16))
 	c.Assert(conf.MaxServerConnections, Equals, uint32(200))
 	c.Assert(conf.MemQuotaQuery, Equals, int64(10000))
 	c.Assert(conf.Experimental.AllowsExpressionIndex, IsTrue)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -190,6 +190,7 @@ split-region-max-num=10000
 enable-batch-dml = true
 server-version = "test_version"
 repair-mode = true
+resolve-lock-lite-threshold = 16
 max-server-connections = 200
 mem-quota-query = 10000
 max-index-length = 3080
@@ -264,6 +265,7 @@ spilled-file-encryption-method = "plaintext"
 	c.Assert(conf.StmtSummary.HistorySize, Equals, 100)
 	c.Assert(conf.EnableBatchDML, Equals, true)
 	c.Assert(conf.RepairMode, Equals, true)
+	c.Assert(conf.ResolveLockLiteThreshold, Equals, 16)
 	c.Assert(conf.MaxServerConnections, Equals, uint32(200))
 	c.Assert(conf.MemQuotaQuery, Equals, int64(10000))
 	c.Assert(conf.Experimental.AllowsExpressionIndex, IsTrue)

--- a/store/tikv/2pc_test.go
+++ b/store/tikv/2pc_test.go
@@ -1177,6 +1177,7 @@ func (s *testCommitterSuite) TestResolveMixed(c *C) {
 
 	// pk is the primary lock of txn1
 	pk := kv.Key("pk")
+	bigTxnThreshold := 16
 	secondaryLockkeys := make([]kv.Key, 0, bigTxnThreshold)
 	for i := 0; i < bigTxnThreshold; i++ {
 		optimisticLock := kv.Key(fmt.Sprintf("optimisticLockKey%d", i))

--- a/store/tikv/lock_resolver.go
+++ b/store/tikv/lock_resolver.go
@@ -40,9 +40,6 @@ import (
 // ResolvedCacheSize is max number of cached txn status.
 const ResolvedCacheSize = 2048
 
-// bigTxnThreshold : transaction involves keys exceed this threshold can be treated as `big transaction`.
-const bigTxnThreshold = 16
-
 // LockResolver resolves locks and also caches resolved txn status.
 type LockResolver struct {
 	store                    *KVStore


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

cherry-pick @Connor1996's #25835 to 5.0

Problem Summary:

When encountering a lock to resolve, TiDB chooses either ResolveLock or ResolveLockLite depending on the transaction size of the lock. Previously, ResolveLockLite is used when the transaction size is smaller than 16 which is a fixed number.

But we meet the case that ResolveLock is relatively slow due to too many tombstones between the range of the Region where the lock locates. To resolve that, we'd better use ResolveLockLite to avoid the effect of too many tombstones, so make the threshold configurable.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed, How it Works:

add a resolveLite threshold config

### Related changes

- Need to cherry-pick to the release branch master(go-client), 5.1

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Just config change

Side effects

- n/a

### Release note <!-- bugfixes or new feature need a release note -->

- Support change resolve lock lite threshold by config file<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
