### PR TITLE
txn: refactor some iters in scanner.go

### DIFF
--- a/store/driver/txn/scanner_test.go
+++ b/store/driver/txn/scanner_test.go
@@ -16,6 +16,7 @@ package txn
 import (
 	"testing"
 
+	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,49 @@ func r(key, value string) *kv.Entry {
 	}
 
 	return &kv.Entry{Key: bKey, Value: bValue}
+}
+
+type TestIter struct {
+	kv.Iterator
+	t                *testing.T
+	nextErr          error
+	closed           bool
+	failOnMultiClose bool
+}
+
+func newDefaultTestIterFromRecords(t *testing.T, records []*kv.Entry) *TestIter {
+	return &TestIter{
+		t:                t,
+		Iterator:         mock.NewSliceIter(records),
+		failOnMultiClose: true,
+	}
+}
+
+func (i *TestIter) InjectNextError(err error) {
+	i.nextErr = err
+}
+
+func (i *TestIter) FailOnMultiClose(fail bool) {
+	i.failOnMultiClose = fail
+}
+
+func (i *TestIter) Next() error {
+	if i.nextErr != nil {
+		return i.nextErr
+	}
+	return i.Iterator.Next()
+}
+
+func (i *TestIter) Close() {
+	if i.closed && i.failOnMultiClose {
+		assert.FailNow(i.t, "Multi close iter")
+	}
+	i.closed = true
+	i.Iterator.Close()
+}
+
+func (i *TestIter) Closed() bool {
+	return i.closed
 }
 
 func checkExpectedIterData(t *testing.T, expected []*kv.Entry, iter kv.Iterator) {
@@ -54,47 +98,121 @@ func checkCloseIter(t *testing.T, iter kv.Iterator) {
 }
 
 func TestOneByOneIter(t *testing.T) {
-	iter1 := mock.NewSliceIter([]*kv.Entry{
-		r("k1", "v1"),
-		r("k5", "v3"),
-	})
-	iter2 := mock.NewSliceIter([]*kv.Entry{
-		r("k2", "v2"),
-		r("k4", "v4"),
-	})
-	iter3 := mock.NewSliceIter([]*kv.Entry{})
-	iter4 := mock.NewSliceIter([]*kv.Entry{
-		r("k3", "v3"),
-		r("k6", "v6"),
-	})
+	allocatedIters := make([]*TestIter, 0)
+
+	makeCreateIterFunc := func(records []*kv.Entry, fail bool) createIterFunc {
+		return func() (kv.Iterator, error) {
+			if fail {
+				return nil, errors.New("fail")
+			}
+
+			iter := newDefaultTestIterFromRecords(t, records)
+			allocatedIters = append(allocatedIters, iter)
+			return iter, nil
+		}
+	}
+
+	checkCreatedIterClosed := func() {
+		for _, iter := range allocatedIters {
+			assert.True(t, iter.Closed())
+		}
+	}
+
+	defer checkCreatedIterClosed()
+	slices := [][]*kv.Entry{
+		{
+			r("k1", "v1"),
+			r("k5", "v3"),
+		},
+		{
+			r("k2", "v2"),
+			r("k4", "v4"),
+		},
+		{
+			// empty
+		},
+		{
+			r("k3", "v3"),
+			r("k6", "v6"),
+		},
+	}
+
+	funcs := make([]createIterFunc, 0)
+	for _, s := range slices {
+		funcs = append(funcs, makeCreateIterFunc(s, false))
+	}
 
 	// test for normal iter
-	oneByOne := newOneByOneIter([]kv.Iterator{iter1, iter2, iter3, iter4})
+	oneByOne, err := newOneByOneIter(funcs)
+	assert.Nil(t, err)
 	expected := make([]*kv.Entry, 0)
-	expected = append(expected, iter1.GetSlice()...)
-	expected = append(expected, iter2.GetSlice()...)
-	expected = append(expected, iter3.GetSlice()...)
-	expected = append(expected, iter4.GetSlice()...)
+	expected = append(expected, slices[0]...)
+	expected = append(expected, slices[1]...)
+	expected = append(expected, slices[2]...)
+	expected = append(expected, slices[3]...)
 	checkExpectedIterData(t, expected, oneByOne)
 
 	// test for close
-	oneByOne = newOneByOneIter([]kv.Iterator{iter1, iter2, iter3, iter4})
+	oneByOne, err = newOneByOneIter(funcs)
+	assert.Nil(t, err)
 	checkCloseIter(t, oneByOne)
 
 	// test for one inner iter
-	iter1 = mock.NewSliceIter([]*kv.Entry{
-		r("k1", "v1"),
-		r("k5", "v3"),
-	})
-	oneByOne = newOneByOneIter([]kv.Iterator{iter1})
+	oneByOne, err = newOneByOneIter(funcs[:1])
+	assert.Nil(t, err)
 	expected = make([]*kv.Entry, 0)
-	expected = append(expected, iter1.GetSlice()...)
+	expected = append(expected, slices[0]...)
 	checkExpectedIterData(t, expected, oneByOne)
 
 	// test for empty iter
-	iter3 = mock.NewSliceIter([]*kv.Entry{})
-	oneByOne = newOneByOneIter([]kv.Iterator{iter3})
+	oneByOne, err = newOneByOneIter(funcs[2:3])
+	assert.Nil(t, err)
 	checkExpectedIterData(t, nil, oneByOne)
+
+	// test for first func return error
+	funcsWithFirstError := make([]createIterFunc, 0)
+	for i, s := range slices {
+		funcsWithFirstError = append(funcsWithFirstError, makeCreateIterFunc(s, i == 0))
+	}
+	oneByOne, err = newOneByOneIter(funcsWithFirstError)
+	assert.Nil(t, oneByOne)
+	assert.NotNil(t, err)
+
+	// test for second func return error
+	funcsWithSecondError := make([]createIterFunc, 0)
+	for i, s := range slices {
+		funcsWithSecondError = append(funcsWithSecondError, makeCreateIterFunc(s, i == 1))
+	}
+	oneByOne, err = newOneByOneIter(funcsWithSecondError)
+	assert.Nil(t, err)
+	for i, record := range slices[0] {
+		assert.True(t, oneByOne.Valid())
+		assert.Equal(t, record.Key, oneByOne.Key())
+		assert.Equal(t, record.Value, oneByOne.Value())
+		err = oneByOne.Next()
+		if i == len(slices[0])-1 {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err)
+		}
+	}
+	assert.False(t, oneByOne.Valid())
+	// check error will close all inner iters
+	checkCreatedIterClosed()
+	// check close after error close only once
+	oneByOne.Close()
+
+	// test for error occurs when iter.Next()
+	oneByOne, err = newOneByOneIter(funcs)
+	assert.Nil(t, err)
+	assert.True(t, oneByOne.Valid())
+	injectedErr := errors.New("error")
+	oneByOne.curIter.(*TestIter).InjectNextError(injectedErr)
+	err = oneByOne.Next()
+	assert.Equal(t, injectedErr, err)
+	assert.False(t, oneByOne.Valid())
+	checkCreatedIterClosed()
+	oneByOne.Close()
 }
 
 func TestFilterEmptyValueIter(t *testing.T) {
@@ -143,14 +261,43 @@ func TestFilterEmptyValueIter(t *testing.T) {
 			}
 		}
 
