### PR TITLE
*: fix ci lint

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -104,11 +104,16 @@ type ddlJobCache struct {
 
 func newWorker(ctx context.Context, tp workerType, sessPool *sessionPool, delRangeMgr delRangeManager) *worker {
 	worker := &worker{
-		id:              atomic.AddInt32(&ddlWorkerID, 1),
-		tp:              tp,
-		ddlJobCh:        make(chan struct{}, 1),
-		ctx:             ctx,
-		ddlJobCache:     ddlJobCache{ddlJobCtx: context.Background()},
+		id:       atomic.AddInt32(&ddlWorkerID, 1),
+		tp:       tp,
+		ddlJobCh: make(chan struct{}, 1),
+		ctx:      ctx,
+		ddlJobCache: ddlJobCache{
+			ddlJobCtx:          context.Background(),
+			cacheSQL:           "",
+			cacheNormalizedSQL: "",
+			cacheDigest:        nil,
+		},
 		reorgCtx:        &reorgCtx{notifyCancelReorgJob: 0},
 		sessPool:        sessPool,
 		delRangeManager: delRangeMgr,

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -240,6 +240,7 @@ func (s *testSuite1) TestAnalyzeTooLongColumns(c *C) {
 }
 
 func (s *testSuite1) TestAnalyzeIndexExtractTopN(c *C) {
+	_ = checkHistogram
 	c.Skip("unstable, skip it and fix it before 20210618")
 	store, err := mockstore.NewMockStore()
 	c.Assert(err, IsNil)

--- a/store/mockstore/unistore/lockstore/lockstore_test.go
+++ b/store/mockstore/unistore/lockstore/lockstore_test.go
@@ -89,6 +89,7 @@ func deleteMemStore(c *C, ls *MemStore, prefix string, n int) {
 }
 
 func (ts testSuite) TestIterator(c *C) {
+	_ = checkKey
 	c.Skip("Skip this unstable test(#26235) and bring it back before 2021-07-29.")
 	ls := NewMemStore(1 << 10)
 	hint := new(Hint)


### PR DESCRIPTION
Signed-off-by: crazycs <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

```
[2021-07-16T09:17:18.190Z] ddl/ddl_worker.go:100:2: `cacheSQL` is unused (structcheck)

[2021-07-16T09:17:18.190Z] 	cacheSQL           string

[2021-07-16T09:17:18.190Z] 	^

[2021-07-16T09:17:18.190Z] ddl/ddl_worker.go:101:2: `cacheNormalizedSQL` is unused (structcheck)

[2021-07-16T09:17:18.190Z] 	cacheNormalizedSQL string

[2021-07-16T09:17:18.190Z] 	^

[2021-07-16T09:17:18.190Z] ddl/ddl_worker.go:102:2: `cacheDigest` is unused (structcheck)

[2021-07-16T09:17:18.190Z] 	cacheDigest        *parser.Digest

[2021-07-16T09:17:18.190Z] 	^
```


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] No code

Side effects

- N/A


### Release note <!-- bugfixes or new feature need a release note -->

- No release note
