### PR TITLE
http_status: add the http api for ballast object

### DIFF
--- a/server/http_status.go
+++ b/server/http_status.go
@@ -212,7 +212,7 @@ func (s *Server) startHTTPServer() {
 				if err != nil {
 					errStr = err.Error()
 				} else {
-					errStr = fmt.Sprintf("input new sz cannot smaller than zero: %d", newSz)
+					errStr = fmt.Sprintf("the input new sz cannot be negative: %d", newSz)
 				}
 				if _, err := w.Write([]byte(errStr)); err != nil {
 					terror.Log(err)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

> Problem Summary:

Try to reduce the GC frequency on some occasions.

### What is changed and how it works?

> What's Changed:

Add a ballast object.

> How it Works:

Here are some articles and documentation.

[SetGCPercent](https://golang.org/pkg/runtime/debug/#SetGCPercent)

[Go memory ballast: How I learnt to stop worrying and love the heap](https://news.ycombinator.com/item?id=21670110)

[proposal: runtime: add a mechanism for specifying a minimum target heap size](https://github.com/golang/go/issues/23044)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

```bash
# get current size of the ballast object
curl -v 127.0.0.1:10080/debug/ballast-object-sz
# reset the size of the ballast object (2GB in this example)
curl -v -d "2147483648" -X POST 127.0.0.1:10080/debug/ballast-object-sz
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [x] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add http api for the ballast object.
```