### PR TITLE
Dockerfile: remove unnecessary RUN layer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+*.md
+.git
+LICENSE*
+Jenkinsfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,6 @@ RUN apk add --no-cache \
 RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.2/dumb-init_1.2.2_amd64 \
  && chmod +x /usr/local/bin/dumb-init
 
-RUN mkdir -p /go/src/github.com/pingcap/tidb
 WORKDIR /go/src/github.com/pingcap/tidb
 
 # Cache dependencies


### PR DESCRIPTION
We don't need the `RUN` layer for `mkdir`, since `WORKDIR` automatically does that.

Also, we don't need to copy any of the markdown files or the `.git` folder into the image.

<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] No code

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
