### PR TITLE
util: Correctly use specificed RSA keysize

### DIFF
--- a/util/misc.go
+++ b/util/misc.go
@@ -591,7 +591,7 @@ func QueryStrForLog(query string) string {
 }
 
 func createTLSCertificates(certpath string, keypath string, rsaKeySize int) error {
-	privkey, err := rsa.GenerateKey(rand.Reader, 4096)
+	privkey, err := rsa.GenerateKey(rand.Reader, rsaKeySize)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: #26947

Problem Summary:

### What is changed and how it works?

The fix in #27393 had a small bug where it fails to actually set the RSA keysize

This should fix the time it takes to run `tidbTestSerialSuite.TestTLSAuto`

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
