### PR TITLE
store/tikv: add retry flag in retry requests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
 	github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989
-	github.com/pingcap/kvproto v0.0.0-20210719093058-3f79c94c42c2
+	github.com/pingcap/kvproto v0.0.0-20210722112940-1a69d0b093f1
 	github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4
 	github.com/pingcap/parser v0.0.0-20210623034316-5ee95ed0081f
 	github.com/pingcap/sysutil v0.0.0-20210221112134-a07bda3bde99

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20200810113304-6157337686b1/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210219064844-c1844a4775d6/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210719093058-3f79c94c42c2 h1:FZeoW3XwAgRoN/+FDoCbt0Q0JxPln1KDMqrSOQk+9r4=
-github.com/pingcap/kvproto v0.0.0-20210719093058-3f79c94c42c2/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210722112940-1a69d0b093f1 h1:ZYsk3z+fMsnuDfGdPGI2Pq3bOphBMfLTcfTOziBPf28=
+github.com/pingcap/kvproto v0.0.0-20210722112940-1a69d0b093f1/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=

--- a/store/tikv/region_request.go
+++ b/store/tikv/region_request.go
@@ -265,8 +265,12 @@ func (s *RegionRequestSender) SendReqCtx(
 
 	tryTimes := 0
 	for {
-		if (tryTimes > 0) && (tryTimes%1000 == 0) {
-			logutil.Logger(bo.ctx).Warn("retry get ", zap.Uint64("region = ", regionID.GetID()), zap.Int("times = ", tryTimes))
+		if tryTimes > 0 {
+			req.IsRetryRequest = true
+
+			if tryTimes%1000 == 0 {
+				logutil.Logger(bo.ctx).Warn("retry get ", zap.Uint64("region = ", regionID.GetID()), zap.Int("times = ", tryTimes))
+			}
 		}
 
 		rpcCtx, err = s.getRPCContext(bo, req, regionID, sType, opts...)


### PR DESCRIPTION
### What problem does this PR solve?

Resolve #26359 in release-5.0 in pair with https://github.com/tikv/tikv/pull/10600.

### What is changed and how it works?

Add a retry flag in `Context` so TiKV only needs to check if the record exists on failures.

See https://github.com/tikv/tikv/pull/10600 for details.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- `Fix the bug that index keys in a pessimistic transaction may be repeatedly committed.`
