### PR TITLE
executor: add show placement scheduling_state

### DIFF
--- a/ddl/placement_policy_test.go
+++ b/ddl/placement_policy_test.go
@@ -190,7 +190,7 @@ func (s *testDBSuite6) TestPlacementValidation(c *C) {
 			err := tk.ExecToErr(sql)
 			c.Assert(err, NotNil)
 			c.Assert(err.Error(), Equals, ca.errmsg)
-			tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east\""))
+			tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east\" "))
 		}
 	}
 	tk.MustExec("drop placement policy x")
@@ -342,14 +342,14 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 
 	// test for normal cases
 	tk.MustExec("alter placement policy x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\"")
-	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\""))
+	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\" "))
 	tk.MustQuery("select * from information_schema.placement_rules where policy_name = 'x'").Check(testkit.Rows(strconv.FormatInt(policy.ID, 10) + " def x <nil> <nil> <nil> bj bj,sh      0 0"))
 
 	tk.MustExec("alter placement policy x " +
 		"PRIMARY_REGION=\"bj\" " +
 		"REGIONS=\"bj\" " +
 		"SCHEDULE=\"EVEN\"")
-	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj\" SCHEDULE=\"EVEN\""))
+	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj\" SCHEDULE=\"EVEN\" "))
 	tk.MustQuery("select * from INFORMATION_SCHEMA.PLACEMENT_RULES WHERE POLICY_NAME='x'").Check(testkit.Rows(strconv.FormatInt(policy.ID, 10) + " def x <nil> <nil> <nil> bj bj     EVEN 0 0"))
 
 	tk.MustExec("alter placement policy x " +
@@ -357,7 +357,7 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 		"FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" " +
 		"FOLLOWERS=3")
 	tk.MustQuery("show placement where target='POLICY x'").Check(
-		testkit.Rows("POLICY x LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\""),
+		testkit.Rows("POLICY x LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" "),
 	)
 	tk.MustQuery("SELECT POLICY_NAME,LEADER_CONSTRAINTS,FOLLOWER_CONSTRAINTS,FOLLOWERS FROM information_schema.PLACEMENT_RULES WHERE POLICY_NAME = 'x'").Check(
 		testkit.Rows("x [+region=us-east-1] [+region=us-east-2] 3"),
@@ -370,7 +370,7 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 		"VOTERS=5 " +
 		"LEARNERS=3")
 	tk.MustQuery("show placement where target='POLICY x'").Check(
-		testkit.Rows("POLICY x CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\""),
+		testkit.Rows("POLICY x CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" "),
 	)
 	tk.MustQuery("SELECT " +
 		"CATALOG_NAME,POLICY_NAME,SCHEMA_NAME,TABLE_NAME,PARTITION_NAME," +
@@ -661,7 +661,7 @@ func (s *testDBSuite6) TestPolicyCacheAndPolicyDependency(c *C) {
 	tk.MustExec("create placement policy x primary_region=\"r1\" regions=\"r1,r2\" schedule=\"EVEN\";")
 	po := testGetPolicyByName(c, tk.Se, "x", true)
 	c.Assert(po, NotNil)
-	tk.MustQuery("show placement").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\""))
+	tk.MustQuery("show placement").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\" "))
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int) placement policy \"x\"")

--- a/ddl/placement_policy_test.go
+++ b/ddl/placement_policy_test.go
@@ -190,7 +190,7 @@ func (s *testDBSuite6) TestPlacementValidation(c *C) {
 			err := tk.ExecToErr(sql)
 			c.Assert(err, NotNil)
 			c.Assert(err.Error(), Equals, ca.errmsg)
-			tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east\" "))
+			tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east\" NULL"))
 		}
 	}
 	tk.MustExec("drop placement policy x")
@@ -342,14 +342,14 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 
 	// test for normal cases
 	tk.MustExec("alter placement policy x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\"")
-	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\" "))
+	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj,sh\" NULL"))
 	tk.MustQuery("select * from information_schema.placement_rules where policy_name = 'x'").Check(testkit.Rows(strconv.FormatInt(policy.ID, 10) + " def x <nil> <nil> <nil> bj bj,sh      0 0"))
 
 	tk.MustExec("alter placement policy x " +
 		"PRIMARY_REGION=\"bj\" " +
 		"REGIONS=\"bj\" " +
 		"SCHEDULE=\"EVEN\"")
