### PR TITLE
expression, executor: fix type infer for greatest/leastest(datetime)

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8789,4 +8789,6 @@ func (s *testSuite) TestIssue26532(c *C) {
 	tk.MustExec("use test")
 	tk.MustQuery("select greatest(cast(\"2020-01-01 01:01:01\" as datetime), cast(\"2019-01-01 01:01:01\" as datetime) )union select null;").Sort().Check(testkit.Rows("2020-01-01 01:01:01", "<nil>"))
 	tk.MustQuery("select least(cast(\"2020-01-01 01:01:01\" as datetime), cast(\"2019-01-01 01:01:01\" as datetime) )union select null;").Sort().Check(testkit.Rows("2019-01-01 01:01:01", "<nil>"))
+	tk.MustQuery("select greatest(\"2020-01-01 01:01:01\" ,\"2019-01-01 01:01:01\" )union select null;").Sort().Check(testkit.Rows("2020-01-01 01:01:01", "<nil>"))
+	tk.MustQuery("select least(\"2020-01-01 01:01:01\" , \"2019-01-01 01:01:01\" )union select null;").Sort().Check(testkit.Rows("2019-01-01 01:01:01", "<nil>"))
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8788,4 +8788,5 @@ func (s *testSuite) TestIssue26532(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustQuery("select greatest(cast(\"2020-01-01 01:01:01\" as datetime), cast(\"2019-01-01 01:01:01\" as datetime) )union select null;").Sort().Check(testkit.Rows("2020-01-01 01:01:01", "<nil>"))
+	tk.MustQuery("select least(cast(\"2020-01-01 01:01:01\" as datetime), cast(\"2019-01-01 01:01:01\" as datetime) )union select null;").Sort().Check(testkit.Rows("2019-01-01 01:01:01", "<nil>"))
 }

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8783,3 +8783,9 @@ func (s *testSuite) TestIssue25506(c *C) {
 	tk.MustExec("insert into tbl_23 values (0xF)")
 	tk.MustQuery("(select col_15 from tbl_23) union all (select col_15 from tbl_3 for update) order by col_15").Check(testkit.Rows("\x00\x00\x0F", "\x00\x00\xFF", "\x00\xFF\xFF"))
 }
+
+func (s *testSuite) TestIssue26532(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustQuery("select greatest(cast(\"2020-01-01 01:01:01\" as datetime), cast(\"2019-01-01 01:01:01\" as datetime) )union select null;").Sort().Check(testkit.Rows("2020-01-01 01:01:01", "<nil>"))
+}

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -686,6 +686,8 @@ func (c *leastFunctionClass) getFunction(ctx sessionctx.Context, args []Expressi
 	}
 	if cmpAsDatetime {
 		tp = types.ETDatetime
+		// length of "yyyy-MM-dd HH:mm:ss.123456"
+		bf.tp.Flen = 26
 	}
 	switch tp {
 	case types.ETInt:

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -467,6 +467,8 @@ func (c *greatestFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	}
 	if cmpAsDatetime {
 		tp = types.ETDatetime
+		// length of "yyyy-MM-dd HH:mm:ss.123456"
+		bf.tp.Flen = 26
 	}
 	switch tp {
 	case types.ETInt:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26532  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?


What's Changed:
Make the flen of greatest/leatest(datetime) correct

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that `greatest(datetime) union null` returns empty string