### PR TITLE
executor: fix APPROX_PERCENTILE unstable panic when parameter be P100

### DIFF
--- a/executor/aggfuncs/export_test.go
+++ b/executor/aggfuncs/export_test.go
@@ -1,0 +1,17 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aggfuncs
+
+// PercentileForTesting exports percentile for testing.
+var PercentileForTesting = percentile

--- a/executor/aggfuncs/func_percentile.go
+++ b/executor/aggfuncs/func_percentile.go
@@ -40,6 +40,9 @@ var (
 func percentile(data sort.Interface, percent int) int {
 	// Ordinal rank k = Ceil(P / 100 * N)
 	k := int(math.Ceil(float64(data.Len()) * (float64(percent) / 100)))
+	if k > data.Len() {
+		k = data.Len()
+	}
 	return selection.Select(data, k)
 }
 

--- a/executor/aggfuncs/func_percentile.go
+++ b/executor/aggfuncs/func_percentile.go
@@ -39,7 +39,7 @@ var (
 
 func percentile(data sort.Interface, percent int) int {
 	// Ordinal rank k = Ceil(P / 100 * N)
-	k := int(math.Ceil(float64(data.Len()) / 100 * float64(percent)))
+	k := int(math.Ceil(float64(data.Len()*percent) / 100))
 	return selection.Select(data, k)
 }
 

--- a/executor/aggfuncs/func_percentile.go
+++ b/executor/aggfuncs/func_percentile.go
@@ -39,7 +39,7 @@ var (
 
 func percentile(data sort.Interface, percent int) int {
 	// Ordinal rank k = Ceil(P / 100 * N)
-	k := int(math.Ceil(float64(data.Len()*percent) / 100))
+	k := int(math.Ceil(float64(data.Len()) * (float64(percent) / 100)))
 	return selection.Select(data, k)
 }
 

--- a/executor/aggfuncs/func_percentile_test.go
+++ b/executor/aggfuncs/func_percentile_test.go
@@ -19,8 +19,15 @@ import (
 	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
+	"github.com/pingcap/tidb/executor/aggfuncs"
 	"github.com/pingcap/tidb/types"
 )
+
+type testSlice []int
+
+func (a testSlice) Len() int           { return len(a) }
+func (a testSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a testSlice) Less(i, j int) bool { return a[i] < a[j] }
 
 func (s *testSuite) TestPercentile(c *C) {
 	tests := []aggTest{
@@ -33,5 +40,14 @@ func (s *testSuite) TestPercentile(c *C) {
 	}
 	for _, test := range tests {
 		s.testAggFunc(c, test)
+	}
+
+	data := testSlice{}
+	for i := 1; i <= 28; i++ {
+		data = append(data, i)
+	}
+	for i := 0; i < 10; i++ {
+		index := aggfuncs.PercentileForTesting(data, 100)
+		c.Assert(28, Equals, data[index])
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26807 <!-- REMOVE this line if no issue to close -->

Problem Summary:

`float64(28) / 100 * float64(100)` will produce `28.000000000000004` and ceil to 29 which over total len 28.

then random pivot index may cause issue's panic

### What is changed and how it works?


What's Changed, How it Works:

it's better to multiple by int and only div in float to avoid this.


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix APPROX_PERCENTILE random panic for some percent value
```
