### PR TITLE
executor: Future proof TiDB specific comment

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1015,7 +1015,7 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	}
 
 	if tableInfo.ShardRowIDBits > 0 {
-		fmt.Fprintf(buf, "/*!90000 SHARD_ROW_ID_BITS=%d ", tableInfo.ShardRowIDBits)
+		fmt.Fprintf(buf, " /*T! SHARD_ROW_ID_BITS=%d ", tableInfo.ShardRowIDBits)
 		if tableInfo.PreSplitRegions > 0 {
 			fmt.Fprintf(buf, "PRE_SPLIT_REGIONS=%d ", tableInfo.PreSplitRegions)
 		}

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -679,7 +679,7 @@ func (s *testSuite5) TestShowCreateTable(c *C) {
 			"t CREATE TABLE `t` (\n"+
 			"  `a` int(11) DEFAULT NULL,\n"+
 			"  `b` int(11) DEFAULT NULL\n"+
-			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin/*!90000 SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=3 */",
+			") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=3 */",
 	))
 	tk.MustExec("drop table t")
 


### PR DESCRIPTION

### What problem does this PR solve?

This is currently in the `SHOW CREATE TABLE...` output:
```
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin/*!90000 SHARD_ROW_ID_BITS=4 PRE_SPLIT_REGIONS=4 */
```

The `/*!90000` is problematic:

- No space in front of it, this could trip some parsers (similar to https://github.com/sqlalchemy/sqlalchemy/issues/6659 )
- The 90000 (MySQL 9.0.0) would start to cause issues when Oracle releases a 9.0 version

Related: https://github.com/pingcap/tidb/pull/18491

### What is changed and how it works?

The solution is to use ` /*T` instead of `/*!90000`.








### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- The `SHOW CREATE TABLE` now uses TiDB specific comments for `SHARD_ROW_ID_BITS`
