### PR TITLE
executor: correct errors in stale_txn_test.go for golangci-lint when executing 'make dev'

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1018,7 +1018,7 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 		},
 		// assert select statement
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: false,
 		},
 		// assert select statement in stale transaction
@@ -1027,7 +1027,7 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 			hasStaleFlag: false,
 		},
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: true,
 		},
 		{
@@ -1040,12 +1040,12 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 			hasStaleFlag: false,
 		},
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: true,
 		},
 		// assert select statement after consumed set transaction
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: false,
 		},
 		// assert prepare statement with select as of statement


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:
execute 'make dev' will got the following errors
executor/stale_txn_test.go:1021:18: S1039: unnecessary use of fmt.Sprintf (gosimple)
                        sql:          fmt.Sprintf("select * from t"),
                                      ^
### What is changed and how it works?

What's Changed:

executor/stale_txn_test.go:1021,1030,1043,1048  fmt.Sprintf("select * from t") => "select * from t"

## What are the type of the changes? 

Improvement

## How has this PR been tested? 

just execute 'make dev' and got no error 

## Does this PR affect documentation (docs/docs-cn) update? 

no