-		iter, err := filterEmptyValue(mock.NewSliceIter(c.data))
+		testIter := newDefaultTestIterFromRecords(t, c.data)
+		iter, err := filterEmptyValue(testIter)
 		assert.Nil(t, err)
 		checkExpectedIterData(t, data, iter)
+		assert.True(t, testIter.Closed())
 
-		iter, err = filterEmptyValue(mock.NewSliceIter(c.data))
+		testIter = newDefaultTestIterFromRecords(t, c.data)
+		iter, err = filterEmptyValue(testIter)
 		assert.Nil(t, err)
 		checkCloseIter(t, iter)
+		assert.True(t, testIter.Closed())
 	}
+
+	// test error for create
+	testIter := newDefaultTestIterFromRecords(t, []*kv.Entry{r("k1", ""), r("k2", "v2")})
+	injectedErr := errors.New("error")
+	testIter.InjectNextError(injectedErr)
+	iter, err := filterEmptyValue(testIter)
+	assert.Nil(t, iter)
+	assert.Equal(t, injectedErr, err)
+	// after error testIter.Close() should not cause multi close
+	testIter.Close()
+
+	// test error for next
+	testIter = newDefaultTestIterFromRecords(t, []*kv.Entry{r("k1", "v1"), r("k2", "v2")})
+	injectedErr = errors.New("error")
+	testIter.InjectNextError(injectedErr)
+	iter, err = filterEmptyValue(testIter)
+	assert.Nil(t, err)
+	assert.True(t, iter.Valid())
+	err = iter.Next()
+	assert.Equal(t, injectedErr, err)
+	assert.False(t, iter.Valid())
+	// inner iter.Close() should not be invoked after error
+	assert.False(t, testIter.Closed())
+	iter.Close()
+	assert.True(t, testIter.Closed())
 }
 
 func TestLowerBoundReverseIter(t *testing.T) {
@@ -193,21 +340,21 @@ func TestLowerBoundReverseIter(t *testing.T) {
 		},
 		{
 			data: []*kv.Entry{
-				r("k1", "v1"),
 				r("k2", "v2"),
+				r("k1", "v1"),
 			},
 			lowerBound: kv.Key("k3"),
 			expected:   nil,
 		},
 		{
 			data: []*kv.Entry{
-				r("k1", "v1"),
 				r("k2", "v2"),
+				r("k1", "v1"),
 			},
 			lowerBound: kv.Key("k0"),
 			expected: []*kv.Entry{
-				r("k1", "v1"),
 				r("k2", "v2"),
+				r("k1", "v1"),
 			},
 		},
 		{
@@ -233,10 +380,31 @@ func TestLowerBoundReverseIter(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		iter := newLowerBoundReverseIter(mock.NewSliceIter(c.data), c.lowerBound)
+		testIter := newDefaultTestIterFromRecords(t, c.data)
+		iter := newLowerBoundReverseIter(testIter, c.lowerBound)
 		checkExpectedIterData(t, c.expected, iter)
+		assert.True(t, testIter.Closed())
 
-		iter = newLowerBoundReverseIter(mock.NewSliceIter(c.data), c.lowerBound)
+		testIter = newDefaultTestIterFromRecords(t, c.data)
+		iter = newLowerBoundReverseIter(testIter, c.lowerBound)
 		checkCloseIter(t, iter)
+		assert.True(t, testIter.Closed())
 	}
+
+	// test for iter.Next() error
+	testIter := newDefaultTestIterFromRecords(t, []*kv.Entry{
+		r("k2", "v2"),
+		r("k1", "v1"),
+	})
+	injectedErr := errors.New("error")
+	testIter.InjectNextError(injectedErr)
+	iter := newLowerBoundReverseIter(testIter, kv.Key("k11"))
+	assert.True(t, iter.Valid())
+	err := iter.Next()
+	assert.Equal(t, injectedErr, err)
+	assert.False(t, iter.Valid())
+	// inner iter.Close() should not be invoked after error
+	assert.False(t, testIter.Closed())
+	iter.Close()
+	assert.True(t, testIter.Closed())
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

There are some problems for the current  wrapper iterator implementions.

* oneByOneIter

In current implement, `oneByOneIter` keeps a list of iterators and iters them on by one. It may cause some problems when we have many iterators. For example, 1000+ iterators may keep 1000+ connections, but only one is used at one time. It's big waste of resources.

* filterEmptyValueIter, lowerBoundReverseIter

We should think more carefully for error cases. For example, when we call `lowerBoundReverseIter.Next()` it actually calls its inner iter's Next function. If it's innert iter returns an error, what's the wrapper's behavior after it.

### What is changed and how it works?

What's Changed:

- For `oneByOneIter` , it keeps a list of function that creates a new iterator instead of a list of iterators. So the creation of iterator becomes lazy. We'll close an iter once it becomes invalid, so there is only one iter alive at one time.

- For `filterEmptyValueIter` and `lowerBoundReverseIter` , when their inner `iter.Next()` return errors , they become invalid but not close their inner iter explicitly. When wrapper iter's `Close()` method is called its inner iter will be closed. Why not close inner iter when error occurs is to forbid multi close. User may bypass the wrapper iter and close the inner iter directly, so if we close the inner iter when error occurs, it will be closed twice. 

- Also added some tests for error behaviors.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
