### PR TITLE
planner: fix stat for CTETable

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -3773,7 +3773,7 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 				}
 
 				cte.recursiveRef = true
-				p := LogicalCTETable{name: cte.def.Name.String(), idForStorage: cte.storageID, seedPlan: cte.seedLP}.Init(b.ctx, b.getSelectOffset())
+				p := LogicalCTETable{name: cte.def.Name.String(), idForStorage: cte.storageID, seedStat: cte.seedStat}.Init(b.ctx, b.getSelectOffset())
 				p.SetSchema(getResultCTESchema(cte.seedLP.Schema(), b.ctx.GetSessionVars()))
 				p.SetOutputNames(cte.seedLP.OutputNames())
 				return p, nil
@@ -3801,7 +3801,7 @@ func (b *PlanBuilder) tryBuildCTE(ctx context.Context, tn *ast.TableName, asName
 			lp := LogicalCTE{cteAsName: tn.Name, cte: &CTEClass{IsDistinct: cte.isDistinct, seedPartLogicalPlan: cte.seedLP,
 				recursivePartLogicalPlan: cte.recurLP, IDForStorage: cte.storageID,
 				optFlag: cte.optFlag, HasLimit: hasLimit, LimitBeg: limitBeg,
-				LimitEnd: limitEnd}}.Init(b.ctx, b.getSelectOffset())
+				LimitEnd: limitEnd}, seedStat: cte.seedStat}.Init(b.ctx, b.getSelectOffset())
 			lp.SetSchema(getResultCTESchema(cte.seedLP.Schema(), b.ctx.GetSessionVars()))
 			p = lp
 			p.SetOutputNames(cte.seedLP.OutputNames())
@@ -6228,7 +6228,7 @@ func (b *PlanBuilder) buildWith(ctx context.Context, w *ast.WithClause) error {
 		nameMap[cte.Name.L] = struct{}{}
 	}
 	for _, cte := range w.CTEs {
-		b.outerCTEs = append(b.outerCTEs, &cteInfo{def: cte, nonRecursive: !w.IsRecursive, isBuilding: true, storageID: b.allocIDForCTEStorage})
+		b.outerCTEs = append(b.outerCTEs, &cteInfo{def: cte, nonRecursive: !w.IsRecursive, isBuilding: true, storageID: b.allocIDForCTEStorage, seedStat: &property.StatsInfo{}})
 		b.allocIDForCTEStorage++
 		saveFlag := b.optFlag
 		// Init the flag to flagPrunColumns, otherwise it's missing.

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1216,13 +1216,14 @@ type LogicalCTE struct {
 
 	cte       *CTEClass
 	cteAsName model.CIStr
+	seedStat  *property.StatsInfo
 }
 
 // LogicalCTETable is for CTE table
 type LogicalCTETable struct {
 	logicalSchemaProducer
 
-	seedPlan     LogicalPlan
+	seedStat     *property.StatsInfo
 	name         string
 	idForStorage int
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -433,6 +433,8 @@ type cteInfo struct {
 	enterSubquery bool
 	recursiveRef  bool
 	limitLP       LogicalPlan
+	// seedStat is shared between logicalCTE and logicalCTETable.
+	seedStat *property.StatsInfo
 }
 
 // PlanBuilder builds Plan from an ast.Node.

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -1110,6 +1110,8 @@ func (p *LogicalCTE) DeriveStats(childStats []*property.StatsInfo, selfSchema *e
 		return nil, err
 	}
 	resStat := p.cte.seedPartPhysicalPlan.Stats()
+	// Changing the pointer so that seedStat in LogicalCTETable can get the new stat.
+	*p.seedStat = *resStat
 	p.stats = &property.StatsInfo{
 		RowCount:    resStat.RowCount,
 		Cardinality: make(map[int64]float64, selfSchema.Len()),
@@ -1140,6 +1142,6 @@ func (p *LogicalCTETable) DeriveStats(childStats []*property.StatsInfo, selfSche
 	if p.stats != nil {
 		return p.stats, nil
 	}
-	p.stats = p.seedPlan.statsInfo()
+	p.stats = p.seedStat
 	return p.stats, nil
 }


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Before this PR, we use seedPlan.statsInfo() to get stat for LogicalCTETable.
But it may be nil. For example, before the logical optimization, selection->xxx-> DataSource. After the logical optimization, it becomes xxx->DataSource(with pushdown selection), in such case,  the stat for selection is nil.


### What is changed and how it works?

Add a pointer for stat. Let LogicalCTETable and LogicalCTE share it.
After deriving the stat for the seed part, set the pointer, then the pointer in LogicalCTETable will point to the stat.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
