### PR TITLE
expression: give the function load_file an empty implement to support navicat premium to edit view

### DIFF
--- a/br/pkg/membuf/buffer_test.go
+++ b/br/pkg/membuf/buffer_test.go
@@ -18,19 +18,11 @@ import (
 	"crypto/rand"
 	"testing"
 
-	. "github.com/pingcap/check"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
 	allocBufLen = 1024
-}
-
-type bufferSuite struct{}
-
-var _ = Suite(&bufferSuite{})
-
-func Test(t *testing.T) {
-	TestingT(t)
 }
 
 type testAllocator struct {
@@ -47,45 +39,49 @@ func (t *testAllocator) Free(_ []byte) {
 	t.frees++
 }
 
-func (*bufferSuite) TestBufferPool(c *C) {
+func TestBufferPool(t *testing.T) {
+	t.Parallel()
+
 	allocator := &testAllocator{}
 	pool := NewPool(2, allocator)
 
 	bytesBuf := pool.NewBuffer()
 	bytesBuf.AllocBytes(256)
-	c.Assert(allocator.allocs, Equals, 1)
+	require.Equal(t, 1, allocator.allocs)
 	bytesBuf.AllocBytes(512)
-	c.Assert(allocator.allocs, Equals, 1)
+	require.Equal(t, 1, allocator.allocs)
 	bytesBuf.AllocBytes(257)
-	c.Assert(allocator.allocs, Equals, 2)
+	require.Equal(t, 2, allocator.allocs)
 	bytesBuf.AllocBytes(767)
-	c.Assert(allocator.allocs, Equals, 2)
+	require.Equal(t, 2, allocator.allocs)
 
-	c.Assert(allocator.frees, Equals, 0)
+	require.Equal(t, 0, allocator.frees)
 	bytesBuf.Destroy()
-	c.Assert(allocator.frees, Equals, 0)
+	require.Equal(t, 0, allocator.frees)
 
 	bytesBuf = pool.NewBuffer()
 	for i := 0; i < 6; i++ {
 		bytesBuf.AllocBytes(512)
 	}
 	bytesBuf.Destroy()
-	c.Assert(allocator.allocs, Equals, 3)
-	c.Assert(allocator.frees, Equals, 1)
+	require.Equal(t, 3, allocator.allocs)
+	require.Equal(t, 1, allocator.frees)
 }
 
-func (*bufferSuite) TestBufferIsolation(c *C) {
+func TestBufferIsolation(t *testing.T) {
+	t.Parallel()
+
 	bytesBuf := NewBuffer()
 	defer bytesBuf.Destroy()
 
 	b1 := bytesBuf.AllocBytes(16)
 	b2 := bytesBuf.AllocBytes(16)
-	c.Assert(cap(b1), Equals, len(b1))
-	c.Assert(cap(b2), Equals, len(b2))
+	require.Equal(t, len(b1), cap(b1))
+	require.Equal(t, len(b2), cap(b2))
 
 	_, err := rand.Read(b2)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	b3 := append([]byte(nil), b2...)
 	b1 = append(b1, 0, 1, 2, 3)
-	c.Assert(b2, DeepEquals, b3)
+	require.Equal(t, b3, b2)
 }

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -3817,7 +3817,31 @@ type loadFileFunctionClass struct {
 }
 
 func (c *loadFileFunctionClass) getFunction(ctx sessionctx.Context, args []Expression) (builtinFunc, error) {
-	return nil, errFunctionNotExists.GenWithStackByArgs("FUNCTION", "load_file")
+	if err := c.verifyArgs(args); err != nil {
+		return nil, err
+	}
+	bf, err := newBaseBuiltinFuncWithTp(ctx, c.funcName, args, types.ETString, types.ETString)
+	if err != nil {
+		return nil, err
+	}
+	bf.tp.Charset, bf.tp.Collate = ctx.GetSessionVars().GetCharsetInfo()
+	bf.tp.Flen = 64
+	sig := &builtinLoadFileSig{bf}
+	return sig, nil
+}
+
+type builtinLoadFileSig struct {
+	baseBuiltinFunc
+}
+
+func (b *builtinLoadFileSig) evalString(row chunk.Row) (string, bool, error) {
+	return "", false, nil
+}
+
+func (b *builtinLoadFileSig) Clone() builtinFunc {
+	newSig := &builtinLoadFileSig{}
+	newSig.cloneFrom(&b.baseBuiltinFunc)
+	return newSig
 }
 
 type weightStringPadding byte

--- a/expression/builtin_string.go
+++ b/expression/builtin_string.go
@@ -3834,7 +3834,11 @@ type builtinLoadFileSig struct {
 	baseBuiltinFunc
 }
 
-func (b *builtinLoadFileSig) evalString(row chunk.Row) (string, bool, error) {
+func (b *builtinLoadFileSig) evalString(row chunk.Row) (d string, isNull bool, err error) {
+	d, isNull, err = b.args[0].EvalString(b.ctx, row)
+	if isNull || err != nil {
+		return d, isNull, err
+	}
 	return "", false, nil
 }
 

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -1652,7 +1652,7 @@ func (s *testEvaluatorSuite) TestLoadFile(c *C) {
 		{"", false, false, ""},
 		{"/tmp/tikv/tikv.frm", false, false, ""},
 		{"tidb.sql", false, false, ""},
-		{nil, true, true, ""},
+		{nil, true, false, ""},
 	}
 	for _, t := range cases {
 		f, err := newFunctionForTest(s.ctx, ast.LoadFile, s.primitiveValsToConstants([]interface{}{t.arg})...)

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -1642,6 +1642,37 @@ func (s *testEvaluatorSuite) TestInstr(c *C) {
 	}
 }
 
+func (s *testEvaluatorSuite) TestLoadFile(c *C) {
+	cases := []struct {
+		arg    interface{}
+		isNil  bool
+		getErr bool
+		res    string
+	}{
+		{"", false, false, ""},
+		{"/tmp/tikv/tikv.frm", false, false, ""},
+		{"tidb.sql", false, false, ""},
+		{nil, true, true, ""},
+	}
+	for _, t := range cases {
+		f, err := newFunctionForTest(s.ctx, ast.LoadFile, s.primitiveValsToConstants([]interface{}{t.arg})...)
+		c.Assert(err, IsNil)
+		d, err := f.Eval(chunk.Row{})
+		if t.getErr {
+			c.Assert(err, NotNil)
+		} else {
+			c.Assert(err, IsNil)
+			if t.isNil {
+				c.Assert(d.Kind(), Equals, types.KindNull)
+			} else {
+				c.Assert(d.GetString(), Equals, t.res)
+			}
+		}
+	}
+	_, err := funcs[ast.LoadFile].getFunction(s.ctx, []Expression{NewZero()})
+	c.Assert(err, IsNil)
+}
+
 func (s *testEvaluatorSuite) TestMakeSet(c *C) {
 	tbl := []struct {
 		argList []interface{}


### PR DESCRIPTION
Signed-off-by: studiolee <1964773741@qq.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary:
TiDB does not have function： load_file.
It leads to that navicat premium can't open view edit page.

### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed: give en empty implement to load_file and add ut

How it Works: return empty string，navicat premium just need an empty result for load_file

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
