### PR TITLE
distsql: fix copr cache events metric

### DIFF
--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -52,8 +52,8 @@ var (
 )
 
 var (
-	coprCacheHistogramHit  = metrics.DistSQLCoprCacheHistogram.WithLabelValues("hit")
-	coprCacheHistogramMiss = metrics.DistSQLCoprCacheHistogram.WithLabelValues("miss")
+	coprCacheCounterHit  = metrics.DistSQLCoprCacheCounter.WithLabelValues("hit")
+	coprCacheCounterMiss = metrics.DistSQLCoprCacheCounter.WithLabelValues("miss")
 )
 
 var (
@@ -156,9 +156,9 @@ type selectResult struct {
 
 func (r *selectResult) fetchResp(ctx context.Context) error {
 	defer func() {
-		if r.stats != nil {
-			coprCacheHistogramHit.Observe(float64(r.stats.CoprCacheHitNum))
-			coprCacheHistogramMiss.Observe(float64(len(r.stats.copRespTime) - int(r.stats.CoprCacheHitNum)))
+		if config.GetGlobalConfig().TiKVClient.CoprCache.CapacityMB > 0 && r.stats != nil {
+			coprCacheCounterHit.Add(float64(r.stats.CoprCacheHitNum))
+			coprCacheCounterMiss.Add(float64(len(r.stats.copRespTime) - int(r.stats.CoprCacheHitNum)))
 			// Ignore internal sql.
 			if !r.ctx.GetSessionVars().InRestrictedSQL && len(r.stats.copRespTime) > 0 {
 				ratio := float64(r.stats.CoprCacheHitNum) / float64(len(r.stats.copRespTime))

--- a/infoschema/metric_table_def.go
+++ b/infoschema/metric_table_def.go
@@ -2513,10 +2513,9 @@ var MetricTableMap = map[string]MetricTableDef{
 		Comment: "The total time of distsql execution(second)",
 	},
 	"tidb_distsql_copr_cache": {
-		Comment:  "The quantile of TiDB distsql coprocessor cache",
-		PromQL:   "histogram_quantile($QUANTILE, sum(rate(tidb_distsql_copr_cache_bucket{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (type,instance))",
-		Labels:   []string{"instance", "type"},
-		Quantile: 0.95,
+		PromQL:  "sum(rate(tidb_distsql_copr_cache{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (type,instance)",
+		Labels:  []string{"instance", "type"},
+		Comment: "The counter of TiDB distsql coprocessor cache events",
 	},
 	"tidb_execute_total_count": {
 		PromQL:  "sum(increase(tidb_session_execute_duration_seconds_count{$LABEL_CONDITIONS}[$RANGE_DURATION])) by (instance,sql_type)",

--- a/metrics/distsql.go
+++ b/metrics/distsql.go
@@ -53,12 +53,11 @@ var (
 			Help:      "number of partial results for each query.",
 		},
 	)
-	DistSQLCoprCacheHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	DistSQLCoprCacheCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: "tidb",
 			Subsystem: "distsql",
 			Name:      "copr_cache",
 			Help:      "coprocessor cache hit, evict and miss number",
-			Buckets:   prometheus.ExponentialBuckets(1, 2, 16),
 		}, []string{LblType})
 )

--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -6657,7 +6657,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tidb_distsql_copr_cache_count{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type)",
+              "expr": "sum(rate(tidb_distsql_copr_cache{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type)",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{type}}",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -84,7 +84,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(DDLWorkerHistogram)
 	prometheus.MustRegister(DeploySyncerHistogram)
 	prometheus.MustRegister(DistSQLPartialCountHistogram)
-	prometheus.MustRegister(DistSQLCoprCacheHistogram)
+	prometheus.MustRegister(DistSQLCoprCacheCounter)
 	prometheus.MustRegister(DistSQLQueryHistogram)
 	prometheus.MustRegister(DistSQLScanKeysHistogram)
 	prometheus.MustRegister(DistSQLScanKeysPartialHistogram)

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -52,7 +52,7 @@ import (
 	"go.uber.org/zap"
 )
 
-var coprCacheHistogramEvict = tidbmetrics.DistSQLCoprCacheHistogram.WithLabelValues("evict")
+var coprCacheCounterEvict = tidbmetrics.DistSQLCoprCacheCounter.WithLabelValues("evict")
 
 // Maximum total sleep time(in ms) for kv/cop commands.
 const (
@@ -656,7 +656,7 @@ func (worker *copIteratorWorker) handleTask(ctx context.Context, task *copTask, 
 		}
 	}
 	if worker.store.coprCache != nil && worker.store.coprCache.cache.Metrics != nil {
-		coprCacheHistogramEvict.Observe(float64(worker.store.coprCache.cache.Metrics.KeysEvicted()))
+		coprCacheCounterEvict.Add(float64(worker.store.coprCache.cache.Metrics.KeysEvicted()))
 	}
 }
 


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/28653
Problem Summary:

The type of copr cache events metric is wrong(histogram). It should be counter.

### What is changed and how it works?

What's Changed:
Fix the metric type.

How it Works:
Before: 
hit and miss are always equal even if the copr cache is disabled.
![image](https://user-images.githubusercontent.com/14819777/136528781-81fb1b58-4883-41bb-a762-1c2099572730.png)

After:
![image](https://user-images.githubusercontent.com/14819777/136528931-415005c8-5f3f-4af3-a017-1712643dcfca.png)


### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects


Documentation

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
