### PR TITLE
ddl: support batch create table 

### DIFF
--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -125,7 +125,7 @@ func (gs *tidbSession) CreateDatabase(ctx context.Context, schema *model.DBInfo)
 	if len(schema.Charset) == 0 {
 		schema.Charset = mysql.DefaultCharset
 	}
-	return d.CreateSchemaWithInfo(gs.se, schema, ddl.OnExistIgnore, true)
+	return d.CreateSchemaWithInfo(gs.se, schema, ddl.OnExistIgnore)
 }
 
 // CreateTable implements glue.Session.
@@ -143,7 +143,7 @@ func (gs *tidbSession) CreateTable(ctx context.Context, dbName model.CIStr, tabl
 		newPartition.Definitions = append([]model.PartitionDefinition{}, table.Partition.Definitions...)
 		table.Partition = &newPartition
 	}
-	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore, true)
+	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore)
 }
 
 // Close implements glue.Session.

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7677,5 +7677,5 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 	// duplicated name
 	infos[1].Name = model.NewCIStr("tables_1")
 	err = d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError)
-	c.Check(err.Error(), Equals, "[schema:1050]Table 'test.tables_1' already exists")
+	c.Check(terror.ErrorEqual(err, infoschema.ErrTableExists), IsTrue)
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7661,8 +7661,10 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 		Name: model.NewCIStr("tables_3"),
 	})
 
+	// correct name
 	err := d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
 	c.Check(err, IsNil)
+
 
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 	job := tk.MustQuery("admin show ddl jobs").Rows()[0]
@@ -7672,4 +7674,9 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 	c.Assert(job[4], Equals, "public")
 	// FIXME: we must change column type to give multiple id
 	// c.Assert(job[6], Matches, "[^,]+,[^,]+,[^,]+")
+
+	// duplicated name
+	infos[1].Name = model.NewCIStr("tables_1")
+	err = d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
+	c.Check(err.Error(), Equals, "[schema:1050]Table 'test.tables_1' already exists")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7665,7 +7665,6 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 	err := d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
 	c.Check(err, IsNil)
 
-
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 	job := tk.MustQuery("admin show ddl jobs").Rows()[0]
 	c.Assert(job[1], Equals, "test")

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7662,7 +7662,7 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 	})
 
 	// correct name
-	err := d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
+	err := d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError)
 	c.Check(err, IsNil)
 
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
@@ -7676,6 +7676,6 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 
 	// duplicated name
 	infos[1].Name = model.NewCIStr("tables_1")
-	err = d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
+	err = d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError)
 	c.Check(err.Error(), Equals, "[schema:1050]Table 'test.tables_1' already exists")
 }

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7645,29 +7645,29 @@ func (s *testDBSuite8) TestCreateTextAdjustLen(c *C) {
 func (s *testDBSuite2) TestCreateTables(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
-	tk.MustExec("drop table if exists s1")
-	tk.MustExec("drop table if exists s2")
-	tk.MustExec("drop table if exists s3")
+	tk.MustExec("drop table if exists tables_1")
+	tk.MustExec("drop table if exists tables_2")
+	tk.MustExec("drop table if exists tables_3")
 
 	d := s.dom.DDL()
 	infos := []*model.TableInfo{}
 	infos = append(infos, &model.TableInfo{
-		Name: model.NewCIStr("s1"),
+		Name: model.NewCIStr("tables_1"),
 	})
 	infos = append(infos, &model.TableInfo{
-		Name: model.NewCIStr("s2"),
+		Name: model.NewCIStr("tables_2"),
 	})
 	infos = append(infos, &model.TableInfo{
-		Name: model.NewCIStr("s3"),
+		Name: model.NewCIStr("tables_3"),
 	})
 
 	err := d.CreateTablesWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
 	c.Check(err, IsNil)
 
-	tk.MustQuery("show tables").Check(testkit.Rows("s1", "s2", "s3"))
+	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))
 	job := tk.MustQuery("admin show ddl jobs").Rows()[0]
 	c.Assert(job[1], Equals, "test")
-	c.Assert(job[2], Equals, "s1,s2,s3")
+	c.Assert(job[2], Equals, "tables_1,tables_2,tables_3")
 	c.Assert(job[3], Equals, "create tables")
 	c.Assert(job[4], Equals, "public")
 	// FIXME: we must change column type to give multiple id

--- a/ddl/db_test.go
+++ b/ddl/db_test.go
@@ -7661,7 +7661,7 @@ func (s *testDBSuite2) TestCreateTables(c *C) {
 		Name: model.NewCIStr("tables_3"),
 	})
 
-	err := d.CreateTablesWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
+	err := d.BatchCreateTableWithInfo(tk.Se, model.NewCIStr("test"), infos, ddl.OnExistError, false)
 	c.Check(err, IsNil)
 
 	tk.MustQuery("show tables like '%tables_%'").Check(testkit.Rows("tables_1", "tables_2", "tables_3"))

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -150,6 +150,13 @@ type DDL interface {
 		onExist OnExist,
 		tryRetainID bool) error
 
+	// CreateTablesWithInfo is like CreateTablesWithInfo, but can handle multiple tables.
+	CreateTablesWithInfo(ctx sessionctx.Context,
+		schema model.CIStr,
+		info []*model.TableInfo,
+		onExist OnExist,
+		tryRetainID bool) error
+
 	// Start campaigns the owner and starts workers.
 	// ctxPool is used for the worker's delRangeManager and creates sessions.
 	Start(ctxPool *pools.ResourcePool) error

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -154,8 +154,7 @@ type DDL interface {
 	BatchCreateTableWithInfo(ctx sessionctx.Context,
 		schema model.CIStr,
 		info []*model.TableInfo,
-		onExist OnExist,
-		tryRetainID bool) error
+		onExist OnExist) error
 
 	// Start campaigns the owner and starts workers.
 	// ctxPool is used for the worker's delRangeManager and creates sessions.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -259,10 +259,10 @@ func asyncNotifyEvent(d *ddlCtx, e *util.Event) {
 			case d.ddlEventCh <- e:
 				return
 			default:
