### PR TITLE
restore: split & scatter regions concurrently

### DIFF
--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -259,6 +259,7 @@ func (importer *FileImporter) Import(
 	files []*backuppb.File,
 	rewriteRules *RewriteRules,
 ) error {
+	start := time.Now()
 	log.Debug("import file", logutil.Files(files))
 	// Rewrite the start key and end key of file to scan regions
 	var startKey, endKey []byte
@@ -348,7 +349,7 @@ func (importer *FileImporter) Import(
 					logutil.ShortError(errDownload))
 				return errors.Trace(errDownload)
 			}
-
+			log.Info("download file done", zap.String("file-sample", files[0].Name), zap.Stringer("take", time.Since(start)))
 			ingestResp, errIngest := importer.ingestSSTs(ctx, downloadMetas, info)
 		ingestRetry:
 			for errIngest == nil {
@@ -414,6 +415,7 @@ func (importer *FileImporter) Import(
 				return errors.Trace(errIngest)
 			}
 		}
+		log.Info("ingtest file done", zap.String("file-sample", files[0].Name), zap.Stringer("take", time.Since(start)))
 		for _, f := range files {
 			summary.CollectSuccessUnit(summary.TotalKV, 1, f.TotalKvs)
 			summary.CollectSuccessUnit(summary.TotalBytes, 1, f.TotalBytes)

--- a/br/pkg/restore/pipeline_items.go
+++ b/br/pkg/restore/pipeline_items.go
@@ -12,7 +12,9 @@ import (
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/rtree"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
 
 const (

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -35,10 +35,16 @@ const (
 	FlagMergeRegionSizeBytes = "merge-region-size-bytes"
 	// FlagMergeRegionKeyCount is the flag name of merge small regions by key count
 	FlagMergeRegionKeyCount = "merge-region-key-count"
+	// FlagPDConcurrency controls concurrency pd-relative operations like split & scatter.
+	FlagPDConcurrency = "pd-concurrency"
+	// FlagBatchFlushInterval controls after how long the restore batch would be auto sended.
+	FlagBatchFlushInterval = "batch-flush-interval"
 
 	defaultRestoreConcurrency = 128
 	maxRestoreBatchSizeLimit  = 10240
 	defaultDDLConcurrency     = 16
+	defaultPDConcurrency      = 16
+	defaultBatchFlushInterval = time.Second
 )
 
 // RestoreCommonConfig is the common configuration for all BR restore tasks.
@@ -71,9 +77,15 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	flags.Uint64(FlagMergeRegionSizeBytes, restore.DefaultMergeRegionSizeBytes,
 		"the threshold of merging small regions (Default 96MB, region split size)")
 	flags.Uint64(FlagMergeRegionKeyCount, restore.DefaultMergeRegionKeyCount,
-		"the threshold of merging smalle regions (Default 960_000, region split key count)")
+		"the threshold of merging small regions (Default 960_000, region split key count)")
+	flags.Uint(FlagPDConcurrency, defaultPDConcurrency,
+		"concurrency pd-relative operations like split & scatter.")
+	flags.Duration(FlagBatchFlushInterval, defaultBatchFlushInterval,
+		"after how long a restore batch would be auto sended.")
 	_ = flags.MarkHidden(FlagMergeRegionSizeBytes)
 	_ = flags.MarkHidden(FlagMergeRegionKeyCount)
+	_ = flags.MarkHidden(FlagPDConcurrency)
+	_ = flags.MarkHidden(FlagBatchFlushInterval)
 }
 
 // ParseFromFlags parses the config from the flag set.
@@ -99,7 +111,9 @@ type RestoreConfig struct {
 	Config
 	RestoreCommonConfig
 
-	NoSchema bool `json:"no-schema" toml:"no-schema"`
+	NoSchema           bool          `json:"no-schema" toml:"no-schema"`
+	PDConcurrency      uint          `json:"pd-concurrency" toml:"pd-concurrency"`
+	BatchFlushInterval time.Duration `json:"batch-flush-interval" toml:"batch-flush-interval"`
 }
 
 // DefineRestoreFlags defines common flags for the restore tidb command.
@@ -130,6 +144,14 @@ func (cfg *RestoreConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	if cfg.Config.Concurrency == 0 {
 		cfg.Config.Concurrency = defaultRestoreConcurrency
 	}
+	cfg.PDConcurrency, err = flags.GetUint(FlagPDConcurrency)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get flag %s", FlagPDConcurrency)
+	}
+	cfg.BatchFlushInterval, err = flags.GetDuration(FlagBatchFlushInterval)
+	if err != nil {
+		return errors.Annotatef(err, "failed to get flag %s", FlagBatchFlushInterval)
+	}
 	return nil
 }
 
