### PR TITLE
*: finer estimation of avg row size when column stats are unavailable in GetAvgRowSize

### DIFF
--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/plancodec"
@@ -486,7 +485,7 @@ func getAvgRowSize(stats *property.StatsInfo, schema *expression.Schema) (size f
 		// Estimate using just the type info.
 		cols := schema.Columns
 		for _, col := range cols {
-			size += float64(chunk.EstimateTypeWidth(col.GetType()))
+			size += float64(statistics.EstimateTypeWidthForChunk(col.GetType()))
 		}
 	}
 	return

--- a/statistics/table_test.go
+++ b/statistics/table_test.go
@@ -15,6 +15,7 @@
 package statistics
 
 import (
+	"github.com/pingcap/tidb/session"
 	"testing"
 
 	"github.com/pingcap/tidb/parser/mysql"
@@ -41,4 +42,11 @@ func TestEstimateTypeWidth(t *testing.T) {
 
 	colType = &types.FieldType{Tp: mysql.TypeString}
 	require.Equal(t, 32, EstimateTypeWidthForChunk(colType)) // value after guessing
+}
+
+func TestGetAvgRowSizeWithoutColStats(t *testing.T) {
+	t.Parallel()
+
+	session.CreateSession4Test(nil)
+
 }

--- a/statistics/table_test.go
+++ b/statistics/table_test.go
@@ -12,13 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package statistics
+package statistics_test
 
 import (
-	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/statistics"
 	"testing"
 
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
 	"github.com/stretchr/testify/require"
 )
@@ -29,24 +32,44 @@ func TestEstimateTypeWidth(t *testing.T) {
 	var colType *types.FieldType
 
 	colType = &types.FieldType{Tp: mysql.TypeLonglong}
-	require.Equal(t, 8, EstimateTypeWidthForChunk(colType)) // fixed-witch type
+	require.Equal(t, 8, statistics.EstimateTypeWidthForChunk(colType)) // fixed-witch type
 
 	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 31}
-	require.Equal(t, 31, EstimateTypeWidthForChunk(colType)) // colLen <= 32
+	require.Equal(t, 31, statistics.EstimateTypeWidthForChunk(colType)) // colLen <= 32
 
 	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 999}
-	require.Equal(t, 515, EstimateTypeWidthForChunk(colType)) // colLen < 1000
+	require.Equal(t, 515, statistics.EstimateTypeWidthForChunk(colType)) // colLen < 1000
 
 	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 2000}
-	require.Equal(t, 516, EstimateTypeWidthForChunk(colType)) // colLen < 1000
+	require.Equal(t, 516, statistics.EstimateTypeWidthForChunk(colType)) // colLen < 1000
 
 	colType = &types.FieldType{Tp: mysql.TypeString}
-	require.Equal(t, 32, EstimateTypeWidthForChunk(colType)) // value after guessing
+	require.Equal(t, 32, statistics.EstimateTypeWidthForChunk(colType)) // value after guessing
 }
 
 func TestGetAvgRowSizeWithoutColStats(t *testing.T) {
 	t.Parallel()
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	se, err := session.CreateSession4Test(store)
+	require.NoError(t, err)
+	coll := &statistics.HistColl{}
+	col := &expression.Column{}
+	se.GetSessionVars().EnableChunkRPC = true
 
-	session.CreateSession4Test(nil)
+	col.RetType = &types.FieldType{Tp: mysql.TypeString, Flen: 999}
+	// 515 + 1/8
+	require.Equal(t, float64(515.125), coll.GetAvgRowSize(se, []*expression.Column{col}, false, false))
 
+	col.RetType = &types.FieldType{Tp: mysql.TypeString}
+	// 32 + 1/8
+	require.Equal(t, float64(32.125), coll.GetAvgRowSize(se, []*expression.Column{col}, false, false))
+
+	col.RetType = &types.FieldType{Tp: mysql.TypeFloat}
+	// 4 + 1/8
+	require.Equal(t, float64(4.125), coll.GetAvgRowSize(se, []*expression.Column{col}, false, false))
+
+	se.GetSessionVars().EnableChunkRPC = false
+	// 8 + 1
+	require.Equal(t, float64(9), coll.GetAvgRowSize(se, []*expression.Column{col}, false, false))
 }

