### PR TITLE
executor , store: fix golangci-lint error when make dev

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1018,7 +1018,7 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 		},
 		// assert select statement
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: false,
 		},
 		// assert select statement in stale transaction
@@ -1027,7 +1027,7 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 			hasStaleFlag: false,
 		},
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: true,
 		},
 		{
@@ -1040,12 +1040,12 @@ func (s *testStaleTxnSuite) TestStmtCtxStaleFlag(c *C) {
 			hasStaleFlag: false,
 		},
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: true,
 		},
 		// assert select statement after consumed set transaction
 		{
-			sql:          fmt.Sprintf("select * from t"),
+			sql:          "select * from t",
 			hasStaleFlag: false,
 		},
 		// assert prepare statement with select as of statement

--- a/store/copr/coprocessor_test.go
+++ b/store/copr/coprocessor_test.go
@@ -155,7 +155,7 @@ func (s *testCoprocessorSuite) TestBuildTasks(c *C) {
 func (s *testCoprocessorSuite) TestSplitRegionRanges(c *C) {
 	// nil --- 'g' --- 'n' --- 't' --- nil
 	// <-  0  -> <- 1 -> <- 2 -> <- 3 ->
-	_, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
+	_, cluster, pdClient, _ := testutils.NewMockTiKV("", nil)
 	testutils.BootstrapWithMultiRegions(cluster, []byte("g"), []byte("n"), []byte("t"))
 	pdCli := &tikv.CodecPDClient{Client: pdClient}
 	cache := NewRegionCache(tikv.NewRegionCache(pdCli))


### PR DESCRIPTION
fix error of unnecessary use of fmt.Sprintf (gosimple) and ineffectual assignment to err (ineffassign)

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:

### What is changed and how it works?

What's Changed:

fmt.Sprintf("select * from t") => "select * from t"
_, cluster, pdClient, err := testutils.NewMockTiKV("", nil) => _, cluster, pdClient, _ := testutils.NewMockTiKV("", nil)

How it Works:

### Related changes

- Need to cherry-pick to the release branch

Tests <!-- At least one of them must be included. -->

- Unit test

Side effects

- Performance regression

- Breaking backward compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