-	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj\" SCHEDULE=\"EVEN\" "))
+	tk.MustQuery("show placement where target='POLICY x'").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"bj\" REGIONS=\"bj\" SCHEDULE=\"EVEN\" NULL"))
 	tk.MustQuery("select * from INFORMATION_SCHEMA.PLACEMENT_RULES WHERE POLICY_NAME='x'").Check(testkit.Rows(strconv.FormatInt(policy.ID, 10) + " def x <nil> <nil> <nil> bj bj     EVEN 0 0"))
 
 	tk.MustExec("alter placement policy x " +
@@ -357,7 +357,7 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 		"FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" " +
 		"FOLLOWERS=3")
 	tk.MustQuery("show placement where target='POLICY x'").Check(
-		testkit.Rows("POLICY x LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" "),
+		testkit.Rows("POLICY x LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" NULL"),
 	)
 	tk.MustQuery("SELECT POLICY_NAME,LEADER_CONSTRAINTS,FOLLOWER_CONSTRAINTS,FOLLOWERS FROM information_schema.PLACEMENT_RULES WHERE POLICY_NAME = 'x'").Check(
 		testkit.Rows("x [+region=us-east-1] [+region=us-east-2] 3"),
@@ -370,7 +370,7 @@ func (s *testDBSuite6) TestAlterPlacementPolicy(c *C) {
 		"VOTERS=5 " +
 		"LEARNERS=3")
 	tk.MustQuery("show placement where target='POLICY x'").Check(
-		testkit.Rows("POLICY x CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" "),
+		testkit.Rows("POLICY x CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" NULL"),
 	)
 	tk.MustQuery("SELECT " +
 		"CATALOG_NAME,POLICY_NAME,SCHEMA_NAME,TABLE_NAME,PARTITION_NAME," +
@@ -661,7 +661,7 @@ func (s *testDBSuite6) TestPolicyCacheAndPolicyDependency(c *C) {
 	tk.MustExec("create placement policy x primary_region=\"r1\" regions=\"r1,r2\" schedule=\"EVEN\";")
 	po := testGetPolicyByName(c, tk.Se, "x", true)
 	c.Assert(po, NotNil)
-	tk.MustQuery("show placement").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\" "))
+	tk.MustQuery("show placement").Check(testkit.Rows("POLICY x PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\" NULL"))
 
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int) placement policy \"x\"")

--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -740,8 +740,8 @@ func (s *testDBSuite6) TestCreateSchemaWithPlacement(c *C) {
 
 	tk.MustExec(`CREATE PLACEMENT POLICY PolicySchemaTest LEADER_CONSTRAINTS = "[+region=nl]" FOLLOWER_CONSTRAINTS="[+region=se]" FOLLOWERS=4 LEARNER_CONSTRAINTS="[+region=be]" LEARNERS=4`)
 	tk.MustExec(`CREATE PLACEMENT POLICY PolicyTableTest LEADER_CONSTRAINTS = "[+region=tl]" FOLLOWER_CONSTRAINTS="[+region=tf]" FOLLOWERS=2 LEARNER_CONSTRAINTS="[+region=tle]" LEARNERS=1`)
-	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicySchemaTest%'").Check(testkit.Rows("POLICY PolicySchemaTest LEADER_CONSTRAINTS=\"[+region=nl]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=se]\" LEARNERS=4 LEARNER_CONSTRAINTS=\"[+region=be]\""))
-	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicyTableTest%'").Check(testkit.Rows("POLICY PolicyTableTest LEADER_CONSTRAINTS=\"[+region=tl]\" FOLLOWERS=2 FOLLOWER_CONSTRAINTS=\"[+region=tf]\" LEARNERS=1 LEARNER_CONSTRAINTS=\"[+region=tle]\""))
+	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicySchemaTest%'").Check(testkit.Rows("POLICY PolicySchemaTest LEADER_CONSTRAINTS=\"[+region=nl]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=se]\" LEARNERS=4 LEARNER_CONSTRAINTS=\"[+region=be]\" "))
+	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicyTableTest%'").Check(testkit.Rows("POLICY PolicyTableTest LEADER_CONSTRAINTS=\"[+region=tl]\" FOLLOWERS=2 FOLLOWER_CONSTRAINTS=\"[+region=tf]\" LEARNERS=1 LEARNER_CONSTRAINTS=\"[+region=tle]\" "))
 	tk.MustExec("CREATE SCHEMA SchemaPolicyPlacementTest PLACEMENT POLICY = `PolicySchemaTest`")
 	tk.MustQuery("SHOW CREATE SCHEMA SCHEMAPOLICYPLACEMENTTEST").Check(testkit.Rows("SchemaPolicyPlacementTest CREATE DATABASE `SchemaPolicyPlacementTest` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /*T![placement] PLACEMENT POLICY=`PolicySchemaTest` */"))
 

--- a/ddl/placement_sql_test.go
+++ b/ddl/placement_sql_test.go
@@ -740,8 +740,8 @@ func (s *testDBSuite6) TestCreateSchemaWithPlacement(c *C) {
 
 	tk.MustExec(`CREATE PLACEMENT POLICY PolicySchemaTest LEADER_CONSTRAINTS = "[+region=nl]" FOLLOWER_CONSTRAINTS="[+region=se]" FOLLOWERS=4 LEARNER_CONSTRAINTS="[+region=be]" LEARNERS=4`)
 	tk.MustExec(`CREATE PLACEMENT POLICY PolicyTableTest LEADER_CONSTRAINTS = "[+region=tl]" FOLLOWER_CONSTRAINTS="[+region=tf]" FOLLOWERS=2 LEARNER_CONSTRAINTS="[+region=tle]" LEARNERS=1`)
-	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicySchemaTest%'").Check(testkit.Rows("POLICY PolicySchemaTest LEADER_CONSTRAINTS=\"[+region=nl]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=se]\" LEARNERS=4 LEARNER_CONSTRAINTS=\"[+region=be]\" "))
-	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicyTableTest%'").Check(testkit.Rows("POLICY PolicyTableTest LEADER_CONSTRAINTS=\"[+region=tl]\" FOLLOWERS=2 FOLLOWER_CONSTRAINTS=\"[+region=tf]\" LEARNERS=1 LEARNER_CONSTRAINTS=\"[+region=tle]\" "))
+	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicySchemaTest%'").Check(testkit.Rows("POLICY PolicySchemaTest LEADER_CONSTRAINTS=\"[+region=nl]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=se]\" LEARNERS=4 LEARNER_CONSTRAINTS=\"[+region=be]\" NULL"))
+	tk.MustQuery("SHOW PLACEMENT like 'POLICY %PolicyTableTest%'").Check(testkit.Rows("POLICY PolicyTableTest LEADER_CONSTRAINTS=\"[+region=tl]\" FOLLOWERS=2 FOLLOWER_CONSTRAINTS=\"[+region=tf]\" LEARNERS=1 LEARNER_CONSTRAINTS=\"[+region=tle]\" NULL"))
 	tk.MustExec("CREATE SCHEMA SchemaPolicyPlacementTest PLACEMENT POLICY = `PolicySchemaTest`")
 	tk.MustQuery("SHOW CREATE SCHEMA SCHEMAPOLICYPLACEMENTTEST").Check(testkit.Rows("SchemaPolicyPlacementTest CREATE DATABASE `SchemaPolicyPlacementTest` /*!40100 DEFAULT CHARACTER SET utf8mb4 */ /*T![placement] PLACEMENT POLICY=`PolicySchemaTest` */"))
 

--- a/docs/design/2020-06-24-placement-rules-in-sql.md
+++ b/docs/design/2020-06-24-placement-rules-in-sql.md
@@ -229,8 +229,8 @@ SHOW PLACEMENT;
 +----------------------------+----------------------------------------------------------------------+------------------+
 | target                     | placement                                                            | scheduling_state |
 +----------------------------+----------------------------------------------------------------------+------------------+
-| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 |                  |
-| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             |                  |
+| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 | NULL             |
+| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | NULL             |
 | DATABASE test              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
 | TABLE test.t1              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
 | TABLE test.t1 PARTITION p1 | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | INPROGRESS       |
@@ -241,8 +241,8 @@ SHOW PLACEMENT LIKE 'POLICY%';
 +----------------------------+----------------------------------------------------------------------+------------------+
 | target                     | placement                                                            | scheduling_state |
 +----------------------------+----------------------------------------------------------------------+------------------+
-| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 |                  |
-| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             |                  |
+| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 | NULL             |
+| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | NULL             |
 +----------------------------+----------------------------------------------------------------------+------------------+
 2 rows in set (0.00 sec)
 
@@ -269,7 +269,7 @@ The output of this statement contains these fields:
   * For table, it is shown in the format `TABLE database_name.table_name`
   * For partition, it is shown in the format `TABLE database_name.table_name PARTITION partition_name`
 * Placement: An equivalent `ALTER` statement on `target` that defines the placement rule.
-* Scheduling state: The scheduling progress from the PD aspect. It is always empty for policies.
+* Scheduling state: The scheduling progress from the PD aspect. It is always `NULL` for policies.
 
 For finding the current use of a placement policy, the following syntax can be used:
 

--- a/docs/design/2020-06-24-placement-rules-in-sql.md
+++ b/docs/design/2020-06-24-placement-rules-in-sql.md
@@ -229,8 +229,8 @@ SHOW PLACEMENT;
 +----------------------------+----------------------------------------------------------------------+------------------+
 | target                     | placement                                                            | scheduling_state |
 +----------------------------+----------------------------------------------------------------------+------------------+
-| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 | SCHEDULED        |
-| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
+| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 |                  |
+| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             |                  |
 | DATABASE test              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
 | TABLE test.t1              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
 | TABLE test.t1 PARTITION p1 | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | INPROGRESS       |
@@ -241,8 +241,8 @@ SHOW PLACEMENT LIKE 'POLICY%';
 +----------------------------+----------------------------------------------------------------------+------------------+
 | target                     | placement                                                            | scheduling_state |
 +----------------------------+----------------------------------------------------------------------+------------------+
-| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 | SCHEDULED        |
-| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             | SCHEDULED        |
+| POLICY system              | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2" FOLLOWERS=4 |                  |
+| POLICY default             | PRIMARY_REGION="us-east-1" REGIONS="us-east-1,us-east-2"             |                  |
 +----------------------------+----------------------------------------------------------------------+------------------+
 2 rows in set (0.00 sec)
 
@@ -257,7 +257,6 @@ SHOW PLACEMENT FOR DATABASE test;
 3 rows in set (0.00 sec)
 ```
 
-
 TiDB will automatically find the effective rule based on the rule priorities.
 
 This statement outputs at most 1 line. For example, when querying a table, only the placement rule defined on the table itself is shown, and the partitions in it will not be shown.
@@ -265,12 +264,12 @@ This statement outputs at most 1 line. For example, when querying a table, only 
 The output of this statement contains these fields:
 
 * Target: The object queried. It can be a database, table, partition, or index.
-    * For policies, it is shown as the policy name.
-    * For database, it is shown in the format `DATABASE database_name`
-    * For table, it is shown in the format `TABLE database_name.table_name`
-    * For partition, it is shown in the format `TABLE database_name.table_name PARTITION partition_name`
+  * For policies, it is shown as the policy name.
+  * For database, it is shown in the format `DATABASE database_name`
+  * For table, it is shown in the format `TABLE database_name.table_name`
+  * For partition, it is shown in the format `TABLE database_name.table_name PARTITION partition_name`
 * Placement: An equivalent `ALTER` statement on `target` that defines the placement rule.
-* Scheduling state: The scheduling progress from the PD aspect.
+* Scheduling state: The scheduling progress from the PD aspect. It is always empty for policies.
 
 For finding the current use of a placement policy, the following syntax can be used:
 
@@ -1040,6 +1039,9 @@ CREATE PLACEMENT POLICY europe CONSTRAINTS="+region=eu-west-1" RESTRICTED;
 This specific semantic will be the hardest to implement because of the other dependencies in the server.
 
 ## Changelog
+
+* 2021-10-29:
+  - Add more description to 'scheduling_state'.
 
 * 2021-09-13:
   - Removed support for `VOTER_CONSTRAINTS` and `VOTERS`. The motivation for this change is that dictionary syntax is ambiguous cases when both `VOTER_CONSTRAINTS` and `FOLLOWER_CONSTAINTS` are set. We can re-add this syntax if there is a clear use-case requirement in future.

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -17,6 +17,7 @@ package infosync
 import (
 	"bytes"
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -366,6 +367,30 @@ func doRequestWithFailpoint(req *http.Request) (resp *http.Response, err error) 
 		return
 	}
 	return util2.InternalHTTPClient().Do(req)
+}
+
+// GetReplicationState is used to check if regions in the given keyranges are replicated from PD.
+func GetReplicationState(ctx context.Context, startKey []byte, endKey []byte) (bool, error) {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return false, err
+	}
+
+	if is.etcdCli == nil {
+		return false, nil
+	}
+
+	addrs := is.etcdCli.Endpoints()
+
+	if len(addrs) == 0 {
+		return false, errors.Errorf("pd unavailable")
+	}
+
+	res, err := doRequest(ctx, addrs, fmt.Sprintf("%s/replicated?startKey=%s&endKey=%s", pdapi.Regions, hex.EncodeToString(startKey), hex.EncodeToString(endKey)), "GET", nil)
+	if err == nil && res != nil {
+		return string(res) == "true\n", nil
+	}
+	return false, err
 }
 
 // GetAllRuleBundles is used to get all rule bundles from PD. It is used to load full rules from PD while fullload infoschema.

--- a/executor/show_placement.go
+++ b/executor/show_placement.go
@@ -259,7 +259,7 @@ func (e *ShowExec) fetchAllPlacementPolicies() error {
 	for _, policy := range policies {
 		name := policy.Name
 		settings := policy.PlacementSettings
-		e.appendRow([]interface{}{"POLICY " + name.String(), settings.String(), ""})
+		e.appendRow([]interface{}{"POLICY " + name.String(), settings.String(), "NULL"})
 	}
 
 	return nil

--- a/executor/show_placement.go
+++ b/executor/show_placement.go
@@ -480,7 +480,6 @@ func fetchDBScheduled(ctx context.Context, scheduleState map[int64]bool, db *mod
 func toScheduleStateString(schedule bool) string {
 	if schedule {
 		return "SCHEDULED"
-	} else {
-		return "INPROGRESS"
 	}
+	return "INPROGRESS"
 }

--- a/executor/show_placement.go
+++ b/executor/show_placement.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/domain/infosync"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
@@ -28,7 +29,9 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/types/json"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
 
@@ -134,7 +137,7 @@ func (e *ShowExec) fetchShowPlacementLabels(ctx context.Context) error {
 	return nil
 }
 
-func (e *ShowExec) fetchShowPlacementForDB(_ context.Context) (err error) {
+func (e *ShowExec) fetchShowPlacementForDB(ctx context.Context) (err error) {
 	checker := privilege.GetPrivilegeManager(e.ctx)
 	if checker != nil && e.ctx.GetSessionVars().User != nil {
 		if !checker.DBIsVisible(e.ctx.GetSessionVars().ActiveRoles, e.DBName.String()) {
@@ -153,13 +156,17 @@ func (e *ShowExec) fetchShowPlacementForDB(_ context.Context) (err error) {
 	}
 
 	if placement != nil {
-		e.appendRow([]interface{}{"DATABASE " + dbInfo.Name.String(), placement.String()})
+		schedule, err := fetchDBScheduled(ctx, nil, dbInfo)
+		if err != nil {
+			return err
+		}
+		e.appendRow([]interface{}{"DATABASE " + dbInfo.Name.String(), placement.String(), toScheduleStateString(schedule)})
 	}
 
 	return nil
 }
 
-func (e *ShowExec) fetchShowPlacementForTable(_ context.Context) (err error) {
+func (e *ShowExec) fetchShowPlacementForTable(ctx context.Context) (err error) {
 	tbl, err := e.getTable()
 	if err != nil {
 		return err
@@ -172,14 +179,18 @@ func (e *ShowExec) fetchShowPlacementForTable(_ context.Context) (err error) {
 	}
 
 	if placement != nil {
+		schedule, err := fetchTableScheduled(ctx, nil, tblInfo)
+		if err != nil {
+			return err
+		}
 		ident := ast.Ident{Schema: e.Table.DBInfo.Name, Name: tblInfo.Name}
-		e.appendRow([]interface{}{"TABLE " + ident.String(), placement.String()})
+		e.appendRow([]interface{}{"TABLE " + ident.String(), placement.String(), toScheduleStateString(schedule)})
 	}
 
 	return nil
 }
 
-func (e *ShowExec) fetchShowPlacementForPartition(_ context.Context) (err error) {
+func (e *ShowExec) fetchShowPlacementForPartition(ctx context.Context) (err error) {
 	tbl, err := e.getTable()
 	if err != nil {
 		return err
@@ -213,26 +224,33 @@ func (e *ShowExec) fetchShowPlacementForPartition(_ context.Context) (err error)
 	}
 
 	if placement != nil {
+		schedule, err := fetchPartitionScheduled(ctx, nil, partition)
+		if err != nil {
+			return err
+		}
 		tableIndent := ast.Ident{Schema: e.Table.DBInfo.Name, Name: tblInfo.Name}
 		e.appendRow([]interface{}{
 			fmt.Sprintf("TABLE %s PARTITION %s", tableIndent.String(), partition.Name.String()),
 			placement.String(),
+			toScheduleStateString(schedule),
 		})
 	}
 
 	return nil
 }
 
-func (e *ShowExec) fetchShowPlacement(_ context.Context) error {
+func (e *ShowExec) fetchShowPlacement(ctx context.Context) error {
 	if err := e.fetchAllPlacementPolicies(); err != nil {
 		return err
 	}
 
-	if err := e.fetchAllDBPlacements(); err != nil {
+	scheduled := make(map[int64]bool)
+
+	if err := e.fetchAllDBPlacements(ctx, scheduled); err != nil {
 		return err
 	}
 
-	return e.fetchAllTablePlacements()
+	return e.fetchAllTablePlacements(ctx, scheduled)
 }
 
 func (e *ShowExec) fetchAllPlacementPolicies() error {
@@ -241,13 +259,13 @@ func (e *ShowExec) fetchAllPlacementPolicies() error {
 	for _, policy := range policies {
 		name := policy.Name
 		settings := policy.PlacementSettings
-		e.appendRow([]interface{}{"POLICY " + name.String(), settings.String()})
+		e.appendRow([]interface{}{"POLICY " + name.String(), settings.String(), ""})
 	}
 
 	return nil
 }
 
-func (e *ShowExec) fetchAllDBPlacements() error {
+func (e *ShowExec) fetchAllDBPlacements(ctx context.Context, scheduleState map[int64]bool) error {
 	checker := privilege.GetPrivilegeManager(e.ctx)
 	activeRoles := e.ctx.GetSessionVars().ActiveRoles
 
@@ -265,14 +283,18 @@ func (e *ShowExec) fetchAllDBPlacements() error {
 		}
 
 		if placement != nil {
-			e.appendRow([]interface{}{"DATABASE " + dbInfo.Name.String(), placement.String()})
+			schedule, err := fetchDBScheduled(ctx, scheduleState, dbInfo)
+			if err != nil {
+				return err
+			}
+			e.appendRow([]interface{}{"DATABASE " + dbInfo.Name.String(), placement.String(), toScheduleStateString(schedule)})
 		}
 	}
 
 	return nil
 }
 
-func (e *ShowExec) fetchAllTablePlacements() error {
+func (e *ShowExec) fetchAllTablePlacements(ctx context.Context, scheduleState map[int64]bool) error {
 	checker := privilege.GetPrivilegeManager(e.ctx)
 	activeRoles := e.ctx.GetSessionVars().ActiveRoles
 
@@ -299,7 +321,11 @@ func (e *ShowExec) fetchAllTablePlacements() error {
 			}
 
 			if tblPlacement != nil {
-				rows = append(rows, []interface{}{"TABLE " + ident.String(), tblPlacement.String()})
+				schedule, err := fetchTableScheduled(ctx, scheduleState, tblInfo)
+				if err != nil {
+					return err
+				}
+				rows = append(rows, []interface{}{"TABLE " + ident.String(), tblPlacement.String(), toScheduleStateString(schedule)})
 			}
 
 			if tblInfo.Partition != nil {
@@ -310,9 +336,14 @@ func (e *ShowExec) fetchAllTablePlacements() error {
 					}
 
 					if partitionPlacement != nil {
+						schedule, err := fetchPartitionScheduled(ctx, scheduleState, &partition)
+						if err != nil {
+							return err
+						}
 						rows = append(rows, []interface{}{
 							fmt.Sprintf("TABLE %s PARTITION %s", ident.String(), partition.Name.String()),
 							partitionPlacement.String(),
+							toScheduleStateString(schedule),
 						})
 					}
 				}
@@ -386,4 +417,70 @@ func (e *ShowExec) getPolicyPlacement(policyRef *model.PolicyRefInfo) (settings 
 		return nil, errors.Errorf("Policy with name '%s' not found", policyRef.Name)
 	}
 	return policy.PlacementSettings, nil
+}
+
+func fetchScheduled(ctx context.Context, scheduleState map[int64]bool, id int64) (bool, error) {
+	if s, ok := scheduleState[id]; ok {
+		return s, nil
+	}
+	startKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(id))
+	endKey := codec.EncodeBytes(nil, tablecodec.GenTablePrefix(id+1))
+	schedule, err := infosync.GetReplicationState(ctx, startKey, endKey)
+	if err == nil && scheduleState != nil {
+		scheduleState[id] = schedule
+	}
+	return schedule, err
+}
+
+func fetchPartitionScheduled(ctx context.Context, scheduleState map[int64]bool, part *model.PartitionDefinition) (bool, error) {
+	return fetchScheduled(ctx, scheduleState, part.ID)
+}
+
+func fetchTableScheduled(ctx context.Context, scheduleState map[int64]bool, table *model.TableInfo) (bool, error) {
+	schedule, err := fetchScheduled(ctx, scheduleState, table.ID)
+	if err != nil {
+		return false, err
+	}
+	if !schedule {
+		return false, nil
+	}
+
+	if table.GetPartitionInfo() != nil {
+		for _, part := range table.GetPartitionInfo().Definitions {
+			schedule, err = fetchScheduled(ctx, scheduleState, part.ID)
+			if err != nil {
+				return false, err
+			}
+			if !schedule {
+				break
+			}
+		}
+	}
+
+	return schedule, nil
+}
+
+func fetchDBScheduled(ctx context.Context, scheduleState map[int64]bool, db *model.DBInfo) (bool, error) {
+	schedule := true
+
+	var err error
+	for _, table := range db.Tables {
+		schedule, err = fetchTableScheduled(ctx, scheduleState, table)
+		if err != nil {
+			return false, err
+		}
+		if !schedule {
+			break
+		}
+	}
+
+	return schedule, nil
+}
+
+func toScheduleStateString(schedule bool) string {
+	if schedule {
+		return "SCHEDULED"
+	} else {
+		return "INPROGRESS"
+	}
 }

--- a/executor/show_placement_test.go
+++ b/executor/show_placement_test.go
@@ -84,33 +84,33 @@ func (s *testSuite5) TestShowPlacement(c *C) {
 	defer tk.MustExec("drop table if exists db2.t2")
 
 	tk.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\"",
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\"",
-		"DATABASE db2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\"",
-		"DATABASE db3 LEADER_CONSTRAINTS=\"[+region=hz]\" FOLLOWERS=3",
-		"TABLE db2.t2 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2",
-		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"TABLE test.t2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2",
-		"TABLE test.t4 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"TABLE test.t4 PARTITION p0 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\"",
-		"TABLE test.t4 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\"",
-		"TABLE test.t4 PARTITION p2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
+		"DATABASE db2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" INPROGRESS",
+		"DATABASE db3 LEADER_CONSTRAINTS=\"[+region=hz]\" FOLLOWERS=3 SCHEDULED",
+		"TABLE db2.t2 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2 INPROGRESS",
+		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
+		"TABLE test.t2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2 INPROGRESS",
+		"TABLE test.t4 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
+		"TABLE test.t4 PARTITION p0 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" INPROGRESS",
+		"TABLE test.t4 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
+		"TABLE test.t4 PARTITION p2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 	))
 
 	tk.MustQuery("show placement like 'POLICY%'").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\"",
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\"",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
 	))
 
 	tk.MustQuery("show placement like 'POLICY pa%'").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\"",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
 	))
 
 	tk.MustQuery("show placement where Target='POLICY pb1'").Check(testkit.Rows(
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\"",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
 	))
 }
 
@@ -163,7 +163,7 @@ func (s *testSuite5) TestShowPlacementPrivilege(c *C) {
 
 	// before grant
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
 	))
 
 	// do some grant
@@ -173,11 +173,11 @@ func (s *testSuite5) TestShowPlacementPrivilege(c *C) {
 
 	// after grant
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"DATABASE db2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"TABLE db2.t1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2",
-		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-		"TABLE test.t3 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\"",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"DATABASE db2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
+		"TABLE db2.t1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2 INPROGRESS",
+		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
+		"TABLE test.t3 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
 	))
 }
 
@@ -204,10 +204,10 @@ func (s *testSuite5) TestShowPlacementForDB(c *C) {
 
 	tk.MustQuery("show placement for database test").Check(testkit.Rows())
 	tk.MustQuery("show placement for database db2").Check(testkit.Rows(
-		"DATABASE db2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"DATABASE db2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" SCHEDULED",
 	))
 	tk.MustQuery("show placement for database db3").Check(testkit.Rows(
-		"DATABASE db3 LEADER_CONSTRAINTS=\"[+region=hz]\" FOLLOWERS=3",
+		"DATABASE db3 LEADER_CONSTRAINTS=\"[+region=hz]\" FOLLOWERS=3 SCHEDULED",
 	))
 }
 
@@ -228,14 +228,14 @@ func (s *testSuite5) TestShowPlacementForTableAndPartition(c *C) {
 	tk.MustExec("create table t1 (id int) placement policy p1")
 	defer tk.MustExec("drop table if exists t1")
 	tk.MustQuery("show placement for table t1").Check(testkit.Rows(
-		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 	))
 
 	// table direct setting
 	tk.MustExec("create table t2 (id int) LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2")
 	defer tk.MustExec("drop table if exists t2")
 	tk.MustQuery("show placement for table t2").Check(testkit.Rows(
-		"TABLE test.t2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2",
+		"TABLE test.t2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2 INPROGRESS",
 	))
 
 	// table no placement
@@ -251,20 +251,20 @@ func (s *testSuite5) TestShowPlacementForTableAndPartition(c *C) {
 		")")
 	defer tk.MustExec("drop table if exists t4")
 	tk.MustQuery("show placement for table t4").Check(testkit.Rows(
-		"TABLE test.t4 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2",
+		"TABLE test.t4 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2 INPROGRESS",
 	))
 
 	// partition inherent table
 	tk.MustQuery("show placement for table t4 partition p0").Check(testkit.Rows(
-		"TABLE test.t4 PARTITION p0 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2",
+		"TABLE test.t4 PARTITION p0 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=2 INPROGRESS",
 	))
 
 	// partition custom placement
 	tk.MustQuery("show placement for table t4 partition p1").Check(testkit.Rows(
-		"TABLE test.t4 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\"",
+		"TABLE test.t4 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
 	))
 	tk.MustQuery("show placement for table t4 partition p2").Check(testkit.Rows(
-		"TABLE test.t4 PARTITION p2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"TABLE test.t4 PARTITION p2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 	))
 
 	// partition without placement
@@ -279,7 +279,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartition(c *C) {
 	tk.MustExec("create table db2.t1 (id int) LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2")
 	defer tk.MustExec("drop table if exists db2.t1")
 	tk.MustQuery("show placement for table db2.t1").Check(testkit.Rows(
-		"TABLE db2.t1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2",
+		"TABLE db2.t1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2 INPROGRESS",
 	))
 
 	// not exists
@@ -341,12 +341,12 @@ func (s *testSuite5) TestShowPlacementForDBPrivilege(c *C) {
 		// do grant
 		tk.MustExec(fmt.Sprintf("grant %s to 'user1'@'%%'", priv))
 		tk1.MustQuery("show placement for database db2").Check(testkit.Rows(
-			"DATABASE db2 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\"",
+			"DATABASE db2 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\" INPROGRESS",
 		))
 
 		tk1.MustQuery("show placement").Check(testkit.Rows(
-			"DATABASE db2 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\"",
-			"TABLE db2.t1 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r3\" SCHEDULE=\"EVEN\"",
+			"DATABASE db2 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r2\" SCHEDULE=\"EVEN\" INPROGRESS",
+			"TABLE db2.t1 PRIMARY_REGION=\"r1\" REGIONS=\"r1,r3\" SCHEDULE=\"EVEN\" INPROGRESS",
 		))
 
 		err = tk1.QueryToErr("show placement for database test")
@@ -419,7 +419,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 	c.Assert(err.Error(), Equals, core.ErrTableaccessDenied.GenWithStackByArgs("SHOW", "user1", "%", "t1").Error())
 
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
 	))
 
 	privs := []string{
@@ -436,17 +436,17 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 		// do grant
 		tk.MustExec(fmt.Sprintf("grant %s to 'user1'@'%%'", priv))
 		tk1.MustQuery("show placement").Check(testkit.Rows(
-			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-			"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
-			"TABLE test.t1 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\"",
+			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+			"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
+			"TABLE test.t1 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
 		))
 
 		tk1.MustQuery("show placement for table test.t1").Check(testkit.Rows(
-			"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+			"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 		))
 
 		tk1.MustQuery("show placement for table test.t1 partition p1").Check(testkit.Rows(
-			"TABLE test.t1 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\"",
+			"TABLE test.t1 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
 		))
 
 		err = tk1.ExecToErr("show placement for table test.t2")
@@ -464,7 +464,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 		c.Assert(err.Error(), Equals, core.ErrTableaccessDenied.GenWithStackByArgs("SHOW", "user1", "%", "t1").Error())
 
 		tk1.MustQuery("show placement").Check(testkit.Rows(
-			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\"",
+			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
 		))
 	}
 }

--- a/executor/show_placement_test.go
+++ b/executor/show_placement_test.go
@@ -84,9 +84,9 @@ func (s *testSuite5) TestShowPlacement(c *C) {
 	defer tk.MustExec("drop table if exists db2.t2")
 
 	tk.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" NULL",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" NULL",
 		"DATABASE db2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" INPROGRESS",
 		"DATABASE db3 LEADER_CONSTRAINTS=\"[+region=hz]\" FOLLOWERS=3 SCHEDULED",
 		"TABLE db2.t2 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2 INPROGRESS",
@@ -99,18 +99,18 @@ func (s *testSuite5) TestShowPlacement(c *C) {
 	))
 
 	tk.MustQuery("show placement like 'POLICY%'").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" NULL",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" NULL",
 	))
 
 	tk.MustQuery("show placement like 'POLICY pa%'").Check(testkit.Rows(
-		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
-		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" ",
+		"POLICY pa1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
+		"POLICY pa2 LEADER_CONSTRAINTS=\"[+region=us-east-1]\" FOLLOWERS=3 FOLLOWER_CONSTRAINTS=\"[+region=us-east-2]\" NULL",
 	))
 
 	tk.MustQuery("show placement where Target='POLICY pb1'").Check(testkit.Rows(
-		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" ",
+		"POLICY pb1 CONSTRAINTS=\"[+disk=ssd]\" VOTERS=5 VOTER_CONSTRAINTS=\"[+region=bj]\" LEARNERS=3 LEARNER_CONSTRAINTS=\"[+region=sh]\" NULL",
 	))
 }
 
@@ -163,7 +163,7 @@ func (s *testSuite5) TestShowPlacementPrivilege(c *C) {
 
 	// before grant
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
 	))
 
 	// do some grant
@@ -173,7 +173,7 @@ func (s *testSuite5) TestShowPlacementPrivilege(c *C) {
 
 	// after grant
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
 		"DATABASE db2 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 		"TABLE db2.t1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=2 INPROGRESS",
 		"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
@@ -419,7 +419,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 	c.Assert(err.Error(), Equals, core.ErrTableaccessDenied.GenWithStackByArgs("SHOW", "user1", "%", "t1").Error())
 
 	tk1.MustQuery("show placement").Check(testkit.Rows(
-		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+		"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
 	))
 
 	privs := []string{
@@ -436,7 +436,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 		// do grant
 		tk.MustExec(fmt.Sprintf("grant %s to 'user1'@'%%'", priv))
 		tk1.MustQuery("show placement").Check(testkit.Rows(
-			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
 			"TABLE test.t1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" INPROGRESS",
 			"TABLE test.t1 PARTITION p1 LEADER_CONSTRAINTS=\"[+region=bj]\" FOLLOWERS=4 FOLLOWER_CONSTRAINTS=\"[+region=sh]\" INPROGRESS",
 		))
@@ -464,7 +464,7 @@ func (s *testSuite5) TestShowPlacementForTableAndPartitionPrivilege(c *C) {
 		c.Assert(err.Error(), Equals, core.ErrTableaccessDenied.GenWithStackByArgs("SHOW", "user1", "%", "t1").Error())
 
 		tk1.MustQuery("show placement").Check(testkit.Rows(
-			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" ",
+			"POLICY p1 PRIMARY_REGION=\"cn-east-1\" REGIONS=\"cn-east-1,cn-east-2\" SCHEDULE=\"EVEN\" NULL",
 		))
 	}
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -4332,7 +4332,7 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		names = []string{"Key", "Values"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeJSON}
 	case ast.ShowPlacement, ast.ShowPlacementForDatabase, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
-		names = []string{"Target", "Placement", "Scheduleing_State"}
+		names = []string{"Target", "Placement", "Scheduling_State"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar}
 	}
 

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -4332,8 +4332,8 @@ func buildShowSchema(s *ast.ShowStmt, isView bool, isSequence bool) (schema *exp
 		names = []string{"Key", "Values"}
 		ftypes = []byte{mysql.TypeVarchar, mysql.TypeJSON}
 	case ast.ShowPlacement, ast.ShowPlacementForDatabase, ast.ShowPlacementForTable, ast.ShowPlacementForPartition:
-		names = []string{"Target", "Placement"}
-		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar}
+		names = []string{"Target", "Placement", "Scheduleing_State"}
+		ftypes = []byte{mysql.TypeVarchar, mysql.TypeVarchar, mysql.TypeVarchar}
 	}
 
 	schema = expression.NewSchema(make([]*expression.Column, 0, len(names))...)


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #28199

Problem Summary: Support schedule state query for placement rules, together with some revisions on the RFC.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)

```sh
mycli -h 127.0.0.1 -P 4000 -u root --no-warn << "EOF"
use test;
drop table if exists test.table1;
drop placement policy if exists x;
create placement policy x FOLLOWERS=1;
create table test.table1 (id int primary key) placement policy = "x";
insert into test.table1 values (1);
insert into test.table1 values (2);
insert into test.table1 values (3);
insert into test.table1 values (4);
insert into test.table1 values (5);
show placement;
show placement for database test;
show placement for table table1;
EOF
```

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Support query scheduling state using `show placement ...` statements.
```
