### PR TITLE
[store/copr, planner/core]: retry mpp task by rebuilding tasks and by blocking failed nodes

### DIFF
--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -29,11 +29,14 @@ import (
 )
 
 // DispatchMPPTasks dispathes all tasks and returns an iterator.
-func DispatchMPPTasks(ctx context.Context, sctx sessionctx.Context, tasks []*kv.MPPDispatchRequest, fieldTypes []*types.FieldType, planIDs []int, rootID int) (SelectResult, error) {
-	resp := sctx.GetMPPClient().DispatchMPPTasks(ctx, sctx.GetSessionVars().KVVars, tasks)
+func DispatchMPPTasks(ctx context.Context, sctx sessionctx.Context, tasks []*kv.MPPDispatchRequest, fieldTypes []*types.FieldType, planIDs []int, rootID int) (SelectResult, []string, error) {
+	resp, blockAddrs := sctx.GetMPPClient().DispatchMPPTasks(ctx, sctx.GetSessionVars().KVVars, tasks)
+	if len(blockAddrs) > 0 {
+		return nil, blockAddrs, nil
+	}
 	if resp == nil {
 		err := errors.New("client returns nil response")
-		return nil, err
+		return nil, nil, err
 	}
 
 	encodeType := tipb.EncodeType_TypeDefault
@@ -52,7 +55,7 @@ func DispatchMPPTasks(ctx context.Context, sctx sessionctx.Context, tasks []*kv.
 		copPlanIDs: planIDs,
 		rootPlanID: rootID,
 		storeType:  kv.TiFlash,
-	}, nil
+	}, nil, nil
 
 }
 

--- a/kv/mpp.go
+++ b/kv/mpp.go
@@ -76,10 +76,10 @@ type MPPDispatchRequest struct {
 type MPPClient interface {
 	// ConstructMPPTasks schedules task for a plan fragment.
 	// TODO:: This interface will be refined after we support more executors.
-	ConstructMPPTasks(context.Context, *MPPBuildTasksRequest) ([]MPPTaskMeta, error)
+	ConstructMPPTasks(context.Context, *MPPBuildTasksRequest, []string) ([]MPPTaskMeta, error)
 
 	// DispatchMPPTasks dispatches ALL mpp requests at once, and returns an iterator that transfers the data.
-	DispatchMPPTasks(context.Context, *Variables, []*MPPDispatchRequest) Response
+	DispatchMPPTasks(context.Context, *Variables, []*MPPDispatchRequest) (Response, []string)
 }
 
 // MPPBuildTasksRequest request the stores allocation for a mpp plan fragment.

--- a/store/copr/batch_coprocessor.go
+++ b/store/copr/batch_coprocessor.go
@@ -139,6 +139,7 @@ func balanceBatchCopTask(ctx context.Context, kvStore *tikv.KVStore, originalTas
 				for _, blockAddr := range blockAddrs {
 					if blockAddr == s.GetAddr() {
 						logutil.BgLogger().Warn("forbid store because of failure at time", zap.String("store address", blockAddr))
+						return
 					}
 				}
 				aliveReq := tikvrpc.NewRequest(tikvrpc.CmdMPPAlive, &mpp.IsAliveRequest{}, kvrpcpb.Context{})

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -52,7 +52,7 @@ var coprCacheHistogramEvict = tidbmetrics.DistSQLCoprCacheHistogram.WithLabelVal
 const (
 	copBuildTaskMaxBackoff = 5000
 	copNextMaxBackoff      = 20000
-	copMPPReqBackoff 	   = 8000
+	copMPPReqBackoff 	   = 3000
 )
 
 // CopClient is coprocessor client.

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -52,6 +52,7 @@ var coprCacheHistogramEvict = tidbmetrics.DistSQLCoprCacheHistogram.WithLabelVal
 const (
 	copBuildTaskMaxBackoff = 5000
 	copNextMaxBackoff      = 20000
+	copMPPReqBackoff 	   = 8000
 )
 
 // CopClient is coprocessor client.

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -52,7 +52,7 @@ var coprCacheHistogramEvict = tidbmetrics.DistSQLCoprCacheHistogram.WithLabelVal
 const (
 	copBuildTaskMaxBackoff = 5000
 	copNextMaxBackoff      = 20000
-	copMPPReqBackoff 	   = 3000
+	copMPPReqBackoff       = 3000
 )
 
 // CopClient is coprocessor client.

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -171,12 +171,12 @@ func (m *mppIterator) prepare(ctx context.Context) ([]string, []*readConnCtx) {
 				blockAddr := mppTask.Meta.GetAddress()
 				blockAddrs = append(blockAddrs, blockAddr)
 				logutil.BgLogger().Warn("mpp request meet error", zap.Uint64("ts", m.startTs), zap.Int64("task id", mppTask.ID), zap.String("store address", blockAddr), zap.Error(err))
-				defer m.mu.Unlock()
+				m.mu.Unlock()
 				m.cancelMppTasks()
 			} else if stream != nil {
 				m.mu.Lock()
 				readConns = append(readConns, &readConnCtx{bo, stream, mppTask})
-				defer m.mu.Unlock()
+				m.mu.Unlock()
 			}
 		}(task)
 	}

--- a/store/copr/mpp.go
+++ b/store/copr/mpp.go
@@ -16,6 +16,7 @@ package copr
 import (
 	"context"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -170,7 +171,7 @@ func (m *mppIterator) prepare(ctx context.Context) ([]string, []*readConnCtx) {
 			tmpMu.Lock()
 			defer tmpMu.Unlock()
 			if err != nil {
-				if len(blockAddrs) > 0 && (errors.Cause(err) == context.Canceled || status.Code(errors.Cause(err)) == codes.Canceled) {
+				if len(blockAddrs) > 0 && (errors.Cause(err) == context.Canceled || status.Code(errors.Cause(err)) == codes.Canceled || strings.Contains(err.Error(), "cancel")) {
 					// it might be cancelled by others
 					return
 				}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
Problem Summary: If a node cannot work during querying mpp, we must rebuild the task.

### What is changed and how it works?
How it Works:
we mark all the failed nodes and request again

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- [store/copr, planner/core]: retry mpp task by rebuilding tasks and by blocking failed nodes
