### PR TITLE
util: fix mistakenly shadowed name `idx`

### DIFF
--- a/util/admin/admin.go
+++ b/util/admin/admin.go
@@ -379,17 +379,17 @@ func CheckRecordAndIndex(ctx context.Context, sessCtx sessionctx.Context, txn kv
 				return tablecodec.EncodeRecordKey(t.RecordPrefix(), handle)
 			},
 			IndexEncode: func(idxRow *consistency.RecordData) kv.Key {
-				var idx table.Index
+				var matchingIdx table.Index
 				for _, v := range t.Indices() {
 					if strings.EqualFold(v.Meta().Name.String(), idx.Meta().Name.O) {
-						idx = v
+						matchingIdx = v
 						break
 					}
 				}
-				if idx == nil {
+				if matchingIdx == nil {
 					return nil
 				}
-				k, _, err := idx.GenIndexKey(sessCtx.GetSessionVars().StmtCtx, idxRow.Values, idxRow.Handle, nil)
+				k, _, err := matchingIdx.GenIndexKey(sessCtx.GetSessionVars().StmtCtx, idxRow.Values, idxRow.Handle, nil)
 				if err != nil {
 					return nil
 				}

--- a/util/admin/admin_integration_test.go
+++ b/util/admin/admin_integration_test.go
@@ -19,7 +19,9 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdminCheckTable(t *testing.T) {
@@ -112,4 +114,38 @@ func TestAdminCheckTableClusterIndex(t *testing.T) {
 
 	tk.MustExec("insert into t values (1000, '1000', 1000, '1000', '1000');")
 	tk.MustExec("admin check table t;")
+}
+
+func TestAdminCheckTableCorrupted(t *testing.T) {
+	t.Parallel()
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(id int, v int, UNIQUE KEY i1(id, v))")
+	tk.MustExec("begin")
+	tk.MustExec("insert into t values (1, 1)")
+
+	txn, err := tk.Session().Txn(false)
+	require.NoError(t, err)
+	memBuffer := txn.GetMemBuffer()
+	it, err := memBuffer.Iter(nil, nil)
+	require.NoError(t, err)
+	for it.Valid() {
+		if tablecodec.IsRecordKey(it.Key()) && len(it.Value()) > 0 {
+			value := make([]byte, len(it.Value()))
+			key := make([]byte, len(it.Key()))
+			copy(key, it.Key())
+			copy(value, it.Value())
+			key[len(key)-1] += 1
+			memBuffer.Set(key, value)
+		}
+		err = it.Next()
+		require.NoError(t, err)
+	}
+
+	tk.MustExec("commit")
+	err = tk.ExecToErr("admin check table t")
+	require.Error(t, err)
 }


### PR DESCRIPTION
Signed-off-by: ekexium <ekexium@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29469 

Problem Summary:

The parameter `idx` is mistakenly shadowed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
