### PR TITLE
*: refactor process info code

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -76,21 +76,18 @@ func (msm *mockSessionManager) ShowTxnList() []*txninfo.TxnInfo {
 	panic("unimplemented!")
 }
 
-func (msm *mockSessionManager) ShowProcessList() map[uint64]*util.ProcessInfo {
-	ret := make(map[uint64]*util.ProcessInfo)
+func (msm *mockSessionManager) ShowProcessList(f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
-		ret[item.ID] = item
+		f(item)
 	}
-	return ret
 }
 
-func (msm *mockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (msm *mockSessionManager) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
 		if item.ID == id {
-			return item, true
+			f(item)
 		}
 	}
-	return &util.ProcessInfo{}, false
 }
 
 func (msm *mockSessionManager) Kill(cid uint64, query bool) {
@@ -1849,9 +1846,11 @@ func (s *testSuite) TestIssue19836(c *C) {
 	tk.MustExec("set @a=1;")
 	tk.MustExec("set @b=2;")
 	tk.MustExec("EXECUTE stmt USING @a, @b;")
-	tk.Se.SetSessionManager(&mockSessionManager{
-		PS: []*util.ProcessInfo{tk.Se.ShowProcess()},
+	var PS []*util.ProcessInfo
+	tk.Se.ShowProcess(func(pi *util.ProcessInfo) {
+		PS = append(PS, pi)
 	})
+	tk.Se.SetSessionManager(&mockSessionManager{PS})
 	explainResult := testkit.Rows(
 		"Limit_8 2.00 0 root  time:0s, loops:0 offset:1, count:2 N/A N/A",
 		"└─TableReader_14 3.00 0 root  time:0s, loops:0 data:Limit_13 N/A N/A",
@@ -1859,7 +1858,7 @@ func (s *testSuite) TestIssue19836(c *C) {
 		"    └─Selection_12 3.00 0 cop[tikv]   eq(test.t.a, 40) N/A N/A",
 		"      └─TableFullScan_11 3000.00 0 cop[tikv] table:t  keep order:false, stats:pseudo N/A N/A",
 	)
-	tk.MustQuery("explain for connection " + strconv.FormatUint(tk.Se.ShowProcess().ID, 10)).Check(explainResult)
+	tk.MustQuery("explain for connection " + strconv.FormatUint(PS[0].ID, 10)).Check(explainResult)
 }
 
 func (s *testSuite) TestReCreateBind(c *C) {

--- a/domain/domain_test.go
+++ b/domain/domain_test.go
@@ -246,21 +246,18 @@ func (msm *mockSessionManager) ShowTxnList() []*txninfo.TxnInfo {
 	panic("unimplemented!")
 }
 
-func (msm *mockSessionManager) ShowProcessList() map[uint64]*util.ProcessInfo {
-	ret := make(map[uint64]*util.ProcessInfo)
+func (msm *mockSessionManager) ShowProcessList(f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
-		ret[item.ID] = item
+		f(item)
 	}
-	return ret
 }
 
-func (msm *mockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (msm *mockSessionManager) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
 		if item.ID == id {
-			return item, true
+			f(item)
 		}
 	}
-	return &util.ProcessInfo{}, false
 }
 
 func (msm *mockSessionManager) Kill(cid uint64, query bool) {}

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -550,8 +550,6 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 		// Server may not start in time.
 		return
 	}
-	pl := is.manager.ShowProcessList()
-
 	// Calculate the lower limit of the start timestamp to avoid extremely old transaction delaying GC.
 	currentVer, err := store.CurrentVersion(kv.GlobalTxnScope)
 	if err != nil {
@@ -562,11 +560,11 @@ func (is *InfoSyncer) ReportMinStartTS(store kv.Storage) {
 	startTSLowerLimit := oracle.GoTimeToLowerLimitStartTS(now, tikv.MaxTxnTimeUse)
 
 	minStartTS := oracle.GoTimeToTS(now)
-	for _, info := range pl {
+	is.manager.ShowProcessList(func(info *util2.ProcessInfo) {
 		if info.CurTxnStartTS > startTSLowerLimit && info.CurTxnStartTS < minStartTS {
 			minStartTS = info.CurTxnStartTS
 		}
-	}
+	})
 
 	is.minStartTS = minStartTS
 	err = is.storeMinStartTS(context.Background())

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -69,21 +69,18 @@ func (msm *mockSessionManager) ShowTxnList() []*txninfo.TxnInfo {
 }
 
 // ShowProcessList implements the SessionManager.ShowProcessList interface.
-func (msm *mockSessionManager) ShowProcessList() map[uint64]*util.ProcessInfo {
-	ret := make(map[uint64]*util.ProcessInfo)
+func (msm *mockSessionManager) ShowProcessList(f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
-		ret[item.ID] = item
+		f(item)
 	}
-	return ret
 }
 
-func (msm *mockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (msm *mockSessionManager) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
 	for _, item := range msm.PS {
 		if item.ID == id {
-			return item, true
+			f(item)
 		}
 	}
-	return &util.ProcessInfo{}, false
 }
 
 // Kill implements the SessionManager.Kill interface.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -7288,11 +7288,14 @@ func (s *testSuite) TestCollectDMLRuntimeStats(c *C) {
 	}
 
 	getRootStats := func() string {
-		info := tk.Se.ShowProcess()
-		c.Assert(info, NotNil)
-		p, ok := info.Plan.(plannercore.Plan)
-		c.Assert(ok, IsTrue)
-		stats := tk.Se.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(p.ID())
+		var id int
+		tk.Se.ShowProcess(func(info *util.ProcessInfo) {
+			c.Assert(info, NotNil)
+			p, ok := info.Plan.(plannercore.Plan)
+			c.Assert(ok, IsTrue)
+			id = p.ID()
+		})
+		stats := tk.Se.GetSessionVars().StmtCtx.RuntimeStatsColl.GetRootStats(id)
 		return stats.String()
 	}
 	for _, sql := range testSQLs {
@@ -8555,11 +8558,12 @@ func (s *testResourceTagSuite) TestResourceGroupTag(c *C) {
 				return
 			}
 			if expectPlanDigest == nil {
-				info := tk.Se.ShowProcess()
-				c.Assert(info, NotNil)
-				p, ok := info.Plan.(plannercore.Plan)
-				c.Assert(ok, IsTrue)
-				_, expectPlanDigest = plannercore.NormalizePlan(p)
+				tk.Se.ShowProcess(func(info *util.ProcessInfo) {
+					c.Assert(info, NotNil)
+					p, ok := info.Plan.(plannercore.Plan)
+					c.Assert(ok, IsTrue)
+					_, expectPlanDigest = plannercore.NormalizePlan(p)
+				})
 			}
 			c.Assert(sqlDigest.String(), Equals, expectSQLDigest.String(), commentf)
 			c.Assert(planDigest.String(), Equals, expectPlanDigest.String())

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1236,20 +1236,18 @@ func (e *memtableRetriever) setDataForProcessList(ctx sessionctx.Context) {
 
 	loginUser := ctx.GetSessionVars().User
 	hasProcessPriv := hasPriv(ctx, mysql.ProcessPriv)
-	pl := sm.ShowProcessList()
-
-	records := make([][]types.Datum, 0, len(pl))
-	for _, pi := range pl {
+	records := make([][]types.Datum, 0, 10)
+	sm.ShowProcessList(func(pi *util.ProcessInfo) {
 		// If you have the PROCESS privilege, you can see all threads.
 		// Otherwise, you can see only your own threads.
 		if !hasProcessPriv && loginUser != nil && pi.User != loginUser.Username {
-			continue
+			return
 		}
 
 		rows := pi.ToRow(ctx.GetSessionVars().StmtCtx.TimeZone)
 		record := types.MakeDatums(rows...)
 		records = append(records, record)
-	}
+	})
 	e.rows = records
 }
 

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -767,13 +767,17 @@ func (sm *mockSessionManager) ShowTxnList() []*txninfo.TxnInfo {
 	panic("unimplemented!")
 }
 
-func (sm *mockSessionManager) ShowProcessList() map[uint64]*util.ProcessInfo {
-	return sm.processInfoMap
+func (sm *mockSessionManager) ShowProcessList(f func(*util.ProcessInfo)) {
+	for _, item := range sm.processInfoMap {
+		f(item)
+	}
 }
 
-func (sm *mockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (sm *mockSessionManager) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
 	rs, ok := sm.processInfoMap[id]
-	return rs, ok
+	if ok {
+		f(rs)
+	}
 }
 
 func (sm *mockSessionManager) Kill(connectionID uint64, query bool) {}

--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -804,14 +804,11 @@ func (msm *mockSessionManager1) ShowTxnList() []*txninfo.TxnInfo {
 }
 
 // ShowProcessList implements the SessionManager.ShowProcessList interface.
-func (msm *mockSessionManager1) ShowProcessList() map[uint64]*util.ProcessInfo {
-	ret := make(map[uint64]*util.ProcessInfo)
-	return ret
+func (msm *mockSessionManager1) ShowProcessList(f func(*util.ProcessInfo)) {
 }
 
-func (msm *mockSessionManager1) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
-	pi := msm.Se.ShowProcess()
-	return pi, true
+func (msm *mockSessionManager1) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
+	msm.Se.ShowProcess(f)
 }
 
 // Kill implements the SessionManager.Kill interface.

--- a/executor/show.go
+++ b/executor/show.go
@@ -350,16 +350,15 @@ func (e *ShowExec) fetchShowProcessList() error {
 		}
 	}
 
-	pl := sm.ShowProcessList()
-	for _, pi := range pl {
+	sm.ShowProcessList(func(pi *util.ProcessInfo) {
 		// If you have the PROCESS privilege, you can see all threads.
 		// Otherwise, you can see only your own threads.
 		if !hasProcessPriv && pi.User != loginUser.Username {
-			continue
+			return
 		}
 		row := pi.ToRowForShow(e.Full)
 		e.appendRow(row)
-	}
+	})
 	return nil
 }
 

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -453,13 +453,17 @@ func (sm *mockSessionManager) ShowTxnList() []*txninfo.TxnInfo {
 	return sm.txnInfo
 }
 
-func (sm *mockSessionManager) ShowProcessList() map[uint64]*util.ProcessInfo {
-	return sm.processInfoMap
+func (sm *mockSessionManager) ShowProcessList(f func(*util.ProcessInfo)) {
+	for _, v := range sm.processInfoMap {
+		f(v)
+	}
 }
 
-func (sm *mockSessionManager) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (sm *mockSessionManager) GetProcessInfo(id uint64, f func(pi *util.ProcessInfo)) {
 	rs, ok := sm.processInfoMap[id]
-	return rs, ok
+	if ok {
+		f(rs)
+	}
 }
 
 func (sm *mockSessionManager) Kill(connectionID uint64, query bool) {}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -2439,14 +2439,14 @@ func (b *PlanBuilder) buildSimple(ctx context.Context, node ast.StmtNode) (Plan,
 		// In which case you require RESTRICTED_CONNECTION_ADMIN to kill connections that belong to RESTRICTED_USER_ADMIN users.
 		sm := b.ctx.GetSessionManager()
 		if sm != nil {
-			if pi, ok := sm.GetProcessInfo(raw.ConnectionID); ok {
+			sm.GetProcessInfo(raw.ConnectionID, func(pi *util2.ProcessInfo) {
 				loginUser := b.ctx.GetSessionVars().User
 				if pi.User != loginUser.Username {
 					err := ErrSpecificAccessDenied.GenWithStackByArgs("SUPER or CONNECTION_ADMIN")
 					b.visitInfo = appendDynamicVisitInfo(b.visitInfo, "CONNECTION_ADMIN", false, err)
 					b.visitInfo = appendVisitInfoIsRestrictedUser(b.visitInfo, b.ctx, &auth.UserIdentity{Username: pi.User, Hostname: pi.Host}, "RESTRICTED_CONNECTION_ADMIN")
 				}
-			}
+			})
 		}
 	case *ast.UseStmt:
 		if raw.DBName == "" {
@@ -3791,8 +3791,11 @@ func (b *PlanBuilder) buildExplainPlan(targetPlan Plan, format string, explainRo
 // buildExplainFor gets *last* (maybe running or finished) query plan from connection #connection id.
 // See https://dev.mysql.com/doc/refman/8.0/en/explain-for-connection.html.
 func (b *PlanBuilder) buildExplainFor(explainFor *ast.ExplainForStmt) (Plan, error) {
-	processInfo, ok := b.ctx.GetSessionManager().GetProcessInfo(explainFor.ConnectionID)
-	if !ok {
+	var processInfo *util2.ProcessInfo
+	b.ctx.GetSessionManager().GetProcessInfo(explainFor.ConnectionID, func(pi *util2.ProcessInfo) {
+		processInfo = pi
+	})
+	if processInfo == nil {
 		return nil, ErrNoSuchThread.GenWithStackByArgs(explainFor.ConnectionID)
 	}
 	if b.ctx.GetSessionVars() != nil && b.ctx.GetSessionVars().User != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -546,16 +546,12 @@ func (s *Server) checkConnectionCount() error {
 }
 
 // ShowProcessList implements the SessionManager interface.
-func (s *Server) ShowProcessList() map[uint64]*util.ProcessInfo {
+func (s *Server) ShowProcessList(f func(*util.ProcessInfo)) {
 	s.rwlock.RLock()
 	defer s.rwlock.RUnlock()
-	rs := make(map[uint64]*util.ProcessInfo, len(s.clients))
 	for _, client := range s.clients {
-		if pi := client.ctx.ShowProcess(); pi != nil {
-			rs[pi.ID] = pi
-		}
+		client.ctx.ShowProcess(f)
 	}
-	return rs
 }
 
 // ShowTxnList shows all txn info for displaying in `TIDB_TRX`
@@ -575,14 +571,13 @@ func (s *Server) ShowTxnList() []*txninfo.TxnInfo {
 }
 
 // GetProcessInfo implements the SessionManager interface.
-func (s *Server) GetProcessInfo(id uint64) (*util.ProcessInfo, bool) {
+func (s *Server) GetProcessInfo(id uint64, f func(*util.ProcessInfo)) {
 	s.rwlock.RLock()
 	conn, ok := s.clients[id]
 	s.rwlock.RUnlock()
-	if !ok {
-		return &util.ProcessInfo{}, false
+	if ok {
+		conn.ctx.ShowProcess(f)
 	}
-	return conn.ctx.ShowProcess(), ok
 }
 
 // Kill implements the SessionManager interface.

--- a/session/session.go
+++ b/session/session.go
@@ -151,7 +151,7 @@ type Session interface {
 	Auth(user *auth.UserIdentity, auth []byte, salt []byte) bool
 	AuthWithoutVerification(user *auth.UserIdentity) bool
 	AuthPluginForUser(user *auth.UserIdentity) (string, error)
-	ShowProcess() *util.ProcessInfo
+	ShowProcess(func(*util.ProcessInfo))
 	// Return the information of the txn current running
 	TxnInfo() *txninfo.TxnInfo
 	// PrepareTxnCtx is exported for test.
@@ -190,9 +190,12 @@ func (h *StmtHistory) Count() int {
 }
 
 type session struct {
-	// processInfo is used by ShowProcess(), and should be modified atomically.
-	processInfo atomic.Value
-	txn         LazyTxn
+	// processInfo is used by ShowProcess(), and should be protected by lock.
+	processInfo struct {
+		sync.RWMutex
+		util.ProcessInfo
+	}
+	txn LazyTxn
 
 	mu struct {
 		sync.RWMutex
@@ -461,10 +464,11 @@ func (s *session) TxnInfo() *txninfo.TxnInfo {
 		return nil
 	}
 
-	processInfo := s.ShowProcess()
-	txnInfo.ConnectionID = processInfo.ID
-	txnInfo.Username = processInfo.User
-	txnInfo.CurrentDB = processInfo.DB
+	s.processInfo.RLock()
+	txnInfo.ConnectionID = s.processInfo.ID
+	txnInfo.Username = s.processInfo.User
+	txnInfo.CurrentDB = s.processInfo.DB
+	s.processInfo.RUnlock()
 
 	return &txnInfo
 }
@@ -1295,22 +1299,26 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte, maxExecu
 		MaxExecutionTime: maxExecutionTime,
 		RedactSQL:        s.sessionVars.EnableRedactLog,
 	}
-	oldPi := s.ShowProcess()
+	_, digest := s.sessionVars.StmtCtx.SQLDigest()
+	pi.Digest = digest.String()
+
+	s.processInfo.Lock()
+	defer s.processInfo.Unlock()
+
+	oldPi := &s.processInfo.ProcessInfo
 	if p == nil {
 		// Store the last valid plan when the current plan is nil.
 		// This is for `explain for connection` statement has the ability to query the last valid plan.
-		if oldPi != nil && oldPi.Plan != nil && len(oldPi.PlanExplainRows) > 0 {
+		if oldPi.Plan != nil && len(oldPi.PlanExplainRows) > 0 {
 			pi.Plan = oldPi.Plan
 			pi.PlanExplainRows = oldPi.PlanExplainRows
 			pi.RuntimeStatsColl = oldPi.RuntimeStatsColl
 		}
 	}
 	// We set process info before building plan, so we extended execution time.
-	if oldPi != nil && oldPi.Info == pi.Info {
+	if oldPi.Info == pi.Info {
 		pi.Time = oldPi.Time
 	}
-	_, digest := s.sessionVars.StmtCtx.SQLDigest()
-	pi.Digest = digest.String()
 	// DO NOT reset the currentPlan to nil until this query finishes execution, otherwise reentrant calls
 	// of SetProcessInfo would override Plan and PlanExplainRows to nil.
 	if command == mysql.ComSleep {
@@ -1320,7 +1328,8 @@ func (s *session) SetProcessInfo(sql string, t time.Time, command byte, maxExecu
 		pi.User = s.sessionVars.User.Username
 		pi.Host = s.sessionVars.User.Hostname
 	}
-	s.processInfo.Store(&pi)
+
+	s.processInfo.ProcessInfo = pi
 }
 
 func (s *session) ExecuteInternal(ctx context.Context, sql string, args ...interface{}) (rs sqlexec.RecordSet, err error) {
@@ -2861,13 +2870,10 @@ func (s *session) GetStore() kv.Storage {
 	return s.store
 }
 
-func (s *session) ShowProcess() *util.ProcessInfo {
-	var pi *util.ProcessInfo
-	tmp := s.processInfo.Load()
-	if tmp != nil {
-		pi = tmp.(*util.ProcessInfo)
-	}
-	return pi
+func (s *session) ShowProcess(f func(*util.ProcessInfo)) {
+	s.processInfo.RLock()
+	defer s.processInfo.RUnlock()
+	f(&s.processInfo.ProcessInfo)
 }
 
 // logStmt logs some crucial SQL including: CREATE USER/GRANT PRIVILEGE/CHANGE PASSWORD/DDL etc and normal SQL

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -56,6 +56,7 @@ import (
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
+	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/pingcap/tidb/util/testkit"
@@ -4191,10 +4192,11 @@ func (s *testSessionSerialSuite) TestProcessInfoIssue22068(c *C) {
 		wg.Done()
 	}()
 	time.Sleep(2 * time.Second)
-	pi := tk.Se.ShowProcess()
-	c.Assert(pi, NotNil)
-	c.Assert(pi.Info, Equals, "select 1 from t where a = (select sleep(5));")
-	c.Assert(pi.Plan, IsNil)
+	tk.Se.ShowProcess(func(pi *util.ProcessInfo) {
+		c.Assert(pi, NotNil)
+		c.Assert(pi.Info, Equals, "select 1 from t where a = (select sleep(5));")
+		c.Assert(pi.Plan, IsNil)
+	})
 	wg.Wait()
 }
 

--- a/util/expensivequery/memory_usage_alarm.go
+++ b/util/expensivequery/memory_usage_alarm.go
@@ -161,13 +161,12 @@ func (record *memoryUsageAlarm) doRecord(memUsage uint64, instanceMemoryUsage ui
 }
 
 func (record *memoryUsageAlarm) recordSQL(sm util.SessionManager) {
-	processInfo := sm.ShowProcessList()
-	pinfo := make([]*util.ProcessInfo, 0, len(processInfo))
-	for _, info := range processInfo {
+	pinfo := make([]*util.ProcessInfo, 0, 5)
+	sm.ShowProcessList(func(info *util.ProcessInfo) {
 		if len(info.Info) != 0 {
 			pinfo = append(pinfo, info)
 		}
-	}
+	})
 
 	fileName := filepath.Join(record.tmpDir, "running_sql"+record.lastCheckTime.Format(time.RFC3339))
 	record.lastLogFileName = append(record.lastLogFileName, fileName)

--- a/util/processinfo.go
+++ b/util/processinfo.go
@@ -161,9 +161,9 @@ func serverStatus2Str(state uint16) string {
 // SessionManager is an interface for session manage. Show processlist and
 // kill statement rely on this interface.
 type SessionManager interface {
-	ShowProcessList() map[uint64]*ProcessInfo
+	ShowProcessList(func(*ProcessInfo))
 	ShowTxnList() []*txninfo.TxnInfo
-	GetProcessInfo(id uint64) (*ProcessInfo, bool)
+	GetProcessInfo(id uint64, f func(*ProcessInfo))
 	Kill(connectionID uint64, query bool)
 	KillAllConnections()
 	UpdateTLSConfig(cfg *tls.Config)


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #26161

Problem Summary:

At the beginning, `util.ProcessInfo` is very simple, just including the SQL, Host, Port, connection ID, Time and so ...
And later the plan is added ...
And then even more fields like the StmtCtx, MemoryTracker, RuntimeStatsColl ... are all added.

**In the initial design, the process info is a atomic, snapshot of the current session statement.**

However, after the *StmtCtx, *RuntimeStatsColl added, it's not a snapshot any more! It's a pointer reference and the actual data are constantly changing.

### What is changed and how it works?

If *StmtCtx, *RuntimeStatsColl, *MemoryTracker are included in the ProcessInfo, we can not create a snapshot of ProcessInfo anymore, unless we make a deep copy of all those objects. 

To address #26161, I'd like to redesign the process info implementation.

What's Changed:


How it Works:

Do not take process info as a snapshot any more.
Instead, this API is provided:

```
func ShowProcess(f (info *util.ProcessInfo) {
}
```

The caller provide a visit function `f`, during visiting, the data is locked.
The caller should not persist the process info pointer for later usage, because what it points to may change over time.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- refactor process info
