### PR TITLE
planner: support stable result mode (#25971)

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -428,6 +428,16 @@ func (s *testSuite5) TestSetVar(c *C) {
 	tk.MustQuery(`select @@session.tidb_slow_log_masking;`).Check(testkit.Rows("0"))
 	tk.MustExec("set session tidb_slow_log_masking = 1")
 	tk.MustQuery(`select @@session.tidb_slow_log_masking;`).Check(testkit.Rows("1"))
+
+	// test for tidb_enable_stable_result_mode
+	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set global tidb_enable_stable_result_mode = 1`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
+	tk.MustExec(`set global tidb_enable_stable_result_mode = 0`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set tidb_enable_stable_result_mode=1`)
+	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
+	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -42,6 +42,7 @@ var AllowCartesianProduct = atomic.NewBool(true)
 const (
 	flagGcSubstitute uint64 = 1 << iota
 	flagPrunColumns
+	flagStabilizeResults
 	flagBuildKeyInfo
 	flagDecorrelate
 	flagEliminateAgg
@@ -59,6 +60,7 @@ const (
 var optRuleList = []logicalOptRule{
 	&gcSubstituter{},
 	&columnPruner{},
+	&resultsStabilizer{},
 	&buildKeySolver{},
 	&decorrelateSolver{},
 	&aggregationEliminator{},
@@ -119,11 +121,20 @@ func CheckTableLock(ctx sessionctx.Context, is infoschema.InfoSchema, vs []visit
 	return nil
 }
 
+func checkStableResultMode(sctx sessionctx.Context) bool {
+	s := sctx.GetSessionVars()
+	st := s.StmtCtx
+	return s.EnableStableResultMode && (!st.InInsertStmt && !st.InUpdateStmt && !st.InDeleteStmt && !st.InLoadDataStmt)
+}
+
 // DoOptimize optimizes a logical plan to a physical plan.
 func DoOptimize(ctx context.Context, sctx sessionctx.Context, flag uint64, logic LogicalPlan) (PhysicalPlan, float64, error) {
 	// if there is something after flagPrunColumns, do flagPrunColumnsAgain
 	if flag&flagPrunColumns > 0 && flag-flagPrunColumns > flagPrunColumns {
 		flag |= flagPrunColumnsAgain
+	}
+	if checkStableResultMode(sctx) {
+		flag |= flagStabilizeResults
 	}
 	logic, err := logicalOptimize(ctx, flag, logic)
 	if err != nil {

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -375,7 +375,7 @@ func TryFastPlan(ctx sessionctx.Context, node ast.Node) (p Plan) {
 		// the rule of stabilizing results has not taken effect yet, so cannot generate a plan here in this mode
 		return nil
 	}
-	
+
 	ctx.GetSessionVars().PlanID = 0
 	ctx.GetSessionVars().PlanColumnID = 0
 	switch x := node.(type) {

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -371,6 +371,11 @@ func (p *BatchPointGetPlan) GetCost(cols []*expression.Column) float64 {
 
 // TryFastPlan tries to use the PointGetPlan for the query.
 func TryFastPlan(ctx sessionctx.Context, node ast.Node) (p Plan) {
+	if checkStableResultMode(ctx) {
+		// the rule of stabilizing results has not taken effect yet, so cannot generate a plan here in this mode
+		return nil
+	}
+	
 	ctx.GetSessionVars().PlanID = 0
 	ctx.GetSessionVars().PlanColumnID = 0
 	switch x := node.(type) {

--- a/planner/core/rule_stabilize_results.go
+++ b/planner/core/rule_stabilize_results.go
@@ -1,0 +1,120 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/planner/util"
+)
+
+/*
+	resultsStabilizer stabilizes query results.
+	NOTE: it's not a common rule for all queries, it's specially implemented for a few customers.
+	Results of some queries are not stable, for example:
+		create table t (a int); insert into t values (1), (2); select a from t;
+	In the case above, the result can be `1 2` or `2 1`, which is not stable.
+	This rule stabilizes results by modifying or injecting a Sort operator:
+	1. iterate the plan from the root, and ignore all input-order operators (Sel/Proj/Limit);
+	2. when meeting the first non-input-order operator,
+		2.1. if it's a Sort, update it by appending all output columns into its order-by list,
+		2.2. otherwise, inject a new Sort upon this operator.
+*/
+type resultsStabilizer struct {
+}
+
+func (rs *resultsStabilizer) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
+	stable := rs.completeSort(lp)
+	if !stable {
+		lp = rs.injectSort(lp)
+	}
+	return lp, nil
+}
+
+func (rs *resultsStabilizer) completeSort(lp LogicalPlan) bool {
+	if rs.isInputOrderKeeper(lp) {
+		return rs.completeSort(lp.Children()[0])
+	} else if sort, ok := lp.(*LogicalSort); ok {
+		cols := sort.Schema().Columns // sort results by all output columns
+		if handleCol := rs.extractHandleCol(sort.Children()[0]); handleCol != nil {
+			cols = []*expression.Column{handleCol} // sort results by the handle column if we can get it
+		}
+		for _, col := range cols {
+			exist := false
+			for _, byItem := range sort.ByItems {
+				if col.Equal(nil, byItem.Expr) {
+					exist = true
+					break
+				}
+			}
+			if !exist {
+				sort.ByItems = append(sort.ByItems, &util.ByItems{Expr: col})
+			}
+		}
+		return true
+	}
+	return false
+}
+
+func (rs *resultsStabilizer) injectSort(lp LogicalPlan) LogicalPlan {
+	if rs.isInputOrderKeeper(lp) {
+		lp.SetChildren(rs.injectSort(lp.Children()[0]))
+		return lp
+	}
+
+	byItems := make([]*util.ByItems, 0, len(lp.Schema().Columns))
+	cols := lp.Schema().Columns
+	if handleCol := rs.extractHandleCol(lp); handleCol != nil {
+		cols = []*expression.Column{handleCol}
+	}
+	for _, col := range cols {
+		byItems = append(byItems, &util.ByItems{Expr: col})
+	}
+	sort := LogicalSort{
+		ByItems: byItems,
+	}.Init(lp.SCtx(), lp.SelectBlockOffset())
+	sort.SetChildren(lp)
+	return sort
+}
+
+func (rs *resultsStabilizer) isInputOrderKeeper(lp LogicalPlan) bool {
+	switch lp.(type) {
+	case *LogicalSelection, *LogicalProjection, *LogicalLimit:
+		return true
+	}
+	return false
+}
+
+// extractHandleCols does the best effort to get the handle column.
+func (rs *resultsStabilizer) extractHandleCol(lp LogicalPlan) *expression.Column {
+	switch x := lp.(type) {
+	case *LogicalSelection, *LogicalLimit:
+		handleCol := rs.extractHandleCol(lp.Children()[0])
+		if x.Schema().Contains(handleCol) {
+			// some Projection Operator might be inlined, so check the column again here
+			return handleCol
+		}
+	case *DataSource:
+		handleCol := x.getPKIsHandleCol()
+		if handleCol != nil {
+			return handleCol
+		}
+	}
+	return nil
+}
+
+func (rs *resultsStabilizer) name() string {
+	return "stabilize_results"
+}

--- a/planner/core/rule_stabilize_results_test.go
+++ b/planner/core/rule_stabilize_results_test.go
@@ -1,0 +1,189 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"math"
+
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
+	plannercore "github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/util/kvcache"
+	"github.com/pingcap/tidb/util/testkit"
+	"github.com/pingcap/tidb/util/testutil"
+)
+
+var _ = Suite(&testRuleStabilizeResults{})
+var _ = SerialSuites(&testRuleStabilizeResultsSerial{})
+
+type testRuleStabilizeResultsSerial struct {
+	store kv.Storage
+	dom   *domain.Domain
+}
+
+func (s *testRuleStabilizeResultsSerial) SetUpTest(c *C) {
+	var err error
+	s.store, s.dom, err = newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+}
+
+func (s *testRuleStabilizeResultsSerial) TestPlanCache(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	orgEnable := plannercore.PreparedPlanCacheEnabled()
+	defer func() {
+		plannercore.SetPreparedPlanCache(orgEnable)
+	}()
+	plannercore.SetPreparedPlanCache(true)
+	var err error
+	tk.Se, err = session.CreateSession4TestWithOpt(s.store, &session.Opt{
+		PreparedPlanCache: kvcache.NewSimpleLRUCache(100, 0.1, math.MaxUint64),
+	})
+	c.Assert(err, IsNil)
+
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
+	tk.MustExec("prepare s1 from 'select * from t where a > ? limit 10'")
+	tk.MustExec("set @a = 10")
+	tk.MustQuery("execute s1 using @a").Check(testkit.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("execute s1 using @a").Check(testkit.Rows())
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1")) // plan cache is still working
+}
+
+func (s *testRuleStabilizeResultsSerial) TestSQLBinding(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
+	tk.MustQuery("explain select * from t where a > 0 limit 1").Check(testkit.Rows(
+		"Limit_11 1.00 root  offset:0, count:1",
+		"└─TableReader_21 1.00 root  data:Limit_20",
+		"  └─Limit_20 1.00 cop[tikv]  offset:0, count:1",
+		"    └─TableRangeScan_19 1.00 cop[tikv] table:t range:(0,+inf], keep order:true, stats:pseudo"))
+
+	tk.MustExec("create session binding for select * from t where a>0 limit 1 using select * from t use index(b) where a>0 limit 1")
+	tk.MustQuery("explain select * from t where a > 0 limit 1").Check(testkit.Rows(
+		"TopN_9 1.00 root  test.t.a:asc, offset:0, count:1",
+		"└─IndexLookUp_18 1.00 root  ",
+		"  ├─TopN_17(Build) 1.00 cop[tikv]  test.t.a:asc, offset:0, count:1",
+		"  │ └─Selection_16 3333.33 cop[tikv]  gt(test.t.a, 0)",
+		"  │   └─IndexFullScan_14 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+		"  └─TableRowIDScan_15(Probe) 1.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+}
+
+type testRuleStabilizeResults struct {
+	store kv.Storage
+	dom   *domain.Domain
+
+	testData testutil.TestData
+}
+
+func (s *testRuleStabilizeResults) SetUpSuite(c *C) {
+	var err error
+	s.store, s.dom, err = newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "stable_result_mode_suite")
+	c.Assert(err, IsNil)
+}
+
+func (s *testRuleStabilizeResults) TearDownSuite(c *C) {
+	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
+}
+
+func (s *testRuleStabilizeResults) runTestData(c *C, tk *testkit.TestKit, name string) {
+	var input []string
+	var output []struct {
+		Plan []string
+	}
+	s.testData.GetTestCasesByName(name, c, &input, &output)
+	c.Assert(len(input), Equals, len(output))
+	for i := range input {
+		s.testData.OnRecord(func() {
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + input[i]).Rows())
+		})
+		tk.MustQuery("explain " + input[i]).Check(testkit.Rows(output[i].Plan...))
+	}
+}
+
+func (s *testRuleStabilizeResults) TestStableResultMode(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
+	s.runTestData(c, tk, "TestStableResultMode")
+}
+
+func (s *testRuleStabilizeResults) TestStableResultModeOnDML(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b int, c int, key(b))")
+	s.runTestData(c, tk, "TestStableResultModeOnDML")
+}
+
+func (s *testRuleStabilizeResults) TestStableResultModeOnSubQuery(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, key(b))")
+	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, key(b))")
+	s.runTestData(c, tk, "TestStableResultModeOnSubQuery")
+}
+
+func (s *testRuleStabilizeResults) TestStableResultModeOnJoin(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, key(b))")
+	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, key(b))")
+	s.runTestData(c, tk, "TestStableResultModeOnJoin")
+}
+
+func (s *testRuleStabilizeResults) TestStableResultModeOnOtherOperators(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, unique key(b))")
+	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, unique key(b))")
+	s.runTestData(c, tk, "TestStableResultModeOnOtherOperators")
+}
+
+func (s *testRuleStabilizeResults) TestStableResultModeOnPartitionTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("drop table if exists thash")
+	tk.MustExec("drop table if exists trange")
+	tk.MustExec("create table thash (a int primary key, b int, c int, d int) partition by hash(a) partitions 4")
+	tk.MustExec(`create table trange (a int primary key, b int, c int, d int) partition by range(a) (
+					partition p0 values less than (100),
+					partition p1 values less than (200),
+					partition p2 values less than (300),
+					partition p3 values less than (400))`)
+	s.runTestData(c, tk, "TestStableResultModeOnPartitionTable")
+}

