### PR TITLE
planner: encode min/max varchar correctly when pruning list-column partitions

### DIFF
--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -621,6 +621,25 @@ PARTITION BY LIST COLUMNS(col1) (
 	tk.MustQuery(`select * from IDT_LP24306 where col1 not between 12021 and 99 and col1 <= -128`).Sort().Check(testkit.Rows("-128"))
 }
 
+func (s *testIntegrationPartitionSerialSuite) TestIssue27030(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk.MustExec("create database issue_27030")
+	tk.MustExec("use issue_27030")
+	tk.MustExec(`set tidb_enable_list_partition = 1`)
+	tk.MustExec(`CREATE TABLE PK_LCP9290 (
+  COL1 varbinary(10) NOT NULL,
+  PRIMARY KEY (COL1) /*T![clustered_index] NONCLUSTERED */
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin
+PARTITION BY LIST COLUMNS(col1) (
+  PARTITION P5 VALUES IN (x'32d8fb9da8b63508a6b8'),
+  PARTITION P6 VALUES IN (x'ffacadeb424179bc4b5c'),
+  PARTITION P8 VALUES IN (x'ae9f733168669fa900be')
+)`)
+	tk.MustExec(`insert into PK_LCP9290 values(0xffacadeb424179bc4b5c),(0xae9f733168669fa900be),(0x32d8fb9da8b63508a6b8)`)
+	tk.MustQuery(`SELECT COL1 FROM PK_LCP9290 WHERE COL1!=x'9f7ebdc957a36f2531b5' AND COL1 IN (x'ffacadeb424179bc4b5c',x'ae9f733168669fa900be',x'32d8fb9da8b63508a6b8')`).Sort().Check(testkit.Rows("2\xd8\xfb\x9d\xa8\xb65\b\xa6\xb8", "\xae\x9fs1hf\x9f\xa9\x00\xbe", "\xff\xac\xad\xebBAy\xbcK\\"))
+	tk.MustQuery(`SELECT COL1 FROM PK_LCP9290 WHERE COL1 IN (x'ffacadeb424179bc4b5c',x'ae9f733168669fa900be',x'32d8fb9da8b63508a6b8')`).Sort().Check(testkit.Rows("2\xd8\xfb\x9d\xa8\xb65\b\xa6\xb8", "\xae\x9fs1hf\x9f\xa9\x00\xbe", "\xff\xac\xad\xebBAy\xbcK\\"))
+}
+
 func genListPartition(begin, end int) string {
 	buf := &bytes.Buffer{}
 	buf.WriteString("(")

--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -839,6 +839,17 @@ func (lp *ForListColumnPruning) LocateRanges(sc *stmtctx.StatementContext, r *ra
 		return nil, errors.Trace(err)
 	}
 
+	if lp.ExprCol.GetType().EvalType() == types.ETString {
+		// for string type, values returned by GetMinValue and GetMaxValue are already encoded,
+		// so it's unnecessary to invoke genKey to encode them.
+		if r.LowVal[0].Kind() == types.KindMinNotNull {
+			lowKey = (&lowVal).GetBytes()
+		}
+		if r.HighVal[0].Kind() == types.KindMaxValue {
+			highKey = (&highVal).GetBytes()
+		}
+	}
+
 	if r.LowExclude {
 		lowKey = kv.Key(lowKey).PrefixNext()
 	}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27030 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: encode min/max varchar correctly when pruning list-column partitions

### What is changed and how it works?

When pruning list-column partitions for string type, if a range has the min/max value, the original procedure is:
```
mVal := GetMin/MaxValue(string-type)
key := genKey(mVal)
usedPartitions := pruner.Search(key)
```

but actually, values returned by GetMin/MaxValue for string type are already encoded, so it's wrong to invoke genKey to encode them again, and the correct procedure should be:
```
mVal := GetMin/MaxValue(string-type)
key := mVal.ConvertToBytes()
usedPartitions := pruner.Search(key)
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
planner: encode min/max varchar correctly when pruning list-column partitions
```