@@ -146,6 +168,12 @@ func (cfg *RestoreConfig) adjustRestoreConfig() {
 	}
 	if cfg.Config.SwitchModeInterval == 0 {
 		cfg.Config.SwitchModeInterval = defaultSwitchInterval
+	}
+	if cfg.PDConcurrency == 0 {
+		cfg.PDConcurrency = defaultPDConcurrency
+	}
+	if cfg.BatchFlushInterval == 0 {
+		cfg.BatchFlushInterval = defaultBatchFlushInterval
 	}
 }
 
@@ -396,14 +424,14 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		int64(rangeSize+len(files)+len(tables)),
 		!cfg.LogProgress)
 	defer updateCh.Close()
-	sender, err := restore.NewTiKVSender(ctx, client, updateCh)
+	sender, err := restore.NewTiKVSender(ctx, client, updateCh, cfg.PDConcurrency)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	manager := restore.NewBRContextManager(client)
 	batcher, afterRestoreStream := restore.NewBatcher(ctx, sender, manager, errCh)
 	batcher.SetThreshold(batchSize)
-	batcher.EnableAutoCommit(ctx, time.Second)
+	batcher.EnableAutoCommit(ctx, cfg.BatchFlushInterval)
 	go restoreTableStream(ctx, rangeStream, batcher, errCh)
 
 	var finish <-chan struct{}

--- a/br/pkg/utils/worker.go
+++ b/br/pkg/utils/worker.go
@@ -37,6 +37,16 @@ func NewWorkerPool(limit uint, name string) *WorkerPool {
 	}
 }
 
+// IdleCount counts how many idle workers in the pool.
+func (pool *WorkerPool) IdleCount() int {
+	return len(pool.workers)
+}
+
+// Limit is the limit of the pool
+func (pool *WorkerPool) Limit() int {
+	return int(pool.limit)
+}
+
 // Apply executes a task.
 func (pool *WorkerPool) Apply(fn taskFunc) {
 	worker := pool.ApplyWorker()
@@ -95,5 +105,5 @@ func (pool *WorkerPool) RecycleWorker(worker *Worker) {
 
 // HasWorker checks if the pool has unallocated workers.
 func (pool *WorkerPool) HasWorker() bool {
-	return len(pool.workers) > 0
+	return pool.IdleCount() > 0
 }


### PR DESCRIPTION
Port of https://github.com/pingcap/br/pull/1363

<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->

### What problem does this PR solve? <!--add issue link with summary if exists-->
Before, when restoring many small tables, the batcher would probably send small batch due to the so called `AutoCommit` feature of the batcher. By this, we can make the split & scatter & restore worker more active.

But frequently send small batches isn't free. The split step is costly and I/O bounded for even small batches. For example, it costs about 3s to splitting 60 ranges, but restore those ranges typically costs only 1s. Then the restore worker get idle at most time. The restore hence has slowed down.

![BR pipeline-2](https://user-images.githubusercontent.com/36239017/126098380-d1061270-f232-4f7d-9841-56ec63ecd3cf.png)

### What is changed and how it works?
Instead of using a single split worker, this PR allow multi restore batches be split concurrently.
We added two **hidden** flags, `--batch-flush-interval` and `--pd-concurrency`, the former for better tuning the behavior of batcher, the latter for tweaking the concurrent split.
Also, more logs were added so the create table speed, download, ingest time cost can be observed via log.

### Check List 

Tests 

 - Integration test
 - Manual test (add detailed scripts or steps below)
 A internal test shows, in a 190GB, 6000 tables workload, this PR can speed up the restoration: the original version takes over **2 hours**  for restoring, and this version takes about **30mins** for restoring. The latter is nearly equal to the time cost of creating tables(see figure below).

<img width="950" alt="image" src="https://user-images.githubusercontent.com/36239017/126098836-c101ed97-54c7-40aa-904c-6e28d746e092.png">

### Release note

 - Restore many small tables would be faster now.

<!-- fill in the release note, or just write "No release note" -->
