### PR TITLE
planner: fix the issue that binding cannot work when `sql_select_limit` is enabled

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -61,7 +61,6 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (*ExecStm
 	if err != nil {
 		return nil, err
 	}
-	stmtNode = plannercore.TryAddExtraLimit(c.Ctx, stmtNode)
 
 	finalPlan, names, err := planner.Optimize(ctx, c.Ctx, stmtNode, ret.InfoSchema)
 	if err != nil {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27949 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix the issue that binding cannot work when `sql_select_limit` is enabled

### What is changed and how it works?

TiDB uses the AST of a query to find its corresponding binding records, but when `sql_select_limit` is enabled, an extra Limit node is inserted upon the AST, and then the changed AST cannot match the original binding record.

This PR just adjusts orders of these two operations, which moves the operation of adding the extra Limit to the front of finding binding records.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
planner: fix the issue that binding cannot work when `sql_select_limit` is enabled
```