### PR TITLE
unistore/pd: Add mock split regions future in pd.go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -97,3 +97,4 @@ require (
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
+replace github.com/tikv/client-go/v2 => ../client/client-go

--- a/go.mod
+++ b/go.mod
@@ -97,4 +97,5 @@ require (
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
-replace github.com/tikv/client-go/v2 => ../client/client-go
+
+replace github.com/tikv/client-go/v2 => github.com/hzh0425/client-go/v2 v2.0.0-alpha.0.20211008064245-6250481b1c38

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hydrogen18/memlistener v0.0.0-20141126152155-54553eb933fb/go.mod h1:qEIFzExnS6016fRpRfxrExeVn2gbClQA99gQhnIcdhE=
 github.com/hypnoglow/gormzap v0.3.0/go.mod h1:5Wom8B7Jl2oK0Im9hs6KQ+Kl92w4Y7gKCrj66rhyvw0=
+github.com/hzh0425/client-go/v2 v2.0.0-alpha.0.20211008064245-6250481b1c38 h1:X2krQgZCvyKsYneMeo+5//K9w75hlPspQKS1Me6G8yI=
+github.com/hzh0425/client-go/v2 v2.0.0-alpha.0.20211008064245-6250481b1c38/go.mod h1:KwtZXt0JD+bP9bWW2ka0ir3Wp3oTEfZUTh22bs2sI4o=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334 h1:VHgatEHNcBFEB7inlalqfNqw65aNkM1lGX2yt3NmbS8=
 github.com/iancoleman/strcase v0.0.0-20191112232945-16388991a334/go.mod h1:SK73tn/9oHe+/Y0h39VT4UCxmurVJkR5NA7kMEAOgSE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
@@ -729,8 +731,6 @@ github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfK
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210913094925-a8fa8acd44e7 h1:ZK5tbTW6v4dr3OhLqqldgzIlGmZso6KrGjFh7T590VA=
-github.com/tikv/client-go/v2 v2.0.0-alpha.0.20210913094925-a8fa8acd44e7/go.mod h1:KwtZXt0JD+bP9bWW2ka0ir3Wp3oTEfZUTh22bs2sI4o=
 github.com/tikv/pd v1.1.0-beta.0.20210323121136-78679e5e209d/go.mod h1:Jw9KG11C/23Rr7DW4XWQ7H5xOgGZo6DFL1OKAF4+Igw=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d h1:AFm1Dzw+QRUevWRfrFp45CPPkuK/zdSWcfxI10z+WVE=
 github.com/tikv/pd v1.1.0-beta.0.20210818082359-acba1da0018d/go.mod h1:rammPjeZgpvfrQRPkijcx8tlxF1XM5+m6kRXrkDzCAA=

--- a/store/mockstore/unistore/pd.go
+++ b/store/mockstore/unistore/pd.go
@@ -111,8 +111,8 @@ func (c *pdClient) ScatterRegions(ctx context.Context, regionsID []uint64, opts 
 }
 
 func (c *pdClient) SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...pd.RegionsOption) (*pdpb.SplitRegionsResponse, error) {
-	regionsId, err := c.MockPD.SplitRegions(ctx, splitKeys)
-	resp := &pdpb.SplitRegionsResponse{RegionsId: regionsId}
+	regionsID, err := c.MockPD.SplitRegions(ctx, splitKeys)
+	resp := &pdpb.SplitRegionsResponse{RegionsId: regionsID}
 	return resp, err
 }
 

--- a/store/mockstore/unistore/pd.go
+++ b/store/mockstore/unistore/pd.go
@@ -111,7 +111,9 @@ func (c *pdClient) ScatterRegions(ctx context.Context, regionsID []uint64, opts 
 }
 
 func (c *pdClient) SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...pd.RegionsOption) (*pdpb.SplitRegionsResponse, error) {
-	return nil, nil
+	regionsId, err := c.MockPD.SplitRegions(ctx, splitKeys)
+	resp := &pdpb.SplitRegionsResponse{RegionsId: regionsId}
+	return resp, err
 }
 
 func (c *pdClient) GetRegionFromMember(ctx context.Context, key []byte, memberURLs []string) (*pd.Region, error) {

--- a/store/mockstore/unistore/pd.go
+++ b/store/mockstore/unistore/pd.go
@@ -112,7 +112,7 @@ func (c *pdClient) ScatterRegions(ctx context.Context, regionsID []uint64, opts 
 
 func (c *pdClient) SplitRegions(ctx context.Context, splitKeys [][]byte, opts ...pd.RegionsOption) (*pdpb.SplitRegionsResponse, error) {
 	regionsID, err := c.MockPD.SplitRegions(ctx, splitKeys)
-	resp := &pdpb.SplitRegionsResponse{RegionsId: regionsID}
+	resp := &pdpb.SplitRegionsResponse{RegionsId: regionsID, FinishedPercentage: 100}
 	return resp, err
 }
 

--- a/store/mockstore/unistore/tikv/mock_region.go
+++ b/store/mockstore/unistore/tikv/mock_region.go
@@ -761,13 +761,13 @@ func (pd *MockPD) SplitRegions(ctx context.Context, SplitKeys [][]byte) ([]uint6
 		return nil, err
 	}
 
-	regionsId := make([]uint64, len(newRegions))
+	regionsID := make([]uint64, len(newRegions))
 
 	for _, regCtx := range newRegions {
-		regionsId = append(regionsId, regCtx.meta.Id)
+		regionsID = append(regionsID, regCtx.meta.Id)
 	}
 
-	return regionsId, nil
+	return regionsID, nil
 }
 
 // AskBatchSplit implements gRPC PDServer.

--- a/store/mockstore/unistore/tikv/mock_region.go
+++ b/store/mockstore/unistore/tikv/mock_region.go
@@ -761,7 +761,7 @@ func (pd *MockPD) SplitRegions(ctx context.Context, SplitKeys [][]byte) ([]uint6
 		return nil, err
 	}
 
-	regionsID := make([]uint64, len(newRegions))
+	regionsID := make([]uint64, 0, len(newRegions))
 
 	for _, regCtx := range newRegions {
 		regionsID = append(regionsID, regCtx.meta.Id)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/tikv/pd/issues/4095

Problem Summary: add split regions future in mock pd

### What is changed and how it works?

What's Changed: 

- Previously, in pd.go, SplitRegions() return nil directly
- In pr https://github.com/tikv/client-go/pull/310, I changed the logic of split and Scatter in Client-go/split-region.go, which caused some tests to fail
- So I proposed this PR and added the feature of mock Split

How it Works:

- Just use MockRegionManager's function -- splitKeys()

### Check List

Tests

-  Unit test
-  Integration test
-  Manual test (add detailed scripts or steps below)
-  No code

Side effects

-  Performance regression: Consumes more CPU
-  Performance regression: Consumes more Memory
-  Breaking backward compatibility

Documentation

-  Affects user behaviors
-  Contains syntax changes
-  Contains variable changes
-  Contains experimental features
-  Changes MySQL compatibility