### PR TITLE
planner: make constant propagation more stringently

### DIFF
--- a/expression/collation.go
+++ b/expression/collation.go
@@ -118,31 +118,6 @@ const (
 	CoercibilityIgnorable Coercibility = 6
 )
 
-var (
-	// CollationStrictnessGroup group collation by strictness
-	CollationStrictnessGroup = map[string]int{
-		"utf8_general_ci":        1,
-		"utf8mb4_general_ci":     1,
-		"utf8_unicode_ci":        2,
-		"utf8mb4_unicode_ci":     2,
-		charset.CollationASCII:   3,
-		charset.CollationLatin1:  3,
-		charset.CollationUTF8:    3,
-		charset.CollationUTF8MB4: 3,
-		charset.CollationBin:     4,
-	}
-
-	// CollationStrictness indicates the strictness of comparison of the collation. The unequal order in a weak collation also holds in a strict collation.
-	// For example, if a != b in a weak collation(e.g. general_ci), then there must be a != b in a strict collation(e.g. _bin).
-	// collation group id in value is stricter than collation group id in key
-	CollationStrictness = map[int][]int{
-		1: {3, 4},
-		2: {3, 4},
-		3: {4},
-		4: {},
-	}
-)
-
 // The Repertoire of a character set is the collection of characters in the set.
 // See https://dev.mysql.com/doc/refman/8.0/en/charset-repertoire.html.
 // Only String expression has Repertoire, for non-string expression, it does not matter what the value it is.

