### PR TITLE
*: temporarily skip some unstable test cases

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -695,6 +695,7 @@ func (s *testSuite5) TestSetCollationAndCharset(c *C) {
 }
 
 func (s *testSuite5) TestValidateSetVar(c *C) {
+	c.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
 	tk := testkit.NewTestKit(c, s.store)
 
 	_, err := tk.Exec("set global tidb_distsql_scan_concurrency='fff';")

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -904,6 +904,7 @@ func (s *testEvaluatorSuite) TestExprPushDownToFlash(c *C) {
 }
 
 func (s *testEvaluatorSuite) TestExprOnlyPushDownToFlash(c *C) {
+	c.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 	dg := new(dataGen4Expr2PbTest)

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -466,6 +466,7 @@ func (*testSysVarSuite) TestIsNoop(c *C) {
 }
 
 func (*testSysVarSuite) TestInstanceScopedVars(c *C) {
+	c.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
 	// This tests instance scoped variables through GetSessionOrGlobalSystemVar().
 	// Eventually these should be changed to use getters so that the switch
 	// statement in GetSessionOnlySysVars can be removed.

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -388,6 +388,7 @@ func (ts *testSuite) TestIterRecords(c *C) {
 }
 
 func (ts *testSuite) TestTableFromMeta(c *C) {
+	c.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
 	tk := testkit.NewTestKitWithInit(c, ts.store)
 	tk.MustExec("use test")
 	tk.MustExec("CREATE TABLE meta (a int primary key auto_increment, b varchar(255) unique)")


### PR DESCRIPTION
Temporarily skip the following test cases because they are not stable, we assume to fix them and bring them back before 2021-07-26:

- testSysVarSuite.TestInstanceScopedVars #25893
- testSuite5.TestValidateSetVar #25781
- testEvaluatorSuite.TestExprOnlyPushDownToFlash #25147
- testSuite.TestTableFromMeta #25126

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
