### PR TITLE
executor: add auto id allocator execution runtime stats

### DIFF
--- a/br/pkg/kv/kv.go
+++ b/br/pkg/kv/kv.go
@@ -16,6 +16,7 @@ package kv
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"math"
 	"sort"
@@ -349,11 +350,11 @@ func (kvcodec *tableKVEncoder) AddRecord(
 			if hasSignBit {
 				incrementalBits--
 			}
-			_ = kvcodec.tbl.RebaseAutoID(kvcodec.se, value.GetInt64()&((1<<incrementalBits)-1), false, autoid.AutoRandomType)
+			_ = kvcodec.tbl.RebaseAutoID(context.Background(), kvcodec.se, value.GetInt64()&((1<<incrementalBits)-1), false, autoid.AutoRandomType)
 		}
 		if isAutoIncCol {
 			// TODO use auto incremental type
-			_ = kvcodec.tbl.RebaseAutoID(kvcodec.se, getAutoRecordID(value, &col.FieldType), false, autoid.RowIDAllocType)
+			_ = kvcodec.tbl.RebaseAutoID(context.Background(), kvcodec.se, getAutoRecordID(value, &col.FieldType), false, autoid.RowIDAllocType)
 		}
 	}
 
@@ -368,7 +369,7 @@ func (kvcodec *tableKVEncoder) AddRecord(
 			return nil, 0, errors.Trace(err)
 		}
 		record = append(record, value)
