### PR TITLE
ddl: support drop table for label rule

### DIFF
--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -274,7 +274,8 @@ func insertJobIntoDeleteRangeTable(ctx context.Context, sctx sessionctx.Context,
 		// The startKey here is for compatibility with previous versions, old version did not endKey so don't have to deal with.
 		var startKey kv.Key
 		var physicalTableIDs []int64
-		if err := job.DecodeArgs(&startKey, &physicalTableIDs); err != nil {
+		var ruleIDs []string
+		if err := job.DecodeArgs(&startKey, &physicalTableIDs, &ruleIDs); err != nil {
 			return errors.Trace(err)
 		}
 		if len(physicalTableIDs) > 0 {

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -35,6 +35,9 @@ var (
 	// TableIDFormat is the format of the label rule ID for a table.
 	// The format follows "schema/database_name/table_name".
 	TableIDFormat = "%s/%s/%s"
+	// PartitionIDFormat is the format of the label rule ID for a partition.
+	// The format follows "schema/database_name/table_name/partition_name".
+	PartitionIDFormat = "%s/%s/%s/%s"
 )
 
 // Rule is used to establish the relationship between labels and a key range.
@@ -93,4 +96,18 @@ func (r *Rule) ResetTable(id int64, dbName, tableName string) *Rule {
 		"end_key":   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(id+1))),
 	}
 	return r
+}
+
+// RulePatch is the patch to update the label rules.
+type RulePatch struct {
+	SetRules    []*Rule  `json:"sets"`
+	DeleteRules []string `json:"deletes"`
+}
+
+// NewRulePatch returns a patch of rules which need to be set or deleted.
+func NewRulePatch(setRules []*Rule, deleteRules []string) *RulePatch {
+	return &RulePatch{
+		SetRules:    setRules,
+		DeleteRules: deleteRules,
+	}
 }

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/ddl/label"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -1494,6 +1495,17 @@ func getPartitionIDs(table *model.TableInfo) []int64 {
 		physicalTableIDs = append(physicalTableIDs, def.ID)
 	}
 	return physicalTableIDs
+}
+
+func getPartitionRuleIDs(dbName string, table *model.TableInfo) []string {
+	if table.GetPartitionInfo() == nil {
+		return []string{}
+	}
+	partRuleIDs := make([]string, 0, len(table.Partition.Definitions))
+	for _, def := range table.Partition.Definitions {
+		partRuleIDs = append(partRuleIDs, fmt.Sprintf(label.PartitionIDFormat, label.IDPrefix, dbName, table.Name.L, def.Name.L))
+	}
+	return partRuleIDs
 }
 
 // checkPartitioningKeysConstraints checks that the range partitioning key is included in the table constraint.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -195,6 +195,7 @@ func onDropTableOrView(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	case model.StateDeleteOnly:
 		tblInfo.State = model.StateNone
 		oldIDs := getPartitionIDs(tblInfo)
+		ruleIDs := append(getPartitionRuleIDs(job.SchemaName, tblInfo), fmt.Sprintf(label.TableIDFormat, label.IDPrefix, job.SchemaName, tblInfo.Name.L))
 		job.CtxVars = []interface{}{oldIDs}
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != tblInfo.State)
 		if err != nil {
@@ -212,7 +213,7 @@ func onDropTableOrView(t *meta.Meta, job *model.Job) (ver int64, _ error) {
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StateNone, ver, tblInfo)
 		startKey := tablecodec.EncodeTablePrefix(job.TableID)
-		job.Args = append(job.Args, startKey, oldIDs)
+		job.Args = append(job.Args, startKey, oldIDs, ruleIDs)
 	default:
 		err = ErrInvalidDDLState.GenWithStackByArgs("table", tblInfo.State)
 	}

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -865,3 +865,29 @@ func UpdateLabelRules(ctx context.Context, patch *label.RulePatch) error {
 	_, err = doRequest(ctx, addrs, path.Join(pdapi.Config, "region-label", "rules"), "PATCH", bytes.NewReader(r))
 	return err
 }
