### PR TITLE
excutor: fix the date precision of builtinCastDurationAsStringSig.vecEvalString (#23332)

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -758,7 +758,7 @@ func (s *testSuiteAgg) TestOnlyFullGroupBy(c *C) {
 	tk.MustQuery("select max(a+b) from t")
 	tk.MustQuery("select avg(a)+1 from t")
 	tk.MustQuery("select count(c), 5 from t")
-	// test functinal depend on primary key
+	// test functional depend on primary key
 	tk.MustQuery("select * from t group by a")
 	// test functional depend on unique not null columns
 	tk.MustQuery("select * from t group by b,d")
@@ -1202,4 +1202,15 @@ func (s *testSuiteAgg) TestIssue23277(c *C) {
 	tk.MustExec("insert into t values (-120), (127);")
 	tk.MustQuery("select avg(a) from t group by a").Sort().Check(testkit.Rows("-120.0000", "127.0000"))
 	tk.MustExec("drop table t;")
+}
+
+// https://github.com/pingcap/tidb/issues/23314
+func (s *testSuiteAgg) TestIssue23314(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1(col1 time(2) NOT NULL)")
+	tk.MustExec("insert into t1 values(\"16:40:20.01\")")
+	res := tk.MustQuery("select col1 from t1 group by col1")
+	res.Check(testkit.Rows("16:40:20.01"))
 }

--- a/expression/builtin_cast_vec.go
+++ b/expression/builtin_cast_vec.go
@@ -1296,12 +1296,13 @@ func (b *builtinCastDurationAsStringSig) vecEvalString(input *chunk.Chunk, resul
 	var isNull bool
 	sc := b.ctx.GetSessionVars().StmtCtx
 	result.ReserveString(n)
+	fsp := b.args[0].GetType().Decimal
 	for i := 0; i < n; i++ {
 		if buf.IsNull(i) {
 			result.AppendNull()
 			continue
 		}
-		res, err = types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, 0).String(), b.tp, sc, false)
+		res, err = types.ProduceStrWithSpecifiedTp(buf.GetDuration(i, fsp).String(), b.tp, sc, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: ti-srebot <ti-srebot@pingcap.com>

cherry-pick #23332 to release-4.0

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26790 <!-- REMOVE this line if no issue to close -->

Problem Summary:
```sql
use test;
drop table if exists t;
create table t(a time(2));
insert into t values("2020-02-02 22:22:22.94");
select length(a),a from t;
```
release-5.1 & master & mysql 8.0.21(EXPECTED):
```sql
mysql> select length(a),a from t;
+-----------+-------------+
| length(a) | a           |
+-----------+-------------+
|        11 | 22:22:22.94 |
+-----------+-------------+
1 row in set (0.00 sec)
```
release-4.0 & release-5.0:
```sql
tidb> select length(a),a from t;
+-----------+-------------+
| length(a) | a           |
+-----------+-------------+
|         8 | 22:22:22.94 |
+-----------+-------------+
1 row in set (0.00 sec)
```
### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
