### PR TITLE
telemetry: TestBuiltinFunctionsUsage should run in serial

### DIFF
--- a/telemetry/data_window_serial_test.go
+++ b/telemetry/data_window_serial_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestBuiltinFunctionsUsage(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 


### PR DESCRIPTION
This function calls telemetry.GlobalBuiltinFunctionsUsage.Dump() that touches global state. We should run it in serial for determinate test result.

This closes #27922 .

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
