### PR TITLE
expression, executor: fix unexpectedly modifying `Flen` and `Decimal` of `CorrelatedColumn`

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -9314,3 +9314,14 @@ func (s *testSuiteP1) TestIssue28935(c *C) {
 	tk.MustQuery(`select trim(leading null from " a "), trim(both null from " a "), trim(trailing null from " a ")`).Check(testkit.Rows("<nil> <nil> <nil>"))
 	tk.MustQuery(`select trim(null from " a ")`).Check(testkit.Rows("<nil>"))
 }
+
+func (s *testSuiteP1) TestIssue29412(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t29142_1")
+	tk.MustExec("drop table if exists t29142_2")
+	tk.MustExec("create table t29142_1(a int);")
+	tk.MustExec("create table t29142_2(a double);")
+	tk.MustExec("insert into t29142_1 value(20);")
+	tk.MustQuery("select sum(distinct a) as x from t29142_1 having x > some ( select a from t29142_2 where x in (a));").Check(nil)
+}

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -1383,6 +1383,11 @@ func PropagateType(evalType types.EvalType, args ...Expression) {
 				newCol.(*Column).RetType = col.RetType.Clone()
 				args[0] = newCol
 			}
+			if col, ok := args[0].(*CorrelatedColumn); ok {
+				newCol := col.Clone()
+				newCol.(*CorrelatedColumn).RetType = col.RetType.Clone()
+				args[0] = newCol
+			}
 			args[0].GetType().Flen, args[0].GetType().Decimal = newFlen, newDecimal
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #29412

Problem Summary:

In changes of https://github.com/pingcap/tidb/pull/26651, the `Column` should be copied. But the `CorrelatedColumn` case is missed.

### What is changed and how it works?

Deep copy `CorrelatedColumn`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
