### PR TITLE
Fill pbCode for builtinFunc InetAton/InetNtoa/Inet6Aton/Inet6Ntoa/IsIPv4/IsIPv4Compat/IsIPv4Mapped/IsIPv6

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -399,6 +399,7 @@ func (c *inetAtonFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf.tp.Flen = 21
 	bf.tp.Flag |= mysql.UnsignedFlag
 	sig := &builtinInetAtonSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_InetAton)
 	return sig, nil
 }
 
@@ -476,6 +477,7 @@ func (c *inetNtoaFunctionClass) getFunction(ctx sessionctx.Context, args []Expre
 	bf.tp.Flen = 93
 	bf.tp.Decimal = 0
 	sig := &builtinInetNtoaSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_InetNtoa)
 	return sig, nil
 }
 
@@ -528,6 +530,7 @@ func (c *inet6AtonFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	types.SetBinChsClnFlag(bf.tp)
 	bf.tp.Decimal = 0
 	sig := &builtinInet6AtonSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Inet6Aton)
 	return sig, nil
 }
 
@@ -600,6 +603,7 @@ func (c *inet6NtoaFunctionClass) getFunction(ctx sessionctx.Context, args []Expr
 	bf.tp.Flen = 117
 	bf.tp.Decimal = 0
 	sig := &builtinInet6NtoaSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_Inet6Ntoa)
 	return sig, nil
 }
 
@@ -654,6 +658,7 @@ func (c *isIPv4FunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	}
 	bf.tp.Flen = 1
 	sig := &builtinIsIPv4Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4)
 	return sig, nil
 }
 
@@ -721,6 +726,7 @@ func (c *isIPv4CompatFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	}
 	bf.tp.Flen = 1
 	sig := &builtinIsIPv4CompatSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4Compat)
 	return sig, nil
 }
 
@@ -769,6 +775,7 @@ func (c *isIPv4MappedFunctionClass) getFunction(ctx sessionctx.Context, args []E
 	}
 	bf.tp.Flen = 1
 	sig := &builtinIsIPv4MappedSig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_IsIPv4Mapped)
 	return sig, nil
 }
 
@@ -817,6 +824,7 @@ func (c *isIPv6FunctionClass) getFunction(ctx sessionctx.Context, args []Express
 	}
 	bf.tp.Flen = 1
 	sig := &builtinIsIPv6Sig{bf}
+	sig.setPbCode(tipb.ScalarFuncSig_IsIPv6)
 	return sig, nil
 }
 

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -978,12 +978,15 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		// encryption functions.
 		ast.MD5, ast.SHA1, ast.UncompressedLength,
 
-		ast.Cast,
+		ast.Cast:
+		return true
 
+	case
 		// misc functions.
+		// TODO(#26942): enable functions below after them are fully tested in TiKV.
 		ast.InetNtoa, ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton, ast.IsIPv4, ast.IsIPv4Compat, ast.IsIPv4Mapped, ast.IsIPv6, ast.UUID:
 
-		return true
+		return false
 
 	// A special case: Only push down Round by signature
 	case ast.Round:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26942 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

1. Fill pbCode for these functions (InetAton/InetNtoa/Inet6Aton/Inet6Ntoa/IsIPv4/IsIPv4Compat/IsIPv4Mapped/IsIPv6).
2. Prevent them from being pushed down to TiKV to keep no behavior changed.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

None, since no behavior is changed.
