### PR TITLE
planner: fix the unstable test case TestListPartitionOrderLimit

### DIFF
--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -272,7 +272,7 @@ func (s *testSuite5) TestIssue19411(c *C) {
 	tk.MustExec("begin")
 	tk.MustExec("insert into t1 values (2)")
 	tk.MustExec("insert into t2 values (2)")
-	tk.MustQuery("select /*+ INL_JOIN(t1,t2) */ * from t1 left join t2 on t1.c_int = t2.c_int").Check(testkit.Rows(
+	tk.MustQuery("select /*+ INL_JOIN(t1,t2) */ * from t1 left join t2 on t1.c_int = t2.c_int").Sort().Check(testkit.Rows(
 		"1 1",
 		"2 2"))
 	tk.MustExec("commit")

--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -113,7 +113,7 @@ func (s *testIntegrationPartitionSerialSuite) TestListPartitionOrderLimit(c *C) 
 		if vals != "" {
 			vals += ", "
 		}
-		vals += fmt.Sprintf("(%v, %v)", i+rand.Intn(2), i+rand.Intn(2))
+		vals += fmt.Sprintf("(%v, %v)", i*2+rand.Intn(2), i*2+rand.Intn(2))
 	}
 	tk.MustExec(`insert into tlist values ` + vals)
 	tk.MustExec(`insert into tnormal values ` + vals)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26796 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix the unstable test case TestListPartitionOrderLimit

### What is changed and how it works?

To make the test query `select * from t order by c limit 5` stable, values on `c` cannot be duplicated.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

planner: fix the unstable test case TestListPartitionOrderLimit