### PR TITLE
store/copr: refactor the Slice function to make the process clearer

### DIFF
--- a/store/copr/key_ranges.go
+++ b/store/copr/key_ranges.go
@@ -75,26 +75,24 @@ func (r *KeyRanges) At(i int) kv.KeyRange {
 // Slice returns the sub ranges [from, to).
 func (r *KeyRanges) Slice(from, to int) *KeyRanges {
 	var ran KeyRanges
+	if to == 0 || from >= to {
+		return &ran
+	}
 	if r.first != nil {
-		if from == 0 && to > 0 {
+		if from == 0 {
 			ran.first = r.first
 		}
 		if from > 0 {
 			from--
 		}
-		if to > 0 {
-			to--
-		}
+		to--
 	}
-	if to <= len(r.mid) {
+	if to > len(r.mid) {
+		ran.last = r.last
+		to = len(r.mid)
+	}
+	if from < to {
 		ran.mid = r.mid[from:to]
-	} else {
-		if from <= len(r.mid) {
-			ran.mid = r.mid[from:]
-		}
-		if from < to {
-			ran.last = r.last
-		}
 	}
 	return &ran
 }


### PR DESCRIPTION
### What is changed and how it works?

**What's Changed**:

Refactor the `Slice` function.

**How it Works**:

```go
// Slice returns the sub ranges [from, to).
func (r *KeyRanges) Slice(from, to int) *KeyRanges {
	var ran KeyRanges
	/*
		Step 1: Return the empty `ran` directly.
			Case 1: `to == 0`,
			Case 2: `from == to`, which means that the interval
				[from, to) does not contain any elements.
				Use `from >= to` to enhance robustness.
	*/
	if to == 0 || from >= to {
		return &ran
	}

	/*
		Step 2: Set the ran.first if needed.
			1. When `r.first != nil` is true, both `from` and
			 `to` should be reduced by one.
			2. Slice index must bigger than zero, so we only do
			 subtraction when the `from` is positive.
			3. Since `to > 0`, do subtraction directly.
	*/
	if r.first != nil {
		if from == 0 {
			ran.first = r.first
		}
		if from > 0 {
			from--
		}
		to--
	}
	/*
		Step 3: Set the ran.last if needed, trim `to` at the
			same time.
	*/
	if to > len(r.mid) {
		ran.last = r.last
		to = len(r.mid)
	}
	/*
		Step 4: Set the `ran.mid` if and only if the interval
			[from, to) is legal.
	*/
	if from < to {
		ran.mid = r.mid[from:to]
	}
	return &ran
}
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
