### PR TITLE
planner/core: fix duplicate enum items

### DIFF
--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -16,7 +16,6 @@ package core
 import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/model"
-	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/distsql"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
@@ -279,9 +278,6 @@ func (e *PhysicalExchangeReceiver) ToPB(ctx sessionctx.Context, storeType kv.Sto
 	fieldTypes := make([]*tipb.FieldType, 0, len(e.Schema().Columns))
 	for _, column := range e.Schema().Columns {
 		pbType := expression.ToPBFieldType(column.RetType)
-		if column.RetType.Tp == mysql.TypeEnum {
-			pbType.Elems = append(pbType.Elems, column.RetType.Elems...)
-		}
 		fieldTypes = append(fieldTypes, pbType)
 	}
 	ecExec := &tipb.ExchangeReceiver{

--- a/planner/core/plan_to_pb_test.go
+++ b/planner/core/plan_to_pb_test.go
@@ -73,4 +73,13 @@ func (s *testDistsqlSuite) TestColumnToProto(c *C) {
 	}
 	pc = util.ColumnToProto(col1)
 	c.Assert(pc.Collation, Equals, int32(-8))
+
+	tp = types.NewFieldType(mysql.TypeEnum)
+	tp.Flag = 10
+	tp.Elems = []string{"a", "b"}
+	col2 := &model.ColumnInfo{
+		FieldType: *tp,
+	}
+	pc = util.ColumnToProto(col2)
+	c.Assert(len(pc.Elems), Equals, 2)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25955 

Problem Summary:
In this pr: https://github.com/pingcap/tidb/pull/23203 , I support enum push down for only mpp exchanger. However, a month later this pr: https://github.com/pingcap/tidb/pull/22686 is merged to support general enum type push-down. This leads to the elem lists are appended two times.


### What is changed and how it works?
What's Changed:
Remove the #23203 code

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test, See https://github.com/pingcap/tics/pull/2384

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- planner/core: fix duplicate enum items
