### PR TITLE
ddl: support alter table attributes to add a label rule

### DIFF
--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/tidb/util/testkit"
+)
+
+func (s *testDBSuite8) TestAlterTableAttributes(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	defer tk.MustExec("drop table if exists t1")
+
+	tk.MustExec(`create table t1 (c int);`)
+
+	// normal cases
+	_, err := tk.Exec(`alter table t1 attributes="nomerge";`)
+	c.Assert(err, IsNil)
+	_, err = tk.Exec(`alter table t1 attributes="nomerge,somethingelse";`)
+	c.Assert(err, IsNil)
+
+	// space cases
+	_, err = tk.Exec(`alter table t1 attributes=" nomerge ";`)
+	c.Assert(err, IsNil)
+	_, err = tk.Exec(`alter table t1 attributes=" nomerge , somethingelse ";`)
+	c.Assert(err, IsNil)
+
+	// without equal
+	_, err = tk.Exec(`alter table t1 attributes " nomerge ";`)
+	c.Assert(err, IsNil)
+	_, err = tk.Exec(`alter table t1 attributes " nomerge , somethingelse ";`)
+	c.Assert(err, IsNil)
+}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -6035,14 +6035,12 @@ func (d *ddl) AlterTableAttributes(ctx sessionctx.Context, ident ast.Ident, spec
 	err = rule.ApplyAttributesSpec(spec.AttributesSpec)
 	if err != nil {
 		var sb strings.Builder
-		sb.Reset()
-
 		restoreCtx := format.NewRestoreCtx(format.RestoreStringSingleQuotes|format.RestoreKeyWordLowercase|format.RestoreNameBackQuotes, &sb)
 
 		if e := spec.Restore(restoreCtx); e != nil {
-			return ErrInvalidAttributesSpec.GenWithStackByArgs("", err)
+			return ErrInvalidAttributesSpec.GenWithStackByArgs(sb.String(), err)
 		}
-		return ErrInvalidAttributesSpec.GenWithStackByArgs(sb.String(), err)
+		return ErrInvalidAttributesSpec.GenWithStackByArgs("", err)
 	}
 
 	rule.ResetTable(meta.ID, schema.Name.L, meta.Name.L)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -6031,7 +6031,7 @@ func (d *ddl) AlterTableAttributes(ctx sessionctx.Context, ident ast.Ident, spec
 	}
 	meta := tb.Meta()
 
-	rule := &label.Rule{}
+	rule := label.NewRule()
 	err = rule.ApplyAttributesSpec(spec.AttributesSpec)
 	if err != nil {
 		var sb strings.Builder

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -6040,7 +6040,7 @@ func (d *ddl) AlterTableAttributes(ctx sessionctx.Context, ident ast.Ident, spec
 		if e := spec.Restore(restoreCtx); e != nil {
 			return ErrInvalidAttributesSpec.GenWithStackByArgs(sb.String(), err)
 		}
-		return ErrInvalidAttributesSpec.GenWithStackByArgs("", err)
+		return ErrInvalidAttributesSpec.GenWithStackByArgs(err)
 	}
 
 	rule.ResetTable(meta.ID, schema.Name.L, meta.Name.L)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -38,6 +38,7 @@ import (
 	"github.com/pingcap/parser/terror"
 	field_types "github.com/pingcap/parser/types"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/ddl/label"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
@@ -2587,6 +2588,8 @@ func (d *ddl) AlterTable(ctx context.Context, sctx sessionctx.Context, ident ast
 			err = d.AlterTableAddStatistics(sctx, ident, spec.Statistics, spec.IfNotExists)
 		case ast.AlterTableDropStatistics:
 			err = d.AlterTableDropStatistics(sctx, ident, spec.Statistics, spec.IfExists)
+		case ast.AlterTableAttributes:
+			err = d.AlterTableAttributes(sctx, ident, spec)
 		default:
 			// Nothing to do now.
 		}
@@ -6010,6 +6013,47 @@ func (d *ddl) AlterTableAlterPartition(ctx sessionctx.Context, ident ast.Ident, 
 		Type:       model.ActionAlterTableAlterPartition,
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       []interface{}{partitionID, bundle},
+	}
+
+	err = d.doDDLJob(ctx, job)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	err = d.callHookOnChanged(err)
+	return errors.Trace(err)
+}
+
+func (d *ddl) AlterTableAttributes(ctx sessionctx.Context, ident ast.Ident, spec *ast.AlterTableSpec) error {
+	schema, tb, err := d.getSchemaAndTableByIdent(ctx, ident)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	meta := tb.Meta()
+
+	rule := &label.Rule{}
+	err = rule.ApplyAttributesSpec(spec.AttributesSpec)
+	if err != nil {
+		var sb strings.Builder
+		sb.Reset()
+
+		restoreCtx := format.NewRestoreCtx(format.RestoreStringSingleQuotes|format.RestoreKeyWordLowercase|format.RestoreNameBackQuotes, &sb)
+
+		if e := spec.Restore(restoreCtx); e != nil {
+			return ErrInvalidAttributesSpec.GenWithStackByArgs("", err)
+		}
+		return ErrInvalidAttributesSpec.GenWithStackByArgs(sb.String(), err)
+	}
+
+	rule.ResetTable(meta.ID, schema.Name.L, meta.Name.L)
+
+	job := &model.Job{
+		SchemaID:   schema.ID,
+		TableID:    meta.ID,
+		SchemaName: schema.Name.L,
+		Type:       model.ActionAlterTableAttributes,
+		BinlogInfo: &model.HistoryInfo{},
+		Args:       []interface{}{rule},
 	}
 
 	err = d.doDDLJob(ctx, job)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -817,6 +817,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onAlterSequence(t, job)
 	case model.ActionRenameTables:
 		ver, err = onRenameTables(d, t, job)
+	case model.ActionAlterTableAttributes:
+		ver, err = onAlterTableAttributes(t, job)
 	default:
 		// Invalid job, cancel it.
 		job.State = model.JobStateCancelled

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -287,4 +287,7 @@ var (
 	errUnsupportedOnCommitPreserve      = dbterror.ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message("TiDB doesn't support ON COMMIT PRESERVE ROWS for now", nil))
 	errUnsupportedEngineTemporary       = dbterror.ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message("TiDB doesn't support this kind of engine for temporary table", nil))
 	errUnsupportedClusteredSecondaryKey = dbterror.ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message("CLUSTERED/NONCLUSTERED keyword is only supported for primary key", nil))
+
+	// ErrInvalidAttributesSpec is returned when meeting invalid attributes.
+	ErrInvalidAttributesSpec = dbterror.ClassDDL.NewStd(mysql.ErrInvalidAttributesSpec)
 )

