### PR TITLE
server: Cleanup UNIX Socket file

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -250,7 +250,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 
 	if s.cfg.Socket != "" {
 
-		err := cleanupSocket(s.cfg.Socket)
+		err := cleanupStaleSocket(s.cfg.Socket)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -301,7 +301,7 @@ func NewServer(cfg *config.Config, driver IDriver) (*Server, error) {
 	return s, nil
 }
 
-func cleanupSocket(socket string) error {
+func cleanupStaleSocket(socket string) error {
 	sockStat, err := os.Stat(socket)
 	if err == nil {
 		if sockStat.Mode().Type() != os.ModeSocket {
@@ -322,7 +322,7 @@ func cleanupSocket(socket string) error {
 			return fmt.Errorf("unix socket %s exists and is functional, not removing it", socket)
 		}
 	}
-	return err
+	return nil
 }
 
 func setSSLVariable(ca, key, cert string) {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #26058

Problem Summary: When `tidb-server` stops unexpectedly it might not be able to cleanup the UNIX socket file it was listening on. The result is that the server can't start again until the file is removed.

### What is changed and how it works?

How it Works:

Getting the list of listening UNIX sockets is possible on Linux, but is not portable.
So instead this tries to `os.Stat()` the socket file and then:

- Checks if this is a socket file
- Checks if it can connect with `net.Dial`
- Removes the file if it is a socket file and if it can't connect.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
On startup `tidb-server` removes unused socket files from previous instances
```
