### PR TITLE
binloginfo: fix tidb-server hang when binlog message is too large

### DIFF
--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -268,7 +268,9 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) *WriteResult {
 
 		if strings.Contains(err.Error(), "received message larger than max") {
 			// This kind of error is not critical, return directly.
-			return &WriteResult{false, errors.Errorf("binlog data is too large (%s)", err.Error())}
+			return &WriteResult{
+				false,
+				terror.ErrCritical.GenWithStackByArgs(errors.Errorf("binlog data is too large (%s)", err.Error()))}
 		}
 
 		return &WriteResult{false, terror.ErrCritical.GenWithStackByArgs(err)}

--- a/sessionctx/binloginfo/binloginfo.go
+++ b/sessionctx/binloginfo/binloginfo.go
@@ -267,7 +267,6 @@ func (info *BinlogInfo) WriteBinlog(clusterID uint64) *WriteResult {
 		}
 
 		if strings.Contains(err.Error(), "received message larger than max") {
-			// This kind of error is not critical, return directly.
 			return &WriteResult{
 				false,
 				terror.ErrCritical.GenWithStackByArgs(errors.Errorf("binlog data is too large (%s)", err.Error()))}

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -283,7 +283,7 @@ func TestMaxRecvSize(t *testing.T) {
 	binlogWR := info.WriteBinlog(1)
 	err := binlogWR.GetError()
 	require.Error(t, err)
-	require.Falsef(t, terror.ErrCritical.Equal(err), fmt.Sprintf("%v", err))
+	require.Truef(t, terror.ErrCritical.Equal(err), fmt.Sprintf("%v", err))
 }
 
 func getLatestBinlogPrewriteValue(t *testing.T, pump *mockBinlogPump) *binlog.PrewriteValue {


### PR DESCRIPTION
Signed-off-by: Shuaipeng Yu <jackysp@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:
When binlog writes failed, tidb-server should stop. But when the binlog grpc message is too large, tide-server will not stop.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:
tide-server checks the critical binlog error to stop the server, but the `message is too large` doesn't use the critical error.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix tidb-server hang when binlog message is too large.
```
