### PR TITLE
executor, privilege: require CONFIG privilege for is.cluster_config

### DIFF
--- a/executor/memtable_reader.go
+++ b/executor/memtable_reader.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/diagnosticspb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/parser/model"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/parser/terror"
 	"github.com/pingcap/sysutil"
 	"github.com/pingcap/tidb/config"
@@ -157,6 +158,9 @@ func fetchClusterConfig(sctx sessionctx.Context, nodeTypes, nodeAddrs set.String
 		idx  int
 		rows [][]types.Datum
 		err  error
+	}
+	if !hasPriv(sctx, mysql.ConfigPriv) {
+		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("CONFIG")
 	}
 	serversInfo, err := infoschema.GetClusterServerInfo(sctx)
 	failpoint.Inject("mockClusterConfigServerInfo", func(val failpoint.Value) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26062

Problem Summary:

The cluster_config table should require the `CONFIG` privilege. This is consistent with the behavior change in https://github.com/pingcap/tidb/pull/25379 which requires `CONFIG` for `SHOW CONFIG`.

It makes sense to cherry pick to 5.1, but not 5.0; because the behavior in 5.0 was not established yet, and `SHOW CONFIG` still requires no privileges.

### What is changed and how it works?

What's Changed:

Reading from the table information_schema.cluster_config now requires the CONFIG privilege.

### Related changes

- Need to cherry-pick to the release branch

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Breaking backward compatibility (yes, but for security)

### Release note <!-- bugfixes or new feature need a release note -->

- Reading from the table information_schema.cluster_config now requires the CONFIG privilege.