### PR TITLE
planner: remove unused field in PhysicalTableScan

### DIFF
--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -246,20 +246,6 @@ func (p *PhysicalTableScan) AccessObject(normalized bool) string {
 // OperatorInfo implements dataAccesser interface.
 func (p *PhysicalTableScan) OperatorInfo(normalized bool) string {
 	var buffer strings.Builder
-	for i, pkCol := range p.PkCols {
-		switch i {
-		case 0:
-			buffer.WriteString("pk cols: (")
-			buffer.WriteString(pkCol.ExplainInfo())
-			buffer.WriteString(", ")
-		case len(p.PkCols) - 1:
-			buffer.WriteString(pkCol.ExplainInfo())
-			buffer.WriteString(")")
-		default:
-			buffer.WriteString(pkCol.ExplainInfo())
-			buffer.WriteString(", ")
-		}
-	}
 	if len(p.rangeDecidedBy) > 0 {
 		buffer.WriteString("range: decided by [")
 		for i, rangeDecidedBy := range p.rangeDecidedBy {

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -452,7 +452,6 @@ type PhysicalTableScan struct {
 	Columns []*model.ColumnInfo
 	DBName  model.CIStr
 	Ranges  []*ranger.Range
-	PkCols  []*expression.Column
 
 	TableAsName *model.CIStr
 
@@ -503,7 +502,6 @@ func (ts *PhysicalTableScan) Clone() (PhysicalPlan, error) {
 	}
 	clonedScan.Columns = cloneColInfos(ts.Columns)
 	clonedScan.Ranges = cloneRanges(ts.Ranges)
-	clonedScan.PkCols = cloneCols(ts.PkCols)
 	clonedScan.TableAsName = ts.TableAsName
 	if ts.Hist != nil {
 		clonedScan.Hist = ts.Hist.Copy()

--- a/planner/core/planbuilder_test.go
+++ b/planner/core/planbuilder_test.go
@@ -232,7 +232,6 @@ func (s *testPlanBuilderSuite) TestPhysicalPlanClone(c *C) {
 	tableScan := &PhysicalTableScan{
 		AccessCondition: []expression.Expression{col, cst},
 		Table:           tblInfo,
-		PkCols:          []*expression.Column{col},
 		Hist:            hist,
 	}
 	tableScan = tableScan.Init(ctx, 0)


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/27190 <!-- REMOVE this line if no issue to close -->

Problem Summary: Since the primary key columns can be found in table schema, let's remove this field in `OperatorInfo`.

### What is changed and how it works?

NA

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None.
```
