### PR TITLE
planner: handle over-flow errors correctly when pruning list partition

### DIFF
--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -621,6 +621,21 @@ PARTITION BY LIST COLUMNS(col1) (
 	tk.MustQuery(`select * from IDT_LP24306 where col1 not between 12021 and 99 and col1 <= -128`).Sort().Check(testkit.Rows("-128"))
 }
 
+func (s *testIntegrationPartitionSerialSuite) TestIssue27031(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create database issue_27031")
+	tk.MustExec("use issue_27031")
+	tk.MustExec(`set tidb_enable_list_partition = 1`)
+	tk.MustExec(`CREATE TABLE NT_LP27390 (
+  COL1 mediumint(28) DEFAULT '114' COMMENT 'NUMERIC NO INDEX'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(col1) (
+  PARTITION P9 VALUES IN (3376825,-7753310,-4123498,6483048,6953968,-996842,-7542484,320451,-8322717,-2426029)
+)`)
+	tk.MustExec(`insert into NT_LP27390 values(-4123498)`)
+	tk.MustQuery(`SELECT COL1 FROM NT_LP27390 WHERE COL1 IN (46015556,-4123498,54419751)`).Sort().Check(testkit.Rows("-4123498"))
+}
+
 func genListPartition(begin, end int) string {
 	buf := &bytes.Buffer{}
 	buf.WriteString("(")

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -465,6 +465,9 @@ func (l *listPartitionPruner) locateColumnPartitionsByCondition(cond expression.
 		var locations []tables.ListPartitionLocation
 		if r.IsPointNullable(sc) {
 			location, err := colPrune.LocatePartition(sc, r.HighVal[0])
+			if types.ErrOverflow.Equal(err) {
+				return nil, true, nil // return full-scan if over-flow
+			}
 			if err != nil {
 				return nil, false, err
 			}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27031 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: handle over-flow errors correctly when pruning list partition

### What is changed and how it works?

planner: handle over-flow errors correctly when pruning list partition

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
planner: handle over-flow errors correctly when pruning list partition
```
