### PR TITLE
expression: fill %s in error of decimal overflow (#28338)

### DIFF
--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -270,6 +270,9 @@ func (s *builtinArithmeticPlusDecimalSig) evalDecimal(row chunk.Row) (*types.MyD
 	c := &types.MyDecimal{}
 	err = types.DecimalAdd(a, b, c)
 	if err != nil {
+		if err == types.ErrOverflow {
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", s.args[0].String(), s.args[1].String()))
+		}
 		return nil, true, err
 	}
 	return c, false, nil
@@ -394,6 +397,9 @@ func (s *builtinArithmeticMinusDecimalSig) evalDecimal(row chunk.Row) (*types.My
 	c := &types.MyDecimal{}
 	err = types.DecimalSub(a, b, c)
 	if err != nil {
+		if err == types.ErrOverflow {
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", s.args[0].String(), s.args[1].String()))
+		}
 		return nil, true, err
 	}
 	return c, false, nil
@@ -594,6 +600,9 @@ func (s *builtinArithmeticMultiplyDecimalSig) evalDecimal(row chunk.Row) (*types
 	c := &types.MyDecimal{}
 	err = types.DecimalMul(a, b, c)
 	if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
+		if err == types.ErrOverflow {
+			err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", s.args[0].String(), s.args[1].String()))
+		}
 		return nil, true, err
 	}
 	return c, false, nil
@@ -721,6 +730,8 @@ func (s *builtinArithmeticDivideDecimalSig) evalDecimal(row chunk.Row) (*types.M
 		if frac < s.baseBuiltinFunc.tp.Decimal {
 			err = c.Round(c, s.baseBuiltinFunc.tp.Decimal, types.ModeHalfEven)
 		}
+	} else if err == types.ErrOverflow {
+		err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", s.args[0].String(), s.args[1].String()))
 	}
 	return c, false, err
 }

--- a/expression/builtin_arithmetic_vec.go
+++ b/expression/builtin_arithmetic_vec.go
@@ -103,6 +103,8 @@ func (b *builtinArithmeticDivideDecimalSig) vecEvalDecimal(input *chunk.Chunk, r
 					return err
 				}
 			}
+		} else if err == types.ErrOverflow {
+			return types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s / %s)", b.args[0].String(), b.args[1].String()))
 		} else {
 			return err
 		}
@@ -359,6 +361,9 @@ func (b *builtinArithmeticMinusDecimalSig) vecEvalDecimal(input *chunk.Chunk, re
 			continue
 		}
 		if err = types.DecimalSub(&x[i], &y[i], &to); err != nil {
+			if err == types.ErrOverflow {
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s - %s)", b.args[0].String(), b.args[1].String()))
+			}
 			return err
 		}
 		x[i] = to
@@ -559,6 +564,9 @@ func (b *builtinArithmeticMultiplyDecimalSig) vecEvalDecimal(input *chunk.Chunk,
 		}
 		err = types.DecimalMul(&x[i], &y[i], &to)
 		if err != nil && !terror.ErrorEqual(err, types.ErrTruncated) {
+			if err == types.ErrOverflow {
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s * %s)", b.args[0].String(), b.args[1].String()))
+			}
 			return err
 		}
 		x[i] = to
@@ -998,6 +1006,9 @@ func (b *builtinArithmeticPlusDecimalSig) vecEvalDecimal(input *chunk.Chunk, res
 			continue
 		}
 		if err = types.DecimalAdd(&x[i], &y[i], to); err != nil {
+			if err == types.ErrOverflow {
+				err = types.ErrOverflow.GenWithStackByArgs("DECIMAL", fmt.Sprintf("(%s + %s)", b.args[0].String(), b.args[1].String()))
+			}
 			return err
 		}
 		x[i] = *to


### PR DESCRIPTION
cherry-pick #28338 to release-5.1
***
Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>

### What problem does this PR solve?

Issue Number: close #27964

Problem Summary:

### What is changed and how it works?

Fill `%s` via `(*Error).GenWithStackByArgs`

Querys in the issues will error as follows:
```
mysql> select cast(9e40 as decimal(65)) * cast(9e40 as decimal(65));
ERROR 1690 (22003): DECIMAL value is out of range in '(90000000000000000000000000000000000000000 * 90000000000000000000000000000000000000000)'

mysql> set @a = cast(9e40 as decimal(65)) * cast(9e39 as decimal(65));
mysql> select @a + @a;
ERROR 1690 (22003): DECIMAL value is out of range in '(getvar(a) + getvar(a))'
mysql> select @a - (-@a);
ERROR 1690 (22003): DECIMAL value is out of range in '(getvar(a) - unaryminus(getvar(a)))'
mysql> select @a / 0.1;
ERROR 1690 (22003): DECIMAL value is out of range in '(getvar(a) / 0.1)'
```

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Fix error message for DECIMAL overflow is just "ERROR 1690 (22003): %s value is out of range in '%s'"
```
