### PR TITLE
planner: Fix Empty string has different meanings in SELECT and UPDATE

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1508,6 +1508,9 @@ func (s *testIntegrationSuite) TestIssue27648(c *C) {
 	tk.MustExec("update t set b = b + 2 where '' or 1")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 0)
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(3))
+
+	tk.MustQuery("select * from t where ''").Check(testkit.Rows())
+	tk.MustQuery("select * from t where '   '").Check(testkit.Rows())
 }
 
 // for issue #14822

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1489,6 +1489,27 @@ func (s *testIntegrationSuite) TestInvisibleIndex(c *C) {
 	tk.MustExec("admin check index t i_a")
 }
 
+func (s *testIntegrationSuite) TestIssue27648(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int)")
+
+	tk.MustExec("insert into t values(1,1),(2,3),(4,5)")
+	tk.MustExec("update t set b = b + 1 where ''")
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 0)
+
+	tk.MustExec("update t set b = b + 2 where '   '")
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 0)
+
+	tk.MustExec("update t set b = b + 2 where '' or 1")
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 3)
+}
+
 // for issue #14822
 func (s *testIntegrationSuite) TestIndexJoinTableRange(c *C) {
 	tk := testkit.NewTestKit(c, s.store)

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1507,7 +1507,7 @@ func (s *testIntegrationSuite) TestIssue27648(c *C) {
 
 	tk.MustExec("update t set b = b + 2 where '' or 1")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(0))
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(3))
 }
 
 // for issue #14822

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1506,7 +1506,7 @@ func (s *testIntegrationSuite) TestIssue27648(c *C) {
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(0))
 
 	tk.MustExec("update t set b = b + 2 where '' or 1")
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 0)
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(3))
 }
 

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -1499,15 +1499,15 @@ func (s *testIntegrationSuite) TestIssue27648(c *C) {
 	tk.MustExec("insert into t values(1,1),(2,3),(4,5)")
 	tk.MustExec("update t set b = b + 1 where ''")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 0)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(0))
 
 	tk.MustExec("update t set b = b + 2 where '   '")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 0)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(0))
 
 	tk.MustExec("update t set b = b + 2 where '' or 1")
 	c.Assert(tk.Se.GetSessionVars().StmtCtx.GetWarnings(), HasLen, 1)
-	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, 3)
+	c.Assert(tk.Se.GetSessionVars().StmtCtx.AffectedRows(), Equals, uint64(0))
 }
 
 // for issue #14822

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -986,7 +986,8 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p LogicalPlan, where a
 		for _, item := range cnfItems {
 			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil && con.ParamMarker == nil {
 				ret, _, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
-				if err != nil || ret {
+				p.SCtx().GetSessionVars().StmtCtx.AppendWarning(err)
+				if ret {
 					continue
 				}
 				// If there is condition which is always false, return dual plan directly.

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -986,7 +986,10 @@ func (b *PlanBuilder) buildSelection(ctx context.Context, p LogicalPlan, where a
 		for _, item := range cnfItems {
 			if con, ok := item.(*expression.Constant); ok && con.DeferredExpr == nil && con.ParamMarker == nil {
 				ret, _, err := expression.EvalBool(b.ctx, expression.CNFExprs{con}, chunk.Row{})
-				p.SCtx().GetSessionVars().StmtCtx.AppendWarning(err)
+				if err != nil {
+					p.SCtx().GetSessionVars().StmtCtx.AppendWarning(err)
+				}
+
 				if ret {
 					continue
 				}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27648  <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
