### PR TITLE
bindinfo: garbage collect deleted bind records

### DIFF
--- a/bindinfo/handle.go
+++ b/bindinfo/handle.go
@@ -390,6 +390,45 @@ func (h *BindHandle) DropBindRecord(originalSQL, db string, binding *Binding) (e
 	return err
 }
 
+// GCBindRecord physically removes the deleted bind records in mysql.bind_info.
+func (h *BindHandle) GCBindRecord() (err error) {
+	h.bindInfo.Lock()
+	h.sctx.Lock()
+	defer func() {
+		h.sctx.Unlock()
+		h.bindInfo.Unlock()
+	}()
+	exec, _ := h.sctx.Context.(sqlexec.SQLExecutor)
+	_, err = exec.ExecuteInternal(context.TODO(), "BEGIN PESSIMISTIC")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err != nil {
+			_, err1 := exec.ExecuteInternal(context.TODO(), "ROLLBACK")
+			terror.Log(err1)
+			return
+		}
+
+		_, err = exec.ExecuteInternal(context.TODO(), "COMMIT")
+		if err != nil {
+			return
+		}
+	}()
+
+	// Lock mysql.bind_info to synchronize with CreateBindRecord / AddBindRecord / DropBindRecord on other tidb instances.
+	if err = h.lockBindInfoTable(); err != nil {
+		return err
+	}
+
+	// To make sure that all the deleted bind records have been acknowledged to all tidb,
+	// we only garbage collect those records with update_time before 10 leases.
+	updateTime := time.Now().Add(-(10 * Lease))
+	updateTimeStr := types.NewTime(types.FromGoTime(updateTime), mysql.TypeTimestamp, 3).String()
+	_, err = exec.ExecuteInternal(context.TODO(), `DELETE FROM mysql.bind_info WHERE status = 'deleted' and update_time < %?`, updateTimeStr)
+	return err
+}
+
 // lockBindInfoTable simulates `LOCK TABLE mysql.bind_info WRITE` by acquiring a pessimistic lock on a
 // special builtin row of mysql.bind_info. Note that this function must be called with h.sctx.Lock() held.
 // We can replace this implementation to normal `LOCK TABLE mysql.bind_info WRITE` if that feature is

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -990,12 +990,13 @@ func (do *Domain) LoadBindInfoLoop(ctxForHandle sessionctx.Context, ctxForEvolve
 		return err
 	}
 
-	do.globalBindHandleWorkerLoop()
-	do.handleEvolvePlanTasksLoop(ctxForEvolve)
+	owner := do.newOwnerManager(bindinfo.Prompt, bindinfo.OwnerKey)
+	do.globalBindHandleWorkerLoop(owner)
+	do.handleEvolvePlanTasksLoop(ctxForEvolve, owner)
 	return nil
 }
 
-func (do *Domain) globalBindHandleWorkerLoop() {
+func (do *Domain) globalBindHandleWorkerLoop(owner owner.Manager) {
 	do.wg.Add(1)
 	go func() {
 		defer func() {
@@ -1004,10 +1005,15 @@ func (do *Domain) globalBindHandleWorkerLoop() {
 			util.Recover(metrics.LabelDomain, "globalBindHandleWorkerLoop", nil, false)
 		}()
 		bindWorkerTicker := time.NewTicker(bindinfo.Lease)
-		defer bindWorkerTicker.Stop()
+		gcBindTicker := time.NewTicker(100 * bindinfo.Lease)
+		defer func() {
+			bindWorkerTicker.Stop()
+			gcBindTicker.Stop()
+		}()
 		for {
 			select {
 			case <-do.exit:
+				owner.Cancel()
 				return
 			case <-bindWorkerTicker.C:
 				err := do.bindHandle.Update(false)
@@ -1019,12 +1025,20 @@ func (do *Domain) globalBindHandleWorkerLoop() {
 					do.bindHandle.CaptureBaselines()
 				}
 				do.bindHandle.SaveEvolveTasksToStore()
+			case <-gcBindTicker.C:
+				if !owner.IsOwner() {
+					continue
+				}
+				err := do.bindHandle.GCBindRecord()
+				if err != nil {
+					logutil.BgLogger().Error("GC bind record failed", zap.Error(err))
+				}
 			}
 		}
 	}()
 }
 
-func (do *Domain) handleEvolvePlanTasksLoop(ctx sessionctx.Context) {
+func (do *Domain) handleEvolvePlanTasksLoop(ctx sessionctx.Context, owner owner.Manager) {
 	do.wg.Add(1)
 	go func() {
 		defer func() {
@@ -1032,7 +1046,6 @@ func (do *Domain) handleEvolvePlanTasksLoop(ctx sessionctx.Context) {
 			logutil.BgLogger().Info("handleEvolvePlanTasksLoop exited.")
 			util.Recover(metrics.LabelDomain, "handleEvolvePlanTasksLoop", nil, false)
 		}()
-		owner := do.newOwnerManager(bindinfo.Prompt, bindinfo.OwnerKey)
 		for {
 			select {
 			case <-do.exit:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26191

Problem Summary:

GC bind record with deleted status.


### What is changed and how it works?

What's Changed:
- add a ticker to trigger the gc in the background loop
- expose bind owner, and only do gc in bind owner


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test: start 2 tidb servers, and create / drop a global binding on one tidb, then observe the results of `show global bindings` and `select * from mysql.bind_info` on 2 tidb servers. Check that, the "deleted" bind record in `mysql.bind_info` is removed after 5.5 minutes.

Side effects

N/A

Documentation

N/A

### Release note <!-- bugfixes or new feature need a release note -->

- Garbage collect deleted bind records