### PR TITLE
planner: add  test for HotRegionsHistoryTableExtractor

### DIFF
--- a/planner/core/memtable_predicate_extractor_test.go
+++ b/planner/core/memtable_predicate_extractor_test.go
@@ -1047,3 +1047,287 @@ func (s *extractorSuite) TestInspectionRuleTableExtractor(c *C) {
 		c.Assert(clusterConfigExtractor.SkipRequest, Equals, ca.skip, Commentf("SQL: %v", ca.sql))
 	}
 }
+
+func (s *extractorSuite) TestTiDBHotRegionsHistoryTableExtractor(c *C) {
+	var cases = []struct {
+		sql                          string
+		skipRequest                  bool
+		startTime, endTime           int64
+		regionIDs, storeIDs, peerIDs []uint64
+		isLearners, isLeaders        []uint64
+		hotRegionTypes               set.StringSet
+	}{
+		// Test full data, it will not call Extract() and executor(retriver) will panic and remind user to add conditions to save network IO.
+		{
+			sql: "select * from information_schema.tidb_hot_regions_history",
+		},
+		// Test startTime and endTime.
+		{
+			// Test for invalid update_time.
+			sql: "select * from information_schema.tidb_hot_regions_history where update_time='2019-10-10 10::10'",
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time='2019-10-10 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10"),
+			endTime:   timestamp(c, "2019-10-10 10:10:10"),
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and update_time<='2019-10-11 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10"),
+			endTime:   timestamp(c, "2019-10-11 10:10:10"),
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>'2019-10-10 10:10:10' and update_time<'2019-10-11 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10") + 1,
+			endTime:   timestamp(c, "2019-10-11 10:10:10") - 1,
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and update_time<'2019-10-11 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10"),
+			endTime:   timestamp(c, "2019-10-11 10:10:10") - 1,
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-12 10:10:10' and update_time<'2019-10-11 10:10:10'",
+			startTime:   timestamp(c, "2019-10-12 10:10:10"),
+			endTime:     timestamp(c, "2019-10-11 10:10:10") - 1,
+			skipRequest: true,
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10"),
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and  update_time>='2019-10-11 10:10:10' and  update_time>='2019-10-12 10:10:10'",
+			startTime: timestamp(c, "2019-10-12 10:10:10"),
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and  update_time>='2019-10-11 10:10:10' and  update_time>='2019-10-12 10:10:10' and update_time='2019-10-13 10:10:10'",
+			startTime: timestamp(c, "2019-10-13 10:10:10"),
+			endTime:   timestamp(c, "2019-10-13 10:10:10"),
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where update_time<='2019-10-10 10:10:10' and update_time='2019-10-13 10:10:10'",
+			startTime:   timestamp(c, "2019-10-13 10:10:10"),
+			endTime:     timestamp(c, "2019-10-10 10:10:10"),
+			skipRequest: true,
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where update_time='2019-10-10 10:10:10' and update_time<='2019-10-13 10:10:10'",
+			startTime: timestamp(c, "2019-10-10 10:10:10"),
+			endTime:   timestamp(c, "2019-10-10 10:10:10"),
+		},
+
+		// Test `region_id`, `store_id`, `peer_id` columns.
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id=100",
+			regionIDs: []uint64{100},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where 100=region_id",
+			regionIDs: []uint64{100},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where 100=region_id or region_id=101",
+			regionIDs: []uint64{100, 101},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where 100=region_id or region_id=101 or region_id=102 or 103 = region_id",
+			regionIDs: []uint64{100, 101, 102, 103},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where (region_id=100 or region_id=101) and (store_id=200 or store_id=201)",
+			regionIDs: []uint64{100, 101},
+			storeIDs:  []uint64{200, 201},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id in (100, 101)",
+			regionIDs: []uint64{100, 101},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id in (100, 101) and store_id=200",
+			regionIDs: []uint64{100, 101},
+			storeIDs:  []uint64{200},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id in (100, 101) and store_id in (200, 201)",
+			regionIDs: []uint64{100, 101},
+			storeIDs:  []uint64{200, 201},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id=100 and store_id in (200, 201)",
+			regionIDs: []uint64{100},
+			storeIDs:  []uint64{200, 201},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id=100 and store_id=200",
+			regionIDs: []uint64{100},
+			storeIDs:  []uint64{200},
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id=101",
+			skipRequest: true,
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id in (100,101)",
+			regionIDs: []uint64{100},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id in (100,101) and store_id=200 and store_id in (200,201)",
+			regionIDs: []uint64{100},
+			storeIDs:  []uint64{200},
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id in (101,102)",
+			skipRequest: true,
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id in (101,102) and store_id=200 and store_id in (200,201)",
+			skipRequest: true,
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where region_id=100 and region_id in (100,101) and store_id=200 and store_id in (201,202)",
+			skipRequest: true,
+		},
+		{
+			sql: `select * from information_schema.tidb_hot_regions_history 
+								where region_id=100 and region_id in (100,101) 
+								and store_id=200 and store_id in (201,202)`,
+			skipRequest: true,
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where region_id in (100,101) and region_id in (101,102)",
+			regionIDs: []uint64{101},
+		},
+		{
+			sql: `select * from information_schema.tidb_hot_regions_history 
+							where region_id in (100,101) 
+							and region_id in (101,102) 
+							and store_id in (200,201) 
+							and store_id in (201,202)`,
+			regionIDs: []uint64{101},
+			storeIDs:  []uint64{201},
+		},
+		{
+			sql: `select * from information_schema.tidb_hot_regions_history 
+							where region_id in (100,101) 
+							and region_id in (101,102) 
+							and store_id in (200,201) 
+							and store_id in (201,202)
+							and peer_id in (3000,3001)
+							and peer_id in (3001,3002)`,
+			regionIDs: []uint64{101},
+			storeIDs:  []uint64{201},
+			peerIDs:   []uint64{3001},
+		},
+		{
+			sql: `select * from information_schema.tidb_hot_regions_history 
+							where region_id in (100,101) 
+							and region_id in (100,102) 
+							and region_id in (102,103) 
+							and region_id in (103,104)`,
+			skipRequest: true,
+		},
+		// Test `type` column.
+		{
+			sql:            "select * from information_schema.tidb_hot_regions_history where type='read'",
+			hotRegionTypes: set.NewStringSet("read"),
+		},
+		{
+			sql:            "select * from information_schema.tidb_hot_regions_history where type in('read')",
+			hotRegionTypes: set.NewStringSet("read"),
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where type='read' and type='write'",
+			skipRequest: true,
+		},
+		{
+			sql:            "select * from information_schema.tidb_hot_regions_history where type in ('read', 'write')",
+			hotRegionTypes: set.NewStringSet("read", "write"),
+		},
+		{
+			sql:            "select * from information_schema.tidb_hot_regions_history where type='read' and type in ('read', 'write')",
+			hotRegionTypes: set.NewStringSet("read"),
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where type in ('read') and type in ('write')",
+			skipRequest: true,
+		},
+		// Test `is_learner`, `is_leaeder` columns.
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner=1",
+			isLearners: []uint64{1},
+		},
+		{
+			sql:       "select * from information_schema.tidb_hot_regions_history where is_leader=0",
+			isLeaders: []uint64{0},
+		},
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner=true",
+			isLearners: []uint64{1},
+		},
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner in(0,1)",
+			isLearners: []uint64{0, 1},
+		},
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner in(true,false)",
+			isLearners: []uint64{0, 1},
+		},
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner in(3,4)",
+			isLearners: []uint64{3, 4},
+		},
+		{
+			sql:        "select * from information_schema.tidb_hot_regions_history where is_learner in(3,4) and is_leader in(0,1,true,false,3,4)",
+			isLearners: []uint64{3, 4},
+			isLeaders:  []uint64{0, 1, 3, 4},
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where is_learner=1 and is_learner=0",
+			skipRequest: true,
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where is_learner=3 and is_learner=false",
+			skipRequest: true,
+		},
+		{
+			sql:         "select * from information_schema.tidb_hot_regions_history where is_learner=3 and is_learner=4",
+			skipRequest: true,
+		},
+	}
+	se, err := session.CreateSession4Test(s.store)
+	se.GetSessionVars().StmtCtx.TimeZone = time.Local
+	c.Assert(err, IsNil)
+	parser := parser.New()
+	for _, ca := range cases {
+		logicalMemTable := s.getLogicalMemTable(c, se, parser, ca.sql)
+		c.Assert(logicalMemTable.Extractor, NotNil, Commentf("SQL: %v", ca.sql))
+
+		hotRegionsHistoryExtractor := logicalMemTable.Extractor.(*plannercore.HotRegionsHistoryTableExtractor)
+		if ca.startTime > 0 {
+			c.Assert(hotRegionsHistoryExtractor.StartTime, Equals, ca.startTime, Commentf("SQL: %v", ca.sql))
+		}
+		if ca.endTime > 0 {
+			c.Assert(hotRegionsHistoryExtractor.EndTime, Equals, ca.endTime, Commentf("SQL: %v", ca.sql))
+		}
+		c.Assert(hotRegionsHistoryExtractor.SkipRequest, DeepEquals, ca.skipRequest, Commentf("SQL: %v", ca.sql))
+		if len(ca.isLearners) > 0 {
+			c.Assert(hotRegionsHistoryExtractor.IsLearners, DeepEquals, ca.isLearners, Commentf("SQL: %v", ca.sql))
+		}
+		if len(ca.isLeaders) > 0 {
+			c.Assert(hotRegionsHistoryExtractor.IsLeaders, DeepEquals, ca.isLeaders, Commentf("SQL: %v", ca.sql))
+		}
+		if ca.hotRegionTypes.Count() > 0 {
+			c.Assert(hotRegionsHistoryExtractor.HotRegionTypes, DeepEquals, ca.hotRegionTypes, Commentf("SQL: %v", ca.sql))
+		}
+		if len(ca.regionIDs) > 0 {
+			c.Assert(hotRegionsHistoryExtractor.RegionIDs, DeepEquals, ca.regionIDs, Commentf("SQL: %v", ca.sql))
+		}
+		if len(ca.storeIDs) > 0 {
+			c.Assert(hotRegionsHistoryExtractor.StoreIDs, DeepEquals, ca.storeIDs, Commentf("SQL: %v", ca.sql))
+		}
+		if len(ca.peerIDs) > 0 {
+			c.Assert(hotRegionsHistoryExtractor.PeerIDs, DeepEquals, ca.peerIDs, Commentf("SQL: %v", ca.sql))
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: IcePigZDB <icepigzdb@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->
Problem Summary: Create a new table `TIDB_HOT_REGIONS_HISTORY` in the `INFORMATION_SCHEMAT` database to retrieve history hotspot information stored by PD periodically.
### What problem does this PR solve?
Proposal: [pingcap/tidb#27487](https://github.com/pingcap/tidb/pull/27487)
Associated Issue: #25281

Associated PRs in TiDB:
PRs splited from oversize PR #27224 in merge order :
1. #27373 
2. #27374 
3. #27375 
4. #27899 **<- current one** 
5. #27900   

Associated PR in PD:  
 PRs splited from old oversize one: tikv/pd/pull/3989 
* tikv/pd/pull/4019
* tikv/pd/pull/4020
* tikv/pd/pull/4021

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and update_time<'2019-10-11 10:10:10'
```