--- a/planner/core/testdata/stable_result_mode_suite_in.json
+++ b/planner/core/testdata/stable_result_mode_suite_in.json
@@ -1,0 +1,81 @@
+[
+  {
+    "name": "TestStableResultMode",
+    "cases": [
+      "select * from t use index(primary)",
+      "select b from t use index(b)",
+      "select a, b from t use index(b)",
+      "select b, c from t use index(b)",
+      "select b, c from t use index(primary)",
+      "select min(b), max(c) from t use index(primary) group by d",
+      "select min(b), max(c) from t use index(primary) group by a",
+      "select * from t use index(b) limit 10",
+      "select * from t use index(primary) limit 10",
+      "select b from t use index(b) order by b",
+      "select b, c, d from t use index(b) order by b",
+      "select t1.a, t2.a from t t1, t t2 where t1.a=t2.a",
+      "select b from t where a>0",
+      "select b from t where a>0 limit 1"
+    ]
+  },
+  {
+    "name": "TestStableResultModeOnDML",
+    "cases": [
+      "insert into t select * from t",
+      "insert into t select * from t where a>1",
+      "insert into t select t1.a, t2.b, t1.c+t2.c from t t1, t t2 where t1.a=t2.a",
+      "insert into t select min(a), max(b), sum(c) from t group by a",
+      "delete from t",
+      "delete from t where a>1",
+      "update t set a=a+1",
+      "update t set a=a+1 where a>1"
+    ]
+  },
+  {
+    "name": "TestStableResultModeOnSubQuery",
+    "cases": [
+      "select * from t1 where t1.a in (select b from t2)",
+      "select * from t1 where t1.a not in (select b from t2)",
+      "select * from t1 where t1.a in (select b from t2 where t2.c>t1.c)",
+      "select * from t1 where t1.a not in (select b from t2 where t2.c>t1.c)",
+      "select * from t1 where exists (select 1 from t2 where t2.c>t1.c)",
+      "select * from t1 where not exists (select 1 from t2 where t2.c>t1.c)",
+      "select * from t1 where exists (select 1 from t2 where t2.c=t1.c)",
+      "select * from t1 where not exists (select 1 from t2 where t2.c=t1.c)",
+      "select t1.* from t1, (select b from t2) tb where t1.b=tb.b"
+    ]
+  },
+  {
+    "name": "TestStableResultModeOnJoin",
+    "cases": [
+      "select * from t1, t2 where t1.a = t2.a",
+      "select * from t1, t2 where t1.a > t2.a and t1.b = t2.b and t1.c < t2.c",
+      "select t1.* from t1 left outer join t2 on t1.a=t2.a",
+      "select t1.* from t1 join t2 on t1.a!=t2.a"
+    ]
+  },
+  {
+    "name": "TestStableResultModeOnOtherOperators",
+    "cases": [
+      "select * from t1 where a = 1 or a = 222 or a = 33333",
+      "select * from t1 where a in (1, 2, 3, 4)",
+      "select b from t1 where b = 1 or b = 222 or b = 33333",
+      "select b from t1 where b in (1, 2, 3, 4)",
+      "select * from t1 where a > 10 union all select * from t2 where b > 20",
+      "select * from t1 where a > 10 union distinct select * from t2 where b > 20",
+      "select row_number() over(partition by a) as row_no, sum(b) over(partition by a) as sum_b from t1",
+      "select min(a), max(b), sum(c) from t1 group by d",
+      "select min(a), max(b), sum(c) from t1 group by d having max(b) < 20",
+      "select case when a=1 then 'a1' when a=2 then 'a2' else 'ax' end from t1 "
+    ]
+  },
+  {
+    "name": "TestStableResultModeOnPartitionTable",
+    "cases": [
+      "select * from thash where a in (1, 200)",
+      "select * from thash where a >= 50 and a <= 150",
+      "select * from trange where a in (1, 200)",
+      "select * from trange where a >= 50 and a <= 150"
+    ]
+  }
+]