+
+// GetAllLabelRules gets all label rules from PD.
+func GetAllLabelRules(ctx context.Context) ([]*label.Rule, error) {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return nil, err
+	}
+
+	if is.etcdCli == nil {
+		return nil, err
+	}
+
+	addrs := is.etcdCli.Endpoints()
+
+	if len(addrs) == 0 {
+		return nil, errors.Errorf("pd unavailable")
+	}
+
+	rules := []*label.Rule{}
+	res, err := doRequest(ctx, addrs, path.Join(pdapi.Config, "region-label", "rules"), "GET", nil)
+
+	if err == nil && res != nil {
+		err = json.Unmarshal(res, &rules)
+	}
+	return rules, err
+}

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -1912,7 +1912,7 @@ func (w *GCWorker) doGCPlacementRules(dr util.DelRangeTask) (pid int64, err erro
 func (w *GCWorker) doGCLabelRules(dr util.DelRangeTask) (err error) {
 	// Get the job from the job history
 	var historyJob *model.Job
-	failpoint.Inject("mockHistoryJobForGC", func(v failpoint.Value) {
+	failpoint.Inject("mockHistoryJob", func(v failpoint.Value) {
 		args, err1 := json.Marshal([]interface{}{kv.Key{}, []int64{}, []string{v.(string)}})
 		if err1 != nil {
 			return

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -34,6 +34,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/terror"
+	"github.com/pingcap/tidb/ddl/label"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/ddl/util"
 	"github.com/pingcap/tidb/domain/infosync"
@@ -729,6 +730,14 @@ func (w *GCWorker) deleteRanges(ctx context.Context, safePoint uint64, concurren
 				zap.Int64("jobID", r.JobID),
 				zap.Int64("elementID", r.ElementID),
 				zap.Int64("pid", pid),
+				zap.Error(err))
+			continue
+		}
+		if err := w.doGCLabelRules(r); err != nil {
+			logutil.Logger(ctx).Error("[gc worker] gc label rules failed on range",
+				zap.String("uuid", w.uuid),
+				zap.Int64("jobID", r.JobID),
+				zap.Int64("elementID", r.ElementID),
 				zap.Error(err))
 			continue
 		}
@@ -1897,6 +1906,52 @@ func (w *GCWorker) doGCPlacementRules(dr util.DelRangeTask) (pid int64, err erro
 	// Notify PD to drop the placement rules, even if there may be no placement rules.
 	bundles := []*placement.Bundle{placement.NewBundle(pid)}
 	err = infosync.PutRuleBundles(context.TODO(), bundles)
+	return
+}
+
+func (w *GCWorker) doGCLabelRules(dr util.DelRangeTask) (err error) {
+	// Get the job from the job history
+	var historyJob *model.Job
+	failpoint.Inject("mockHistoryJobForGC", func(v failpoint.Value) {
+		args, err1 := json.Marshal([]interface{}{kv.Key{}, []int64{}, []string{v.(string)}})
+		if err1 != nil {
+			return
+		}
+		historyJob = &model.Job{
+			ID:      dr.JobID,
+			Type:    model.ActionDropTable,
+			RawArgs: args,
+		}
+	})
+	if historyJob == nil {
+		err = kv.RunInNewTxn(context.Background(), w.store, false, func(ctx context.Context, txn kv.Transaction) error {
+			var err1 error
+			t := meta.NewMeta(txn)
+			historyJob, err1 = t.GetHistoryDDLJob(dr.JobID)
+			return err1
+		})
+		if err != nil {
+			return
+		}
+		if historyJob == nil {
+			return admin.ErrDDLJobNotFound.GenWithStackByArgs(dr.JobID)
+		}
+	}
+
+	var ruleIDs []string
+	switch historyJob.Type {
+	case model.ActionDropTable:
+		var (
+			startKey         kv.Key
+			physicalTableIDs []int64
+		)
+		if err = historyJob.DecodeArgs(&startKey, &physicalTableIDs, &ruleIDs); err != nil {
+			return
+		}
+	}
+
+	patch := label.NewRulePatch(nil, ruleIDs)
+	err = infosync.UpdateLabelRules(context.TODO(), patch)
 	return
 }
 

--- a/store/gcworker/gc_worker.go
+++ b/store/gcworker/gc_worker.go
@@ -1938,20 +1938,19 @@ func (w *GCWorker) doGCLabelRules(dr util.DelRangeTask) (err error) {
 		}
 	}
 
-	var ruleIDs []string
-	switch historyJob.Type {
-	case model.ActionDropTable:
+	if historyJob.Type == model.ActionDropTable {
 		var (
 			startKey         kv.Key
 			physicalTableIDs []int64
+			ruleIDs          []string
 		)
 		if err = historyJob.DecodeArgs(&startKey, &physicalTableIDs, &ruleIDs); err != nil {
 			return
 		}
-	}
 
-	patch := label.NewRulePatch(nil, ruleIDs)
-	err = infosync.UpdateLabelRules(context.TODO(), patch)
+		patch := label.NewRulePatch(nil, ruleIDs)
+		err = infosync.UpdateLabelRules(context.TODO(), patch)
+	}
 	return
 }
 

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -1591,9 +1591,9 @@ func (s *testGCWorkerSuite) TestGCPlacementRules(c *C) {
 }
 
 func (s *testGCWorkerSuite) TestGCLabelRules(c *C) {
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/gcworker/mockHistoryJobForGC", "return(\"schema/d1/t1\")"), IsNil)
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/gcworker/mockHistoryJob", "return(\"schema/d1/t1\")"), IsNil)
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/gcworker/mockHistoryJobForGC"), IsNil)
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/gcworker/mockHistoryJob"), IsNil)
 	}()
 
 	dr := util.DelRangeTask{JobID: 1, ElementID: 1}

--- a/store/gcworker/gc_worker_test.go
+++ b/store/gcworker/gc_worker_test.go
@@ -1590,6 +1590,17 @@ func (s *testGCWorkerSuite) TestGCPlacementRules(c *C) {
 	c.Assert(err, IsNil)
 }
 
+func (s *testGCWorkerSuite) TestGCLabelRules(c *C) {
+	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/gcworker/mockHistoryJobForGC", "return(\"schema/d1/t1\")"), IsNil)
+	defer func() {
+		c.Assert(failpoint.Disable("github.com/pingcap/tidb/store/gcworker/mockHistoryJobForGC"), IsNil)
+	}()
+
+	dr := util.DelRangeTask{JobID: 1, ElementID: 1}
+	err := s.gcWorker.doGCLabelRules(dr)
+	c.Assert(err, IsNil)
+}
+
 func (s *testGCWorkerSuite) TestGCWithPendingTxn(c *C) {
 	ctx := context.Background()
 	gcSafePointCacheInterval = 0


### PR DESCRIPTION
### What problem does this PR solve?

Closes https://github.com/pingcap/tidb/issues/26693. It can be reviewed after https://github.com/pingcap/tidb/pull/26511 is merged. 

### What is changed and how it works?

Add a rule for a table, show it from PD API:
```
mysql> alter table t1 attributes="attr";

# curl http://127.0.0.1:2379/pd/api/v1/config/region-label/rules
[
  {
    "id": "schema/test/t1",
    "labels": [
      {
        "key": "attr",
        "value": "true"
      },
      {
        "key": "db",
        "value": "test"
      },
      {
        "key": "table",
        "value": "t1"
      }
    ],
    "rule_type": "key-range",
    "rule": {
      "start_key": "7480000000000000ff355f720000000000fa",
      "end_key": "7480000000000000ff365f720000000000fa"
    }
  }
]
```
After GC finish:
```
# curl http://127.0.0.1:2379/pd/api/v1/config/region-label/rules
[]
```


What's Changed:
1. add GC logic for label rules
2. add `UpdateLabelRules` to batch update/delete the rules
 


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->
```release-note
None
```