-		_ = kvcodec.tbl.RebaseAutoID(kvcodec.se, value.GetInt64(), false, autoid.RowIDAllocType)
+		_ = kvcodec.tbl.RebaseAutoID(context.Background(), kvcodec.se, value.GetInt64(), false, autoid.RowIDAllocType)
 	}
 	_, err = kvcodec.tbl.AddRecord(kvcodec.se, record)
 	if err != nil {

--- a/br/pkg/lightning/backend/kv/allocator.go
+++ b/br/pkg/lightning/backend/kv/allocator.go
@@ -17,6 +17,7 @@
 package kv
 
 import (
+	"context"
 	"sync/atomic"
 
 	"github.com/pingcap/tidb/meta/autoid"
@@ -40,7 +41,7 @@ func NewPanickingAllocators(base int64) autoid.Allocators {
 }
 
 // Rebase implements the autoid.Allocator interface
-func (alloc *panickingAllocator) Rebase(newBase int64, allocIDs bool) error {
+func (alloc *panickingAllocator) Rebase(ctx context.Context, newBase int64, allocIDs bool) error {
 	// CAS
 	for {
 		oldBase := atomic.LoadInt64(alloc.base)

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -1486,12 +1486,12 @@ func (tr *TableRestore) restoreTable(
 		// rebase the allocator so it exceeds the number of rows.
 		if tr.tableInfo.Core.PKIsHandle && tr.tableInfo.Core.ContainsAutoRandomBits() {
 			cp.AllocBase = mathutil.MaxInt64(cp.AllocBase, tr.tableInfo.Core.AutoRandID)
-			if err := tr.alloc.Get(autoid.AutoRandomType).Rebase(cp.AllocBase, false); err != nil {
+			if err := tr.alloc.Get(autoid.AutoRandomType).Rebase(context.Background(), cp.AllocBase, false); err != nil {
 				return false, err
 			}
 		} else {
 			cp.AllocBase = mathutil.MaxInt64(cp.AllocBase, tr.tableInfo.Core.AutoIncID)
-			if err := tr.alloc.Get(autoid.RowIDAllocType).Rebase(cp.AllocBase, false); err != nil {
+			if err := tr.alloc.Get(autoid.RowIDAllocType).Rebase(context.Background(), cp.AllocBase, false); err != nil {
 				return false, err
 			}
 		}

--- a/ddl/column.go
+++ b/ddl/column.go
@@ -1652,7 +1652,7 @@ func applyNewAutoRandomBits(d *ddlCtx, m *meta.Meta, dbInfo *model.DBInfo,
 	if err != nil {
 		return errors.Trace(err)
 	}
-	err = autoRandAlloc.Rebase(nextAutoIncID, false)
+	err = autoRandAlloc.Rebase(context.Background(), nextAutoIncID, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2244,7 +2244,7 @@ func checkCharsetAndCollation(cs string, co string) error {
 func (d *ddl) handleAutoIncID(tbInfo *model.TableInfo, schemaID int64, newEnd int64, tp autoid.AllocatorType) error {
 	allocs := autoid.NewAllocatorsFromTblInfo(d.store, schemaID, tbInfo)
 	if alloc := allocs.Get(tp); alloc != nil {
-		err := alloc.Rebase(newEnd, false)
+		err := alloc.Rebase(context.Background(), newEnd, false)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -633,7 +633,7 @@ func onRebaseAutoID(store kv.Storage, t *meta.Meta, job *model.Job, tp autoid.Al
 		if force {
 			err = alloc.ForceRebase(newEnd)
 		} else {
-			err = alloc.Rebase(newEnd, false)
+			err = alloc.Rebase(context.Background(), newEnd, false)
 		}
 		if err != nil {
 			job.State = model.JobStateCancelled

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -902,7 +902,7 @@ func (s *testSuite8) TestShardRowIDBits(c *C) {
 	tbl, err = dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
 	c.Assert(err, IsNil)
 	maxID := 1<<(64-15-1) - 1
-	err = tbl.RebaseAutoID(tk.Se, int64(maxID)-1, false, autoid.RowIDAllocType)
+	err = tbl.RebaseAutoID(context.Background(), tk.Se, int64(maxID)-1, false, autoid.RowIDAllocType)
 	c.Assert(err, IsNil)
 	tk.MustExec("insert into t1 values(1)")
 

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -18,16 +18,15 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/pingcap/tidb/meta/autoid"
 	"runtime/trace"
 	"time"
 
-	"github.com/pingcap/parser/model"
-
 	"github.com/opentracing/opentracing-go"
+	"github.com/pingcap/parser/model"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -306,7 +306,7 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 func (e *InsertExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if e.collectRuntimeStatsEnabled() {
-		ctx = context.WithValue(ctx, autoid.AutoIDAllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
 	}
 
 	if len(e.children) > 0 && e.children[0] != nil {

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
+	"github.com/pingcap/tidb/meta/autoid"
 	"runtime/trace"
 	"time"
 
@@ -304,6 +305,10 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 // Next implements the Executor Next interface.
 func (e *InsertExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
+	if e.collectRuntimeStatsEnabled() {
+		ctx = context.WithValue(ctx, autoid.AutoIDAllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+	}
+
 	if len(e.children) > 0 && e.children[0] != nil {
 		return insertRowsFromSelect(ctx, e)
 	}

--- a/executor/insert.go
+++ b/executor/insert.go
@@ -306,7 +306,7 @@ func (e *InsertExec) batchUpdateDupRows(ctx context.Context, newRows [][]types.D
 func (e *InsertExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if e.collectRuntimeStatsEnabled() {
-		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
 	}
 
 	if len(e.children) > 0 && e.children[0] != nil {

--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -1016,8 +1016,6 @@ func (e *InsertValues) collectRuntimeStatsEnabled() bool {
 				BasicRuntimeStats:     e.runtimeStats,
 				SnapshotRuntimeStats:  snapshotStats,
 				AllocatorRuntimeStats: autoid.NewAllocatorRuntimeStats(),
-				Prefetch:              0,
-				CheckInsertTime:       0,
 			}
 			e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, e.stats)
 		}
@@ -1158,10 +1156,19 @@ type InsertRuntimeStat struct {
 
 func (e *InsertRuntimeStat) String() string {
 	buf := bytes.NewBuffer(make([]byte, 0, 32))
-	e.genPrepareString(buf)
+	var allocatorStatsStr string
+	if e.AllocatorRuntimeStats != nil {
+		allocatorStatsStr = e.AllocatorRuntimeStats.String()
+	}
 	if e.CheckInsertTime == 0 {
 		// For replace statement.
+		if allocatorStatsStr != "" {
+			buf.WriteString(allocatorStatsStr)
+		}
 		if e.Prefetch > 0 && e.SnapshotRuntimeStats != nil {
+			if buf.Len() > 0 {
+				buf.WriteString(", ")
+			}
 			buf.WriteString("prefetch: ")
 			buf.WriteString(execdetails.FormatDuration(e.Prefetch))
 			buf.WriteString(", rpc: {")
@@ -1170,6 +1177,17 @@ func (e *InsertRuntimeStat) String() string {
 			return buf.String()
 		}
 		return ""
+	}
+	if allocatorStatsStr != "" {
+		buf.WriteString("prepare: {total: ")
+		buf.WriteString(execdetails.FormatDuration(time.Duration(e.BasicRuntimeStats.GetTime()) - e.CheckInsertTime))
+		buf.WriteString(", ")
+		buf.WriteString(allocatorStatsStr)
+		buf.WriteString("}, ")
+	} else {
+		buf.WriteString("prepare: ")
+		buf.WriteString(execdetails.FormatDuration(time.Duration(e.BasicRuntimeStats.GetTime()) - e.CheckInsertTime))
+		buf.WriteString(", ")
 	}
 	if e.Prefetch > 0 {
 		buf.WriteString(fmt.Sprintf("check_insert: {total_time: %v, mem_insert_time: %v, prefetch: %v",
@@ -1186,32 +1204,6 @@ func (e *InsertRuntimeStat) String() string {
 		buf.WriteString(fmt.Sprintf("insert:%v", execdetails.FormatDuration(e.CheckInsertTime)))
 	}
 	return buf.String()
-}
-
-func (e *InsertRuntimeStat) genPrepareString(buf *bytes.Buffer) {
-	var allocatorStatsStr string
-	if e.AllocatorRuntimeStats != nil {
-		allocatorStatsStr = e.AllocatorRuntimeStats.String()
-	}
-	if allocatorStatsStr == "" {
-		if e.CheckInsertTime == 0 {
-			return
-		}
-		buf.WriteString("prepare: ")
-		buf.WriteString(execdetails.FormatDuration(time.Duration(e.BasicRuntimeStats.GetTime()) - e.CheckInsertTime))
-		buf.WriteString(", ")
-		return
-	}
-	if e.CheckInsertTime != 0 {
-		buf.WriteString("prepare: {total: ")
-		buf.WriteString(execdetails.FormatDuration(time.Duration(e.BasicRuntimeStats.GetTime()) - e.CheckInsertTime))
-		buf.WriteString(", ")
-		buf.WriteString(allocatorStatsStr)
-		buf.WriteString("}, ")
-	} else {
-		buf.WriteString(allocatorStatsStr)
-		buf.WriteString(", ")
-	}
 }
 
 // Clone implements the RuntimeStats interface.

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -253,7 +253,7 @@ func (e *ReplaceExec) exec(ctx context.Context, newRows [][]types.Datum) error {
 func (e *ReplaceExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if e.collectRuntimeStatsEnabled() {
-		ctx = context.WithValue(ctx, autoid.AutoIDAllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
 	}
 
 	if len(e.children) > 0 && e.children[0] != nil {

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types"
@@ -251,6 +252,10 @@ func (e *ReplaceExec) exec(ctx context.Context, newRows [][]types.Datum) error {
 // Next implements the Executor Next interface.
 func (e *ReplaceExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
+	if e.collectRuntimeStatsEnabled() {
+		ctx = context.WithValue(ctx, autoid.AutoIDAllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+	}
+
 	if len(e.children) > 0 && e.children[0] != nil {
 		return insertRowsFromSelect(ctx, e)
 	}

--- a/executor/replace.go
+++ b/executor/replace.go
@@ -253,7 +253,7 @@ func (e *ReplaceExec) exec(ctx context.Context, newRows [][]types.Datum) error {
 func (e *ReplaceExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if e.collectRuntimeStatsEnabled() {
-		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AutoIDAllocatorRuntimeStats)
+		ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
 	}
 
 	if len(e.children) > 0 && e.children[0] != nil {

--- a/executor/update.go
+++ b/executor/update.go
@@ -459,7 +459,7 @@ func (e *UpdateExec) collectRuntimeStatsEnabled() bool {
 	return false
 }
 
-// updateRuntimeStats record the execution stats about update statements.
+// updateRuntimeStats is the execution stats about update statements.
 type updateRuntimeStats struct {
 	*txnsnapshot.SnapshotRuntimeStats
 	*autoid.AllocatorRuntimeStats

--- a/executor/update.go
+++ b/executor/update.go
@@ -15,6 +15,7 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"runtime/trace"
@@ -23,11 +24,13 @@ import (
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
+	"github.com/pingcap/tidb/meta/autoid"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/tikv/client-go/v2/txnkv/txnsnapshot"
 )
@@ -58,7 +61,7 @@ type UpdateExec struct {
 	drained                   bool
 	memTracker                *memory.Tracker
 
-	stats *runtimeStatsWithSnapshot
+	stats *updateRuntimeStats
 
 	handles        []kv.Handle
 	tableUpdatable []bool
@@ -217,6 +220,9 @@ func (e *UpdateExec) unmatchedOuterRow(tblPos plannercore.TblColPosInfo, waitUpd
 func (e *UpdateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	req.Reset()
 	if !e.drained {
+		if e.collectRuntimeStatsEnabled() {
+			ctx = context.WithValue(ctx, autoid.AllocatorRuntimeStatsCtxKey, e.stats.AllocatorRuntimeStats)
+		}
 		numRows, err := e.updateRows(ctx)
 		if err != nil {
 			return err
@@ -442,13 +448,81 @@ func (e *UpdateExec) setMessage() {
 func (e *UpdateExec) collectRuntimeStatsEnabled() bool {
 	if e.runtimeStats != nil {
 		if e.stats == nil {
-			snapshotStats := &txnsnapshot.SnapshotRuntimeStats{}
-			e.stats = &runtimeStatsWithSnapshot{
-				SnapshotRuntimeStats: snapshotStats,
+			e.stats = &updateRuntimeStats{
+				SnapshotRuntimeStats:  &txnsnapshot.SnapshotRuntimeStats{},
+				AllocatorRuntimeStats: autoid.NewAllocatorRuntimeStats(),
 			}
 			e.ctx.GetSessionVars().StmtCtx.RuntimeStatsColl.RegisterStats(e.id, e.stats)
 		}
 		return true
 	}
 	return false
+}
+
+// updateRuntimeStats record the execution stats about update statements.
+type updateRuntimeStats struct {
+	*txnsnapshot.SnapshotRuntimeStats
+	*autoid.AllocatorRuntimeStats
+}
+
+func (e *updateRuntimeStats) String() string {
+	if e.SnapshotRuntimeStats == nil && e.AllocatorRuntimeStats == nil {
+		return ""
+	}
+	buf := bytes.NewBuffer(make([]byte, 0, 16))
+	if e.SnapshotRuntimeStats != nil {
+		stats := e.SnapshotRuntimeStats.String()
+		if stats != "" {
+			buf.WriteString(stats)
+		}
+	}
+	if e.AllocatorRuntimeStats != nil {
+		stats := e.AllocatorRuntimeStats.String()
+		if stats != "" {
+			if buf.Len() > 0 {
+				buf.WriteString(", ")
+			}
+			buf.WriteString(stats)
+		}
+	}
+	return buf.String()
+}
+
+// Clone implements the RuntimeStats interface.
+func (e *updateRuntimeStats) Clone() execdetails.RuntimeStats {
+	newRs := &updateRuntimeStats{}
+	if e.SnapshotRuntimeStats != nil {
+		snapshotStats := e.SnapshotRuntimeStats.Clone()
+		newRs.SnapshotRuntimeStats = snapshotStats
+	}
+	if e.AllocatorRuntimeStats != nil {
+		newRs.AllocatorRuntimeStats = e.AllocatorRuntimeStats.Clone()
+	}
+	return newRs
+}
+
+// Merge implements the RuntimeStats interface.
+func (e *updateRuntimeStats) Merge(other execdetails.RuntimeStats) {
+	tmp, ok := other.(*updateRuntimeStats)
+	if !ok {
+		return
+	}
+	if tmp.SnapshotRuntimeStats != nil {
+		if e.SnapshotRuntimeStats == nil {
+			snapshotStats := tmp.SnapshotRuntimeStats.Clone()
+			e.SnapshotRuntimeStats = snapshotStats
+		} else {
+			e.SnapshotRuntimeStats.Merge(tmp.SnapshotRuntimeStats)
+		}
+	}
+	if tmp.AllocatorRuntimeStats != nil {
+		if e.AllocatorRuntimeStats == nil {
+			e.AllocatorRuntimeStats = tmp.AllocatorRuntimeStats.Clone()
+		}
+	}
+}
+
+// Tp implements the RuntimeStats interface.
+func (e *updateRuntimeStats) Tp() int {
+	return execdetails.TpUpdateRuntimeStats
 }

--- a/executor/write.go
+++ b/executor/write.go
@@ -111,14 +111,14 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 				if err != nil {
 					return false, err
 				}
-				if err = t.RebaseAutoID(sctx, recordID, true, autoid.RowIDAllocType); err != nil {
+				if err = t.RebaseAutoID(ctx, sctx, recordID, true, autoid.RowIDAllocType); err != nil {
 					return false, err
 				}
 			}
 			if col.IsPKHandleColumn(t.Meta()) {
 				handleChanged = true
 				// Rebase auto random id if the field is changed.
-				if err := rebaseAutoRandomValue(sctx, t, &newData[i], col); err != nil {
+				if err := rebaseAutoRandomValue(ctx, sctx, t, &newData[i], col); err != nil {
 					return false, err
 				}
 			}
@@ -222,7 +222,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 	return true, nil
 }
 
-func rebaseAutoRandomValue(sctx sessionctx.Context, t table.Table, newData *types.Datum, col *table.Column) error {
+func rebaseAutoRandomValue(ctx context.Context, sctx sessionctx.Context, t table.Table, newData *types.Datum, col *table.Column) error {
 	tableInfo := t.Meta()
 	if !tableInfo.ContainsAutoRandomBits() {
 		return nil
@@ -237,7 +237,7 @@ func rebaseAutoRandomValue(sctx sessionctx.Context, t table.Table, newData *type
 	layout := autoid.NewShardIDLayout(&col.FieldType, tableInfo.AutoRandomBits)
 	// Set bits except incremental_bits to zero.
 	recordID = recordID & (1<<layout.IncrementalBits - 1)
-	return t.Allocators(sctx).Get(autoid.AutoRandomType).Rebase(recordID, true)
+	return t.Allocators(sctx).Get(autoid.AutoRandomType).Rebase(ctx, recordID, true)
 }
 
 // resetErrDataTooLong reset ErrDataTooLong error msg.

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1988,7 +1988,7 @@ func (it *infoschemaTable) Allocators(_ sessionctx.Context) autoid.Allocators {
 }
 
 // RebaseAutoID implements table.Table RebaseAutoID interface.
-func (it *infoschemaTable) RebaseAutoID(ctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
+func (it *infoschemaTable) RebaseAutoID(ctx context.Context, sctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
 	return table.ErrUnsupportedOp
 }
 
@@ -2071,7 +2071,7 @@ func (vt *VirtualTable) Allocators(_ sessionctx.Context) autoid.Allocators {
 }
 
 // RebaseAutoID implements table.Table RebaseAutoID interface.
-func (vt *VirtualTable) RebaseAutoID(ctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
+func (vt *VirtualTable) RebaseAutoID(ctx context.Context, sctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
 	return table.ErrUnsupportedOp
 }
 

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -83,22 +83,22 @@ func TestSignedAutoid(t *testing.T) {
 	require.Equal(t, autoid.GetStep()+1, globalAutoID)
 
 	// rebase
-	err = alloc.Rebase(int64(1), true)
+	err = alloc.Rebase(context.Background(), int64(1), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), id)
-	err = alloc.Rebase(int64(3), true)
+	err = alloc.Rebase(context.Background(), int64(3), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), id)
-	err = alloc.Rebase(int64(10), true)
+	err = alloc.Rebase(context.Background(), int64(10), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(11), id)
-	err = alloc.Rebase(int64(3010), true)
+	err = alloc.Rebase(context.Background(), int64(3010), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestSignedAutoid(t *testing.T) {
 
 	alloc = autoid.NewAllocator(store, 1, 2, false, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(1), false)
+	err = alloc.Rebase(context.Background(), int64(1), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -120,27 +120,27 @@ func TestSignedAutoid(t *testing.T) {
 
 	alloc = autoid.NewAllocator(store, 1, 3, false, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(3210), false)
+	err = alloc.Rebase(context.Background(), int64(3210), false)
 	require.NoError(t, err)
 	alloc = autoid.NewAllocator(store, 1, 3, false, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(3000), false)
+	err = alloc.Rebase(context.Background(), int64(3000), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(3211), id)
-	err = alloc.Rebase(int64(6543), false)
+	err = alloc.Rebase(context.Background(), int64(6543), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(6544), id)
 
 	// Test the MaxInt64 is the upper bound of `alloc` function but not `rebase`.
-	err = alloc.Rebase(int64(math.MaxInt64-1), true)
+	err = alloc.Rebase(context.Background(), int64(math.MaxInt64-1), true)
 	require.NoError(t, err)
 	_, _, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.Error(t, err)
-	err = alloc.Rebase(int64(math.MaxInt64), true)
+	err = alloc.Rebase(context.Background(), int64(math.MaxInt64), true)
 	require.NoError(t, err)
 
 	// alloc N for signed
@@ -169,7 +169,7 @@ func TestSignedAutoid(t *testing.T) {
 		expected++
 	}
 
-	err = alloc.Rebase(int64(1000), false)
+	err = alloc.Rebase(context.Background(), int64(1000), false)
 	require.NoError(t, err)
 	min, max, err = alloc.Alloc(ctx, 3, 1, 1)
 	require.NoError(t, err)
@@ -179,7 +179,7 @@ func TestSignedAutoid(t *testing.T) {
 	require.Equal(t, int64(1003), max)
 
 	lastRemainOne := alloc.End()
-	err = alloc.Rebase(alloc.End()-2, false)
+	err = alloc.Rebase(context.Background(), alloc.End()-2, false)
 	require.NoError(t, err)
 	min, max, err = alloc.Alloc(ctx, 5, 1, 1)
 	require.NoError(t, err)
@@ -287,22 +287,22 @@ func TestUnsignedAutoid(t *testing.T) {
 	require.Equal(t, autoid.GetStep()+1, globalAutoID)
 
 	// rebase
-	err = alloc.Rebase(int64(1), true)
+	err = alloc.Rebase(context.Background(), int64(1), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(3), id)
-	err = alloc.Rebase(int64(3), true)
+	err = alloc.Rebase(context.Background(), int64(3), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(4), id)
-	err = alloc.Rebase(int64(10), true)
+	err = alloc.Rebase(context.Background(), int64(10), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(11), id)
-	err = alloc.Rebase(int64(3010), true)
+	err = alloc.Rebase(context.Background(), int64(3010), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -316,7 +316,7 @@ func TestUnsignedAutoid(t *testing.T) {
 
 	alloc = autoid.NewAllocator(store, 1, 2, true, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(1), false)
+	err = alloc.Rebase(context.Background(), int64(1), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -324,16 +324,16 @@ func TestUnsignedAutoid(t *testing.T) {
 
 	alloc = autoid.NewAllocator(store, 1, 3, true, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(3210), false)
+	err = alloc.Rebase(context.Background(), int64(3210), false)
 	require.NoError(t, err)
 	alloc = autoid.NewAllocator(store, 1, 3, true, autoid.RowIDAllocType)
 	require.NotNil(t, alloc)
-	err = alloc.Rebase(int64(3000), false)
+	err = alloc.Rebase(context.Background(), int64(3000), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(3211), id)
-	err = alloc.Rebase(int64(6543), false)
+	err = alloc.Rebase(context.Background(), int64(6543), false)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -342,12 +342,12 @@ func TestUnsignedAutoid(t *testing.T) {
 	// Test the MaxUint64 is the upper bound of `alloc` func but not `rebase`.
 	var n uint64 = math.MaxUint64 - 1
 	un := int64(n)
-	err = alloc.Rebase(un, true)
+	err = alloc.Rebase(context.Background(), un, true)
 	require.NoError(t, err)
 	_, _, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.Error(t, err)
 	un = int64(n + 1)
-	err = alloc.Rebase(un, true)
+	err = alloc.Rebase(context.Background(), un, true)
 	require.NoError(t, err)
 
 	// alloc N for unsigned
@@ -363,7 +363,7 @@ func TestUnsignedAutoid(t *testing.T) {
 	require.Equal(t, int64(1), min+1)
 	require.Equal(t, int64(2), max)
 
-	err = alloc.Rebase(int64(500), true)
+	err = alloc.Rebase(context.Background(), int64(500), true)
 	require.NoError(t, err)
 	min, max, err = alloc.Alloc(ctx, 2, 1, 1)
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestUnsignedAutoid(t *testing.T) {
 	require.Equal(t, int64(502), max)
 
 	lastRemainOne := alloc.End()
-	err = alloc.Rebase(alloc.End()-2, false)
+	err = alloc.Rebase(context.Background(), alloc.End()-2, false)
 	require.NoError(t, err)
 	min, max, err = alloc.Alloc(ctx, 5, 1, 1)
 	require.NoError(t, err)
@@ -521,7 +521,7 @@ func TestRollbackAlloc(t *testing.T) {
 	require.Equal(t, int64(0), alloc.Base())
 	require.Equal(t, int64(0), alloc.End())
 
-	err = alloc.Rebase(100, true)
+	err = alloc.Rebase(context.Background(), 100, true)
 	require.Error(t, err)
 	require.Equal(t, int64(0), alloc.Base())
 	require.Equal(t, int64(0), alloc.End())
@@ -573,10 +573,10 @@ func TestAllocComputationIssue(t *testing.T) {
 	require.NotNil(t, signedAlloc2)
 
 	// the next valid two value must be 13 & 16, batch size = 6.
-	err = unsignedAlloc1.Rebase(10, false)
+	err = unsignedAlloc1.Rebase(context.Background(), 10, false)
 	require.NoError(t, err)
 	// the next valid two value must be 10 & 13, batch size = 6.
-	err = signedAlloc2.Rebase(7, false)
+	err = signedAlloc2.Rebase(context.Background(), 7, false)
 	require.NoError(t, err)
 	// Simulate the rest cache is not enough for next batch, assuming 10 & 13, batch size = 4.
 	autoid.TestModifyBaseAndEndInjection(unsignedAlloc1, 9, 9)

--- a/meta/autoid/memid.go
+++ b/meta/autoid/memid.go
@@ -86,7 +86,7 @@ func (alloc *inMemoryAllocator) Alloc(ctx context.Context, n uint64, increment, 
 // Rebase implements autoid.Allocator Rebase interface.
 // The requiredBase is the minimum base value after Rebase.
 // The real base may be greater than the required base.
-func (alloc *inMemoryAllocator) Rebase(requiredBase int64, allocIDs bool) error {
+func (alloc *inMemoryAllocator) Rebase(ctx context.Context, requiredBase int64, allocIDs bool) error {
 	if alloc.isUnsigned {
 		if uint64(requiredBase) > uint64(alloc.base) {
 			alloc.base = requiredBase

--- a/meta/autoid/memid_test.go
+++ b/meta/autoid/memid_test.go
@@ -72,19 +72,19 @@ func TestInMemoryAlloc(t *testing.T) {
 	require.Equal(t, int64(30), id)
 
 	// rebase
-	err = alloc.Rebase(int64(40), true)
+	err = alloc.Rebase(context.Background(), int64(40), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(41), id)
-	err = alloc.Rebase(int64(10), true)
+	err = alloc.Rebase(context.Background(), int64(10), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
 	require.Equal(t, int64(42), id)
 
 	// maxInt64
-	err = alloc.Rebase(int64(math.MaxInt64-2), true)
+	err = alloc.Rebase(context.Background(), int64(math.MaxInt64-2), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestInMemoryAlloc(t *testing.T) {
 	require.NotNil(t, alloc)
 
 	var n uint64 = math.MaxUint64 - 2
-	err = alloc.Rebase(int64(n), true)
+	err = alloc.Rebase(context.Background(), int64(n), true)
 	require.NoError(t, err)
 	_, id, err = alloc.Alloc(ctx, 1, 1, 1)
 	require.NoError(t, err)

--- a/table/table.go
+++ b/table/table.go
@@ -188,7 +188,7 @@ type Table interface {
 	// RebaseAutoID rebases the auto_increment ID base.
 	// If allocIDs is true, it will allocate some IDs and save to the cache.
 	// If allocIDs is false, it will not allocate IDs.
-	RebaseAutoID(ctx sessionctx.Context, newBase int64, allocIDs bool, tp autoid.AllocatorType) error
+	RebaseAutoID(ctx context.Context, sctx sessionctx.Context, newBase int64, allocIDs bool, tp autoid.AllocatorType) error
 
 	// Meta returns TableInfo.
 	Meta() *model.TableInfo

--- a/table/tables/tables.go
+++ b/table/tables/tables.go
@@ -1468,8 +1468,8 @@ func (t *TableCommon) Allocators(ctx sessionctx.Context) autoid.Allocators {
 
 // RebaseAutoID implements table.Table RebaseAutoID interface.
 // Both auto-increment and auto-random can use this function to do rebase on explicit newBase value (without shadow bits).
-func (t *TableCommon) RebaseAutoID(ctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
-	return t.Allocators(ctx).Get(tp).Rebase(newBase, isSetStep)
+func (t *TableCommon) RebaseAutoID(ctx context.Context, sctx sessionctx.Context, newBase int64, isSetStep bool, tp autoid.AllocatorType) error {
+	return t.Allocators(sctx).Get(tp).Rebase(ctx, newBase, isSetStep)
 }
 
 // Type implements table.Table Type interface.

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -198,7 +198,7 @@ func (ts *testSuite) TestBasic(c *C) {
 	alc := tb.Allocators(nil).Get(autoid.RowIDAllocType)
 	c.Assert(alc, NotNil)
 
-	err = tb.RebaseAutoID(nil, 0, false, autoid.RowIDAllocType)
+	err = tb.RebaseAutoID(context.Background(), nil, 0, false, autoid.RowIDAllocType)
 	c.Assert(err, IsNil)
 }
 
@@ -433,7 +433,7 @@ func (ts *testSuite) TestTableFromMeta(c *C) {
 	c.Assert(err, IsNil)
 
 	maxID := 1<<(64-15-1) - 1
-	err = tb.RebaseAutoID(tk.Se, int64(maxID), false, autoid.RowIDAllocType)
+	err = tb.RebaseAutoID(context.Background(), tk.Se, int64(maxID), false, autoid.RowIDAllocType)
 	c.Assert(err, IsNil)
 
 	_, err = tables.AllocHandle(context.Background(), tk.Se, tb)

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -415,16 +415,18 @@ const (
 	TpSelectResultRuntimeStats
 	// TpInsertRuntimeStat is the tp for InsertRuntimeStat
 	TpInsertRuntimeStat
-	// TpIndexLookUpRunTimeStats is the tp for TpIndexLookUpRunTimeStats
+	// TpIndexLookUpRunTimeStats is the tp for IndexLookUpRunTimeStats
 	TpIndexLookUpRunTimeStats
-	// TpSlowQueryRuntimeStat is the tp for TpSlowQueryRuntimeStat
+	// TpSlowQueryRuntimeStat is the tp for SlowQueryRuntimeStat
 	TpSlowQueryRuntimeStat
 	// TpHashAggRuntimeStat is the tp for HashAggRuntimeStat
 	TpHashAggRuntimeStat
-	// TpIndexMergeRunTimeStats is the tp for TpIndexMergeRunTimeStats
+	// TpIndexMergeRunTimeStats is the tp for IndexMergeRunTimeStats
 	TpIndexMergeRunTimeStats
-	// TpBasicCopRunTimeStats is the tp for TpBasicCopRunTimeStats
+	// TpBasicCopRunTimeStats is the tp for BasicCopRunTimeStats
 	TpBasicCopRunTimeStats
+	// TpAutoIDAllocatorRuntimeStats is s the tp for AutoIDAllocatorRuntimeStats
+	TpAutoIDAllocatorRuntimeStats
 )
 
 // RuntimeStats is used to express the executor runtime information.

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -425,8 +425,8 @@ const (
 	TpIndexMergeRunTimeStats
 	// TpBasicCopRunTimeStats is the tp for BasicCopRunTimeStats
 	TpBasicCopRunTimeStats
-	// TpAutoIDAllocatorRuntimeStats is s the tp for AutoIDAllocatorRuntimeStats
-	TpAutoIDAllocatorRuntimeStats
+	// TpUpdateRuntimeStats is the tp for UpdateRuntimeStats
+	TpUpdateRuntimeStats
 )
 
 // RuntimeStats is used to express the executor runtime information.
@@ -810,7 +810,9 @@ func (e *RuntimeStatsWithCommit) Merge(rs RuntimeStats) {
 
 // Clone implements the RuntimeStats interface.
 func (e *RuntimeStatsWithCommit) Clone() RuntimeStats {
-	newRs := RuntimeStatsWithCommit{}
+	newRs := RuntimeStatsWithCommit{
+		TxnCnt: e.TxnCnt,
+	}
 	if e.Commit != nil {
 		newRs.Commit = e.Commit.Clone()
 	}

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -772,7 +772,7 @@ func (e *RuntimeStatsWithCommit) Tp() int {
 	return TpRuntimeStatsWithCommit
 }
 
-// Merge implements the RuntimeStats interface.
+// MergeCommitDetails merges the commit details.
 func (e *RuntimeStatsWithCommit) MergeCommitDetails(detail *util.CommitDetails) {
 	if detail == nil {
 		return


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27810

Problem Summary: TiDB doesn't record the auto-id allocator execution runtime stats in the execution plan, so it is hard to understand why Insert/Update SQL executes so slow sometimes.

### What is changed and how it works?

Add auto-id allocator execution runtime stats. Here are some examples.

As you can see, I add `allocator_stats` in the execution stats:

```sql
create table t (a bigint unsigned auto_increment,b int, primary key (a));
```

```sql
-- First insert will trigger auto id allocator get ID from TiKV.
> explain analyze insert into t () values ();
+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
| id       | estRows | actRows | task | access object | execution info                                                                                                                                                                                                                                                                                                                                                                                                                      | operator info | memory    | disk |
+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
| Insert_1 | N/A     | 0       | root |               | time:3.43ms, loops:1, prepare: {total: 3.39ms, allocator_stats: {alloc_cnt: 1, Get:{num_rpc:4, total_time:1.26ms}, scan_detail: {total_process_keys: 2, total_keys: 4, rocksdb: {delete_skipped_count: 0, key_skipped_count: 0, block: {cache_hit_count: 0, read_count: 0, read_byte: 0 Bytes}}}, commit_txn: {prewrite:909.2µs, get_commit_ts:149.1µs, commit:703.3µs, region_num:1, write_keys:1, write_byte:32}}}, insert:35.5µs | N/A           | 169 Bytes | N/A  |
+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
-- This time doesn't have auto-id allocator stats since TiDB doesn't need to do allocation or rebase from TiKV.
> explain analyze insert into t () values ();
+----------+---------+---------+------+---------------+--------------------------------------------------------+---------------+-----------+------+
| id       | estRows | actRows | task | access object | execution info                                         | operator info | memory    | disk |
+----------+---------+---------+------+---------------+--------------------------------------------------------+---------------+-----------+------+
| Insert_1 | N/A     | 0       | root |               | time:200.3µs, loops:1, prepare: 170.5µs, insert:29.8µs | N/A           | 169 Bytes | N/A  |
+----------+---------+---------+------+---------------+--------------------------------------------------------+---------------+-----------+------+

-- Rebase auto-id.
> explain analyze insert into t (a) values (100000000000);

+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
| id       | estRows | actRows | task | access object | execution info                                                                                                                                                                                                                                                                                                                                                                                                                      | operator info | memory    | disk |
+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
| Insert_1 | N/A     | 0       | root |               | time:2.96ms, loops:1, prepare: {total: 2.93ms, allocator_stats: {rebase_cnt: 1, Get:{num_rpc:4, total_time:901µs}, scan_detail: {total_process_keys: 4, total_keys: 4, rocksdb: {delete_skipped_count: 0, key_skipped_count: 0, block: {cache_hit_count: 0, read_count: 0, read_byte: 0 Bytes}}}, commit_txn: {prewrite:741.3µs, get_commit_ts:111.8µs, commit:715.4µs, region_num:1, write_keys:1, write_byte:39}}}, insert:34.3µs | N/A           | 169 Bytes | N/A  |
+----------+---------+---------+------+---------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+---------------+-----------+------+
```



### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects

- N/A

Documentation

- N/A

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
