### PR TITLE
session: avoid useless interceptor when the temporary table is not used

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -2089,7 +2089,9 @@ func (s *session) NewTxn(ctx context.Context) error {
 		IsStaleness: false,
 		TxnScope:    s.sessionVars.CheckAndGetTxnScope(),
 	}
-	s.txn.SetOption(kv.SnapInterceptor, s.getSnapshotInterceptor())
+	if s.sessionVars.TemporaryTableData != nil {
+		s.txn.SetOption(kv.SnapInterceptor, s.getSnapshotInterceptor())
+	}
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

When the temporary table is not used, there shouldn't be any performance affect related to it.

![image](https://user-images.githubusercontent.com/1420062/138660233-a472eb99-d107-42f3-9502-aad7624071a7.png)


### What is changed and how it works?

Check whether temporary table is not used before setting the `SnapInterceptor` transaction option.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
