### PR TITLE
*: Update client-go to fix retryable deadlock information collecting of information_schema.deadlocks (#27413)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210806085616-14892a598eab
+	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210820060448-daddf73a0706
 	github.com/tikv/pd v1.1.0-beta.0.20210818112400-0c5667766690
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber-go/atomic v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -693,8 +693,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210806085616-14892a598eab h1:YkAaROMOAp995r6eA5f2oKpGy21nl/CTWoSyOKLoR90=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210806085616-14892a598eab/go.mod h1:KwtZXt0JD+bP9bWW2ka0ir3Wp3oTEfZUTh22bs2sI4o=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210820060448-daddf73a0706 h1:UwEODRazer/iP7fi7K9xKWoSsDSIAHNIhtklh1+28a8=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210820060448-daddf73a0706/go.mod h1:KwtZXt0JD+bP9bWW2ka0ir3Wp3oTEfZUTh22bs2sI4o=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d/go.mod h1:Jw9KG11C/23Rr7DW4XWQ7H5xOgGZo6DFL1OKAF4+Igw=
 github.com/tikv/pd v1.1.0-beta.0.20210818112400-0c5667766690 h1:qGn7fDqj7IZ5dozy7QVkoj+0bama92ruVGHqoCBg7W4=
 github.com/tikv/pd v1.1.0-beta.0.20210818112400-0c5667766690/go.mod h1:rammPjeZgpvfrQRPkijcx8tlxF1XM5+m6kRXrkDzCAA=


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

Cherry-picks #27413

### What problem does this PR solve?

Issue Number: close #27400 

Problem Summary: The information about retryable deadlocks is collected incorrectly as if they are non-retryable ones. Currently the bug is in client-go, and this PR fixes this problem by updating client-go.

### What is changed and how it works?

What's Changed: Updates client-go

Requires https://github.com/tikv/client-go/pull/274

Needs to be picked to 5.2 and 5.1 branch, bug will be done manually.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

Side effects

- None

Documentation

- None

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
