### PR TITLE
ddl: change attributes to key-value form

### DIFF
--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -39,21 +39,21 @@ func (s *testDBSuite8) TestAlterTableAttributes(c *C) {
 	tk.MustExec(`create table t1 (c int);`)
 
 	// normal cases
-	_, err = tk.Exec(`alter table t1 attributes="merge=true";`)
+	_, err = tk.Exec(`alter table t1 attributes="merge_option=allow";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes="merge=true,somethingelse=false";`)
+	_, err = tk.Exec(`alter table t1 attributes="merge_option=allow,key=value";`)
 	c.Assert(err, IsNil)
 
 	// space cases
-	_, err = tk.Exec(`alter table t1 attributes=" merge=true ";`)
+	_, err = tk.Exec(`alter table t1 attributes=" merge_option=allow ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes=" merge = true , somethingelse = false ";`)
+	_, err = tk.Exec(`alter table t1 attributes=" merge_option = allow , key = value ";`)
 	c.Assert(err, IsNil)
 
 	// without equal
-	_, err = tk.Exec(`alter table t1 attributes " merge=true ";`)
+	_, err = tk.Exec(`alter table t1 attributes " merge_option=allow ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes " merge=true , somethingelse=false ";`)
+	_, err = tk.Exec(`alter table t1 attributes " merge_option=allow , key=value ";`)
 	c.Assert(err, IsNil)
 }
 
@@ -78,21 +78,21 @@ PARTITION BY RANGE (c) (
 );`)
 
 	// normal cases
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="merge=true";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="merge_option=allow";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p1 attributes="merge=true,somethingelse=false";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes="merge_option=allow,key=value";`)
 	c.Assert(err, IsNil)
 
 	// space cases
-	_, err = tk.Exec(`alter table t1 partition p2 attributes=" merge=true ";`)
+	_, err = tk.Exec(`alter table t1 partition p2 attributes=" merge_option=allow ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p3 attributes=" merge = true , somethingelse = false ";`)
+	_, err = tk.Exec(`alter table t1 partition p3 attributes=" merge_option = allow , key = value ";`)
 	c.Assert(err, IsNil)
 
 	// without equal
-	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge=true ";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge_option=allow ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge=true , somethingelse=false ";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge_option=allow , key=value ";`)
 	c.Assert(err, IsNil)
 }
 
@@ -175,7 +175,7 @@ PARTITION BY RANGE (c) (
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	// check partition p0's rule
 	c.Assert(rows1[1][0], Equals, "schema/test/t2/p0")
-	c.Assert(rows1[1][2], Equals, `"attr1"`)
+	c.Assert(rows1[1][2], Equals, `"key1=value1"`)
 	c.Assert(rows1[1][3], Equals, rows[1][3])
 	c.Assert(rows1[1][4], Equals, rows[1][4])
 }
@@ -208,9 +208,9 @@ PARTITION BY RANGE (c) (
 	c.Assert(err, IsNil)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows), Equals, 2)
@@ -224,12 +224,12 @@ PARTITION BY RANGE (c) (
 	c.Assert(len(rows1), Equals, 2)
 	// check table t1's rule
 	c.Assert(rows1[0][0], Equals, "schema/test/t1")
-	c.Assert(rows1[0][2], Equals, `"attr"`)
+	c.Assert(rows1[0][2], Equals, `"key=value"`)
 	c.Assert(rows1[0][3], Equals, rows[0][3])
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	// check partition p0's rule
 	c.Assert(rows1[1][0], Equals, "schema/test/t1/p0")
-	c.Assert(rows1[1][2], Equals, `"attr1"`)
+	c.Assert(rows1[1][2], Equals, `"key1=value1"`)
 	c.Assert(rows1[1][3], Equals, rows[1][3])
 	c.Assert(rows1[1][4], Equals, rows[1][4])
 }
@@ -262,9 +262,9 @@ PARTITION BY RANGE (c) (
 	c.Assert(err, IsNil)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows), Equals, 2)
