### PR TITLE
telemetry, server, metrics: Add handshake and authentication telemetry

### DIFF
--- a/metrics/session.go
+++ b/metrics/session.go
@@ -156,4 +156,5 @@ const (
 	LblVersion     = "version"
 	LblHash        = "hash"
 	LblCTEType     = "cte_type"
+	LblAuthType    = "auth_type"
 )


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Adds metrics for:
* HandshakeV9 (pre-v4.1) vs HandshakeV10 (post-v4.1)
* `mysql_native_password` vs `caching_sha2_password`

from `admin show telemetry`:
```json
    "authType": {
      "handshakeV9": 34,
      "handshakeV10": 4,
      "mysql_native_password": 37,
      "caching_sha2_password": 1
    }
```

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Documentation

- [x] Affects user behaviors

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Telemetry was added for authentication method and handshake type usage counters
```
