### PR TITLE
executor: union scan checks unique indexes

### DIFF
--- a/br/tests/br_rawkv/client.go
+++ b/br/tests/br_rawkv/client.go
@@ -133,7 +133,7 @@ func randGen(client *rawkv.Client, startKey, endKey []byte, maxLen int, concurre
 					values = append(values, value)
 				}
 
-				err := client.BatchPut(context.TODO(), keys, values)
+				err := client.BatchPut(context.TODO(), keys, values, nil)
 				if err != nil {
 					errCh <- errors.Trace(err)
 				}
@@ -307,7 +307,7 @@ func put(client *rawkv.Client, dataStr string) error {
 
 	log.Info("Put rawkv data", zap.ByteStrings("keys", keys), zap.ByteStrings("values", values))
 
-	err := client.BatchPut(context.TODO(), keys, values)
+	err := client.BatchPut(context.TODO(), keys, values, nil)
 	return errors.Trace(err)
 }
 

--- a/executor/temporary_table_serial_test.go
+++ b/executor/temporary_table_serial_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestTemporaryTableNoNetwork(t *testing.T) {
-	return
 	t.Run("global", func(t *testing.T) {
 		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
 			tk.MustExec("set tidb_enable_global_temporary_table=true")

--- a/executor/temporary_table_serial_test.go
+++ b/executor/temporary_table_serial_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestTemporaryTableNoNetwork(t *testing.T) {
+	return
 	t.Run("global", func(t *testing.T) {
 		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
 			tk.MustExec("set tidb_enable_global_temporary_table=true")

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -279,8 +279,11 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) ([]types.Datum, err
 						if err != nil {
 							return nil, err
 						}
-						// optimistic transactions: will mark keys as locked but do not actually acquire the lock
-						// pessimistic transactions: will acquire the pessimistic lock when writing rows, so skip locked keys only
+						// optimistic: will mark keys as locked but do not actually acquire the lock
+						//             e.g. select for update statement will leave a locked key in membuffer, we should read that row
+						//             only skip the snapshot row when key is not locked,
+						// pessimistic: will acquire the pessimistic lock when writing rows
+						//             so skip locked keys only
 						if flag.HasLocked() == isPessimistic {
 							continue ITER
 						}

--- a/executor/union_scan.go
+++ b/executor/union_scan.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"runtime/trace"
 
-	"go.uber.org/zap"
-
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
@@ -30,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
-	"github.com/pingcap/tidb/util/logutil"
 )
 
 // UnionScanExec merges the rows from dirty table and the rows from distsql request.
@@ -174,16 +171,6 @@ func (us *UnionScanExec) getOneRow(ctx context.Context) ([]types.Datum, error) {
 	}
 	addedRow := us.getAddedRow()
 
-	if us.ctx.GetSessionVars().ConnectionID > 0 {
-		logutil.Logger(ctx).Info("MYLOG get one row",
-			zap.Int("sr", us.cursor4SnapshotRows),
-			zap.Int("sr all", len(us.snapshotRows)),
-			zap.Int("ar", us.cursor4AddRows),
-			zap.Int("ad all", len(us.addedRows)),
-			zap.String("snapshot row", fmt.Sprintf("%v", snapshotRow)),
-			zap.String("added row", fmt.Sprintf("%v", addedRow)))
-	}
-
 	var row []types.Datum
 	var isSnapshotRow bool
 	if addedRow == nil {
@@ -245,7 +232,7 @@ func (us *UnionScanExec) getSnapshotRow(ctx context.Context) ([]types.Datum, err
 			// Though the handle does not appear in added rows, there may be still some conflicts on unique indexes,
 			// UnionScan with two records which have same unique index is weird. This should be handled here.
 			// The newly added rows will overwrite the snapshot rows.
-			// FIXME: it's better to handle the conflict on unique indexes when execute the DMLs instead of handling here.
+			// It's better to handle the conflict on unique indexes when execute the DMLs instead of handling here.
 			if !us.table.Meta().IsCommonHandle {
 				cols := us.table.Meta().Columns
 				if datumCols == nil {

--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -403,3 +403,78 @@ func (s *testSuite7) TestForApplyAndUnionScan(c *C) {
 	tk.MustQuery("select c_int, c_str from t where (select count(*) from t1 where t1.c_int in (t.c_int, t.c_int + 2, t.c_int + 10)) > 2").Check(testkit.Rows())
 	tk.MustExec("rollback")
 }
+
+func (s *testSuite7) TestIssueOptimisticConflictUnionScan(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	clusteredIndexOptions := []string{"ON", "OFF", "INT_ONLY"}
+	for _, clusteredIndexOption := range clusteredIndexOptions {
+		tk.MustExec("set session tidb_enable_clustered_index = '" + clusteredIndexOption + "'")
+		// multi-column index
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (a int, b int, primary key (a, b))")
+		tk.MustExec("insert into t values (1, 10)")
+		tk.MustExec("begin optimistic")
+		tk.MustExec("insert into t values (1, 10)")
+		tk.MustQuery("select * from t").Check(testkit.Rows("1 10"))
+		err := tk.ExecToErr("commit")
+		c.Assert(err, NotNil)
+
+		// int index
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (a int, b int, primary key (a))")
+		tk.MustExec("insert into t values(1, 10)")
+		// insert same value
+		tk.MustExec("begin optimistic")
+		tk.MustExec("insert into t values (1, 10)")
+		tk.MustQuery("select * from t").Check(testkit.Rows("1 10"))
+		err = tk.ExecToErr("commit")
+		c.Assert(err, NotNil)
+		// insert same pk
+		tk.MustExec("begin optimistic")
+		tk.MustExec("insert into t values (1, 11)")
+		tk.MustQuery("select * from t").Check(testkit.Rows("1 11"))
+		err = tk.ExecToErr("commit")
+		c.Assert(err, NotNil)
+
+		// non-int index
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (a varchar(255), b int, primary key (a))")
+		tk.MustExec("insert into t values('tag', 10)")
+		// insert same value
+		tk.MustExec("begin optimistic")
+		tk.MustExec("insert into t values ('tag', 10)")
+		tk.MustQuery("select * from t").Check(testkit.Rows("tag 10"))
+		err = tk.ExecToErr("commit")
+		c.Assert(err, NotNil)
+		// insert same pk
+		tk.MustExec("begin optimistic")
+		tk.MustExec("insert into t values ('tag', 11)")
+		tk.MustQuery("select * from t").Check(testkit.Rows("tag 11"))
+		err = tk.ExecToErr("commit")
+		c.Assert(err, NotNil)
+	}
+}
+
+func (s *testSuite7) TestIssuePessimisticConflictUnionScan(c *C) {
+	tk := testkit.NewTestKitWithInit(c, s.store)
+	tk1 := testkit.NewTestKitWithInit(c, s.store)
+	clusteredIndexOptions := []string{"ON", "OFF", "INT_ONLY"}
+	for _, clusteredIndexOption := range clusteredIndexOptions {
+		tk.MustExec("set session tidb_enable_clustered_index = '" + clusteredIndexOption + "'")
+		// multi-column index
+		tk.MustExec("drop table if exists t")
+		tk.MustExec("create table t (c1 varchar(10), c2 int, c3 char(20), primary key (c1, c2))")
+		tk.MustExec("insert into t values ('tag', 10, 't'), ('cat', 20, 'c')")
+		tk.MustExec("begin pessimistic")
+		tk.MustExec("update t set c1=reverse(c1) where c1='tag'")
+		tk1.MustExec("begin  pessimistic")
+		errCh := make(chan error)
+		go func() {
+			errCh <- tk1.ExecToErr("insert into t values('dress',40,'d'),('tag', 10, 't')")
+		}()
+		tk.MustExec("commit")
+		c.Assert(<-errCh, IsNil)
+		tk1.MustQuery("select * from t use index(primary) order by c1, c2").
+			Check(testkit.Rows("cat 20 c", "dress 40 d", "tag 10 t"))
+	}
+}

--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -476,5 +476,8 @@ func (s *testSuite7) TestIssuePessimisticConflictUnionScan(c *C) {
 		c.Assert(<-errCh, IsNil)
 		tk1.MustQuery("select * from t use index(primary) order by c1, c2").
 			Check(testkit.Rows("cat 20 c", "dress 40 d", "tag 10 t"))
+		tk1.MustExec("commit")
+		tk1.MustQuery("select * from t use index(primary) order by c1, c2").
+			Check(testkit.Rows("cat 20 c", "dress 40 d", "gat 10 t", "tag 10 t"))
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20210425183316-da1aaba5fb63
 	github.com/pingcap/failpoint v0.0.0-20210316064728-7acb0f0a3dfd
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
-	github.com/pingcap/kvproto v0.0.0-20210806074406-317f69fb54b4
+	github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad
 	github.com/pingcap/log v0.0.0-20210906054005-afc726e70354
 	github.com/pingcap/parser v0.0.0-20211004012448-687005894c4e
 	github.com/pingcap/sysutil v0.0.0-20210730114356-fcd8a63f68c5
@@ -96,3 +96,5 @@ require (
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
+
+replace github.com/tikv/client-go/v2 => ../../tikv/client-go

--- a/go.mod
+++ b/go.mod
@@ -64,7 +64,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210926100628-3cc2459779ca
+	github.com/tikv/client-go/v2 v2.0.0-alpha.0.20211009043003-843a5378aa91
 	github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber/jaeger-client-go v2.22.1+incompatible
@@ -96,5 +96,3 @@ require (
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
-
-replace github.com/tikv/client-go/v2 => ../../tikv/client-go

--- a/go.sum
+++ b/go.sum
@@ -593,8 +593,6 @@ github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO
 github.com/pingcap/kvproto v0.0.0-20200411081810-b85805c9476c/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210219064844-c1844a4775d6/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210805052247-76981389e818/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20210806074406-317f69fb54b4 h1:4EUpHzPFHwleKkVALyMqQbQcNziPZvU+vhUT9Wzj93E=
-github.com/pingcap/kvproto v0.0.0-20210806074406-317f69fb54b4/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad h1:suBPTeuY6yVF7xvTGeTQ9+tiGzufnORJpCRwzbdN2sc=
 github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
@@ -733,8 +731,6 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210926100628-3cc2459779ca h1:aE/y7lkygl716M6eIos95BKjM1mGew+EoLWRQAXDoAE=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210926100628-3cc2459779ca/go.mod h1:KwtZXt0JD+bP9bWW2ka0ir3Wp3oTEfZUTh22bs2sI4o=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d/go.mod h1:Jw9KG11C/23Rr7DW4XWQ7H5xOgGZo6DFL1OKAF4+Igw=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d h1:AFm1Dzw+QRUevWRfrFp45CPPkuK/zdSWcfxI10z+WVE=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d/go.mod h1:rammPjeZgpvfrQRPkijcx8tlxF1XM5+m6kRXrkDzCAA=

--- a/go.sum
+++ b/go.sum
@@ -731,6 +731,8 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20211009043003-843a5378aa91 h1:SYxMYsvy/MglD30T3w1YCu/6rSR1Hhgts9AgTJImclY=
+github.com/tikv/client-go/v2 v2.0.0-alpha.0.20211009043003-843a5378aa91/go.mod h1:00plYwQsQ5kBUmafHO+JkjznGgFaBokMZl82TZIbsQk=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d/go.mod h1:Jw9KG11C/23Rr7DW4XWQ7H5xOgGZo6DFL1OKAF4+Igw=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d h1:AFm1Dzw+QRUevWRfrFp45CPPkuK/zdSWcfxI10z+WVE=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d/go.mod h1:rammPjeZgpvfrQRPkijcx8tlxF1XM5+m6kRXrkDzCAA=

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,8 @@ github.com/pingcap/kvproto v0.0.0-20210219064844-c1844a4775d6/go.mod h1:IOdRDPLy
 github.com/pingcap/kvproto v0.0.0-20210805052247-76981389e818/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20210806074406-317f69fb54b4 h1:4EUpHzPFHwleKkVALyMqQbQcNziPZvU+vhUT9Wzj93E=
 github.com/pingcap/kvproto v0.0.0-20210806074406-317f69fb54b4/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad h1:suBPTeuY6yVF7xvTGeTQ9+tiGzufnORJpCRwzbdN2sc=
+github.com/pingcap/kvproto v0.0.0-20210915062418-0f5764a128ad/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20201112100606-8f1e84a3abc8/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=

--- a/kv/keyflags.go
+++ b/kv/keyflags.go
@@ -19,6 +19,7 @@ type KeyFlags uint8
 
 const (
 	flagPresumeKNE KeyFlags = 1 << iota
+	flagKeyLocked
 	flagNeedLocked
 )
 
@@ -32,12 +33,19 @@ func (f KeyFlags) HasNeedLocked() bool {
 	return f&flagNeedLocked != 0
 }
 
+// HasLocked returns whether the associated key has acquired pessimistic lock.
+func (f KeyFlags) HasLocked() bool {
+	return f&flagKeyLocked != 0
+}
+
 // FlagsOp describes KeyFlags modify operation.
 type FlagsOp uint16
 
 const (
 	// SetPresumeKeyNotExists marks the existence of the associated key is checked lazily.
 	SetPresumeKeyNotExists FlagsOp = iota
+	// SetKeyLocked marks the associated key has acquired lock.
+	SetKeyLocked
 	// SetNeedLocked marks the associated key need to be acquired lock.
 	SetNeedLocked
 )
@@ -48,6 +56,8 @@ func ApplyFlagsOps(origin KeyFlags, ops ...FlagsOp) KeyFlags {
 		switch op {
 		case SetPresumeKeyNotExists:
 			origin |= flagPresumeKNE
+		case SetKeyLocked:
+			origin |= flagKeyLocked
 		case SetNeedLocked:
 			origin |= flagNeedLocked
 		}

--- a/kv/keyflags.go
+++ b/kv/keyflags.go
@@ -19,8 +19,8 @@ type KeyFlags uint8
 
 const (
 	flagPresumeKNE KeyFlags = 1 << iota
-	flagKeyLocked
 	flagNeedLocked
+	flagReadable
 )
 
 // HasPresumeKeyNotExists returns whether the associated key use lazy check.
@@ -33,9 +33,9 @@ func (f KeyFlags) HasNeedLocked() bool {
 	return f&flagNeedLocked != 0
 }
 
-// HasLocked returns whether the associated key has acquired pessimistic lock.
-func (f KeyFlags) HasLocked() bool {
-	return f&flagKeyLocked != 0
+// HasReadable returns whether the in-transaction operations is able to read the key.
+func (f KeyFlags) HasReadable() bool {
+	return f&flagReadable == 0
 }
 
 // FlagsOp describes KeyFlags modify operation.
@@ -44,10 +44,10 @@ type FlagsOp uint16
 const (
 	// SetPresumeKeyNotExists marks the existence of the associated key is checked lazily.
 	SetPresumeKeyNotExists FlagsOp = iota
-	// SetKeyLocked marks the associated key has acquired lock.
-	SetKeyLocked
 	// SetNeedLocked marks the associated key need to be acquired lock.
 	SetNeedLocked
+	// SetReadable marks the key is readable by in-transaction read.
+	SetReadable
 )
 
 // ApplyFlagsOps applys flagspos to origin.
@@ -56,8 +56,8 @@ func ApplyFlagsOps(origin KeyFlags, ops ...FlagsOp) KeyFlags {
 		switch op {
 		case SetPresumeKeyNotExists:
 			origin |= flagPresumeKNE
-		case SetKeyLocked:
-			origin |= flagKeyLocked
+		case SetReadable:
+			origin |= flagReadable
 		case SetNeedLocked:
 			origin |= flagNeedLocked
 		}

--- a/kv/keyflags.go
+++ b/kv/keyflags.go
@@ -35,7 +35,7 @@ func (f KeyFlags) HasNeedLocked() bool {
 
 // HasReadable returns whether the in-transaction operations is able to read the key.
 func (f KeyFlags) HasReadable() bool {
-	return f&flagReadable == 0
+	return f&flagReadable != 0
 }
 
 // FlagsOp describes KeyFlags modify operation.
@@ -56,10 +56,10 @@ func ApplyFlagsOps(origin KeyFlags, ops ...FlagsOp) KeyFlags {
 		switch op {
 		case SetPresumeKeyNotExists:
 			origin |= flagPresumeKNE
-		case SetReadable:
-			origin |= flagReadable
 		case SetNeedLocked:
 			origin |= flagNeedLocked
+		case SetReadable:
+			origin |= flagReadable
 		}
 	}
 	return origin

--- a/store/driver/txn/unionstore_driver.go
+++ b/store/driver/txn/unionstore_driver.go
@@ -143,6 +143,9 @@ func getTiDBKeyFlags(flag tikvstore.KeyFlags) kv.KeyFlags {
 	if flag.HasPresumeKeyNotExists() {
 		v = kv.ApplyFlagsOps(v, kv.SetPresumeKeyNotExists)
 	}
+	if flag.HasLocked() {
+		v = kv.ApplyFlagsOps(v, kv.SetKeyLocked)
+	}
 	if flag.HasNeedLocked() {
 		v = kv.ApplyFlagsOps(v, kv.SetNeedLocked)
 	}

--- a/store/driver/txn/unionstore_driver.go
+++ b/store/driver/txn/unionstore_driver.go
@@ -143,11 +143,11 @@ func getTiDBKeyFlags(flag tikvstore.KeyFlags) kv.KeyFlags {
 	if flag.HasPresumeKeyNotExists() {
 		v = kv.ApplyFlagsOps(v, kv.SetPresumeKeyNotExists)
 	}
-	if flag.HasReadable() {
-		v = kv.ApplyFlagsOps(v, kv.SetReadable)
-	}
 	if flag.HasNeedLocked() {
 		v = kv.ApplyFlagsOps(v, kv.SetNeedLocked)
+	}
+	if flag.HasReadable() {
+		v = kv.ApplyFlagsOps(v, kv.SetReadable)
 	}
 	return v
 }
@@ -158,6 +158,8 @@ func getTiKVFlagsOp(op kv.FlagsOp) tikvstore.FlagsOp {
 		return tikvstore.SetPresumeKeyNotExists
 	case kv.SetNeedLocked:
 		return tikvstore.SetNeedLocked
+	case kv.SetReadable:
+		return tikvstore.SetReadable
 	}
 	return 0
 }

--- a/store/driver/txn/unionstore_driver.go
+++ b/store/driver/txn/unionstore_driver.go
@@ -143,8 +143,8 @@ func getTiDBKeyFlags(flag tikvstore.KeyFlags) kv.KeyFlags {
 	if flag.HasPresumeKeyNotExists() {
 		v = kv.ApplyFlagsOps(v, kv.SetPresumeKeyNotExists)
 	}
-	if flag.HasLocked() {
-		v = kv.ApplyFlagsOps(v, kv.SetKeyLocked)
+	if flag.HasReadable() {
+		v = kv.ApplyFlagsOps(v, kv.SetReadable)
 	}
 	if flag.HasNeedLocked() {
 		v = kv.ApplyFlagsOps(v, kv.SetNeedLocked)

--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -213,9 +213,9 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 	}
 	if err != nil || len(value) == 0 {
 		if sctx.GetSessionVars().LazyCheckKeyNotExists() && err != nil {
-			err = txn.GetMemBuffer().SetWithFlags(key, idxVal, kv.SetPresumeKeyNotExists)
+			err = txn.GetMemBuffer().SetWithFlags(key, idxVal, kv.SetPresumeKeyNotExists, kv.SetReadable)
 		} else {
-			err = txn.GetMemBuffer().Set(key, idxVal)
+			err = txn.GetMemBuffer().SetWithFlags(key, idxVal, kv.SetReadable)
 		}
 		return nil, err
 	}

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -812,9 +812,9 @@ func (t *TableCommon) AddRecord(sctx sessionctx.Context, r []types.Datum, opts .
 	}
 
 	if setPresume {
-		err = memBuffer.SetWithFlags(key, value, kv.SetPresumeKeyNotExists)
+		err = memBuffer.SetWithFlags(key, value, kv.SetPresumeKeyNotExists, kv.SetReadable)
 	} else {
-		err = memBuffer.Set(key, value)
+		err = memBuffer.SetWithFlags(key, value, kv.SetReadable)
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #24195

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

With clustered index is off, there will be different row keys for the same record(with the same primary key) which brings some inconsistency, this PR fixes it by checking the primary index.

For optimistic, I think the special behavior is reasonable, the dup-entry union scan can be avoided by setting `tidb_constraint_check_in_place` to true.

Generally, this PR does the following changes:

1. Unify the behavior of clustered-index and non-clustered-index.
2. Avoid dup-entry union scan in the pessimistic transactions.

How it Works:

Filter the rows which have duplicated indexes from snapshot results.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
fix results with duplicated unique indexes in unionscan.
```