--- a/expression/constant_propagation.go
+++ b/expression/constant_propagation.go
@@ -16,6 +16,7 @@ package expression
 
 import (
 	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"

--- a/expression/util.go
+++ b/expression/util.go
@@ -277,27 +277,6 @@ func ColumnSubstituteImpl(expr Expression, schema *Schema, newExprs []Expression
 	return false, expr
 }
 
-// checkCollationStrictness check collation strictness-ship between `coll` and `newFuncColl`
-// return true iff `newFuncColl` is not weaker than `coll`
-func checkCollationStrictness(coll, newFuncColl string) bool {
-	collGroupID, ok1 := CollationStrictnessGroup[coll]
-	newFuncCollGroupID, ok2 := CollationStrictnessGroup[newFuncColl]
-
-	if ok1 && ok2 {
-		if collGroupID == newFuncCollGroupID {
-			return true
-		}
-
-		for _, id := range CollationStrictness[collGroupID] {
-			if newFuncCollGroupID == id {
-				return true
-			}
-		}
-	}
-
-	return false
-}
-
 // getValidPrefix gets a prefix of string which can parsed to a number with base. the minimum base is 2 and the maximum is 36.
 func getValidPrefix(s string, base int64) string {
 	var (

--- a/expression/util.go
+++ b/expression/util.go
@@ -262,21 +262,9 @@ func ColumnSubstituteImpl(expr Expression, schema *Schema, newExprs []Expression
 		// cowExprRef is a copy-on-write util, args array allocation happens only
 		// when expr in args is changed
 		refExprArr := cowExprRef{v.GetArgs(), nil}
-		_, coll := DeriveCollationFromExprs(v.GetCtx(), v.GetArgs()...)
+		substituted := false
 		for idx, arg := range v.GetArgs() {
 			changed, newFuncExpr := ColumnSubstituteImpl(arg, schema, newExprs)
-			if collate.NewCollationEnabled() {
-				// Make sure the collation used by the ScalarFunction isn't changed and its result collation is not weaker than the collation used by the ScalarFunction.
-				if changed {
-					changed = false
-					tmpArgs := make([]Expression, 0, len(v.GetArgs()))
-					_ = append(append(append(tmpArgs, refExprArr.Result()[0:idx]...), refExprArr.Result()[idx+1:]...), newFuncExpr)
-					_, newColl := DeriveCollationFromExprs(v.GetCtx(), append(v.GetArgs(), newFuncExpr)...)
-					if coll == newColl {
-						changed = checkCollationStrictness(coll, newFuncExpr.GetType().Collate)
-					}
-				}
-			}
 			refExprArr.Set(idx, changed, newFuncExpr)
 			if changed {
 				substituted = true

--- a/planner/core/testdata/point_get_plan_out.json
+++ b/planner/core/testdata/point_get_plan_out.json
@@ -45,10 +45,10 @@
         "SQL": "select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2))",
         "Plan": [
           "Projection 0.00 root  test.t.a, test.t.b, test.t.c, test.t.d, test.t.a, test.t.b, test.t.c, test.t.d",
-          "└─HashJoin 0.00 root  CARTESIAN inner join",
-          "  ├─Selection(Build) 0.00 root  or(and(eq(test.t.b, 1), eq(test.t.c, 1)), and(eq(test.t.b, 2), eq(test.t.c, 2)))",
-          "  │ └─Point_Get 1.00 root table:t, index:PRIMARY(a) ",
-          "  └─Point_Get(Probe) 1.00 root table:t, index:PRIMARY(a) "
+          "└─MergeJoin 0.00 root  inner join, left key:test.t.a, right key:test.t.a",
+          "  ├─Point_Get(Build) 1.00 root table:t, index:PRIMARY(a) ",
+          "  └─Selection(Probe) 0.00 root  or(and(eq(test.t.b, 1), eq(test.t.c, 1)), and(eq(test.t.b, 2), eq(test.t.c, 2)))",
+          "    └─Point_Get 1.00 root table:t, index:PRIMARY(a) "
         ],
         "Res": [
           "4 1 1 4 4 1 1 4"

--- a/planner/core/testdata/point_get_plan_out.json
+++ b/planner/core/testdata/point_get_plan_out.json
@@ -45,10 +45,10 @@
         "SQL": "select * from t t1 join t t2 on t1.a = t2.a where t1.a = '4' and (t2.b, t2.c) in ((1,1),(2,2))",
         "Plan": [
           "Projection 0.00 root  test.t.a, test.t.b, test.t.c, test.t.d, test.t.a, test.t.b, test.t.c, test.t.d",
-          "└─MergeJoin 0.00 root  inner join, left key:test.t.a, right key:test.t.a",
-          "  ├─Point_Get(Build) 1.00 root table:t, index:PRIMARY(a) ",
-          "  └─Selection(Probe) 0.00 root  or(and(eq(test.t.b, 1), eq(test.t.c, 1)), and(eq(test.t.b, 2), eq(test.t.c, 2)))",
-          "    └─Point_Get 1.00 root table:t, index:PRIMARY(a) "
+          "└─HashJoin 0.00 root  CARTESIAN inner join",
+          "  ├─Selection(Build) 0.00 root  or(and(eq(test.t.b, 1), eq(test.t.c, 1)), and(eq(test.t.b, 2), eq(test.t.c, 2)))",
+          "  │ └─Point_Get 1.00 root table:t, index:PRIMARY(a) ",
+          "  └─Point_Get(Probe) 1.00 root table:t, index:PRIMARY(a) "
         ],
         "Res": [
           "4 1 1 4 4 1 1 4"


### PR DESCRIPTION
<!-- Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/28743

constant propagation can help to get a better plan e.g. `a=b and b=1` ==> `a=1 and b=1`, it works fine for number type value, but string type value has collation to determined how to compare two strings, sometimes `'a'` could be eq to `'A'` so that `a=b and b='a'` cannot simply replace to `a='a' and b='a'`

consider we have a table 
```
+------+------+
| a    | b    |
+------+------+
| A    | A    |
+------+------+
```

if column a is utf8mb4_bin collation and b is utf8mb4_general_ci collation, `a=b and b='a'` is true while `a='a' and b='a'` is false, to solve this issue, https://github.com/pingcap/tidb/pull/16227 introduce `Strictness-ship` between collations to forbid the wrong   constant propagation.

But the `ColumnSubstitute` functions is not only used for constant propagation, in the SQL `select t2.b from (select t.a as b from t union all select t.a as b from t) t2 where t2.b > 'a' collate utf8mb4_bin`  `t2.b` should substituted by `t.a`, but according to the `Strictness-ship`, utf8mb4_general_ci is weaker than `utf8mb4_bin`, the substitute is rejected and planner cannot find who `t2.b` is.

The main problem we can not replace `b` by `'a'` in `a=b and b='a'` is that `'a'` is not the unique one makes `b='a'` is true (it can be `'A', 'a', 'a   '`). This PR makes the constant propagation more stringently, only the eq function use `binary` collation to compare that can do the constant propagation. It does not affect the non-string type because all of them can only use `binary` collation. 

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
Please add a release note, or a 'None' if it is not needed.
```
