### PR TITLE
config: add log.sampling; rate limit logs with same level+msg (#29190)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -319,6 +319,8 @@ type Log struct {
 	EnableErrorStack nullableBool `toml:"enable-error-stack" json:"enable-error-stack"`
 	// File log config.
 	File logutil.FileLogConfig `toml:"file" json:"file"`
+	// Sampler config (per second) for rate limiting the log
+	Sampling *zap.SamplingConfig `toml:"sampling" json:"sampling"`
 
 	EnableSlowLog       bool   `toml:"enable-slow-log" json:"enable-slow-log"`
 	SlowQueryFile       string `toml:"slow-query-file" json:"slow-query-file"`
@@ -984,7 +986,9 @@ var TableLockDelayClean = func() uint64 {
 
 // ToLogConfig converts *Log to *logutil.LogConfig.
 func (l *Log) ToLogConfig() *logutil.LogConfig {
-	return logutil.NewLogConfig(l.Level, l.Format, l.SlowQueryFile, l.File, l.getDisableTimestamp(), func(config *zaplog.Config) { config.DisableErrorVerbose = l.getDisableErrorStack() })
+	return logutil.NewLogConfig(l.Level, l.Format, l.SlowQueryFile, l.File, l.getDisableTimestamp(),
+		func(config *zaplog.Config) { config.DisableErrorVerbose = l.getDisableErrorStack() },
+		func(config *zaplog.Config) { config.Sampling = l.Sampling })
 }
 
 // ToTracingConfig converts *OpenTracing to *tracing.Configuration.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29190

Problem Summary:
TiDB general log flooding. By allowing to configure sampling for the log (through uber-go/zap library) we can allow administrators to rate limit the log and avoid log flooding, to the expense of possibly discard important messages.

### What is changed and how it works?
Add something like this in the configuration toml file:
```
# Sampling to rate limit the same messages on the same log level per second (initial = number of messages before sampling, thereafter = sample every Nth message)
# Will use additional memory for storing logged messages
sampling = { initial = 10, thereafter = 20 }
```

Which will result in the first 10 messages and every 20th message will be logged within a second.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Manual test:
Set log.sampling = { initial = 2, thereafter = 5 } and ran `select non_existing_col1 .. 10;` 10 times, which resulted in first two messages like below, and the seventh:
```
[2021/11/02 16:35:07.028 +01:00] [WARN] [session.go:1570] ["compile SQL failed"] [conn=3] [error="[planner:1054]Unknown column 'nan1' in 'field list'"] [SQL="select nan1"]
[2021/11/02 16:35:07.029 +01:00] [INFO] [conn.go:1058] ["command dispatched failed"] ...
```

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Added log.sampling configuration for sample/rate limit tidb log
```
