### PR TITLE
store/tikv: increase batch split region limit (#24508)

### DIFF
--- a/store/tikv/split_region.go
+++ b/store/tikv/split_region.go
@@ -33,7 +33,7 @@ import (
 	"go.uber.org/zap"
 )
 
-const splitBatchRegionLimit = 16
+const splitBatchRegionLimit = 2048
 
 func equalRegionStartKey(key, regionStartKey []byte) bool {
 	return bytes.Equal(key, regionStartKey)


### PR DESCRIPTION
Signed-off-by: nolouch <nolouch@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Ref: https://github.com/pingcap/tidb/issues/22969
Problem Summary:
Splitting and Scattering at the same time will cause multiple conflicts on the same region.
![image](https://user-images.githubusercontent.com/6428910/111289009-af99e880-867f-11eb-99e6-d441a3b2acf3.png)


### What is changed and how it works?


How it Works: increase the split regions' limit in 4.0.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->


- Make the time consuming of `split table` more stable 
```
I have run multiple times  to split 4000 regions, and the time is stale about `1m30s`
split single sql result: [map[SCATTER_FINISH_RATIO:1 TOTAL_SPLIT_REGION:2001]]
split all sql run total cost: 1m28.908304306s
split all sql run success!!!
```
### Release note <!-- bugfixes or new feature need a release note -->

- Increasing the split region limit makes the `split table` and `pre split` more stable