### PR TITLE
br: add cleanup meta in lightning-ctl

### DIFF
--- a/br/pkg/lightning/common/util.go
+++ b/br/pkg/lightning/common/util.go
@@ -317,6 +317,21 @@ func InterpolateMySQLString(s string) string {
 	return builder.String()
 }
 
+// TableExists return whether table with specified name exists in target db
+func TableExists(ctx context.Context, db *sql.DB, schema, table string) (bool, error) {
+	query := "SELECT 1 from INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ?"
+	var exist string
+	err := db.QueryRowContext(ctx, query, schema, table).Scan(&exist)
+	switch {
+	case err == nil:
+		return true, nil
+	case err == sql.ErrNoRows:
+		return false, nil
+	default:
+		return false, errors.Annotatef(err, "check table exists failed")
+	}
+}
+
 // GetJSON fetches a page and parses it as JSON. The parsed result will be
 // stored into the `v`. The variable `v` must be a pointer to a type that can be
 // unmarshalled from JSON.

--- a/br/pkg/lightning/restore/meta_manager_test.go
+++ b/br/pkg/lightning/restore/meta_manager_test.go
@@ -65,7 +65,7 @@ func (s *metaMgrSuite) SetUpTest(c *C) {
 		session:      db,
 		taskID:       1,
 		tr:           s.tr,
-		tableName:    common.UniqueTable("test", tableMetaTableName),
+		tableName:    common.UniqueTable("test", TableMetaTableName),
 		needChecksum: true,
 	}
 	s.mockDB = m

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -77,8 +77,8 @@ const (
 )
 
 const (
-	taskMetaTableName  = "task_meta"
-	tableMetaTableName = "table_meta"
+	TaskMetaTableName  = "task_meta"
+	TableMetaTableName = "table_meta"
 	// CreateTableMetadataTable stores the per-table sub jobs information used by TiDB Lightning
 	CreateTableMetadataTable = `CREATE TABLE IF NOT EXISTS %s (
 		task_id 			BIGINT(20) UNSIGNED,


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

### What is changed and how it works?
Try to cleanup meta table data in `checkpoint-remove`, `checkpoint-ignore` and `checkpoint-destroy`. In these three command, first try to cleanup target table metas, and if all table metas are cleaned, will then drop the meta schema.

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
Side effects

Documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Cleanup lightning metadata when cleanup checkpoint with lightning-ctl
```
