### PR TITLE
planner: fix the unstable test TestOrderedResultModeOnOtherOperators

### DIFF
--- a/planner/core/testdata/ordered_result_mode_suite_in.json
+++ b/planner/core/testdata/ordered_result_mode_suite_in.json
@@ -65,7 +65,7 @@
       "select * from t1 where a > 10 union distinct select * from t2 where b > 20",
       "select * from t1 where a > 10 intersect select * from t2 where b > 20",
       "select * from t1 where a > 10 except select * from t2 where b > 20",
-      "select row_number() over(partition by a) as row_no, sum(b) over(partition by a) as sum_b from t1",
+      "select sum(b) over(partition by a) as sum_b from t1",
       "select min(a), max(b), sum(c) from t1 group by d",
       "select min(a), max(b), sum(c) from t1 group by d having max(b) < 20",
       "select case when a=1 then 'a1' when a=2 then 'a2' else 'ax' end from t1 "

--- a/planner/core/testdata/ordered_result_mode_suite_out.json
+++ b/planner/core/testdata/ordered_result_mode_suite_out.json
@@ -399,12 +399,11 @@
       },
       {
         "Plan": [
-          "Projection_10 10000.00 root  Column#8, Column#7",
-          "└─Sort_11 10000.00 root  test.t1.a, Column#7, Column#8",
-          "  └─Window_13 10000.00 root  row_number()->Column#8 over(partition by test.t1.a rows between current row and current row)",
-          "    └─Window_14 10000.00 root  sum(cast(test.t1.b, decimal(32,0) BINARY))->Column#7 over(partition by test.t1.a)",
-          "      └─TableReader_17 10000.00 root  data:TableFullScan_16",
-          "        └─TableFullScan_16 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
+          "Projection_8 10000.00 root  Column#6",
+          "└─Sort_9 10000.00 root  test.t1.b, test.t1.a, Column#6",
+          "  └─Window_11 10000.00 root  sum(cast(test.t1.b, decimal(32,0) BINARY))->Column#6 over(partition by test.t1.a)",
+          "    └─TableReader_13 10000.00 root  data:TableFullScan_12",
+          "      └─TableFullScan_12 10000.00 cop[tikv] table:t1 keep order:true, stats:pseudo"
         ]
       },
       {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26376 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix the unstable test TestOrderedResultModeOnOtherOperators

### What is changed and how it works?

This query has two window-spec fields that both are partitioned by `a`, but now the optimizer cannot sort them stably in this case: 
![image](https://user-images.githubusercontent.com/7499936/126630029-7369e5e0-ce57-4379-b9c3-679baabeead9.png)
![image](https://user-images.githubusercontent.com/7499936/126630078-e1fdfa46-b39e-4295-9ea3-764e2c28d6fa.png)

To fix this unstable test quickly, I remove one field.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- `No release note`
