### PR TITLE
tidb-server: prevent the misuse of the terror API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -96,3 +96,5 @@ require (
 // cloud.google.com/go/storage will upgrade grpc to v1.40.0
 // we need keep the replacement until go.etcd.io supports the higher version of grpc.
 replace google.golang.org/grpc => google.golang.org/grpc v1.29.1
+
+replace github.com/pingcap/parser => github.com/tiancaiamao/parser v0.0.0-20210927124404-e1f9e0fe4efa

--- a/go.sum
+++ b/go.sum
@@ -726,6 +726,8 @@ github.com/thoas/go-funk v0.7.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xz
 github.com/thoas/go-funk v0.8.0/go.mod h1:+IWnUfUmFO1+WVYQWQtIJHeRRdaIyyYglZN7xzUPe4Q=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
+github.com/tiancaiamao/parser v0.0.0-20210927124404-e1f9e0fe4efa h1:BSjjCkZYAPEl6rx55ezJKv5eN5DpWHVzxa+ZGsEsNLc=
+github.com/tiancaiamao/parser v0.0.0-20210927124404-e1f9e0fe4efa/go.mod h1:+xcMiiZzdIktT/Nqdfm81dkECJ2EPuoAYywd57py4Pk=
 github.com/tidwall/gjson v1.3.5/go.mod h1:P256ACg0Mn+j1RXIDXoss50DeIABTYK1PULOJHhxOls=
 github.com/tidwall/match v1.0.1/go.mod h1:LujAq0jyVjBy028G1WhWfIzbpQfMO8bBZ6Tyb0+pL9E=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -191,6 +191,11 @@ func main() {
 	storage, dom := createStoreAndDomain()
 	svr := createServer(storage, dom)
 
+	// Register error API is not thread-safe, the caller MUST NOT register errors after initialization.
+	// To prevent misuse, set a flag to indicate that register new error will panic immediately.
+	// For regression of issue like https://github.com/pingcap/tidb/issues/28190
+	terror.RegisterFinish()
+
 	exited := make(chan struct{})
 	signal.SetupSignalHandler(func(graceful bool) {
 		svr.Close()


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?


Problem Summary:

We've get stuck on #28190 this kind of error more than once.
It's better to do something to prevent regression in the future.

### What is changed and how it works?

Use a API ... to make the misuse expose early.

What's Changed:

How it Works:

When some one misuse the API, the server will panic immediately.
So we can catch the bug.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Manual test (add detailed scripts or steps below)

Mock an error usage and see the panic:

```
panic: register error after initialized is prohibited [recovered]
	panic: register error after initialized is prohibited
```

```
diff --git a/executor/point_get.go b/executor/point_get.go
index c96282304..3fae6a234 100644
--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -18,6 +18,9 @@ import (
        "context"
        "fmt"
 
+       "github.com/pingcap/tidb/errno"
+       "github.com/pingcap/tidb/util/dbterror"
+
        "github.com/pingcap/errors"
        "github.com/pingcap/failpoint"
        "github.com/pingcap/kvproto/pkg/metapb"
@@ -206,6 +209,10 @@ func (e *PointGetExecutor) Close() error {
 
 // Next implements the Executor interface.
 func (e *PointGetExecutor) Next(ctx context.Context, req *chunk.Chunk) error {
+
+       dbterror.ClassDDL.NewStd(errno.ErrUnsupportedDDLOperation)
+
+
        req.Reset()
        if e.done {
                return nil
```




### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
