### PR TITLE
planner/core: fix index out of bound bug when empty dual table is remove for mpp query

### DIFF
--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -697,6 +697,28 @@ func (s *tiflashTestSuite) TestMppUnionAll(c *C) {
 
 }
 
+func (s *tiflashTestSuite) TestUnionWithEmptyDualTable(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t (a int not null, b int, c varchar(20))")
+	tk.MustExec("create table t1 (a int, b int not null, c double)")
+	tk.MustExec("alter table t set tiflash replica 1")
+	tk.MustExec("alter table t1 set tiflash replica 1")
+	tb := testGetTableByName(c, tk.Se, "test", "t")
+	err := domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
+	c.Assert(err, IsNil)
+	tb = testGetTableByName(c, tk.Se, "test", "t1")
+	err = domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
+	c.Assert(err, IsNil)
+	tk.MustExec("insert into t values(1,2,3)")
+	tk.MustExec("insert into t1 values(1,2,3)")
+	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
+	tk.MustExec("set @@session.tidb_enforce_mpp=ON")
+	tk.MustQuery("select count(*) from (select a , b from t union all select a , c from t1 where false) tt").Check(testkit.Rows("1"))
+}
+
 func (s *tiflashTestSuite) TestMppApply(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -28,10 +28,25 @@ func ToString(p Plan) string {
 	return strings.Join(strs, "->")
 }
 
+func needIncludeChildrenString(plan Plan) bool {
+	switch x := plan.(type) {
+	case *LogicalUnionAll, *PhysicalUnionAll, *LogicalPartitionUnionAll:
+		// after https://github.com/pingcap/tidb/pull/25218, the union may contain only 1 child,
+		// but we still wants to include its child plan's information when calling `toString` on union.
+		return true
+	case LogicalPlan:
+		return len(x.Children()) > 1
+	case PhysicalPlan:
+		return len(x.Children()) > 1
+	default:
+		return false
+	}
+}
+
 func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 	switch x := in.(type) {
 	case LogicalPlan:
-		if len(x.Children()) > 1 {
+		if needIncludeChildrenString(in) {
 			idxs = append(idxs, len(strs))
 		}
 
@@ -40,7 +55,7 @@ func toString(in Plan, strs []string, idxs []int) ([]string, []int) {
 		}
 	case *PhysicalExchangeReceiver: // do nothing
 	case PhysicalPlan:
-		if len(x.Children()) > 1 {
+		if needIncludeChildrenString(in) {
 			idxs = append(idxs, len(strs))
 		}
 

--- a/planner/core/stringer.go
+++ b/planner/core/stringer.go
@@ -31,7 +31,7 @@ func ToString(p Plan) string {
 func needIncludeChildrenString(plan Plan) bool {
 	switch x := plan.(type) {
 	case *LogicalUnionAll, *PhysicalUnionAll, *LogicalPartitionUnionAll:
-		// after https://github.com/pingcap/tidb/pull/25218, the union may contain only 1 child,
+		// after https://github.com/pingcap/tidb/pull/25218, the union may contain less than 2 children,
 		// but we still wants to include its child plan's information when calling `toString` on union.
 		return true
 	case LogicalPlan:


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #28250 <!-- REMOVE this line if no issue to close -->

Problem Summary:
As described in the issue.
### What is changed and how it works?

Proposal: [xxx](url) <!-- REMOVE this line if not applicable -->

What's Changed:

How it Works:
The root cause is after #25218, union may contain less than 2 children, but in `stringer.ToString`, it still assume that `union` always contains at least 2 children. This pr refine the related code to consider the case that `union` contains less than 2 children.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix index out of bound bug when empty dual table is remove for mpp query
```
