### PR TITLE
domain: revert unintended changes

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -622,11 +622,10 @@ func (do *Domain) Close() {
 		terror.Log(errors.Trace(do.etcdClient.Close()))
 	}
 
-	do.sysSessionPool.Close()
 	do.slowQuery.Close()
-
 	do.cancel()
 	do.wg.Wait()
+	do.sysSessionPool.Close()
 	logutil.BgLogger().Info("domain closed", zap.Duration("take time", time.Since(startTime)))
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary: While fixing the timeout CI of #22859, I thought statistics package are stuck. Then I change the deconstruction order of `sysSessionPool`. But I forgot to revert it back after identifying the problem, after one month.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
