### PR TITLE
store/copr: use lite resolve lock for coprocessor

### DIFF
--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -405,7 +405,7 @@ func (it *copIterator) open(ctx context.Context, enabledRateLimitAction bool) {
 			respChan:        it.respChan,
 			finishCh:        it.finishCh,
 			vars:            it.vars,
-			kvclient:        tikv.NewClientHelper(it.store.store, &it.resolvedLocks, false),
+			kvclient:        tikv.NewClientHelper(it.store.store, &it.resolvedLocks, true),
 			memTracker:      it.memTracker,
 			replicaReadSeed: it.replicaReadSeed,
 			actionOnExceed:  it.actionOnExceed,


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Issue Number: https://github.com/pingcap/tidb/issues/26557

Problem Summary: Coprocessor does not use resolveLockLite

Note: cannot cherry-pick, I'll send separated PRs for release-5.0 and release-5.1.

### What is changed and how it works?

What's Changed: pass `true`

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

- Fix the issue that coprocessor does not use lite resolve lock
