### PR TITLE
executor: fix user without process privilege can access cluster's systemInfo, Load, Hardware

### DIFF
--- a/executor/memtable_reader.go
+++ b/executor/memtable_reader.go
@@ -293,6 +293,10 @@ type clusterServerInfoRetriever struct {
 
 // retrieve implements the memTableRetriever interface
 func (e *clusterServerInfoRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
+	// To access TableClusterSystemInfo, TableClusterHardware, TableClusterLoad, PROCESS privileges is needed.
+	if !hasPriv(sctx, mysql.ProcessPriv) {
+		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("PROCESS")
+	}
 	if e.extractor.SkipRequest || e.retrieved {
 		return nil, nil
 	}

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -798,6 +798,28 @@ func (s *testClusterTableSuite) TestForClusterServerInfo(c *C) {
 		c.Assert(gotAddrs, DeepEquals, cas.addrs, Commentf("sql: %s", cas.sql))
 		c.Assert(gotNames, DeepEquals, cas.names, Commentf("sql: %s", cas.sql))
 	}
+
+	// More test about the systemInfo's privileges.
+	tk.MustExec("create user 'testuser'@'localhost'")
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{
+		Username: "testuser",
+		Hostname: "localhost",
+	}, nil, nil), Equals, true)
+
+	err := tk.QueryToErr("select * from information_schema.CLUSTER_SYSTEMINFO")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
+
+	err = tk.QueryToErr("select * from information_schema.CLUSTER_HARDWARE")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
+
+	err = tk.QueryToErr("select * from information_schema.CLUSTER_LOAD")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
 }
 
 func (s *testTableSuite) TestSystemSchemaID(c *C) {


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26121, https://github.com/pingcap/tidb/issues/26123, https://github.com/pingcap/tidb/issues/26126

### What is changed and how it works?

*: What's Changed: executor: fix user without process privilege can access cluster's systemInfo, Load, Hardware


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- executor: fix user without process privilege can access cluster's systemInfo, Load, Hardware
