### PR TITLE
config: set the default value of auto_tls to false

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -676,7 +676,7 @@ var defaultConf = Config{
 	Security: Security{
 		SpilledFileEncryptionMethod: SpilledFileEncryptionMethodPlaintext,
 		EnableSEM:                   false,
-		AutoTLS:                     true,
+		AutoTLS:                     false,
 	},
 	DeprecateIntegerDisplayWidth: false,
 	EnableEnumLengthLimit:        true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -205,7 +205,9 @@ spilled-file-encryption-method = "plaintext"
 # Security Enhanced Mode (SEM) restricts the "SUPER" privilege and requires fine-grained privileges instead.
 enable-sem = false
 
-# Automatic creation of TLS certificates
+# Automatic creation of TLS certificates.
+# Setting it to 'true' is recommended because it is safer and tie with the default configuration of MySQL.
+# If this config is commented/missed, the value would be 'false' for the compatibility with TiDB versions that does not support it.
 auto-tls = true
 
 [status]

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -337,7 +337,8 @@ spilled-file-encryption-method = "aes128-ctr"
 	configFile = filepath.Join(filepath.Dir(localFile), "config.toml.example")
 	c.Assert(conf.Load(configFile), IsNil)
 
-	// Make sure the example config is the same as default config.
+	// Make sure the example config is the same as default config except `auto_tls`.
+	conf.Security.AutoTLS = false
 	c.Assert(conf, DeepEquals, GetGlobalConfig())
 
 	// Test for log config.


### PR DESCRIPTION
Backport #27486 to release-5.2:

-----------------------------------------------------------------------
### What is changed and how it works?

What's Changed:

As described in the title, we would set the default value of `auto_tls` to `false` for compatibility with earlier releases:

In #24141 the 'automatical creation of TLS certificates' is introduced for the consideration of MySQL's default behavior. However, when the client specifies to use an encrypted connection(the default behavior for most clients/connectors), a performance regression can be noticed.

The problem here is, many of the users may not be aware if they're using a client with the encrypted connection, so we decided to set the default value of `auto_tls` in the code to avoid the potential performance regression while keeping it to `true` in the config example file.

However, the value in the config example file will be kept to `true` so that it is recommended(mostly for new clusters).

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Manual test (add detailed scripts or steps below)

Start a new TiDB with a configuration that does not contain `auto_tls`, and confirm that the default value is `false`.

Documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
