### PR TITLE
executor: trim `(` and `)` for the outputs of expression

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -191,7 +191,7 @@ TABLE_SCHEMA	TABLE_NAME	NON_UNIQUE	KEY_NAME	SEQ_IN_INDEX	COLUMN_NAME	SUB_PART	IN
 test	t4	0	PRIMARY	1	a	NULL		NULL	0	YES	YES
 test	t4	1	idx	1	a	NULL		NULL	1	YES	NO
 test	t4	1	idx	2	b	NULL		NULL	1	YES	NO
-test	t4	1	expr_idx	1	NULL	NULL		(`a` + `b` + 1)	2	YES	NO
+test	t4	1	expr_idx	1	NULL	NULL		`a` + `b` + 1	2	YES	NO
 explain format = 'brief' select count(1) from (select count(1) from (select * from t1 where c3 = 100) k) k2;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(1)->Column#5

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -438,7 +438,7 @@ func (e *memtableRetriever) setDataForStatisticsInTable(schema *model.DBInfo, ta
 			tblCol := table.Columns[col.Offset]
 			if tblCol.Hidden {
 				colName = "NULL"
-				expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
+				expression = tblCol.GeneratedExprString
 			}
 
 			record := types.MakeDatums(
@@ -913,7 +913,7 @@ func (e *memtableRetriever) setDataFromIndexes(ctx sessionctx.Context, schemas [
 					tblCol := tb.Columns[col.Offset]
 					if tblCol.Hidden {
 						colName = "NULL"
-						expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
+						expression = tblCol.GeneratedExprString
 					}
 					visible := "YES"
 					if idxInfo.Invisible {

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -438,7 +438,7 @@ func (e *memtableRetriever) setDataForStatisticsInTable(schema *model.DBInfo, ta
 			tblCol := table.Columns[col.Offset]
 			if tblCol.Hidden {
 				colName = "NULL"
-				expression = fmt.Sprintf("(%s)", tblCol.GeneratedExprString)
+				expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
 			}
 
 			record := types.MakeDatums(
@@ -913,7 +913,7 @@ func (e *memtableRetriever) setDataFromIndexes(ctx sessionctx.Context, schemas [
 					tblCol := tb.Columns[col.Offset]
 					if tblCol.Hidden {
 						colName = "NULL"
-						expression = fmt.Sprintf("(%s)", tblCol.GeneratedExprString)
+						expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
 					}
 					visible := "YES"
 					if idxInfo.Invisible {

--- a/executor/seqtest/seq_executor_test.go
+++ b/executor/seqtest/seq_executor_test.go
@@ -336,7 +336,7 @@ func (s *seqTestSuite) TestShow(c *C) {
 		"show_index|1|idx7|1|id|A|0|<nil>|<nil>||BTREE| |YES|<nil>|NO",
 		"show_index|1|idx8|1|id|A|0|<nil>|<nil>||BTREE| |YES|<nil>|NO",
 		"show_index|1|idx9|1|id|A|0|<nil>|<nil>||BTREE| |NO|<nil>|NO",
-		"show_index|1|expr_idx|1|NULL|A|0|<nil>|<nil>|YES|BTREE| |YES|(`id` * 2 + 1)|NO",
+		"show_index|1|expr_idx|1|NULL|A|0|<nil>|<nil>|YES|BTREE| |YES|`id` * 2 + 1|NO",
 	))
 
 	// For show like with escape

--- a/executor/show.go
+++ b/executor/show.go
@@ -614,7 +614,7 @@ func (e *ShowExec) fetchShowIndex() error {
 			var expression interface{}
 			if tblCol.Hidden {
 				colName = "NULL"
-				expression = fmt.Sprintf("(%s)", tblCol.GeneratedExprString)
+				expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
 			}
 
 			e.appendRow([]interface{}{

--- a/executor/show.go
+++ b/executor/show.go
@@ -614,7 +614,7 @@ func (e *ShowExec) fetchShowIndex() error {
 			var expression interface{}
 			if tblCol.Hidden {
 				colName = "NULL"
-				expression = fmt.Sprintf("%s", tblCol.GeneratedExprString)
+				expression = tblCol.GeneratedExprString
 			}
 
 			e.appendRow([]interface{}{


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
Refine the outputs of expression, make it the same as MySQL.


### What is changed and how it works?

Trim `(` and `)` for the outputs of expression
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
'None'
```
