### PR TITLE
conifg, sessionctx: set default value "/data/deploy/plugin" for plugin_dir

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -675,6 +675,10 @@ var defaultConf = Config{
 		WriteTimeout: "15s",
 		Strategy:     "range",
 	},
+	Plugin: Plugin{
+		Dir:  "/data/deploy/plugin",
+		Load: "",
+	},
 	PessimisticTxn: DefaultPessimisticTxn(),
 	StmtSummary: StmtSummary{
 		Enable:              true,

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1718,10 +1718,10 @@ var defaultSysVars = []*SysVar{
 	}},
 	{Scope: ScopeNone, Name: TiDBEnableEnhancedSecurity, Value: Off, Type: TypeBool},
 	{Scope: ScopeSession, Name: PluginLoad, Value: "", GetSession: func(s *SessionVars) (string, error) {
-		return config.GetGlobalConfig().Plugin.Dir, nil
+		return config.GetGlobalConfig().Plugin.Load, nil
 	}},
 	{Scope: ScopeSession, Name: PluginDir, Value: "/data/deploy/plugin", GetSession: func(s *SessionVars) (string, error) {
-		return config.GetGlobalConfig().Plugin.Load, nil
+		return config.GetGlobalConfig().Plugin.Dir, nil
 	}},
 
 	/* tikv gc metrics */


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #28084

Problem Summary: set default value "/data/deploy/plugin" for plugin_dir

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
