### PR TITLE
config,util: Add setting for TLS version

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -367,7 +367,8 @@ type Security struct {
 	// EnableSEM prevents SUPER users from having full access.
 	EnableSEM bool `toml:"enable-sem" json:"enable-sem"`
 	// Allow automatic TLS certificate generation
-	AutoTLS bool `toml:"auto-tls" json:"auto-tls"`
+	AutoTLS       bool   `toml:"auto-tls" json:"auto-tls"`
+	MinTLSVersion string `toml:"tls-version" json:"tls-version"`
 }
 
 // The ErrConfigValidationFailed error is used so that external callers can do a type assertion

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -208,6 +208,9 @@ enable-sem = false
 # Automatic creation of TLS certificates
 auto-tls = true
 
+# Minium TLS version to use, e.g. "TLSv1.2"
+tls-version = ""
+
 [status]
 # If enable status report HTTP service.
 report-status = true

--- a/util/misc.go
+++ b/util/misc.go
@@ -466,6 +466,28 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool) (tlsConfig *tls.Con
 	}
 
 	requireTLS := config.GetGlobalConfig().Security.RequireSecureTransport
+	var minTLSVersion uint16 = tls.VersionTLS11
+	switch tlsver := config.GetGlobalConfig().Security.MinTLSVersion; tlsver {
+	case "TLSv1.0":
+		minTLSVersion = tls.VersionTLS10
+	case "TLSv1.1":
+		minTLSVersion = tls.VersionTLS11
+	case "TLSv1.2":
+		minTLSVersion = tls.VersionTLS12
+	case "TLSv1.3":
+		minTLSVersion = tls.VersionTLS13
+	case "":
+	default:
+		logutil.BgLogger().Warn(
+			"Invalid TLS version, using default instead",
+			zap.String("tls-version", tlsver),
+		)
+	}
+	if minTLSVersion < tls.VersionTLS12 {
+		logutil.BgLogger().Warn(
+			"Minimum TLS version allows pre-TLSv1.2 protocols, this is not recommended",
+		)
+	}
 
 	// Try loading CA cert.
 	clientAuthPolicy := tls.NoClientCert
@@ -494,6 +516,7 @@ func LoadTLSCertificates(ca, key, cert string, autoTLS bool) (tlsConfig *tls.Con
 		Certificates: []tls.Certificate{tlsCert},
 		ClientCAs:    certPool,
 		ClientAuth:   clientAuthPolicy,
+		MinVersion:   minTLSVersion,
 	}
 	return
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

This is a follow up for https://github.com/pingcap/tidb/pull/26907#issuecomment-893339820 

This makes it possible to configure the minimum version of the TLS protocol that the server supports. This makes it possible to disable older TLS versions that are less secure.

Note that the PCI-DSS standard doesn't allow the use of TLSv1.0 and recommends TLSv1.2 or newer.

See also [Deprecating TLSv1.0 and TLSv1.1](https://tools.ietf.org/id/draft-ietf-tls-oldversions-deprecate-02.html) from the IETF

### What is changed and how it works?

- The minimum version is read from the config.
- This sets the minimum version to TLSv1.1 by default. Before this TLSv1.0 was also allowed.
- It is still possible to set this to allow TLSv1.0 (e.g. to support MySQL 5.6 client libraries)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)


Side effects

- [x] Breaking backward compatibility (disabling TLSv1.0 by default)

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
The `tls-version` setting as added to set the minimum version of the TLS protocol.
```
