### PR TITLE
distsql: fix goroutine/memory leak for streaming when query is cancelled

### DIFF
--- a/distsql/stream.go
+++ b/distsql/stream.go
@@ -170,5 +170,8 @@ func (r *streamResult) Close() error {
 		metrics.DistSQLScanKeysHistogram.Observe(float64(r.feedback.Actual()))
 	}
 	metrics.DistSQLPartialCountHistogram.Observe(float64(r.partialCount))
+	if r.resp != nil {
+		return r.resp.Close()
+	}
 	return nil
 }


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Close https://github.com/pingcap/tidb/issues/27353

### What is changed and how it works?

It's was caused by `streamResult.Close` doesn't close the `kv.Response`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Manual test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
