### PR TITLE
planner: support expression index for view

### DIFF
--- a/cmd/explaintest/r/explain_easy.result
+++ b/cmd/explaintest/r/explain_easy.result
@@ -500,8 +500,8 @@ PRIMARY KEY (`id`)
 explain format = 'brief' SELECT COUNT(1) FROM (SELECT COALESCE(b.region_name, '不详') region_name, SUM(a.registration_num) registration_num FROM (SELECT stat_date, show_date, region_id, 0 registration_num FROM test01 WHERE period = 1 AND stat_date >= 20191202 AND stat_date <= 20191202 UNION ALL SELECT stat_date, show_date, region_id, registration_num registration_num FROM test01 WHERE period = 1 AND stat_date >= 20191202 AND stat_date <= 20191202) a LEFT JOIN test02 b ON a.region_id = b.id WHERE registration_num > 0 AND a.stat_date >= '20191202' AND a.stat_date <= '20191202' GROUP BY a.stat_date , a.show_date , COALESCE(b.region_name, '不详') ) JLS;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:count(1)->Column#22
-└─HashAgg	8000.00	root		group by:Column#32, Column#33, Column#34, funcs:count(1)->Column#31
-  └─Projection	10000.01	root		Column#14, Column#15, coalesce(test.test02.region_name, 不详)->Column#34
+└─HashAgg	8000.00	root		group by:Column#31, Column#32, Column#33, funcs:count(1)->Column#30
+  └─Projection	10000.01	root		Column#14, Column#15, coalesce(test.test02.region_name, 不详)->Column#33
     └─HashJoin	10000.01	root		left outer join, equal:[eq(Column#16, test.test02.id)]
       ├─TableReader(Build)	10000.00	root		data:TableFullScan
       │ └─TableFullScan	10000.00	cop[tikv]	table:b	keep order:false, stats:pseudo

--- a/cmd/explaintest/r/explain_generate_column_substitute.result
+++ b/cmd/explaintest/r/explain_generate_column_substitute.result
@@ -456,3 +456,36 @@ HashAgg	6.00	root		group by:Column#9, funcs:max(Column#8)->Column#7
 └─Projection	6.00	root		upper(test.t.b)->Column#8, upper(test.t.b)->Column#9
   └─TableReader	6.00	root		data:TableFullScan
     └─TableFullScan	6.00	cop[tikv]	table:t	keep order:false
+drop table if exists t, t1;
+create table t(a int, b int, key((b+1)), key((b+1), a));
+create table t1(a int, b int, key((b+1)), key((b+1), a));
+insert into t values (1, 2), (3, 4), (0, NULL), (12, 34);
+insert into t1 values (1, 2), (3, 4), (0, NULL);
+analyze table t;
+analyze table t1;
+create view vx as select * from t;
+desc format = 'brief' select * from vx where b+1 = 100;
+id	estRows	task	access object	operator info
+Projection	0.00	root		test.t.a, test.t.b
+└─IndexLookUp	0.00	root		
+  ├─IndexRangeScan(Build)	0.00	cop[tikv]	table:t, index:expression_index(`b` + 1)	range:[100,100], keep order:false
+  └─TableRowIDScan(Probe)	0.00	cop[tikv]	table:t	keep order:false
+select * from vx where b+1 = 3;
+a	b
+1	2
+create view vx2 as select t1.b+1 from t , t1 where t.b+1>=t1.b+1 and t.b+1>=2;
+desc format = 'brief' select * from vx2;
+id	estRows	task	access object	operator info
+Projection	6.00	root		plus(test.t1.b, 1)
+└─HashJoin	6.00	root		CARTESIAN inner join, other cond:ge(plus(test.t.b, 1), plus(test.t1.b, 1))
+  ├─IndexReader(Build)	2.00	root		index:IndexFullScan
+  │ └─IndexFullScan	2.00	cop[tikv]	table:t1, index:expression_index(`b` + 1)	keep order:false
+  └─IndexReader(Probe)	3.00	root		index:IndexRangeScan
+    └─IndexRangeScan	3.00	cop[tikv]	table:t, index:expression_index(`b` + 1)	range:[2,+inf], keep order:false
+select * from vx2;
+t1.b+1
+3
+5
+3
+5
+3

--- a/cmd/explaintest/t/explain_generate_column_substitute.test
+++ b/cmd/explaintest/t/explain_generate_column_substitute.test
@@ -192,3 +192,17 @@ desc format = 'brief' select count(upper(b)) from t group by upper(b);
 desc format = 'brief' select max(upper(b)) from t group by upper(b);
 desc format = 'brief' select count(upper(b)) from t use index() group by upper(b);
 desc format = 'brief' select max(upper(b)) from t use index() group by upper(b);
+
+drop table if exists t, t1;
+create table t(a int, b int, key((b+1)), key((b+1), a));
+create table t1(a int, b int, key((b+1)), key((b+1), a));
+insert into t values (1, 2), (3, 4), (0, NULL), (12, 34);
+insert into t1 values (1, 2), (3, 4), (0, NULL);
+analyze table t;
+analyze table t1;
+create view vx as select * from t;
+desc format = 'brief' select * from vx where b+1 = 100;
+select * from vx where b+1 = 3;
+create view vx2 as select t1.b+1 from t , t1 where t.b+1>=t1.b+1 and t.b+1>=2;
+desc format = 'brief' select * from vx2;
+select * from vx2;

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -926,7 +926,7 @@ func (s *testPlanSuite) TestAggPrune(c *C) {
 		p, _, err := BuildLogicalPlan(ctx, s.ctx, stmt, s.is)
 		c.Assert(err, IsNil)
 
-		p, err = logicalOptimize(context.TODO(), flagPredicatePushDown|flagPrunColumns|flagPrunColumnsAgain|flagBuildKeyInfo|flagEliminateAgg|flagEliminateProjection, p.(LogicalPlan))
+		p, err = logicalOptimize(context.TODO(), flagPredicatePushDown|flagPrunColumns|flagPrunColumnsAgain|flagBuildKeyInfo|flagEliminateAgg|flagEliminateProjection|flagEliminateProjectionAgain, p.(LogicalPlan))
 		c.Assert(err, IsNil)
 		planString := ToString(p)
 		s.testData.OnRecord(func() {

--- a/planner/core/logical_plan_test.go
+++ b/planner/core/logical_plan_test.go
@@ -1410,6 +1410,9 @@ func (s *testPlanSuite) TestUnion(c *C) {
 		}
 		c.Assert(err, IsNil)
 		p := plan.(LogicalPlan)
+		if builder.optFlag&flagEliminateProjection > 0 && builder.optFlag-flagEliminateProjection > flagEliminateProjection {
+			builder.optFlag |= flagEliminateProjectionAgain
+		}
 		p, err = logicalOptimize(ctx, builder.optFlag, p)
 		s.testData.OnRecord(func() {
 			output[i].Best = ToString(p)
@@ -1510,6 +1513,9 @@ func (s *testPlanSuite) TestOuterJoinEliminator(c *C) {
 		builder, _ := NewPlanBuilder().Init(MockContext(), s.is, &hint.BlockHintProcessor{})
 		p, err := builder.Build(ctx, stmt)
 		c.Assert(err, IsNil)
+		if builder.optFlag&flagEliminateProjection > 0 && builder.optFlag-flagEliminateProjection > flagEliminateProjection {
+			builder.optFlag |= flagEliminateProjectionAgain
+		}
 		p, err = logicalOptimize(ctx, builder.optFlag, p.(LogicalPlan))
 		c.Assert(err, IsNil)
 		planString := ToString(p)
@@ -1629,6 +1635,9 @@ func (s *testPlanSuite) optimize(ctx context.Context, sql string) (PhysicalPlan,
 	p, err := builder.Build(ctx, stmt)
 	if err != nil {
 		return nil, nil, err
+	}
+	if builder.optFlag&flagEliminateProjection > 0 && builder.optFlag-flagEliminateProjection > flagEliminateProjection {
+		builder.optFlag |= flagEliminateProjectionAgain
 	}
 	p, err = logicalOptimize(ctx, builder.optFlag, p.(LogicalPlan))
 	if err != nil {


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Support expression index for view

### What is changed and how it works?

Before use gcsubsitute to change expression, do projectionElimcate.
Then the extra projection added by view would be removed.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
support expression index for view
```
