### PR TITLE
Revert: "*: keep the precision of intermediate decimal result as accurate as possible"

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8783,22 +8783,3 @@ func (s *testSuite) TestIssue25506(c *C) {
 	tk.MustExec("insert into tbl_23 values (0xF)")
 	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update) order by col_15").Check(testkit.Rows("\x00\x00\x0F", "\x00\x00\xFF", "\x00\xFF\xFF"))
 }
-
-func (s *testSuite) TestIssue26348(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-
-	tk.MustExec("drop table if exists t")
-	tk.MustExec(`CREATE TABLE t (
-a varchar(8) DEFAULT NULL,
-b varchar(8) DEFAULT NULL,
-c decimal(20,2) DEFAULT NULL,
-d decimal(15,8) DEFAULT NULL
-);`)
-	tk.MustExec(`insert into t values(20210606, 20210606, 50000.00, 5.04600000);`)
-	tk.MustQuery(`select a * c *(d/36000) from t;`).Check(testkit.Rows("141642663.71666598"))
-	tk.MustQuery("select \"20210606\"*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.71666598"))
-	// differs from MySQL, MySQL returns 141642663.71666599297980.
-	tk.MustQuery("select 20210606*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.716665992979800000000000000000"))
-	tk.MustQuery("select cast(\"20210606\" as double)*50000.00*(5.04600000/36000)").Check(testkit.Rows("141642663.71666598"))
-}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -658,11 +658,6 @@ func (c *arithmeticDivideFunctionClass) getFunction(ctx sessionctx.Context, args
 		return nil, err
 	}
 	c.setType4DivDecimal(bf.tp, lhsTp, rhsTp)
-	if ctx.GetSessionVars().StmtCtx.DepthInExprTree > 1 {
-		diff := mysql.MaxDecimalScale - bf.tp.Decimal
-		bf.tp.Decimal = mysql.MaxDecimalScale
-		bf.tp.Flen += diff
-	}
 	sig := &builtinArithmeticDivideDecimalSig{bf}
 	sig.setPbCode(tipb.ScalarFuncSig_DivideDecimal)
 	return sig, nil

--- a/expression/builtin_other.go
+++ b/expression/builtin_other.go
@@ -451,11 +451,11 @@ func (b *builtinInDecimalSig) evalInt(row chunk.Row) (int64, bool, error) {
 	}
 
 	args := b.args[1:]
+	key, err := arg0.ToHashKey()
+	if err != nil {
+		return 0, true, err
+	}
 	if len(b.hashSet) != 0 {
-		key, err := arg0.ToHashKey()
-		if err != nil {
-			return 0, true, err
-		}
 		if b.hashSet.Exist(string(key)) {
 			return 1, false, nil
 		}

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -150,7 +150,6 @@ func (b *PlanBuilder) getExpressionRewriter(ctx context.Context, p LogicalPlan) 
 			rewriter.schema = p.Schema()
 			rewriter.names = p.OutputNames()
 		}
-		rewriter.sctx.GetSessionVars().StmtCtx.DepthInExprTree = 0
 	}()
 
 	if len(b.rewriterPool) < b.rewriterCounter {
@@ -443,7 +442,6 @@ func (er *expressionRewriter) Enter(inNode ast.Node) (ast.Node, bool) {
 			er.tryFoldCounter++
 		}
 	case *ast.BinaryOperationExpr:
-		er.sctx.GetSessionVars().StmtCtx.DepthInExprTree++
 		er.asScalar = true
 		if v.Op == opcode.LogicAnd || v.Op == opcode.LogicOr {
 			er.tryFoldCounter++
@@ -1077,7 +1075,6 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 			er.tryFoldCounter--
 		}
 		er.binaryOpToExpression(v)
-		er.sctx.GetSessionVars().StmtCtx.DepthInExprTree--
 	case *ast.BetweenExpr:
 		er.betweenToExpression(v)
 	case *ast.CaseExpr:

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -182,14 +182,6 @@ type StatementContext struct {
 		DiskTracker disk.Tracker
 		LogOnExceed [2]memory.LogOnExceed
 	}
-
-	// DepthInExprTree indicates the depth of the current expression being
-	// rewritten in an expression tree.
-	// NOTE: This var is introduced to remind an arithmetic expression to keep
-	// the precision of an real/decimal intermediate result as accurate as
-	// possible. Thus we only take the arithmetic expression into consideration.
-	// e.g. tidb/issues/26348
-	DepthInExprTree int
 }
 
 // StmtHints are SessionVars related sql hints.


### PR DESCRIPTION
Reverts pingcap/tidb#26372

Cause the commit is a compatibility-breaker, we decide to revert it.

Test Report
https://docs.google.com/document/d/1t1Ghpy8M2GGEoPX3ihw28YjM6PO_o_p1JjpwvHG02Ws/edit#heading=h.7cfb20jmu5o9

### Release note <!-- bugfixes or new feature need a release note -->

- No release note