### PR TITLE
metrics: fix copr-cache metrics

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -6657,7 +6657,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "histogram_quantile(1, sum(rate(tidb_distsql_copr_cache_bucket{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type))",
+              "expr": "sum(rate(tidb_distsql_copr_cache_count{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}",


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26338 <!-- REMOVE this line if no issue to close -->

Problem Summary:
The metrics formula is wrong on Grafana.
<img width="1415" alt="截屏2021-07-19 下午2 45 33" src="https://user-images.githubusercontent.com/4352397/126116464-0facc584-8d1b-4231-b708-e312b0739cd7.png">


### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
Fix it as a counter.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
The same step in the issue #26338 .

### Release note <!-- bugfixes or new feature need a release note -->

- Fix copt-cache metrics, it will display the number of  hits/miss/evict on Grafana.
