### PR TITLE
ddl: fix ttlManager leak in TestWriteReorgForColumnTypeChangeOnAmendTxn

### DIFF
--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -339,6 +339,11 @@ func (s *testSerialDBSuite) TestWriteReorgForColumnTypeChangeOnAmendTxn(c *C) {
 
 		var checkErr error
 		tk1 := testkit.NewTestKit(c, s.store)
+		defer func() {
+			if tk1.Se != nil {
+				tk1.Se.Close()
+			}
+		}()
 		hook := &ddl.TestDDLCallback{Do: s.dom}
 		times := 0
 		hook.OnJobUpdatedExported = func(job *model.Job) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #26997

### What is changed and how it works?

`TestWriteReorgForColumnTypeChangeOnAmendTxn` begins an explicit pessimistic transaction and locks some keys. But it does not close the session at the end of the test. So the `ttlManager` keeps updating TTL for the transaction, leading to a goroutine leak.

This PR closes the session at the end of the test.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
