### PR TITLE
sessionctx/variable: avoid SysVar clone every time when visiting system variable

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -80,6 +80,7 @@ const (
 )
 
 // SysVar is for system variable.
+// All the fields of SysVar should be READ ONLY after created.
 type SysVar struct {
 	// Scope is for whether can be changed or not
 	Scope ScopeFlag
@@ -556,41 +557,32 @@ func UnregisterSysVar(name string) {
 	sysVarsLock.Unlock()
 }
 
-// Clone deep copies the sysvar struct to avoid a race
-func (sv *SysVar) Clone() *SysVar {
-	dst := *sv
-	return &dst
-}
-
 // GetSysVar returns sys var info for name as key.
 func GetSysVar(name string) *SysVar {
 	name = strings.ToLower(name)
 	sysVarsLock.RLock()
 	defer sysVarsLock.RUnlock()
-	if sysVars[name] == nil {
-		return nil
-	}
-	return sysVars[name].Clone()
+
+	return sysVars[name]
 }
 
-// SetSysVar sets a sysvar. This will not propagate to the cluster, so it should only be
+// SetSysVar sets a sysvar. In fact, SysVar is immutable.
+// SetSysVar is implemented by register a new SysVar with the same name again.
+// This will not propagate to the cluster, so it should only be
 // used for instance scoped AUTO variables such as system_time_zone.
 func SetSysVar(name string, value string) {
-	name = strings.ToLower(name)
-	sysVarsLock.Lock()
-	defer sysVarsLock.Unlock()
-	sysVars[name].Value = value
+	old := GetSysVar(name)
+	tmp := *old
+	tmp.Value = value
+	RegisterSysVar(&tmp)
 }
 
 // GetSysVars deep copies the sysVars list under a RWLock
 func GetSysVars() map[string]*SysVar {
 	sysVarsLock.RLock()
 	defer sysVarsLock.RUnlock()
-	copy := make(map[string]*SysVar, len(sysVars))
-	for name, sv := range sysVars {
-		copy[name] = sv.Clone()
-	}
-	return copy
+
+	return sysVars
 }
 
 // PluginVarNames is global plugin var names set.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -581,8 +581,12 @@ func SetSysVar(name string, value string) {
 func GetSysVars() map[string]*SysVar {
 	sysVarsLock.RLock()
 	defer sysVarsLock.RUnlock()
-
-	return sysVars
+	copy := make(map[string]*SysVar, len(sysVars))
+	for name, sv := range sysVars {
+		tmp := *sv
+		copy[name] = &tmp
+	}
+	return copy
 }
 
 // PluginVarNames is global plugin var names set.

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -571,33 +571,6 @@ func (*testSysVarSuite) TestInstanceScopedVars(c *C) {
 	c.Assert(val, Equals, vars.TxnScope.GetVarValue())
 }
 
-// Calling GetSysVars/GetSysVar needs to return a deep copy, otherwise there will be data races.
-// This is a bit unfortunate, since the only time the race occurs is in the testsuite (Enabling/Disabling SEM) and
-// during startup (setting the .Value of ScopeNone variables). In future it might also be able
-// to fix this by delaying the LoadSysVarCacheLoop start time until after the server is fully initialized.
-func (*testSysVarSuite) TestDeepCopyGetSysVars(c *C) {
-	// Check GetSysVar
-	sv := SysVar{Scope: ScopeGlobal | ScopeSession, Name: "datarace", Value: On, Type: TypeBool}
-	RegisterSysVar(&sv)
-	svcopy := GetSysVar("datarace")
-	svcopy.Name = "datarace2"
-	c.Assert(sv.Name, Equals, "datarace")
-	c.Assert(GetSysVar("datarace").Name, Equals, "datarace")
-	UnregisterSysVar("datarace")
-
-	// Check GetSysVars
-	sv = SysVar{Scope: ScopeGlobal | ScopeSession, Name: "datarace", Value: On, Type: TypeBool}
-	RegisterSysVar(&sv)
-	for name, svcopy := range GetSysVars() {
-		if name == "datarace" {
-			svcopy.Name = "datarace2"
-		}
-	}
-	c.Assert(sv.Name, Equals, "datarace")
-	c.Assert(GetSysVar("datarace").Name, Equals, "datarace")
-	UnregisterSysVar("datarace")
-}
-
 // Test that sysvars defaults are logically valid. i.e.
 // the default itself must validate without error provided the scope and read-only is correct.
 // The default values should also be normalized for consistency.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

The current implementation for system variable is not good. To avoid DATA RACE in the unit test, it Clone() a new object every time.

When I handle #25573, I find it cause unnecessary allocation (every query needs to visit the session variable, and it's copy on read)

### What is changed and how it works?


What's Changed:

Change `SetSysVar` implementation to removing the object from the map and then register a new object...

How it Works:

`SysVar` are **almost** immutable ...  Here I say **almost**, I mean after initialized, they are not changed any more.

So we do not really need to Clone to avoid data race.

We can register this SysVar again, the map is protected under lock, and the SysVar is immutable, it do not need a lock or clone.

This change avoid the copy-on-read and is better for performance.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- [ ] No code

```
cd session
go test -test.run TestXXX -test.bench BenchmarkPreparedPointGet -memprofile mem.out -benchmem -benchtime 30s
```

Before vs After:

```
BenchmarkPreparedPointGet-16    	 4316589	      8428 ns/op	    6510 B/op	      81 allocs/op
BenchmarkPreparedPointGet-16    	 4369659	      8196 ns/op	    6317 B/op	      80 allocs/op
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
