### PR TITLE
privilege_test: add ignore for goroutines leak

### DIFF
--- a/privilege/privileges/main_test.go
+++ b/privilege/privileges/main_test.go
@@ -25,6 +25,8 @@ func TestMain(m *testing.M) {
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+		goleak.IgnoreTopFunction("net/http.(*persistConn).writeLoop"),
+		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),
 	}
 	testbridge.WorkaroundGoCheckFlags()
 


### PR DESCRIPTION


### What problem does this PR solve?

Problem Summary:

The PR https://github.com/pingcap/tidb/pull/26991 introduced a regression, where at least on my local machine the privilege test suite can no longer run.

This provides a workaround so that it can run again.

### What is changed and how it works?

What's Changed:

Change in tests only.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code (tests only)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
