### PR TITLE
ddl/table_test.go: migrate infra to testify

### DIFF
--- a/ddl/callback_test.go
+++ b/ddl/callback_test.go
@@ -117,7 +117,7 @@ func (tc *TestDDLCallback) OnWatched(ctx context.Context) {
 	tc.BaseCallback.OnWatched(ctx)
 }
 
-func (s *testDDLSuite) TestCallback(c *C) {
+func (tc *TestDDLCallback) TestCallback(c *C) {
 	cb := &BaseCallback{}
 	c.Assert(cb.OnChanged(nil), IsNil)
 	cb.OnJobRunBefore(nil)

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -17,7 +17,6 @@ package ddl
 import (
 	"context"
 	"os"
-	"reflect"
 	"testing"
 	"time"
 
@@ -148,15 +147,9 @@ func checkEqualTable(t *testing.T, t1, t2 *model.TableInfo) {
 	require.Equal(t, t1.Name, t2.Name)
 	require.Equal(t, t1.Charset, t2.Charset)
 	require.Equal(t, t1.Collate, t2.Collate)
-	if !reflect.DeepEqual(t1.PKIsHandle, t2.PKIsHandle) {
-		t.FailNow()
-	}
-	if !reflect.DeepEqual(t1.Comment, t2.Comment) {
-		t.FailNow()
-	}
-	if !reflect.DeepEqual(t1.AutoIncID, t2.AutoIncID) {
-		t.FailNow()
-	}
+	require.Equal(t, t1.PKIsHandle, t2.PKIsHandle)
+	require.Equal(t, t1.Comment, t2.Comment)
+	require.Equal(t, t1.AutoIncID, t2.AutoIncID)
 }
 
 func checkHistoryJob(t *testing.T, job *model.Job) {
@@ -179,9 +172,7 @@ func checkHistoryJobArgs(t *testing.T, ctx sessionctx.Context, id int64, args *h
 
 	// for handling schema job
 	require.Equal(t, historyJob.BinlogInfo.SchemaVersion, args.ver)
-	if !reflect.DeepEqual(historyJob.BinlogInfo.DBInfo, args.db) {
-		t.FailNow()
-	}
+	require.Equal(t, historyJob.BinlogInfo.DBInfo, args.db)
 	// only for creating schema job
 	if args.db != nil && len(args.tblIDs) == 0 {
 		return

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -17,6 +17,7 @@ package ddl
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
+	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/tikv"
 )
 
@@ -96,21 +98,24 @@ func TestT(t *testing.T) {
 	testleak.AfterTestT(t)()
 }
 
-func testNewDDLAndStart(ctx context.Context, c *C, options ...Option) *ddl {
+func testNewDDLAndStart(ctx context.Context, t *testing.T, options ...Option) *ddl {
 	// init infoCache and a stub infoSchema
 	ic := infoschema.NewCache(2)
 	ic.Insert(infoschema.MockInfoSchemaWithSchemaVer(nil, 0), 0)
 	options = append(options, WithInfoCache(ic))
 	d := newDDL(ctx, options...)
 	err := d.Start(nil)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
+
+	_, err = infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, true)
+	require.NoError(t, err)
 
 	return d
 }
 
-func testCreateStore(c *C, name string) kv.Storage {
+func testCreateStore(t *testing.T, name string) kv.Storage {
 	store, err := mockstore.NewMockStore()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	return store
 }
 
@@ -120,14 +125,14 @@ func testNewContext(d *ddl) sessionctx.Context {
 	return ctx
 }
 
-func getSchemaVer(c *C, ctx sessionctx.Context) int64 {
+func getSchemaVer(t *testing.T, ctx sessionctx.Context) int64 {
 	err := ctx.NewTxn(context.Background())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	txn, err := ctx.Txn(true)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	m := meta.NewMeta(txn)
 	ver, err := m.GetSchemaVersion()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	return ver
 }
 
@@ -138,37 +143,45 @@ type historyJobArgs struct {
 	tblIDs map[int64]struct{}
 }
 
-func checkEqualTable(c *C, t1, t2 *model.TableInfo) {
-	c.Assert(t1.ID, Equals, t2.ID)
-	c.Assert(t1.Name, Equals, t2.Name)
-	c.Assert(t1.Charset, Equals, t2.Charset)
-	c.Assert(t1.Collate, Equals, t2.Collate)
-	c.Assert(t1.PKIsHandle, DeepEquals, t2.PKIsHandle)
-	c.Assert(t1.Comment, DeepEquals, t2.Comment)
-	c.Assert(t1.AutoIncID, DeepEquals, t2.AutoIncID)
+func checkEqualTable(t *testing.T, t1, t2 *model.TableInfo) {
+	require.Equal(t, t1.ID, t2.ID)
+	require.Equal(t, t1.Name, t2.Name)
+	require.Equal(t, t1.Charset, t2.Charset)
+	require.Equal(t, t1.Collate, t2.Collate)
+	if !reflect.DeepEqual(t1.PKIsHandle, t2.PKIsHandle) {
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(t1.Comment, t2.Comment) {
+		t.FailNow()
+	}
+	if !reflect.DeepEqual(t1.AutoIncID, t2.AutoIncID) {
+		t.FailNow()
+	}
 }
 
-func checkHistoryJob(c *C, job *model.Job) {
-	c.Assert(job.State, Equals, model.JobStateSynced)
+func checkHistoryJob(t *testing.T, job *model.Job) {
+	require.Equal(t, job.State, model.JobStateSynced)
 }
 
-func checkHistoryJobArgs(c *C, ctx sessionctx.Context, id int64, args *historyJobArgs) {
+func checkHistoryJobArgs(t *testing.T, ctx sessionctx.Context, id int64, args *historyJobArgs) {
 	txn, err := ctx.Txn(true)
-	c.Assert(err, IsNil)
-	t := meta.NewMeta(txn)
-	historyJob, err := t.GetHistoryDDLJob(id)
-	c.Assert(err, IsNil)
-	c.Assert(historyJob.BinlogInfo.FinishedTS, Greater, uint64(0))
+	require.NoError(t, err)
+	trans := meta.NewMeta(txn)
+	historyJob, err := trans.GetHistoryDDLJob(id)
+	require.NoError(t, err)
+	require.Greater(t, historyJob.BinlogInfo.FinishedTS, uint64(0))
 
 	if args.tbl != nil {
-		c.Assert(historyJob.BinlogInfo.SchemaVersion, Equals, args.ver)
-		checkEqualTable(c, historyJob.BinlogInfo.TableInfo, args.tbl)
+		require.Equal(t, historyJob.BinlogInfo.SchemaVersion, args.ver)
+		checkEqualTable(t, historyJob.BinlogInfo.TableInfo, args.tbl)
 		return
 	}
 
 	// for handling schema job
-	c.Assert(historyJob.BinlogInfo.SchemaVersion, Equals, args.ver)
-	c.Assert(historyJob.BinlogInfo.DBInfo, DeepEquals, args.db)
+	require.Equal(t, historyJob.BinlogInfo.SchemaVersion, args.ver)
+	if !reflect.DeepEqual(historyJob.BinlogInfo.DBInfo, args.db) {
+		t.FailNow()
+	}
 	// only for creating schema job
 	if args.db != nil && len(args.tblIDs) == 0 {
 		return
@@ -199,26 +212,26 @@ func buildModifyColJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo) *model.Jo
 	}
 }
 
-func testCreatePrimaryKey(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, colName string) *model.Job {
+func testCreatePrimaryKey(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, colName string) *model.Job {
 	job := buildCreateIdxJob(dbInfo, tblInfo, true, "primary", colName)
 	job.Type = model.ActionAddPrimaryKey
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
-func testCreateIndex(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bool, indexName string, colName string) *model.Job {
+func testCreateIndex(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bool, indexName string, colName string) *model.Job {
 	job := buildCreateIdxJob(dbInfo, tblInfo, unique, indexName, colName)
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
-func testAddColumn(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, args []interface{}) *model.Job {
+func testAddColumn(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, args []interface{}) *model.Job {
 	job := &model.Job{
 		SchemaID:   dbInfo.ID,
 		TableID:    tblInfo.ID,
@@ -227,13 +240,13 @@ func testAddColumn(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, t
 		BinlogInfo: &model.HistoryInfo{},
 	}
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
-func testAddColumns(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, args []interface{}) *model.Job {
+func testAddColumns(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, args []interface{}) *model.Job {
 	job := &model.Job{
 		SchemaID:   dbInfo.ID,
 		TableID:    tblInfo.ID,
@@ -242,9 +255,9 @@ func testAddColumns(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, 
 		BinlogInfo: &model.HistoryInfo{},
 	}
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
@@ -262,12 +275,12 @@ func buildDropIdxJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, indexName s
 	}
 }
 
-func testDropIndex(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, indexName string) *model.Job {
+func testDropIndex(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, indexName string) *model.Job {
 	job := buildDropIdxJob(dbInfo, tblInfo, indexName)
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
@@ -281,7 +294,7 @@ func buildRebaseAutoIDJobJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, new
 	}
 }
 
-func (s *testDDLSuite) TestGetIntervalFromPolicy(c *C) {
+func TestGetIntervalFromPolicy(t *testing.T) {
 	policy := []time.Duration{
 		1 * time.Second,
 		2 * time.Second,
@@ -292,18 +305,18 @@ func (s *testDDLSuite) TestGetIntervalFromPolicy(c *C) {
 	)
 
 	val, changed = getIntervalFromPolicy(policy, 0)
-	c.Assert(val, Equals, 1*time.Second)
-	c.Assert(changed, Equals, true)
+	require.Equal(t, val, 1*time.Second)
+	require.Equal(t, changed, true)
 
 	val, changed = getIntervalFromPolicy(policy, 1)
-	c.Assert(val, Equals, 2*time.Second)
-	c.Assert(changed, Equals, true)
+	require.Equal(t, val, 2*time.Second)
+	require.Equal(t, changed, true)
 
 	val, changed = getIntervalFromPolicy(policy, 2)
-	c.Assert(val, Equals, 2*time.Second)
-	c.Assert(changed, Equals, false)
+	require.Equal(t, val, 2*time.Second)
+	require.Equal(t, changed, false)
 
 	val, changed = getIntervalFromPolicy(policy, 3)
-	c.Assert(val, Equals, 2*time.Second)
-	c.Assert(changed, Equals, false)
+	require.Equal(t, val, 2*time.Second)
+	require.Equal(t, changed, false)
 }

--- a/ddl/fail_test.go
+++ b/ddl/fail_test.go
@@ -16,40 +16,43 @@ package ddl
 
 import (
 	"context"
+	"testing"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
 )
 
-func (s *testColumnChangeSuite) TestFailBeforeDecodeArgs(c *C) {
+func TestFailBeforeDecodeArgs(t *testing.T) {
+	s, clean := createColumnChangeSuite(t)
+	defer clean()
 	d := testNewDDLAndStart(
 		context.Background(),
-		c,
+		t,
 		WithStore(s.store),
 		WithLease(testLease),
 	)
 	defer func() {
 		err := d.Stop()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 	// create table t_fail (c1 int, c2 int);
-	tblInfo := testTableInfo(c, d, "t_fail", 2)
+	tblInfo := testTableInfo(t, d, "t_fail", 2)
 	ctx := testNewContext(d)
 	err := ctx.NewTxn(context.Background())
-	c.Assert(err, IsNil)
-	testCreateTable(c, ctx, d, s.dbInfo, tblInfo)
+	require.NoError(t, err)
+	testCreateTable(t, ctx, d, s.dbInfo, tblInfo)
 	// insert t_fail values (1, 2);
-	originTable := testGetTable(c, d, s.dbInfo.ID, tblInfo.ID)
+	originTable := testGetTable(t, d, s.dbInfo.ID, tblInfo.ID)
 	row := types.MakeDatums(1, 2)
 	_, err = originTable.AddRecord(ctx, row)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	txn, err := ctx.Txn(true)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = txn.Commit(context.Background())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	tc := &TestDDLCallback{}
 	first := true
@@ -61,17 +64,17 @@ func (s *testColumnChangeSuite) TestFailBeforeDecodeArgs(c *C) {
 			stateCnt++
 		} else if job.SchemaState == model.StateWriteReorganization {
 			if first {
-				c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/errorBeforeDecodeArgs", `return(true)`), IsNil)
+				require.Nil(t, failpoint.Enable("github.com/pingcap/tidb/ddl/errorBeforeDecodeArgs", `return(true)`))
 				first = false
 			} else {
-				c.Assert(failpoint.Disable("github.com/pingcap/tidb/ddl/errorBeforeDecodeArgs"), IsNil)
+				require.Nil(t, failpoint.Disable("github.com/pingcap/tidb/ddl/errorBeforeDecodeArgs"))
 			}
 		}
 	}
 	d.SetHook(tc)
 	defaultValue := int64(3)
-	job := testCreateColumn(c, ctx, d, s.dbInfo, tblInfo, "c3", &ast.ColumnPosition{Tp: ast.ColumnPositionNone}, defaultValue)
+	job := testCreateColumn(t, ctx, d, s.dbInfo, tblInfo, "c3", &ast.ColumnPosition{Tp: ast.ColumnPositionNone}, defaultValue)
 	// Make sure the schema state only appears once.
-	c.Assert(stateCnt, Equals, 1)
-	testCheckJobDone(c, d, job, true)
+	require.Equal(t, stateCnt, 1)
+	testCheckJobDone(t, d, job, true)
 }

--- a/ddl/partition_test.go
+++ b/ddl/partition_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -27,22 +26,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-var _ = SerialSuites(&testPartitionSuite{})
-
-type testPartitionSuite struct {
+type partitionSuite struct {
 	store kv.Storage
 }
 
-func (s *testPartitionSuite) SetUpSuite(t *testing.T) {
+func createPartitionSuite(t *testing.T) (s *partitionSuite, clean func()) {
+	s = new(partitionSuite)
 	s.store = testCreateStore(t, "test_store")
+	clean = func() {
+		err := s.store.Close()
+		require.NoError(t, err)
+	}
+	return
 }
 
-func (s *testPartitionSuite) TearDownSuite(t *testing.T) {
-	err := s.store.Close()
-	require.NoError(t, err)
-}
-
-func (s *testPartitionSuite) TestDropAndTruncatePartition(t *testing.T) {
+func TestDropAndTruncatePartition(t *testing.T) {
+	s, clean := createPartitionSuite(t)
+	defer clean()
 	d := testNewDDLAndStart(
 		context.Background(),
 		t,

--- a/ddl/partition_test.go
+++ b/ddl/partition_test.go
@@ -16,6 +16,7 @@ package ddl
 
 import (
 	"context"
+	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/kv"
@@ -23,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
 )
 
 var _ = SerialSuites(&testPartitionSuite{})
@@ -31,39 +33,39 @@ type testPartitionSuite struct {
 	store kv.Storage
 }
 
-func (s *testPartitionSuite) SetUpSuite(c *C) {
-	s.store = testCreateStore(c, "test_store")
+func (s *testPartitionSuite) SetUpSuite(t *testing.T) {
+	s.store = testCreateStore(t, "test_store")
 }
 
-func (s *testPartitionSuite) TearDownSuite(c *C) {
+func (s *testPartitionSuite) TearDownSuite(t *testing.T) {
 	err := s.store.Close()
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 }
 
-func (s *testPartitionSuite) TestDropAndTruncatePartition(c *C) {
+func (s *testPartitionSuite) TestDropAndTruncatePartition(t *testing.T) {
 	d := testNewDDLAndStart(
 		context.Background(),
-		c,
+		t,
 		WithStore(s.store),
 		WithLease(testLease),
 	)
 	defer func() {
 		err := d.Stop()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
-	dbInfo := testSchemaInfo(c, d, "test_partition")
-	testCreateSchema(c, testNewContext(d), d, dbInfo)
+	dbInfo := testSchemaInfo(t, d, "test_partition")
+	testCreateSchema(t, testNewContext(d), d, dbInfo)
 	// generate 5 partition in tableInfo.
-	tblInfo, partIDs := buildTableInfoWithPartition(c, d)
+	tblInfo, partIDs := buildTableInfoWithPartition(t, d)
 	ctx := testNewContext(d)
-	testCreateTable(c, ctx, d, dbInfo, tblInfo)
+	testCreateTable(t, ctx, d, dbInfo, tblInfo)
 
-	testDropPartition(c, ctx, d, dbInfo, tblInfo, []string{"p0", "p1"})
+	testDropPartition(t, ctx, d, dbInfo, tblInfo, []string{"p0", "p1"})
 
-	testTruncatePartition(c, ctx, d, dbInfo, tblInfo, []int64{partIDs[3], partIDs[4]})
+	testTruncatePartition(t, ctx, d, dbInfo, tblInfo, []int64{partIDs[3], partIDs[4]})
 }
 
-func buildTableInfoWithPartition(c *C, d *ddl) (*model.TableInfo, []int64) {
+func buildTableInfoWithPartition(t *testing.T, d *ddl) (*model.TableInfo, []int64) {
 	tbl := &model.TableInfo{
 		Name: model.NewCIStr("t"),
 	}
@@ -75,14 +77,14 @@ func buildTableInfoWithPartition(c *C, d *ddl) (*model.TableInfo, []int64) {
 		ID:        allocateColumnID(tbl),
 	}
 	genIDs, err := d.genGlobalIDs(1)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	tbl.ID = genIDs[0]
 	tbl.Columns = []*model.ColumnInfo{col}
 	tbl.Charset = "utf8"
 	tbl.Collate = "utf8_bin"
 
 	partIDs, err := d.genGlobalIDs(5)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	partInfo := &model.PartitionInfo{
 		Type:   model.PartitionTypeRange,
 		Expr:   tbl.Columns[0].Name.L,
@@ -129,12 +131,12 @@ func buildDropPartitionJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, partN
 	}
 }
 
-func testDropPartition(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, partNames []string) *model.Job {
+func testDropPartition(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, partNames []string) *model.Job {
 	job := buildDropPartitionJob(dbInfo, tblInfo, partNames)
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }
 
@@ -148,11 +150,11 @@ func buildTruncatePartitionJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, p
 	}
 }
 
-func testTruncatePartition(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, pids []int64) *model.Job {
+func testTruncatePartition(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, pids []int64) *model.Job {
 	job := buildTruncatePartitionJob(dbInfo, tblInfo, pids)
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
-	v := getSchemaVer(c, ctx)
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
+	require.NoError(t, err)
+	v := getSchemaVer(t, ctx)
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v, tbl: tblInfo})
 	return job
 }

--- a/ddl/placement_policy_ddl_test.go
+++ b/ddl/placement_policy_ddl_test.go
@@ -15,27 +15,28 @@ package ddl
 
 import (
 	"context"
+	"testing"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/stretchr/testify/require"
 )
 
-func testPlacementPolicyInfo(c *C, d *ddl, name string, settings *model.PlacementSettings) *model.PolicyInfo {
+func testPlacementPolicyInfo(t *testing.T, d *ddl, name string, settings *model.PlacementSettings) *model.PolicyInfo {
 	policy := &model.PolicyInfo{
 		Name:              model.NewCIStr(name),
 		PlacementSettings: settings,
 	}
 	genIDs, err := d.genGlobalIDs(1)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	policy.ID = genIDs[0]
 	return policy
 }
 
-func testCreatePlacementPolicy(c *C, ctx sessionctx.Context, d *ddl, policyInfo *model.PolicyInfo) *model.Job {
+func testCreatePlacementPolicy(t *testing.T, ctx sessionctx.Context, d *ddl, policyInfo *model.PolicyInfo) *model.Job {
 	job := &model.Job{
 		SchemaName: policyInfo.Name.L,
 		Type:       model.ActionCreatePlacementPolicy,
@@ -43,72 +44,72 @@ func testCreatePlacementPolicy(c *C, ctx sessionctx.Context, d *ddl, policyInfo 
 		Args:       []interface{}{policyInfo},
 	}
 	err := d.doDDLJob(ctx, job)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
-	v := getSchemaVer(c, ctx)
+	v := getSchemaVer(t, ctx)
 	policyInfo.State = model.StatePublic
-	checkHistoryJobArgs(c, ctx, job.ID, &historyJobArgs{ver: v})
+	checkHistoryJobArgs(t, ctx, job.ID, &historyJobArgs{ver: v})
 	policyInfo.State = model.StateNone
 	return job
 }
 
-func (s *testDDLSuite) TestPlacementPolicyInUse(c *C) {
-	store := testCreateStore(c, "test_placement_policy_in_use")
+func TestPlacementPolicyInUse(t *testing.T) {
+	store := testCreateStore(t, "test_placement_policy_in_use")
 	defer func() {
 		err := store.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	ctx := context.Background()
-	d := testNewDDLAndStart(ctx, c, WithStore(store))
+	d := testNewDDLAndStart(ctx, t, WithStore(store))
 	sctx := testNewContext(d)
 
-	db1 := testSchemaInfo(c, d, "db1")
-	testCreateSchema(c, sctx, d, db1)
+	db1 := testSchemaInfo(t, d, "db1")
+	testCreateSchema(t, sctx, d, db1)
 	db1.State = model.StatePublic
 
-	db2 := testSchemaInfo(c, d, "db2")
-	testCreateSchema(c, sctx, d, db2)
+	db2 := testSchemaInfo(t, d, "db2")
+	testCreateSchema(t, sctx, d, db2)
 	db2.State = model.StatePublic
 
 	policySettings := &model.PlacementSettings{PrimaryRegion: "r1", Regions: "r1,r2"}
-	p1 := testPlacementPolicyInfo(c, d, "p1", policySettings)
-	p2 := testPlacementPolicyInfo(c, d, "p2", policySettings)
-	p3 := testPlacementPolicyInfo(c, d, "p3", policySettings)
-	p4 := testPlacementPolicyInfo(c, d, "p4", policySettings)
-	p5 := testPlacementPolicyInfo(c, d, "p5", policySettings)
-	testCreatePlacementPolicy(c, sctx, d, p1)
-	testCreatePlacementPolicy(c, sctx, d, p2)
-	testCreatePlacementPolicy(c, sctx, d, p3)
-	testCreatePlacementPolicy(c, sctx, d, p4)
-	testCreatePlacementPolicy(c, sctx, d, p5)
+	p1 := testPlacementPolicyInfo(t, d, "p1", policySettings)
+	p2 := testPlacementPolicyInfo(t, d, "p2", policySettings)
+	p3 := testPlacementPolicyInfo(t, d, "p3", policySettings)
+	p4 := testPlacementPolicyInfo(t, d, "p4", policySettings)
+	p5 := testPlacementPolicyInfo(t, d, "p5", policySettings)
+	testCreatePlacementPolicy(t, sctx, d, p1)
+	testCreatePlacementPolicy(t, sctx, d, p2)
+	testCreatePlacementPolicy(t, sctx, d, p3)
+	testCreatePlacementPolicy(t, sctx, d, p4)
+	testCreatePlacementPolicy(t, sctx, d, p5)
 
-	t1 := testTableInfo(c, d, "t1", 1)
+	t1 := testTableInfo(t, d, "t1", 1)
 	t1.PlacementPolicyRef = &model.PolicyRefInfo{ID: p1.ID, Name: p1.Name}
-	testCreateTable(c, sctx, d, db1, t1)
+	testCreateTable(t, sctx, d, db1, t1)
 	t1.State = model.StatePublic
 	db1.Tables = append(db1.Tables, t1)
 
-	t2 := testTableInfo(c, d, "t2", 1)
+	t2 := testTableInfo(t, d, "t2", 1)
 	t2.PlacementPolicyRef = &model.PolicyRefInfo{ID: p1.ID, Name: p1.Name}
-	testCreateTable(c, sctx, d, db2, t2)
+	testCreateTable(t, sctx, d, db2, t2)
 	t2.State = model.StatePublic
 	db2.Tables = append(db2.Tables, t2)
 
-	t3 := testTableInfo(c, d, "t3", 1)
+	t3 := testTableInfo(t, d, "t3", 1)
 	t3.PlacementPolicyRef = &model.PolicyRefInfo{ID: p2.ID, Name: p2.Name}
-	testCreateTable(c, sctx, d, db1, t3)
+	testCreateTable(t, sctx, d, db1, t3)
 	t3.State = model.StatePublic
 	db1.Tables = append(db1.Tables, t3)
 
-	dbP := testSchemaInfo(c, d, "db_p")
+	dbP := testSchemaInfo(t, d, "db_p")
 	dbP.PlacementPolicyRef = &model.PolicyRefInfo{ID: p4.ID, Name: p4.Name}
 	dbP.State = model.StatePublic
-	testCreateSchema(c, sctx, d, dbP)
+	testCreateSchema(t, sctx, d, dbP)
 
-	t4 := testTableInfoWithPartition(c, d, "t4", 1)
+	t4 := testTableInfoWithPartition(t, d, "t4", 1)
 	t4.Partition.Definitions[0].PlacementPolicyRef = &model.PolicyRefInfo{ID: p5.ID, Name: p5.Name}
-	testCreateTable(c, sctx, d, db1, t4)
+	testCreateTable(t, sctx, d, db1, t4)
 	t4.State = model.StatePublic
 	db1.Tables = append(db1.Tables, t4)
 
@@ -118,22 +119,22 @@ func (s *testDDLSuite) TestPlacementPolicyInUse(c *C) {
 		[]*model.PolicyInfo{p1, p2, p3, p4, p5},
 		1,
 	)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	is := builder.Build()
 
 	for _, policy := range []*model.PolicyInfo{p1, p2, p4, p5} {
-		c.Assert(ErrPlacementPolicyInUse.Equal(checkPlacementPolicyNotInUseFromInfoSchema(is, policy)), IsTrue)
-		c.Assert(kv.RunInNewTxn(ctx, sctx.GetStore(), false, func(ctx context.Context, txn kv.Transaction) error {
+		require.True(t, ErrPlacementPolicyInUse.Equal(checkPlacementPolicyNotInUseFromInfoSchema(is, policy)))
+		require.Nil(t, kv.RunInNewTxn(ctx, sctx.GetStore(), false, func(ctx context.Context, txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
-			c.Assert(ErrPlacementPolicyInUse.Equal(checkPlacementPolicyNotInUseFromMeta(m, policy)), IsTrue)
+			require.True(t, ErrPlacementPolicyInUse.Equal(checkPlacementPolicyNotInUseFromMeta(m, policy)))
 			return nil
-		}), IsNil)
+		}))
 	}
 
-	c.Assert(checkPlacementPolicyNotInUseFromInfoSchema(is, p3), IsNil)
-	c.Assert(kv.RunInNewTxn(ctx, sctx.GetStore(), false, func(ctx context.Context, txn kv.Transaction) error {
+	require.Nil(t, checkPlacementPolicyNotInUseFromInfoSchema(is, p3))
+	require.Nil(t, kv.RunInNewTxn(ctx, sctx.GetStore(), false, func(ctx context.Context, txn kv.Transaction) error {
 		m := meta.NewMeta(txn)
-		c.Assert(checkPlacementPolicyNotInUseFromMeta(m, p3), IsNil)
+		require.Nil(t, checkPlacementPolicyNotInUseFromMeta(m, p3))
 		return nil
-	}), IsNil)
+	}))
 }

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -16,7 +16,6 @@ package ddl
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -133,12 +132,8 @@ func (s *DDLSuite) testReorgWithSuite(t *testing.T) {
 			m = meta.NewMeta(txn)
 			info, err1 := getReorgInfo(d.ddlCtx, m, job, mockTbl, nil)
 			require.NoError(t, err1)
-			if !reflect.DeepEqual(info.StartKey, kv.Key(handle.Encoded())) {
-				t.FailNow()
-			}
-			if !reflect.DeepEqual(info.currElement, e) {
-				t.FailNow()
-			}
+			require.Equal(t, info.StartKey, kv.Key(handle.Encoded()))
+			require.Equal(t, info.currElement, e)
 			_, doneHandle, _ := d.generalWorker().reorgCtx.getRowCountAndKey()
 			require.Nil(t, doneHandle)
 			break
@@ -179,15 +174,9 @@ func (s *DDLSuite) testReorgWithSuite(t *testing.T) {
 		transMeta := meta.NewMeta(txn)
 		info1, err1 := getReorgInfo(d.ddlCtx, transMeta, job, mockTbl, []*meta.Element{element})
 		require.Nil(t, err1)
-		if !reflect.DeepEqual(info1.currElement, info.currElement) {
-			t.FailNow()
-		}
-		if !reflect.DeepEqual(info1.StartKey, info.StartKey) {
-			t.FailNow()
-		}
-		if !reflect.DeepEqual(info1.EndKey, info.EndKey) {
-			t.FailNow()
-		}
+		require.Equal(t, info1.currElement, info.currElement)
+		require.Equal(t, info1.StartKey, info.StartKey)
+		require.Equal(t, info1.EndKey, info.EndKey)
 		require.Equal(t, info1.PhysicalTableID, info.PhysicalTableID)
 		return nil
 	})

--- a/ddl/reorg_test.go
+++ b/ddl/reorg_test.go
@@ -207,9 +207,11 @@ func (s *DDLSuite) testReorgWithSuite(t *testing.T) {
 
 	// TODO: should be usings.RerunWithCommonHandleEnabled(c, s.TestReorg).
 	// but doing it manually while we finish migrating to testify.
-	s.IsCommonHandle = true
-	s.testReorgWithSuite(t)
-	s.IsCommonHandle = false
+	if !s.IsCommonHandle {
+		s.IsCommonHandle = true
+		s.testReorgWithSuite(t)
+		s.IsCommonHandle = false
+	}
 }
 
 func (s *DDLSuite) TestReorgOwner(t *testing.T) {

--- a/ddl/restart_test.go
+++ b/ddl/restart_test.go
@@ -19,12 +19,13 @@ package ddl
 import (
 	"context"
 	"errors"
+	"testing"
 	"time"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/util/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // this test file include some test that will cause data race, mainly because restartWorkers modify d.ctx
@@ -53,7 +54,7 @@ func (d *ddl) restartWorkers(ctx context.Context) {
 }
 
 // runInterruptedJob should be called concurrently with restartWorkers
-func runInterruptedJob(c *C, d *ddl, job *model.Job, doneCh chan error) {
+func runInterruptedJob(t *testing.T, d *ddl, job *model.Job, doneCh chan error) {
 	ctx := mock.NewContext()
 	ctx.Store = d.store
 
@@ -82,9 +83,9 @@ func runInterruptedJob(c *C, d *ddl, job *model.Job, doneCh chan error) {
 	doneCh <- err
 }
 
-func testRunInterruptedJob(c *C, d *ddl, job *model.Job) {
+func testRunInterruptedJob(t *testing.T, d *ddl, job *model.Job) {
 	done := make(chan error, 1)
-	go runInterruptedJob(c, d, job, done)
+	go runInterruptedJob(t, d, job, done)
 
 	ticker := time.NewTicker(d.lease * 1)
 	defer ticker.Stop()
@@ -93,79 +94,82 @@ LOOP:
 		select {
 		case <-ticker.C:
 			err := d.Stop()
-			c.Assert(err, IsNil)
+			require.NoError(t, err)
 			d.restartWorkers(context.Background())
 			time.Sleep(time.Millisecond * 20)
 		case err := <-done:
-			c.Assert(err, IsNil)
+			// Checking for nil instead of NoError because err doesn't seem to be
+			// nil, but an object equal to nil.
+			require.Nil(t, err)
 			break LOOP
 		}
 	}
 }
 
-func (s *testSchemaSuite) TestSchemaResume(c *C) {
-	store := testCreateStore(c, "test_schema_resume")
+func TestSchemaResume(t *testing.T) {
+	store := testCreateStore(t, "test_schema_resume")
 	defer func() {
 		err := store.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	d1 := testNewDDLAndStart(
 		context.Background(),
-		c,
+		t,
 		WithStore(store),
 		WithLease(testLease),
 	)
 	defer func() {
 		err := d1.Stop()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
-	testCheckOwner(c, d1, true)
+	testCheckOwner(t, d1, true)
 
-	dbInfo := testSchemaInfo(c, d1, "test_restart")
+	dbInfo := testSchemaInfo(t, d1, "test_restart")
 	job := &model.Job{
 		SchemaID:   dbInfo.ID,
 		Type:       model.ActionCreateSchema,
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       []interface{}{dbInfo},
 	}
-	testRunInterruptedJob(c, d1, job)
-	testCheckSchemaState(c, d1, dbInfo, model.StatePublic)
+	testRunInterruptedJob(t, d1, job)
+	testCheckSchemaState(t, d1, dbInfo, model.StatePublic)
 
 	job = &model.Job{
 		SchemaID:   dbInfo.ID,
 		Type:       model.ActionDropSchema,
 		BinlogInfo: &model.HistoryInfo{},
 	}
-	testRunInterruptedJob(c, d1, job)
-	testCheckSchemaState(c, d1, dbInfo, model.StateNone)
+	testRunInterruptedJob(t, d1, job)
+	testCheckSchemaState(t, d1, dbInfo, model.StateNone)
 }
 
-func (s *testStatSuite) TestStat(c *C) {
-	store := testCreateStore(c, "test_stat")
+func TestStat(t *testing.T) {
+	s := new(statSuite)
+	store := testCreateStore(t, "test_stat")
 	defer func() {
 		err := store.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	d := testNewDDLAndStart(
 		context.Background(),
-		c,
+		t,
 		WithStore(store),
 		WithLease(testLease),
 	)
 	defer func() {
 		err := d.Stop()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
-	dbInfo := testSchemaInfo(c, d, "test_restart")
-	testCreateSchema(c, testNewContext(d), d, dbInfo)
+	dbInfo := testSchemaInfo(t, d, "test_restart")
+	testCreateSchema(t, testNewContext(d), d, dbInfo)
 
 	// TODO: Get this information from etcd.
 	//	m, err := d.Stats(nil)
-	//	c.Assert(err, IsNil)
+	//	require.NoError(t, err)
 	//	c.Assert(m[ddlOwnerID], Equals, d.uuid)
 
 	job := &model.Job{
@@ -176,35 +180,37 @@ func (s *testStatSuite) TestStat(c *C) {
 	}
 
 	done := make(chan error, 1)
-	go runInterruptedJob(c, d, job, done)
+	go runInterruptedJob(t, d, job, done)
 
 	ticker := time.NewTicker(d.lease * 1)
 	defer ticker.Stop()
-	ver := s.getDDLSchemaVer(c, d)
+	ver := s.getDDLSchemaVer(t, d)
 LOOP:
 	for {
 		select {
 		case <-ticker.C:
 			err := d.Stop()
-			c.Assert(err, IsNil)
-			c.Assert(s.getDDLSchemaVer(c, d), GreaterEqual, ver)
+			require.NoError(t, err)
+			require.GreaterOrEqual(t, s.getDDLSchemaVer(t, d), ver)
 			d.restartWorkers(context.Background())
 			time.Sleep(time.Millisecond * 20)
 		case err := <-done:
 			// TODO: Get this information from etcd.
 			// m, err := d.Stats(nil)
-			c.Assert(err, IsNil)
+			require.NoError(t, err)
 			break LOOP
 		}
 	}
 }
 
-func (s *testTableSuite) TestTableResume(c *C) {
+func TestTableResume(t *testing.T) {
+	s, clean := createTableSuite(t)
+	defer clean()
 	d := s.d
 
-	testCheckOwner(c, d, true)
+	testCheckOwner(t, d, true)
 
-	tblInfo := testTableInfo(c, d, "t1", 3)
+	tblInfo := testTableInfo(t, d, "t1", 3)
 	job := &model.Job{
 		SchemaID:   s.dbInfo.ID,
 		TableID:    tblInfo.ID,
@@ -212,8 +218,8 @@ func (s *testTableSuite) TestTableResume(c *C) {
 		BinlogInfo: &model.HistoryInfo{},
 		Args:       []interface{}{tblInfo},
 	}
-	testRunInterruptedJob(c, d, job)
-	testCheckTableState(c, d, s.dbInfo, tblInfo, model.StatePublic)
+	testRunInterruptedJob(t, d, job)
+	testCheckTableState(t, d, s.dbInfo, tblInfo, model.StatePublic)
 
 	job = &model.Job{
 		SchemaID:   s.dbInfo.ID,
@@ -221,6 +227,6 @@ func (s *testTableSuite) TestTableResume(c *C) {
 		Type:       model.ActionDropTable,
 		BinlogInfo: &model.HistoryInfo{},
 	}
-	testRunInterruptedJob(c, d, job)
-	testCheckTableState(c, d, s.dbInfo, tblInfo, model.StateNone)
+	testRunInterruptedJob(t, d, job)
+	testCheckTableState(t, d, s.dbInfo, tblInfo, model.StateNone)
 }

--- a/ddl/restart_test.go
+++ b/ddl/restart_test.go
@@ -197,7 +197,7 @@ LOOP:
 		case err := <-done:
 			// TODO: Get this information from etcd.
 			// m, err := d.Stats(nil)
-			require.NoError(t, err)
+			require.Nil(t, err)
 			break LOOP
 		}
 	}

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -16,7 +16,6 @@ package ddl
 
 import (
 	"context"
-	"reflect"
 	"testing"
 	"time"
 
@@ -103,9 +102,7 @@ func testCheckSchemaState(t *testing.T, d *ddl, dbInfo *model.DBInfo, state mode
 				return nil
 			}
 
-			if !reflect.DeepEqual(info.Name, dbInfo.Name) {
-				t.FailNow()
-			}
+			require.Equal(t, info.Name, dbInfo.Name)
 			require.Equal(t, info.State, state)
 			return nil
 		})

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -16,76 +16,65 @@ package ddl
 
 import (
 	"context"
+	"testing"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/types"
+	"github.com/stretchr/testify/require"
 )
 
-var _ = Suite(&testStatSuite{})
-var _ = SerialSuites(&testSerialStatSuite{})
+type statSuite struct{}
 
-type testStatSuite struct {
-}
-
-func (s *testStatSuite) SetUpSuite(c *C) {
-}
-
-func (s *testStatSuite) TearDownSuite(c *C) {
-}
-
-type testSerialStatSuite struct {
-}
-
-func (s *testStatSuite) getDDLSchemaVer(c *C, d *ddl) int64 {
+func (s *statSuite) getDDLSchemaVer(t *testing.T, d *ddl) int64 {
 	m, err := d.Stats(nil)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	v := m[ddlSchemaVersion]
 	return v.(int64)
 }
 
-func (s *testSerialStatSuite) TestDDLStatsInfo(c *C) {
-	store := testCreateStore(c, "test_stat")
+func TestDDLStatsInfo(t *testing.T) {
+	t.Parallel()
+	store := testCreateStore(t, "test_stat")
 	defer func() {
 		err := store.Close()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
 	d := testNewDDLAndStart(
 		context.Background(),
-		c,
+		t,
 		WithStore(store),
 		WithLease(testLease),
 	)
 	defer func() {
 		err := d.Stop()
-		c.Assert(err, IsNil)
+		require.NoError(t, err)
 	}()
 
-	dbInfo := testSchemaInfo(c, d, "test_stat")
-	testCreateSchema(c, testNewContext(d), d, dbInfo)
-	tblInfo := testTableInfo(c, d, "t", 2)
+	dbInfo := testSchemaInfo(t, d, "test_stat")
+	testCreateSchema(t, testNewContext(d), d, dbInfo)
+	tblInfo := testTableInfo(t, d, "t", 2)
 	ctx := testNewContext(d)
-	testCreateTable(c, ctx, d, dbInfo, tblInfo)
+	testCreateTable(t, ctx, d, dbInfo, tblInfo)
 
-	t := testGetTable(c, d, dbInfo.ID, tblInfo.ID)
+	meta := testGetTable(t, d, dbInfo.ID, tblInfo.ID)
 	// insert t values (1, 1), (2, 2), (3, 3)
-	_, err := t.AddRecord(ctx, types.MakeDatums(1, 1))
-	c.Assert(err, IsNil)
-	_, err = t.AddRecord(ctx, types.MakeDatums(2, 2))
-	c.Assert(err, IsNil)
-	_, err = t.AddRecord(ctx, types.MakeDatums(3, 3))
-	c.Assert(err, IsNil)
+	_, err := meta.AddRecord(ctx, types.MakeDatums(1, 1))
+	require.NoError(t, err)
+	_, err = meta.AddRecord(ctx, types.MakeDatums(2, 2))
+	require.NoError(t, err)
+	_, err = meta.AddRecord(ctx, types.MakeDatums(3, 3))
+	require.NoError(t, err)
 	txn, err := ctx.Txn(true)
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	err = txn.Commit(context.Background())
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 
 	job := buildCreateIdxJob(dbInfo, tblInfo, true, "idx", "c1")
 
-	c.Assert(failpoint.Enable("github.com/pingcap/tidb/ddl/checkBackfillWorkerNum", `return(true)`), IsNil)
+	require.Nil(t, failpoint.Enable("github.com/pingcap/tidb/ddl/checkBackfillWorkerNum", `return(true)`))
 	defer func() {
-		c.Assert(failpoint.Disable("github.com/pingcap/tidb/ddl/checkBackfillWorkerNum"), IsNil)
+		require.Nil(t, failpoint.Disable("github.com/pingcap/tidb/ddl/checkBackfillWorkerNum"))
 	}()
 
 	done := make(chan error, 1)
@@ -97,12 +86,12 @@ func (s *testSerialStatSuite) TestDDLStatsInfo(c *C) {
 	for !exit {
 		select {
 		case err := <-done:
-			c.Assert(err, IsNil)
+			require.NoError(t, err)
 			exit = true
 		case <-TestCheckWorkerNumCh:
 			varMap, err := d.Stats(nil)
-			c.Assert(err, IsNil)
-			c.Assert(varMap[ddlJobReorgHandle], Equals, "1")
+			require.NoError(t, err)
+			require.Equal(t, varMap[ddlJobReorgHandle], "1")
 		}
 	}
 }

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -437,17 +437,22 @@ func checkTableCacheTest(t *testing.T, d *ddl, dbInfo *model.DBInfo, tblInfo *mo
 		require.NotNil(t, info.TableCacheStatusType)
 		require.Equal(t, info.TableCacheStatusType, model.TableCacheStatusEnable)
 		return nil
+	})
+	require.NoError(t, err)
 }
 
 func checkTableNoCacheTest(t *testing.T, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo) {
 	err := kv.RunInNewTxn(context.Background(), d.store, false, func(ctx context.Context, txn kv.Transaction) error {
-		t := meta.NewMeta(txn)
-		info, err := t.GetTable(dbInfo.ID, tblInfo.ID)
+		trans := meta.NewMeta(txn)
+		info, err := trans.GetTable(dbInfo.ID, tblInfo.ID)
 		require.NoError(t, err)
 		require.NotNil(t, info)
 		require.Equal(t, info.TableCacheStatusType, model.TableCacheStatusEnable)
 		return nil
 	})
+	require.NoError(t, err)
+}
+
 func testAlterCacheTable(t *testing.T, ctx sessionctx.Context, d *ddl, newSchemaID int64, tblInfo *model.TableInfo) *model.Job {
 
 	job := &model.Job{

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"reflect"
 	"testing"
 
 	"github.com/pingcap/errors"
@@ -332,9 +331,7 @@ func testCheckTableState(t *testing.T, d *ddl, dbInfo *model.DBInfo, tblInfo *mo
 			require.Nil(t, info)
 			return nil
 		}
-		if !reflect.DeepEqual(info.Name, tblInfo.Name) {
-			t.FailNow()
-		}
+		require.Equal(t, info.Name, tblInfo.Name)
 		require.Equal(t, info.State, state)
 		return nil
 	})


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29116

Problem Summary:

### What is changed and how it works?
Uses testify for `ddl/table_test.go`. In the process, I had to make the same change across multiple test files for the tests to compile.

Could not fully run tests on my machine as it went out of memory very fast.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