--- a/ddl/label/attributes.go
+++ b/ddl/label/attributes.go
@@ -17,6 +17,11 @@ import (
 	"strings"
 )
 
+const (
+	dbKey    = "db"
+	tableKey = "table"
+)
+
 // Label is used to describe attributes
 type Label struct {
 	Key   string `json:"key,omitempty"`
@@ -41,7 +46,7 @@ func (labels *Labels) Restore() string {
 	var sb strings.Builder
 	for i, label := range *labels {
 		switch label.Key {
-		case "db", "table", "partition":
+		case dbKey, tableKey:
 			continue
 		default:
 		}

--- a/ddl/label/attributes.go
+++ b/ddl/label/attributes.go
@@ -1,0 +1,82 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import (
+	"strings"
+)
+
+// Label is used to describe attributes
+type Label struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// Labels is a slice of Label.
+type Labels []Label
+
+// NewLabels create a slice of Label for given attributes.
+func NewLabels(attrs []string) Labels {
+	labels := make(Labels, 0, len(attrs))
+	for _, attr := range attrs {
+		label := NewLabel(attr)
+		labels.Add(label)
+	}
+	return labels
+}
+
+// Restore converts Attributes to a string.
+func (labels *Labels) Restore() string {
+	var sb strings.Builder
+	for i, label := range *labels {
+		switch label.Key {
+		case "db", "table", "partition":
+			continue
+		default:
+		}
+
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteByte('"')
+		conStr := label.Restore()
+		sb.WriteString(conStr)
+		sb.WriteByte('"')
+	}
+	return sb.String()
+}
+
+// Add adds a new label to existed labels.
+func (labels *Labels) Add(l Label) {
+	for _, label := range *labels {
+		if l.Key != label.Key {
+			continue
+		}
+		return
+	}
+
+	*labels = append(*labels, l)
+}
+
+// NewLabel create a new label for a given string.
+func NewLabel(attr string) Label {
+	return Label{Key: strings.TrimSpace(attr), Value: "true"}
+}
+
+// Restore converts a Attribute to a string.
+func (a *Label) Restore() string {
+	var sb strings.Builder
+	sb.WriteString(a.Key)
+	return sb.String()
+}

--- a/ddl/label/attributes.go
+++ b/ddl/label/attributes.go
@@ -31,7 +31,7 @@ type Label struct {
 // Labels is a slice of Label.
 type Labels []Label
 
-// NewLabels create a slice of Label for given attributes.
+// NewLabels creates a slice of Label for given attributes.
 func NewLabels(attrs []string) Labels {
 	labels := make(Labels, 0, len(attrs))
 	for _, attr := range attrs {
@@ -55,8 +55,7 @@ func (labels *Labels) Restore() string {
 			sb.WriteByte(',')
 		}
 		sb.WriteByte('"')
-		conStr := label.Restore()
-		sb.WriteString(conStr)
+		sb.WriteString(label.Restore())
 		sb.WriteByte('"')
 	}
 	return sb.String()
@@ -74,14 +73,12 @@ func (labels *Labels) Add(l Label) {
 	*labels = append(*labels, l)
 }
 
-// NewLabel create a new label for a given string.
+// NewLabel creates a new label for a given string.
 func NewLabel(attr string) Label {
 	return Label{Key: strings.TrimSpace(attr), Value: "true"}
 }
 
 // Restore converts a Attribute to a string.
 func (a *Label) Restore() string {
-	var sb strings.Builder
-	sb.WriteString(a.Key)
-	return sb.String()
+	return a.Key
 }

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -53,9 +53,8 @@ func (t *testLabelSuite) TestNew(c *C) {
 	}
 
 	for _, t := range tests {
-		c.Log(t.name)
 		label := NewLabel(t.input)
-		c.Assert(label, DeepEquals, t.label)
+		c.Assert(label, DeepEquals, t.label, Commentf("%s", t.name))
 	}
 }
 
@@ -82,9 +81,8 @@ func (t *testLabelSuite) TestRestore(c *C) {
 	})
 
 	for _, t := range tests {
-		c.Log(t.name)
 		output := t.input.Restore()
-		c.Assert(output, Equals, t.output)
+		c.Assert(output, Equals, t.output, Commentf("%s", t.name))
 	}
 }
 
@@ -146,9 +144,8 @@ func (t *testLabelsSuite) TestAdd(c *C) {
 	})
 
 	for _, t := range tests {
-		c.Log(t.name)
 		t.labels.Add(t.label)
-		c.Assert(t.labels[len(t.labels)-1], DeepEquals, t.label)
+		c.Assert(t.labels[len(t.labels)-1], DeepEquals, t.label, Commentf("%s", t.name))
 	}
 }
 
