### PR TITLE
privileges: Fix panic when using skip-grant-table

### DIFF
--- a/privilege/privileges/privileges.go
+++ b/privilege/privileges/privileges.go
@@ -222,6 +222,10 @@ func (p *UserPrivileges) GetEncodedPassword(user, host string) string {
 
 // GetAuthPlugin gets the authentication plugin for the account identified by the user and host
 func (p *UserPrivileges) GetAuthPlugin(user, host string) (string, error) {
+	if SkipWithGrant {
+		return mysql.AuthNativePassword, nil
+	}
+
 	mysqlPriv := p.Handle.Get()
 	record := mysqlPriv.connectionVerification(user, host)
 	if record == nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #27555

Problem Summary: `tidb-server` panics with `skip-grant-tables` enabled

### What is changed and how it works?

Check for `SkipWithGrant` when getting the auth plugin for a user.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```

This doesn't yet have good unittest(s) or integration test(s), I'm planning to spend some time on trying to find a good way to do this.