### PR TITLE
test: fix user without process privilege can access cluster_tidb_trx

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -2075,6 +2075,9 @@ func (e *memtableRetriever) setDataForTiDBTrx(ctx sessionctx.Context) {
 }
 
 func (e *memtableRetriever) setDataForClusterTiDBTrx(ctx sessionctx.Context) error {
+	if !hasPriv(ctx, mysql.ProcessPriv) {
+		return plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("Process")
+	}
 	e.setDataForTiDBTrx(ctx)
 	rows, err := infoschema.AppendHostInfoToRows(ctx, e.rows)
 	if err != nil {

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -798,6 +798,28 @@ func (s *testClusterTableSuite) TestForClusterServerInfo(c *C) {
 		c.Assert(gotAddrs, DeepEquals, cas.addrs, Commentf("sql: %s", cas.sql))
 		c.Assert(gotNames, DeepEquals, cas.names, Commentf("sql: %s", cas.sql))
 	}
+
+	// More test about the systemInfo's privileges.
+	tk.MustExec("create user 'testuser'@'localhost'")
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{
+		Username: "testuser",
+		Hostname: "localhost",
+	}, nil, nil), Equals, true)
+
+	err := tk.QueryToErr("select * from information_schema.CLUSTER_SYSTEMINFO")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
+
+	err = tk.QueryToErr("select * from information_schema.CLUSTER_HARDWARE")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
+
+	err = tk.QueryToErr("select * from information_schema.CLUSTER_LOAD")
+	c.Assert(err, NotNil)
+	// This error is come from cop(TiDB) fetch from rpc server.
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
 }
 
 func (s *testTableSuite) TestSystemSchemaID(c *C) {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26127

### What is changed and how it works?

*: What's Changed: add the privileges check when read the memory table


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- test: fix user without process privilege can access cluster_tidb_trx