@@ -278,7 +278,7 @@ PARTITION BY RANGE (c) (
 	c.Assert(len(rows1), Equals, 2)
 	// check table t2's rule
 	c.Assert(rows1[0][0], Equals, "schema/test/t2")
-	c.Assert(rows1[0][2], Equals, `"attr"`)
+	c.Assert(rows1[0][2], Equals, `"key=value"`)
 	c.Assert(rows1[0][3], Equals, rows[0][3])
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	// check partition p0's rule
@@ -297,12 +297,12 @@ PARTITION BY RANGE (c) (
 	c.Assert(len(rows1), Equals, 2)
 	// check table t3's rule
 	c.Assert(rows2[0][0], Equals, "schema/test/t3")
-	c.Assert(rows2[0][2], Equals, `"attr"`)
+	c.Assert(rows2[0][2], Equals, `"key=value"`)
 	c.Assert(rows2[0][3], Equals, rows[0][3])
 	c.Assert(rows2[0][4], Equals, rows[0][4])
 	// check partition p0's rule
 	c.Assert(rows2[1][0], Equals, "schema/test/t3/p0")
-	c.Assert(rows2[1][2], Equals, `"attr1"`)
+	c.Assert(rows2[1][2], Equals, `"key1=value1"`)
 	c.Assert(rows2[1][3], Equals, rows[1][3])
 	c.Assert(rows2[1][4], Equals, rows[1][4])
 }

--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -39,21 +39,21 @@ func (s *testDBSuite8) TestAlterTableAttributes(c *C) {
 	tk.MustExec(`create table t1 (c int);`)
 
 	// normal cases
-	_, err = tk.Exec(`alter table t1 attributes="nomerge";`)
+	_, err = tk.Exec(`alter table t1 attributes="merge=true";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes="nomerge,somethingelse";`)
+	_, err = tk.Exec(`alter table t1 attributes="merge=true,somethingelse=false";`)
 	c.Assert(err, IsNil)
 
 	// space cases
-	_, err = tk.Exec(`alter table t1 attributes=" nomerge ";`)
+	_, err = tk.Exec(`alter table t1 attributes=" merge=true ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes=" nomerge , somethingelse ";`)
+	_, err = tk.Exec(`alter table t1 attributes=" merge = true , somethingelse = false ";`)
 	c.Assert(err, IsNil)
 
 	// without equal
-	_, err = tk.Exec(`alter table t1 attributes " nomerge ";`)
+	_, err = tk.Exec(`alter table t1 attributes " merge=true ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 attributes " nomerge , somethingelse ";`)
+	_, err = tk.Exec(`alter table t1 attributes " merge=true , somethingelse=false ";`)
 	c.Assert(err, IsNil)
 }
 
@@ -78,21 +78,21 @@ PARTITION BY RANGE (c) (
 );`)
 
 	// normal cases
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="nomerge";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="merge=true";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p1 attributes="nomerge,somethingelse";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes="merge=true,somethingelse=false";`)
 	c.Assert(err, IsNil)
 
 	// space cases
-	_, err = tk.Exec(`alter table t1 partition p2 attributes=" nomerge ";`)
+	_, err = tk.Exec(`alter table t1 partition p2 attributes=" merge=true ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p3 attributes=" nomerge , somethingelse ";`)
+	_, err = tk.Exec(`alter table t1 partition p3 attributes=" merge = true , somethingelse = false ";`)
 	c.Assert(err, IsNil)
 
 	// without equal
-	_, err = tk.Exec(`alter table t1 partition p1 attributes " nomerge ";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge=true ";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p1 attributes " nomerge , somethingelse ";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes " merge=true , somethingelse=false ";`)
 	c.Assert(err, IsNil)
 }
 
@@ -115,9 +115,9 @@ PARTITION BY RANGE (c) (
 );`)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows), Equals, 2)
@@ -128,12 +128,12 @@ PARTITION BY RANGE (c) (
 	c.Assert(len(rows1), Equals, 2)
 	// check table t1's rule
 	c.Assert(rows1[0][0], Equals, "schema/test/t1")
-	c.Assert(rows1[0][2], Equals, `"attr"`)
+	c.Assert(rows1[0][2], Equals, `"key=value"`)
 	c.Assert(rows1[0][3], Not(Equals), rows[0][3])
 	c.Assert(rows1[0][4], Not(Equals), rows[0][4])
 	// check partition p0's rule
 	c.Assert(rows1[1][0], Equals, "schema/test/t1/p0")
-	c.Assert(rows1[1][2], Equals, `"attr1"`)
+	c.Assert(rows1[1][2], Equals, `"key1=value1"`)
 	c.Assert(rows1[1][3], Not(Equals), rows[1][3])
 	c.Assert(rows1[1][4], Not(Equals), rows[1][4])
 }
@@ -157,9 +157,9 @@ PARTITION BY RANGE (c) (
 );`)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows), Equals, 2)
