### PR TITLE
refactor: migrate test-infra to testify for mainly window_func_test.go

### DIFF
--- a/executor/aggfuncs/func_cume_dist_test.go
+++ b/executor/aggfuncs/func_cume_dist_test.go
@@ -15,13 +15,14 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 )
 
-func (s *testSuite) TestMemCumeDist(c *C) {
+func TestMemCumeDist(t *testing.T) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4CumeDistSize, rowMemDeltaGens),
@@ -31,6 +32,6 @@ func (s *testSuite) TestMemCumeDist(c *C) {
 			aggfuncs.DefPartialResult4CumeDistSize, rowMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/func_cume_dist_test.go
+++ b/executor/aggfuncs/func_cume_dist_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMemCumeDist(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4CumeDistSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_lead_lag_test.go
+++ b/executor/aggfuncs/func_lead_lag_test.go
@@ -25,6 +25,8 @@ import (
 )
 
 func TestLeadLag(t *testing.T) {
+	t.Parallel()
+
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{
@@ -118,6 +120,8 @@ func TestLeadLag(t *testing.T) {
 }
 
 func TestMemLeadLag(t *testing.T) {
+	t.Parallel()
+
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{

--- a/executor/aggfuncs/func_lead_lag_test.go
+++ b/executor/aggfuncs/func_lead_lag_test.go
@@ -15,7 +15,8 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
@@ -23,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/types"
 )
 
-func (s *testSuite) TestLeadLag(c *C) {
+func TestLeadLag(t *testing.T) {
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{
@@ -111,12 +112,12 @@ func (s *testSuite) TestLeadLag(c *C) {
 			[]expression.Expression{million, defaultArg}, 0, numRows, 0, 1, 2),
 	}
 	for _, test := range tests {
-		s.testWindowFunc(c, test)
+		testWindowFunc(t, test)
 	}
 
 }
 
-func (s *testSuite) TestMemLeadLag(c *C) {
+func TestMemLeadLag(t *testing.T) {
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{
@@ -160,7 +161,7 @@ func (s *testSuite) TestMemLeadLag(c *C) {
 	}
 
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 
 }

--- a/executor/aggfuncs/func_ntile_test.go
+++ b/executor/aggfuncs/func_ntile_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMemNtile(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncNtile, mysql.TypeLonglong, 1, 1, 1,
 			aggfuncs.DefPartialResult4Ntile, defaultUpdateMemDeltaGens),

--- a/executor/aggfuncs/func_ntile_test.go
+++ b/executor/aggfuncs/func_ntile_test.go
@@ -15,14 +15,14 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
-
 	"github.com/pingcap/tidb/executor/aggfuncs"
 )
 
-func (s *testSuite) TestMemNtile(c *C) {
+func TestMemNtile(t *testing.T) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncNtile, mysql.TypeLonglong, 1, 1, 1,
 			aggfuncs.DefPartialResult4Ntile, defaultUpdateMemDeltaGens),
@@ -32,6 +32,6 @@ func (s *testSuite) TestMemNtile(c *C) {
 			aggfuncs.DefPartialResult4Ntile, defaultUpdateMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/func_percent_rank_test.go
+++ b/executor/aggfuncs/func_percent_rank_test.go
@@ -15,13 +15,14 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 )
 
-func (s *testSuite) TestMemPercentRank(c *C) {
+func TestMemPercentRank(t *testing.T) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncPercentRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
@@ -31,6 +32,6 @@ func (s *testSuite) TestMemPercentRank(c *C) {
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/func_percent_rank_test.go
+++ b/executor/aggfuncs/func_percent_rank_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMemPercentRank(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncPercentRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_rank_test.go
+++ b/executor/aggfuncs/func_rank_test.go
@@ -15,13 +15,14 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 )
 
-func (s *testSuite) TestMemRank(c *C) {
+func TestMemRank(t *testing.T) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
@@ -31,6 +32,6 @@ func (s *testSuite) TestMemRank(c *C) {
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/func_rank_test.go
+++ b/executor/aggfuncs/func_rank_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMemRank(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_value_test.go
+++ b/executor/aggfuncs/func_value_test.go
@@ -15,7 +15,8 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
@@ -59,7 +60,7 @@ func nthValueEvaluateRowUpdateMemDeltaGens(nth int) updateMemDeltaGens {
 	}
 }
 
-func (s *testSuite) TestMemValue(c *C) {
+func TestMemValue(t *testing.T) {
 	firstMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(1)
 	secondMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(2)
 	fifthMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(5)
@@ -96,6 +97,6 @@ func (s *testSuite) TestMemValue(c *C) {
 			aggfuncs.DefPartialResult4NthValueSize+aggfuncs.DefValue4StringSize, fifthMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/func_value_test.go
+++ b/executor/aggfuncs/func_value_test.go
@@ -61,6 +61,8 @@ func nthValueEvaluateRowUpdateMemDeltaGens(nth int) updateMemDeltaGens {
 }
 
 func TestMemValue(t *testing.T) {
+	t.Parallel()
+
 	firstMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(1)
 	secondMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(2)
 	fifthMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(5)

--- a/executor/aggfuncs/row_number_test.go
+++ b/executor/aggfuncs/row_number_test.go
@@ -15,18 +15,19 @@
 package aggfuncs_test
 
 import (
-	. "github.com/pingcap/check"
+	"testing"
+
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 )
 
-func (s *testSuite) TestMemRowNumber(c *C) {
+func TestMemRowNumber(t *testing.T) {
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRowNumber, mysql.TypeLonglong, 0, 0, 4,
 			aggfuncs.DefPartialResult4RowNumberSize, defaultUpdateMemDeltaGens),
 	}
 	for _, test := range tests {
-		s.testWindowAggMemFunc(c, test)
+		testWindowAggMemFunc(t, test)
 	}
 }

--- a/executor/aggfuncs/row_number_test.go
+++ b/executor/aggfuncs/row_number_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestMemRowNumber(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRowNumber, mysql.TypeLonglong, 0, 0, 4,
 			aggfuncs.DefPartialResult4RowNumberSize, defaultUpdateMemDeltaGens),

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -73,7 +73,7 @@ func testWindowFunc(t *testing.T, p windowTest) {
 		require.NoError(t, err)
 	}
 
-	require.Equal(t, len(p.results), p.numRows)
+	require.Len(t, p.results, p.numRows)
 	for i := 0; i < p.numRows; i++ {
 		err = finalFunc.AppendFinalResult2Chunk(ctx, finalPr, resultChk)
 		require.NoError(t, err)
@@ -104,7 +104,7 @@ func testWindowAggMemFunc(t *testing.T, p windowMemTest) {
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
 		memDelta, err = finalFunc.UpdatePartialResult(ctx, []chunk.Row{row}, finalPr)
 		require.NoError(t, err)
-		require.Equal(t, memDelta, updateMemDeltas[i])
+		require.Equal(t, updateMemDeltas[i], memDelta)
 		i++
 	}
 }
@@ -172,6 +172,8 @@ func buildWindowMemTesterWithArgs(funcName string, tp byte, args []expression.Ex
 }
 
 func TestWindowFunctions(t *testing.T) {
+	t.Parallel()
+
 	tests := []windowTest{
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1, 1),
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 0, 2, 1, 1),

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -15,9 +15,9 @@
 package aggfuncs_test
 
 import (
+	"testing"
 	"time"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/parser/ast"
 	"github.com/pingcap/parser/mysql"
 
@@ -27,6 +27,9 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
+
+	"github.com/stretchr/testify/require"
 )
 
 type windowTest struct {
@@ -54,52 +57,54 @@ type windowMemTest struct {
 	updateMemDeltaGens updateMemDeltaGens
 }
 
-func (s *testSuite) testWindowFunc(c *C, p windowTest) {
+func testWindowFunc(t *testing.T, p windowTest) {
 	srcChk := p.genSrcChk()
+	ctx := mock.NewContext()
 
-	desc, err := aggregation.NewAggFuncDesc(s.ctx, p.funcName, p.args, false)
-	c.Assert(err, IsNil)
-	finalFunc := aggfuncs.BuildWindowFunctions(s.ctx, desc, 0, p.orderByCols)
+	desc, err := aggregation.NewAggFuncDesc(ctx, p.funcName, p.args, false)
+	require.NoError(t, err)
+	finalFunc := aggfuncs.BuildWindowFunctions(ctx, desc, 0, p.orderByCols)
 	finalPr, _ := finalFunc.AllocPartialResult()
 	resultChk := chunk.NewChunkWithCapacity([]*types.FieldType{desc.RetTp}, 1)
 
 	iter := chunk.NewIterator4Chunk(srcChk)
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		_, err = finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
-		c.Assert(err, IsNil)
+		_, err = finalFunc.UpdatePartialResult(ctx, []chunk.Row{row}, finalPr)
+		require.NoError(t, err)
 	}
 
-	c.Assert(p.numRows, Equals, len(p.results))
+	require.Equal(t, len(p.results), p.numRows)
 	for i := 0; i < p.numRows; i++ {
-		err = finalFunc.AppendFinalResult2Chunk(s.ctx, finalPr, resultChk)
-		c.Assert(err, IsNil)
+		err = finalFunc.AppendFinalResult2Chunk(ctx, finalPr, resultChk)
+		require.NoError(t, err)
 		dt := resultChk.GetRow(0).GetDatum(0, desc.RetTp)
-		result, err := dt.CompareDatum(s.ctx.GetSessionVars().StmtCtx, &p.results[i])
-		c.Assert(err, IsNil)
-		c.Assert(result, Equals, 0)
+		result, err := dt.CompareDatum(ctx.GetSessionVars().StmtCtx, &p.results[i])
+		require.NoError(t, err)
+		require.Equal(t, 0, result)
 		resultChk.Reset()
 	}
 	finalFunc.ResetPartialResult(finalPr)
 }
 
-func (s *testSuite) testWindowAggMemFunc(c *C, p windowMemTest) {
+func testWindowAggMemFunc(t *testing.T, p windowMemTest) {
 	srcChk := p.windowTest.genSrcChk()
+	ctx := mock.NewContext()
 
-	desc, err := aggregation.NewAggFuncDesc(s.ctx, p.windowTest.funcName, p.windowTest.args, false)
-	c.Assert(err, IsNil)
-	finalFunc := aggfuncs.BuildWindowFunctions(s.ctx, desc, 0, p.windowTest.orderByCols)
+	desc, err := aggregation.NewAggFuncDesc(ctx, p.windowTest.funcName, p.windowTest.args, false)
+	require.NoError(t, err)
+	finalFunc := aggfuncs.BuildWindowFunctions(ctx, desc, 0, p.windowTest.orderByCols)
 	finalPr, memDelta := finalFunc.AllocPartialResult()
-	c.Assert(memDelta, Equals, p.allocMemDelta)
+	require.Equal(t, p.allocMemDelta, memDelta)
 
 	updateMemDeltas, err := p.updateMemDeltaGens(srcChk, p.windowTest.dataType)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	i := 0
 	iter := chunk.NewIterator4Chunk(srcChk)
 	for row := iter.Begin(); row != iter.End(); row = iter.Next() {
-		memDelta, err = finalFunc.UpdatePartialResult(s.ctx, []chunk.Row{row}, finalPr)
-		c.Assert(err, IsNil)
-		c.Assert(memDelta, Equals, updateMemDeltas[i])
+		memDelta, err = finalFunc.UpdatePartialResult(ctx, []chunk.Row{row}, finalPr)
+		require.NoError(t, err)
+		require.Equal(t, memDelta, updateMemDeltas[i])
 		i++
 	}
 }
@@ -166,7 +171,7 @@ func buildWindowMemTesterWithArgs(funcName string, tp byte, args []expression.Ex
 	return pt
 }
 
-func (s *testSuite) TestWindowFunctions(c *C) {
+func TestWindowFunctions(t *testing.T) {
 	tests := []windowTest{
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1, 1),
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 0, 2, 1, 1),
@@ -203,6 +208,6 @@ func (s *testSuite) TestWindowFunctions(c *C) {
 		buildWindowTester(ast.WindowFuncRowNumber, mysql.TypeLonglong, 0, 0, 4, 1, 2, 3, 4),
 	}
 	for _, test := range tests {
-		s.testWindowFunc(c, test)
+		testWindowFunc(t, test)
 	}
 }


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

* close #28502
* close #28507
* close #28512 
* close #28514 
* close #28515 
* close #28517
* close #28521 
* close #28503 

Problem Summary:
Migrate test-infra to testify for `window_func_test.go`. BUT in the file `window_func_test.go` there are the functions `testWindowAggMemFunc()` and `testWindowFunc()` that has been changed to use testify. This brakes the code in the other tests that calls one of the previously mentioned functions. So, I had to make some changes to some other files too, listed below.

Other files that are also included and finished:
 - row_number_test.go
 - func_value_test.go
 - func_rank_test.go
 - func_percent_rank_test.go
 - func_ntile_test.go
 - func_lead_lag_test.go
 - func_cume_dist_test.go

### What is changed and how it works?

What's Changed:
Migrate test-infra to testify for mainly `window_func_test.go`.

How it Works:
All tests passed.

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```