### PR TITLE
config: support set audit log related param by config file

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -871,6 +871,9 @@ func (c *Config) Valid() error {
 	if c.Log.File.MaxSize > MaxLogFileSize {
 		return fmt.Errorf("invalid max log file size=%v which is larger than max=%v", c.Log.File.MaxSize, MaxLogFileSize)
 	}
+	if c.Log.AuditLogMaxSize > MaxLogFileSize {
+		return fmt.Errorf("invalid max log file size=%v which is larger than max=%v", c.Log.AuditLogMaxSize, MaxLogFileSize)
+	}
 	c.OOMAction = strings.ToLower(c.OOMAction)
 	if c.OOMAction != OOMActionLog && c.OOMAction != OOMActionCancel {
 		return fmt.Errorf("unsupported OOMAction %v, TiDB only supports [%v, %v]", c.OOMAction, OOMActionLog, OOMActionCancel)

--- a/config/config.go
+++ b/config/config.go
@@ -320,6 +320,8 @@ type Log struct {
 	ExpensiveThreshold  uint   `toml:"expensive-threshold" json:"expensive-threshold"`
 	QueryLogMaxLen      uint64 `toml:"query-log-max-len" json:"query-log-max-len"`
 	RecordPlanInSlowLog uint32 `toml:"record-plan-in-slow-log" json:"record-plan-in-slow-log"`
+	AuditLogFile        string `toml:"audit-log-file" json:"audit-log-file"`
+	AuditLogMaxSize     int    `toml:"audit-log-max-size" json:"audit-log-max-size"`
 }
 
 func (l *Log) getDisableTimestamp() bool {
@@ -608,6 +610,8 @@ var defaultConf = Config{
 		QueryLogMaxLen:      logutil.DefaultQueryLogMaxLen,
 		RecordPlanInSlowLog: logutil.DefaultRecordPlanInSlowLog,
 		EnableSlowLog:       logutil.DefaultTiDBEnableSlowLog,
+		AuditLogFile:        "tidb-audit.log",
+		AuditLogMaxSize:     logutil.DefaultAuditLogMaxSize,
 	},
 	Status: Status{
 		ReportStatus:    true,

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -168,7 +168,7 @@ query-log-max-len = 4096
 audit-log-file = "tidb-audit.log"
 
 # Max audit log file size im MB (upper limit to 4096MB).
-audit-log-max-size = 10
+audit-log-max-size = 300
 
 # File logging.
 [log.file]

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -164,6 +164,12 @@ expensive-threshold = 10000
 # Maximum query length recorded in log.
 query-log-max-len = 4096
 
+# Stores audit log into separated files.
+audit-log-file = "tidb-audit.log"
+
+# Max audit log file size im MB (upper limit to 4096MB).
+audit-log-max-size = 10
+
 # File logging.
 [log.file]
 # Log file name.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -236,6 +236,9 @@ deadlock-history-capacity = 123
 deadlock-history-collect-retryable = true
 [top-sql]
 receiver-address = "127.0.0.1:10100"
+[log]
+audit-log-file = "audit.log"
+audit-log-max-size = 5
 `)
 
 	require.NoError(t, err)
@@ -292,6 +295,8 @@ receiver-address = "127.0.0.1:10100"
 	require.True(t, conf.PessimisticTxn.DeadlockHistoryCollectRetryable)
 	require.False(t, conf.Experimental.EnableNewCharset)
 	require.Equal(t, "127.0.0.1:10100", conf.TopSQL.ReceiverAddress)
+	require.Equal(t, "audit.log", conf.Log.AuditLogFile)
+	require.Equal(t, 5, conf.Log.AuditLogMaxSize)
 
 	_, err = f.WriteString(`
 [log.file]

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -43,6 +43,8 @@ const (
 	DefaultRecordPlanInSlowLog = 1
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
 	DefaultTiDBEnableSlowLog = true
+	// DefaultAuditLogMaxSize is the default size of audit log files;
+	DefaultAuditLogMaxSize = 10 // MB
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.

--- a/util/logutil/log.go
+++ b/util/logutil/log.go
@@ -44,7 +44,7 @@ const (
 	// DefaultTiDBEnableSlowLog enables TiDB to log slow queries.
 	DefaultTiDBEnableSlowLog = true
 	// DefaultAuditLogMaxSize is the default size of audit log files;
-	DefaultAuditLogMaxSize = 10 // MB
+	DefaultAuditLogMaxSize = 300 // MB
 )
 
 // EmptyFileLogConfig is an empty FileLogConfig.


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #28429 

Problem Summary: Add `audit-log-file` and `audit-log-max-size` in tidb-server config log.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Add audit-log-file and audit-log-max-size in tidb-server config log
```
