### PR TITLE
planner: rename stable-result-mode to ordered-result-mode (#26093)

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -429,15 +429,15 @@ func (s *testSuite5) TestSetVar(c *C) {
 	tk.MustExec("set session tidb_slow_log_masking = 1")
 	tk.MustQuery(`select @@session.tidb_slow_log_masking;`).Check(testkit.Rows("1"))
 
-	// test for tidb_enable_stable_result_mode
-	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
-	tk.MustExec(`set global tidb_enable_stable_result_mode = 1`)
-	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
-	tk.MustExec(`set global tidb_enable_stable_result_mode = 0`)
-	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
-	tk.MustExec(`set tidb_enable_stable_result_mode=1`)
-	tk.MustQuery(`select @@global.tidb_enable_stable_result_mode`).Check(testkit.Rows("0"))
-	tk.MustQuery(`select @@tidb_enable_stable_result_mode`).Check(testkit.Rows("1"))
+	// test for tidb_enable_ordered_result_mode
+	tk.MustQuery(`select @@tidb_enable_ordered_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set global tidb_enable_ordered_result_mode = 1`)
+	tk.MustQuery(`select @@global.tidb_enable_ordered_result_mode`).Check(testkit.Rows("1"))
+	tk.MustExec(`set global tidb_enable_ordered_result_mode = 0`)
+	tk.MustQuery(`select @@global.tidb_enable_ordered_result_mode`).Check(testkit.Rows("0"))
+	tk.MustExec(`set tidb_enable_ordered_result_mode=1`)
+	tk.MustQuery(`select @@global.tidb_enable_ordered_result_mode`).Check(testkit.Rows("0"))
+	tk.MustQuery(`select @@tidb_enable_ordered_result_mode`).Check(testkit.Rows("1"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -60,7 +60,7 @@ const (
 var optRuleList = []logicalOptRule{
 	&gcSubstituter{},
 	&columnPruner{},
-	&resultsStabilizer{},
+	&resultReorder{},
 	&buildKeySolver{},
 	&decorrelateSolver{},
 	&aggregationEliminator{},

--- a/planner/core/rule_result_reorder.go
+++ b/planner/core/rule_result_reorder.go
@@ -23,7 +23,8 @@ import (
 /*
 	resultReorder reorder query results.
 	NOTE: it's not a common rule for all queries, it's specially implemented for a few customers.
-	Results of some queries are not stable, for example:
+
+	Results of some queries are not ordered, for example:
 		create table t (a int); insert into t values (1), (2); select a from t;
 	In the case above, the result can be `1 2` or `2 1`, which is not ordered.
 	This rule reorders results by modifying or injecting a Sort operator:
@@ -36,8 +37,8 @@ type resultReorder struct {
 }
 
 func (rs *resultReorder) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
-	stable := rs.completeSort(lp)
-	if !stable {
+	ordered := rs.completeSort(lp)
+	if !ordered {
 		lp = rs.injectSort(lp)
 	}
 	return lp, nil
@@ -116,5 +117,5 @@ func (rs *resultReorder) extractHandleCol(lp LogicalPlan) *expression.Column {
 }
 
 func (rs *resultReorder) name() string {
-	return "stabilize_results"
+	return "result_reorder"
 }

--- a/planner/core/rule_result_reorder.go
+++ b/planner/core/rule_result_reorder.go
@@ -21,21 +21,21 @@ import (
 )
 
 /*
-	resultsStabilizer stabilizes query results.
+	resultReorder reorder query results.
 	NOTE: it's not a common rule for all queries, it's specially implemented for a few customers.
 	Results of some queries are not stable, for example:
 		create table t (a int); insert into t values (1), (2); select a from t;
-	In the case above, the result can be `1 2` or `2 1`, which is not stable.
-	This rule stabilizes results by modifying or injecting a Sort operator:
+	In the case above, the result can be `1 2` or `2 1`, which is not ordered.
+	This rule reorders results by modifying or injecting a Sort operator:
 	1. iterate the plan from the root, and ignore all input-order operators (Sel/Proj/Limit);
 	2. when meeting the first non-input-order operator,
 		2.1. if it's a Sort, update it by appending all output columns into its order-by list,
 		2.2. otherwise, inject a new Sort upon this operator.
 */
-type resultsStabilizer struct {
+type resultReorder struct {
 }
 
-func (rs *resultsStabilizer) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
+func (rs *resultReorder) optimize(ctx context.Context, lp LogicalPlan) (LogicalPlan, error) {
 	stable := rs.completeSort(lp)
 	if !stable {
 		lp = rs.injectSort(lp)
@@ -43,7 +43,7 @@ func (rs *resultsStabilizer) optimize(ctx context.Context, lp LogicalPlan) (Logi
 	return lp, nil
 }
 
-func (rs *resultsStabilizer) completeSort(lp LogicalPlan) bool {
+func (rs *resultReorder) completeSort(lp LogicalPlan) bool {
 	if rs.isInputOrderKeeper(lp) {
 		return rs.completeSort(lp.Children()[0])
 	} else if sort, ok := lp.(*LogicalSort); ok {
@@ -68,7 +68,7 @@ func (rs *resultsStabilizer) completeSort(lp LogicalPlan) bool {
 	return false
 }
 
-func (rs *resultsStabilizer) injectSort(lp LogicalPlan) LogicalPlan {
+func (rs *resultReorder) injectSort(lp LogicalPlan) LogicalPlan {
 	if rs.isInputOrderKeeper(lp) {
 		lp.SetChildren(rs.injectSort(lp.Children()[0]))
 		return lp
@@ -89,7 +89,7 @@ func (rs *resultsStabilizer) injectSort(lp LogicalPlan) LogicalPlan {
 	return sort
 }
 
-func (rs *resultsStabilizer) isInputOrderKeeper(lp LogicalPlan) bool {
+func (rs *resultReorder) isInputOrderKeeper(lp LogicalPlan) bool {
 	switch lp.(type) {
 	case *LogicalSelection, *LogicalProjection, *LogicalLimit:
 		return true
@@ -98,7 +98,7 @@ func (rs *resultsStabilizer) isInputOrderKeeper(lp LogicalPlan) bool {
 }
 
 // extractHandleCols does the best effort to get the handle column.
-func (rs *resultsStabilizer) extractHandleCol(lp LogicalPlan) *expression.Column {
+func (rs *resultReorder) extractHandleCol(lp LogicalPlan) *expression.Column {
 	switch x := lp.(type) {
 	case *LogicalSelection, *LogicalLimit:
 		handleCol := rs.extractHandleCol(lp.Children()[0])
@@ -115,6 +115,6 @@ func (rs *resultsStabilizer) extractHandleCol(lp LogicalPlan) *expression.Column
 	return nil
 }
 
-func (rs *resultsStabilizer) name() string {
+func (rs *resultReorder) name() string {
 	return "stabilize_results"
 }

--- a/planner/core/rule_result_reorder_test.go
+++ b/planner/core/rule_result_reorder_test.go
@@ -99,7 +99,7 @@ func (s *testRuleReorderResults) SetUpSuite(c *C) {
 	s.store, s.dom, err = newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 
-	s.testData, err = testutil.LoadTestSuiteData("testdata", "stable_result_mode_suite")
+	s.testData, err = testutil.LoadTestSuiteData("testdata", "ordered_result_mode_suite")
 	c.Assert(err, IsNil)
 }
 

--- a/planner/core/rule_result_reorder_test.go
+++ b/planner/core/rule_result_reorder_test.go
@@ -26,21 +26,21 @@ import (
 	"github.com/pingcap/tidb/util/testutil"
 )
 
-var _ = Suite(&testRuleStabilizeResults{})
-var _ = SerialSuites(&testRuleStabilizeResultsSerial{})
+var _ = Suite(&testRuleReorderResults{})
+var _ = SerialSuites(&testRuleReorderResultsSerial{})
 
-type testRuleStabilizeResultsSerial struct {
+type testRuleReorderResultsSerial struct {
 	store kv.Storage
 	dom   *domain.Domain
 }
 
-func (s *testRuleStabilizeResultsSerial) SetUpTest(c *C) {
+func (s *testRuleReorderResultsSerial) SetUpTest(c *C) {
 	var err error
 	s.store, s.dom, err = newStoreWithBootstrap()
 	c.Assert(err, IsNil)
 }
 
-func (s *testRuleStabilizeResultsSerial) TestPlanCache(c *C) {
+func (s *testRuleReorderResultsSerial) TestPlanCache(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	orgEnable := plannercore.PreparedPlanCacheEnabled()
 	defer func() {
@@ -54,7 +54,7 @@ func (s *testRuleStabilizeResultsSerial) TestPlanCache(c *C) {
 	c.Assert(err, IsNil)
 
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
 	tk.MustExec("prepare s1 from 'select * from t where a > ? limit 10'")
@@ -65,10 +65,10 @@ func (s *testRuleStabilizeResultsSerial) TestPlanCache(c *C) {
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1")) // plan cache is still working
 }
 
-func (s *testRuleStabilizeResultsSerial) TestSQLBinding(c *C) {
+func (s *testRuleReorderResultsSerial) TestSQLBinding(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
 	tk.MustQuery("explain select * from t where a > 0 limit 1").Check(testkit.Rows(
@@ -87,14 +87,14 @@ func (s *testRuleStabilizeResultsSerial) TestSQLBinding(c *C) {
 		"  └─TableRowIDScan_15(Probe) 1.00 cop[tikv] table:t keep order:false, stats:pseudo"))
 }
 
-type testRuleStabilizeResults struct {
+type testRuleReorderResults struct {
 	store kv.Storage
 	dom   *domain.Domain
 
 	testData testutil.TestData
 }
 
-func (s *testRuleStabilizeResults) SetUpSuite(c *C) {
+func (s *testRuleReorderResults) SetUpSuite(c *C) {
 	var err error
 	s.store, s.dom, err = newStoreWithBootstrap()
 	c.Assert(err, IsNil)
@@ -103,11 +103,11 @@ func (s *testRuleStabilizeResults) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 }
 
-func (s *testRuleStabilizeResults) TearDownSuite(c *C) {
+func (s *testRuleReorderResults) TearDownSuite(c *C) {
 	c.Assert(s.testData.GenerateOutputIfNeeded(), IsNil)
 }
 
-func (s *testRuleStabilizeResults) runTestData(c *C, tk *testkit.TestKit, name string) {
+func (s *testRuleReorderResults) runTestData(c *C, tk *testkit.TestKit, name string) {
 	var input []string
 	var output []struct {
 		Plan []string
@@ -122,61 +122,61 @@ func (s *testRuleStabilizeResults) runTestData(c *C, tk *testkit.TestKit, name s
 	}
 }
 
-func (s *testRuleStabilizeResults) TestStableResultMode(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultMode(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int primary key, b int, c int, d int, key(b))")
-	s.runTestData(c, tk, "TestStableResultMode")
+	s.runTestData(c, tk, "TestOrderedResultMode")
 }
 
-func (s *testRuleStabilizeResults) TestStableResultModeOnDML(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultModeOnDML(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int primary key, b int, c int, key(b))")
-	s.runTestData(c, tk, "TestStableResultModeOnDML")
+	s.runTestData(c, tk, "TestOrderedResultModeOnDML")
 }
 
-func (s *testRuleStabilizeResults) TestStableResultModeOnSubQuery(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultModeOnSubQuery(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, key(b))")
 	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, key(b))")
-	s.runTestData(c, tk, "TestStableResultModeOnSubQuery")
+	s.runTestData(c, tk, "TestOrderedResultModeOnSubQuery")
 }
 
-func (s *testRuleStabilizeResults) TestStableResultModeOnJoin(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultModeOnJoin(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, key(b))")
 	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, key(b))")
-	s.runTestData(c, tk, "TestStableResultModeOnJoin")
+	s.runTestData(c, tk, "TestOrderedResultModeOnJoin")
 }
 
-func (s *testRuleStabilizeResults) TestStableResultModeOnOtherOperators(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultModeOnOtherOperators(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("drop table if exists t2")
 	tk.MustExec("create table t1 (a int primary key, b int, c int, d int, unique key(b))")
 	tk.MustExec("create table t2 (a int primary key, b int, c int, d int, unique key(b))")
-	s.runTestData(c, tk, "TestStableResultModeOnOtherOperators")
+	s.runTestData(c, tk, "TestOrderedResultModeOnOtherOperators")
 }
 
-func (s *testRuleStabilizeResults) TestStableResultModeOnPartitionTable(c *C) {
+func (s *testRuleReorderResults) TestOrderedResultModeOnPartitionTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_stable_result_mode=1")
+	tk.MustExec("set tidb_enable_ordered_result_mode=1")
 	tk.MustExec("drop table if exists thash")
 	tk.MustExec("drop table if exists trange")
 	tk.MustExec("create table thash (a int primary key, b int, c int, d int) partition by hash(a) partitions 4")
@@ -185,5 +185,5 @@ func (s *testRuleStabilizeResults) TestStableResultModeOnPartitionTable(c *C) {
 					partition p1 values less than (200),
 					partition p2 values less than (300),
 					partition p3 values less than (400))`)
-	s.runTestData(c, tk, "TestStableResultModeOnPartitionTable")
+	s.runTestData(c, tk, "TestOrderedResultModeOnPartitionTable")
 }

--- a/planner/core/testdata/ordered_result_mode_suite_in.json
+++ b/planner/core/testdata/ordered_result_mode_suite_in.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "TestStableResultMode",
+    "name": "TestOrderedResultMode",
     "cases": [
       "select * from t use index(primary)",
       "select b from t use index(b)",
@@ -19,7 +19,7 @@
     ]
   },
   {
-    "name": "TestStableResultModeOnDML",
+    "name": "TestOrderedResultModeOnDML",
     "cases": [
       "insert into t select * from t",
       "insert into t select * from t where a>1",
@@ -32,7 +32,7 @@
     ]
   },
   {
-    "name": "TestStableResultModeOnSubQuery",
+    "name": "TestOrderedResultModeOnSubQuery",
     "cases": [
       "select * from t1 where t1.a in (select b from t2)",
       "select * from t1 where t1.a not in (select b from t2)",
@@ -46,7 +46,7 @@
     ]
   },
   {
-    "name": "TestStableResultModeOnJoin",
+    "name": "TestOrderedResultModeOnJoin",
     "cases": [
       "select * from t1, t2 where t1.a = t2.a",
       "select * from t1, t2 where t1.a > t2.a and t1.b = t2.b and t1.c < t2.c",
@@ -55,7 +55,7 @@
     ]
   },
   {
-    "name": "TestStableResultModeOnOtherOperators",
+    "name": "TestOrderedResultModeOnOtherOperators",
     "cases": [
       "select * from t1 where a = 1 or a = 222 or a = 33333",
       "select * from t1 where a in (1, 2, 3, 4)",
@@ -70,7 +70,7 @@
     ]
   },
   {
-    "name": "TestStableResultModeOnPartitionTable",
+    "name": "TestOrderedResultModeOnPartitionTable",
     "cases": [
       "select * from thash where a in (1, 200)",
       "select * from thash where a >= 50 and a <= 150",

--- a/planner/core/testdata/ordered_result_mode_suite_out.json
+++ b/planner/core/testdata/ordered_result_mode_suite_out.json
@@ -1,6 +1,6 @@
 [
   {
-    "Name": "TestStableResultMode",
+    "Name": "TestOrderedResultMode",
     "Cases": [
       {
         "Plan": [
@@ -113,7 +113,7 @@
     ]
   },
   {
-    "Name": "TestStableResultModeOnDML",
+    "Name": "TestOrderedResultModeOnDML",
     "Cases": [
       {
         "Plan": [
@@ -179,7 +179,7 @@
     ]
   },
   {
-    "Name": "TestStableResultModeOnSubQuery",
+    "Name": "TestOrderedResultModeOnSubQuery",
     "Cases": [
       {
         "Plan": [
@@ -283,7 +283,7 @@
     ]
   },
   {
-    "Name": "TestStableResultModeOnJoin",
+    "Name": "TestOrderedResultModeOnJoin",
     "Cases": [
       {
         "Plan": [
@@ -330,7 +330,7 @@
     ]
   },
   {
-    "Name": "TestStableResultModeOnOtherOperators",
+    "Name": "TestOrderedResultModeOnOtherOperators",
     "Cases": [
       {
         "Plan": [
@@ -414,7 +414,7 @@
     ]
   },
   {
-    "Name": "TestStableResultModeOnPartitionTable",
+    "Name": "TestOrderedResultModeOnPartitionTable",
     "Cases": [
       {
         "Plan": [

--- a/session/session.go
+++ b/session/session.go
@@ -2220,7 +2220,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBEnableRateLimitAction,
 	variable.TiDBMemoryUsageAlarmRatio,
 	variable.TiDBMultiStatementMode,
-	variable.TiDBEnableStableResultMode,
+	variable.TiDBEnableOrderedResultMode,
 }
 
 var (

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1412,7 +1412,7 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		MemoryUsageAlarmRatio.Store(floatVal)
 	case TiDBMultiStatementMode:
 		s.MultiStatementMode = TiDBOptMultiStmt(val)
-	case TiDBEnableStableResultMode:
+	case TiDBEnableOrderedResultMode:
 		s.EnableStableResultMode = TiDBOptOn(val)
 	}
 	s.systems[name] = val

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -742,7 +742,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal, TiDBEnableTelemetry, BoolToIntStr(DefTiDBEnableTelemetry)},
 	{ScopeGlobal | ScopeSession, TiDBEnableAmendPessimisticTxn, boolToOnOff(DefTiDBEnableAmendPessimisticTxn)},
 	{ScopeGlobal | ScopeSession, TiDBMultiStatementMode, Warn},
-	{ScopeGlobal | ScopeSession, TiDBEnableStableResultMode, boolToOnOff(DefTiDBEnableStableResultMode)},
+	{ScopeGlobal | ScopeSession, TiDBEnableOrderedResultMode, boolToOnOff(DefTiDBEnableOrderedResultMode)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -433,8 +433,8 @@ const (
 	// TiDBMemoryUsageAlarmRatio indicates the alarm threshold when memory usage of the tidb-server exceeds.
 	TiDBMemoryUsageAlarmRatio = "tidb_memory_usage_alarm_ratio"
 
-	// TiDBEnableStableResultMode indicates if stabilize query results.
-	TiDBEnableStableResultMode = "tidb_enable_stable_result_mode"
+	// TiDBEnableOrderedResultMode indicates if stabilize query results.
+	TiDBEnableOrderedResultMode = "tidb_enable_ordered_result_mode"
 )
 
 // Default TiDB system variable values.
@@ -538,7 +538,7 @@ const (
 	DefTiDBEnableTelemetry             = true
 	DefTiDBEnableAmendPessimisticTxn   = false
 	DefTiDBEnableRateLimitAction       = true
-	DefTiDBEnableStableResultMode      = false
+	DefTiDBEnableOrderedResultMode     = false
 )
 
 // Process global variables.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -459,7 +459,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string, scope Sc
 		TiDBCheckMb4ValueInUTF8, TiDBEnableSlowLog, TiDBRecordPlanInSlowLog,
 		TiDBScatterRegion, TiDBGeneralLog, TiDBConstraintCheckInPlace,
 		TiDBEnableVectorizedExpression, TiDBFoundInPlanCache, TiDBEnableCollectExecutionInfo,
-		TiDBAllowAutoRandExplicitInsert, TiDBEnableTelemetry, TiDBEnableAmendPessimisticTxn, TiDBEnableStableResultMode:
+		TiDBAllowAutoRandExplicitInsert, TiDBEnableTelemetry, TiDBEnableAmendPessimisticTxn, TiDBEnableOrderedResultMode:
 		fallthrough
 	case GeneralLog, AvoidTemporalUpgrade, BigTables, CheckProxyUsers, LogBin,
 		CoreFile, EndMakersInJSON, SQLLogBin, OfflineMode, PseudoSlaveMode, LowPriorityUpdates,


### PR DESCRIPTION
cherry-pick #26093 to release-4.0
You can switch your code base to this Pull Request by using [git-extras](https://github.com/tj/git-extras):
```bash
# In tidb repo:
git pr https://github.com/pingcap/tidb/pull/26133
```

After apply modifications, you can push your change to this PR via:
```bash
git push git@github.com:ti-srebot/tidb.git pr/26133:release-4.0-0db5df550b65
```

---

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: rename stable-result-mode to ordered-result-mode

### What is changed and how it works?

planner: rename stable-result-mode to ordered-result-mode

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
