### PR TITLE
expression: throw error instead of returning infinity when DEGREES() overflow

### DIFF
--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -1813,7 +1813,7 @@ func (b *builtinDegreesSig) evalReal(ctx EvalContext, row chunk.Row) (float64, b
 	}
 	res := val * 180 / math.Pi
 	if math.IsInf(res, 0) {
-		s := fmt.Sprintf("degrees(%s)", b.args[0])
+		s := fmt.Sprintf("degrees(%s)", b.args[0].StringWithCtx(ctx, perrors.RedactLogDisable))
 		return 0, false, types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
 	}
 	return res, false, nil

--- a/pkg/expression/builtin_math.go
+++ b/pkg/expression/builtin_math.go
@@ -1812,6 +1812,10 @@ func (b *builtinDegreesSig) evalReal(ctx EvalContext, row chunk.Row) (float64, b
 		return 0, isNull, err
 	}
 	res := val * 180 / math.Pi
+	if math.IsInf(res, 0) {
+		s := fmt.Sprintf("degrees(%s)", b.args[0])
+		return 0, false, types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
+	}
 	return res, false, nil
 }
 

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -273,7 +273,7 @@ func (b *builtinDegreesSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, res
 		}
 		res := f64s[i] * 180 / math.Pi
 		if math.IsInf(res, 0) {
-			s := fmt.Sprintf("degrees(%s)", b.args[0])
+			s := fmt.Sprintf("degrees(%s)", b.args[0].StringWithCtx(ctx, errors.RedactLogDisable))
 			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
 		}
 		f64s[i] = res

--- a/pkg/expression/builtin_math_vec.go
+++ b/pkg/expression/builtin_math_vec.go
@@ -271,7 +271,12 @@ func (b *builtinDegreesSig) vecEvalReal(ctx EvalContext, input *chunk.Chunk, res
 		if result.IsNull(i) {
 			continue
 		}
-		f64s[i] = f64s[i] * 180 / math.Pi
+		res := f64s[i] * 180 / math.Pi
+		if math.IsInf(res, 0) {
+			s := fmt.Sprintf("degrees(%s)", b.args[0])
+			return types.ErrOverflow.GenWithStackByArgs("DOUBLE", s)
+		}
+		f64s[i] = res
 	}
 	return nil
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #28488

Problem Summary:

`DEGREES(1e308)` returns infinity rather than raising an overflow error.

### What is changed and how it works?

What's Changed:

In implementation of `DEGREES()`, if `x * 180 / π` becomes infinity, raise an error instead of proceeding to return.

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
When DEGREES() overflows, it now raises "ERROR 1690 (22003): DOUBLE value is out of range" instead of silently returning an invalid value.
```
