### PR TITLE
telemetry: wrong skip test when apple intel or linux arm

### DIFF
--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -76,7 +76,7 @@ func TestPreview(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, trackingID, jsonParsed.Path("trackingId").Data().(string))
 	// Apple M1 doesn't contain cpuFlags
-	if runtime.GOARCH != "arm" && runtime.GOOS != "darwin" {
+	if !(runtime.GOARCH == "arm" && runtime.GOOS == "darwin") {
 		require.True(t, jsonParsed.ExistsP("hostExtra.cpuFlags"))
 	}
 	require.True(t, jsonParsed.ExistsP("hostExtra.os"))


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>


### What problem does this PR solve?

wrongly skip test when apple intel or Linux arm 

Problem Summary:

### What is changed and how it works?

change condition to fix this problem

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
