### PR TITLE
executor: add test for hotRegionsHistoryRetriver

### DIFF
--- a/executor/memtable_reader_test.go
+++ b/executor/memtable_reader_test.go
@@ -16,9 +16,13 @@ package executor_test
 
 import (
 	"context"
+	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net"
+	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
@@ -33,8 +37,10 @@ import (
 	"github.com/pingcap/kvproto/pkg/diagnosticspb"
 	"github.com/pingcap/sysutil"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/executor"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/util/pdapi"
 	"github.com/pingcap/tidb/util/testkit"
 	pmodel "github.com/prometheus/common/model"
@@ -940,5 +946,447 @@ func (s *testMemTableReaderSuite) TestTiDBClusterLogError(c *C) {
 	_, err = session.ResultSetToStringSlice(context.Background(), tk.Se, rs)
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "denied to scan full logs (use `SELECT * FROM cluster_log WHERE message LIKE '%'` explicitly if intentionally)")
+	c.Assert(rs.Close(), IsNil)
+}
+
+var _ = SerialSuites(&testHotRegionsHistoryTableSuite{testInfoschemaTableSuiteBase: &testInfoschemaTableSuiteBase{}})
+
+type testHotRegionsHistoryTableSuite struct {
+	*testInfoschemaTableSuiteBase
+	httpServers []*httptest.Server
+	startTime   time.Time
+}
+
+type mockStoreWithMultiPD struct {
+	helper.Storage
+	hosts []string
+}
+
+var hotRegionsResponses = make(map[string]*executor.HistoryHotRegions, 3)
+
+func (s *mockStoreWithMultiPD) EtcdAddrs() ([]string, error) { return s.hosts, nil }
+func (s *mockStoreWithMultiPD) TLSConfig() *tls.Config       { panic("not implemented") }
+func (s *mockStoreWithMultiPD) StartGCWorker() error         { panic("not implemented") }
+func (s *mockStoreWithMultiPD) Name() string                 { return "mockStore" }
+func (s *mockStoreWithMultiPD) Describe() string             { return "" }
+
+func (s *testHotRegionsHistoryTableSuite) SetUpSuite(c *C) {
+	s.testInfoschemaTableSuiteBase.SetUpSuite(c)
+	store := &mockStoreWithMultiPD{
+		s.store.(helper.Storage),
+		make([]string, 3),
+	}
+	// start 3 PD server with hotRegionsServer and store them in s.store
+	for i := 0; i < 3; i++ {
+		httpServer, mockAddr := s.setUpMockPDHTTPServer(c)
+		c.Assert(httpServer, NotNil)
+		s.httpServers = append(s.httpServers, httpServer)
+		store.hosts[i] = mockAddr
+	}
+	s.store = store
+	s.startTime = time.Now()
+}
+
+func writeJSONError(w http.ResponseWriter, code int, prefix string, err error) {
+	type errorResponse struct {
+		Error string `json:"error"`
+	}
+	w.WriteHeader(code)
+	if err != nil {
+		prefix += ": " + err.Error()
+	}
+	_ = json.NewEncoder(w).Encode(errorResponse{Error: prefix})
+}
+
+func hisHotRegionsHandler(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	data, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "unable to read req", err)
+		return
+	}
+	r.Body.Close()
+	req := &executor.HistoryHotRegionsRequest{}
+	err = json.Unmarshal(data, req)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "unable to serialize req", err)
+		return
+	}
+	resp := &executor.HistoryHotRegions{}
+	for _, typ := range req.HotRegionTypes {
+		resp.HistoryHotRegion = append(resp.HistoryHotRegion, hotRegionsResponses[strings.ToUpper(typ)+r.Host].HistoryHotRegion...)
+	}
+	w.WriteHeader(http.StatusOK)
+	jsonResp, err := json.Marshal(resp)
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "unable to marshal resp", err)
+		return
+	}
+	w.Write(jsonResp)
+}
+
+func (s *testHotRegionsHistoryTableSuite) setUpMockPDHTTPServer(c *C) (*httptest.Server, string) {
+	// mock PD http server
+	router := mux.NewRouter()
+	server := httptest.NewServer(router)
+	mockAddr := strings.TrimPrefix(server.URL, "http://")
+	// mock PD API
+	router.Handle(pdapi.ClusterVersion, fn.Wrap(func() (string, error) { return "4.0.0-alpha", nil }))
+	router.Handle(pdapi.Status, fn.Wrap(func() (interface{}, error) {
+		return struct {
+			GitHash        string `json:"git_hash"`
+			StartTimestamp int64  `json:"start_timestamp"`
+		}{
+			GitHash:        "mock-pd-githash",
+			StartTimestamp: s.startTime.Unix(),
+		}, nil
+	}))
+	// mock hisory hot regions response
+	router.HandleFunc(pdapi.HotHistory, hisHotRegionsHandler)
+	return server, mockAddr
+}
+
+func (s *testHotRegionsHistoryTableSuite) TearDownSuite(c *C) {
+	for _, server := range s.httpServers {
+		server.Close()
+	}
+	s.testInfoschemaTableSuiteBase.TearDownSuite(c)
+}
+
+func (s *testHotRegionsHistoryTableSuite) TestTiDBHotRegionsHistory(c *C) {
+	var unixTimeMs = func(s string) int64 {
+		t, err := time.ParseInLocation("2006-01-02 15:04:05", s, time.Local)
+		c.Assert(err, IsNil)
+		return t.UnixNano() / int64(time.Millisecond)
+	}
+	fullHotRegions := [][]string{
+		// mysql table_id = 11, record_id = 1, table_name = TABLES_PRIV
+		{"2019-10-10 10:10:11", "MYSQL", "TABLES_PRIV", "11", "<nil>", "<nil>", "1", "1", "11111", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:12", "MYSQL", "TABLES_PRIV", "11", "<nil>", "<nil>", "2", "2", "22222", "0", "0", "WRITE", "99", "99", "99", "99"},
+		// mysql table_id = 21, record_id = 1, table_name = STATS_META
+		{"2019-10-10 10:10:13", "MYSQL", "STATS_META", "21", "<nil>", "<nil>", "3", "3", "33333", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:14", "MYSQL", "STATS_META", "21", "<nil>", "<nil>", "4", "4", "44444", "0", "0", "WRITE", "99", "99", "99", "99"},
+		//      table_id = 131, record_id=1, deleted schema
+		{"2019-10-10 10:10:15", "UNKONW", "UNKONW", "131", "UNKONW", "<nil>", "5", "5", "55555", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:16", "UNKONW", "UNKONW", "131", "UNKONW", "<nil>", "6", "6", "66666", "0", "0", "WRITE", "99", "99", "99", "99"},
+		// mysql table_id = 11, index_id = 1, index_value = 1, table_name = TABLES_PRIV, index_name = PRIMARY
+		{"2019-10-10 10:10:17", "MYSQL", "TABLES_PRIV", "11", "PRIMARY", "1", "1", "1", "11111", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:18", "MYSQL", "TABLES_PRIV", "11", "PRIMARY", "1", "2", "2", "22222", "0", "0", "WRITE", "99", "99", "99", "99"},
+		// mysql table_id = 21 ,index_id = 1, index_value = 1, table_name = STATS_META, index_name = IDX_VER
+		{"2019-10-10 10:10:19", "MYSQL", "STATS_META", "21", "IDX_VER", "1", "3", "3", "33333", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:20", "MYSQL", "STATS_META", "21", "IDX_VER", "1", "4", "4", "44444", "0", "0", "WRITE", "99", "99", "99", "99"},
+		// mysql table_id = 21 ,index_id = 2, index_value = 1, table_name = STATS_META, index_name = TBL
+		{"2019-10-10 10:10:21", "MYSQL", "STATS_META", "21", "TBL", "2", "5", "5", "55555", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:22", "MYSQL", "STATS_META", "21", "TBL", "2", "6", "6", "66666", "0", "0", "WRITE", "99", "99", "99", "99"},
+		//      table_id = 131, index_id = 1, index_value = 1, deleted schema
+		{"2019-10-10 10:10:23", "UNKONW", "UNKONW", "131", "UNKONW", "1", "5", "5", "55555", "0", "1", "READ", "99", "99", "99", "99"},
+		{"2019-10-10 10:10:24", "UNKONW", "UNKONW", "131", "UNKONW", "1", "6", "6", "66666", "0", "0", "WRITE", "99", "99", "99", "99"},
+	}
+
+	c.Assert(fullHotRegions, NotNil)
+
+	pdResps := []map[string]*executor.HistoryHotRegions{
+		{
+			executor.HotRegionTypeRead: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					// mysql table_id = 11, record_id = 1, table_name = TABLES_PRIV
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:11"), RegionID: 1, StoreID: 1, PeerID: 11111, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 21, record_id = 1, table_name = STATS_META
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:13"), RegionID: 3, StoreID: 3, PeerID: 33333, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+			executor.HotRegionTypeWrite: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					// mysql table_id = 11, record_id = 1, table_name = TABLES_PRIV
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:12"), RegionID: 2, StoreID: 2, PeerID: 22222, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 21, record_id = 1, table_name = STATS_META
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:14"), RegionID: 4, StoreID: 4, PeerID: 44444, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+		},
+		{
+			executor.HotRegionTypeRead: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					//      table_id = 131, record_id=1, deleted schema
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:15"), RegionID: 5, StoreID: 5, PeerID: 55555, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 11, index_id = 1, index_value = 1, table_name = TABLES_PRIV, index_name = PRIMARY
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:17"), RegionID: 1, StoreID: 1, PeerID: 11111, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+			executor.HotRegionTypeWrite: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					//      table_id = 131, record_id=1, deleted schema
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:16"), RegionID: 6, StoreID: 6, PeerID: 66666, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 11, index_id = 1, index_value = 1, table_name = TABLES_PRIV, index_name = PRIMARY
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:18"), RegionID: 2, StoreID: 2, PeerID: 22222, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0xb, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+		},
+		{
+			executor.HotRegionTypeRead: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					// mysql table_id = 21 ,index_id = 1, index_value = 1, table_name = STATS_META, index_name = IDX_VER
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:19"), RegionID: 3, StoreID: 3, PeerID: 33333, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 21 ,index_id = 2, index_value = 1, table_name = STATS_META, index_name = TBL
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:21"), RegionID: 5, StoreID: 5, PeerID: 55555, IsLearner: false, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					//      table_id = 131, index_id = 1, index_value = 1, deleted schema
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:23"), RegionID: 5, StoreID: 5, PeerID: 55555, IsLeader: true, HotRegionType: "READ", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+			executor.HotRegionTypeWrite: {
+				HistoryHotRegion: []*executor.HistoryHotRegion{
+					// mysql table_id = 21 ,index_id = 1, index_value = 1, table_name = STATS_META, index_name = IDX_VER
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:20"), RegionID: 4, StoreID: 4, PeerID: 44444, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					// mysql table_id = 21 ,index_id = 2, index_value = 1, table_name = STATS_META, index_name = TBL
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:22"), RegionID: 6, StoreID: 6, PeerID: 66666, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x15, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x2, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+					//      table_id = 131, index_id = 1, index_value = 1, deleted schema
+					{UpdateTime: unixTimeMs("2019-10-10 10:10:24"), RegionID: 6, StoreID: 6, PeerID: 66666, IsLearner: false, IsLeader: false, HotRegionType: "WRITE", HotDegree: 99, FlowBytes: 99, KeyRate: 99, QueryRate: 99,
+						StartKey: []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa},
+						EndKey:   []byte{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xff, 0x83, 0x5f, 0x69, 0x80, 0x0, 0x0, 0x0, 0x0, 0xff, 0x0, 0x0, 0x1, 0x0, 0x0, 0x0, 0x0, 0x0, 0xfa}},
+				},
+			},
+		},
+	}
+
+	var cases = []struct {
+		conditions []string
+		reqCount   int32
+		expected   [][]string
+	}{
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+			}, // time filtered by PD, assume response suit time range, and ignore deleted schemas
+			expected: [][]string{
+				fullHotRegions[0], fullHotRegions[1], fullHotRegions[2],
+				fullHotRegions[3],
+				fullHotRegions[6], fullHotRegions[7], fullHotRegions[8],
+				fullHotRegions[9], fullHotRegions[10], fullHotRegions[11],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>=TIMESTAMP('2019-10-10 10:10:10')",
+				"update_time<=TIMESTAMP('2019-10-11 10:10:10')",
+			}, // test support of timestamp
+			expected: [][]string{
+				fullHotRegions[0], fullHotRegions[1], fullHotRegions[2],
+				fullHotRegions[3],
+				fullHotRegions[6], fullHotRegions[7], fullHotRegions[8],
+				fullHotRegions[9], fullHotRegions[10], fullHotRegions[11],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=11",
+			},
+			expected: [][]string{
+				fullHotRegions[0], fullHotRegions[1], fullHotRegions[6], fullHotRegions[7],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_name='TABLES_PRIV'",
+			},
+			expected: [][]string{
+				fullHotRegions[0], fullHotRegions[1], fullHotRegions[6], fullHotRegions[7],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=21",
+				"index_id=1",
+			},
+			expected: [][]string{
+				fullHotRegions[8], fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=21",
+				"index_id=1",
+				"table_name='TABLES_PRIV'",
+			}, // table_id != table_name -> nil
+			expected: [][]string{},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=21",
+				"index_id=1",
+				"table_name='STATS_META'",
+			}, // table_id = table_name
+			expected: [][]string{
+				fullHotRegions[8], fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=21",
+				"index_id=1",
+				"index_name='UNKONW'",
+			}, // index_id != index_name -> nil
+			expected: [][]string{},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"table_id=21",
+				"index_id=1",
+				"index_name='IDX_VER'",
+			}, // index_id = index_name
+			expected: [][]string{
+				fullHotRegions[8], fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"index_id=1",
+				"index_name='IDX_VER'",
+				"table_id>=21", // unpushed down predicates 21>=21
+			},
+			expected: [][]string{
+				fullHotRegions[8], fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"index_id=1",
+				"index_name='IDX_VER'",
+				"table_id>21", // unpushed down predicates
+			}, // 21!>21 -> nil
+			expected: [][]string{},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"index_id=1",
+				"index_name='IDX_VER'",
+				"table_id>=21", // unpushed down predicates
+				"db_name='MYSQL'",
+			},
+			expected: [][]string{
+				fullHotRegions[8], fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"index_id=1",
+				"index_name='IDX_VER'",
+				"table_id>=21", // unpushed down predicates
+				"db_name='MYSQL'",
+				"peer_id>=33334",
+			},
+			expected: [][]string{
+				fullHotRegions[9],
+			},
+		},
+		{
+			conditions: []string{
+				"update_time>='2019-10-10 10:10:10'",
+				"update_time<='2019-10-11 10:10:10'",
+				"index_id=1",
+				"index_name='IDX_VER'",
+				"table_id>=21", // unpushed down predicates
+				"db_name='UNKNOW'",
+			},
+			expected: [][]string{},
+		},
+	}
+	// failpoint
+	fpName := "github.com/pingcap/tidb/executor/mockTiDBHotRegionsHistory"
+	c.Assert(failpoint.Enable(fpName, `return("")`), IsNil)
+	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
+	// mock http resp
+	store := s.store.(*mockStoreWithMultiPD)
+	for i, resp := range pdResps {
+		for k, v := range resp {
+			hotRegionsResponses[k+store.hosts[i]] = v
+		}
+	}
+	tk := testkit.NewTestKit(c, s.store)
+	for _, cas := range cases {
+		sql := "select * from information_schema.tidb_hot_regions_history"
+		if len(cas.conditions) > 0 {
+			sql = fmt.Sprintf("%s where %s", sql, strings.Join(cas.conditions, " and "))
+		}
+		result := tk.MustQuery(sql)
+		warnings := tk.Se.GetSessionVars().StmtCtx.GetWarnings()
+		c.Assert(len(warnings), Equals, 0, Commentf("unexpected warnigns: %+v", warnings))
+		var expected []string
+		for _, row := range cas.expected {
+			expectedRow := row
+			expected = append(expected, strings.Join(expectedRow, " "))
+		}
+		result.Check(testkit.Rows(expected...))
+	}
+}
+
+func (s *testHotRegionsHistoryTableSuite) TestTiDBHotRegionsHistoryError(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	fpName := "github.com/pingcap/tidb/executor/mockTiDBHotRegionsHistory"
+	c.Assert(failpoint.Enable(fpName, `return("")`), IsNil)
+	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
+
+	// Test without start time error
+	rs, err := tk.Exec("select * from information_schema.tidb_hot_regions_history")
+	c.Assert(err, IsNil)
+	_, err = session.ResultSetToStringSlice(context.Background(), tk.Se, rs)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "denied to scan hot regions, please specified the start time, such as `update_time > '2020-01-01 00:00:00'`")
+	c.Assert(rs.Close(), IsNil)
+
+	// Test without end time error.
+	rs, err = tk.Exec("select * from information_schema.tidb_hot_regions_history where update_time>='2019/08/26 06:18:13.011'")
+	c.Assert(err, IsNil)
+	_, err = session.ResultSetToStringSlice(context.Background(), tk.Se, rs)
+	c.Assert(err, NotNil)
+	c.Assert(err.Error(), Equals, "denied to scan hot regions, please specified the end time, such as `update_time < '2020-01-01 00:00:00'`")
 	c.Assert(rs.Close(), IsNil)
 }


### PR DESCRIPTION
Signed-off-by: IcePigZDB <icepigzdb@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed
-->
Problem Summary: Create a new table `TIDB_HOT_REGIONS_HISTORY` in the `INFORMATION_SCHEMAT` database to retrieve history hotspot information stored by PD periodically.
### What problem does this PR solve?
Proposal: [pingcap/tidb#27487](https://github.com/pingcap/tidb/pull/27487)
Associated Issue: #25281

Associated PRs in TiDB:
PRs splited from oversize PR #27224 in merge order :
1. #27373 
2. #27374 
3. #27375 
4. #27899
5. #27900  **<- current one** 

Associated PR in PD:  
 PRs splited from old oversize one: tikv/pd/pull/3989 
* tikv/pd/pull/4019
* tikv/pd/pull/4020
* tikv/pd/pull/4021

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
select * from information_schema.tidb_hot_regions_history where update_time>='2019-10-10 10:10:10' and update_time<'2019-10-11 10:10:10'
```
