### PR TITLE
planner: fix the issue that some PointGet plans generated in physical-stage cannot be cached

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -791,7 +791,7 @@ func SplitDNFItems(onExpr Expression) []Expression {
 // If the Expression is a non-constant value, it means the result is unknown.
 func EvaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expression) Expression {
 	if MaybeOverOptimized4PlanCache(ctx, []Expression{expr}) {
-		ctx.GetSessionVars().StmtCtx.MaybeOverOptimized4PlanCache = true
+		return expr
 	}
 	return evaluateExprWithNull(ctx, schema, expr)
 }

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -812,7 +812,10 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 				p: dual,
 			}, cntPlan, nil
 		}
-		canConvertPointGet := len(path.Ranges) > 0 && path.StoreType == kv.TiKV && ds.isPointGetConvertableSchema()
+		canConvertPointGet := len(path.Ranges) > 0 && path.StoreType == kv.TiKV && ds.isPointGetConvertableSchema() &&
+			// to avoid the over-optimized risk, do not generate PointGet for plan cache, for example,
+			// `pk>=$a and pk<=$b` can be optimized to a PointGet when `$a==$b`, but it can cause wrong results when `$a!=$b`.
+			!ds.ctx.GetSessionVars().StmtCtx.UseCache
 		if canConvertPointGet && !path.IsIntHandlePath {
 			// We simply do not build [batch] point get for prefix indexes. This can be optimized.
 			canConvertPointGet = path.Index.Unique && !path.Index.HasPrefixIndex()

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -343,8 +343,6 @@ func (ds *DataSource) derivePathStatsAndTryHeuristics() error {
 	if selected != nil {
 		ds.possibleAccessPaths[0] = selected
 		ds.possibleAccessPaths = ds.possibleAccessPaths[:1]
-		// TODO: Can we make a more careful check on whether the optimization depends on mutable constants?
-		ds.ctx.GetSessionVars().StmtCtx.MaybeOverOptimized4PlanCache = true
 		if ds.ctx.GetSessionVars().StmtCtx.InVerboseExplain {
 			var tableName string
 			if ds.TableAsName.O == "" {

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -566,7 +566,9 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 				// Maybe we can improve it later.
 				columnValues[i] = &valueInfo{mutable: true}
 			}
-			sctx.GetSessionVars().StmtCtx.MaybeOverOptimized4PlanCache = true
+			if expression.MaybeOverOptimized4PlanCache(sctx, conditions) {
+				return nil, conditions, nil, nil, false
+			}
 		}
 	}
 	for i, offset := range offsets {


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #26868

 <!-- REMOVE this line if no issue to close -->

Problem Summary: planner: fix the issue that some PointGet plans generated in physical-stage cannot be cached

### What is changed and how it works?

planner: fix the issue that some PointGet plans generated in physical-stage cannot be cached




### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
planner: fix the issue that some PointGet plans generated in physical-stage cannot be cached
```
