### PR TITLE
tikv: fix wrong backoff metric label

### DIFF
--- a/store/tikv/backoff.go
+++ b/store/tikv/backoff.go
@@ -62,6 +62,10 @@ func (t BackoffType) metric() prometheus.Observer {
 		return metrics.BackoffHistogramServerBusy
 	case boStaleCmd:
 		return metrics.BackoffHistogramStaleCmd
+	case boTxnNotFound:
+		return metrics.BackoffHistogramTxnNotFound
+	case boMaxTsNotSynced:
+		return metrics.BackoffHistogramMaxTsNotSynced
 	}
 	return metrics.BackoffHistogramEmpty
 }

--- a/store/tikv/metrics/shortcuts.go
+++ b/store/tikv/metrics/shortcuts.go
@@ -33,14 +33,16 @@ var (
 	RawkvSizeHistogramWithKey          prometheus.Observer
 	RawkvSizeHistogramWithValue        prometheus.Observer
 
-	BackoffHistogramRPC        prometheus.Observer
-	BackoffHistogramLock       prometheus.Observer
-	BackoffHistogramLockFast   prometheus.Observer
-	BackoffHistogramPD         prometheus.Observer
-	BackoffHistogramRegionMiss prometheus.Observer
-	BackoffHistogramServerBusy prometheus.Observer
-	BackoffHistogramStaleCmd   prometheus.Observer
-	BackoffHistogramEmpty      prometheus.Observer
+	BackoffHistogramRPC            prometheus.Observer
+	BackoffHistogramLock           prometheus.Observer
+	BackoffHistogramLockFast       prometheus.Observer
+	BackoffHistogramPD             prometheus.Observer
+	BackoffHistogramRegionMiss     prometheus.Observer
+	BackoffHistogramServerBusy     prometheus.Observer
+	BackoffHistogramStaleCmd       prometheus.Observer
+	BackoffHistogramTxnNotFound    prometheus.Observer
+	BackoffHistogramMaxTsNotSynced prometheus.Observer
+	BackoffHistogramEmpty          prometheus.Observer
 
 	TxnRegionsNumHistogramWithSnapshot         prometheus.Observer
 	TxnRegionsNumHistogramPrewrite             prometheus.Observer
@@ -122,6 +124,8 @@ func initShortcuts() {
 	BackoffHistogramRegionMiss = TiKVBackoffHistogram.WithLabelValues("regionMiss")
 	BackoffHistogramServerBusy = TiKVBackoffHistogram.WithLabelValues("serverBusy")
 	BackoffHistogramStaleCmd = TiKVBackoffHistogram.WithLabelValues("staleCommand")
+	BackoffHistogramTxnNotFound = TiKVBackoffHistogram.WithLabelValues("txnNotFound")
+	BackoffHistogramMaxTsNotSynced = TiKVBackoffHistogram.WithLabelValues("maxTsNotSynced")
 	BackoffHistogramEmpty = TiKVBackoffHistogram.WithLabelValues("")
 
 	TxnRegionsNumHistogramWithSnapshot = TiKVTxnRegionsNumHistogram.WithLabelValues("snapshot")


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: ref https://github.com/pingcap/tidb/issues/30779

there some backoff metric labels are displayed as "type", it's confusing to user.

### What is changed and how it works?

What's Changed, How it Works:

fix label value for two miss types

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
