### PR TITLE
br, tidb: Add backup and restore size for TiDB SQL brie task

### DIFF
--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -468,6 +468,8 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 	}
 
 	g.Record(summary.BackupDataSize, metawriter.ArchiveSize())
+	//backup from tidb will fetch a general Size
+	g.Record("Size", metawriter.ArchiveSize())
 	failpoint.Inject("s3-outage-during-writing-file", func(v failpoint.Value) {
 		log.Info("failpoint s3-outage-during-writing-file injected, " +
 			"process will sleep for 3s and notify the shell to kill s3 service.")

--- a/br/pkg/task/backup.go
+++ b/br/pkg/task/backup.go
@@ -466,10 +466,10 @@ func RunBackup(c context.Context, g glue.Glue, cmdName string, cfg *BackupConfig
 			return errors.Trace(err)
 		}
 	}
-
-	g.Record(summary.BackupDataSize, metawriter.ArchiveSize())
-	//backup from tidb will fetch a general Size
-	g.Record("Size", metawriter.ArchiveSize())
+	archiveSize := metawriter.ArchiveSize()
+	g.Record(summary.BackupDataSize, archiveSize)
+	//backup from tidb will fetch a general Size issue https://github.com/pingcap/tidb/issues/27247
+	g.Record("Size", archiveSize)
 	failpoint.Inject("s3-outage-during-writing-file", func(v failpoint.Value) {
 		log.Info("failpoint s3-outage-during-writing-file injected, " +
 			"process will sleep for 3s and notify the shell to kill s3 service.")

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -267,6 +267,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 	archiveSize := reader.ArchiveSize(ctx, files)
 	g.Record(summary.RestoreDataSize, archiveSize)
+	//restore from tidb will fetch a general Size issue https://github.com/pingcap/tidb/issues/27247
 	g.Record("Size", archiveSize)
 	restoreTS, err := client.GetTS(ctx)
 	if err != nil {

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -267,6 +267,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 	archiveSize := reader.ArchiveSize(ctx, files)
 	g.Record(summary.RestoreDataSize, archiveSize)
+	g.Record("Size", archiveSize)
 	restoreTS, err := client.GetTS(ctx)
 	if err != nil {
 		return errors.Trace(err)
@@ -277,6 +278,8 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		TTL:      utils.DefaultBRGCSafePointTTL,
 		ID:       utils.MakeSafePointID(),
 	}
+	g.Record("BackupTS", restoreTS)
+	
 	// restore checksum will check safe point with its start ts, see details at
 	// https://github.com/pingcap/tidb/blob/180c02127105bed73712050594da6ead4d70a85f/store/tikv/kv.go#L186-L190
 	// so, we should keep the safe point unchangeable. to avoid GC life time is shorter than transaction duration.

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -279,7 +279,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		ID:       utils.MakeSafePointID(),
 	}
 	g.Record("BackupTS", restoreTS)
-	
+
 	// restore checksum will check safe point with its start ts, see details at
 	// https://github.com/pingcap/tidb/blob/180c02127105bed73712050594da6ead4d70a85f/store/tikv/kv.go#L186-L190
 	// so, we should keep the safe point unchangeable. to avoid GC life time is shorter than transaction duration.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27247 

Problem Summary:
SQL backup and restore show a 0 size
### What is changed and how it works?
SQL backup and restore shall show a correct size, not 0.
Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
add backup size
How it Works:
glue is communitation class between tidb and br, glue does not record a size for general tidb sql.
### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
