### PR TITLE
executor: allow SET CONFIG to accept hostnames

### DIFF
--- a/executor/set_config.go
+++ b/executor/set_config.go
@@ -153,15 +153,15 @@ func (s *SetConfigExec) doRequest(url string) (retErr error) {
 }
 
 func isValidInstance(instance string) bool {
-	ip, port, err := net.SplitHostPort(instance)
+	host, port, err := net.SplitHostPort(instance)
 	if err != nil {
 		return false
 	}
 	if port == "" {
 		return false
 	}
-	v := net.ParseIP(ip)
-	return v != nil
+	_, err = net.LookupIP(host)
+	return err == nil
 }
 
 // ConvertConfigItem2JSON converts the config item specified by key and val to json.

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -1332,7 +1332,8 @@ func (s *testSuite5) TestSetClusterConfig(c *C) {
 	c.Assert(tk.ExecToErr("set config xxx log.level='info'"), ErrorMatches, "unknown type xxx")
 	c.Assert(tk.ExecToErr("set config tidb log.level='info'"), ErrorMatches, "TiDB doesn't support to change configs online, please use SQL variables")
 	c.Assert(tk.ExecToErr("set config '127.0.0.1:1111' log.level='info'"), ErrorMatches, "TiDB doesn't support to change configs online, please use SQL variables")
-	c.Assert(tk.ExecToErr("set config '127.a.b.c:1234' log.level='info'"), ErrorMatches, "invalid instance 127.a.b.c:1234")
+	c.Assert(tk.ExecToErr("set config '127.a.b.c:1234' log.level='info'"), ErrorMatches, "invalid instance 127.a.b.c:1234")                          // name doesn't resolve.
+	c.Assert(tk.ExecToErr("set config 'example.com:1111' log.level='info'"), ErrorMatches, "instance example.com:1111 is not found in this cluster") // name resolves.
 	c.Assert(tk.ExecToErr("set config tikv log.level=null"), ErrorMatches, "can't set config to null")
 	c.Assert(tk.ExecToErr("set config '1.1.1.1:1111' log.level='info'"), ErrorMatches, "instance 1.1.1.1:1111 is not found in this cluster")
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25448

Problem Summary:

`SET CONFIG` previously only accepted ip addresses as valid. Now it accepts any hostname or IP address provided that it can resolve.

### What is changed and how it works?

What's Changed:

Fixes a bug in `SET CONFIG`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
`SET CONFIG` previously only accepted ip addresses as valid. Now it accepts any hostname or IP address provided that it can resolve.
```