@@ -194,8 +191,7 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 	})
 
 	for _, t := range tests {
-		c.Log(t.name)
 		res := t.input.Restore()
-		c.Assert(res, Equals, t.output)
+		c.Assert(res, Equals, t.output, Commentf("%s", t.name))
 	}
 }

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -64,21 +64,21 @@ func (t *testLabelSuite) TestRestore(c *C) {
 		input  Label
 		output string
 	}
-	var tests []TestCase
 
 	input := NewLabel("nomerge")
-	tests = append(tests, TestCase{
-		name:   "normal",
-		input:  input,
-		output: "nomerge",
-	})
-
-	input = NewLabel(" nomerge  ")
-	tests = append(tests, TestCase{
-		name:   "normal with spaces",
-		input:  input,
-		output: "nomerge",
-	})
+	input1 := NewLabel(" nomerge  ")
+	tests := []TestCase{
+		{
+			name:   "normal",
+			input:  input,
+			output: "nomerge",
+		},
+		{
+			name:   "normal with spaces",
+			input:  input1,
+			output: "nomerge",
+		},
+	}
 
 	for _, t := range tests {
 		output := t.input.Restore()
@@ -119,29 +119,26 @@ func (t *testLabelsSuite) TestAdd(c *C) {
 		labels Labels
 		label  Label
 	}
-	var tests []TestCase
 
 	labels := NewLabels([]string{"nomerge"})
 	label := NewLabel("somethingelse")
-	tests = append(tests, TestCase{
-		"normal",
-		labels, label,
-	})
-
-	labels = NewLabels([]string{"nomerge"})
-	label = NewLabel("nomerge")
-	tests = append(tests, TestCase{
-		"duplicated attributes, skip",
-		labels, label,
-	})
-
-	tests = append(tests, TestCase{
-		"duplicated attributes, skip",
-		append(labels, Label{
-			Key:   "nomerge",
-			Value: "true",
-		}), label,
-	})
+	tests := []TestCase{
+		{
+			"normal",
+			labels, label,
+		},
+		{
+			"duplicated attributes, skip",
+			NewLabels([]string{"nomerge"}), NewLabel("nomerge"),
+		},
+		{
+			"duplicated attributes, skip",
+			append(labels, Label{
+				Key:   "nomerge",
+				Value: "true",
+			}), label,
+		},
+	}
 
 	for _, t := range tests {
 		t.labels.Add(t.label)
@@ -154,41 +151,35 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		name   string
 		input  Labels
 		output string
-		err    error
 	}
-	var tests []TestCase
-
-	tests = append(tests, TestCase{
-		"normal1",
-		Labels{},
-		"",
-		nil,
-	})
 
 	input1 := NewLabel("nomerge")
 	input2 := NewLabel("somethingelse")
-	tests = append(tests, TestCase{
-		"normal2",
-		Labels{input1, input2},
-		`"nomerge","somethingelse"`,
-		nil,
-	})
+	input3 := NewLabel("db")
+	input4 := NewLabel("table")
 
-	input4 := NewLabel("db")
-	input5 := NewLabel("table")
-	tests = append(tests, TestCase{
-		"normal3",
-		Labels{input4, input5},
-		"",
-		nil,
-	})
-
-	tests = append(tests, TestCase{
-		"normal4",
-		Labels{input1, input2, input4},
-		`"nomerge","somethingelse"`,
-		nil,
-	})
+	tests := []TestCase{
+		{
+			"normal1",
+			Labels{},
+			"",
+		},
+		{
+			"normal2",
+			Labels{input1, input2},
+			`"nomerge","somethingelse"`,
+		},
+		{
+			"normal3",
+			Labels{input3, input4},
+			"",
+		},
+		{
+			"normal4",
+			Labels{input1, input2, input3},
+			`"nomerge","somethingelse"`,
+		},
+	}
 
 	for _, t := range tests {
 		res := t.input.Restore()

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -1,0 +1,201 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import (
+	"testing"
+
+	. "github.com/pingcap/check"
+)
+
+func TestT(t *testing.T) {
+	TestingT(t)
+}
+
+var _ = Suite(&testLabelSuite{})
+
+type testLabelSuite struct{}
+
+func (t *testLabelSuite) TestNew(c *C) {
+	type TestCase struct {
+		name  string
+		input string
+		label Label
+	}
+	tests := []TestCase{
+		{
+			name:  "normal",
+			input: "nomerge",
+			label: Label{
+				Key:   "nomerge",
+				Value: "true",
+			},
+		},
+		{
+			name:  "normal with space",
+			input: " nomerge ",
+			label: Label{
+				Key:   "nomerge",
+				Value: "true",
+			},
+		},
+	}
+
+	for _, t := range tests {
+		c.Log(t.name)
+		label := NewLabel(t.input)
+		c.Assert(label, DeepEquals, t.label)
+	}
+}
+
+func (t *testLabelSuite) TestRestore(c *C) {
+	type TestCase struct {
+		name   string
+		input  Label
+		output string
+	}
+	var tests []TestCase
+
+	input := NewLabel("nomerge")
+	tests = append(tests, TestCase{
+		name:   "normal",
+		input:  input,
+		output: "nomerge",
+	})
+
+	input = NewLabel(" nomerge  ")
+	tests = append(tests, TestCase{
+		name:   "normal with spaces",
+		input:  input,
+		output: "nomerge",
+	})
+
+	for _, t := range tests {
+		c.Log(t.name)
+		output := t.input.Restore()
+		c.Assert(output, Equals, t.output)
+	}
+}
+
+var _ = Suite(&testLabelsSuite{})
+
+type testLabelsSuite struct{}
+
+func (t *testLabelsSuite) TestNew(c *C) {
+	labels := NewLabels(nil)
+	c.Assert(labels, HasLen, 0)
+
+	labels = NewLabels([]string{})
+	c.Assert(labels, HasLen, 0)
+
+	labels = NewLabels([]string{"nomerge"})
+	c.Assert(labels, HasLen, 1)
+	c.Assert(labels[0].Key, Equals, "nomerge")
+
+	// test multiple attributes
+	labels = NewLabels([]string{"nomerge", "somethingelse"})
+	c.Assert(labels, HasLen, 2)
+	c.Assert(labels[0].Key, Equals, "nomerge")
+	c.Assert(labels[1].Key, Equals, "somethingelse")
+
+	// test duplicated attributes
+	labels = NewLabels([]string{"nomerge", "nomerge"})
+	c.Assert(labels, HasLen, 1)
+	c.Assert(labels[0].Key, Equals, "nomerge")
+}
+
+func (t *testLabelsSuite) TestAdd(c *C) {
+	type TestCase struct {
+		name   string
+		labels Labels
+		label  Label
+	}
+	var tests []TestCase
+
+	labels := NewLabels([]string{"nomerge"})
+	label := NewLabel("somethingelse")
+	tests = append(tests, TestCase{
+		"normal",
+		labels, label,
+	})
+
+	labels = NewLabels([]string{"nomerge"})
+	label = NewLabel("nomerge")
+	tests = append(tests, TestCase{
+		"duplicated attributes, skip",
+		labels, label,
+	})
+
+	tests = append(tests, TestCase{
+		"duplicated attributes, skip",
+		append(labels, Label{
+			Key:   "nomerge",
+			Value: "true",
+		}), label,
+	})
+
+	for _, t := range tests {
+		c.Log(t.name)
+		t.labels.Add(t.label)
+		c.Assert(t.labels[len(t.labels)-1], DeepEquals, t.label)
+	}
+}
+
+func (t *testLabelsSuite) TestRestore(c *C) {
+	type TestCase struct {
+		name   string
+		input  Labels
+		output string
+		err    error
+	}
+	var tests []TestCase
+
+	tests = append(tests, TestCase{
+		"normal1",
+		Labels{},
+		"",
+		nil,
+	})
+
+	input1 := NewLabel("nomerge")
+	input2 := NewLabel("somethingelse")
+	tests = append(tests, TestCase{
+		"normal2",
+		Labels{input1, input2},
+		`"nomerge","somethingelse"`,
+		nil,
+	})
+
+	input4 := NewLabel("db")
+	input5 := NewLabel("table")
+	tests = append(tests, TestCase{
+		"normal3",
+		Labels{input4, input5},
+		"",
+		nil,
+	})
+
+	tests = append(tests, TestCase{
+		"normal4",
+		Labels{input1, input2, input4},
+		`"nomerge","somethingelse"`,
+		nil,
+	})
+
+	for _, t := range tests {
+		c.Log(t.name)
+		res := t.input.Restore()
+		c.Assert(res, Equals, t.output)
+	}
+}

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -83,8 +83,8 @@ func (r *Rule) Clone() *Rule {
 func (r *Rule) ResetTable(id int64, dbName, tableName string) *Rule {
 	r.ID = fmt.Sprintf(TableIDFormat, IDPrefix, dbName, tableName)
 	r.Labels = append(r.Labels, []Label{
-		{Key: "db", Value: dbName},
-		{Key: "table", Value: tableName},
+		{Key: dbKey, Value: dbName},
+		{Key: tableKey, Value: tableName},
 	}...)
 
 	r.RuleType = ruleType

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -1,0 +1,87 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/util/codec"
+	"gopkg.in/yaml.v2"
+)
+
+// IDPrefix is the prefix for label rule ID.
+const IDPrefix = "schema"
+
+var (
+	// TableIDFormat is the format of the label rule ID for a table.
+	// The format follows "schema/database_name/table_name".
+	TableIDFormat = "%s/%s/%s"
+)
+
+// Rule is used to establish the relationship between labels and a key range.
+type Rule struct {
+	ID       string      `json:"id"`
+	Labels   Labels      `json:"labels"`
+	RuleType string      `json:"rule_type"`
+	Rule     interface{} `json:"rule"`
+}
+
+// ApplyAttributesSpec will transfer attributes defined in AttributesSpec to the labels.
+func (r *Rule) ApplyAttributesSpec(spec *ast.AttributesSpec) error {
+	// construct a string list
+	attrBytes := []byte("[" + spec.Attributes + "]")
+	attributes := []string{}
+	err := yaml.UnmarshalStrict(attrBytes, &attributes)
+	if err != nil {
+		return err
+	}
+	r.Labels = NewLabels(attributes)
+	return nil
+}
+
+// String implements fmt.Stringer.
+func (r *Rule) String() string {
+	t, err := json.Marshal(r)
+	if err != nil {
+		return ""
+	}
+	return string(t)
+}
+
+// Clone clones a rule.
+func (r *Rule) Clone() *Rule {
+	newRule := &Rule{}
+	*newRule = *r
+	return newRule
+}
+
+// ResetTable will reset the label rule for a table with a given ID and names.
+func (r *Rule) ResetTable(id int64, dbName, tableName string) *Rule {
+	r.ID = fmt.Sprintf(TableIDFormat, IDPrefix, dbName, tableName)
+	r.Labels = append(r.Labels, []Label{
+		{Key: "db", Value: dbName},
+		{Key: "table", Value: tableName},
+	}...)
+
+	r.RuleType = "key-range"
+	r.Rule = map[string]string{
+		"start_key": hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(id))),
+		"end_key":   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(id+1))),
+	}
+	return r
+}

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -24,8 +24,12 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-// IDPrefix is the prefix for label rule ID.
-const IDPrefix = "schema"
+const (
+	// IDPrefix is the prefix for label rule ID.
+	IDPrefix = "schema"
+
+	ruleType = "key-range"
+)
 
 var (
 	// TableIDFormat is the format of the label rule ID for a table.
@@ -39,6 +43,11 @@ type Rule struct {
 	Labels   Labels      `json:"labels"`
 	RuleType string      `json:"rule_type"`
 	Rule     interface{} `json:"rule"`
+}
+
+// NewRule creates a rule.
+func NewRule() *Rule {
+	return &Rule{}
 }
 
 // ApplyAttributesSpec will transfer attributes defined in AttributesSpec to the labels.
@@ -65,7 +74,7 @@ func (r *Rule) String() string {
 
 // Clone clones a rule.
 func (r *Rule) Clone() *Rule {
-	newRule := &Rule{}
+	newRule := NewRule()
 	*newRule = *r
 	return newRule
 }
@@ -78,7 +87,7 @@ func (r *Rule) ResetTable(id int64, dbName, tableName string) *Rule {
 		{Key: "table", Value: tableName},
 	}...)
 
-	r.RuleType = "key-range"
+	r.RuleType = ruleType
 	r.Rule = map[string]string{
 		"start_key": hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(id))),
 		"end_key":   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(id+1))),