-				logutil.BgLogger().Warn("[ddl] fail to notify DDL event", zap.String("event", e.String()))
 				time.Sleep(time.Microsecond * 10)
 			}
 		}
+		logutil.BgLogger().Warn("[ddl] fail to notify DDL event", zap.String("event", e.String()))
 	}
 }
 

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -150,7 +150,7 @@ type DDL interface {
 		onExist OnExist,
 		tryRetainID bool) error
 
-	// CreateTablesWithInfo is like CreateTablesWithInfo, but can handle multiple tables.
+	// CreateTablesWithInfo is like CreateTableWithInfo, but can handle multiple tables.
 	CreateTablesWithInfo(ctx sessionctx.Context,
 		schema model.CIStr,
 		info []*model.TableInfo,

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -150,8 +150,8 @@ type DDL interface {
 		onExist OnExist,
 		tryRetainID bool) error
 
-	// CreateTablesWithInfo is like CreateTableWithInfo, but can handle multiple tables.
-	CreateTablesWithInfo(ctx sessionctx.Context,
+	// BatchCreateTableWithInfo is like CreateTableWithInfo, but can handle multiple tables.
+	BatchCreateTableWithInfo(ctx sessionctx.Context,
 		schema model.CIStr,
 		info []*model.TableInfo,
 		onExist OnExist,

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -123,23 +123,14 @@ type DDL interface {
 
 	// CreateSchemaWithInfo creates a database (schema) given its database info.
 	//
-	// If `tryRetainID` is true, this method will try to keep the database ID specified in
-	// the `info` rather than generating new ones. This is just a hint though, if the ID collides
-	// with an existing database a new ID will always be used.
-	//
 	// WARNING: the DDL owns the `info` after calling this function, and will modify its fields
 	// in-place. If you want to keep using `info`, please call Clone() first.
 	CreateSchemaWithInfo(
 		ctx sessionctx.Context,
 		info *model.DBInfo,
-		onExist OnExist,
-		tryRetainID bool) error
+		onExist OnExist) error
 
 	// CreateTableWithInfo creates a table, view or sequence given its table info.
-	//
-	// If `tryRetainID` is true, this method will try to keep the table ID specified in the `info`
-	// rather than generating new ones. This is just a hint though, if the ID collides with an
-	// existing table a new ID will always be used.
 	//
 	// WARNING: the DDL owns the `info` after calling this function, and will modify its fields
 	// in-place. If you want to keep using `info`, please call Clone() first.
@@ -147,8 +138,7 @@ type DDL interface {
 		ctx sessionctx.Context,
 		schema model.CIStr,
 		info *model.TableInfo,
-		onExist OnExist,
-		tryRetainID bool) error
+		onExist OnExist) error
 
 	// BatchCreateTableWithInfo is like CreateTableWithInfo, but can handle multiple tables.
 	BatchCreateTableWithInfo(ctx sessionctx.Context,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2170,6 +2170,8 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 			continue
 		}
 
+		// if jobs.Type == model.ActionCreateTables, it is initialized
+		// if not, initialize jobs by job.XXXX
 		if jobs.Type != model.ActionCreateTables {
 			jobs.Type = model.ActionCreateTables
 			jobs.SchemaID = job.SchemaID

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2063,10 +2063,8 @@ func (d *ddl) createTableWithInfoJob(
 		if err := d.assignTableID(tbInfo); err != nil {
 			return nil, errors.Trace(err)
 		}
-	}
 
-	if tbInfo.Partition != nil {
-		if !retainID {
+		if tbInfo.Partition != nil {
 			if err := d.assignPartitionIDs(tbInfo.Partition.Definitions); err != nil {
 				return nil, errors.Trace(err)
 			}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2181,11 +2181,11 @@ func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 
 		// append table job args
 		if len(job.Args) != 1 {
-			return fmt.Errorf("except only one argument")
+			return errors.Trace(fmt.Errorf("except only one argument"))
 		}
 		info, ok := job.Args[0].(*model.TableInfo)
 		if !ok {
-			return fmt.Errorf("except table info")
+			return errors.Trace(fmt.Errorf("except table info"))
 		}
 		args = append(args, info)
 	}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2020,17 +2020,19 @@ func setTemporaryType(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.Cr
 	return nil
 }
 
-func (d *ddl) CreateTableWithInfo(
+// createTableWithInfoJob returns the table creation job.
+// WARNING: it may return a nil job, which means you don't need to submit any DDL job.
+func (d *ddl) createTableWithInfoJob(
 	ctx sessionctx.Context,
 	dbName model.CIStr,
 	tbInfo *model.TableInfo,
 	onExist OnExist,
 	tryRetainID bool,
-) (err error) {
+) (job *model.Job, err error) {
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	schema, ok := is.SchemaByName(dbName)
 	if !ok {
-		return infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName)
+		return nil, infoschema.ErrDatabaseNotExists.GenWithStackByArgs(dbName)
 	}
 
 	var oldViewTblID int64
@@ -2039,7 +2041,7 @@ func (d *ddl) CreateTableWithInfo(
 		switch onExist {
 		case OnExistIgnore:
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
-			return nil
+			return nil, nil
 		case OnExistReplace:
 			// only CREATE OR REPLACE VIEW is supported at the moment.
 			if tbInfo.View != nil {
@@ -2048,27 +2050,27 @@ func (d *ddl) CreateTableWithInfo(
 					break
 				}
 				// The object to replace isn't a view.
-				return ErrWrongObject.GenWithStackByArgs(dbName, tbInfo.Name, "VIEW")
+				return nil, ErrWrongObject.GenWithStackByArgs(dbName, tbInfo.Name, "VIEW")
 			}
-			return err
+			return nil, err
 		default:
-			return err
+			return nil, err
 		}
 	}
 
 	// FIXME: Implement `tryRetainID`
 	if err := d.assignTableID(tbInfo); err != nil {
-		return errors.Trace(err)
+		return nil, errors.Trace(err)
 	}
 
 	if tbInfo.Partition != nil {
 		if err := d.assignPartitionIDs(tbInfo.Partition.Definitions); err != nil {
-			return errors.Trace(err)
+			return nil, errors.Trace(err)
 		}
 	}
 
 	if err := checkTableInfoValidExtra(tbInfo); err != nil {
-		return err
+		return nil, err
 	}
 
 	var actionType model.ActionType
@@ -2083,13 +2085,54 @@ func (d *ddl) CreateTableWithInfo(
 		actionType = model.ActionCreateTable
 	}
 
-	job := &model.Job{
+	job = &model.Job{
 		SchemaID:   schema.ID,
 		TableID:    tbInfo.ID,
 		SchemaName: schema.Name.L,
 		Type:       actionType,
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       args,
+	}
+	return job, nil
+}
+
+func (d *ddl) createTableWithInfoPost(
+	ctx sessionctx.Context,
+	tbInfo *model.TableInfo,
+	schemaID int64,
+) error {
+	var err error
+	d.preSplitAndScatter(ctx, tbInfo, tbInfo.GetPartitionInfo())
+	if tbInfo.AutoIncID > 1 {
+		// Default tableAutoIncID base is 0.
+		// If the first ID is expected to greater than 1, we need to do rebase.
+		newEnd := tbInfo.AutoIncID - 1
+		if err = d.handleAutoIncID(tbInfo, schemaID, newEnd, autoid.RowIDAllocType); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	if tbInfo.AutoRandID > 1 {
+		// Default tableAutoRandID base is 0.
+		// If the first ID is expected to greater than 1, we need to do rebase.
+		newEnd := tbInfo.AutoRandID - 1
+		err = d.handleAutoIncID(tbInfo, schemaID, newEnd, autoid.AutoRandomType)
+	}
+	return err
+}
+
+func (d *ddl) CreateTableWithInfo(
+	ctx sessionctx.Context,
+	dbName model.CIStr,
+	tbInfo *model.TableInfo,
+	onExist OnExist,
+	tryRetainID bool,
+) (err error) {
+	job, err := d.createTableWithInfoJob(ctx, dbName, tbInfo, onExist, tryRetainID)
+	if err != nil {
+		return err
+	}
+	if job == nil {
+		return nil
 	}
 
 	err = d.doDDLJob(ctx, job)
@@ -2099,26 +2142,72 @@ func (d *ddl) CreateTableWithInfo(
 			ctx.GetSessionVars().StmtCtx.AppendNote(err)
 			err = nil
 		}
-	} else if actionType == model.ActionCreateTable {
-		d.preSplitAndScatter(ctx, tbInfo, tbInfo.GetPartitionInfo())
-		if tbInfo.AutoIncID > 1 {
-			// Default tableAutoIncID base is 0.
-			// If the first ID is expected to greater than 1, we need to do rebase.
-			newEnd := tbInfo.AutoIncID - 1
-			if err = d.handleAutoIncID(tbInfo, schema.ID, newEnd, autoid.RowIDAllocType); err != nil {
-				return errors.Trace(err)
-			}
-		}
-		if tbInfo.AutoRandID > 1 {
-			// Default tableAutoRandID base is 0.
-			// If the first ID is expected to greater than 1, we need to do rebase.
-			newEnd := tbInfo.AutoRandID - 1
-			err = d.handleAutoIncID(tbInfo, schema.ID, newEnd, autoid.AutoRandomType)
-		}
+	} else {
+		err = d.createTableWithInfoPost(ctx, tbInfo, job.SchemaID)
 	}
 
 	err = d.callHookOnChanged(err)
 	return errors.Trace(err)
+}
+
+func (d *ddl) CreateTablesWithInfo(ctx sessionctx.Context,
+	dbName model.CIStr,
+	infos []*model.TableInfo,
+	onExist OnExist,
+	tryRetainID bool) error {
+	jobs := &model.Job{
+		BinlogInfo: &model.HistoryInfo{},
+		Args:       make([]interface{}, 0, 2),
+	}
+	ids := make([]int64, 0, len(infos))
+	args := make([]interface{}, 0, len(infos))
+	idx := make([]int, 0, len(infos))
+	for i, info := range infos {
+		job, err := d.createTableWithInfoJob(ctx, dbName, info, onExist, tryRetainID)
+		if err != nil {
+			return errors.Trace(err)
+		}
+		if job == nil {
+			continue
+		}
+
+		if jobs.Type != model.ActionCreateTables {
+			jobs.Type = model.ActionCreateTables
+			jobs.SchemaID = job.SchemaID
+			jobs.SchemaName = job.SchemaName
+		}
+
+		// store index to table info
+		idx = append(idx, i)
+
+		// append table id
+		ids = append(ids, job.TableID)
+
+		// append table job args
+		args = append(args, job.Args)
+	}
+	if len(ids) == 0 {
+		return nil
+	}
+	jobs.Args = append(jobs.Args, ids, args)
+
+	err := d.doDDLJob(ctx, jobs)
+	if err != nil {
+		// table exists, but if_not_exists flags is true, so we ignore this error.
+		if onExist == OnExistIgnore && infoschema.ErrTableExists.Equal(err) {
+			ctx.GetSessionVars().StmtCtx.AppendNote(err)
+			err = nil
+		}
+		return errors.Trace(d.callHookOnChanged(err))
+	}
+
+	for _, j := range idx {
+		if err = d.createTableWithInfoPost(ctx, infos[j], jobs.SchemaID); err != nil {
+			return errors.Trace(d.callHookOnChanged(err))
+		}
+	}
+
+	return nil
 }
 
 // preSplitAndScatter performs pre-split and scatter of the table's regions.

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2150,7 +2150,7 @@ func (d *ddl) CreateTableWithInfo(
 	return errors.Trace(err)
 }
 
-func (d *ddl) CreateTablesWithInfo(ctx sessionctx.Context,
+func (d *ddl) BatchCreateTableWithInfo(ctx sessionctx.Context,
 	dbName model.CIStr,
 	infos []*model.TableInfo,
 	onExist OnExist,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2159,8 +2159,7 @@ func (d *ddl) CreateTablesWithInfo(ctx sessionctx.Context,
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       make([]interface{}, 0, 2),
 	}
-	ids := make([]int64, 0, len(infos))
-	args := make([]interface{}, 0, len(infos))
+	args := make([]*model.TableInfo, 0, len(infos))
 	idx := make([]int, 0, len(infos))
 	for i, info := range infos {
 		job, err := d.createTableWithInfoJob(ctx, dbName, info, onExist, tryRetainID)
@@ -2180,16 +2179,20 @@ func (d *ddl) CreateTablesWithInfo(ctx sessionctx.Context,
 		// store index to table info
 		idx = append(idx, i)
 
-		// append table id
-		ids = append(ids, job.TableID)
-
 		// append table job args
-		args = append(args, job.Args)
+		if len(job.Args) != 1 {
+			return fmt.Errorf("except only one argument")
+		}
+		info, ok := job.Args[0].(*model.TableInfo)
+		if !ok {
+			return fmt.Errorf("except table info")
+		}
+		args = append(args, info)
 	}
-	if len(ids) == 0 {
+	if len(args) == 0 {
 		return nil
 	}
-	jobs.Args = append(jobs.Args, ids, args)
+	jobs.Args = append(jobs.Args, args)
 
 	err := d.doDDLJob(ctx, jobs)
 	if err != nil {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -94,14 +94,13 @@ func (d *ddl) CreateSchema(ctx sessionctx.Context, schema model.CIStr, charsetIn
 		return errors.Trace(err)
 	}
 
-	return d.CreateSchemaWithInfo(ctx, dbInfo, OnExistError, false /*tryRetainID*/)
+	return d.CreateSchemaWithInfo(ctx, dbInfo, OnExistError)
 }
 
 func (d *ddl) CreateSchemaWithInfo(
 	ctx sessionctx.Context,
 	dbInfo *model.DBInfo,
 	onExist OnExist,
-	tryRetainID bool,
 ) error {
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	_, ok := is.SchemaByName(dbInfo.Name)
@@ -2001,7 +2000,7 @@ func (d *ddl) CreateTable(ctx sessionctx.Context, s *ast.CreateTableStmt) (err e
 		onExist = OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, onExist, false /*tryRetainID*/)
+	return d.CreateTableWithInfo(ctx, schema.Name, tbInfo, onExist)
 }
 
 func setTemporaryType(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.CreateTableStmt) error {
@@ -2022,12 +2021,14 @@ func setTemporaryType(ctx sessionctx.Context, tbInfo *model.TableInfo, s *ast.Cr
 
 // createTableWithInfoJob returns the table creation job.
 // WARNING: it may return a nil job, which means you don't need to submit any DDL job.
+// WARNING!!!: if retainID == true, it will not allocate ID by itself. That means if the caller
+// can not promise ID is unique, then we got inconsistency.
 func (d *ddl) createTableWithInfoJob(
 	ctx sessionctx.Context,
 	dbName model.CIStr,
 	tbInfo *model.TableInfo,
 	onExist OnExist,
-	tryRetainID bool,
+	retainID bool,
 ) (job *model.Job, err error) {
 	is := d.GetInfoSchemaWithInterceptor(ctx)
 	schema, ok := is.SchemaByName(dbName)
@@ -2058,20 +2059,14 @@ func (d *ddl) createTableWithInfoJob(
 		}
 	}
 
-	_, exists := is.TableByID(tbInfo.ID)
-	if !tryRetainID || exists {
+	if !retainID {
 		if err := d.assignTableID(tbInfo); err != nil {
 			return nil, errors.Trace(err)
 		}
 	}
 
 	if tbInfo.Partition != nil {
-		// NOTE: does not check if partition ID exists.
-		// it assumes that:
-		// 1. the final transaction will detect if there is a duplication
-		// 2. if table id is not duplicated, so do partition IDs
-		// since partition search is slow, it is avoided.
-		if !tryRetainID || exists {
+		if !retainID {
 			if err := d.assignPartitionIDs(tbInfo.Partition.Definitions); err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -2134,9 +2129,8 @@ func (d *ddl) CreateTableWithInfo(
 	dbName model.CIStr,
 	tbInfo *model.TableInfo,
 	onExist OnExist,
-	tryRetainID bool,
 ) (err error) {
-	job, err := d.createTableWithInfoJob(ctx, dbName, tbInfo, onExist, tryRetainID)
+	job, err := d.createTableWithInfoJob(ctx, dbName, tbInfo, onExist, false)
 	if err != nil {
 		return err
 	}
@@ -2358,7 +2352,7 @@ func (d *ddl) CreateView(ctx sessionctx.Context, s *ast.CreateViewStmt) (err err
 		onExist = OnExistReplace
 	}
 
-	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, onExist, false /*tryRetainID*/)
+	return d.CreateTableWithInfo(ctx, s.ViewName.Schema, tbInfo, onExist)
 }
 
 func buildViewInfo(ctx sessionctx.Context, s *ast.CreateViewStmt) (*model.ViewInfo, error) {
@@ -6328,7 +6322,7 @@ func (d *ddl) CreateSequence(ctx sessionctx.Context, stmt *ast.CreateSequenceStm
 		onExist = OnExistIgnore
 	}
 
-	return d.CreateTableWithInfo(ctx, ident.Schema, tbInfo, onExist, false /*tryRetainID*/)
+	return d.CreateTableWithInfo(ctx, ident.Schema, tbInfo, onExist)
 }
 
 func (d *ddl) AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequenceStmt) error {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -412,8 +412,16 @@ func (w *worker) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
 			err = w.deleteRange(w.ddlJobCtx, job)
 		}
 	}
-	if job.Type == model.ActionRecoverTable {
+
+	switch job.Type {
+	case model.ActionRecoverTable:
 		err = finishRecoverTable(w, job)
+	case model.ActionCreateTables:
+		if job.IsCancelled() {
+			// it may be too large that it can not be added to the history queue, too
+			// delete its arguments
+			job.Args = nil
+		}
 	}
 	if err != nil {
 		return errors.Trace(err)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -421,10 +421,6 @@ func (w *worker) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
 			// it may be too large that it can not be added to the history queue, too
 			// delete its arguments
 			job.Args = nil
-			// truncate its query in case, it is too long
-			if len(job.Query) > 1000 {
-				job.Query = job.Query[:1000]
-			}
 		}
 	}
 	if err != nil {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -421,6 +421,10 @@ func (w *worker) finishDDLJob(t *meta.Meta, job *model.Job) (err error) {
 			// it may be too large that it can not be added to the history queue, too
 			// delete its arguments
 			job.Args = nil
+			// truncate its query in case, it is too long
+			if len(job.Query) > 1000 {
+				job.Query = job.Query[:1000]
+			}
 		}
 	}
 	if err != nil {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -759,6 +759,8 @@ func (w *worker) runDDLJob(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, 
 		ver, err = onModifySchemaDefaultPlacement(t, job)
 	case model.ActionCreateTable:
 		ver, err = onCreateTable(d, t, job)
+	case model.ActionCreateTables:
+		ver, err = onCreateTables(d, t, job)
 	case model.ActionRepairTable:
 		ver, err = onRepairTable(d, t, job)
 	case model.ActionCreateView:
@@ -983,6 +985,22 @@ func updateSchemaVersion(t *meta.Meta, job *model.Job) (int64, error) {
 		SchemaID: job.SchemaID,
 	}
 	switch job.Type {
+	case model.ActionCreateTables:
+		tableIDs := []int64{}
+		tableInfos := []*model.TableInfo{}
+		err = job.DecodeArgs(&tableIDs, &tableInfos)
+		if err != nil {
+			return 0, errors.Trace(err)
+		}
+		diff.AffectedOpts = make([]*model.AffectedOption, len(tableIDs))
+		for i := range tableIDs {
+			diff.AffectedOpts[i] = &model.AffectedOption{
+				SchemaID:    job.SchemaID,
+				OldSchemaID: job.SchemaID,
+				TableID:     tableIDs[i],
+				OldTableID:  tableIDs[i],
+			}
+		}
 	case model.ActionTruncateTable:
 		// Truncate table has two table ID, should be handled differently.
 		err = job.DecodeArgs(&diff.TableID)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -986,19 +986,18 @@ func updateSchemaVersion(t *meta.Meta, job *model.Job) (int64, error) {
 	}
 	switch job.Type {
 	case model.ActionCreateTables:
-		tableIDs := []int64{}
 		tableInfos := []*model.TableInfo{}
-		err = job.DecodeArgs(&tableIDs, &tableInfos)
+		err = job.DecodeArgs(&tableInfos)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
-		diff.AffectedOpts = make([]*model.AffectedOption, len(tableIDs))
-		for i := range tableIDs {
+		diff.AffectedOpts = make([]*model.AffectedOption, len(tableInfos))
+		for i := range tableInfos {
 			diff.AffectedOpts[i] = &model.AffectedOption{
 				SchemaID:    job.SchemaID,
 				OldSchemaID: job.SchemaID,
-				TableID:     tableIDs[i],
-				OldTableID:  tableIDs[i],
+				TableID:     tableInfos[i].ID,
+				OldTableID:  tableInfos[i].ID,
 			}
 		}
 	case model.ActionTruncateTable:

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -142,6 +142,10 @@ func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 		return ver, errors.Trace(err)
 	}
 
+	// We don't construct jobs for every table, but only tableInfo
+	// The following loop creates a stub job for every table
+	//
+	// &*job clones a stub job from the ActionCreateTables job
 	stubJob := &*job
 	stubJob.Args = make([]interface{}, 1)
 	for i := range args {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -44,20 +44,12 @@ import (
 
 const tiflashCheckTiDBHTTPAPIHalfInterval = 2500 * time.Millisecond
 
-func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
-	failpoint.Inject("mockExceedErrorLimit", func(val failpoint.Value) {
-		if val.(bool) {
-			failpoint.Return(ver, errors.New("mock do job error"))
-		}
-	})
-
+// DANGER: it is an internal function used by onCreateTable and onCreateTables, for reusing code. Be careful.
+// 1. it expects the argument of job has been deserialized.
+// 2. it won't call updateSchemaVersion, FinishTableJob and asyncNotifyEvent.
+func createTable(d *ddlCtx, t *meta.Meta, job *model.Job) (*model.TableInfo, error) {
 	schemaID := job.SchemaID
-	tbInfo := &model.TableInfo{}
-	if err := job.DecodeArgs(tbInfo); err != nil {
-		// Invalid arguments, cancel this job.
-		job.State = model.JobStateCancelled
-		return ver, errors.Trace(err)
-	}
+	tbInfo := job.Args[0].(*model.TableInfo)
 
 	tbInfo.State = model.StateNone
 	err := checkTableNotExists(d, t, schemaID, tbInfo.Name.L)
@@ -65,12 +57,7 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableExists.Equal(err) {
 			job.State = model.JobStateCancelled
 		}
-		return ver, errors.Trace(err)
-	}
-
-	ver, err = updateSchemaVersion(t, job)
-	if err != nil {
-		return ver, errors.Trace(err)
+		return tbInfo, errors.Trace(err)
 	}
 
 	switch tbInfo.State {
@@ -80,40 +67,111 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 		tbInfo.UpdateTS = t.StartTS
 		err = createTableOrViewWithCheck(t, job, schemaID, tbInfo)
 		if err != nil {
-			return ver, errors.Trace(err)
+			return tbInfo, errors.Trace(err)
 		}
 
 		failpoint.Inject("checkOwnerCheckAllVersionsWaitTime", func(val failpoint.Value) {
 			if val.(bool) {
-				failpoint.Return(ver, errors.New("mock create table error"))
+				failpoint.Return(tbInfo, errors.New("mock create table error"))
 			}
 		})
 
 		// build table & partition bundles if any.
 		if err = checkAllTablePlacementPoliciesExistAndCancelNonExistJob(t, job, tbInfo); err != nil {
-			return ver, errors.Trace(err)
+			return tbInfo, errors.Trace(err)
 		}
 
 		bundles, err := placement.NewFullTableBundles(t, tbInfo)
 		if err != nil {
 			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+			return tbInfo, errors.Trace(err)
 		}
 
 		// Send the placement bundle to PD.
 		err = infosync.PutRuleBundlesWithDefaultRetry(context.TODO(), bundles)
 		if err != nil {
 			job.State = model.JobStateCancelled
-			return ver, errors.Wrapf(err, "failed to notify PD the placement rules")
+			return tbInfo, errors.Wrapf(err, "failed to notify PD the placement rules")
 		}
 
-		// Finish this job.
-		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tbInfo)
-		asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateTable, TableInfo: tbInfo})
-		return ver, nil
+		return tbInfo, nil
 	default:
-		return ver, ErrInvalidDDLState.GenWithStackByArgs("table", tbInfo.State)
+		return tbInfo, ErrInvalidDDLState.GenWithStackByArgs("table", tbInfo.State)
 	}
+}
+
+func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
+	failpoint.Inject("mockExceedErrorLimit", func(val failpoint.Value) {
+		if val.(bool) {
+			failpoint.Return(ver, errors.New("mock do job error"))
+		}
+	})
+
+	// just decode, createTable will use it as Args[0]
+	tbInfo := &model.TableInfo{}
+	if err := job.DecodeArgs(tbInfo); err != nil {
+		// Invalid arguments, cancel this job.
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+
+	tbInfo, err := createTable(d, t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	ver, err = updateSchemaVersion(t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	// Finish this job.
+	job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tbInfo)
+	asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateTable, TableInfo: tbInfo})
+	return ver, errors.Trace(err)
+}
+
+func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
+	var ver int64
+
+	ids := []int64{}
+	args := []*model.TableInfo{}
+	err := job.DecodeArgs(&ids, &args)
+	if err != nil {
+		// Invalid arguments, cancel this job.
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+
+	stubJob := &*job
+	stubJob.Args = make([]interface{}, 1)
+	for i := range ids {
+		stubJob.TableID = ids[i]
+		stubJob.Args[0] = args[i]
+		tbInfo, err := createTable(d, t, stubJob)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
+		args[i] = tbInfo
+	}
+
+	ver, err = updateSchemaVersion(t, job)
+	if err != nil {
+		return ver, errors.Trace(err)
+	}
+
+	job.State = model.JobStateDone
+	job.SchemaState = model.StatePublic
+	for i := range ids {
+		job.BinlogInfo.AddTableInfo(ver, args[i])
+	}
+
+	for i := range ids {
+		asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateTable, TableInfo: args[i]})
+	}
+
+	return ver, errors.Trace(err)
 }
 
 func createTableOrViewWithCheck(t *meta.Meta, job *model.Job, schemaID int64, tbInfo *model.TableInfo) error {

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -134,9 +134,8 @@ func onCreateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error)
 func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 	var ver int64
 
-	ids := []int64{}
 	args := []*model.TableInfo{}
-	err := job.DecodeArgs(&ids, &args)
+	err := job.DecodeArgs(&args)
 	if err != nil {
 		// Invalid arguments, cancel this job.
 		job.State = model.JobStateCancelled
@@ -145,8 +144,8 @@ func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 
 	stubJob := &*job
 	stubJob.Args = make([]interface{}, 1)
-	for i := range ids {
-		stubJob.TableID = ids[i]
+	for i := range args {
+		stubJob.TableID = args[i].ID
 		stubJob.Args[0] = args[i]
 		tbInfo, err := createTable(d, t, stubJob)
 		if err != nil {
@@ -163,11 +162,9 @@ func onCreateTables(d *ddlCtx, t *meta.Meta, job *model.Job) (int64, error) {
 
 	job.State = model.JobStateDone
 	job.SchemaState = model.StatePublic
-	for i := range ids {
-		job.BinlogInfo.AddTableInfo(ver, args[i])
-	}
+	job.BinlogInfo.SetTableInfos(ver, args)
 
-	for i := range ids {
+	for i := range args {
 		asyncNotifyEvent(d, &util.Event{Tp: model.ActionCreateTable, TableInfo: args[i]})
 	}
 

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -415,15 +415,15 @@ func TestCreateTables(t *testing.T) {
 	require.NoError(t, err)
 
 	infos = append(infos, &model.TableInfo{
-		ID: genIDs[0],
+		ID:   genIDs[0],
 		Name: model.NewCIStr("s1"),
 	})
 	infos = append(infos, &model.TableInfo{
-		ID: genIDs[1],
+		ID:   genIDs[1],
 		Name: model.NewCIStr("s2"),
 	})
 	infos = append(infos, &model.TableInfo{
-		ID: genIDs[2],
+		ID:   genIDs[2],
 		Name: model.NewCIStr("s3"),
 	})
 

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -393,3 +393,50 @@ func ExportTestRenameTables(t *testing.T) {
 	require.Equal(t, wantTblInfos[0].Name.L, "tt1")
 	require.Equal(t, wantTblInfos[1].Name.L, "tt2")
 }
+
+func TestCreateTables(t *testing.T) {
+	store, err := mockstore.NewMockStore()
+	require.NoError(t, err)
+	ddl, err := testNewDDLAndStart(
+		context.Background(),
+		WithStore(store),
+		WithLease(testLease),
+	)
+	require.NoError(t, err)
+
+	dbInfo, err := testSchemaInfo(ddl, "test_table")
+	require.NoError(t, err)
+	testCreateSchemaT(t, testNewContext(ddl), ddl, dbInfo)
+
+	ctx := testNewContext(ddl)
+
+	infos := []*model.TableInfo{}
+	genIDs, err := ddl.genGlobalIDs(3)
+	require.NoError(t, err)
+
+	infos = append(infos, &model.TableInfo{
+		ID: genIDs[0],
+		Name: model.NewCIStr("s1"),
+	})
+	infos = append(infos, &model.TableInfo{
+		ID: genIDs[1],
+		Name: model.NewCIStr("s2"),
+	})
+	infos = append(infos, &model.TableInfo{
+		ID: genIDs[2],
+		Name: model.NewCIStr("s3"),
+	})
+
+	job := &model.Job{
+		SchemaID:   dbInfo.ID,
+		Type:       model.ActionCreateTables,
+		BinlogInfo: &model.HistoryInfo{},
+		Args:       []interface{}{infos},
+	}
+	err = ddl.doDDLJob(ctx, job)
+	require.NoError(t, err)
+
+	testGetTableT(t, ddl, dbInfo.ID, genIDs[0])
+	testGetTableT(t, ddl, dbInfo.ID, genIDs[1])
+	testGetTableT(t, ddl, dbInfo.ID, genIDs[2])
+}

--- a/executor/brie.go
+++ b/executor/brie.go
@@ -483,7 +483,7 @@ func (gs *tidbGlueSession) CreateDatabase(ctx context.Context, schema *model.DBI
 	if len(schema.Charset) == 0 {
 		schema.Charset = mysql.DefaultCharset
 	}
-	return d.CreateSchemaWithInfo(gs.se, schema, ddl.OnExistIgnore, true)
+	return d.CreateSchemaWithInfo(gs.se, schema, ddl.OnExistIgnore)
 }
 
 // CreateTable implements glue.Session
@@ -498,7 +498,7 @@ func (gs *tidbGlueSession) CreateTable(ctx context.Context, dbName model.CIStr, 
 		table.Partition = &newPartition
 	}
 
-	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore, true)
+	return d.CreateTableWithInfo(gs.se, dbName, table, ddl.OnExistIgnore)
 }
 
 // Close implements glue.Session

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -472,6 +472,16 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 		if job.BinlogInfo.TableInfo != nil {
 			tableName = job.BinlogInfo.TableInfo.Name.L
 		}
+		if job.BinlogInfo.Affected != nil {
+			tablenames := new(strings.Builder)
+			for i, affect := range job.BinlogInfo.Affected {
+				if i > 0 {
+					fmt.Fprintf(tablenames, ",")
+				}
+				fmt.Fprintf(tablenames, "%s", affect.TableInfo.Name.L)
+			}
+			tableName = tablenames.String()
+		}
 		if len(schemaName) == 0 && job.BinlogInfo.DBInfo != nil {
 			schemaName = job.BinlogInfo.DBInfo.Name.L
 		}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -472,13 +472,13 @@ func (e *DDLJobRetriever) appendJobToChunk(req *chunk.Chunk, job *model.Job, che
 		if job.BinlogInfo.TableInfo != nil {
 			tableName = job.BinlogInfo.TableInfo.Name.L
 		}
-		if job.BinlogInfo.Affected != nil {
+		if job.BinlogInfo.MultipleTableInfos != nil {
 			tablenames := new(strings.Builder)
-			for i, affect := range job.BinlogInfo.Affected {
+			for i, affect := range job.BinlogInfo.MultipleTableInfos {
 				if i > 0 {
 					fmt.Fprintf(tablenames, ",")
 				}
-				fmt.Fprintf(tablenames, "%s", affect.TableInfo.Name.L)
+				fmt.Fprintf(tablenames, "%s", affect.Name.L)
 			}
 			tableName = tablenames.String()
 		}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -57,8 +57,6 @@ type Builder struct {
 // Return the detail updated table IDs that are produced from SchemaDiff and an error.
 func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, error) {
 	b.is.schemaMetaVersion = diff.Version
-	var tblIDs []int64
-	var err error
 	switch diff.Type {
 	case model.ActionCreateSchema:
 		return nil, b.applyCreateSchema(m, diff)
@@ -74,19 +72,39 @@ func (b *Builder) ApplyDiff(m *meta.Meta, diff *model.SchemaDiff) ([]int64, erro
 		return b.applyDropPolicy(diff.SchemaID), nil
 	case model.ActionAlterPlacementPolicy:
 		return b.applyAlterPolicy(m, diff)
+	case model.ActionTruncateTablePartition, model.ActionTruncateTable:
+		return b.applyTruncateTableOrPartition(m, diff)
+	case model.ActionDropTable, model.ActionDropTablePartition:
+		return b.applyDropTableOrParition(m, diff)
+	case model.ActionRecoverTable:
+		return b.applyRecoverTable(m, diff)
+	case model.ActionCreateTables:
+		return b.applyCreateTables(m, diff)
 	default:
-		switch diff.Type {
-		case model.ActionTruncateTablePartition, model.ActionTruncateTable:
-			tblIDs, err = b.applyTruncateTableOrPartition(m, diff)
-		case model.ActionDropTable, model.ActionDropTablePartition:
-			tblIDs, err = b.applyDropTableOrParition(m, diff)
-		case model.ActionRecoverTable:
-			tblIDs, err = b.applyRecoverTable(m, diff)
-		default:
-			tblIDs, err = b.applyDefaultAction(m, diff)
+		return b.applyDefaultAction(m, diff)
+	}
+}
+
+func (b *Builder) applyCreateTables(m *meta.Meta, diff *model.SchemaDiff) ([]int64, error) {
+	tblIDs := make([]int64, 0, len(diff.AffectedOpts))
+	if diff.AffectedOpts != nil {
+		for _, opt := range diff.AffectedOpts {
+			affectedDiff := &model.SchemaDiff{
+				Version:     diff.Version,
+				Type:        model.ActionCreateTable,
+				SchemaID:    opt.SchemaID,
+				TableID:     opt.TableID,
+				OldSchemaID: opt.OldSchemaID,
+				OldTableID:  opt.OldTableID,
+			}
+			affectedIDs, err := b.ApplyDiff(m, affectedDiff)
+			if err != nil {
+				return nil, errors.Trace(err)
+			}
+			tblIDs = append(tblIDs, affectedIDs...)
 		}
 	}
-	return tblIDs, err
+	return tblIDs, nil
 }
 
 func (b *Builder) applyTruncateTableOrPartition(m *meta.Meta, diff *model.SchemaDiff) ([]int64, error) {

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -171,11 +171,6 @@ func (action ActionType) String() string {
 	return "none"
 }
 
-type HistoryInfoAffected struct {
-	DBInfo    *DBInfo
-	TableInfo *TableInfo
-}
-
 // HistoryInfo is used for binlog.
 type HistoryInfo struct {
 	SchemaVersion int64

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -171,6 +171,11 @@ func (action ActionType) String() string {
 	return "none"
 }
 
+type HistoryInfoAffected struct {
+	DBInfo    *DBInfo
+	TableInfo *TableInfo
+}
+
 // HistoryInfo is used for binlog.
 type HistoryInfo struct {
 	SchemaVersion int64
@@ -194,6 +199,15 @@ func (h *HistoryInfo) AddDBInfo(schemaVer int64, dbInfo *DBInfo) {
 func (h *HistoryInfo) AddTableInfo(schemaVer int64, tblInfo *TableInfo) {
 	h.SchemaVersion = schemaVer
 	h.TableInfo = tblInfo
+}
+
+// SetTableInfos is like AddTableInfo, but will add multiple table infos to the binlog.
+func (h *HistoryInfo) SetTableInfos(schemaVer int64, tblInfos []*TableInfo) {
+	h.SchemaVersion = schemaVer
+	h.MultipleTableInfos = make([]*TableInfo, len(tblInfos))
+	for i, info := range tblInfos {
+		h.MultipleTableInfos[i] = info
+	}
 }
 
 // Clean cleans history information.

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -94,12 +94,14 @@ const (
 	ActionAlterCacheTable               ActionType = 57
 	ActionAlterTableStatsOptions        ActionType = 58
 	ActionAlterNoCacheTable             ActionType = 59
+	ActionCreateTables                  ActionType = 60
 )
 
 var actionMap = map[ActionType]string{
 	ActionCreateSchema:                  "create schema",
 	ActionDropSchema:                    "drop schema",
 	ActionCreateTable:                   "create table",
+	ActionCreateTables:                  "create tables",
 	ActionDropTable:                     "drop table",
 	ActionAddColumn:                     "add column",
 	ActionDropColumn:                    "drop column",


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: refer #30272

Problem Summary: add an internal batch create table api for br, all happens in one schema version.

Some notes on the behavior:

1. This API does not set `query` since it is not from parser. One must set `ctx.Value(sessionctx.QueryString)` manually for displaying `admin show ddl queries`.
2. `admin show ddl jobs` can not show multiple ids in `tableID` column, but will show comma separated list of table names in `tableName` column.

### What is changed and how it works?

What's Changed:

1. add `CreateTablesWithInfo`, the new batch api.
2. Common part in `CreateTableWithInfo` and `CreateTablesWithInfo` are extracted.
3. Common part in `onCreateTable` and `onCreateTables` are extracted.
4. add simple unit tests in `db_test.go` and `table_test.go`.
5. add `Affected      []HistoryInfoAffected` in `binlog.HistoryInfo` for display multiple table names.
6. When the job is cancelled, its arguments will be deleted. Since someone may issued a super large job that does not fit into the history queue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
