### PR TITLE
*: keep the precision of intermediate decimal result as accurate as possible

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8815,3 +8815,22 @@ func (s *testSuite) TestIssue25506(c *C) {
 	tk.MustExec("insert into tbl_23 values (0xF)")
 	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update) order by col_15").Check(testkit.Rows("\x00\x00\x0F", "\x00\x00\xFF", "\x00\xFF\xFF"))
 }
+
+func (s *testSuite) TestIssue26348(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t")
+	tk.MustExec(`CREATE TABLE t (
+a varchar(8) DEFAULT NULL,
+b varchar(8) DEFAULT NULL,
+c decimal(20,2) DEFAULT NULL,
+d decimal(15,8) DEFAULT NULL
+);`)
+	tk.MustExec(`insert into t values(20210606, 20210606, 50000.00, 5.04600000);`)
+	tk.MustQuery(`select a * c *(d/36000) from t;`).Check(testkit.Rows("141642663.71666598"))
+	tk.MustQuery("select \"20210606\"*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.71666598"))
+	// differs from MySQL, MySQL returns 141642663.71666599297980.
+	tk.MustQuery("select 20210606*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.716665992979800000000000000000"))
+	tk.MustQuery("select cast(\"20210606\" as double)*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.71666598"))
+}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -659,7 +659,9 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args
 	}
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
 	if ctx.GetSessionVars().StmtCtx.DepthInExprTree > 1 {
+		diff := mysql.MaxDecimalScale - bf.tp.Decimal
 		bf.tp.Decimal = mysql.MaxDecimalScale
+		bf.tp.Flen += diff
 	}
 	sig := &builtinArithmeticDivideDecimalSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DivideDecimal)

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -674,9 +674,7 @@ func (s *builtinArithmeticDivideRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticDivideDecimalSig struct{
-	baseBuiltinFunc
-}
+type builtinArithmeticDivideDecimalSig struct{ baseBuiltinFunc }
 
 func (s *builtinArithmeticDivideDecimalSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticDivideDecimalSig{}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -658,7 +658,7 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args
 		return nil, err
 	}
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
-	if ctx.GetSessionVars().StmtCtx.DepthInExprTree > 0 {
+	if ctx.GetSessionVars().StmtCtx.DepthInExprTree > 1 {
 		bf.tp.Decimal = mysql.MaxDecimalScale
 	}
 	sig := &builtinArithmeticDivideDecimalSig{bf}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -658,6 +658,9 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args
 		return nil, err
 	}
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
+	if ctx.GetSessionVars().StmtCtx.DepthInExprTree > 0 {
+		bf.tp.Decimal = mysql.MaxDecimalScale
+	}
 	sig := &builtinArithmeticDivideDecimalSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DivideDecimal)
 	return sig, nil
@@ -671,7 +674,9 @@ func (s *builtinArithmeticDivideRealSig) Clone() builtinFunc {
 	return newSig
 }
 
-type builtinArithmeticDivideDecimalSig struct{ baseBuiltinFunc }
+type builtinArithmeticDivideDecimalSig struct{
+	baseBuiltinFunc
+}
 
 func (s *builtinArithmeticDivideDecimalSig) Clone() builtinFunc {
 	newSig := &builtinArithmeticDivideDecimalSig{}

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -451,11 +451,11 @@ func (b *builtinInDecimalSig) evalInt(row chunk.Row) (int64, bool, error) {
 	}
 
 	args := b.args[1:]
-	key, err := arg0.ToHashKey()
-	if err != nil {
-		return 0, true, err
-	}
 	if len(b.hashSet) != 0 {
+		key, err := arg0.ToHashKey()
+		if err != nil {
+			return 0, true, err
+		}
 		if b.hashSet.Exist(string(key)) {
 			return 1, false, nil
 		}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -150,7 +150,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p LogicalPlan) 
 			rewriter.schema = p.Schema()
 			rewriter.names = p.OutputNames()
 		}
-		rewriter.sctx.GetSessionVars().StmtCtx.DepthInExprTree = 1
+		rewriter.sctx.GetSessionVars().StmtCtx.DepthInExprTree = 0
 	}()
 
 	if len(b.rewriterPool) < b.rewriterCounter {

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1732,7 +1732,6 @@ func (er *expressionRewriter) funcCallToExpression(v *ast.FuncCallExpr) {
 
 	var function expression.Expression
 	er.ctxStackPop(len(v.Args))
-	// If stackLen is 0, it means that the FuncCallExpr being processed is an argument of another expression.
 	if _, ok := expression.DeferredFunctions[v.FnName.L]; er.useCache() && ok {
 		// When the expression is unix_timestamp and the number of argument is not zero,
 		// we deal with it as normal expression.

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -150,7 +150,7 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p LogicalPlan) 
 			rewriter.schema = p.Schema()
 			rewriter.names = p.OutputNames()
 		}
-		rewriter.sctx.GetSessionVars().StmtCtx.DepthInExprTree = 0
+		rewriter.sctx.GetSessionVars().StmtCtx.DepthInExprTree = 1
 	}()
 
 	if len(b.rewriterPool) < b.rewriterCounter {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -180,6 +180,14 @@ type StatementContext struct {
 		DiskTracker disk.Tracker
 		LogOnExceed [2]memory.LogOnExceed
 	}
+
+	// DepthInExprTree indicates the depth of the current expression being
+	// rewritten in an expression tree.
+	// NOTE: This var is introduced to remind an arithmetic expression to keep
+	// the precision of an real/decimal intermediate result as accurate as
+	// possible. Thus we only take the arithmetic expression into consideration.
+	// e.g. tidb/issues/26348
+	DepthInExprTree int
 }
 
 // StmtHints are SessionVars related sql hints.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26348  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:
If the div expression is not the root node of an expression tree, we need to keep the precision of the intermediate result as accurate as possible.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the problem that the div function may lose precision when it's a subpart of the whole expression.