### PR TITLE
docs: add design doc for analyze predicate columns

### DIFF
--- a/docs/design/2021-10-15-analyze-predicate-columns.md
+++ b/docs/design/2021-10-15-analyze-predicate-columns.md
@@ -22,7 +22,7 @@ We want to support the `ANALYZE` option to only collect the statistics of predic
 ANALYZE TABLE TableNameList (ALL COLUMNS | PREDICATE COLUMNS | COLUMNS ColumnNameList)? AnalyzeOptionListOpt
 ANALYZE TABLE TableName (PARTITION PartitionNameList)? (PREDICATE COLUMNS | COLUMNS ColumnNameList)? AnalyzeOptionListOpt
 ```
-1. FOR `ANALYZE ALL COLUMNS`, the statistics of all columns would be collected.
+1. For `ANALYZE ALL COLUMNS`, the statistics of all columns would be collected.
 1. For `ANALYZE PREDICATE COLUMNS`, the statistics of predicate columns and indexed columns would be collected. If there is no predicate columns in record, TiDB would collect the statistics of all columns and give a warning to the client.
 2. For `ANALYZE COLUMNS ColumnNameList`, the statistics of the columns in `ColumnNameList` and indexed columns would be collected.
 3. By default, the statistics of all columns would be collected.


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:

It takes lots of time, memory and cpu to analyze large and wide tables.

### What is changed and how it works?

Make a proposal to support `ANALYZE PREDICATE COLUMNS` or `ANALYZE COLUMNS c1, ..., cn`, which only collects statistics of the columns which are used(needed) by the optimizer and can reduce the cost of `ANALYZE`.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note <!-- bugfixes or new feature need a release note -->

```release-note
None
```
