### PR TITLE
*: Change default for unix socket

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -564,6 +564,7 @@ var defaultConf = Config{
 	Host:                         DefHost,
 	AdvertiseAddress:             "",
 	Port:                         DefPort,
+	Socket:                       "/tmp/tidb.sock",
 	Cors:                         "",
 	Store:                        "unistore",
 	Path:                         "/tmp/tidb",

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -16,7 +16,7 @@ store = "unistore"
 path = "/tmp/tidb"
 
 # The socket file to use for connection.
-socket = ""
+socket = "/tmp/tidb.sock"
 
 # Run ddl worker on this tidb-server.
 run-ddl = true

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -178,6 +178,7 @@ func TestInitialHandshake(t *testing.T) {
 
 	var outBuffer bytes.Buffer
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = 0
 	cfg.Status.StatusPort = 0
 	drv := NewTiDBDriver(store)
@@ -486,6 +487,7 @@ func testDispatch(t *testing.T, inputs []dispatchInput, capability uint32) {
 	var outBuffer bytes.Buffer
 	tidbdrv := NewTiDBDriver(store)
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port, cfg.Status.StatusPort = 0, 0
 	cfg.Status.ReportStatus = false
 	server, err := NewServer(cfg, tidbdrv)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -129,6 +129,7 @@ func (ts *tidbTestSuiteBase) SetUpSuite(c *C) {
 	c.Assert(err, IsNil)
 	ts.tidbdrv = NewTiDBDriver(ts.store)
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = ts.port
 	cfg.Status.ReportStatus = true
 	cfg.Status.StatusPort = ts.statusPort
@@ -274,6 +275,7 @@ func (ts *tidbTestSuite) TestStatusPort(c *C) {
 	defer dom.Close()
 	ts.tidbdrv = NewTiDBDriver(store)
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = 0
 	cfg.Status.ReportStatus = true
 	cfg.Status.StatusPort = ts.statusPort
@@ -300,6 +302,7 @@ func (ts *tidbTestSuite) TestStatusAPIWithTLS(c *C) {
 	cli := newTestServerClient()
 	cli.statusScheme = "https"
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.StatusPort = cli.statusPort
 	cfg.Security.ClusterSSLCA = "/tmp/ca-cert-2.pem"
@@ -351,6 +354,7 @@ func (ts *tidbTestSuite) TestStatusAPIWithTLSCNCheck(c *C) {
 	cli := newTestServerClient()
 	cli.statusScheme = "https"
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.StatusPort = cli.statusPort
 	cfg.Security.ClusterSSLCA = caPath
@@ -865,6 +869,7 @@ func registerTLSConfig(configName string, caCertPath string, clientCertPath stri
 func (ts *tidbTestSuite) TestSystemTimeZone(c *C) {
 	tk := testkit.NewTestKit(c, ts.store)
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port, cfg.Status.StatusPort = 0, 0
 	cfg.Status.ReportStatus = false
 	server, err := NewServer(cfg, ts.tidbdrv)
@@ -882,6 +887,7 @@ func (ts *tidbTestSerialSuite) TestTLSAuto(c *C) {
 	}
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.ReportStatus = false
 	cfg.Security.AutoTLS = true
@@ -934,6 +940,7 @@ func (ts *tidbTestSerialSuite) TestTLSBasic(c *C) {
 	}
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.ReportStatus = false
 	cfg.Security = config.Security{
@@ -1000,6 +1007,7 @@ func (ts *tidbTestSerialSuite) TestTLSVerify(c *C) {
 	// Start the server with TLS & CA, if the client presents its certificate, the certificate will be verified.
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.ReportStatus = false
 	cfg.Security = config.Security{
@@ -1065,6 +1073,7 @@ func (ts *tidbTestSerialSuite) TestReloadTLS(c *C) {
 	// try old cert used in startup configuration.
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.ReportStatus = false
 	cfg.Security = config.Security{
@@ -1165,6 +1174,7 @@ func (ts *tidbTestSerialSuite) TestErrorNoRollback(c *C) {
 
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.Port = cli.port
 	cfg.Status.ReportStatus = false
 
@@ -1499,6 +1509,7 @@ func (ts *tidbTestSuite) TestGracefulShutdown(c *C) {
 	ts.tidbdrv = NewTiDBDriver(ts.store)
 	cli := newTestServerClient()
 	cfg := newTestConfig()
+	cfg.Socket = ""
 	cfg.GracefulWaitBeforeShutdown = 2 // wait before shutdown
 	cfg.Port = 0
 	cfg.Status.StatusPort = 0


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: https://github.com/pingcap/tidb/issues/28484

Problem Summary:

In https://github.com/pingcap/tidb/pull/28482 it is proposed that the security be improved by using AuthSocket.

This only makes sense when socket listening is enabled by default.

### What is changed and how it works?

What's Changed:

As well as listening on `TCP:4000`, the tidb-server now listens on a unix socket at `/tmp/tidb.sock` by default.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
We actually have great existing tests for this (checking if the config file differs by defaults, and socket listening in the server package).
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
As well as listening on `TCP:4000`, the tidb-server now listens on a unix socket at `/tmp/tidb.sock` by default.
```