--- a/ddl/label/rule_test.go
+++ b/ddl/label/rule_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import (
+	. "github.com/pingcap/check"
+	"github.com/pingcap/parser/ast"
+)
+
+var _ = Suite(&testRuleSuite{})
+
+type testRuleSuite struct{}
+
+func (t *testRuleSuite) TestApplyAttributesSpec(c *C) {
+	spec := &ast.AttributesSpec{Attributes: "attr1,attr2"}
+	rule := NewRule()
+	rule.ApplyAttributesSpec(spec)
+	c.Assert(rule.Labels, HasLen, 2)
+	c.Assert(rule.Labels[0].Key, Equals, "attr1")
+	c.Assert(rule.Labels[1].Key, Equals, "attr2")
+}
+
+func (t *testRuleSuite) TestResetID(c *C) {
+	rule := NewRule()
+	rule.ResetTable(1, "db1", "t1")
+	c.Assert(rule.ID, Equals, "schema/db1/t1")
+	c.Assert(rule.RuleType, Equals, ruleType)
+	c.Assert(rule.Labels, HasLen, 2)
+	c.Assert(rule.Labels[0].Value, Equals, "db1")
+	c.Assert(rule.Labels[1].Value, Equals, "t1")
+	r := rule.Rule.(map[string]string)
+	c.Assert(r["start_key"], Equals, "7480000000000000ff015f720000000000fa")
+	c.Assert(r["end_key"], Equals, "7480000000000000ff025f720000000000fa")
+
+	r1 := rule.Clone()
+	c.Assert(rule, DeepEquals, r1)
+}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -1121,7 +1121,7 @@ func onRepairTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 }
 
 func onAlterTableAttributes(t *meta.Meta, job *model.Job) (ver int64, err error) {
-	rule := &label.Rule{}
+	rule := label.NewRule()
 	err = job.DecodeArgs(&rule)
 	if err != nil {
 		job.State = model.JobStateCancelled

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	field_types "github.com/pingcap/parser/types"
+	"github.com/pingcap/tidb/ddl/label"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -1117,4 +1118,31 @@ func onRepairTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 	default:
 		return ver, ErrInvalidDDLState.GenWithStackByArgs("table", tblInfo.State)
 	}
+}
+
+func onAlterTableAttributes(t *meta.Meta, job *model.Job) (ver int64, err error) {
+	rule := &label.Rule{}
+	err = job.DecodeArgs(&rule)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return 0, errors.Trace(err)
+	}
+
+	tblInfo, err := getTableInfoAndCancelFaultJob(t, job, job.SchemaID)
+	if err != nil {
+		return 0, err
+	}
+
+	err = infosync.PutLabelRule(context.TODO(), rule)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return 0, errors.Wrapf(err, "failed to notify PD label rule")
+	}
+	ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
+
+	return ver, nil
 }

