### PR TITLE
planner: fix panic of aggregation distinct function when distinct_agg…

### DIFF
--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -60,7 +60,8 @@
       "select /*+ STREAM_AGG() */ count(distinct c) from t;", // should push down after stream agg implemented
       "select /*+ HASH_AGG() */ count(distinct c) from t;",
       "select count(distinct c) from t group by c;",
-      "select count(distinct c) from t;"
+      "select count(distinct c) from t;",
+      "select count(*) from t group by a having avg(distinct a)>1;" // #24449 Projection should be add between HashAgg and TableReader
     ]
   },
   {

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -601,6 +601,21 @@
         "Result": [
           "2"
         ]
+      },
+      {
+        "SQL": "select count(*) from t group by a having avg(distinct a)>1;",
+        "Plan": [
+          "Projection_14 6400.00 root  Column#5",
+          "└─Selection_15 6400.00 root  gt(Column#6, 1)",
+          "  └─HashAgg_20 8000.00 root  group by:test.t.a, funcs:count(Column#8)->Column#5, funcs:avg(distinct Column#10)->Column#6",
+          "    └─Projection_21 8000.00 root  Column#8, cast(test.t.a, decimal(15,4) BINARY)->Column#10, test.t.a",
+          "      └─TableReader_22 8000.00 root  data:HashAgg_23",
+          "        └─HashAgg_23 8000.00 cop[tikv]  group by:test.t.a, funcs:count(1)->Column#8",
+          "          └─TableFullScan_19 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1"
+        ]
       }
     ]
   },

--- a/planner/core/logical_plans_test.go
+++ b/planner/core/logical_plans_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
@@ -206,4 +207,29 @@ func (s *testUnitTestSuit) TestIndexPathSplitCorColCond(c *C) {
 		c.Assert(fmt.Sprintf("%s", remained), Equals, tt.remained, comment)
 	}
 	collate.SetNewCollationEnabledForTest(false)
+}
+
+func (s *testUnitTestSuit) TestHasCompleteModeAgg(c *C) {
+	defer testleak.AfterTest(c)()
+
+	aggFuncs := make([]*aggregation.AggFuncDesc, 2)
+	aggFuncs[0] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.FinalMode,
+		HasDistinct: true,
+	}
+	aggFuncs[1] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.CompleteMode,
+		HasDistinct: true,
+	}
+
+	newAgg := &LogicalAggregation{
+		AggFuncs: aggFuncs,
+	}
+	c.Assert(newAgg.HasCompleteModeAgg(), Equals, true)
+
+	aggFuncs[1] = &aggregation.AggFuncDesc{
+		Mode:        aggregation.FinalMode,
+		HasDistinct: true,
+	}
+	c.Assert(newAgg.HasCompleteModeAgg(), Equals, false)
 }


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #24449

Problem Summary: 
 - when tidb_opt_distinct_agg_push_down and tidb_enable_cascades_planner are open, if agg are Partially pushed down, the InjectProjectionBelowAgg will not be matched, so the groupExpr will be wrong.

### What is changed and how it works?

What's Changed:
 - logical_plans.go
 - transformation_rules.go

How it Works:
 - update IsCompleteModeAgg to find if any of aggFuncs are CompleteMode, not just compare the first aggFunc
 - if aggFunc input is from 'partial data', no need to wrap cast for agg args

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [*] Unit test
- [*] Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

- No release note
