### PR TITLE
Revert "planner: fix the issue that UnionScan returns wrong results in dynamic mode"

### DIFF
--- a/cmd/explaintest/r/generated_columns.result
+++ b/cmd/explaintest/r/generated_columns.result
@@ -105,37 +105,14 @@ PARTITION p5 VALUES LESS THAN (6),
 PARTITION max VALUES LESS THAN MAXVALUE);
 EXPLAIN format = 'brief' SELECT * FROM sgc3 WHERE a <= 1;
 id	estRows	task	access object	operator info
-PartitionUnion	6646.67	root		
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		le(test.sgc3.a, 1)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p0	keep order:false, stats:pseudo
-└─TableReader	3323.33	root		data:Selection
-  └─Selection	3323.33	cop[tikv]		le(test.sgc3.a, 1)
-    └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p1	keep order:false, stats:pseudo
+TableReader	3323.33	root	partition:p0,p1	data:Selection
+└─Selection	3323.33	cop[tikv]		le(test.sgc3.a, 1)
+  └─TableFullScan	10000.00	cop[tikv]	table:sgc3	keep order:false, stats:pseudo
 EXPLAIN format = 'brief' SELECT * FROM sgc3 WHERE a < 7;
 id	estRows	task	access object	operator info
-PartitionUnion	23263.33	root		
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p0	keep order:false, stats:pseudo
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p1	keep order:false, stats:pseudo
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p2	keep order:false, stats:pseudo
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p3	keep order:false, stats:pseudo
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p4	keep order:false, stats:pseudo
-├─TableReader	3323.33	root		data:Selection
-│ └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-│   └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:p5	keep order:false, stats:pseudo
-└─TableReader	3323.33	root		data:Selection
-  └─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
-    └─TableFullScan	10000.00	cop[tikv]	table:sgc3, partition:max	keep order:false, stats:pseudo
+TableReader	3323.33	root	partition:all	data:Selection
+└─Selection	3323.33	cop[tikv]		lt(test.sgc3.a, 7)
+  └─TableFullScan	10000.00	cop[tikv]	table:sgc3	keep order:false, stats:pseudo
 DROP TABLE IF EXISTS t1;
 CREATE TABLE t1(a INT, b INT AS (a+1) VIRTUAL, c INT AS (b+1) VIRTUAL, d INT AS (c+1) VIRTUAL, KEY(b), INDEX IDX(c, d));
 INSERT INTO t1 (a) VALUES (0);

--- a/cmd/explaintest/r/select.result
+++ b/cmd/explaintest/r/select.result
@@ -359,25 +359,17 @@ insert into th values (0,0),(1,1),(2,2),(3,3),(4,4),(5,5),(6,6),(7,7),(8,8);
 insert into th values (-1,-1),(-2,-2),(-3,-3),(-4,-4),(-5,-5),(-6,-6),(-7,-7),(-8,-8);
 desc select * from th where a=-2;
 id	estRows	task	access object	operator info
-TableReader_9	10.00	root		data:Selection_8
-└─Selection_8	10.00	cop[tikv]		eq(test.th.a, -2)
-  └─TableFullScan_7	10000.00	cop[tikv]	table:th, partition:p2	keep order:false, stats:pseudo
+TableReader_7	10.00	root	partition:p2	data:Selection_6
+└─Selection_6	10.00	cop[tikv]		eq(test.th.a, -2)
+  └─TableFullScan_5	10000.00	cop[tikv]	table:th	keep order:false, stats:pseudo
 desc select * from th;
 id	estRows	task	access object	operator info
-PartitionUnion_9	30000.00	root		
-├─TableReader_11	10000.00	root		data:TableFullScan_10
-│ └─TableFullScan_10	10000.00	cop[tikv]	table:th, partition:p0	keep order:false, stats:pseudo
-├─TableReader_13	10000.00	root		data:TableFullScan_12
-│ └─TableFullScan_12	10000.00	cop[tikv]	table:th, partition:p1	keep order:false, stats:pseudo
-└─TableReader_15	10000.00	root		data:TableFullScan_14
-  └─TableFullScan_14	10000.00	cop[tikv]	table:th, partition:p2	keep order:false, stats:pseudo
+TableReader_5	10000.00	root	partition:all	data:TableFullScan_4
+└─TableFullScan_4	10000.00	cop[tikv]	table:th	keep order:false, stats:pseudo
 desc select * from th partition (p2,p1);
 id	estRows	task	access object	operator info
-PartitionUnion_8	20000.00	root		
-├─TableReader_10	10000.00	root		data:TableFullScan_9
-│ └─TableFullScan_9	10000.00	cop[tikv]	table:th, partition:p1	keep order:false, stats:pseudo
-└─TableReader_12	10000.00	root		data:TableFullScan_11
-  └─TableFullScan_11	10000.00	cop[tikv]	table:th, partition:p2	keep order:false, stats:pseudo
+TableReader_5	10000.00	root	partition:p1,p2	data:TableFullScan_4
+└─TableFullScan_4	10000.00	cop[tikv]	table:th	keep order:false, stats:pseudo
 drop table if exists t;
 create table t(a int, b int);
 explain format = 'brief' select a != any (select a from t t2) from t t1;

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -3163,20 +3163,6 @@ func (s *testIntegrationSuite) TestIssue22892(c *C) {
 	tk.MustQuery("select * from t2 where a not between 1 and 2;").Check(testkit.Rows("0"))
 }
 
-func (s *testIntegrationSuite) TestIssue26719(c *C) {
-	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("use test")
-	tk.MustExec(`create table tx (a int) partition by range (a) (partition p0 values less than (10), partition p1 values less than (20))`)
-	tk.MustExec(`insert into tx values (1)`)
-	tk.MustExec("set @@tidb_partition_prune_mode='dynamic'")
-
-	tk.MustExec(`begin`)
-	tk.MustExec(`delete from tx where a in (1)`)
-	tk.MustQuery(`select * from tx PARTITION(p0)`).Check(testkit.Rows())
-	tk.MustQuery(`select * from tx`).Check(testkit.Rows())
-	tk.MustExec(`rollback`)
-}
-
 func (s *testIntegrationSerialSuite) TestPushDownProjectionForTiFlash(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -917,11 +917,6 @@ func (s *SessionVars) CheckAndGetTxnScope() string {
 
 // UseDynamicPartitionPrune indicates whether use new dynamic partition prune.
 func (s *SessionVars) UseDynamicPartitionPrune() bool {
-	if s.InTxn() {
-		// UnionScan cannot get partition table IDs in dynamic-mode, this is a quick-fix for issues/26719,
-		// please see it for more details.
-		return false
-	}
 	return PartitionPruneMode(s.PartitionPruneMode.Load()) == Dynamic
 }
 


### PR DESCRIPTION
Reverts pingcap/tidb#26755

I forgot to update `tidb-test` as well when merging #26755, so #26755 breaks some `randgen-test` in `tidb-test`.
To avoid blocking other PRs, we decided to revert this PR first and then submit a new PR later.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```