### PR TITLE
exec: access the table_storage_stats need privilege

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1675,7 +1675,7 @@ func (e *tableStorageStatsRetriever) initialize(sctx sessionctx.Context) error {
 	// Privilege checker.
 	checker := func(db, table string) bool {
 		if pm := privilege.GetPrivilegeManager(sctx); pm != nil {
-			return pm.RequestVerification(sctx.GetSessionVars().ActiveRoles, db, table, "", mysql.SuperPriv)
+			return pm.RequestVerification(sctx.GetSessionVars().ActiveRoles, db, table, "", mysql.AllPrivMask)
 		}
 		return true
 	}

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1616,9 +1616,6 @@ type tableStorageStatsRetriever struct {
 }
 
 func (e *tableStorageStatsRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
-	if !hasPriv(sctx, mysql.SuperPriv) {
-		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
-	}
 	if e.retrieved {
 		return nil, nil
 	}
@@ -1674,19 +1671,33 @@ func (e *tableStorageStatsRetriever) initialize(sctx sessionctx.Context) error {
 		}
 	}
 
+	// Privilege checker.
+	checker := func(db, table string) bool {
+		if pm := privilege.GetPrivilegeManager(sctx); pm != nil {
+			return pm.RequestVerification(sctx.GetSessionVars().ActiveRoles, db, table, "", mysql.SuperPriv)
+		}
+		return true
+	}
+
 	// Extract the tables to the initialTable.
 	for _, DB := range databases {
 		// The user didn't specified the table, extract all tables of this db to initialTable.
 		if len(tables) == 0 {
 			tbs := is.SchemaTables(model.NewCIStr(DB))
 			for _, tb := range tbs {
-				e.initialTables = append(e.initialTables, &initialTable{DB, tb.Meta()})
+				// For every db.table, check it's privileges.
+				if checker(DB, tb.Meta().Name.L) {
+					e.initialTables = append(e.initialTables, &initialTable{DB, tb.Meta()})
+				}
 			}
 		} else {
 			// The user specified the table, extract the specified tables of this db to initialTable.
 			for tb := range tables {
 				if tb, err := is.TableByName(model.NewCIStr(DB), model.NewCIStr(tb)); err == nil {
-					e.initialTables = append(e.initialTables, &initialTable{DB, tb.Meta()})
+					// For every db.table, check it's privileges.
+					if checker(DB, tb.Meta().Name.L) {
+						e.initialTables = append(e.initialTables, &initialTable{DB, tb.Meta()})
+					}
 				}
 			}
 		}

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1616,8 +1616,8 @@ type tableStorageStatsRetriever struct {
 }
 
 func (e *tableStorageStatsRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
-	if !hasPriv(sctx, mysql.ProcessPriv) {
-		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("PROCESS")
+	if !hasPriv(sctx, mysql.SuperPriv) {
+		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("SUPER")
 	}
 	if e.retrieved {
 		return nil, nil

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -1616,6 +1616,9 @@ type tableStorageStatsRetriever struct {
 }
 
 func (e *tableStorageStatsRetriever) retrieve(ctx context.Context, sctx sessionctx.Context) ([][]types.Datum, error) {
+	if !hasPriv(sctx, mysql.ProcessPriv) {
+		return nil, plannercore.ErrSpecificAccessDenied.GenWithStackByArgs("PROCESS")
+	}
 	if e.retrieved {
 		return nil, nil
 	}

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -919,9 +919,11 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	// More tests about the privileges.
 	tk.MustExec("create user 'testuser'@'localhost'")
 	tk.MustExec("create user 'testuser2'@'localhost'")
+	tk.MustExec("create user 'testuser3'@'localhost'")
 	tk1 := testkit.NewTestKit(c, store)
 	defer tk1.MustExec("drop user 'testuser'@'localhost'")
 	defer tk1.MustExec("drop user 'testuser2'@'localhost'")
+	defer tk1.MustExec("drop user 'testuser3'@'localhost'")
 
 	tk.MustExec("grant all privileges on *.* to 'testuser2'@'localhost'")
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
@@ -930,7 +932,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	}, nil, nil), Equals, true)
 
 	// User has no access to this schema, so the result set is empty.
-	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'information_schema'").Check(testkit.Rows("0"))
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("0"))
 
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser2",
@@ -938,6 +940,13 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	}, nil, nil), Equals, true)
 
 	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("24"))
+
+	c.Assert(tk.Se.Auth(&auth.UserIdentity{
+		Username: "testuser3",
+		Hostname: "localhost",
+	}, nil, nil), Equals, true)
+
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("0"))
 }
 
 func (s *testInfoschemaTableSuite) TestSequences(c *C) {

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -926,6 +926,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	defer tk1.MustExec("drop user 'testuser3'@'localhost'")
 
 	tk.MustExec("grant all privileges on *.* to 'testuser2'@'localhost'")
+	tk.MustExec("grant select on *.* to 'testuser3'@'localhost'")
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser",
 		Hostname: "localhost",
@@ -946,7 +947,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 		Hostname: "localhost",
 	}, nil, nil), Equals, true)
 
-	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("0"))
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("24"))
 }
 
 func (s *testInfoschemaTableSuite) TestSequences(c *C) {

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -917,7 +917,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	defer tk1.MustExec("drop user 'testuser'@'localhost'")
 	defer tk1.MustExec("drop user 'testuser2'@'localhost'")
 
-	tk.MustExec("grant process on *.* to 'testuser2'@'localhost'")
+	tk.MustExec("grant super on *.* to 'testuser2'@'localhost'")
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser",
 		Hostname: "localhost",
@@ -926,7 +926,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	err = tk.QueryToErr("select * from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'information_schema'")
 	c.Assert(err, NotNil)
 	// This error is come from cop(TiDB) fetch from rpc server.
-	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the PROCESS privilege(s) for this operation")
+	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the SUPER privilege(s) for this operation")
 
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser2",

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -923,7 +923,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	defer tk1.MustExec("drop user 'testuser'@'localhost'")
 	defer tk1.MustExec("drop user 'testuser2'@'localhost'")
 
-	tk.MustExec("grant super on *.* to 'testuser2'@'localhost'")
+	tk.MustExec("grant all privileges on *.* to 'testuser2'@'localhost'")
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser",
 		Hostname: "localhost",

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -923,18 +923,15 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 		Hostname: "localhost",
 	}, nil, nil), Equals, true)
 
-	err = tk.QueryToErr("select * from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'information_schema'")
-	c.Assert(err, NotNil)
-	// This error is come from cop(TiDB) fetch from rpc server.
-	c.Assert(err.Error(), Equals, "[planner:1227]Access denied; you need (at least one of) the SUPER privilege(s) for this operation")
+	// User has no access to this schema, so the result set is empty.
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'information_schema'").Check(testkit.Rows("0"))
 
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser2",
 		Hostname: "localhost",
 	}, nil, nil), Equals, true)
 
-	err = tk.QueryToErr("select * from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'information_schema'")
-	c.Assert(err, IsNil)
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("24"))
 }
 
 func (s *testInfoschemaTableSuite) TestSequences(c *C) {


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26128

### What is changed and how it works?

*: What's Changed: add the super privilege control for access table_storage_stats


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- exec: access the table_storage_stats need super privilege