--- a/planner/core/testdata/stable_result_mode_suite_out.json
+++ b/planner/core/testdata/stable_result_mode_suite_out.json
@@ -1,0 +1,469 @@
+[
+  {
+    "Name": "TestStableResultMode",
+    "Cases": [
+      {
+        "Plan": [
+          "TableReader_10 10000.00 root  data:TableFullScan_9",
+          "└─TableFullScan_9 10000.00 cop[tikv] table:t keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "IndexReader_10 10000.00 root  index:IndexFullScan_9",
+          "└─IndexFullScan_9 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.a:asc",
+          "└─IndexReader_8 10000.00 root  index:IndexFullScan_7",
+          "  └─IndexFullScan_7 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.b:asc, test.t.c:asc",
+          "└─IndexLookUp_9 10000.00 root  ",
+          "  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_5 10000.00 root  test.t.b:asc, test.t.c:asc",
+          "└─TableReader_8 10000.00 root  data:TableFullScan_7",
+          "  └─TableFullScan_7 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_6 8000.00 root  Column#5:asc, Column#6:asc",
+          "└─HashAgg_12 8000.00 root  group by:test.t.d, funcs:min(Column#7)->Column#5, funcs:max(Column#8)->Column#6",
+          "  └─TableReader_13 8000.00 root  data:HashAgg_8",
+          "    └─HashAgg_8 8000.00 cop[tikv]  group by:test.t.d, funcs:min(test.t.b)->Column#7, funcs:max(test.t.c)->Column#8",
+          "      └─TableFullScan_11 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_7 10000.00 root  Column#5:asc, Column#6:asc",
+          "└─Projection_9 10000.00 root  cast(test.t.b, int(11))->Column#5, cast(test.t.c, int(11))->Column#6",
+          "  └─TableReader_11 10000.00 root  data:TableFullScan_10",
+          "    └─TableFullScan_10 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "TopN_8 10.00 root  test.t.a:asc, offset:0, count:10",
+          "└─IndexLookUp_16 10.00 root  ",
+          "  ├─TopN_15(Build) 10.00 cop[tikv]  test.t.a:asc, offset:0, count:10",
+          "  │ └─IndexFullScan_13 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_14(Probe) 10.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Limit_10 10.00 root  offset:0, count:10",
+          "└─TableReader_20 10.00 root  data:Limit_19",
+          "  └─Limit_19 10.00 cop[tikv]  offset:0, count:10",
+          "    └─TableFullScan_18 10.00 cop[tikv] table:t keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "IndexReader_11 10000.00 root  index:IndexFullScan_10",
+          "└─IndexFullScan_10 10000.00 cop[tikv] table:t, index:b(b) keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_4 10000.00 root  test.t.b:asc, test.t.c:asc, test.t.d:asc",
+          "└─IndexLookUp_9 10000.00 root  ",
+          "  ├─IndexFullScan_7(Build) 10000.00 cop[tikv] table:t, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_8(Probe) 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 12500.00 root  test.t.a:asc, test.t.a:asc",
+          "└─HashJoin_22 12500.00 root  inner join, equal:[eq(test.t.a, test.t.a)]",
+          "  ├─IndexReader_35(Build) 10000.00 root  index:IndexFullScan_34",
+          "  │ └─IndexFullScan_34 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─IndexReader_31(Probe) 10000.00 root  index:IndexFullScan_30",
+          "    └─IndexFullScan_30 10000.00 cop[tikv] table:t1, index:b(b) keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Projection_5 3333.33 root  test.t.b",
+          "└─TableReader_11 3333.33 root  data:TableRangeScan_10",
+          "  └─TableRangeScan_10 3333.33 cop[tikv] table:t range:(0,+inf], keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Projection_7 1.00 root  test.t.b",
+          "└─Limit_11 1.00 root  offset:0, count:1",
+          "  └─TableReader_21 1.00 root  data:Limit_20",
+          "    └─Limit_20 1.00 cop[tikv]  offset:0, count:1",
+          "      └─TableRangeScan_19 1.00 cop[tikv] table:t range:(0,+inf], keep order:true, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestStableResultModeOnDML",
+    "Cases": [
+      {
+        "Plan": [
+          "Insert_1 N/A root  N/A",
+          "└─TableReader_7 10000.00 root  data:TableFullScan_6",
+          "  └─TableFullScan_6 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Insert_1 N/A root  N/A",
+          "└─TableReader_8 3333.33 root  data:TableRangeScan_7",
+          "  └─TableRangeScan_7 3333.33 cop[tikv] table:t range:(1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Insert_1 N/A root  N/A",
+          "└─Projection_9 12500.00 root  test.t.a, test.t.b, plus(test.t.c, test.t.c)->Column#10",
+          "  └─MergeJoin_10 12500.00 root  inner join, left key:test.t.a, right key:test.t.a",
+          "    ├─TableReader_26(Build) 10000.00 root  data:TableFullScan_25",
+          "    │ └─TableFullScan_25 10000.00 cop[tikv] table:t2 keep order:true, stats:pseudo",
+          "    └─TableReader_24(Probe) 10000.00 root  data:TableFullScan_23",
+          "      └─TableFullScan_23 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Insert_1 N/A root  N/A",
+          "└─Projection_7 10000.00 root  cast(test.t.a, int(11))->Column#7, cast(test.t.b, int(11))->Column#8, cast(test.t.c, decimal(32,0) BINARY)->Column#9",
+          "  └─TableReader_9 10000.00 root  data:TableFullScan_8",
+          "    └─TableFullScan_8 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Delete_3 N/A root  N/A",
+          "└─TableReader_6 10000.00 root  data:TableFullScan_5",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Delete_4 N/A root  N/A",
+          "└─TableReader_7 3333.33 root  data:TableRangeScan_6",
+          "  └─TableRangeScan_6 3333.33 cop[tikv] table:t range:(1,+inf], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Update_3 N/A root  N/A",
+          "└─TableReader_6 10000.00 root  data:TableFullScan_5",
+          "  └─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Update_4 N/A root  N/A",
+          "└─TableReader_7 3333.33 root  data:TableRangeScan_6",
+          "  └─TableRangeScan_6 3333.33 cop[tikv] table:t range:(1,+inf], keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestStableResultModeOnSubQuery",
+    "Cases": [
+      {
+        "Plan": [
+          "Sort_11 9990.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_19 9990.00 root  inner join, equal:[eq(test.t1.a, test.t2.b)]",
+          "  ├─HashAgg_32(Build) 7992.00 root  group by:test.t2.b, funcs:firstrow(test.t2.b)->test.t2.b",
+          "  │ └─IndexReader_39 9990.00 root  index:IndexFullScan_38",
+          "  │   └─IndexFullScan_38 9990.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableReader_43(Probe) 10000.00 root  data:TableFullScan_42",
+          "    └─TableFullScan_42 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 8000.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_11 8000.00 root  CARTESIAN anti semi join, other cond:eq(test.t1.a, test.t2.b)",
+          "  ├─IndexReader_17(Build) 10000.00 root  index:IndexFullScan_16",
+          "  │ └─IndexFullScan_16 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableReader_13(Probe) 10000.00 root  data:TableFullScan_12",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 7992.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_21 7992.00 root  semi join, equal:[eq(test.t1.a, test.t2.b)], other cond:gt(test.t2.c, test.t1.c)",
+          "  ├─TableReader_35(Build) 9980.01 root  data:Selection_34",
+          "  │ └─Selection_34 9980.01 cop[tikv]  not(isnull(test.t2.b)), not(isnull(test.t2.c))",
+          "  │   └─TableFullScan_33 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_32(Probe) 9990.00 root  data:Selection_31",
+          "    └─Selection_31 9990.00 cop[tikv]  not(isnull(test.t1.c))",
+          "      └─TableFullScan_30 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 8000.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_12 8000.00 root  CARTESIAN anti semi join, other cond:eq(test.t1.a, test.t2.b), gt(test.t2.c, test.t1.c)",
+          "  ├─TableReader_16(Build) 10000.00 root  data:TableFullScan_15",
+          "  │ └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 10000.00 root  data:TableFullScan_13",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 7992.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_12 7992.00 root  CARTESIAN semi join, other cond:gt(test.t2.c, test.t1.c)",
+          "  ├─TableReader_18(Build) 9990.00 root  data:Selection_17",
+          "  │ └─Selection_17 9990.00 cop[tikv]  not(isnull(test.t2.c))",
+          "  │   └─TableFullScan_16 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 9990.00 root  data:Selection_14",
+          "    └─Selection_14 9990.00 cop[tikv]  not(isnull(test.t1.c))",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 8000.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_12 8000.00 root  CARTESIAN anti semi join, other cond:gt(test.t2.c, test.t1.c)",
+          "  ├─TableReader_16(Build) 10000.00 root  data:TableFullScan_15",
+          "  │ └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 10000.00 root  data:TableFullScan_13",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 7992.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_12 7992.00 root  semi join, equal:[eq(test.t1.c, test.t2.c)]",
+          "  ├─TableReader_18(Build) 9990.00 root  data:Selection_17",
+          "  │ └─Selection_17 9990.00 cop[tikv]  not(isnull(test.t2.c))",
+          "  │   └─TableFullScan_16 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_15(Probe) 9990.00 root  data:Selection_14",
+          "    └─Selection_14 9990.00 cop[tikv]  not(isnull(test.t1.c))",
+          "      └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_10 8000.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_12 8000.00 root  anti semi join, equal:[eq(test.t1.c, test.t2.c)]",
+          "  ├─TableReader_16(Build) 10000.00 root  data:TableFullScan_15",
+          "  │ └─TableFullScan_15 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_14(Probe) 10000.00 root  data:TableFullScan_13",
+          "    └─TableFullScan_13 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Projection_9 12487.50 root  test.t1.a, test.t1.b, test.t1.c, test.t1.d",
+          "└─Sort_10 12487.50 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc, test.t2.b:asc",
+          "  └─HashJoin_26 12487.50 root  inner join, equal:[eq(test.t1.b, test.t2.b)]",
+          "    ├─IndexReader_40(Build) 9990.00 root  index:IndexFullScan_39",
+          "    │ └─IndexFullScan_39 9990.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "    └─TableReader_35(Probe) 9990.00 root  data:Selection_34",
+          "      └─Selection_34 9990.00 cop[tikv]  not(isnull(test.t1.b))",
+          "        └─TableFullScan_33 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestStableResultModeOnJoin",
+    "Cases": [
+      {
+        "Plan": [
+          "Sort_9 12500.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc, test.t2.a:asc, test.t2.b:asc, test.t2.c:asc, test.t2.d:asc",
+          "└─MergeJoin_11 12500.00 root  inner join, left key:test.t1.a, right key:test.t2.a",
+          "  ├─TableReader_27(Build) 10000.00 root  data:TableFullScan_26",
+          "  │ └─TableFullScan_26 10000.00 cop[tikv] table:t2 keep order:true, stats:pseudo",
+          "  └─TableReader_25(Probe) 10000.00 root  data:TableFullScan_24",
+          "    └─TableFullScan_24 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 12475.01 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc, test.t2.a:asc, test.t2.b:asc, test.t2.c:asc, test.t2.d:asc",
+          "└─HashJoin_28 12475.01 root  inner join, equal:[eq(test.t1.b, test.t2.b)], other cond:gt(test.t1.a, test.t2.a), lt(test.t1.c, test.t2.c)",
+          "  ├─TableReader_47(Build) 9980.01 root  data:Selection_46",
+          "  │ └─Selection_46 9980.01 cop[tikv]  not(isnull(test.t2.b)), not(isnull(test.t2.c))",
+          "  │   └─TableFullScan_45 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+          "  └─TableReader_40(Probe) 9980.01 root  data:Selection_39",
+          "    └─Selection_39 9980.01 cop[tikv]  not(isnull(test.t1.b)), not(isnull(test.t1.c))",
+          "      └─TableFullScan_38 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_7 12500.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_15 12500.00 root  left outer join, equal:[eq(test.t1.a, test.t2.a)]",
+          "  ├─IndexReader_26(Build) 10000.00 root  index:IndexFullScan_25",
+          "  │ └─IndexFullScan_25 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableReader_22(Probe) 10000.00 root  data:TableFullScan_21",
+          "    └─TableFullScan_21 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_8 100000000.00 root  test.t1.a:asc, test.t1.b:asc, test.t1.c:asc, test.t1.d:asc",
+          "└─HashJoin_10 100000000.00 root  CARTESIAN inner join, other cond:ne(test.t1.a, test.t2.a)",
+          "  ├─IndexReader_17(Build) 10000.00 root  index:IndexFullScan_16",
+          "  │ └─IndexFullScan_16 10000.00 cop[tikv] table:t2, index:b(b) keep order:false, stats:pseudo",
+          "  └─TableReader_13(Probe) 10000.00 root  data:TableFullScan_12",
+          "    └─TableFullScan_12 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestStableResultModeOnOtherOperators",
+    "Cases": [
+      {
+        "Plan": [
+          "Batch_Point_Get_9 3.00 root table:t1 handle:[1 222 33333], keep order:true, desc:false"
+        ]
+      },
+      {
+        "Plan": [
+          "Batch_Point_Get_9 4.00 root table:t1 handle:[1 2 3 4], keep order:true, desc:false"
+        ]
+      },
+      {
+        "Plan": [
+          "Batch_Point_Get_9 3.00 root table:t1, index:b(b) keep order:true, desc:false"
+        ]
+      },
+      {
+        "Plan": [
+          "Batch_Point_Get_9 4.00 root table:t1, index:b(b) keep order:true, desc:false"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_11 6666.67 root  Column#9:asc, Column#10:asc, Column#11:asc, Column#12:asc",
+          "└─Union_13 6666.67 root  ",
+          "  ├─TableReader_16 3333.33 root  data:TableRangeScan_15",
+          "  │ └─TableRangeScan_15 3333.33 cop[tikv] table:t1 range:(10,+inf], keep order:false, stats:pseudo",
+          "  └─TableReader_20 3333.33 root  data:Selection_19",
+          "    └─Selection_19 3333.33 cop[tikv]  gt(test.t2.b, 20)",
+          "      └─TableFullScan_18 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_12 5333.33 root  Column#9:asc, Column#10:asc, Column#11:asc, Column#12:asc",
+          "└─HashAgg_14 5333.33 root  group by:Column#10, Column#11, Column#12, Column#9, funcs:firstrow(Column#9)->Column#9, funcs:firstrow(Column#10)->Column#10, funcs:firstrow(Column#11)->Column#11, funcs:firstrow(Column#12)->Column#12",
+          "  └─Union_15 6666.67 root  ",
+          "    ├─TableReader_18 3333.33 root  data:TableRangeScan_17",
+          "    │ └─TableRangeScan_17 3333.33 cop[tikv] table:t1 range:(10,+inf], keep order:false, stats:pseudo",
+          "    └─TableReader_22 3333.33 root  data:Selection_21",
+          "      └─Selection_21 3333.33 cop[tikv]  gt(test.t2.b, 20)",
+          "        └─TableFullScan_20 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Projection_10 10000.00 root  Column#8, Column#7",
+          "└─Sort_11 10000.00 root  test.t1.a:asc, Column#7:asc, Column#8:asc",
+          "  └─Window_13 10000.00 root  row_number()->Column#8 over(partition by test.t1.a)",
+          "    └─Window_14 10000.00 root  sum(cast(test.t1.b, decimal(32,0) BINARY))->Column#7 over(partition by test.t1.a)",
+          "      └─TableReader_17 10000.00 root  data:TableFullScan_16",
+          "        └─TableFullScan_16 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_6 8000.00 root  Column#5:asc, Column#6:asc, Column#7:asc",
+          "└─HashAgg_12 8000.00 root  group by:test.t1.d, funcs:min(Column#8)->Column#5, funcs:max(Column#9)->Column#6, funcs:sum(Column#10)->Column#7",
+          "  └─TableReader_13 8000.00 root  data:HashAgg_8",
+          "    └─HashAgg_8 8000.00 cop[tikv]  group by:test.t1.d, funcs:min(test.t1.a)->Column#8, funcs:max(test.t1.b)->Column#9, funcs:sum(test.t1.c)->Column#10",
+          "      └─TableFullScan_11 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 6400.00 root  Column#5:asc, Column#6:asc, Column#7:asc",
+          "└─Selection_11 6400.00 root  lt(Column#6, 20)",
+          "  └─HashAgg_16 8000.00 root  group by:test.t1.d, funcs:min(Column#11)->Column#5, funcs:max(Column#12)->Column#6, funcs:sum(Column#13)->Column#7",
+          "    └─TableReader_17 8000.00 root  data:HashAgg_12",
+          "      └─HashAgg_12 8000.00 cop[tikv]  group by:test.t1.d, funcs:min(test.t1.a)->Column#11, funcs:max(test.t1.b)->Column#12, funcs:sum(test.t1.c)->Column#13",
+          "        └─TableFullScan_15 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Projection_4 10000.00 root  case(eq(test.t1.a, 1), a1, eq(test.t1.a, 2), a2, ax)->Column#5",
+          "└─TableReader_12 10000.00 root  data:TableFullScan_11",
+          "  └─TableFullScan_11 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestStableResultModeOnPartitionTable",
+    "Cases": [
+      {
+        "Plan": [
+          "Sort_11 8.00 root  test.thash.a:asc",
+          "└─PartitionUnion_13 8.00 root  ",
+          "  ├─TableReader_15 2.00 root  data:TableRangeScan_14",
+          "  │ └─TableRangeScan_14 2.00 cop[tikv] table:thash, partition:p0 range:[1,1], [200,200], keep order:false, stats:pseudo",
+          "  ├─TableReader_17 2.00 root  data:TableRangeScan_16",
+          "  │ └─TableRangeScan_16 2.00 cop[tikv] table:thash, partition:p1 range:[1,1], [200,200], keep order:false, stats:pseudo",
+          "  ├─TableReader_19 2.00 root  data:TableRangeScan_18",
+          "  │ └─TableRangeScan_18 2.00 cop[tikv] table:thash, partition:p2 range:[1,1], [200,200], keep order:false, stats:pseudo",
+          "  └─TableReader_21 2.00 root  data:TableRangeScan_20",
+          "    └─TableRangeScan_20 2.00 cop[tikv] table:thash, partition:p3 range:[1,1], [200,200], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_11 400.00 root  test.thash.a:asc",
+          "└─PartitionUnion_13 400.00 root  ",
+          "  ├─TableReader_15 100.00 root  data:TableRangeScan_14",
+          "  │ └─TableRangeScan_14 100.00 cop[tikv] table:thash, partition:p0 range:[50,150], keep order:false, stats:pseudo",
+          "  ├─TableReader_17 100.00 root  data:TableRangeScan_16",
+          "  │ └─TableRangeScan_16 100.00 cop[tikv] table:thash, partition:p1 range:[50,150], keep order:false, stats:pseudo",
+          "  ├─TableReader_19 100.00 root  data:TableRangeScan_18",
+          "  │ └─TableRangeScan_18 100.00 cop[tikv] table:thash, partition:p2 range:[50,150], keep order:false, stats:pseudo",
+          "  └─TableReader_21 100.00 root  data:TableRangeScan_20",
+          "    └─TableRangeScan_20 100.00 cop[tikv] table:thash, partition:p3 range:[50,150], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 4.00 root  test.trange.a:asc",
+          "└─PartitionUnion_11 4.00 root  ",
+          "  ├─TableReader_13 2.00 root  data:TableRangeScan_12",
+          "  │ └─TableRangeScan_12 2.00 cop[tikv] table:trange, partition:p0 range:[1,1], [200,200], keep order:false, stats:pseudo",
+          "  └─TableReader_15 2.00 root  data:TableRangeScan_14",
+          "    └─TableRangeScan_14 2.00 cop[tikv] table:trange, partition:p2 range:[1,1], [200,200], keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "Plan": [
+          "Sort_9 200.00 root  test.trange.a:asc",
+          "└─PartitionUnion_11 200.00 root  ",
+          "  ├─TableReader_13 100.00 root  data:TableRangeScan_12",
+          "  │ └─TableRangeScan_12 100.00 cop[tikv] table:trange, partition:p0 range:[50,150], keep order:false, stats:pseudo",
+          "  └─TableReader_15 100.00 root  data:TableRangeScan_14",
+          "    └─TableRangeScan_14 100.00 cop[tikv] table:trange, partition:p1 range:[50,150], keep order:false, stats:pseudo"
+        ]
+      }
+    ]
+  }
+]

--- a/session/session.go
+++ b/session/session.go
@@ -2220,6 +2220,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBEnableRateLimitAction,
 	variable.TiDBMemoryUsageAlarmRatio,
 	variable.TiDBMultiStatementMode,
+	variable.TiDBEnableStableResultMode,
 }
 
 var (

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -674,6 +674,9 @@ type SessionVars struct {
 
 	// EnabledRateLimitAction indicates whether enabled ratelimit action during coprocessor
 	EnabledRateLimitAction bool
+
+	// EnableStableResultMode if stabilize query results.
+	EnableStableResultMode bool
 }
 
 // PreparedParams contains the parameters of the current prepared statement when executing it.
@@ -1409,6 +1412,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		MemoryUsageAlarmRatio.Store(floatVal)
 	case TiDBMultiStatementMode:
 		s.MultiStatementMode = TiDBOptMultiStmt(val)
+	case TiDBEnableStableResultMode:
+		s.EnableStableResultMode = TiDBOptOn(val)
 	}
 	s.systems[name] = val
 	return nil

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -742,6 +742,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, TiDBEnableTelemetry, BoolToIntStr(DefTiDBEnableTelemetry)},
 	{ScopeGlobal | ScopeSession, TiDBEnableAmendPessimisticTxn, boolToOnOff(DefTiDBEnableAmendPessimisticTxn)},
 	{ScopeGlobal | ScopeSession, TiDBMultiStatementMode, Warn},
+	{ScopeGlobal | ScopeSession, TiDBEnableStableResultMode, boolToOnOff(DefTiDBEnableStableResultMode)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -432,6 +432,9 @@ const (
 
 	// TiDBMemoryUsageAlarmRatio indicates the alarm threshold when memory usage of the tidb-server exceeds.
 	TiDBMemoryUsageAlarmRatio = "tidb_memory_usage_alarm_ratio"
+
+	// TiDBEnableStableResultMode indicates if stabilize query results.
+	TiDBEnableStableResultMode = "tidb_enable_stable_result_mode"
 )
 
 // Default TiDB system variable values.
@@ -535,6 +538,7 @@ const (
 	DefTiDBEnableTelemetry             = true
 	DefTiDBEnableAmendPessimisticTxn   = false
 	DefTiDBEnableRateLimitAction       = true
+	DefTiDBEnableStableResultMode      = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -459,7 +459,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string, scope Sc
 		TiDBCheckMb4ValueInUTF8, TiDBEnableSlowLog, TiDBRecordPlanInSlowLog,
 		TiDBScatterRegion, TiDBGeneralLog, TiDBConstraintCheckInPlace,
 		TiDBEnableVectorizedExpression, TiDBFoundInPlanCache, TiDBEnableCollectExecutionInfo,
-		TiDBAllowAutoRandExplicitInsert, TiDBEnableTelemetry, TiDBEnableAmendPessimisticTxn:
+		TiDBAllowAutoRandExplicitInsert, TiDBEnableTelemetry, TiDBEnableAmendPessimisticTxn, TiDBEnableStableResultMode:
 		fallthrough
 	case GeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
 		CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode, PseudoSlaveMode, LowPriorityUpdates,


### PR DESCRIPTION
cherry-pick #25971 to release-4.0
You can switch your code base to this Pull Request by using [git-extras](https://github.com/tj/git-extras):
```bash
# In tidb repo:
git pr https://github.com/pingcap/tidb/pull/25994
```

After apply modifications, you can push your change to this PR via:
```bash
git push git@github.com:ti-srebot/tidb.git pr/25994:release-4.0-c24a90f9e7f5
```

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: support stable result mode in the planner

### What is changed and how it works?
Results of some queries are not stable, for example:
```
create table t (a int);
insert into t values (1), (2);
select a from t;
```
In the case above, the result can be `1 2` or `2 1`, which is not stable.
This PR introduces a new switch that can make the results of these queries stable.

This feature is implemented as **a logical optimization rule**, which stabilizes results by modifying `Sort` in plans or inject new `Sort` into plans.
First, all operators are divided into 2 types:
1. input-order keepers: Selection, Projection, Limit;
2. all other operators.

**The basic idea of this rule is**:
1. iterate the plan from the root, and ignore all input-order keepers;
2. when meeting the first non-input-order keeper,
	2.1. if it's a Sort, complete it by appending its output columns into its order-by list,
	2.2. otherwise, inject a new Sort upon this operator.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- planner: support stable result mode
