### PR TITLE
execution: fix cte dead lock when used with IndexLookupJoin

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8982,3 +8982,15 @@ func (s *testSuite) TestIssue25447(c *C) {
 	tk.MustExec("insert into t2(a) values(1)")
 	tk.MustQuery("select /*+ tidb_inlj(t2) */ t2.b, t1.b from t1 join t2 ON t2.a=t1.a").Check(testkit.Rows("<nil> 1"))
 }
+
+func (s *testSuite) TestCTEWithIndexLookupJoinDeadLock(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t (a int(11) default null,b int(11) default null,key b (b),key ba (b))")
+	tk.MustExec("create table t1 (a int(11) default null,b int(11) default null,key idx_ab (a,b),key idx_a (a),key idx_b (b))")
+	tk.MustExec("create table t2 (a int(11) default null,b int(11) default null,key idx_ab (a,b),key idx_a (a),key idx_b (b))")
+	// It's easy to reproduce this problem in 30 times execution of IndexLookUpJoin.
+	for i := 0; i < 30; i++ {
+		tk.MustExec("with cte as (with cte1 as (select * from t2 use index(idx_ab) where a > 1 and b > 1) select * from cte1) select /*+use_index(t1 idx_ab)*/ * from cte join t1 on t1.a=cte.a;")
+	}
+}

--- a/session/session.go
+++ b/session/session.go
@@ -1830,10 +1830,10 @@ type execStmtResult struct {
 
 func (rs *execStmtResult) Close() error {
 	se := rs.se
-	if err := resetCTEStorageMap(se); err != nil {
+	if err := rs.RecordSet.Close(); err != nil {
 		return finishStmt(context.Background(), se, err, rs.sql)
 	}
-	if err := rs.RecordSet.Close(); err != nil {
+	if err := resetCTEStorageMap(se); err != nil {
 		return finishStmt(context.Background(), se, err, rs.sql)
 	}
 	return finishStmt(context.Background(), se, nil, rs.sql)


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27410 <!-- REMOVE this line if no issue to close -->

Problem Summary:  
1. IndexLookupJoin Opens, and outer worker starts to use cte1.resTbl and cte2.resTbl
2. execStmtResult.Close() is called directly without querying any result(e.g. IndexLookupJoin.Next() is never called)
3. We reset cte1's resTbl and then reset cte2's resTbl, but the outer worker of IndexLookupJoin already hold cte2's resTbl and is waiting for cte1's resTbl.

Following is the log of `execStmtResult.Close()` and `CTEExec.Next()`, which prove above:
```
!!!!CTEExec.Next() &{{0 0} 1 [0xc004ae5ce0 0xc004ae5e00] 1024 0xc0059ba7e0 false 0 0xc004f27100}
!!!!! resetCTEStorageMap  &{{0 0} 1 [0xc004ae5860 0xc004ae58c0] 1024 0xc0059ba720 false 0 0xc004f26e00}
!!!!! resetCTEStorageMap  &{{1 0} 1 [0xc004ae5ce0 0xc004ae5e00] 1024 0xc0059ba7e0 false 0 0xc004f27100}
!!!!CTEExec.Next() &{{0 0} 1 [0xc004ae5860 0xc004ae58c0] 1024 0xc0059ba720 false 0 0xc004f26e00}
```
### What is changed and how it works?

How it Works: Should wait for all workers to finish then we can reset cte.resTbl.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
execution: fix cte dead lock when used with IndexLookupJoin
```