@@ -170,7 +170,7 @@ PARTITION BY RANGE (c) (
 	c.Assert(len(rows1), Equals, 2)
 	// check table t1's rule
 	c.Assert(rows1[0][0], Equals, "schema/test/t2")
-	c.Assert(rows1[0][2], Equals, `"attr"`)
+	c.Assert(rows1[0][2], Equals, `"key=value"`)
 	c.Assert(rows1[0][3], Equals, rows[0][3])
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	// check partition p0's rule
@@ -283,7 +283,7 @@ PARTITION BY RANGE (c) (
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	// check partition p0's rule
 	c.Assert(rows1[1][0], Equals, "schema/test/t2/p0")
-	c.Assert(rows1[1][2], Equals, `"attr1"`)
+	c.Assert(rows1[1][2], Equals, `"key1=value1"`)
 	c.Assert(rows1[1][3], Equals, rows[1][3])
 	c.Assert(rows1[1][4], Equals, rows[1][4])
 
@@ -328,11 +328,11 @@ PARTITION BY RANGE (c) (
 	tk.MustExec(`create table t2 (c int);`)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p1 attributes="attr2";`)
+	_, err = tk.Exec(`alter table t1 partition p1 attributes="key2=value2";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows), Equals, 3)
@@ -343,11 +343,11 @@ PARTITION BY RANGE (c) (
 	rows1 := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows1), Equals, 2)
 	c.Assert(rows1[0][0], Equals, "schema/test/t1")
-	c.Assert(rows1[0][2], Equals, `"attr"`)
+	c.Assert(rows1[0][2], Equals, `"key=value"`)
 	c.Assert(rows1[0][3], Equals, rows[0][3])
 	c.Assert(rows1[0][4], Equals, rows[0][4])
 	c.Assert(rows1[1][0], Equals, "schema/test/t1/p1")
-	c.Assert(rows1[1][2], Equals, `"attr2"`)
+	c.Assert(rows1[1][2], Equals, `"key2=value2"`)
 	c.Assert(rows1[1][3], Equals, rows[2][3])
 	c.Assert(rows1[1][4], Equals, rows[2][4])
 
@@ -358,7 +358,7 @@ PARTITION BY RANGE (c) (
 	rows2 := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows2), Equals, 2)
 	c.Assert(rows2[1][0], Equals, "schema/test/t1/p1")
-	c.Assert(rows2[1][2], Equals, `"attr2"`)
+	c.Assert(rows2[1][2], Equals, `"key2=value2"`)
 	c.Assert(rows2[1][3], Not(Equals), rows1[1][3])
 	c.Assert(rows2[1][4], Not(Equals), rows1[1][4])
 
@@ -371,7 +371,7 @@ PARTITION BY RANGE (c) (
 	rows3 := tk.MustQuery(`select * from information_schema.region_label;`).Sort().Rows()
 	c.Assert(len(rows3), Equals, 2)
 	c.Assert(rows3[1][0], Equals, "schema/test/t2")
-	c.Assert(rows3[1][2], Equals, `"attr2"`)
+	c.Assert(rows3[1][2], Equals, `"key2=value2"`)
 	c.Assert(rows3[1][3], Equals, rows2[1][3])
 	c.Assert(rows3[1][4], Equals, rows2[1][4])
 }
