### PR TITLE
util/checksum: fix unstable test

### DIFF
--- a/util/checksum/checksum_test.go
+++ b/util/checksum/checksum_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	encrypt2 "github.com/pingcap/tidb/util/encrypt"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestChecksumReadAt(t *testing.T) {
@@ -32,19 +32,19 @@ func TestChecksumReadAt(t *testing.T) {
 
 	csw := NewWriter(NewWriter(NewWriter(NewWriter(f))))
 	n1, err := csw.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	n2, err := csw.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = csw.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertReadAt := func(off int64, assertErr error, assertN int, assertString string) {
 		cs := NewReader(NewReader(NewReader(NewReader(f))))
 		r := make([]byte, 10)
 		n, err := cs.ReadAt(r, off)
-		assert.ErrorIs(t, err, assertErr)
-		assert.Equal(t, assertN, n)
-		assert.Equal(t, assertString, string(r))
+		require.ErrorIs(t, err, assertErr)
+		require.Equal(t, assertN, n)
+		require.Equal(t, assertString, string(r))
 	}
 
 	assertReadAt(0, nil, 10, "0123456789")
@@ -88,9 +88,9 @@ func testAddOneByte(t *testing.T, encrypt bool) {
 			break
 		}
 		if i < 5 {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.ErrorIs(t, err, errChecksumFail)
+			require.ErrorIs(t, err, errChecksumFail)
 		}
 	}
 }
@@ -131,9 +131,9 @@ func testDeleteOneByte(t *testing.T, encrypt bool) {
 			break
 		}
 		if i < 5 {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.ErrorIs(t, err, errChecksumFail)
+			require.ErrorIs(t, err, errChecksumFail)
 		}
 	}
 }
@@ -158,7 +158,7 @@ func testModifyOneByte(t *testing.T, encrypt bool) {
 	fc := func(b []byte, offset int) []byte {
 		if offset < modifyPos && offset+len(b) >= modifyPos {
 			pos := modifyPos - offset
-			b[pos-1] = 255
+			b[pos-1] = b[pos-1] - 1
 		}
 		return b
 	}
@@ -174,9 +174,9 @@ func testModifyOneByte(t *testing.T, encrypt bool) {
 			break
 		}
 		if i != 5 {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.ErrorIs(t, err, errChecksumFail)
+			require.ErrorIs(t, err, errChecksumFail)
 		}
 	}
 }
@@ -213,7 +213,7 @@ func testReadEmptyFile(t *testing.T, encrypt bool) {
 		underlying = NewReader(underlying)
 		r := make([]byte, 10)
 		_, err := underlying.ReadAt(r, int64(i*1020))
-		assert.ErrorIs(t, err, io.EOF)
+		require.ErrorIs(t, err, io.EOF)
 	}
 }
 
@@ -238,9 +238,9 @@ func testModifyThreeBytes(t *testing.T, encrypt bool) {
 		if offset < modifyPos && offset+len(b) >= modifyPos {
 			// modify 3 bytes
 			if len(b) == 1024 {
-				b[200] = 255
-				b[300] = 255
-				b[400] = 255
+				b[200] = b[200] - 1
+				b[300] = b[300] - 1
+				b[400] = b[400] - 1
 			}
 		}
 		return b
@@ -257,9 +257,9 @@ func testModifyThreeBytes(t *testing.T, encrypt bool) {
 			break
 		}
 		if i != 5 {
-			assert.NoError(t, err)
+			require.NoError(t, err)
 		} else {
-			assert.ErrorIs(t, err, errChecksumFail)
+			require.ErrorIs(t, err, errChecksumFail)
 		}
 	}
 }
