### PR TITLE
br: tools uses the same version detecting mechanism

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -243,16 +243,16 @@ br_web:
 	@cd br/web && npm install && npm run build
 
 build_br:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(TOOL_LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) br/cmd/br/*.go
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(BR_BIN) br/cmd/br/*.go
 
 build_lightning_for_web:
-	CGO_ENABLED=1 $(GOBUILD) -tags dev $(RACE_FLAG) -ldflags '$(TOOL_LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) br/cmd/tidb-lightning/main.go
+	CGO_ENABLED=1 $(GOBUILD) -tags dev $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) br/cmd/tidb-lightning/main.go
 
 build_lightning:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(TOOL_LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) br/cmd/tidb-lightning/main.go
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_BIN) br/cmd/tidb-lightning/main.go
 
 build_lightning-ctl:
-	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(TOOL_LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_CTL_BIN) br/cmd/tidb-lightning-ctl/main.go
+	CGO_ENABLED=1 $(GOBUILD) $(RACE_FLAG) -ldflags '$(LDFLAGS) $(CHECK_FLAG)' -o $(LIGHTNING_CTL_BIN) br/cmd/tidb-lightning-ctl/main.go
 
 build_for_br_integration_test:
 	@make failpoint-enable

--- a/Makefile.common
+++ b/Makefile.common
@@ -87,24 +87,3 @@ LIGHTNING_BIN     := bin/tidb-lightning
 LIGHTNING_CTL_BIN := bin/tidb-lightning-ctl
 BR_BIN            := bin/br
 TEST_DIR          := /tmp/backup_restore_test
-
-TOOL_RELEASE_VERSION =
-ifeq ($(TOOL_RELEASE_VERSION),)
-        TOOL_RELEASE_VERSION := v4.0.0-dev
-        release_version_regex := ^v4\..*$$
-        release_branch_regex := "^release-[0-9]\.[0-9].*$$|^HEAD$$|^.*/*tags/v[0-9]\.[0-9]\..*$$"
-        ifneq ($(shell git rev-parse --abbrev-ref HEAD | egrep $(release_branch_regex)),)
-                # If we are in release branch, try to use tag version.
-                ifneq ($(shell git describe --tags --dirty | egrep $(release_version_regex)),)
-                        TOOL_RELEASE_VERSION := $(shell git describe --tags --dirty)
-                endif
-        else ifneq ($(shell git status --porcelain),)
-                # Add -dirty if the working tree is dirty for non release branch.
-                TOOL_RELEASE_VERSION := $(TOOL_RELEASE_VERSION)-dirty
-        endif
-endif
-
-TOOL_LDFLAGS += -X "$(BR_PKG)/pkg/version/build.ReleaseVersion=$(TOOL_RELEASE_VERSION)"
-TOOL_LDFLAGS += -X "$(BR_PKG)/pkg/version/build.BuildTS=$(shell date -u '+%Y-%m-%d %I:%M:%S')"
-TOOL_LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitHash=$(shell git rev-parse HEAD)"
-TOOL_LDFLAGS += -X "$(BR_PKG)/pkg/version/build.GitBranch=$(shell git rev-parse --abbrev-ref HEAD)"

--- a/br/pkg/version/build/info.go
+++ b/br/pkg/version/build/info.go
@@ -8,16 +8,18 @@ import (
 	"runtime"
 
 	"github.com/pingcap/log"
+	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/util/israce"
+	"github.com/pingcap/tidb/util/versioninfo"
 	"go.uber.org/zap"
 )
 
 // Version information.
 var (
-	ReleaseVersion = "v5.0.0-master"
-	BuildTS        = "None"
-	GitHash        = "None"
-	GitBranch      = "None"
+	ReleaseVersion = mysql.TiDBReleaseVersion
+	BuildTS        = versioninfo.TiDBBuildTS
+	GitHash        = versioninfo.TiDBGitHash
+	GitBranch      = versioninfo.TiDBGitBranch
 	goVersion      = runtime.Version()
 )
 


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

Merge the build environment detect mechanism between TiDB and BR.

### What is changed and how it works?

What's Changed: `TOOLS_LDFLAG` has been removed, and BR detect the build context via `mysql.TiDBReleaseVersion` and package `versioninfo`.  

How it Works: (omitted)

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
<img width="1584" alt="image" src="https://user-images.githubusercontent.com/36239017/128821164-2d754605-4da6-4b4e-9201-55f4a2547659.png">
<img width="607" alt="image" src="https://user-images.githubusercontent.com/36239017/128821316-8c594490-bba1-4c62-bfb4-22574d6433fe.png">
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->
(For the external viewers, tools should ALWAYS share the same version with TiDB.)
```release-note
None
```
