### PR TITLE
session: Update bootstrap version

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -2077,7 +2077,7 @@ func CreateSessionWithDomain(store kv.Storage, dom *domain.Domain) (*session, er
 
 const (
 	notBootstrapped         = 0
-	currentBootstrapVersion = version51
+	currentBootstrapVersion = version52
 )
 
 func getStoreBootstrapVersion(store kv.Storage) int64 {


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This fixes an error in https://github.com/pingcap/tidb/pull/25749

In the v4.0 branch, the bootstrap version is stored in `session/session.go` and not `session/bootstrap.go`. I missed it when porting the patch from master.

This only affects the v4.0 branch, and not the v5.0 or v5.1 cherry pick.

### What is changed and how it works?

What's Changed:

The bootstrap version is incremented.

### Related changes

- PR to update `pingcap/docs`/`pingcap/docs-cn`:
- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- None

Side effects

- None

### Release note <!-- bugfixes or new feature need a release note -->

- No release note