@@ -296,11 +296,11 @@ func testReadDifferentBlockSize(t *testing.T, encrypt bool) {
 
 	w := newTestBuff("0123456789", 510)
 	_, err = underlying.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = underlying.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = underlying.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assertReadAt := assertReadAtFunc(t, encrypt, ctrCipher)
 
@@ -363,28 +363,28 @@ func testWriteDifferentBlockSize(t *testing.T, encrypt bool) {
 
 	// Write all data.
 	_, err = underlying1.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = underlying1.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Write data by 100 bytes one batch.
 	lastPos := 0
 	for i := 100; ; i += 100 {
 		if i < len(w.Bytes()) {
 			_, err = underlying2.Write(w.Bytes()[lastPos:i])
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			lastPos = i
 		} else {
 			_, err = underlying2.Write(w.Bytes()[lastPos:])
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			break
 		}
 	}
 	err = underlying2.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// check two files is same
-	assert.EqualValues(t, f1.buf.Bytes(), f2.buf.Bytes())
+	require.EqualValues(t, f1.buf.Bytes(), f2.buf.Bytes())
 
 	// check data
 	assertReadAt := assertReadAtFunc(t, encrypt, ctrCipher)
@@ -400,16 +400,16 @@ func TestChecksumWriter(t *testing.T) {
 	// Write 1000 bytes and flush.
 	w := NewWriter(f)
 	n, err := w.Write(buf.Bytes())
-	assert.NoError(t, err)
-	assert.Equal(t, 1000, n)
+	require.NoError(t, err)
+	require.Equal(t, 1000, n)
 
 	err = w.Flush()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	checkFlushedData(t, f, 0, 1000, 1000, nil, buf.Bytes())
 
 	// All data flushed, so no data in cache.
 	cacheOff := w.GetCacheDataOffset()
-	assert.Equal(t, int64(1000), cacheOff)
+	require.Equal(t, int64(1000), cacheOff)
 }
 
 func TestChecksumWriterAutoFlush(t *testing.T) {
@@ -419,16 +419,16 @@ func TestChecksumWriterAutoFlush(t *testing.T) {
 	buf := newTestBuff("0123456789", 102)
 	w := NewWriter(f)
 	n, err := w.Write(buf.Bytes())
-	assert.NoError(t, err)
-	assert.Equal(t, len(buf.Bytes()), n)
+	require.NoError(t, err)
+	require.Equal(t, len(buf.Bytes()), n)
 
 	// This write will trigger flush.
 	n, err = w.Write([]byte("0"))
-	assert.NoError(t, err)
-	assert.Equal(t, 1, n)
+	require.NoError(t, err)
+	require.Equal(t, 1, n)
 	checkFlushedData(t, f, 0, 1020, 1020, nil, buf.Bytes())
 	cacheOff := w.GetCacheDataOffset()
-	assert.Equal(t, int64(len(buf.Bytes())), cacheOff)
+	require.Equal(t, int64(len(buf.Bytes())), cacheOff)
 }
 
 func newTestBuff(str string, n int) *bytes.Buffer {
@@ -487,11 +487,11 @@ func assertUnderlyingWrite(t *testing.T, encrypt bool, f io.WriteCloser, fc func
 
 	w := newTestBuff("0123456789", 510)
 	_, err = underlying.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = underlying.Write(w.Bytes())
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	err = underlying.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	return ctrCipher, false
 }
 
@@ -516,9 +516,9 @@ func assertReadAtFunc(t *testing.T, encrypt bool, ctrCipher *encrypt2.CtrCipher)
 
 		underlying = NewReader(underlying)
 		n, err := underlying.ReadAt(r, off)
-		assert.ErrorIs(t, err, assertErr)
-		assert.Equal(t, assertN, n)
-		assert.Equal(t, assertString, string(r))
+		require.ErrorIs(t, err, assertErr)
+		require.Equal(t, assertN, n)
+		require.Equal(t, assertString, string(r))
 	}
 }
 
@@ -526,9 +526,9 @@ var checkFlushedData = func(t *testing.T, f io.ReaderAt, off int64, readBufLen i
 	readBuf := make([]byte, readBufLen)
 	r := NewReader(f)
 	n, err := r.ReadAt(readBuf, off)
-	assert.ErrorIs(t, err, assertErr)
-	assert.Equal(t, assertN, n)
-	assert.Equal(t, 0, bytes.Compare(readBuf, assertRes))
+	require.ErrorIs(t, err, assertErr)
+	require.Equal(t, assertN, n)
+	require.Equal(t, 0, bytes.Compare(readBuf, assertRes))
 }
 
 func newFakeFile() *fakeFile {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #28299 <!-- REMOVE this line if no issue to close -->

Problem Summary:
```
[2021-09-23T16:00:22.934Z] --- FAIL: TestModifyOneByte (0.00s)
[2021-09-23T16:00:22.934Z]     --- FAIL: TestModifyOneByte/encrypted (0.00s)
[2021-09-23T16:00:22.934Z]         checksum_test.go:179: 
[2021-09-23T16:00:22.934Z]             	Error Trace:	checksum_test.go:179
[2021-09-23T16:00:22.934Z]             	            				checksum_test.go:150
[2021-09-23T16:00:22.934Z]             	Error:      	Target error should be in err chain:
[2021-09-23T16:00:22.934Z]             	            	expected: "error checksum"
[2021-09-23T16:00:22.934Z]             	            	in chain: 
[2021-09-23T16:00:22.934Z]             	Test:       	TestModifyOneByte/encrypted
```
### What is changed and how it works?
The instability is caused by the fact that the encrypted characters are exactly equal to the modified characters, thus causing the problem.
The solution is not to use predefined characters for substitution, but to use the current value minus one to ensure the difference.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
