### PR TITLE
server: fix the time format for `TestTLS` unit test

### DIFF
--- a/server/stat.go
+++ b/server/stat.go
@@ -52,7 +52,7 @@ func (s *Server) Stats(vars *variable.SessionVars) (map[string]interface{}, erro
 				logutil.BgLogger().Error("Failed to parse TLS certficates to get server status", zap.Error(err))
 			} else {
 				m[serverNotAfter] = pc.NotAfter.Format("Jan _2 15:04:05 2006 MST")
-				m[serverNotBefore] = pc.NotBefore.Format("Jan 2 15:04:05 2006 MST")
+				m[serverNotBefore] = pc.NotBefore.Format("Jan _2 15:04:05 2006 MST")
 			}
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #26776

Problem Summary:

### What is changed and how it works?

What's Changed:
This PR fixes a typo(maybe?) that causes a failed case due to the inconsistent format between

https://github.com/pingcap/tidb/blob/16d947d7cb9cdb1e0a8ed9276cd4198a4ab52d28/server/tidb_test.go#L960

and

https://github.com/pingcap/tidb/blob/16d947d7cb9cdb1e0a8ed9276cd4198a4ab52d28/server/stat.go#L55

How it Works:

It changes https://github.com/pingcap/tidb/blob/16d947d7cb9cdb1e0a8ed9276cd4198a4ab52d28/server/stat.go#L55 to '`_2`'(same with '`m[serverNotAfter]`').

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x ] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
