### PR TITLE
session, test: make `TestClusteredIndexSyntax` stable

### DIFF
--- a/session/clustered_index_test.go
+++ b/session/clustered_index_test.go
@@ -517,7 +517,7 @@ func (s *testClusteredSuite) TestClusteredIndexSelectWhereInNull(c *C) {
 	tk.MustQuery("select * from t where a in (null);").Check(testkit.Rows( /* empty result */ ))
 }
 
-func (s *testClusteredSuite) TestClusteredIndexSyntax(c *C) {
+func (s *testClusteredSerialSuite) TestClusteredIndexSyntax(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
 	const showPKType = `select tidb_pk_type from information_schema.tables where table_schema = 'test' and table_name = 't';`
 	const nonClustered, clustered = `NONCLUSTERED`, `CLUSTERED`


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #24759

### What is changed and how it works?

`ErrClass.New` from the parser(https://github.com/pingcap/parser/blob/master/terror/terror.go#L166) is not goroutine-safe, which causes #24759, but I'm not sure if it's a good idea to simply change `TestClusteredIndexSyntax`.

Maybe the better way is making `ErrClass.New` goroutine-safe instead.

### Release note
```release-note
None
```
