### PR TITLE
lightning: auto adjust region-split-size

### DIFF
--- a/br/cmd/tidb-lightning-ctl/main.go
+++ b/br/cmd/tidb-lightning-ctl/main.go
@@ -438,7 +438,7 @@ func importEngine(ctx context.Context, cfg *config.Config, tls *common.TLS, engi
 		return errors.Trace(err)
 	}
 
-	return errors.Trace(ce.Import(ctx))
+	return errors.Trace(ce.Import(ctx, int64(cfg.TikvImporter.RegionSplitSize)))
 }
 
 func cleanupEngine(ctx context.Context, cfg *config.Config, tls *common.TLS, engine string) error {

--- a/br/pkg/lightning/backend/importer/importer.go
+++ b/br/pkg/lightning/backend/importer/importer.go
@@ -201,7 +201,7 @@ func (importer *importer) Flush(_ context.Context, _ uuid.UUID) error {
 	return nil
 }
 
-func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID) error {
+func (importer *importer) ImportEngine(ctx context.Context, engineUUID uuid.UUID, _ int64) error {
 	importer.lock.Lock()
 	defer importer.lock.Unlock()
 	req := &import_kvpb.ImportEngineRequest{

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -939,12 +939,6 @@ func NewLocalBackend(
 		}
 	}
 
-	regionSplitSize := int64(cfg.RegionSplitSize)
-	regionSplitKeys := int64(regionMaxKeyCount)
-	if regionSplitSize > defaultRegionSplitSize {
-		regionSplitKeys = int64(float64(regionSplitSize) / float64(defaultRegionSplitSize) * float64(regionMaxKeyCount))
-	}
-
 	local := &local{
 		engines:  sync.Map{},
 		pdCtl:    pdCtl,
@@ -953,10 +947,7 @@ func NewLocalBackend(
 		pdAddr:   pdAddr,
 		g:        g,
 
-		localStoreDir:   localFile,
-		regionSplitSize: regionSplitSize,
-		regionSplitKeys: regionSplitKeys,
-
+		localStoreDir:     localFile,
 		rangeConcurrency:  worker.NewPool(ctx, rangeConcurrency, "range"),
 		ingestConcurrency: worker.NewPool(ctx, rangeConcurrency*2, "ingest"),
 		tcpConcurrency:    rangeConcurrency,
@@ -1185,11 +1176,6 @@ func (local *local) RetryImportDelay() time.Duration {
 	return defaultRetryBackoffTime
 }
 
-func (local *local) MaxChunkSize() int {
-	// a batch size write to leveldb
-	return int(local.regionSplitSize)
-}
-
 func (local *local) ShouldPostProcess() bool {
 	return true
 }
@@ -1365,6 +1351,7 @@ func (local *local) WriteToTiKV(
 	engineFile *File,
 	region *split.RegionInfo,
 	start, end []byte,
+	regionSplitSize int64,
 ) ([]*sst.SSTMeta, Range, rangeStats, error) {
 	for _, peer := range region.Region.GetPeers() {
 		var e error
@@ -1463,7 +1450,7 @@ func (local *local) WriteToTiKV(
 	size := int64(0)
 	totalCount := int64(0)
 	firstLoop := true
-	regionMaxSize := local.regionSplitSize * 4 / 3
+	regionMaxSize := regionSplitSize * 4 / 3
 
 	for iter.First(); iter.Valid(); iter.Next() {
 		size += int64(len(iter.Key()) + len(iter.Value()))
@@ -1492,7 +1479,7 @@ func (local *local) WriteToTiKV(
 			bytesBuf.Reset()
 			firstLoop = false
 		}
-		if size >= regionMaxSize || totalCount >= local.regionSplitKeys {
+		if size >= regionMaxSize {
 			break
 		}
 	}
@@ -1624,7 +1611,7 @@ func splitRangeBySizeProps(fullRange Range, sizeProps *sizeProperties, sizeLimit
 	return ranges
 }
 
-func (local *local) readAndSplitIntoRange(ctx context.Context, engineFile *File) ([]Range, error) {
+func (local *local) readAndSplitIntoRange(ctx context.Context, engineFile *File, regionSplitSize int64, regionSplitKeys int64) ([]Range, error) {
 	iter := newKeyIter(ctx, engineFile, &pebble.IterOptions{})
 	defer iter.Close()
 
@@ -1653,7 +1640,7 @@ func (local *local) readAndSplitIntoRange(ctx context.Context, engineFile *File)
 	engineFileLength := engineFile.Length.Load()
 
 	// <= 96MB no need to split into range
-	if engineFileTotalSize <= local.regionSplitSize && engineFileLength <= local.regionSplitKeys {
+	if engineFileTotalSize <= regionSplitSize && engineFileLength <= regionSplitKeys {
 		ranges := []Range{{start: firstKey, end: endKey}}
 		return ranges, nil
 	}
@@ -1664,7 +1651,7 @@ func (local *local) readAndSplitIntoRange(ctx context.Context, engineFile *File)
 	}
 
 	ranges := splitRangeBySizeProps(Range{start: firstKey, end: endKey}, sizeProps,
-		local.regionSplitSize, local.regionSplitKeys)
+		regionSplitSize, regionSplitKeys)
 
 	log.L().Info("split engine key ranges", zap.Stringer("engine", engineFile.UUID),
 		zap.Int64("totalSize", engineFileTotalSize), zap.Int64("totalCount", engineFileLength),
@@ -1678,6 +1665,7 @@ func (local *local) writeAndIngestByRange(
 	ctxt context.Context,
 	engineFile *File,
 	start, end []byte,
+	regionSplitSize int64,
 ) error {
 	ito := &pebble.IterOptions{
 		LowerBound: start,
@@ -1736,7 +1724,7 @@ WriteAndIngest:
 				zap.Binary("end", region.Region.GetEndKey()), zap.Reflect("peers", region.Region.GetPeers()))
 
 			w := local.ingestConcurrency.Apply()
-			err = local.writeAndIngestPairs(ctx, engineFile, region, pairStart, end)
+			err = local.writeAndIngestPairs(ctx, engineFile, region, pairStart, end, regionSplitSize)
 			local.ingestConcurrency.Recycle(w)
 			if err != nil {
 				if common.IsContextCanceledError(err) {
@@ -1774,6 +1762,7 @@ func (local *local) writeAndIngestPairs(
 	engineFile *File,
 	region *split.RegionInfo,
 	start, end []byte,
+	regionSplitSize int64,
 ) error {
 	var err error
 
@@ -1782,7 +1771,7 @@ loopWrite:
 		var metas []*sst.SSTMeta
 		var finishedRange Range
 		var rangeStats rangeStats
-		metas, finishedRange, rangeStats, err = local.WriteToTiKV(ctx, engineFile, region, start, end)
+		metas, finishedRange, rangeStats, err = local.WriteToTiKV(ctx, engineFile, region, start, end, regionSplitSize)
 		if err != nil {
 			if common.IsContextCanceledError(err) {
 				return err
@@ -1889,7 +1878,7 @@ loopWrite:
 	return errors.Trace(err)
 }
 
-func (local *local) writeAndIngestByRanges(ctx context.Context, engineFile *File, ranges []Range) error {
+func (local *local) writeAndIngestByRanges(ctx context.Context, engineFile *File, ranges []Range, regionSplitKeys int64) error {
 	if engineFile.Length.Load() == 0 {
 		// engine is empty, this is likes because it's a index engine but the table contains no index
 		log.L().Info("engine contains no data", zap.Stringer("uuid", engineFile.UUID))
@@ -1921,7 +1910,7 @@ func (local *local) writeAndIngestByRanges(ctx context.Context, engineFile *File
 			// max retry backoff time: 2+4+8+16=30s
 			backOffTime := time.Second
 			for i := 0; i < maxRetryTimes; i++ {
-				err = local.writeAndIngestByRange(ctx, engineFile, startKey, endKey)
+				err = local.writeAndIngestByRange(ctx, engineFile, startKey, endKey, regionSplitKeys)
 				if err == nil || common.IsContextCanceledError(err) {
 					return
 				}
@@ -1967,7 +1956,7 @@ func (r *syncedRanges) reset() {
 	r.Unlock()
 }
 
-func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID) error {
+func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID, regionSplitSize int64) error {
 	lf := local.lockEngine(engineUUID, importMutexStateImport)
 	if lf == nil {
 		// skip if engine not exist. See the comment of `CloseEngine` for more detail.
@@ -1981,9 +1970,13 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID) erro
 		log.L().Info("engine contains no kv, skip import", zap.Stringer("engine", engineUUID))
 		return nil
 	}
+	regionSplitKeys := int64(regionMaxKeyCount)
+	if regionSplitSize > defaultRegionSplitSize {
+		regionSplitKeys = int64(float64(regionSplitSize) / float64(defaultRegionSplitSize) * float64(regionMaxKeyCount))
+	}
 
 	// split sorted file into range by 96MB size per file
-	ranges, err := local.readAndSplitIntoRange(ctx, lf)
+	ranges, err := local.readAndSplitIntoRange(ctx, lf, regionSplitSize, regionSplitKeys)
 	if err != nil {
 		return err
 	}
@@ -1999,10 +1992,10 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID) erro
 
 		// if all the kv can fit in one region, skip split regions. TiDB will split one region for
 		// the table when table is created.
-		needSplit := len(unfinishedRanges) > 1 || lfTotalSize > local.regionSplitSize || lfLength > local.regionSplitKeys
+		needSplit := len(unfinishedRanges) > 1 || lfTotalSize > regionSplitSize || lfLength > regionSplitKeys
 		// split region by given ranges
 		for i := 0; i < maxRetryTimes; i++ {
-			err = local.SplitAndScatterRegionByRanges(ctx, unfinishedRanges, lf.tableInfo, needSplit)
+			err = local.SplitAndScatterRegionByRanges(ctx, unfinishedRanges, lf.tableInfo, needSplit, regionSplitSize)
 			if err == nil || common.IsContextCanceledError(err) {
 				break
 			}
@@ -2016,7 +2009,7 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID) erro
 		}
 
 		// start to write to kv and ingest
-		err = local.writeAndIngestByRanges(ctx, lf, unfinishedRanges)
+		err = local.writeAndIngestByRanges(ctx, lf, unfinishedRanges, regionSplitKeys)
 		if err != nil {
 			log.L().Error("write and ingest engine failed", log.ShortError(err))
 			return err

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -67,6 +67,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 	ranges []Range,
 	tableInfo *checkpoints.TidbTableInfo,
 	needSplit bool,
+	regionSplitSize int64,
 ) error {
 	if len(ranges) == 0 {
 		return nil
@@ -270,7 +271,7 @@ func (local *local) SplitAndScatterRegionByRanges(
 			if !ok {
 				log.L().Warn("region stats not found", zap.Uint64("region", regionID))
 			}
-			if len(keys) == 1 && regionSize < local.regionSplitSize {
+			if len(keys) == 1 && regionSize < regionSplitSize {
 				skippedKeys++
 			}
 			select {

--- a/br/pkg/lightning/backend/noop/noop.go
+++ b/br/pkg/lightning/backend/noop/noop.go
@@ -78,7 +78,7 @@ func (b noopBackend) CloseEngine(ctx context.Context, cfg *backend.EngineConfig,
 	return nil
 }
 
-func (b noopBackend) ImportEngine(ctx context.Context, engineUUID uuid.UUID) error {
+func (b noopBackend) ImportEngine(ctx context.Context, engineUUID uuid.UUID, regionSplitSize int64) error {
 	return nil
 }
 

--- a/br/pkg/lightning/backend/tidb/tidb.go
+++ b/br/pkg/lightning/backend/tidb/tidb.go
@@ -368,7 +368,7 @@ func (be *tidbBackend) CollectRemoteDuplicateRows(ctx context.Context, tbl table
 	panic("Unsupported Operation")
 }
 
-func (be *tidbBackend) ImportEngine(context.Context, uuid.UUID) error {
+func (be *tidbBackend) ImportEngine(context.Context, uuid.UUID, int64) error {
 	return nil
 }
 

--- a/br/pkg/lightning/config/const.go
+++ b/br/pkg/lightning/config/const.go
@@ -20,10 +20,11 @@ import (
 
 const (
 	// mydumper
-	ReadBlockSize   ByteSize = 64 * units.KiB
-	MinRegionSize   ByteSize = 256 * units.MiB
-	MaxRegionSize   ByteSize = 256 * units.MiB
-	SplitRegionSize ByteSize = 96 * units.MiB
+	ReadBlockSize           ByteSize = 64 * units.KiB
+	MinRegionSize           ByteSize = 256 * units.MiB
+	MaxRegionSize           ByteSize = 256 * units.MiB
+	SplitRegionSize         ByteSize = 96 * units.MiB
+	MaxSplitRegionSizeRatio int      = 5
 
 	BufferSizeScale = 5
 

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -1708,7 +1708,8 @@ func (rc *Controller) enforceDiskQuota(ctx context.Context) {
 			task := logger.Begin(zap.WarnLevel, "importing large engines for disk quota")
 			var importErr error
 			for _, engine := range largeEngines {
-				if err := rc.backend.UnsafeImportAndReset(ctx, engine); err != nil {
+				if err := rc.backend.UnsafeImportAndReset(ctx, engine,
+					int64(rc.cfg.TikvImporter.RegionSplitSize)); err != nil {
 					importErr = multierr.Append(importErr, err)
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Little-Wallace <bupt2013211450@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->


Problem Summary:

### What is changed and how it works?

When there are many lightning instance importing data to TiKV, they may split the same region and make every region so small that the data from lightning are splitted into many small SST file.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
