### PR TITLE
planner: handle over-flow errors correctly when pruning list-column partitions

### DIFF
--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -471,8 +471,11 @@ func (l *listPartitionPruner) locateColumnPartitionsByCondition(cond expression.
 			locations = []tables.ListPartitionLocation{location}
 		} else {
 			locations, err = colPrune.LocateRanges(sc, r)
+			if types.ErrOverflow.Equal(err) {
+				return nil, true, nil // return full-scan if over-flow
+			}
 			if err != nil {
-				return nil, false, nil
+				return nil, false, err
 			}
 		}
 		for _, location := range locations {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27012, #27017, #27018 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: handle over-flow errors correctly when pruning list-column partitions

### What is changed and how it works?

planner: handle over-flow errors correctly when pruning list-column partitions

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
planner: handle over-flow errors correctly when pruning list-column partitions
```
