### PR TITLE
store/gcworker: remove NotifyDeleteRangeTask after UnsafeDestroyRange

### DIFF
--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -848,13 +848,6 @@ func (w *GCWorker) doUnsafeDestroyRangeRequest(ctx context.Context, startKey []b
 		return errors.Errorf("[gc worker] destroy range finished with errors: %v", errs)
 	}
 
-	// Notify all affected regions in the range that UnsafeDestroyRange occurs.
-	notifyTask := tikv.NewNotifyDeleteRangeTask(w.tikvStore, startKey, endKey, concurrency)
-	err = notifyTask.Execute(ctx)
-	if err != nil {
-		return errors.Annotate(err, "[gc worker] failed notifying regions affected by UnsafeDestroyRange")
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: AndreMouche

### What problem does this PR solve?
This PR removes `NotifyDeleteRangeTask` after `UnsafeDestoryRange`.


Part of https://github.com/pingcap/tidb/issues/22513

### Check List <!--REMOVE the items that are not applicable-->
Tests 
- Unit test

### Release note <!-- bugfixes or new feature need a release note -->
- No release note