### PR TITLE
planner: avoid unnecessary optimizer warning when sql_select_limit is set

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2212,6 +2212,7 @@ func (s *testIntegrationSuite) TestSelectLimit(c *C) {
 	// normal test
 	tk.MustExec("set @@session.sql_select_limit=1")
 	result := tk.MustQuery("select * from t order by a")
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 0)
 	result.Check(testkit.Rows("1"))
 	result = tk.MustQuery("select * from t order by a limit 2")
 	result.Check(testkit.Rows("1", "1"))

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -127,10 +127,6 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 	if !ok {
 		useBinding = false
 	}
-	if useBinding && sessVars.SelectLimit != math.MaxUint64 {
-		sessVars.StmtCtx.AppendWarning(errors.New("sql_select_limit is set, ignore SQL bindings"))
-		useBinding = false
-	}
 	var (
 		bindRecord *bindinfo.BindRecord
 		scope      string
@@ -141,6 +137,10 @@ func Optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is in
 		if err != nil || bindRecord == nil || len(bindRecord.Bindings) == 0 {
 			useBinding = false
 		}
+	}
+	if useBinding && sessVars.SelectLimit != math.MaxUint64 {
+		sessVars.StmtCtx.AppendWarning(errors.New("sql_select_limit is set, ignore SQL bindings"))
+		useBinding = false
 	}
 
 	var names types.NameSlice


### PR DESCRIPTION

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/26900

Problem Summary:

When `sql_select_limit` is set, even if there is no binding, a warning of "ignore SQL bindings" is reported.

### What is changed and how it works?

What's Changed:

Report warning only if there is candidate sql binding for the query.

How it Works:


Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

N/A

Documentation

N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
