### PR TITLE
expression: mod check null if zero

### DIFF
--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -136,10 +136,10 @@ func (b *builtinArithmeticModIntUnsignedUnsignedSig) vecEvalInt(input *chunk.Chu
 	rhi64s := rh.Int64s()
 
 	for i := 0; i < len(lhi64s); i++ {
-		if rh.IsNull(i) {
-			continue
-		}
 		if rhi64s[i] == 0 {
+			if rh.IsNull(i) {
+				continue
+			}
 			if err := handleDivisionByZeroError(b.ctx); err != nil {
 				return err
 			}
@@ -181,10 +181,10 @@ func (b *builtinArithmeticModIntUnsignedSignedSig) vecEvalInt(input *chunk.Chunk
 	rhi64s := rh.Int64s()
 
 	for i := 0; i < len(lhi64s); i++ {
-		if rh.IsNull(i) {
-			continue
-		}
 		if rhi64s[i] == 0 {
+			if rh.IsNull(i) {
+				continue
+			}
 			if err := handleDivisionByZeroError(b.ctx); err != nil {
 				return err
 			}
@@ -230,10 +230,10 @@ func (b *builtinArithmeticModIntSignedUnsignedSig) vecEvalInt(input *chunk.Chunk
 	rhi64s := rh.Int64s()
 
 	for i := 0; i < len(lhi64s); i++ {
-		if rh.IsNull(i) {
-			continue
-		}
 		if rhi64s[i] == 0 {
+			if rh.IsNull(i) {
+				continue
+			}
 			if err := handleDivisionByZeroError(b.ctx); err != nil {
 				return err
 			}
@@ -279,10 +279,10 @@ func (b *builtinArithmeticModIntSignedSignedSig) vecEvalInt(input *chunk.Chunk, 
 	rhi64s := rh.Int64s()
 
 	for i := 0; i < len(lhi64s); i++ {
-		if rh.IsNull(i) {
-			continue
-		}
 		if rhi64s[i] == 0 {
+			if rh.IsNull(i) {
+				continue
+			}
 			if err := handleDivisionByZeroError(b.ctx); err != nil {
 				return err
 			}


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Similar to #25466
Some simple arithmetic function like 

```
builtinArithmeticModIntUnsignedUnsignedSig
builtinArithmeticModIntUnsignedSignedSig
builtinArithmeticModIntSignedUnsignedSig
builtinArithmeticModIntSignedSignedSig
```

, check nulls every run, and the check is more expensive then the compute.
The bitmaps have been already merged, so the check is unnecessary, we can compute it anyway while there is no zero , and we don't care the result.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed and How it Works:
Avoid some branch in mod

I've done a trivial benchmark:
before
```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-VecBuiltinFunc-16               107262             10601 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-NonVecBuiltinFunc-16             34041             35901 ns/op               

BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-VecBuiltinFunc-16             113208             10728 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-NonVecBuiltinFunc-16           38600             31614 ns/op               

BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-VecBuiltinFunc-16                89119             13991 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-NonVecBuiltinFunc-16             35640             35189 ns/op               

BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc-16                  53667             21616 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc-16               37198             30562 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#01
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#01-16              104835             11966 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#01
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#01-16            37492             30950 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#02
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#02-16               96591             11434 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#02
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#02-16            40381             32317 ns/op               
```
after

```
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-VecBuiltinFunc-16                98136             11212 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedSignedSig-NonVecBuiltinFunc-16             34935             34138 ns/op               

BenchmarkVectorizedBuiltinArithmeticFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-VecBuiltinFunc-16             125559              9862 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntUnsignedUnsignedSig-NonVecBuiltinFunc-16           41026             28780 ns/op               

BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-VecBuiltinFunc-16               105028              9778 ns/op           
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedUnsignedSig-NonVecBuiltinFunc-16             37844             31231 ns/op             

        

BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc-16                  57204             20215 ns/op          
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc-16               41130             28762 ns/op             
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#01
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#01-16              118806              9830 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#01
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#01-16            36062             28183 ns/op        
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#02
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-VecBuiltinFunc#02-16              116606             10410 ns/op               
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#02
BenchmarkVectorizedBuiltinArithmeticFunc/builtinArithmeticModIntSignedSignedSig-NonVecBuiltinFunc#02-16            41118             29049 ns/op               
       
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
