### PR TITLE
tikvclient: add more logs to debug

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -155,6 +155,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVBatchRequests)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
 	prometheus.MustRegister(TiKVBatchWaitRespDuration)
+	prometheus.MustRegister(TiKVRecycleConnDuration)
 	prometheus.MustRegister(TiKVBatchSendLatency)
 	prometheus.MustRegister(TiKvBatchWaitOverLoad)
 	prometheus.MustRegister(TiKVBatchClientUnavailable)

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -154,6 +154,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TiKVBatchPendingRequests)
 	prometheus.MustRegister(TiKVBatchRequests)
 	prometheus.MustRegister(TiKVBatchWaitDuration)
+	prometheus.MustRegister(TiKVBatchWaitRespDuration)
 	prometheus.MustRegister(TiKVBatchSendLatency)
 	prometheus.MustRegister(TiKvBatchWaitOverLoad)
 	prometheus.MustRegister(TiKVBatchClientUnavailable)

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -180,6 +180,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
 			Help:      "batch wait resp duration",
 		})
+	TiKVRecycleConnDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "recycle_conn_duration",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
+			Help:      "recycle conn duration",
+		})
 	TiKVBatchSendLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",

--- a/metrics/tikvclient.go
+++ b/metrics/tikvclient.go
@@ -172,6 +172,14 @@ var (
 			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
 			Help:      "batch wait duration",
 		})
