### PR TITLE
*:  enhance the performance of parsing slow log

### DIFF
--- a/executor/slow_query.go
+++ b/executor/slow_query.go
@@ -590,6 +590,7 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 					fieldValues := strings.Split(line, " ")
 					for i := 0; i < len(fieldValues)-1; i += 2 {
 						field := strings.TrimSuffix(fieldValues[i], ":")
+						// if trim does not work, it means it is not a field
 						if field == fieldValues[i] {
 							needCompatibleParse = true
 							break
@@ -599,7 +600,7 @@ func (e *slowQueryRetriever) parseLog(ctx context.Context, sctx sessionctx.Conte
 					}
 					// compatible for Backoff_types: [tikvRPC regionMiss], but low performance with regex
 					// see issue: https://github.com/pingcap/tidb/issues/27895
-					if needCompatibleParse{
+					if needCompatibleParse {
 						fields, values = splitByColon(line)
 					}
 					for i := 0; i < len(fields); i++ {

--- a/infoschema/cluster_tables_serial_test.go
+++ b/infoschema/cluster_tables_serial_test.go
@@ -218,13 +218,13 @@ func SubTestSelectClusterTable(s *clusterTablesSuite) func(*testing.T) {
 			tk.MustExec(fmt.Sprintf("set @@tidb_enable_streaming=%d", i))
 			tk.MustExec("set @@global.tidb_enable_stmt_summary=1")
 			tk.MustExec("set time_zone = '+08:00';")
-			tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("2"))
+			tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY`").Check(testkit.Rows("3"))
 			tk.MustQuery("select time from `CLUSTER_SLOW_QUERY` where time='2019-02-12 19:33:56.571953'").Check(testutil.RowsWithSep("|", "2019-02-12 19:33:56.571953"))
 			tk.MustQuery("select count(*) from `CLUSTER_PROCESSLIST`").Check(testkit.Rows("1"))
 			tk.MustQuery("select * from `CLUSTER_PROCESSLIST`").Check(testkit.Rows(fmt.Sprintf(":10080 1 root 127.0.0.1 <nil> Query 9223372036 %s <nil>  0 0 ", "")))
 			tk.MustQuery("select query_time, conn_id from `CLUSTER_SLOW_QUERY` order by time limit 1").Check(testkit.Rows("4.895492 6"))
-			tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1", "1"))
-			tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest order by digest").Check(testkit.Rows("124acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc 1", "42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))
+			tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` group by digest").Check(testkit.Rows("1", "1", "1"))
+			tk.MustQuery("select digest, count(*) from `CLUSTER_SLOW_QUERY` group by digest order by digest").Check(testkit.Rows("123acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc 1", "124acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc 1", "42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772 1"))
 			tk.MustQuery(`select length(query) as l,time from information_schema.cluster_slow_query where time > "2019-02-12 19:33:56" order by abs(l) desc limit 10;`).Check(testkit.Rows("21 2019-02-12 19:33:56.571953"))
 			tk.MustQuery("select count(*) from `CLUSTER_SLOW_QUERY` where time > now() group by digest").Check(testkit.Rows())
 			re := tk.MustQuery("select * from `CLUSTER_statements_summary`")
@@ -303,8 +303,8 @@ func SubTestStmtSummaryEvictedCountTable(s *clusterTablesSuite) func(*testing.T)
 		tk := s.newTestKitWithRoot(t)
 		// disable refreshing
 		tk.MustExec("set global tidb_stmt_summary_refresh_interval=9999")
-		// set information_schema.statements_summary's size to 2
-		tk.MustExec("set global tidb_stmt_summary_max_stmt_count = 2")
+		// set information_schema.statements_summary's size to 3
+		tk.MustExec("set global tidb_stmt_summary_max_stmt_count = 3")
 		// no evict happened, no record in cluster evicted table.
 		tk.MustQuery("select count(*) from information_schema.cluster_statements_summary_evicted;").Check(testkit.Rows("0"))
 		tk.MustExec("set global tidb_stmt_summary_max_stmt_count = 1")

--- a/infoschema/tables_serial_test.go
+++ b/infoschema/tables_serial_test.go
@@ -487,6 +487,32 @@ select * from t_slim;
 # Write_sql_response_total: 0
 # Succ: true
 INSERT INTO ...;
+# Time: 2021-09-08T14:39:54.506967433+08:00
+# Txn_start_ts: 427578666238083075
+# User@Host: root[root] @ 172.16.0.0 [172.16.0.0]
+# Conn_ID: 40507
+# Query_time: 25.571605962
+# Parse_time: 0.002923536
+# Compile_time: 0.006800973
+# Rewrite_time: 0.002100764
+# Optimize_time: 0
+# Wait_TS: 0.000015801
+# Prewrite_time: 25.542014572 Commit_time: 0.002294647 Get_commit_ts_time: 0.000605473 Commit_backoff_time: 12.483 Backoff_types: [tikvRPC,regionMiss,tikvRPC,regionMiss,regionMiss] Write_keys: 624 Write_size: 172064 Prewrite_region: 60
+# DB: rtdb
+# Is_internal: false
+# Digest: 123acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc
+# Num_cop_tasks: 0
+# Mem_max: 856544
+# Prepared: false
+# Plan_from_cache: false
+# Plan_from_binding: false
+# Has_more_results: false
+# KV_total: 86.635049185
+# PD_total: 0.015486658
+# Backoff_total: 100.054
+# Write_sql_response_total: 0
+# Succ: true
+INSERT INTO ...;
 `))
 	require.NoError(t, f.Close())
 	require.NoError(t, err)
@@ -559,11 +585,13 @@ func TestSlowQuery(t *testing.T) {
 	re.Check(testutil.RowsWithSep("|",
 		"2019-02-12 19:33:56.571953|406315658548871171|root|localhost|6|57|0.12|4.895492|0.4|0.2|0.000000003|2|0.000000002|0.00000001|0.000000003|0.19|0.21|0.01|0|0.18|[txnLock]|0.03|0|15|480|1|8|0.3824278|0.161|0.101|0.092|1.71|1|100001|100000|100|10|10|10|100|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|65536|0|0|0|0||0|1|1|0|abcd|60e9378c746d9a2be1c791047e008967cf252eb6de9167ad3aa6098fa2d523f4|update t set i = 2;|select * from t_slim;",
 		"2021-09-08|14:39:54.506967|427578666238083075|root|172.16.0.0|40507|0|0|25.571605962|0.002923536|0.006800973|0.002100764|0|0|0|0.000015801|25.542014572|0|0.002294647|0.000605473|12.483|[tikvRPC regionMiss tikvRPC regionMiss regionMiss]|0|0|624|172064|60|0|0|0|0|0|0|0|0|0|0|0|0|0|0|rtdb||0|124acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc||0|0|0||0|0|0||856544|0|86.635049185|0.015486658|100.054|0||0|1|0|0||||INSERT INTO ...;",
+		"2021-09-08|14:39:54.506967|427578666238083075|root|172.16.0.0|40507|0|0|25.571605962|0.002923536|0.006800973|0.002100764|0|0|0|0.000015801|25.542014572|0|0.002294647|0.000605473|12.483|[tikvRPC,regionMiss,tikvRPC,regionMiss,regionMiss]|0|0|624|172064|60|0|0|0|0|0|0|0|0|0|0|0|0|0|0|rtdb||0|123acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc||0|0|0||0|0|0||856544|0|86.635049185|0.015486658|100.054|0||0|1|0|0||||INSERT INTO ...;",
 	))
 	tk.MustExec("set time_zone = '+00:00';")
 	re = tk.MustQuery("select * from information_schema.slow_query")
 	re.Check(testutil.RowsWithSep("|", "2019-02-12 11:33:56.571953|406315658548871171|root|localhost|6|57|0.12|4.895492|0.4|0.2|0.000000003|2|0.000000002|0.00000001|0.000000003|0.19|0.21|0.01|0|0.18|[txnLock]|0.03|0|15|480|1|8|0.3824278|0.161|0.101|0.092|1.71|1|100001|100000|100|10|10|10|100|test||0|42a1c8aae6f133e934d4bf0147491709a8812ea05ff8819ec522780fe657b772|t1:1,t2:2|0.1|0.2|0.03|127.0.0.1:20160|0.05|0.6|0.8|0.0.0.0:20160|70724|65536|0|0|0|0||0|1|1|0|abcd|60e9378c746d9a2be1c791047e008967cf252eb6de9167ad3aa6098fa2d523f4|update t set i = 2;|select * from t_slim;",
 		"2021-09-08|06:39:54.506967|427578666238083075|root|172.16.0.0|40507|0|0|25.571605962|0.002923536|0.006800973|0.002100764|0|0|0|0.000015801|25.542014572|0|0.002294647|0.000605473|12.483|[tikvRPC regionMiss tikvRPC regionMiss regionMiss]|0|0|624|172064|60|0|0|0|0|0|0|0|0|0|0|0|0|0|0|rtdb||0|124acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc||0|0|0||0|0|0||856544|0|86.635049185|0.015486658|100.054|0||0|1|0|0||||INSERT INTO ...;",
+		"2021-09-08|06:39:54.506967|427578666238083075|root|172.16.0.0|40507|0|0|25.571605962|0.002923536|0.006800973|0.002100764|0|0|0|0.000015801|25.542014572|0|0.002294647|0.000605473|12.483|[tikvRPC,regionMiss,tikvRPC,regionMiss,regionMiss]|0|0|624|172064|60|0|0|0|0|0|0|0|0|0|0|0|0|0|0|rtdb||0|123acb3a0bec903176baca5f9da00b4e7512a41c93b417923f26502edeb324cc||0|0|0||0|0|0||856544|0|86.635049185|0.015486658|100.054|0||0|1|0|0||||INSERT INTO ...;",
 	))
 
 	// Test for long query.

--- a/util/execdetails/execdetails.go
+++ b/util/execdetails/execdetails.go
@@ -149,7 +149,7 @@ func (d ExecDetails) String() string {
 			parts = append(parts, CommitBackoffTimeStr+": "+strconv.FormatFloat(time.Duration(commitBackoffTime).Seconds(), 'f', -1, 64))
 		}
 		if len(commitDetails.Mu.BackoffTypes) > 0 {
-			parts = append(parts, BackoffTypesStr+": "+fmt.Sprintf("%v", commitDetails.Mu.BackoffTypes))
+			parts = append(parts, BackoffTypesStr+": "+strings.Replace(fmt.Sprintf("%v", commitDetails.Mu.BackoffTypes), " ", ",", -1))
 		}
 		commitDetails.Mu.Unlock()
 		resolveLockTime := atomic.LoadInt64(&commitDetails.ResolveLockTime)

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -69,7 +69,7 @@ func TestString(t *testing.T) {
 		},
 	}
 	expected := "Cop_time: 1.003 Process_time: 2.005 Wait_time: 1 Backoff_time: 1 Request_count: 1 Prewrite_time: 1 Commit_time: 1 " +
-		"Get_commit_ts_time: 1 Commit_backoff_time: 1 Backoff_types: [backoff1 backoff2] Resolve_lock_time: 1 Local_latch_wait_time: 1 Write_keys: 1 Write_size: 1 Prewrite_region: 1 Txn_retry: 1 " +
+		"Get_commit_ts_time: 1 Commit_backoff_time: 1 Backoff_types: [backoff1,backoff2] Resolve_lock_time: 1 Local_latch_wait_time: 1 Write_keys: 1 Write_size: 1 Prewrite_region: 1 Txn_retry: 1 " +
 		"Process_keys: 10 Total_keys: 100 Rocksdb_delete_skipped_count: 1 Rocksdb_key_skipped_count: 1 Rocksdb_block_cache_hit_count: 1 Rocksdb_block_read_count: 1 Rocksdb_block_read_byte: 100"
 	require.Equal(t, expected, detail.String())
 	detail = &ExecDetails{}


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

related to: #28160 & #27950

Problem Summary:
#28160 & #27950 are both not very satisfied to solve https://github.com/pingcap/tidb/issues/27895.

### What is changed and how it works?

How it Works:
As I mentioned at #27950 
> I think about the solution once again. I prefer the comma added solution, reasons are like follows:

> 1. clear format makes it easy to parse by other tools, which makes code and performance better.
> 2. compatibility problem above is a small probability event, and even it happens, we can easily solve it by flush logs.
> 3. slow log can rotate by the default config, which makes the little bug disappear when time goes on.
> 4. In the long run, the terrible format of the slow log may bring more pain to us.

So I combine the two prs mentioned, looking forward to fix the bug with little performance affected. this pr can make side effects lower.

Since the benchmark at #28160 shows that `SpaceSplit` is 10+ times faster than `RegexSplit`, the compatibility checker does not take too much .

Besides, fields&values memory make&gc cost double than value assigned directly, but I think it's OK.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