--- a/statistics/table_test.go
+++ b/statistics/table_test.go
@@ -1,0 +1,44 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statistics
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEstimateTypeWidth(t *testing.T) {
+	t.Parallel()
+
+	var colType *types.FieldType
+
+	colType = &types.FieldType{Tp: mysql.TypeLonglong}
+	require.Equal(t, 8, EstimateTypeWidthForChunk(colType)) // fixed-witch type
+
+	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 31}
+	require.Equal(t, 31, EstimateTypeWidthForChunk(colType)) // colLen <= 32
+
+	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 999}
+	require.Equal(t, 515, EstimateTypeWidthForChunk(colType)) // colLen < 1000
+
+	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 2000}
+	require.Equal(t, 516, EstimateTypeWidthForChunk(colType)) // colLen < 1000
+
+	colType = &types.FieldType{Tp: mysql.TypeString}
+	require.Equal(t, 32, EstimateTypeWidthForChunk(colType)) // value after guessing
+}

--- a/statistics/table_test.go
+++ b/statistics/table_test.go
@@ -15,12 +15,12 @@
 package statistics_test
 
 import (
-	"github.com/pingcap/tidb/statistics"
 	"testing"
 
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/types"
 	"github.com/stretchr/testify/require"

--- a/util/chunk/codec.go
+++ b/util/chunk/codec.go
@@ -191,37 +191,6 @@ func GetFixedLen(colType *types.FieldType) int {
 	return getFixedLen(colType)
 }
 
-// EstimateTypeWidth estimates the average width of values of the type.
-// This is used by the planner, which doesn't require absolutely correct results;
-// it's OK (and expected) to guess if we don't know for sure.
-//
-// mostly study from https://github.com/postgres/postgres/blob/REL_12_STABLE/src/backend/utils/cache/lsyscache.c#L2356
-func EstimateTypeWidth(colType *types.FieldType) int {
-	colLen := getFixedLen(colType)
-	// Easy if it's a fixed-width type
-	if colLen != varElemLen {
-		return colLen
-	}
-
-	colLen = colType.Flen
-	if colLen > 0 {
-		if colLen <= 32 {
-			return colLen
-		}
-		if colLen < 1000 {
-			return 32 + (colLen-32)/2 // assume 50%
-		}
-		/*
-		 * Beyond 1000, assume we're looking at something like
-		 * "varchar(10000)" where the limit isn't actually reached often, and
-		 * use a fixed estimate.
-		 */
-		return 32 + (1000-32)/2
-	}
-	// Oops, we have no idea ... wild guess time.
-	return 32
-}
-
 func init() {
 	for i := 0; i < 128; i++ {
 		allNotNullBitmap[i] = 0xFF

--- a/util/chunk/codec_test.go
+++ b/util/chunk/codec_test.go
@@ -76,27 +76,6 @@ func TestCodec(t *testing.T) {
 	}
 }
 
-func TestEstimateTypeWidth(t *testing.T) {
-	t.Parallel()
-
-	var colType *types.FieldType
-
-	colType = &types.FieldType{Tp: mysql.TypeLonglong}
-	require.Equal(t, 8, EstimateTypeWidth(colType)) // fixed-witch type
-
-	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 31}
-	require.Equal(t, 31, EstimateTypeWidth(colType)) // colLen <= 32
-
-	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 999}
-	require.Equal(t, 515, EstimateTypeWidth(colType)) // colLen < 1000
-
-	colType = &types.FieldType{Tp: mysql.TypeString, Flen: 2000}
-	require.Equal(t, 516, EstimateTypeWidth(colType)) // colLen < 1000
-
-	colType = &types.FieldType{Tp: mysql.TypeString}
-	require.Equal(t, 32, EstimateTypeWidth(colType)) // value after guessing
-}
-
 func BenchmarkEncodeChunk(b *testing.B) {
 	numCols := 4
 	numRows := 1024


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #28986 <!-- REMOVE this line if no issue to close -->

Problem Summary:
In `(*HistColl).GetAvgRowSize`, when the column stats are unavailable, we just use `pseudoColSize` as the average column size. However, we can do finer estimation by utilizing `col.GetType()`. 

### What is changed and how it works?

What is changed?

Move `EstimateTypeWidth` from `chunk` package to `statistics` package, make some modification and apply it in `(*HistColl).GetAvgRowSize`.

How it works?

Make finer estimation of the average column size by utilizing `col.GetType()` to make a guess when the column stats are unavailable.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
