### PR TITLE
server: replace `ioutil.TempDir` by `os.MkdirTemp`

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -25,7 +25,6 @@ import (
 	"database/sql"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net/http"
 	"os"
@@ -461,7 +460,7 @@ func (ts *tidbTestSuite) TestSocket(c *C) {
 
 func (ts *tidbTestSuite) TestSocketAndIp(c *C) {
 	osTempDir := os.TempDir()
-	tempDir, err := ioutil.TempDir(osTempDir, "tidb-test.*.socket")
+	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	c.Assert(err, IsNil)
 	socketFile := tempDir + "/tidbtest.sock" // Unix Socket does not work on Windows, so '/' should be OK
 	defer os.RemoveAll(tempDir)
@@ -619,7 +618,7 @@ func (ts *tidbTestSuite) TestSocketAndIp(c *C) {
 // TestOnlySocket for server configuration without network interface for mysql clients
 func (ts *tidbTestSuite) TestOnlySocket(c *C) {
 	osTempDir := os.TempDir()
-	tempDir, err := ioutil.TempDir(osTempDir, "tidb-test.*.socket")
+	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	c.Assert(err, IsNil)
 	socketFile := tempDir + "/tidbtest.sock" // Unix Socket does not work on Windows, so '/' should be OK
 	defer os.RemoveAll(tempDir)


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

Replace deprecated `ioutil.Tempdir` with `os.MkdirTemp`, see also https://golang.org/doc/go1.16#ioutil

### Release note

```release-note
None
```