--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -1046,6 +1046,7 @@ const (
 	ErrInvalidPlacementSpec               = 8234
 	ErrDDLReorgElementNotExist            = 8235
 	ErrPlacementPolicyCheck               = 8236
+	ErrInvalidAttributesSpec              = 8237
 
 	// TiKV/PD/TiFlash errors.
 	ErrPDServerTimeout           = 9001

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -1053,6 +1053,7 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrPlacementPolicyCheck:   mysql.Message("Placement policy didn't meet the constraint, reason: %s", nil),
 	ErrMultiStatementDisabled: mysql.Message("client has multi-statement capability disabled. Run SET GLOBAL tidb_multi_statement_mode='ON' after you understand the security risk", nil),
 	ErrAsOf:                   mysql.Message("invalid as of timestamp: %s", nil),
+	ErrInvalidAttributesSpec:  mysql.Message("Invalid attributes '%s': %s", nil),
 
 	// TiKV/PD errors.
 	ErrPDServerTimeout:           mysql.Message("PD server timeout", nil),

--- a/errors.toml
+++ b/errors.toml
@@ -471,6 +471,11 @@ error = '''
 Placement policy didn't meet the constraint, reason: %s
 '''
 
+["ddl:8237"]
+error = '''
+Invalid attributes '%s': %s
+'''
+
 ["domain:8027"]
 error = '''
 Information schema is out of date: schema failed to update in 1 lease, please make sure TiDB can connect to TiKV

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19
 	github.com/pingcap/br v5.2.0-alpha.0.20210714104733-65ae7dd3a2f2+incompatible
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
-	github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b
+	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
 	github.com/pingcap/kvproto v0.0.0-20210722091755-91a52cd9e8db

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
 	github.com/pingcap/kvproto v0.0.0-20210722091755-91a52cd9e8db
 	github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7
-	github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2
+	github.com/pingcap/parser v0.0.0-20210728071818-915a01041dbb
 	github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3
 	github.com/pingcap/tidb-tools v5.0.3+incompatible
 	github.com/pingcap/tipb v0.0.0-20210708040514-0f154bb0dc0f
@@ -84,5 +84,3 @@ require (
 )
 
 go 1.16
-
-replace github.com/pingcap/parser => github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/pingcap/badger v1.5.1-0.20200908111422-2e78ee155d19
 	github.com/pingcap/br v5.2.0-alpha.0.20210714104733-65ae7dd3a2f2+incompatible
 	github.com/pingcap/check v0.0.0-20200212061837-5e12011dc712
-	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
+	github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
 	github.com/pingcap/kvproto v0.0.0-20210722091755-91a52cd9e8db
@@ -78,10 +78,11 @@ require (
 	google.golang.org/grpc v1.27.1
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
 	gopkg.in/yaml.v2 v2.4.0
-	honnef.co/go/tools v0.2.0 // indirect
 	modernc.org/mathutil v1.2.2 // indirect
 	sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0
 	sourcegraph.com/sourcegraph/appdash-data v0.0.0-20151005221446-73f23eafcf67
 )
 
 go 1.16
+
+replace github.com/pingcap/parser => github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc

--- a/go.sum
+++ b/go.sum
@@ -420,7 +420,9 @@ github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d/go.mod h1:g4vx//d6VakjJ0mk7iLBlKA8LFavV/sAVINT/1PFxeQ=
+github.com/pingcap/errors v0.11.5-0.20201029093017-5a7df2af2ac7/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
 github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
+github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b h1:j9MP8ma4e75tckq11+n4EhB2xq0xwYNoxL8w9JTZRhs=
 github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
@@ -442,6 +444,9 @@ github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7 h1:k2BbABz9+TNpYRwsCCFS8pEEnFVOdbgEjL/kTlLuzZQ=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
+github.com/pingcap/parser v0.0.0-20210525032559-c37778aff307/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
+github.com/pingcap/parser v0.0.0-20210728071818-915a01041dbb h1:TX35KERCC2YumPK1MzUmqbgJSxbzjrM9CmfmFJTJNws=
+github.com/pingcap/parser v0.0.0-20210728071818-915a01041dbb/go.mod h1:Ek0mLKEqUGnQqBw1JnYrJQxsguU433DU68yUbsoeJ7s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
@@ -482,13 +487,12 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
+github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
-github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc h1:NhQy4Wgtm+jv9uTpSBZzj5uTHDYzg0hxyLaKLBic1Sw=
-github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc/go.mod h1:0JrGN/1YAvHx/ruYM0Uhv86s5HVfkmsn0SyhC58Tj0Y=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -420,10 +420,9 @@ github.com/pingcap/errors v0.11.0/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTw
 github.com/pingcap/errors v0.11.4/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi2kEtXXLMJk9l1cGmz20kV3TaQ0usTwv5KuLY8=
 github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d/go.mod h1:g4vx//d6VakjJ0mk7iLBlKA8LFavV/sAVINT/1PFxeQ=
-github.com/pingcap/errors v0.11.5-0.20201029093017-5a7df2af2ac7/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
 github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
-github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 h1:+FZIDR/D97YOPik4N4lPDaUcLDF/EQPogxtlHB2ZZRM=
-github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
+github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b h1:j9MP8ma4e75tckq11+n4EhB2xq0xwYNoxL8w9JTZRhs=
+github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd h1:I8IeI8MNiZVKnwuXhcIIzz6pREcOSbq18Q31KYIzFVM=
@@ -443,9 +442,6 @@ github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIf
 github.com/pingcap/log v0.0.0-20210317133921-96f4fcab92a4/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7 h1:k2BbABz9+TNpYRwsCCFS8pEEnFVOdbgEjL/kTlLuzZQ=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=
-github.com/pingcap/parser v0.0.0-20210525032559-c37778aff307/go.mod h1:xZC8I7bug4GJ5KtHhgAikjTfU4kBv1Sbo3Pf1MZ6lVw=
-github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2 h1:2cwX3RI5skZ4rEC1yz+VuS70DkLsCr2g9/Bur/UWBac=
-github.com/pingcap/parser v0.0.0-20210728060616-75cff0c906d2/go.mod h1:Ek0mLKEqUGnQqBw1JnYrJQxsguU433DU68yUbsoeJ7s=
 github.com/pingcap/sysutil v0.0.0-20200206130906-2bfa6dc40bcd/go.mod h1:EB/852NMQ+aRKioCpToQ94Wl7fktV+FNnxf3CX/TTXI=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3 h1:A9KL9R+lWSVPH8IqUuH1QSTRJ5FGoY1bT2IcfPKsWD8=
 github.com/pingcap/sysutil v0.0.0-20210315073920-cc0985d983a3/go.mod h1:tckvA041UWP+NqYzrJ3fMgC/Hw9wnmQ/tUkp/JaHly8=
@@ -486,12 +482,13 @@ github.com/prometheus/procfs v0.0.5/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDa
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 h1:OdAsTTz6OkFY5QxjkYwrChwuRruF69c169dPK26NUlk=
 github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc h1:NhQy4Wgtm+jv9uTpSBZzj5uTHDYzg0hxyLaKLBic1Sw=
+github.com/rleungx/parser v0.0.0-20210722114805-a8bb32c0fddc/go.mod h1:0JrGN/1YAvHx/ruYM0Uhv86s5HVfkmsn0SyhC58Tj0Y=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/go.sum
+++ b/go.sum
@@ -422,9 +422,8 @@ github.com/pingcap/errors v0.11.5-0.20190809092503-95897b64e011/go.mod h1:Oi8TUi
 github.com/pingcap/errors v0.11.5-0.20200917111840-a15ef68f753d/go.mod h1:g4vx//d6VakjJ0mk7iLBlKA8LFavV/sAVINT/1PFxeQ=
 github.com/pingcap/errors v0.11.5-0.20201029093017-5a7df2af2ac7/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
 github.com/pingcap/errors v0.11.5-0.20201126102027-b0a155152ca3/go.mod h1:G7x87le1poQzLB/TqvTJI2ILrSgobnq4Ut7luOwvfvI=
+github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63 h1:+FZIDR/D97YOPik4N4lPDaUcLDF/EQPogxtlHB2ZZRM=
 github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
-github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b h1:j9MP8ma4e75tckq11+n4EhB2xq0xwYNoxL8w9JTZRhs=
-github.com/pingcap/errors v0.11.5-0.20210513014640-40f9a1999b3b/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pingcap/failpoint v0.0.0-20191029060244-12f4ac2fd11d/go.mod h1:DNS3Qg7bEDhU6EXNHF+XSv/PGznQaMJ5FWvctpm6pQI=
 github.com/pingcap/failpoint v0.0.0-20200702092429-9f69995143ce/go.mod h1:w4PEZ5y16LeofeeGwdgZB4ddv9bLyDuIX+ljstgKZyk=
 github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd h1:I8IeI8MNiZVKnwuXhcIIzz6pREcOSbq18Q31KYIzFVM=


### PR DESCRIPTION
### What problem does this PR solve?

Closes https://github.com/pingcap/tidb/issues/26692.

This PR is going to support
```
ALTER TABLE t ATTRIBUTES="xxx"
```
to add an attribute for a table.

### What is changed and how it works?

What's Changed:
1. add a new type `AlterTableAttributes` in `AlterTable`.
2. introduce a new struct `Rule` which is the same as `LabelRule` defined in PD
3. support synchronizing a new rule to PD. 
 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test (need more unit tests)


Documentation

- [x] Affects user behaviors
- [x] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->
```release-note
None
```