### PR TITLE
statistics: fix "data too long" error when dumping stats from table with new collation data (#27033)

### DIFF
--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -1269,7 +1269,7 @@ workLoop:
 				// When it's new collation data, we need to use its collate key instead of original value because only
 				// the collate key can ensure the correct ordering.
 				// This is also corresponding to similar operation in (*statistics.Column).GetColumnRowCount().
-				if ft.EvalType() == types.ETString {
+				if ft.EvalType() == types.ETString && ft.Tp != mysql.TypeEnum && ft.Tp != mysql.TypeSet {
 					val.SetBytes(collate.GetCollator(ft.Collate).Key(val.GetString()))
 				}
 				sampleItems = append(sampleItems, &statistics.SampleItem{

--- a/statistics/handle/handle.go
+++ b/statistics/handle/handle.go
@@ -1094,6 +1094,12 @@ func (h *Handle) histogramFromStorage(reader *statsReader, tableID int64, colID 
 		} else {
 			sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 			d := rows[i].GetDatum(2, &fields[2].Column.FieldType)
+			// When there's new collation data, the length of bounds of histogram(the collate key) might be
+			// longer than the FieldType.Flen of this column.
+			// We change it to TypeBlob to bypass the length check here.
+			if tp.EvalType() == types.ETString && tp.Tp != mysql.TypeEnum && tp.Tp != mysql.TypeSet {
+				tp = types.NewFieldType(mysql.TypeBlob)
+			}
 			lowerBound, err = d.ConvertTo(sc, tp)
 			if err != nil {
 				return nil, errors.Trace(err)

--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -2829,6 +2829,27 @@ func (s *testSerialStatsSuite) TestCorrelationWithDefinedCollate(c *C) {
 	c.Assert(rows[0][5], Equals, "-1.000000")
 }
 
+func (s *testSerialStatsSuite) TestLoadHistogramWithCollate(c *C) {
+	defer cleanEnv(c, s.store, s.do)
+	testKit := testkit.NewTestKit(c, s.store)
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+	testKit.MustExec("use test")
+	testKit.MustExec("drop table if exists t")
+	testKit.MustExec("create table t(a varchar(10) collate utf8mb4_unicode_ci);")
+	testKit.MustExec("insert into t values('abcdefghij');")
+	testKit.MustExec("insert into t values('abcdufghij');")
+	testKit.MustExec("analyze table t with 0 topn;")
+	do := s.do
+	h := do.StatsHandle()
+	is := do.InfoSchema()
+	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	c.Assert(err, IsNil)
+	tblInfo := tbl.Meta()
+	_, err = h.TableStatsFromStorage(tblInfo, tblInfo.ID, true, 0)
+	c.Assert(err, IsNil)
+}
+
 func (s *testSerialStatsSuite) TestFastAnalyzeColumnHistWithNullValue(c *C) {
 	defer cleanEnv(c, s.store, s.do)
 	testKit := testkit.NewTestKit(c, s.store)


### PR DESCRIPTION
cherry-pick #27033 to release-5.1-20211012

---

### What problem does this PR solve?

Issue Number: close #27024

When storing a histogram for a new collation column, we store its collate key instead of the original value.
However (1) when loading the histogram into stats cache, we try to convert the bounds of the histogram to the `FieldType` of this column (2) the collate key of a value is usually longer than the original value.
So when doing the type conversion, the value may exceed the `FieldType.Flen`, which caused the "Data Too Long" error.

### What is changed and how it works?

When loading stats from storage into stats cache, for `String` values, no longer convert them to the `FieldType` of this column.
Now we always convert them to `TypeBlob` to bypass length checks.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
