### PR TITLE
store: requst another PD node if some of them is down

### DIFF
--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -233,9 +233,16 @@ func (h *Helper) FetchHotRegion(rw string) (map[uint64]RegionMetric, error) {
 	if len(pdHosts) == 0 {
 		return nil, errors.New("pd unavailable")
 	}
-	req, err := http.NewRequest("GET", util.InternalHTTPSchema()+"://"+pdHosts[0]+rw, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
+	req := new(http.Request)
+	for _, host := range pdHosts {
+		req, err = http.NewRequest("GET", util.InternalHTTPSchema()+"://"+host+rw, nil)
+		if err != nil {
+			// Try to request from another PD node when some nodes may down.
+			if strings.Contains(err.Error(), "connection refused") {
+				continue
+			}
+			return nil, errors.Trace(err)
+		}
 	}
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {
@@ -777,9 +784,16 @@ func (h *Helper) requestPD(method, uri string, body io.Reader, res interface{}) 
 		return errors.New("pd unavailable")
 	}
 	logutil.BgLogger().Debug("RequestPD URL", zap.String("url", util.InternalHTTPSchema()+"://"+pdHosts[0]+uri))
-	req, err := http.NewRequest(method, util.InternalHTTPSchema()+"://"+pdHosts[0]+uri, body)
-	if err != nil {
-		return errors.Trace(err)
+	req := new(http.Request)
+	for _, host := range pdHosts {
+		req, err = http.NewRequest(method, util.InternalHTTPSchema()+"://"+host+uri, body)
+		if err != nil {
+			// Try to request from another PD node when some nodes may down.
+			if strings.Contains(err.Error(), "connection refused") {
+				continue
+			}
+			return errors.Trace(err)
+		}
 	}
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {
@@ -862,9 +876,16 @@ func (h *Helper) GetStoresStat() (*StoresStat, error) {
 	if len(pdHosts) == 0 {
 		return nil, errors.New("pd unavailable")
 	}
-	req, err := http.NewRequest("GET", util.InternalHTTPSchema()+"://"+pdHosts[0]+pdapi.Stores, nil)
-	if err != nil {
-		return nil, errors.Trace(err)
+	req := new(http.Request)
+	for _, host := range pdHosts {
+		req, err = http.NewRequest("GET", util.InternalHTTPSchema()+"://"+host+pdapi.Stores, nil)
+		if err != nil {
+			// Try to request from another PD node when some nodes may down.
+			if strings.Contains(err.Error(), "connection refused") {
+				continue
+			}
+			return nil, errors.Trace(err)
+		}
 	}
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -762,6 +762,9 @@ func (h *Helper) requestPD(method, uri string, body io.Reader, res interface{}) 
 			return errors.Trace(err)
 		}
 	}
+	if err != nil {
+		return err
+	}
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {
 		return errors.Trace(err)

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -222,42 +222,9 @@ func (h *Helper) ScrapeHotInfo(rw string, allSchemas []*model.DBInfo) ([]HotTabl
 
 // FetchHotRegion fetches the hot region information from PD's http api.
 func (h *Helper) FetchHotRegion(rw string) (map[uint64]RegionMetric, error) {
-	etcd, ok := h.Store.(kv.EtcdBackend)
-	if !ok {
-		return nil, errors.WithStack(errors.New("not implemented"))
-	}
-	pdHosts, err := etcd.EtcdAddrs()
-	if err != nil {
-		return nil, err
-	}
-	if len(pdHosts) == 0 {
-		return nil, errors.New("pd unavailable")
-	}
-	req := new(http.Request)
-	for _, host := range pdHosts {
-		req, err = http.NewRequest("GET", util.InternalHTTPSchema()+"://"+host+rw, nil)
-		if err != nil {
-			// Try to request from another PD node when some nodes may down.
-			if strings.Contains(err.Error(), "connection refused") {
-				continue
-			}
-			return nil, errors.Trace(err)
-		}
-	}
-	resp, err := util.InternalHTTPClient().Do(req)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			logutil.BgLogger().Error("close body failed", zap.Error(err))
-		}
-	}()
 	var regionResp StoreHotRegionInfos
-	err = json.NewDecoder(resp.Body).Decode(&regionResp)
-	if err != nil {
-		return nil, errors.Trace(err)
+	if err := h.requestPD("GET", rw, nil, &regionResp); err != nil {
+		return nil, err
 	}
 	metricCnt := 0
 	for _, hotRegions := range regionResp.AsLeader {
@@ -865,44 +832,9 @@ type StoreDetailStat struct {
 
 // GetStoresStat gets the TiKV store information by accessing PD's api.
 func (h *Helper) GetStoresStat() (*StoresStat, error) {
-	etcd, ok := h.Store.(kv.EtcdBackend)
-	if !ok {
-		return nil, errors.WithStack(errors.New("not implemented"))
-	}
-	pdHosts, err := etcd.EtcdAddrs()
-	if err != nil {
-		return nil, err
-	}
-	if len(pdHosts) == 0 {
-		return nil, errors.New("pd unavailable")
-	}
-	req := new(http.Request)
-	for _, host := range pdHosts {
-		req, err = http.NewRequest("GET", util.InternalHTTPSchema()+"://"+host+pdapi.Stores, nil)
-		if err != nil {
-			// Try to request from another PD node when some nodes may down.
-			if strings.Contains(err.Error(), "connection refused") {
-				continue
-			}
-			return nil, errors.Trace(err)
-		}
-	}
-	resp, err := util.InternalHTTPClient().Do(req)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	defer func() {
-		err = resp.Body.Close()
-		if err != nil {
-			logutil.BgLogger().Error("close body failed", zap.Error(err))
-		}
-	}()
 	var storesStat StoresStat
-	err = json.NewDecoder(resp.Body).Decode(&storesStat)
-	if err != nil {
-		return nil, errors.Trace(err)
-	}
-	return &storesStat, nil
+	err := h.requestPD("GET", pdapi.Stores, nil, &storesStat)
+	return &storesStat, err
 }
 
 // GetPDAddr return the PD Address.

--- a/store/helper/helper_test.go
+++ b/store/helper/helper_test.go
@@ -79,7 +79,7 @@ func (s *HelperTestSuite) SetUpSuite(c *C) {
 
 	s.store = &mockStore{
 		mockTikvStore.(helper.Storage),
-		[]string{url[len("http://"):]},
+		[]string{"invalid_pd_address", url[len("http://"):]},
 	}
 	c.Assert(err, IsNil)
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26303  <!-- REMOVE this line if no issue to close -->

Problem Summary:
As the problem described in the issue to be fixed.

### What is changed and how it works?

What's Changed:
Request another PD node if some of them is down.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the problem that tidb-server tries to request from a PD node even if it's down when quering the table in information_schema database.
