### PR TITLE
planner: use multi-layer projections for subquery selection (#8190)

### DIFF
--- a/planner/core/testdata/plan_suite_unexported_in.json
+++ b/planner/core/testdata/plan_suite_unexported_in.json
@@ -131,7 +131,13 @@
       "select t1.b from t t1 where t1.b in (select t2.b from t t2 where t2.a = t1.a order by t2.a)",
       "select t1.b from t t1 where exists(select t2.b from t t2 where t2.a = t1.a order by t2.a)",
       // `Sort` will not be eliminated, if it is not the top level operator.
-      "select t1.b from t t1 where t1.b = (select t2.b from t t2 where t2.a = t1.a order by t2.a limit 1)"
+      "select t1.b from t t1 where t1.b = (select t2.b from t t2 where t2.a = t1.a order by t2.a limit 1)",
+      // Test the column of the subquery is reference to the outer alias column.
+      "select 1 as a, (select a)",
+      "select 1 as a, (select a union select a)",
+      "select c t1c, (select t1c from t2) t2c, a, (select t2c from t2), b from t",
+      "select c t1c, (select t1c) t2c, d t1d, (select t2c), (select t1d), b from t",
+      "select c as t1c, (select c from t2 where t1c = a) t2c, (select t2c from t2 where a > 0) from t"
     ]
   },
   {

--- a/planner/core/testdata/plan_suite_unexported_out.json
+++ b/planner/core/testdata/plan_suite_unexported_out.json
@@ -117,7 +117,12 @@
       "Join{DataScan(t1)->DataScan(t2)->Aggr(max(test.t.a),firstrow(test.t.b))}(test.t.b,test.t.b)->Projection->Sel([eq(test.t.b, Column#25)])->Projection",
       "Join{DataScan(t1)->DataScan(t2)}(test.t.a,test.t.a)(test.t.b,test.t.b)->Projection",
       "Join{DataScan(t1)->DataScan(t2)}(test.t.a,test.t.a)->Projection",
-      "Apply{DataScan(t1)->DataScan(t2)->Sel([eq(test.t.a, test.t.a)])->Projection->Sort->Limit}->Projection->Sel([eq(test.t.b, test.t.b)])->Projection"
+      "Apply{DataScan(t1)->DataScan(t2)->Sel([eq(test.t.a, test.t.a)])->Projection->Sort->Limit}->Projection->Sel([eq(test.t.b, test.t.b)])->Projection",
+      "Join{Dual->Projection->Dual}->Projection->Projection",
+      "Apply{Dual->Projection->UnionAll{Dual->Projection->Projection->Dual->Projection->Projection}->Aggr(firstrow(Column#5))->MaxOneRow}->Projection",
+      "Apply{Apply{Apply{DataScan(t)->Projection->DataScan(t2)->Projection->MaxOneRow}->Projection->DataScan(t2)->Projection->MaxOneRow}->DataScan(t2)->Projection->MaxOneRow}->Projection",
+      "Join{Join{Join{Join{Join{Join{DataScan(t)->Projection->Dual->Projection->MaxOneRow}->Projection->Dual}->Projection->Dual->Projection->MaxOneRow}->Projection->Dual}->Projection->Dual}->Projection->Dual}->Projection->Projection",
+      "Apply{Join{Join{DataScan(t)->Projection->DataScan(t2)}(test.t.c,test.t2.a)->Projection->Projection->DataScan(t2)}(test.t.c,test.t2.a)->Projection->DataScan(t2)->Sel([gt(test.t2.a, 0)])->Projection->MaxOneRow}->Projection"
     ]
   },
   {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: #8190 <!-- REMOVE this line if no issue to close -->

Problem Summary: Use multi-layer projections to ensure the column in the subquery can find its reference to the outer alias column.

### What is changed and how it works?

How it Works:
- As for building select plan, use multi-layer projections for alias columns and subqueries columns if some selectFields are subqueries.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- [x] Performance regression: Consumes more CPU


### Release note <!-- bugfixes or new feature need a release note -->

- Ensure the column in the subquery can find its reference to the outer alias column.
<!-- Please write a release note here to describe the change you made when it is released to the users of TiDB. If your PR doesn't involve any change to TiDB(like test enhancements, RFC proposals...), you can write `No release note`. -->
