### PR TITLE
planner: refine prefer-range-scan behavior

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -539,6 +539,16 @@ func (s *testSerialSuite1) TestSetVar(c *C) {
 	tk.MustExec(`set tidb_opt_limit_push_down_threshold = 20`)
 	tk.MustQuery(`select @@global.tidb_opt_limit_push_down_threshold`).Check(testkit.Rows("100"))
 	tk.MustQuery(`select @@tidb_opt_limit_push_down_threshold`).Check(testkit.Rows("20"))
+
+	tk.MustQuery("select @@tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
+	tk.MustExec("set global tidb_opt_prefer_range_scan = 1")
+	tk.MustQuery("select @@global.tidb_opt_prefer_range_scan").Check(testkit.Rows("1"))
+	tk.MustExec("set global tidb_opt_prefer_range_scan = 0")
+	tk.MustQuery("select @@global.tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
+	tk.MustExec("set session tidb_opt_prefer_range_scan = 1")
+	tk.MustQuery("select @@session.tidb_opt_prefer_range_scan").Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_opt_prefer_range_scan = 0")
+	tk.MustQuery("select @@session.tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
 }
 
 func (s *testSuite5) TestTruncateIncorrectIntSessionVar(c *C) {

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -184,7 +184,7 @@ func (p *PhysicalIndexScan) isFullScan() bool {
 		return false
 	}
 	for _, ran := range p.Ranges {
-		if !ran.IsFullRange() {
+		if !ran.IsFullRange(false) {
 			return false
 		}
 	}
@@ -322,7 +322,13 @@ func (p *PhysicalTableScan) isFullScan() bool {
 		return false
 	}
 	for _, ran := range p.Ranges {
-		if !ran.IsFullRange() {
+		var unsignedIntHandle bool
+		if p.Table.PKIsHandle {
+			if pkColInfo := p.Table.GetPkColInfo(); pkColInfo != nil {
+				unsignedIntHandle = mysql.HasUnsignedFlag(pkColInfo.Flag)
+			}
+		}
+		if !ran.IsFullRange(unsignedIntHandle) {
 			return false
 		}
 	}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -4201,3 +4201,27 @@ func (s *testIntegrationSuite) TestOutputSkylinePruningInfo(c *C) {
 		tk.MustQuery("show warnings").Check(testkit.Rows(output[i].Warnings...))
 	}
 }
+
+func (s *testIntegrationSuite) TestPreferRangeScanForUnsignedIntHandle(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int unsigned primary key, b int, c int, index idx_b(b))")
+
+	var input []string
+	var output []struct {
+		SQL      string
+		Plan     []string
+		Warnings []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			output[i].Warnings = s.testData.ConvertRowsToStrings(tk.MustQuery("show warnings").Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+		tk.MustQuery("show warnings").Check(testkit.Rows(output[i].Warnings...))
+	}
+}

--- a/planner/core/testdata/integration_partition_suite_out.json
+++ b/planner/core/testdata/integration_partition_suite_out.json
@@ -1021,11 +1021,11 @@
         ]
       },
       {
-        "SQL": "create table tto_seconds (a date, b datetime) partition by list (TO_SECONDS(a)) (partition p0 values in (0, 1, 2, 3, 63745012800), partition p1 values in (4, 5, 6, 7, 63744969600))",
+        "SQL": "create table tto_seconds (a date, b datetime) partition by list (TO_SECONDS(a)) (partition p0 values in (0, 1, 2, 3, 63740649600), partition p1 values in (4, 5, 6, 7, 63744969600))",
         "Results": null
       },
       {
-        "SQL": "insert into tto_seconds values ('2019-12-31 12:00:00', '2019-12-31 23:59:59'), ('2019-12-31 23:06:59', '2019-12-31 12:00:00')",
+        "SQL": "insert into tto_seconds values ('2019-12-31 12:00:00', '2019-12-31 23:59:59'), ('2019-11-11 23:06:59', '2019-12-31 12:00:00')",
         "Results": null
       },
       {

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -341,5 +341,14 @@
       "select * from t where g = 5 order by f",
       "select * from t where d = 3 order by c, e"
     ]
+  },
+  {
+    "name": "TestPreferRangeScanForUnsignedIntHandle",
+    "cases": [
+      "set tidb_opt_prefer_range_scan = 0",
+      "explain format = 'verbose' select * from t where b > 5",
+      "set tidb_opt_prefer_range_scan = 1",
+      "explain format = 'verbose' select * from t where b > 5"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -347,8 +347,12 @@
     "cases": [
       "set tidb_opt_prefer_range_scan = 0",
       "explain format = 'verbose' select * from t where b > 5",
+      "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+      "explain format = 'verbose' select * from t where b = 6 limit 1",
       "set tidb_opt_prefer_range_scan = 1",
-      "explain format = 'verbose' select * from t where b > 5"
+      "explain format = 'verbose' select * from t where b > 5",
+      "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+      "explain format = 'verbose' select * from t where b = 6 limit 1"
     ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -1824,6 +1824,27 @@
         "Warnings": null
       },
       {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+        "Plan": [
+          "TopN_9 1.00 72.74 root  test.t.a, offset:0, count:1",
+          "└─IndexLookUp_20 1.00 69.74 root  ",
+          "  ├─TopN_19(Build) 1.00 0.00 cop[tikv]  test.t.a, offset:0, count:1",
+          "  │ └─IndexRangeScan_17 10.00 590.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_18(Probe) 1.00 590.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": null
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 limit 1",
+        "Plan": [
+          "IndexLookUp_17 1.00 33.54 root  limit embedded(offset:0, count:1)",
+          "├─Limit_16(Build) 1.00 77.00 cop[tikv]  offset:0, count:1",
+          "│ └─IndexRangeScan_14 1.00 77.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_15(Probe) 1.00 77.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": null
+      },
+      {
         "SQL": "set tidb_opt_prefer_range_scan = 1",
         "Plan": null,
         "Warnings": null
@@ -1831,12 +1852,37 @@
       {
         "SQL": "explain format = 'verbose' select * from t where b > 5",
         "Plan": [
-          "IndexLookUp_7 3333.33 70785.94 root ",
+          "IndexLookUp_7 3333.33 70785.94 root  ",
           "├─IndexRangeScan_5(Build) 3333.33 190020.00 cop[tikv] table:t, index:idx_b(b) range:(5,+inf], keep order:false, stats:pseudo",
           "└─TableRowIDScan_6(Probe) 3333.33 190020.00 cop[tikv] table:t keep order:false, stats:pseudo"
         ],
         "Warnings": [
           "Note 1105 [idx_b] remain after pruning paths for t given Prop{SortItems: [], TaskTp: rootTask}"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+        "Plan": [
+          "TopN_9 1.00 72.74 root  test.t.a, offset:0, count:1",
+          "└─IndexLookUp_16 1.00 69.74 root  ",
+          "  ├─TopN_15(Build) 1.00 0.00 cop[tikv]  test.t.a, offset:0, count:1",
+          "  │ └─IndexRangeScan_13 10.00 590.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false, stats:pseudo",
+          "  └─TableRowIDScan_14(Probe) 1.00 590.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": [
+          "Note 1105 [idx_b] remain after pruning paths for t given Prop{SortItems: [], TaskTp: copDoubleReadTask}"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 limit 1",
+        "Plan": [
+          "IndexLookUp_13 1.00 33.54 root  limit embedded(offset:0, count:1)",
+          "├─Limit_12(Build) 1.00 77.00 cop[tikv]  offset:0, count:1",
+          "│ └─IndexRangeScan_10 1.00 77.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_11(Probe) 1.00 77.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": [
+          "Note 1105 [idx_b] remain after pruning paths for t given Prop{SortItems: [], TaskTp: copDoubleReadTask}"
         ]
       }
     ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -1805,5 +1805,40 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestPreferRangeScanForUnsignedIntHandle",
+    "Cases": [
+      {
+        "SQL": "set tidb_opt_prefer_range_scan = 0",
+        "Plan": null,
+        "Warnings": null
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b > 5",
+        "Plan": [
+          "TableReader_7 3333.33 45418.00 root  data:Selection_6",
+          "└─Selection_6 3333.33 600020.00 cop[tikv]  gt(test.t.b, 5)",
+          "  └─TableFullScan_5 10000.00 570020.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": null
+      },
+      {
+        "SQL": "set tidb_opt_prefer_range_scan = 1",
+        "Plan": null,
+        "Warnings": null
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b > 5",
+        "Plan": [
+          "IndexLookUp_7 3333.33 70785.94 root ",
+          "├─IndexRangeScan_5(Build) 3333.33 190020.00 cop[tikv] table:t, index:idx_b(b) range:(5,+inf], keep order:false, stats:pseudo",
+          "└─TableRowIDScan_6(Probe) 3333.33 190020.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        ],
+        "Warnings": [
+          "Note 1105 [idx_b] remain after pruning paths for t given Prop{SortItems: [], TaskTp: rootTask}"
+        ]
+      }
+    ]
   }
 ]

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -921,7 +921,7 @@ var defaultSysVars = []*SysVar{
 		s.SetAllowInSubqToJoinAndAgg(TiDBOptOn(val))
 		return nil
 	}},
-	{Scope: ScopeSession, Name: TiDBOptPreferRangeScan, Value: BoolToOnOff(DefOptPreferRangeScan), Type: TypeBool, IsHintUpdatable: true, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBOptPreferRangeScan, Value: BoolToOnOff(DefOptPreferRangeScan), Type: TypeBool, IsHintUpdatable: true, SetSession: func(s *SessionVars, val string) error {
 		s.SetAllowPreferRangeScan(TiDBOptOn(val))
 		return nil
 	}},

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -106,7 +106,15 @@ func (ran *Range) IsPointNullable(sc *stmtctx.StatementContext) bool {
 }
 
 // IsFullRange check if the range is full scan range
-func (ran *Range) IsFullRange() bool {
+func (ran *Range) IsFullRange(unsignedIntHandle bool) bool {
+	if unsignedIntHandle {
+		if len(ran.LowVal) != 1 || len(ran.HighVal) != 1 {
+			return false
+		}
+		lowValRawString := formatDatum(ran.LowVal[0], true)
+		highValRawString := formatDatum(ran.HighVal[0], false)
+		return lowValRawString == "0" && highValRawString == "+inf"
+	}
 	if len(ran.LowVal) != len(ran.HighVal) {
 		return false
 	}
@@ -123,9 +131,9 @@ func (ran *Range) IsFullRange() bool {
 }
 
 // HasFullRange checks if any range in the slice is a full range.
-func HasFullRange(ranges []*Range) bool {
+func HasFullRange(ranges []*Range, unsignedIntHandle bool) bool {
 	for _, ran := range ranges {
-		if ran.IsFullRange() {
+		if ran.IsFullRange(unsignedIntHandle) {
 			return true
 		}
 	}

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -136,14 +136,16 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 	nullDatum := types.MinNotNullDatum()
 	nullDatum.SetNull()
 	isFullRangeTests := []struct {
-		ran         ranger.Range
-		isFullRange bool
+		ran               ranger.Range
+		unsignedIntHandle bool
+		isFullRange       bool
 	}{
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(math.MinInt64)},
 				HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)},
 			},
+			unsignedIntHandle: false,
 			isFullRange: true,
 		},
 		{
@@ -151,6 +153,7 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 				LowVal:  []types.Datum{types.NewIntDatum(math.MaxInt64)},
 				HighVal: []types.Datum{types.NewIntDatum(math.MinInt64)},
 			},
+			unsignedIntHandle: false,
 			isFullRange: false,
 		},
 		{
@@ -158,6 +161,7 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 			},
+			unsignedIntHandle: false,
 			isFullRange: false,
 		},
 		{
@@ -165,6 +169,7 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 				LowVal:  []types.Datum{*nullDatum.Clone()},
 				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 			},
+			unsignedIntHandle: false,
 			isFullRange: true,
 		},
 		{
@@ -172,6 +177,7 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 				LowVal:  []types.Datum{*nullDatum.Clone()},
 				HighVal: []types.Datum{*nullDatum.Clone()},
 			},
+			unsignedIntHandle: false,
 			isFullRange: false,
 		},
 		{
@@ -179,10 +185,19 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 				LowVal:  []types.Datum{types.MinNotNullDatum()},
 				HighVal: []types.Datum{types.MaxValueDatum()},
 			},
+			unsignedIntHandle: false,
+			isFullRange: true,
+		},
+		{
+			ran: ranger.Range{
+				LowVal:  []types.Datum{types.NewUintDatum(0)},
+				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
+			},
+			unsignedIntHandle: true,
 			isFullRange: true,
 		},
 	}
 	for _, t := range isFullRangeTests {
-		c.Assert(t.ran.IsFullRange(), Equals, t.isFullRange)
+		c.Assert(t.ran.IsFullRange(t.unsignedIntHandle), Equals, t.isFullRange)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

1. Refine `IsFullRange` check. The full range of the unsigned int handle table scan is `[0, +inf]`, which is regarded as not full range by `IsFullRange`. The PR fixes it.
2. Before the PR, prefer-range-scan only removes the first full scan path if some range scan path exists. After the PR, prefer-range-scan removes all the full scan paths if some range scan path exists (TiFlash path or hint-indicated path will not be removed).
3. Set `tidb_opt_prefer_range_scan` as global/session switch.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
