### PR TITLE
*: set global temporary table as GA 

### DIFF
--- a/bindinfo/session_handle_serial_test.go
+++ b/bindinfo/session_handle_serial_test.go
@@ -397,7 +397,6 @@ func TestTemporaryTable(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("set tidb_enable_global_temporary_table = true")
 	tk.MustExec("create global temporary table t(a int, b int, key(a), key(b)) on commit delete rows")
 	tk.MustExec("create table t2(a int, b int, key(a), key(b))")
 	tk.MustGetErrCode("create session binding for select * from t where b = 123 using select * from t ignore index(b) where b = 123;", errno.ErrOptOnTemporaryTable)

--- a/bindinfo/temptable_serial_test.go
+++ b/bindinfo/temptable_serial_test.go
@@ -29,7 +29,6 @@ func TestSelectBindingOnGlobalTempTableProhibited(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table = true")
 	tk.MustExec("drop table if exists t1,tmp1")
 	tk.MustExec("create table t1(a int(11))")
 	tk.MustExec("create global temporary table tmp1(a int(11), key idx_a(a)) on commit delete rows;")
@@ -64,7 +63,6 @@ func TestDMLBindingOnGlobalTempTableProhibited(t *testing.T) {
 
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table = true")
 	tk.MustExec("drop table if exists t1,tmp1,tmp2")
 	tk.MustExec("create table t1(a int(11))")
 	tk.MustExec("create global temporary table tmp1(a int(11), key idx_a(a)) on commit delete rows;")

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2881,7 +2881,6 @@ func (s *testIntegrationSuite3) TestCreateTemporaryTable(c *C) {
 	tk.MustExec("drop table if exists t;")
 
 	// Grammar error.
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustGetErrCode("create global temporary table t(a double(0, 0))", errno.ErrParse)
 	tk.MustGetErrCode("create temporary table t(id int) on commit delete rows", errno.ErrParse)
 	tk.MustGetErrCode("create temporary table t(id int) on commit preserve rows", errno.ErrParse)
@@ -3157,7 +3156,6 @@ func (s *testIntegrationSuite3) TestDropTemporaryTable(c *C) {
 func (s *testIntegrationSuite3) TestDropWithGlobalTemporaryTableKeyWord(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	clearSQL := "drop table if exists tb, tb2, temp, temp1, ltemp1, ltemp2"
 	tk.MustExec(clearSQL)
 	defer tk.MustExec(clearSQL)
@@ -3231,7 +3229,6 @@ func (s *testIntegrationSuite3) TestDropWithGlobalTemporaryTableKeyWord(c *C) {
 func (s *testIntegrationSuite3) TestDropWithLocalTemporaryTableKeyWord(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	clearSQL := "drop table if exists tb, tb2, temp, temp1, ltemp1, ltemp2, testt.ltemp3"
 	tk.MustExec(clearSQL)
 	defer tk.MustExec(clearSQL)

--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -3401,7 +3401,6 @@ func (s *testSerialDBSuite1) TestPartitionListWithNewCollation(c *C) {
 func (s *testSerialDBSuite1) TestAddTableWithPartition(c *C) {
 	// for global temporary table
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("use test;")
 	tk.MustExec("drop table if exists global_partition_table;")
 	tk.MustGetErrCode("create global temporary table global_partition_table (a int, b int) partition by hash(a) partitions 3 ON COMMIT DELETE ROWS;", errno.ErrPartitionNoTemporary)

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -3380,7 +3380,6 @@ func (s *testDBSuite2) TestTemporaryTableForeignKey(c *C) {
 	tk.MustExec("drop table if exists t1;")
 	tk.MustExec("create table t1 (a int, b int);")
 	tk.MustExec("drop table if exists t1_tmp;")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table t1_tmp (a int, b int) on commit delete rows;")
 	tk.MustExec("create temporary table t2_tmp (a int, b int)")
 	// test add foreign key.
@@ -3864,7 +3863,6 @@ out:
 
 func (s *testDBSuite3) TestVirtualColumnDDL(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists test_gv_ddl")
 	tk.MustExec(`create global temporary table test_gv_ddl(a int, b int as (a+8) virtual, c int as (b + 2) stored) on commit delete rows;`)
@@ -5774,7 +5772,6 @@ func (s *testSerialDBSuite) TestSetTiFlashReplicaForTemporaryTable(c *C) {
 	}()
 
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("drop table if exists temp, temp2")
 	tk.MustExec("drop table if exists temp")
 	tk.MustExec("create global temporary table temp(id int) on commit delete rows")
@@ -5841,7 +5838,6 @@ func (s *testSerialDBSuite) TestShardRowIDBitsOnTemporaryTable(c *C) {
 	tk.MustExec("use test")
 	// for global temporary table
 	tk.MustExec("drop table if exists shard_row_id_temporary")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	_, err := tk.Exec("create global temporary table shard_row_id_temporary (a int) shard_row_id_bits = 5 on commit delete rows;")
 	c.Assert(err.Error(), Equals, core.ErrOptOnTemporaryTable.GenWithStackByArgs("shard_row_id_bits").Error())
 	tk.MustExec("create global temporary table shard_row_id_temporary (a int) on commit delete rows;")

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1908,7 +1908,7 @@ func setTemporaryType(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.Cr
 	case ast.TemporaryGlobal:
 		tbInfo.TempTableType = model.TempTableGlobal
 		if !ctx.GetSessionVars().EnableGlobalTemporaryTable {
-			return errors.New("global temporary table is experimental and it is switched off by tidb_enable_global_temporary_table")
+			return errors.New("It is switched off by tidb_enable_global_temporary_table")
 		}
 		// "create global temporary table ... on commit preserve rows"
 		if !s.OnCommitDelete {

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -532,7 +532,6 @@ func (s *testSerialSuite) TestCreateTableWithLikeAtTemporaryMode(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 
 	// Test create table like at temporary mode.
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists temporary_table;")
 	tk.MustExec("create global temporary table temporary_table (a int, b int,index(a)) on commit delete rows")
@@ -1108,7 +1107,6 @@ func (s *testSerialDBSuite) TestAutoRandomOnTemporaryTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists auto_random_temporary")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	_, err := tk.Exec("create global temporary table auto_random_temporary (a bigint primary key auto_random(3), b varchar(255)) on commit delete rows;")
 	c.Assert(err.Error(), Equals, core.ErrOptOnTemporaryTable.GenWithStackByArgs("auto_random").Error())
 	_, err = tk.Exec("create temporary table t(a bigint key auto_random);")

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -82,7 +82,6 @@ func (s *testSuite5) TestAdminCheckIndexInTemporaryMode(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists temporary_admin_test;")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table temporary_admin_test (c1 int, c2 int, c3 int default 1, primary key (c1), index (c1), unique key(c2)) ON COMMIT DELETE ROWS;")
 	tk.MustExec("insert temporary_admin_test (c1, c2) values (1, 1), (2, 2), (3, 3);")
 	_, err := tk.Exec("admin check table temporary_admin_test;")

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -327,7 +327,6 @@ func (s *testBatchPointGetSuite) TestPointGetForTemporaryTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table t1 (id int primary key, val int) on commit delete rows")
 	tk.MustExec("begin")
 	tk.MustExec("insert into t1 values (1,1)")

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5231,7 +5231,6 @@ func (s *testSplitTable) TestShowTableRegion(c *C) {
 
 	// Test show table regions and split table on global temporary table.
 	tk.MustExec("drop table if exists t_regions_temporary_table")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table t_regions_temporary_table (a int key, b int, c int, index idx(b), index idx2(c)) ON COMMIT DELETE ROWS;")
 	// Test show table regions.
 	_, err = tk.Exec("show table t_regions_temporary_table regions")
@@ -6054,7 +6053,6 @@ func (s *testRecoverTable) TestRecoverTempTable(c *C) {
 	tk.MustExec("create database if not exists test_recover")
 	tk.MustExec("use test_recover")
 	tk.MustExec("drop table if exists t_recover")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table t_recover (a int) on commit delete rows;")
 
 	tk.MustExec("use test_recover")

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1630,7 +1630,6 @@ func (s *testSuite13) TestGlobalTempTableAutoInc(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
 	tk.MustExec("drop table if exists temp_test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table temp_test(id int primary key auto_increment) on commit delete rows")
 	defer tk.MustExec("drop table if exists temp_test")
 
@@ -1676,7 +1675,6 @@ func (s *testSuite13) TestGlobalTempTableRowID(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
 	tk.MustExec("drop table if exists temp_test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table temp_test(id int) on commit delete rows")
 	defer tk.MustExec("drop table if exists temp_test")
 
@@ -1712,7 +1710,6 @@ func (s *testSuite13) TestGlobalTempTableParallel(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec(`use test`)
 	tk.MustExec("drop table if exists temp_test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table temp_test(id int primary key auto_increment) on commit delete rows")
 	defer tk.MustExec("drop table if exists temp_test")
 

--- a/executor/show_test.go
+++ b/executor/show_test.go
@@ -1414,7 +1414,6 @@ func (s *testSuite5) TestShowPerformanceSchema(c *C) {
 func (s *testSuite5) TestShowTemporaryTable(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table t1 (id int) on commit delete rows")
 	tk.MustExec("create global temporary table t3 (i int primary key, j int) on commit delete rows")
 	// For issue https://github.com/pingcap/tidb/issues/24752

--- a/executor/temporary_table_serial_test.go
+++ b/executor/temporary_table_serial_test.go
@@ -29,7 +29,6 @@ import (
 func TestTemporaryTableNoNetwork(t *testing.T) {
 	t.Run("global", func(t *testing.T) {
 		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("set tidb_enable_global_temporary_table=true")
 			tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
 		})
 	})

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -2862,7 +2862,6 @@ func (s *testSuite7) TestDeferConstraintCheckForInsert(c *C) {
 	c.Assert(err, NotNil)
 
 	// Cover the temporary table.
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	for val := range []int{0, 1} {
 		tk.MustExec("set tidb_constraint_check_in_place = ?", val)
 

--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -743,7 +743,6 @@ func (s *testIntegrationPartitionSerialSuite) TestListPartitionTempTable(c *C) {
 	tk.MustExec("use list_partition_temp_table")
 	tk.MustExec("drop table if exists tlist")
 	tk.MustExec(`set tidb_enable_list_partition = 1`)
-	tk.MustExec("set tidb_enable_global_temporary_table = true")
 	c.Assert(tk.ExecToErr("create global temporary table t(a int, b int) partition by list(a) (partition p0 values in (0)) on commit delete rows"), ErrorMatches, ".*Cannot create temporary table with partitions.*")
 	c.Assert(tk.ExecToErr("create global temporary table t(a int, b int) partition by list columns (a) (partition p0 values in (0)) on commit delete rows"), ErrorMatches, ".*Cannot create temporary table with partitions.*")
 }

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -341,7 +341,6 @@ func (s *testValidatorSuite) TestDropGlobalTempTable(c *C) {
 	ctx := context.Background()
 	execSQLList := []string{
 		"use test",
-		"set tidb_enable_global_temporary_table=true",
 		"create table tb(id int);",
 		"create global temporary table temp(id int) on commit delete rows;",
 		"create global temporary table temp1(id int) on commit delete rows;",

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -807,7 +807,6 @@ func (s *testSessionSuite) TestRetryUnion(c *C) {
 
 func (s *testSessionSuite) TestRetryGlobalTempTable(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("drop table if exists normal_table")
 	tk.MustExec("create table normal_table(a int primary key, b int)")
 	defer tk.MustExec("drop table if exists normal_table")
@@ -2211,7 +2210,6 @@ func (s *testSchemaSerialSuite) TestSchemaCheckerTempTable(c *C) {
 	tk.MustExec(`drop table if exists normal_table`)
 	tk.MustExec(`create table normal_table (id int, c int);`)
 	defer tk.MustExec(`drop table if exists normal_table`)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec(`drop table if exists temp_table`)
 	tk.MustExec(`create global temporary table temp_table (id int primary key, c int) on commit delete rows;`)
 	defer tk.MustExec(`drop table if exists temp_table`)
@@ -4375,7 +4373,6 @@ func (s *testSessionSerialSuite) TestParseWithParams(c *C) {
 
 func (s *testSessionSuite3) TestGlobalTemporaryTable(c *C) {
 	tk := testkit.NewTestKitWithInit(c, s.store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("create global temporary table g_tmp (a int primary key, b int, c int, index i_b(b)) on commit delete rows")
 	tk.MustExec("begin")
 	tk.MustExec("insert into g_tmp values (3, 3, 3)")
@@ -4771,7 +4768,6 @@ func (s *testSessionSuite) TestTMPTableSize(c *C) {
 	// Test the @@tmp_table_size system variable.
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("set tidb_enable_global_temporary_table=on")
 	tk.MustExec("create global temporary table t (c1 int, c2 varchar(512)) on commit delete rows")
 	tk.MustExec("create temporary table tl (c1 int, c2 varchar(512))")
 

--- a/sessionctx/binloginfo/binloginfo_test.go
+++ b/sessionctx/binloginfo/binloginfo_test.go
@@ -716,7 +716,6 @@ func TestTempTableBinlog(t *testing.T) {
 	tk.MustExec("use test")
 	tk.Session().GetSessionVars().BinlogClient = s.client
 	tk.MustExec("begin")
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("drop table if exists temp_table")
 	ddlQuery := "create global temporary table temp_table(id int) on commit delete rows"
 	tk.MustExec(ddlQuery)

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -740,7 +740,7 @@ const (
 	DefTiDBTopSQLMaxStatementCount        = 200
 	DefTiDBTopSQLMaxCollect               = 10000
 	DefTiDBTopSQLReportIntervalSeconds    = 60
-	DefTiDBEnableGlobalTemporaryTable     = false
+	DefTiDBEnableGlobalTemporaryTable     = true
 	DefTMPTableSize                       = 16777216
 	DefTiDBEnableLocalTxn                 = false
 	DefTiDBEnableOrderedResultMode        = false

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -76,7 +76,6 @@ func TestTemporaryTable(t *testing.T) {
 	defer clean()
 
 	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("set tidb_enable_global_temporary_table=true")
 	tk.MustExec("use test")
 
 	usage, err := telemetry.GetFeatureUsage(tk.Session())


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #28496

### What is changed and how it works?

What's Changed:
- Set default value of `tidb_enable_global_temporary_table` to 1
- Remove manually set `tidb_enable_global_temporary_table` to 1 in tests
- Change error msg when `tidb_enable_global_temporary_table` is 0

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
Set global temporary table as GA 
```
