### PR TITLE
expression: fix compare string with hex string literal makes tidb panic

### DIFF
--- a/expression/builtin.go
+++ b/expression/builtin.go
@@ -135,7 +135,7 @@ func CheckIllegalMixCollation(funcName string, args []Expression, evalType types
 	// behavior because we tread utf8mb3 same as utf8mb4 except insert, just keep things simple.
 	// Since we only have utf8mb4 and its subset charset for now, so that just check the data's validity is ok, no
 	// need to convert it.
-	// For the future, we may add more charsets support, but it actually still utf8mb4 encoding at runtime, so we
+	// In the future, we may add more charsets support, but it actually still utf8mb4 encoding at runtime, so we
 	// also no need to do the convert.
 	for _, arg := range args {
 		_, ok := arg.(*Constant)
@@ -155,7 +155,7 @@ func CheckIllegalMixCollation(funcName string, args []Expression, evalType types
 }
 
 // isValidString test if the val is valid for charset dstChs.
-// todo: remove this function when full charset is supported, we will have better way to do this job.
+// TODO: Remove this function when the full charset is supported, we will have a better way to do this job.
 func isValidString(val string, srcChs, dstChs string) bool {
 	if srcChs == dstChs {
 		return true
@@ -163,15 +163,15 @@ func isValidString(val string, srcChs, dstChs string) bool {
 	switch dstChs {
 	case charset.CharsetASCII:
 		for _, c := range val {
-			if !(c < 0x80) {
+			if c >= 0x80 {
 				return false
 			}
 		}
 	case charset.CharsetLatin1:
-		// todo: for latin, we now have no convenience way to check it, just let it go.
-		// todo: will fix it after full charset is supported.
+		// TODO: For latin, we now have no convenience way to check it, just let it go.
+		// We will fix it after the full charset is supported.
 	default:
-		// the charset in tidb are all utf8mb4 or its subset except binary, so that we just check binary charset is enough.
+		// The charset in tidb are all utf8mb4 or its subset except binary, so that we just check binary charset is enough.
 		if srcChs == charset.CharsetBin {
 			return utf8.ValidString(val)
 		}

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -332,11 +332,11 @@ func (s *testEvaluatorSuite) TestGreatestLeastFunc(c *C) {
 		},
 	} {
 		f0, err := newFunctionForTest(s.ctx, ast.Greatest, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		d, err := f0.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f0.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)
@@ -346,11 +346,11 @@ func (s *testEvaluatorSuite) TestGreatestLeastFunc(c *C) {
 		}
 
 		f1, err := newFunctionForTest(s.ctx, ast.Least, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		d, err = f1.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f1.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)

--- a/expression/builtin_control_test.go
+++ b/expression/builtin_control_test.go
@@ -125,11 +125,11 @@ func (s *testEvaluatorSuite) TestIfNull(c *C) {
 
 	for _, t := range tbl {
 		f, err := newFunctionForTest(s.ctx, ast.Ifnull, s.primitiveValsToConstants([]interface{}{t.arg1, t.arg2})...)
-		c.Assert(err, IsNil)
-		d, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -264,12 +264,12 @@ func (s *testEvaluatorSuite) TestConcatWS(c *C) {
 	c.Assert(err, NotNil)
 
 	for _, t := range cases {
-		f, err := newFunctionForTest(s.ctx, fcName, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		val, err1 := f.Eval(chunk.Row{})
+		f, err1 := newFunctionForTest(s.ctx, fcName, s.primitiveValsToConstants(t.args)...)
 		if t.getErr {
 			c.Assert(err1, NotNil)
 		} else {
+			c.Assert(err1, IsNil)
+			val, err1 := f.Eval(chunk.Row{})
 			c.Assert(err1, IsNil)
 			if t.isNil {
 				c.Assert(val.Kind(), Equals, types.KindNull)
@@ -361,11 +361,11 @@ func (s *testEvaluatorSuite) TestLeft(c *C) {
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Left, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		v, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			v, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(v.Kind(), Equals, types.KindNull)
@@ -410,11 +410,11 @@ func (s *testEvaluatorSuite) TestRight(c *C) {
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Right, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		v, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			v, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(v.Kind(), Equals, types.KindNull)
@@ -652,11 +652,11 @@ func (s *testEvaluatorSuite) TestStrcmp(c *C) {
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Strcmp, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		d, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)
@@ -688,12 +688,12 @@ func (s *testEvaluatorSuite) TestReplace(c *C) {
 	}
 	for i, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Replace, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil, Commentf("test %v", i))
-		c.Assert(f.GetType().Flen, Equals, t.flen, Commentf("test %v", i))
-		d, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil, Commentf("test %v", i))
 		} else {
+			c.Assert(err, IsNil, Commentf("test %v", i))
+			c.Assert(f.GetType().Flen, Equals, t.flen, Commentf("test %v", i))
+			d, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil, Commentf("test %v", i))
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull, Commentf("test %v", i))
@@ -733,11 +733,11 @@ func (s *testEvaluatorSuite) TestSubstring(c *C) {
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.Substring, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		d, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)
@@ -841,11 +841,11 @@ func (s *testEvaluatorSuite) TestSubstringIndex(c *C) {
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.SubstringIndex, s.primitiveValsToConstants(t.args)...)
-		c.Assert(err, IsNil)
-		d, err := f.Eval(chunk.Row{})
 		if t.getErr {
 			c.Assert(err, NotNil)
 		} else {
+			c.Assert(err, IsNil)
+			d, err := f.Eval(chunk.Row{})
 			c.Assert(err, IsNil)
 			if t.isNil {
 				c.Assert(d.Kind(), Equals, types.KindNull)

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6007,9 +6007,11 @@ func (s *testIntegrationSerialSuite) TestIssue23506(c *C) {
 	tk.MustGetErrMsg("select 'a' collate utf8mb4_general_ci = 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,EXPLICIT) and (binary,COERCIBLE) for operation '='")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a char(10), primary key (a)) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;")
-	tk.MustGetErrMsg("select * from t1 where a > 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (binary,COERCIBLE) for operation '>'")
 	tk.MustExec("insert into t1 values ('a')")
+	tk.MustGetErrMsg("select * from t1 where a > 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (binary,COERCIBLE) for operation '>'")
 	tk.MustGetErrMsg("select * from t1 where a between 0x808E and 0x80BD;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (binary,COERCIBLE) for operation '>='")
+	tk.MustGetErrMsg("select _ascii 'a' collate ascii_bin = 'ㅂ';", "[expression:1267]Illegal mix of collations (ascii_bin,EXPLICIT) and (utf8mb4_bin,COERCIBLE) for operation '='")
+	tk.MustGetErrMsg("select _ascii 'a' collate ascii_bin = 0x80;", "[expression:1267]Illegal mix of collations (ascii_bin,EXPLICIT) and (binary,COERCIBLE) for operation '='")
 }
 
 func (s *testIntegrationSuite) TestNotExistFunc(c *C) {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -5997,6 +5997,21 @@ func (s *testIntegrationSerialSuite) TestIssue15315(c *C) {
 	tk.MustQuery("select cast('0-1234' as real)").Check(testkit.Rows("0"))
 }
 
+func (s *testIntegrationSerialSuite) TestIssue23506(c *C) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	// fixme: MySQL will get error [HY000][3854] Cannot convert string '\x80' from binary to utf8mb4,
+	// fixme: at this moment, we can only get error like this, will try to fix in the future.
+	tk.MustGetErrMsg("select 'a' collate utf8mb4_general_ci = 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,EXPLICIT) and (binary,COERCIBLE) for operation '='")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(a char(10), primary key (a)) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;")
+	tk.MustGetErrMsg("select * from t1 where a > 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (binary,COERCIBLE) for operation '>'")
+	tk.MustExec("insert into t1 values ('a')")
+	tk.MustGetErrMsg("select * from t1 where a between 0x808E and 0x80BD;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,IMPLICIT) and (binary,COERCIBLE) for operation '>='")
+}
+
 func (s *testIntegrationSuite) TestNotExistFunc(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -6002,8 +6002,8 @@ func (s *testIntegrationSerialSuite) TestIssue23506(c *C) {
 	defer collate.SetNewCollationEnabledForTest(false)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	// fixme: MySQL will get error [HY000][3854] Cannot convert string '\x80' from binary to utf8mb4,
-	// fixme: at this moment, we can only get error like this, will try to fix in the future.
+	// FIXME: MySQL will get an error [HY000][3854] Cannot convert string '\x80' from binary to utf8mb4, at this moment,
+	// we can only get an error like this, will try to fix in the future.
 	tk.MustGetErrMsg("select 'a' collate utf8mb4_general_ci = 0x80;", "[expression:1267]Illegal mix of collations (utf8mb4_general_ci,EXPLICIT) and (binary,COERCIBLE) for operation '='")
 	tk.MustExec("drop table if exists t1")
 	tk.MustExec("create table t1(a char(10), primary key (a)) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;")

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -240,7 +240,7 @@ func (s *testInferTypeSuite) createTestCase4StrFuncs() []typeInferTestCase {
 		{"space(c_int_d)", mysql.TypeLongBlob, mysql.DefaultCharset, 0, mysql.MaxBlobWidth, types.UnspecifiedLength},
 		{"CONCAT(c_binary, c_int_d)", mysql.TypeVarString, charset.CharsetBin, mysql.BinaryFlag, 40, types.UnspecifiedLength},
 		{"CONCAT(c_bchar, c_int_d)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 40, types.UnspecifiedLength},
-		{"CONCAT(c_bchar, 0x80)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 23, types.UnspecifiedLength},
+		{"CONCAT(c_bchar, 0x63)", mysql.TypeVarString, charset.CharsetUTF8MB4, 0, 23, types.UnspecifiedLength},
 		{"CONCAT('T', 'i', 'DB')", mysql.TypeVarString, charset.CharsetUTF8MB4, 0 | mysql.NotNullFlag, 4, types.UnspecifiedLength},
 		{"CONCAT('T', 'i', 'DB', c_binary)", mysql.TypeVarString, charset.CharsetBin, mysql.BinaryFlag, 24, types.UnspecifiedLength},
 		{"CONCAT_WS('-', 'T', 'i', 'DB')", mysql.TypeVarString, charset.CharsetUTF8MB4, 0 | mysql.NotNullFlag, 6, types.UnspecifiedLength},


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: 
close https://github.com/pingcap/tidb/issues/23507
close https://github.com/pingcap/tidb/issues/23506

Problem Summary:

### What is changed and how it works?

if the function's arguments are constant and string type, we should check its validity, so that this pr will eval string expression at `getfunction` phase if the argument is constant and string type and some error arise earlier, see the changed tests.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
make illegal collation check more strictness
```