@@ -395,9 +395,9 @@ PARTITION BY RANGE (c) (
 );`)
 
 	// add rules
-	_, err = tk.Exec(`alter table t1 attributes="attr";`)
+	_, err = tk.Exec(`alter table t1 attributes="key=value";`)
 	c.Assert(err, IsNil)
-	_, err = tk.Exec(`alter table t1 partition p0 attributes="attr1";`)
+	_, err = tk.Exec(`alter table t1 partition p0 attributes="key1=value1";`)
 	c.Assert(err, IsNil)
 	rows := tk.MustQuery(`select * from information_schema.region_label;`).Rows()
 	c.Assert(len(rows), Equals, 2)

--- a/ddl/label/attributes.go
+++ b/ddl/label/attributes.go
@@ -15,6 +15,7 @@
 package label
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -24,23 +25,84 @@ const (
 	partitionKey = "partition"
 )
 
+// AttributesCompatibility is the return type of CompatibleWith.
+type AttributesCompatibility byte
+
+const (
+	// AttributesCompatible indicates two attributes are compatible.
+	AttributesCompatible AttributesCompatibility = iota
+	// AttributesIncompatible indicates two attributes are incompatible.
+	AttributesIncompatible
+	// AttributesDuplicated indicates two attributes are duplicated.
+	AttributesDuplicated
+)
+
 // Label is used to describe attributes
 type Label struct {
 	Key   string `json:"key,omitempty"`
 	Value string `json:"value,omitempty"`
 }
 
+// NewLabel creates a new label for a given string.
+func NewLabel(attr string) (Label, error) {
+	l := Label{}
+	kv := strings.Split(attr, "=")
+	if len(kv) != 2 {
+		return l, fmt.Errorf("%w: %s", ErrInvalidAttributesFormat, attr)
+	}
+
+	key := strings.TrimSpace(kv[0])
+	if key == "" {
+		return l, fmt.Errorf("%w: %s", ErrInvalidAttributesFormat, attr)
+	}
+
+	val := strings.TrimSpace(kv[1])
+	if val == "" {
+		return l, fmt.Errorf("%w: %s", ErrInvalidAttributesFormat, attr)
+	}
+
+	l.Key = key
+	l.Value = val
+	return l, nil
+}
+
+// Restore converts a Attribute to a string.
+func (l *Label) Restore() string {
+	return l.Key + "=" + l.Value
+}
+
+// CompatibleWith will check if two constraints are compatible.
+// Return (compatible, duplicated).
+func (l *Label) CompatibleWith(o *Label) AttributesCompatibility {
+	sameKey := l.Key == o.Key
+	if !sameKey {
+		return AttributesCompatible
+	}
+
+	sameVal := l.Value == o.Value
+	if sameVal {
+		return AttributesDuplicated
+	}
+
+	return AttributesIncompatible
+}
+
 // Labels is a slice of Label.
 type Labels []Label
 
 // NewLabels creates a slice of Label for given attributes.
-func NewLabels(attrs []string) Labels {
+func NewLabels(attrs []string) (Labels, error) {
 	labels := make(Labels, 0, len(attrs))
 	for _, attr := range attrs {
-		label := NewLabel(attr)
-		labels.Add(label)
+		label, err := NewLabel(attr)
+		if err != nil {
+			return nil, err
+		}
+		if err := labels.Add(label); err != nil {
+			return nil, err
+		}
 	}
-	return labels
+	return labels, nil
 }
 
 // Restore converts Attributes to a string.
@@ -63,24 +125,26 @@ func (labels *Labels) Restore() string {
 	return sb.String()
 }
 
-// Add adds a new label to existed labels.
-func (labels *Labels) Add(l Label) {
-	for _, label := range *labels {
-		if l.Key != label.Key {
+// Add will add a new attribute, with validation of all attributes.
+func (labels *Labels) Add(label Label) error {
+	pass := true
+
+	for _, l := range *labels {
+		res := label.CompatibleWith(&l)
+		if res == AttributesCompatible {
 			continue
 		}
-		return
+		if res == AttributesDuplicated {
+			pass = false
+			continue
+		}
+		s1 := label.Restore()
+		s2 := l.Restore()
+		return fmt.Errorf("%w: '%s' and '%s'", ErrConflictingAttributes, s1, s2)
 	}
 
-	*labels = append(*labels, l)
-}
-
-// NewLabel creates a new label for a given string.
-func NewLabel(attr string) Label {
-	return Label{Key: strings.TrimSpace(attr), Value: "true"}
-}
-
-// Restore converts a Attribute to a string.
-func (a *Label) Restore() string {
-	return a.Key
+	if pass {
+		*labels = append(*labels, label)
+	}
+	return nil
 }

--- a/ddl/label/attributes.go
+++ b/ddl/label/attributes.go
@@ -74,13 +74,11 @@ func (l *Label) Restore() string {
 // CompatibleWith will check if two constraints are compatible.
 // Return (compatible, duplicated).
 func (l *Label) CompatibleWith(o *Label) AttributesCompatibility {
-	sameKey := l.Key == o.Key
-	if !sameKey {
+	if l.Key != o.Key {
 		return AttributesCompatible
 	}
 
-	sameVal := l.Value == o.Value
-	if sameVal {
+	if l.Value == o.Value {
 		return AttributesDuplicated
 	}
 
@@ -127,24 +125,19 @@ func (labels *Labels) Restore() string {
 
 // Add will add a new attribute, with validation of all attributes.
 func (labels *Labels) Add(label Label) error {
-	pass := true
-
 	for _, l := range *labels {
 		res := label.CompatibleWith(&l)
 		if res == AttributesCompatible {
 			continue
 		}
 		if res == AttributesDuplicated {
-			pass = false
-			continue
+			return nil
 		}
 		s1 := label.Restore()
 		s2 := l.Restore()
 		return fmt.Errorf("%w: '%s' and '%s'", ErrConflictingAttributes, s1, s2)
 	}
 
-	if pass {
-		*labels = append(*labels, label)
-	}
+	*labels = append(*labels, label)
 	return nil
 }

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -38,18 +38,18 @@ func (t *testLabelSuite) TestNew(c *C) {
 	tests := []TestCase{
 		{
 			name:  "normal",
-			input: "merge=true",
+			input: "merge_option=allow",
 			label: Label{
-				Key:   "merge",
-				Value: "true",
+				Key:   "merge_option",
+				Value: "allow",
 			},
 		},
 		{
 			name:  "normal with space",
-			input: " merge=true ",
+			input: " merge_option=allow ",
 			label: Label{
-				Key:   "merge",
-				Value: "true",
+				Key:   "merge_option",
+				Value: "allow",
 			},
 		},
 	}
@@ -68,20 +68,20 @@ func (t *testLabelSuite) TestRestore(c *C) {
 		output string
 	}
 
-	input, err := NewLabel("merge=true")
+	input, err := NewLabel("merge_option=allow")
 	c.Assert(err, IsNil)
-	input1, err := NewLabel(" merge=true  ")
+	input1, err := NewLabel(" merge_option=allow  ")
 	c.Assert(err, IsNil)
 	tests := []TestCase{
 		{
 			name:   "normal",
 			input:  input,
-			output: "merge=true",
+			output: "merge_option=allow",
 		},
 		{
 			name:   "normal with spaces",
 			input:  input1,
-			output: "merge=true",
+			output: "merge_option=allow",
 		},
 	}
 
@@ -104,27 +104,27 @@ func (t *testLabelsSuite) TestNew(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 0)
 
-	labels, err = NewLabels([]string{"merge=true"})
+	labels, err = NewLabels([]string{"merge_option=allow"})
 	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 1)
-	c.Assert(labels[0].Key, Equals, "merge")
-	c.Assert(labels[0].Value, Equals, "true")
+	c.Assert(labels[0].Key, Equals, "merge_option")
+	c.Assert(labels[0].Value, Equals, "allow")
 
 	// test multiple attributes
-	labels, err = NewLabels([]string{"merge=true", "somethingelse=false"})
+	labels, err = NewLabels([]string{"merge_option=allow", "key=value"})
 	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 2)
-	c.Assert(labels[0].Key, Equals, "merge")
-	c.Assert(labels[0].Value, Equals, "true")
-	c.Assert(labels[1].Key, Equals, "somethingelse")
-	c.Assert(labels[1].Value, Equals, "false")
+	c.Assert(labels[0].Key, Equals, "merge_option")
+	c.Assert(labels[0].Value, Equals, "allow")
+	c.Assert(labels[1].Key, Equals, "key")
+	c.Assert(labels[1].Value, Equals, "value")
 
 	// test duplicated attributes
-	labels, err = NewLabels([]string{"merge=true", "merge=true"})
+	labels, err = NewLabels([]string{"merge_option=allow", "merge_option=allow"})
 	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 1)
-	c.Assert(labels[0].Key, Equals, "merge")
-	c.Assert(labels[0].Value, Equals, "true")
+	c.Assert(labels[0].Key, Equals, "merge_option")
+	c.Assert(labels[0].Value, Equals, "allow")
 }
 
 func (t *testLabelsSuite) TestAdd(c *C) {
@@ -135,15 +135,15 @@ func (t *testLabelsSuite) TestAdd(c *C) {
 		err    error
 	}
 
-	labels, err := NewLabels([]string{"merge=true"})
+	labels, err := NewLabels([]string{"merge_option=allow"})
 	c.Assert(err, IsNil)
 	label, err := NewLabel("somethingelse=true")
 	c.Assert(err, IsNil)
-	l1, err := NewLabels([]string{"attr=true"})
+	l1, err := NewLabels([]string{"key=value"})
 	c.Assert(err, IsNil)
-	l2, err := NewLabel("attr=true")
+	l2, err := NewLabel("key=value")
 	c.Assert(err, IsNil)
-	l3, err := NewLabels([]string{"attr=false"})
+	l3, err := NewLabels([]string{"key=value1"})
 	c.Assert(err, IsNil)
 	tests := []TestCase{
 		{
@@ -159,8 +159,8 @@ func (t *testLabelsSuite) TestAdd(c *C) {
 		{
 			"duplicated attributes, skip",
 			append(labels, Label{
-				Key:   "merge",
-				Value: "true",
+				Key:   "merge_option",
+				Value: "allow",
 			}), label,
 			nil,
 		},
@@ -190,9 +190,9 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		output string
 	}
 
-	input1, err := NewLabel("merge=true")
+	input1, err := NewLabel("merge_option=allow")
 	c.Assert(err, IsNil)
-	input2, err := NewLabel("somethingelse=false")
+	input2, err := NewLabel("key=value")
 	c.Assert(err, IsNil)
 	input3, err := NewLabel("db=d1")
 	c.Assert(err, IsNil)
@@ -210,7 +210,7 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		{
 			"normal2",
 			Labels{input1, input2},
-			`"merge=true","somethingelse=false"`,
+			`"merge_option=allow","key=value"`,
 		},
 		{
 			"normal3",
@@ -220,7 +220,7 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		{
 			"normal4",
 			Labels{input1, input2, input3},
-			`"merge=true","somethingelse=false"`,
+			`"merge_option=allow","key=value"`,
 		},
 	}
 

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -15,6 +15,7 @@
 package label
 
 import (
+	"errors"
 	"testing"
 
 	. "github.com/pingcap/check"
@@ -37,24 +38,25 @@ func (t *testLabelSuite) TestNew(c *C) {
 	tests := []TestCase{
 		{
 			name:  "normal",
-			input: "nomerge",
+			input: "merge=true",
 			label: Label{
-				Key:   "nomerge",
+				Key:   "merge",
 				Value: "true",
 			},
 		},
 		{
 			name:  "normal with space",
-			input: " nomerge ",
+			input: " merge=true ",
 			label: Label{
-				Key:   "nomerge",
+				Key:   "merge",
 				Value: "true",
 			},
 		},
 	}
 
 	for _, t := range tests {
-		label := NewLabel(t.input)
+		label, err := NewLabel(t.input)
+		c.Assert(err, IsNil)
 		c.Assert(label, DeepEquals, t.label, Commentf("%s", t.name))
 	}
 }
@@ -66,18 +68,20 @@ func (t *testLabelSuite) TestRestore(c *C) {
 		output string
 	}
 
-	input := NewLabel("nomerge")
-	input1 := NewLabel(" nomerge  ")
+	input, err := NewLabel("merge=true")
+	c.Assert(err, IsNil)
+	input1, err := NewLabel(" merge=true  ")
+	c.Assert(err, IsNil)
 	tests := []TestCase{
 		{
 			name:   "normal",
 			input:  input,
-			output: "nomerge",
+			output: "merge=true",
 		},
 		{
 			name:   "normal with spaces",
 			input:  input1,
-			output: "nomerge",
+			output: "merge=true",
 		},
 	}
 
@@ -92,26 +96,35 @@ var _ = Suite(&testLabelsSuite{})
 type testLabelsSuite struct{}
 
 func (t *testLabelsSuite) TestNew(c *C) {
-	labels := NewLabels(nil)
+	labels, err := NewLabels(nil)
+	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 0)
 
-	labels = NewLabels([]string{})
+	labels, err = NewLabels([]string{})
+	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 0)
 
-	labels = NewLabels([]string{"nomerge"})
+	labels, err = NewLabels([]string{"merge=true"})
+	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 1)
-	c.Assert(labels[0].Key, Equals, "nomerge")
+	c.Assert(labels[0].Key, Equals, "merge")
+	c.Assert(labels[0].Value, Equals, "true")
 
 	// test multiple attributes
-	labels = NewLabels([]string{"nomerge", "somethingelse"})
+	labels, err = NewLabels([]string{"merge=true", "somethingelse=false"})
+	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 2)
-	c.Assert(labels[0].Key, Equals, "nomerge")
+	c.Assert(labels[0].Key, Equals, "merge")
+	c.Assert(labels[0].Value, Equals, "true")
 	c.Assert(labels[1].Key, Equals, "somethingelse")
+	c.Assert(labels[1].Value, Equals, "false")
 
 	// test duplicated attributes
-	labels = NewLabels([]string{"nomerge", "nomerge"})
+	labels, err = NewLabels([]string{"merge=true", "merge=true"})
+	c.Assert(err, IsNil)
 	c.Assert(labels, HasLen, 1)
-	c.Assert(labels[0].Key, Equals, "nomerge")
+	c.Assert(labels[0].Key, Equals, "merge")
+	c.Assert(labels[0].Value, Equals, "true")
 }
 
 func (t *testLabelsSuite) TestAdd(c *C) {
@@ -119,31 +132,54 @@ func (t *testLabelsSuite) TestAdd(c *C) {
 		name   string
 		labels Labels
 		label  Label
+		err    error
 	}
 
-	labels := NewLabels([]string{"nomerge"})
-	label := NewLabel("somethingelse")
+	labels, err := NewLabels([]string{"merge=true"})
+	c.Assert(err, IsNil)
+	label, err := NewLabel("somethingelse=true")
+	c.Assert(err, IsNil)
+	l1, err := NewLabels([]string{"attr=true"})
+	c.Assert(err, IsNil)
+	l2, err := NewLabel("attr=true")
+	c.Assert(err, IsNil)
+	l3, err := NewLabels([]string{"attr=false"})
+	c.Assert(err, IsNil)
 	tests := []TestCase{
 		{
 			"normal",
 			labels, label,
+			nil,
 		},
 		{
 			"duplicated attributes, skip",
-			NewLabels([]string{"nomerge"}), NewLabel("nomerge"),
+			l1, l2,
+			nil,
 		},
 		{
 			"duplicated attributes, skip",
 			append(labels, Label{
-				Key:   "nomerge",
+				Key:   "merge",
 				Value: "true",
 			}), label,
+			nil,
+		},
+		{
+			"conflict attributes",
+			l3, l2,
+			ErrConflictingAttributes,
 		},
 	}
 
 	for _, t := range tests {
-		t.labels.Add(t.label)
-		c.Assert(t.labels[len(t.labels)-1], DeepEquals, t.label, Commentf("%s", t.name))
+		err := t.labels.Add(t.label)
+		comment := Commentf("%s: %v", t.name, err)
+		if t.err == nil {
+			c.Assert(err, IsNil, comment)
+			c.Assert(t.labels[len(t.labels)-1], DeepEquals, t.label, comment)
+		} else {
+			c.Assert(errors.Is(err, t.err), IsTrue, comment)
+		}
 	}
 }
 
@@ -154,11 +190,16 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		output string
 	}
 
-	input1 := NewLabel("nomerge")
-	input2 := NewLabel("somethingelse")
-	input3 := NewLabel("db")
-	input4 := NewLabel("table")
-	input5 := NewLabel("partition")
+	input1, err := NewLabel("merge=true")
+	c.Assert(err, IsNil)
+	input2, err := NewLabel("somethingelse=false")
+	c.Assert(err, IsNil)
+	input3, err := NewLabel("db=d1")
+	c.Assert(err, IsNil)
+	input4, err := NewLabel("table=t1")
+	c.Assert(err, IsNil)
+	input5, err := NewLabel("partition=p1")
+	c.Assert(err, IsNil)
 
 	tests := []TestCase{
 		{
@@ -169,7 +210,7 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		{
 			"normal2",
 			Labels{input1, input2},
-			`"nomerge","somethingelse"`,
+			`"merge=true","somethingelse=false"`,
 		},
 		{
 			"normal3",
@@ -179,7 +220,7 @@ func (t *testLabelsSuite) TestRestore(c *C) {
 		{
 			"normal4",
 			Labels{input1, input2, input3},
-			`"nomerge","somethingelse"`,
+			`"merge=true","somethingelse=false"`,
 		},
 	}
 

--- a/ddl/label/errors.go
+++ b/ddl/label/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package label
+
+import "errors"
+
+var (
+	// ErrInvalidAttributesFormat is from attributes.go
+	ErrInvalidAttributesFormat = errors.New("attributes should be in format 'key=value'")
+	// ErrConflictingAttributes is from attributes.go
+	ErrConflictingAttributes = errors.New("conflicting attributes")
+)

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -67,8 +67,8 @@ func (r *Rule) ApplyAttributesSpec(spec *ast.AttributesSpec) error {
 	if err != nil {
 		return err
 	}
-	r.Labels = NewLabels(attributes)
-	return nil
+	r.Labels, err = NewLabels(attributes)
+	return err
 }
 
 // String implements fmt.Stringer.

--- a/ddl/label/rule_test.go
+++ b/ddl/label/rule_test.go
@@ -24,29 +24,34 @@ var _ = Suite(&testRuleSuite{})
 type testRuleSuite struct{}
 
 func (t *testRuleSuite) TestApplyAttributesSpec(c *C) {
-	spec := &ast.AttributesSpec{Attributes: "attr1,attr2"}
+	spec := &ast.AttributesSpec{Attributes: "attr1=true,attr2=false"}
 	rule := NewRule()
-	rule.ApplyAttributesSpec(spec)
+	err := rule.ApplyAttributesSpec(spec)
+	c.Assert(err, IsNil)
 	c.Assert(rule.Labels, HasLen, 2)
 	c.Assert(rule.Labels[0].Key, Equals, "attr1")
+	c.Assert(rule.Labels[0].Value, Equals, "true")
 	c.Assert(rule.Labels[1].Key, Equals, "attr2")
+	c.Assert(rule.Labels[1].Value, Equals, "false")
 }
 
 func (t *testRuleSuite) TestDefaultOrEmpty(c *C) {
 	spec := &ast.AttributesSpec{Attributes: ""}
 	rule := NewRule()
-	rule.ApplyAttributesSpec(spec)
+	err := rule.ApplyAttributesSpec(spec)
+	c.Assert(err, IsNil)
 	rule.Reset(1, "db", "t")
 	c.Assert(rule.Labels, HasLen, 0)
 	spec = &ast.AttributesSpec{Default: true}
 	rule = NewRule()
-	rule.ApplyAttributesSpec(spec)
+	err = rule.ApplyAttributesSpec(spec)
+	c.Assert(err, IsNil)
 	rule.Reset(1, "db", "t")
 	c.Assert(rule.Labels, HasLen, 0)
 }
 
 func (t *testRuleSuite) TestReset(c *C) {
-	spec := &ast.AttributesSpec{Attributes: "attr"}
+	spec := &ast.AttributesSpec{Attributes: "attr=true"}
 	rule := NewRule()
 	rule.ApplyAttributesSpec(spec)
 	rule.Reset(1, "db1", "t1")

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -2774,7 +2774,7 @@ func (e *memtableRetriever) setDataForRegionLabel(ctx sessionctx.Context) error 
 		rules = []*label.Rule{
 			{
 				ID:       "schema/test/test_label",
-				Labels:   []label.Label{{Key: "merge", Value: "true"}, {Key: "db", Value: "test"}, {Key: "table", Value: "test_label"}},
+				Labels:   []label.Label{{Key: "merge_option", Value: "allow"}, {Key: "db", Value: "test"}, {Key: "table", Value: "test_label"}},
 				RuleType: "key-range",
 				Rule: convert(map[string]interface{}{
 					"start_key": "7480000000000000ff395f720000000000fa",

--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -2774,7 +2774,7 @@ func (e *memtableRetriever) setDataForRegionLabel(ctx sessionctx.Context) error 
 		rules = []*label.Rule{
 			{
 				ID:       "schema/test/test_label",
-				Labels:   []label.Label{{Key: "nomerge", Value: "true"}, {Key: "db", Value: "test"}, {Key: "table", Value: "test_label"}},
+				Labels:   []label.Label{{Key: "merge", Value: "true"}, {Key: "db", Value: "test"}, {Key: "table", Value: "test_label"}},
 				RuleType: "key-range",
 				Rule: convert(map[string]interface{}{
 					"start_key": "7480000000000000ff395f720000000000fa",

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1841,11 +1841,7 @@ func (s *testTableSuite) TestRegionLabel(c *C) {
 	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
 
 	tk.MustQuery(`select * from information_schema.region_label`).Check(testkit.Rows(
-		`schema/test/test_label key-range "nomerge" 7480000000000000ff395f720000000000fa 7480000000000000ff3a5f720000000000fa`,
-	))
-
-	tk.MustQuery(`select rule_id, region_label from information_schema.region_label`).Check(testkit.Rows(
-		`schema/test/test_label "nomerge"`,
+		`schema/test/test_label key-range "merge=true" 7480000000000000ff395f720000000000fa 7480000000000000ff3a5f720000000000fa`,
 	))
 }
 

--- a/infoschema/tables_test.go
+++ b/infoschema/tables_test.go
@@ -1841,7 +1841,7 @@ func (s *testTableSuite) TestRegionLabel(c *C) {
 	defer func() { c.Assert(failpoint.Disable(fpName), IsNil) }()
 
 	tk.MustQuery(`select * from information_schema.region_label`).Check(testkit.Rows(
-		`schema/test/test_label key-range "merge=true" 7480000000000000ff395f720000000000fa 7480000000000000ff3a5f720000000000fa`,
+		`schema/test/test_label key-range "merge_option=allow" 7480000000000000ff395f720000000000fa 7480000000000000ff3a5f720000000000fa`,
 	))
 }
 


### PR DESCRIPTION
### What problem does this PR solve?

Separate setting form and renaming from #27660.

### What is changed and how it works?

What's Changed:
- change attributes to key-value form
- use `merge_option=allow/deny` to control the merge operation. 

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [x] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
