### PR TITLE
executor, privilege: require CONFIG privilege for is.cluster_info

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -78,6 +78,12 @@ type memtableRetriever struct {
 
 // retrieve implements the infoschemaRetriever interface
 func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
+	switch e.table.Name.O {
+	case infoschema.TableClusterInfo:
+		if !hasPriv(sctx, mysql.ConfigPriv) {
+			return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("CONFIG")
+		}
+	}
 	if e.retrieved {
 		return nil, nil
 	}

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -1488,12 +1488,16 @@ func (s *testPrivilegeSuite) TestClusterConfigInfoschema(c *C) {
 	err := tk.QueryToErr("SELECT * FROM information_schema.cluster_config")
 	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the CONFIG privilege(s) for this operation")
 
+	err = tk.QueryToErr("SELECT * FROM information_schema.cluster_info")
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the CONFIG privilege(s) for this operation")
+
 	// With correct permissions
 	tk.Se.Auth(&auth.UserIdentity{
 		Username: "ccconfig",
 		Hostname: "localhost",
 	}, nil, nil)
 	tk.MustQuery("SELECT * FROM information_schema.cluster_config")
+	tk.MustQuery("SELECT * FROM information_schema.cluster_info")
 }
 
 func (s *testPrivilegeSuite) TestSecurityEnhancedModeStatusVars(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26122

Problem Summary:
The cluster_info table should require the CONFIG privilege. This is consistent with the behavior change in #25379 which requires CONFIG for SHOW CONFIG.

It makes sense to cherry pick to 5.1, but not 5.0; because the behavior in 5.0 was not established yet, and SHOW CONFIG still requires no privileges.

### What is changed and how it works?

What's Changed:

Reading from the table information_schema.cluster_info now requires the CONFIG privilege.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. --> 

- [X] Unit test

Side effects

- [X] Breaking backward compatibility (**for security**)

### Release note <!-- bugfixes or new feature need a release note --> 

- Reading from the table information_schema.cluster_info now requires the CONFIG privilege.