### PR TITLE
infoschema: Change tables in Lock View to views that fetches the SQL text by digests internally

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -1578,8 +1578,8 @@ func (b *executorBuilder) buildMemTable(v *plannercore.PhysicalMemTable) Executo
 			strings.ToLower(infoschema.TableClientErrorsSummaryGlobal),
 			strings.ToLower(infoschema.TableClientErrorsSummaryByUser),
 			strings.ToLower(infoschema.TableClientErrorsSummaryByHost),
-			strings.ToLower(infoschema.TableTiDBTrx),
-			strings.ToLower(infoschema.ClusterTableTiDBTrx),
+			strings.ToLower(infoschema.TableTiDBTrxImpl),
+			strings.ToLower(infoschema.ClusterTableTiDBTrxImpl),
 			strings.ToLower(infoschema.TableDeadlocks),
 			strings.ToLower(infoschema.ClusterTableDeadlocks),
 			strings.ToLower(infoschema.TableDataLockWaits):

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -538,11 +538,15 @@ func (e *memtableRetriever) setDataFromTables(ctx sessionctx.Context, schemas []
 				)
 				rows = append(rows, record)
 			} else {
+				tableType := "VIEW"
+				if util.IsSystemView(schema.Name.L) {
+					tableType = "SYSTEM VIEW"
+				}
 				record := types.MakeDatums(
 					infoschema.CatalogVal, // TABLE_CATALOG
 					schema.Name.O,         // TABLE_SCHEMA
 					table.Name.O,          // TABLE_NAME
-					"VIEW",                // TABLE_TYPE
+					tableType,             // TABLE_TYPE
 					nil,                   // ENGINE
 					nil,                   // VERSION
 					nil,                   // ROW_FORMAT

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -152,9 +152,9 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 			infoschema.TableClientErrorsSummaryByUser,
 			infoschema.TableClientErrorsSummaryByHost:
 			err = e.setDataForClientErrorsSummary(sctx, e.table.Name.O)
-		case infoschema.TableTiDBTrx:
+		case infoschema.TableTiDBTrxImpl:
 			e.setDataForTiDBTrx(sctx)
-		case infoschema.ClusterTableTiDBTrx:
+		case infoschema.ClusterTableTiDBTrxImpl:
 			err = e.setDataForClusterTiDBTrx(sctx)
 		case infoschema.TableDeadlocks:
 			err = e.setDataForDeadlock(sctx)

--- a/executor/show.go
+++ b/executor/show.go
@@ -389,6 +389,10 @@ func (e *ShowExec) fetchShowTables() error {
 		if checker != nil && !checker.RequestVerification(activeRoles, e.DBName.O, v.Meta().Name.O, "", mysql.AllPrivMask) {
 			continue
 		}
+		// Filter out some special hidden tables in information_schema
+		if infoschema.IsInformationSchemaHiddenTable(e.DBName.L, v.Meta().Name.O) {
+			continue
+		}
 		tableNames = append(tableNames, v.Meta().Name.O)
 		if v.Meta().IsView() {
 			tableTypes[v.Meta().Name.O] = "VIEW"

--- a/executor/show.go
+++ b/executor/show.go
@@ -394,12 +394,12 @@ func (e *ShowExec) fetchShowTables() error {
 			continue
 		}
 		tableNames = append(tableNames, v.Meta().Name.O)
-		if v.Meta().IsView() {
+		if util.IsSystemView(e.DBName.L) {
+			tableTypes[v.Meta().Name.O] = "SYSTEM VIEW"
+		} else if v.Meta().IsView() {
 			tableTypes[v.Meta().Name.O] = "VIEW"
 		} else if v.Meta().IsSequence() {
 			tableTypes[v.Meta().Name.O] = "SEQUENCE"
-		} else if util.IsSystemView(e.DBName.L) {
-			tableTypes[v.Meta().Name.O] = "SYSTEM VIEW"
 		} else {
 			tableTypes[v.Meta().Name.O] = "BASE TABLE"
 		}

--- a/infoschema/cluster.go
+++ b/infoschema/cluster.go
@@ -39,8 +39,8 @@ const (
 	ClusterTableStatementsSummaryHistory = "CLUSTER_STATEMENTS_SUMMARY_HISTORY"
 	// ClusterTableStatementsSummaryEvicted is the string constant of cluster statement summary evict table.
 	ClusterTableStatementsSummaryEvicted = "CLUSTER_STATEMENTS_SUMMARY_EVICTED"
-	// ClusterTableTiDBTrx is the string constant of cluster transaction running table.
-	ClusterTableTiDBTrx = "CLUSTER_TIDB_TRX"
+	// ClusterTableTiDBTrxImpl is the string constant of cluster transaction running table.
+	ClusterTableTiDBTrxImpl = "CLUSTER_TIDB_TRX_IMPL"
 	// ClusterTableDeadlocks is the string constant of cluster dead lock table.
 	ClusterTableDeadlocks = "CLUSTER_DEADLOCKS"
 )
@@ -52,7 +52,7 @@ var memTableToClusterTables = map[string]string{
 	TableStatementsSummary:        ClusterTableStatementsSummary,
 	TableStatementsSummaryHistory: ClusterTableStatementsSummaryHistory,
 	TableStatementsSummaryEvicted: ClusterTableStatementsSummaryEvicted,
-	TableTiDBTrx:                  ClusterTableTiDBTrx,
+	TableTiDBTrxImpl:              ClusterTableTiDBTrxImpl,
 	TableDeadlocks:                ClusterTableDeadlocks,
 }
 

--- a/infoschema/cluster.go
+++ b/infoschema/cluster.go
@@ -39,7 +39,7 @@ const (
 	ClusterTableStatementsSummaryHistory = "CLUSTER_STATEMENTS_SUMMARY_HISTORY"
 	// ClusterTableStatementsSummaryEvicted is the string constant of cluster statement summary evict table.
 	ClusterTableStatementsSummaryEvicted = "CLUSTER_STATEMENTS_SUMMARY_EVICTED"
-	// ClusterTableTiDBTrxImpl is the string constant of cluster transaction running table.
+	// ClusterTableTiDBTrxImpl is the string constant of the hidden table on which ViewClusterTiDBTrx is built.
 	ClusterTableTiDBTrxImpl = "CLUSTER_TIDB_TRX_IMPL"
 	// ClusterTableDeadlocks is the string constant of cluster dead lock table.
 	ClusterTableDeadlocks = "CLUSTER_DEADLOCKS"

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -302,6 +302,9 @@ func (*testSuite) TestInfoTables(c *C) {
 		"COLLATION_CHARACTER_SET_APPLICABILITY",
 		"PROCESSLIST",
 		"TIDB_TRX_IMPL",
+		"TIDB_TRX",
+		"CLUSTER_TIDB_TRX_IMPL",
+		"CLUSTER_TIDB_TRX",
 		"DEADLOCKS",
 	}
 	for _, t := range infoTables {

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -301,7 +301,7 @@ func (*testSuite) TestInfoTables(c *C) {
 		"TABLESPACES",
 		"COLLATION_CHARACTER_SET_APPLICABILITY",
 		"PROCESSLIST",
-		"TIDB_TRX",
+		"TIDB_TRX_IMPL",
 		"DEADLOCKS",
 	}
 	for _, t := range infoTables {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -350,7 +350,7 @@ func setViewMeta(tableInfo *model.TableInfo, viewInfo *infoSchemaViewInfo) {
 			AuthUsername: "",
 			AuthHostname: "",
 		},
-		Security:    model.SecurityInvoker,
+		Security: model.SecurityInvoker,
 		// TODO: The statement is better to be parsed and restored to clean the format.
 		SelectStmt:  viewInfo.selectStmt,
 		CheckOption: model.CheckOptionCascaded,
@@ -1847,13 +1847,13 @@ var tableNameToColumns = map[string][]columnInfo{
 }
 
 var viewNameToViewInfo = map[string]*infoSchemaViewInfo{
-	ViewTiDBTrx: &viewTiDBTrxInfo,
+	ViewTiDBTrx:        &viewTiDBTrxInfo,
 	ViewClusterTiDBTrx: &viewClusterTiDBTrxInfo,
 }
 
 // Tables that should not be shown in SHOW TABLES statement. Cluster tables are also included here.
 var invisibleTables = map[string]interface{}{
-	TableTiDBTrxImpl: nil,
+	TableTiDBTrxImpl:        nil,
 	ClusterTableTiDBTrxImpl: nil,
 }
 

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1834,6 +1834,18 @@ var viewNameToViewInfo = map[string]*infoSchemaViewInfo{
 	ViewTiDBTrx: &viewTidbTrxInfo,
 }
 
+var invisibleTables = map[string]interface{}{
+	TableTiDBTrxImpl: nil,
+}
+
+func IsInformationSchemaHiddenTable(dbName, tableName string) bool {
+	if strings.ToLower(dbName) != util.InformationSchemaName.L {
+		return false
+	}
+	_, ok := invisibleTables[strings.ToUpper(tableName)]
+	return ok
+}
+
 func createInfoSchemaTable(_ autoid.Allocators, meta *model.TableInfo) (table.Table, error) {
 	columns := make([]*table.Column, len(meta.Columns))
 	for i, col := range meta.Columns {

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -167,13 +167,14 @@ const (
 	TableClientErrorsSummaryByUser = "CLIENT_ERRORS_SUMMARY_BY_USER"
 	// TableClientErrorsSummaryByHost is the string constant of client errors table.
 	TableClientErrorsSummaryByHost = "CLIENT_ERRORS_SUMMARY_BY_HOST"
-	// TableTiDBTrxImpl is current running transaction status table.
+	// TableTiDBTrxImpl is the string constant of the hidden table on which ViewTiDBTrx is built.
 	TableTiDBTrxImpl = "TIDB_TRX_IMPL"
-	// TableDeadlocks is the string constatnt of deadlock table.
+	// TableDeadlocks is the string constant of deadlock table.
 	TableDeadlocks = "DEADLOCKS"
-	// TableDataLockWaits is current lock waiting status table.
+	// TableDataLockWaits is the string constant of current lock waiting status table.
 	TableDataLockWaits = "DATA_LOCK_WAITS"
-	ViewTiDBTrx        = "TIDB_TRX"
+	// ViewTiDBTrx is the string constant of current running transaction status table.
+	ViewTiDBTrx = "TIDB_TRX"
 )
 
 var tableIDMap = map[string]int64{
@@ -1838,6 +1839,7 @@ var invisibleTables = map[string]interface{}{
 	TableTiDBTrxImpl: nil,
 }
 
+// IsInformationSchemaHiddenTable checks if a table is a hidden table in information_schema.
 func IsInformationSchemaHiddenTable(dbName, tableName string) bool {
 	if strings.ToLower(dbName) != util.InformationSchemaName.L {
 		return false

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1679,7 +1679,7 @@ func (s *testTableSuite) TestTrx(c *C) {
 	sm.txnInfo[1].BlockStartTime.Valid = true
 	sm.txnInfo[1].BlockStartTime.Time = blockTime2
 	tk.Se.SetSessionManager(sm)
-	tk.MustQuery("select * from information_schema.TIDB_TRX;").Check(testkit.Rows(
+	tk.MustQuery("select * from information_schema.TIDB_TRX_IMPL;").Check(testkit.Rows(
 		"424768545227014155 2021-05-07 12:56:48.001000 "+digest.String()+" Normal <nil> 1 19 2 root test []",
 		"425070846483628033 2021-05-20 21:16:35.778000 <nil> LockWaiting 2021-05-20 13:18:30.123456 0 0 10 user1 db1 [sql1, sql2]"))
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: This PR makes the original `TIDB_TRX` and `CLUSTER_TIDB_TRX` hidden from `SHOW TABLES` statement and renamed to `TIDB_TRX_IMPL` and `CLUSTER_TIDB_TRX_IMPL`, and added new views `TIDB_TRX` and `CLUTER_TIDB_TRX` instead. It internally uses the two hidden "IMPL" tables, and joins them with statements_summary and statements_summary_history to get the SQL text of the digest.

Later the same changes to `DEADLOCKS`, `CLUSTER_DEADLOCKS` and `DATA_LOCK_WATIS` will also be made in this PR.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
* [x] Following changes to `TIDB_TRX` and `CLUSTER_TIDB_TRX` are made:
  * Rename `TIDB_TRX` to `TIDB_TRX_IMPL` and `CLUSTER_TIDB_TRX` to `CLUSTER_TIDB_TRX_IMPL`
  * Make `TIDB_TRX_IMPL` and `CLUSTER_TIDB_TRX_IMPL` hidden from the `SHOW TABLES` result.
  * Add two views `TIDB_TRX` and `CLUSTER_TIDB_TRX` that joins the `*_IMPL` tables with statements_summary and statements_summary_history to find the SQL text corresponding to the digests.
* [ ] The same changes to `DEADLOCKS` and `CLUSTER_DEADLOCKS`
* [ ] The same changes to `DATA_LOCK_WAITS`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test (TODO)

Documentation

- [ ] Affects user behaviors
  - Needs updating the table definition.

### Release note <!-- bugfixes or new feature need a release note -->

- Adds SQL text to `TIDB_TRX` and `CLUSTER_TIDB_TRX` tables.
