### PR TITLE
tests: fix br_views_and_sequences

### DIFF
--- a/br/tests/br_views_and_sequences/run.sh
+++ b/br/tests/br_views_and_sequences/run.sh
@@ -39,7 +39,7 @@ run_sql "insert into $DB.auto_inc values (), (), (), (), ();"
 last_id=$(run_sql "select n from $DB.auto_inc order by n desc limit 1" | trim_sql_result)
 
 run_sql "create table $DB.auto_rnd (n BIGINT primary key AUTO_RANDOM(8));"
-last_rnd_id=$(run_sql "insert into $DB.auto_rnd values (), (), (), (), ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+last_rnd_id=$(run_sql "insert into $DB.auto_rnd values (), (), (), (), ();select last_insert_id() & 0x7fffffffffffff;" | trim_sql_result )
 
 echo "backup start..."
 run_br backup db --db "$DB" -s "local://$TEST_DIR/$DB" --pd $PD_ADDR
@@ -61,7 +61,7 @@ seq_val=$(run_sql "select a >= 8 and b >= 4 as g from $DB.table_2 where c = 33;"
 run_sql "insert into $DB.auto_inc values ();"
 last_id_after_restore=$(run_sql "select n from $DB.auto_inc order by n desc limit 1;" | trim_sql_result)
 [ $last_id_after_restore -gt $last_id ]
-rnd_last_id_after_restore=$(run_sql "insert into $DB.auto_rnd values ();select last_insert_id() & 0xffffffffffffff;" | trim_sql_result )
+rnd_last_id_after_restore=$(run_sql "insert into $DB.auto_rnd values ();select last_insert_id() & 0x7fffffffffffff;" | trim_sql_result )
 [ $rnd_last_id_after_restore -gt $last_rnd_id ]
 rnd_count_after_restore=$(run_sql "select count(*) from $DB.auto_rnd;" | trim_sql_result )
 [ $rnd_count_after_restore -gt 5 ]


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: 
fix a unstable test case `br_views_and_sequences `

Problem Summary:
we used AUTO_RANDOM(8) but use the mask omitting the leftmost 8 bits, ignored the symbol. 

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
ignore the leftmost 9 bits.

How it Works:
So it probably works.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