+	TiKVBatchWaitRespDuration = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "tikvclient",
+			Name:      "batch_wait_resp_duration",
+			Buckets:   prometheus.ExponentialBuckets(1, 2, 34), // 1ns ~ 8s
+			Help:      "batch wait resp duration",
+		})
 	TiKVBatchSendLatency = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
 			Namespace: "tidb",

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -16,6 +16,7 @@ package tikv
 
 import (
 	"context"
+	"go.uber.org/zap"
 	"io"
 	"math"
 	"runtime/trace"
@@ -351,6 +352,12 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 	connArray, err := c.getConnArray(addr, enableBatch)
 	if err != nil {
 		return nil, errors.Trace(err)
+	}
+
+	if ctx.Value("isMeta") == true {
+		duration := time.Since(start)
+		startTs := ctx.Value(txnStartKey)
+		logutil.Logger(ctx).Info("load meta SendRequest", zap.Reflect("startTs", startTs), zap.Duration("recycle conn", duration))
 	}
 
 	// TiDB RPC server supports batch RPC, but batch connection will send heart beat, It's not necessary since

--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -16,7 +16,6 @@ package tikv
 
 import (
 	"context"
-	"go.uber.org/zap"
 	"io"
 	"math"
 	"runtime/trace"
@@ -39,6 +38,7 @@ import (
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/connectivity"
@@ -354,6 +354,7 @@ func (c *rpcClient) SendRequest(ctx context.Context, addr string, req *tikvrpc.R
 		return nil, errors.Trace(err)
 	}
 
+	metrics.TiKVRecycleConnDuration.Observe(float64(time.Since(start)))
 	if ctx.Value("isMeta") == true {
 		duration := time.Since(start)
 		startTs := ctx.Value(txnStartKey)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -426,7 +426,7 @@ func (s *tikvSnapshot) get(ctx context.Context, bo *Backoffer, k kv.Key) ([]byte
 	isMeta := ctx.Value("isMeta")
 	startTs := ctx.Value(txnStartKey)
 	i := 0
-	for {
+	for ; ; i++ {
 		loc, err := s.store.regionCache.LocateKey(bo, k)
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/store/tikv/snapshot.go
+++ b/store/tikv/snapshot.go
@@ -350,9 +350,20 @@ func (s *tikvSnapshot) Get(ctx context.Context, k kv.Key) ([]byte, error) {
 	}(time.Now())
 
 	ctx = context.WithValue(ctx, txnStartKey, s.version.Ver)
+	isMeta := ctx.Value("isMeta")
+	var start time.Time
+	if isMeta == true {
+		start = time.Now()
+		logutil.Logger(ctx).Info("load meta start", zap.Reflect("startTs", s.version.Ver))
+	}
 	bo := NewBackofferWithVars(ctx, getMaxBackoff, s.vars)
 	val, err := s.get(ctx, bo, k)
 	s.recordBackoffInfo(bo)
+	if isMeta == true {
+		duration := time.Since(start)
+		logutil.Logger(ctx).Info("load meta end", zap.Reflect("startTs", s.version.Ver), zap.Duration("duration", duration),
+			zap.String("backoff", bo.String()), zap.Bool("tooLong", duration > 5*time.Second))
+	}
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
@@ -412,11 +423,20 @@ func (s *tikvSnapshot) get(ctx context.Context, bo *Backoffer, k kv.Key) ([]byte
 			TaskId:       s.mu.taskID,
 		})
 	s.mu.RUnlock()
+	isMeta := ctx.Value("isMeta")
+	startTs := ctx.Value(txnStartKey)
+	i := 0
 	for {
 		loc, err := s.store.regionCache.LocateKey(bo, k)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
+
+		if isMeta == true {
+			logutil.Logger(ctx).Info("load meta tikvSnapshot", zap.Reflect("startTs", startTs), zap.Int("time", i),
+				zap.String("backoff", bo.String()))
+		}
+
 		resp, _, _, err := cli.SendReqCtx(bo, req, loc.Region, readTimeoutShort, kv.TiKV, "")
 		if err != nil {
 			return nil, errors.Trace(err)

--- a/structure/string.go
+++ b/structure/string.go
@@ -14,6 +14,7 @@
 package structure
 
 import (
+	"bytes"
 	"context"
 	"strconv"
 
@@ -33,7 +34,12 @@ func (t *TxStructure) Set(key []byte, value []byte) error {
 // Get gets the string value of a key.
 func (t *TxStructure) Get(key []byte) ([]byte, error) {
 	ek := t.encodeStringDataKey(key)
-	value, err := t.reader.Get(context.TODO(), ek)
+	ctx := context.TODO()
+	isMeta := bytes.Equal([]byte("SchemaVersionKey"), key)
+	if isMeta {
+		ctx = context.WithValue(ctx, "isMeta", true)
+	}
+	value, err := t.reader.Get(ctx, ek)
 	if kv.ErrNotExist.Equal(err) {
 		err = nil
 	}


### PR DESCRIPTION
When it's normal:
```
[2021/07/27 20:28:03.221 +08:00] [INFO] [snapshot.go:357] ["load meta start"] [startTs=426610231403085825]
[2021/07/27 20:28:03.222 +08:00] [INFO] [snapshot.go:436] ["load meta tikvSnapshot"] [startTs=426610231403085825] [time=0] [backoff=]
[2021/07/27 20:28:03.222 +08:00] [INFO] [client.go:361] ["load meta SendRequest"] [startTs=426610231403085825] ["recycle conn"=3.31µs]
[2021/07/27 20:28:03.222 +08:00] [INFO] [client_batch.go:649] ["load meta sendBatchRequest"] [startTs=426610231403085825] ["send request"=12.145µs]
[2021/07/27 20:28:03.223 +08:00] [INFO] [client_batch.go:383] ["load meta batchRecvLoop"] [startTs=426610231403085825]
[2021/07/27 20:28:03.223 +08:00] [INFO] [client_batch.go:654] ["load meta sendBatchRequest"] [startTs=426610231403085825] ["wait response"=844.629µs]
[2021/07/27 20:28:03.223 +08:00] [INFO] [client_batch.go:395] ["batch receive too long"] [recv_time=4.487867592s] [resp_time=166.45µs] [resp_num=1]
[2021/07/27 20:28:03.223 +08:00] [INFO] [snapshot.go:364] ["load meta end"] [startTs=426610231403085825] [duration=1.506342ms] [backoff=] [tooLong=false]
```

mock a backoff:
```
[2021/07/27 19:48:45.885 +08:00] [INFO] [snapshot.go:357] ["load meta start"] [startTs=426609613432684545]
[2021/07/27 19:48:45.891 +08:00] [INFO] [snapshot.go:436] ["load meta tikvSnapshot"] [startTs=426609613432684545] [time=0] [backoff=]
[2021/07/27 19:48:45.891 +08:00] [INFO] [client.go:361] ["load meta SendRequest"] [startTs=426609613432684545] ["recycle conn"=1.848µs]
[2021/07/27 19:48:45.891 +08:00] [INFO] [client_batch.go:640] ["load meta sendBatchRequest"] [startTs=426609613432684545] ["send request"=5.012µs]
[2021/07/27 19:48:45.891 +08:00] [INFO] [client_batch.go:646] ["load meta sendBatchRequest"] [startTs=426609613432684545] ["wait response"=559.011µs]
[2021/07/27 19:48:45.893 +08:00] [INFO] [snapshot.go:436] ["load meta tikvSnapshot"] [startTs=426609613432684545] [time=1] [backoff=" backoff(2ms [regionMiss])"]
[2021/07/27 19:48:45.893 +08:00] [INFO] [client.go:361] ["load meta SendRequest"] [startTs=426609613432684545] ["recycle conn"=849ns]
[2021/07/27 19:48:45.893 +08:00] [INFO] [client_batch.go:640] ["load meta sendBatchRequest"] [startTs=426609613432684545] ["send request"=2.685µs]
[2021/07/27 19:48:45.894 +08:00] [INFO] [client_batch.go:646] ["load meta sendBatchRequest"] [startTs=426609613432684545] ["wait response"=366.775µs]
[2021/07/27 19:48:45.894 +08:00] [INFO] [snapshot.go:364] ["load meta end"] [startTs=426609613432684545] [duration=8.672869ms] [backoff=" backoff(2ms [regionMiss])"] [tooLong=false]
```

added 2 grafana items:

![image](https://user-images.githubusercontent.com/29590578/127150623-591f4646-fe6a-443d-ae25-96368153cf4c.png)
