### PR TITLE
expression, executor: forbid pushing trim2Args, trim3Args to tiflash

### DIFF
--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -970,7 +970,9 @@ func (s *tiflashTestSuite) TestIssue29154(c *C) {
 	err := domain.GetDomain(tk.Se).DDL().UpdateTableReplicaInfo(tk.Se, tb.Meta().ID, true)
 	c.Assert(err, IsNil)
 	time.Sleep(2 * time.Second)
-	tk.MustExec("insert into t values (' x ')")
-	tk.MustQuery("select * from t where trim('x' from a)")
-	tk.MustQuery("select * from t where trim(trailing 'x' from a)")
+	tk.MustExec("set session tidb_isolation_read_engines=\"tiflash\";")
+	tk.MustQuery("explain select * from t where trim('x' from a)")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Scalar function 'trim'(signature: Trim2Args, return type: var_string(5)) can not be pushed to storage layer"))
+	tk.MustQuery("explain select * from t where trim(trailing 'x' from a)")
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Scalar function 'trim'(signature: Trim3Args, return type: var_string(20)) can not be pushed to storage layer"))
 }

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1032,8 +1032,13 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		ast.Radians, ast.Degrees, ast.Conv, ast.CRC32,
 		ast.JSONLength,
 		ast.InetNtoa, ast.InetAton, ast.Inet6Ntoa, ast.Inet6Aton,
-		ast.Coalesce, ast.ASCII, ast.Length, ast.Trim, ast.Position:
+		ast.Coalesce, ast.ASCII, ast.Length, ast.Position:
 		return true
+	case ast.Trim:
+		switch function.Function.PbCode() {
+		case tipb.ScalarFuncSig_Trim2Args, tipb.ScalarFuncSig_Trim3Args:
+			return false
+		}
 	case ast.Substr, ast.Substring, ast.Left, ast.Right, ast.CharLength:
 		switch function.Function.PbCode() {
 		case

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1036,8 +1036,8 @@ func scalarExprSupportedByFlash(function *ScalarFunction) bool {
 		return true
 	case ast.Trim:
 		switch function.Function.PbCode() {
-		case tipb.ScalarFuncSig_Trim2Args, tipb.ScalarFuncSig_Trim3Args:
-			return false
+		case tipb.ScalarFuncSig_Trim1Arg:
+			return true
 		}
 	case ast.Substr, ast.Substring, ast.Left, ast.Right, ast.CharLength:
 		switch function.Function.PbCode() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29154 
caused by https://github.com/pingcap/tidb/pull/26786

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Integration test


Side effects

N/A

Documentation
N/A

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the problem that mistakenly pushing down `trim(trailing|both|leading remstr from str)` and `trim(remstr from str)` to tiflash.
```
