### PR TITLE
planner: optimize CTE performance by inlining only singly-referenced CTEs

### DIFF
--- a/cmd/explaintest/r/cte.result
+++ b/cmd/explaintest/r/cte.result
@@ -360,25 +360,19 @@ drop table if exists t;
 create table t(a int, b int, key (b));
 desc with cte as (select * from t) select * from cte;
 id	estRows	task	access object	operator info
-CTEFullScan_9	10000.00	root	CTE:cte	data:CTE_0
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_7(Seed Part)	10000.00	root		data:TableFullScan_6
-  └─TableFullScan_6	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+TableReader_8	10000.00	root		data:TableFullScan_7
+└─TableFullScan_7	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 create SESSION binding for with cte as (select * from t) select * from cte using with cte as (select * from t use index(b)) select * from cte;
 desc with cte as (select * from t) select * from cte;
 id	estRows	task	access object	operator info
-CTEFullScan_10	10000.00	root	CTE:cte	data:CTE_0
-CTE_0	10000.00	root		Non-Recursive CTE
-└─IndexLookUp_8(Seed Part)	10000.00	root		
-  ├─IndexFullScan_6(Build)	10000.00	cop[tikv]	table:t, index:b(b)	keep order:false, stats:pseudo
-  └─TableRowIDScan_7(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+IndexLookUp_9	10000.00	root		
+├─IndexFullScan_7(Build)	10000.00	cop[tikv]	table:t, index:b(b)	keep order:false, stats:pseudo
+└─TableRowIDScan_8(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 desc with cte as (select * from t use index()) select * from cte;
 id	estRows	task	access object	operator info
-CTEFullScan_10	10000.00	root	CTE:cte	data:CTE_0
-CTE_0	10000.00	root		Non-Recursive CTE
-└─IndexLookUp_8(Seed Part)	10000.00	root		
-  ├─IndexFullScan_6(Build)	10000.00	cop[tikv]	table:t, index:b(b)	keep order:false, stats:pseudo
-  └─TableRowIDScan_7(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+IndexLookUp_9	10000.00	root		
+├─IndexFullScan_7(Build)	10000.00	cop[tikv]	table:t, index:b(b)	keep order:false, stats:pseudo
+└─TableRowIDScan_8(Probe)	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
 drop table if exists t1, tpk;
 create table t1(c1 int);
 insert into t1 values(1), (2), (1), (2);
@@ -387,17 +381,15 @@ insert into tpk values(1), (2), (3);
 // Expect a Sort operator on CTE.
 explain with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_26	10000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_24(Build)	8000.00	root		test.t1.c1
-│ └─Selection_22	8000.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_23	10000.00	root	CTE:dt2	data:CTE_0
-└─Sort_20(Probe)	9990.00	root		test.t1.c1
-  └─TableReader_19	9990.00	root		data:Selection_18
-    └─Selection_18	9990.00	cop[tikv]		not(isnull(test.t1.c1))
-      └─TableFullScan_17	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_12(Seed Part)	10000.00	root		data:TableFullScan_11
-  └─TableFullScan_11	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+MergeJoin_23	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_21(Build)	9990.00	root		test.t1.c1
+│ └─TableReader_20	9990.00	root		data:Selection_19
+│   └─Selection_19	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│     └─TableFullScan_18	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Sort_17(Probe)	9990.00	root		test.t1.c1
+  └─TableReader_16	9990.00	root		data:Selection_15
+    └─Selection_15	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_14	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -411,15 +403,11 @@ c1	c1
 // Sort should not exist, because tpk.c1 is pk. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_24	10000.00	root		inner join, left key:test.tpk.c1, right key:test.tpk.c1
-├─Sort_22(Build)	8000.00	root		test.tpk.c1
-│ └─Selection_20	8000.00	root		not(isnull(test.tpk.c1))
-│   └─CTEFullScan_21	10000.00	root	CTE:dt2	data:CTE_0
-└─TableReader_18(Probe)	10000.00	root		data:TableFullScan_17
-  └─TableFullScan_17	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_12(Seed Part)	10000.00	root		data:TableFullScan_11
-  └─TableFullScan_11	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
+MergeJoin_25	12500.00	root		inner join, left key:test.tpk.c1, right key:test.tpk.c1
+├─TableReader_22(Build)	10000.00	root		data:TableFullScan_21
+│ └─TableFullScan_21	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
+└─TableReader_20(Probe)	10000.00	root		data:TableFullScan_19
+  └─TableFullScan_19	10000.00	cop[tikv]	table:dt1	keep order:true, stats:pseudo
 with cte1 as (select c1 from tpk) select /*+ MERGE_JOIN(dt1, dt2) */ * from tpk dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -428,18 +416,15 @@ c1	c1
 // Sort should not exist, because we have order by in CTE definition. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_30	10000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_28(Build)	8000.00	root		test.t1.c1
-│ └─Selection_26	8000.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_27	10000.00	root	CTE:dt2	data:CTE_0
-└─Sort_24(Probe)	9990.00	root		test.t1.c1
-  └─TableReader_23	9990.00	root		data:Selection_22
-    └─Selection_22	9990.00	cop[tikv]		not(isnull(test.t1.c1))
-      └─TableFullScan_21	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─Sort_11(Seed Part)	10000.00	root		test.t1.c1
-  └─TableReader_15	10000.00	root		data:TableFullScan_14
-    └─TableFullScan_14	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+MergeJoin_29	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_20(Build)	9990.00	root		test.t1.c1
+│ └─TableReader_26	9990.00	root		data:Selection_25
+│   └─Selection_25	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│     └─TableFullScan_24	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Sort_19(Probe)	9990.00	root		test.t1.c1
+  └─TableReader_18	9990.00	root		data:Selection_17
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -500,18 +485,15 @@ c1	c1
 // Expect Sort operator in CTE definition.
 explain with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_30	10000.00	root		inner join, left key:test.t1.c1, right key:test.t1.c1
-├─Sort_28(Build)	8000.00	root		test.t1.c1
-│ └─Selection_26	8000.00	root		not(isnull(test.t1.c1))
-│   └─CTEFullScan_27	10000.00	root	CTE:dt2	data:CTE_0
-└─Sort_24(Probe)	9990.00	root		test.t1.c1
-  └─TableReader_23	9990.00	root		data:Selection_22
-    └─Selection_22	9990.00	cop[tikv]		not(isnull(test.t1.c1))
-      └─TableFullScan_21	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─Sort_11(Seed Part)	10000.00	root		test.t1.c1
-  └─TableReader_15	10000.00	root		data:TableFullScan_14
-    └─TableFullScan_14	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+MergeJoin_29	12487.50	root		inner join, left key:test.t1.c1, right key:test.t1.c1
+├─Sort_20(Build)	9990.00	root		test.t1.c1
+│ └─TableReader_26	9990.00	root		data:Selection_25
+│   └─Selection_25	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+│     └─TableFullScan_24	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+└─Sort_19(Probe)	9990.00	root		test.t1.c1
+  └─TableReader_18	9990.00	root		data:Selection_17
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1 order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -525,17 +507,13 @@ c1	c1
 // Sort should not exist, because tpk is ordered. Not the best plan for now(#25674).
 explain with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 id	estRows	task	access object	operator info
-MergeJoin_32	10000.00	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
-├─Sort_30(Build)	8000.00	root		test.tpk.c1
-│ └─Selection_28	8000.00	root		not(isnull(test.tpk.c1))
-│   └─CTEFullScan_29	10000.00	root	CTE:dt2	data:CTE_0
-└─Sort_26(Probe)	9990.00	root		test.t1.c1
-  └─TableReader_25	9990.00	root		data:Selection_24
-    └─Selection_24	9990.00	cop[tikv]		not(isnull(test.t1.c1))
-      └─TableFullScan_23	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_18(Seed Part)	10000.00	root		data:TableFullScan_17
-  └─TableFullScan_17	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
+MergeJoin_31	12487.50	root		inner join, left key:test.t1.c1, right key:test.tpk.c1
+├─TableReader_27(Build)	10000.00	root		data:TableFullScan_26
+│ └─TableFullScan_26	10000.00	cop[tikv]	table:tpk	keep order:true, stats:pseudo
+└─Sort_19(Probe)	9990.00	root		test.t1.c1
+  └─TableReader_18	9990.00	root		data:Selection_17
+    └─Selection_17	9990.00	cop[tikv]		not(isnull(test.t1.c1))
+      └─TableFullScan_16	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from tpk order by c1) select /*+ MERGE_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = dt1.c1 order by 1, 2;
 c1	c1
 1	1
@@ -545,15 +523,13 @@ c1	c1
 // HashJoin. No need to sort
 explain with cte1 as (select c1 from t1) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_13	80000000.00	root		test.t1.c1, test.t1.c1
-└─HashJoin_16	80000000.00	root		CARTESIAN inner join
-  ├─Selection_20(Build)	8000.00	root		eq(test.t1.c1, 1)
-  │ └─CTEFullScan_21	10000.00	root	CTE:dt2	data:CTE_0
-  └─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
-    └─TableFullScan_18	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_12(Seed Part)	10000.00	root		data:TableFullScan_11
-  └─TableFullScan_11	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+Sort_10	100000.00	root		test.t1.c1, test.t1.c1
+└─HashJoin_13	100000.00	root		CARTESIAN inner join
+  ├─TableReader_19(Build)	10.00	root		data:Selection_18
+  │ └─Selection_18	10.00	cop[tikv]		eq(test.t1.c1, 1)
+  │   └─TableFullScan_17	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+  └─TableReader_16(Probe)	10000.00	root		data:TableFullScan_15
+    └─TableFullScan_15	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from t1) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 c1	c1
 1	1
@@ -566,15 +542,11 @@ c1	c1
 2	1
 explain with cte1 as (select c1 from tpk) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 id	estRows	task	access object	operator info
-Sort_13	80000000.00	root		test.t1.c1, test.tpk.c1
-└─HashJoin_16	80000000.00	root		CARTESIAN inner join
-  ├─Selection_20(Build)	8000.00	root		eq(test.tpk.c1, 1)
-  │ └─CTEFullScan_21	10000.00	root	CTE:dt2	data:CTE_0
-  └─TableReader_19(Probe)	10000.00	root		data:TableFullScan_18
-    └─TableFullScan_18	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
-CTE_0	10000.00	root		Non-Recursive CTE
-└─TableReader_12(Seed Part)	10000.00	root		data:TableFullScan_11
-  └─TableFullScan_11	10000.00	cop[tikv]	table:tpk	keep order:false, stats:pseudo
+Sort_10	10000.00	root		test.t1.c1, test.tpk.c1
+└─HashJoin_13	10000.00	root		CARTESIAN inner join
+  ├─Point_Get_17(Build)	1.00	root	table:tpk	handle:1
+  └─TableReader_16(Probe)	10000.00	root		data:TableFullScan_15
+    └─TableFullScan_15	10000.00	cop[tikv]	table:dt1	keep order:false, stats:pseudo
 with cte1 as (select c1 from tpk) select /*+ HASH_JOIN(dt1, dt2) */ * from t1 dt1 inner join cte1 dt2 on dt2.c1 = 1 order by 1, 2;
 c1	c1
 1	1
@@ -607,3 +579,53 @@ c1	c1	c1
 1	1	1
 2	2	2
 3	3	3
+drop table if exists t;
+create table t(a int, b int, key (b));
+insert into t(a, b) values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+// Basic subquery that can be inlined.
+explain
+with x as (select * from (select b from t) ss)
+select * from x where b = 1;
+id	estRows	task	access object	operator info
+IndexReader_11	10.00	root		index:IndexRangeScan_10
+└─IndexRangeScan_10	10.00	cop[tikv]	table:t, index:b(b)	range:[1,1], keep order:false, stats:pseudo
+// Stable functions are safe to inline.
+explain
+with x as (select * from (select b, sleep(1) from t) ss)
+select * from x where b = 1;
+id	estRows	task	access object	operator info
+Projection_10	10.00	root		test.t.b, sleep(1)->Column#8
+└─IndexReader_12	10.00	root		index:IndexRangeScan_11
+  └─IndexRangeScan_11	10.00	cop[tikv]	table:t, index:b(b)	range:[1,1], keep order:false, stats:pseudo
+// SELECT FOR UPDATE cannot be inlined.
+explain
+with x as (select * from (select b from t for update) ss)
+select * from x where b = 1;
+id	estRows	task	access object	operator info
+Selection_15	8000.00	root		eq(test.t.b, 1)
+└─CTEFullScan_16	10000.00	root	CTE:x	data:CTE_0
+CTE_0	10000.00	root		Non-Recursive CTE
+└─Projection_8(Seed Part)	10000.00	root		test.t.b
+  └─SelectLock_9	10000.00	root		for update 0
+    └─TableReader_11	10000.00	root		data:TableFullScan_10
+      └─TableFullScan_10	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo
+// Multiply-referenced CTEs cannot be inlined.
+explain
+with x as (select * from (select b from t) ss)
+select * from x, x x2 where x.b = x2.b;
+id	estRows	task	access object	operator info
+HashJoin_18	10000.00	root		inner join, equal:[eq(test.t.b, test.t.b)]
+├─Selection_22(Build)	8000.00	root		not(isnull(test.t.b))
+│ └─CTEFullScan_23	10000.00	root	CTE:x2	data:CTE_0
+└─Selection_20(Probe)	8000.00	root		not(isnull(test.t.b))
+  └─CTEFullScan_21	10000.00	root	CTE:x	data:CTE_0
+CTE_0	10000.00	root		Non-Recursive CTE
+└─IndexReader_15(Seed Part)	10000.00	root		index:IndexFullScan_14
+  └─IndexFullScan_14	10000.00	cop[tikv]	table:t, index:b(b)	keep order:false, stats:pseudo
+// Check handling of outer references.
+explain
+with x as (select * from t)
+select * from (with y as (select * from x) select * from y) ss;
+id	estRows	task	access object	operator info
+TableReader_13	10000.00	root		data:TableFullScan_12
+└─TableFullScan_12	10000.00	cop[tikv]	table:t	keep order:false, stats:pseudo

--- a/cmd/explaintest/t/cte.test
+++ b/cmd/explaintest/t/cte.test
@@ -226,3 +226,32 @@ create table tpk1(c1 int primary key);
 insert into tpk1 values(1), (2), (3);
 explain with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
 with cte1 as (select c1 from tpk) select /*+ merge_join(dt1, dt2) */ * from tpk1 dt1 inner join cte1 dt2 inner join cte1 dt3 on dt1.c1 = dt2.c1 and dt2.c1 = dt3.c1;
+# case 34
+drop table if exists t;
+create table t(a int, b int, key (b));
+insert into t(a, b) values (1, 1), (2, 2), (3, 3), (4, 4), (5, 5);
+
+--echo // Basic subquery that can be inlined.
+explain
+with x as (select * from (select b from t) ss)
+select * from x where b = 1;
+
+--echo // Stable functions are safe to inline.
+explain
+with x as (select * from (select b, sleep(1) from t) ss)
+select * from x where b = 1;
+
+--echo // SELECT FOR UPDATE cannot be inlined.
+explain
+with x as (select * from (select b from t for update) ss)
+select * from x where b = 1;
+
+--echo // Multiply-referenced CTEs cannot be inlined.
+explain
+with x as (select * from (select b from t) ss)
+select * from x, x x2 where x.b = x2.b;
+
+--echo // Check handling of outer references.
+explain
+with x as (select * from t)
+select * from (with y as (select * from x) select * from y) ss;


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25149 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

1. Visit the query's nodes and record number of `TableName` referencing this CTE.

2. For CTEs that are referenced only once, check if they have side-effects; this includes either not being a plain SELECT, or containing non-deterministic functions.

3. Visit the query's nodes and inline the singly-referenced CTE.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
