### PR TITLE
session, variable: cleanup TiDBEvolvePlanBaselines sysvar validation

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -1158,9 +1158,6 @@ func (s *session) SetGlobalSysVar(name, value string) (err error) {
 	if value, err = sv.Validate(s.sessionVars, value, variable.ScopeGlobal); err != nil {
 		return err
 	}
-	if sv.Name == variable.TiDBEvolvePlanBaselines && value == "ON" && !config.CheckTableBeforeDrop {
-		return errors.Errorf("Cannot enable baseline evolution feature, it is not generally available now")
-	}
 	if err = sv.SetGlobalFromHook(s.sessionVars, value, false); err != nil {
 		return err
 	}


### PR DESCRIPTION

### What problem does this PR solve?

Problem Summary:

This is a cleanup following https://github.com/pingcap/tidb/pull/26333

### What is changed and how it works?

What's Changed:

In the PR https://github.com/pingcap/tidb/pull/26333 validation for the sysvar was performed in the functions `SetGlobalSysVar` and `SetSessionFromHook`. But the API for sysvars allows for a validation function to be specified in the sysvar struct. Handling it this way is preferred because then plugins have access to exactly the same API. It also keeps the sysvar handling centralized and consistent.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test (covered by existing tests)
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
