### PR TITLE
server: Fix TestTLSAuto stability

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -886,6 +886,8 @@ func (ts *tidbTestSerialSuite) TestTLSAuto(c *C) {
 	cfg.Status.ReportStatus = false
 	cfg.Security.AutoTLS = true
 	cfg.Security.RSAKeySize = 528 // Reduces unittest runtime
+	err := os.MkdirAll(cfg.TempStoragePath, 0700)
+	c.Assert(err, IsNil)
 	server, err := NewServer(cfg, ts.tidbdrv)
 	c.Assert(err, IsNil)
 	cli.port = getPortFromTCPAddr(server.listener.Addr())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #27711 

Problem Summary:

`tidbTestSerialSuite.TestTLSAuto` fails due to the temp storage not (yet) being created.

This only happens during the tests when `/tmp/1000_tidb` doesn't exist when the test starts.

### What is changed and how it works?

Explicitly create the temp storage when testing.

In a non-testing setup the issue doesn't happen:
```
[dvaneeden@dve-carbon tidb]$ for i in {1..10}; do rm -rf /tmp/1000_tidb; timeout 3s ./bin/tidb-server | grep 'TLS Cert'; done
[2021/09/01 17:06:15.514 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:18.522 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:21.531 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:24.535 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:27.544 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:30.558 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:33.561 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:36.566 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:39.579 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
[2021/09/01 17:06:42.586 +02:00] [INFO] [misc.go:652] ["TLS Certificates created"] [cert="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/cert.pem"] [key="/tmp/1000_tidb/MC4wLjAuMDo0MDAwLzAuMC4wLjA6MTAwODA=/tmp-storage/key.pem"] [validity=2160h0m0s] [rsaKeySize=528]
Terminated
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
