### PR TITLE
planner: fix the wrong access conditions for indexScan

### DIFF
--- a/planner/util/path.go
+++ b/planner/util/path.go
@@ -79,7 +79,7 @@ func (path *AccessPath) SplitCorColAccessCondFromFilters(ctx sessionctx.Context,
 	for i := eqOrInCount; i < len(path.IdxCols); i++ {
 		matched := false
 		for j, filter := range path.TableFilters {
-			if used[j] || !isColEqCorColOrConstant(ctx, filter, path.IdxCols[i]) {
+			if used[j] || !isColEqCorColOrConstant(ctx, filter, path.IdxCols[i]) || expression.MaybeOverOptimized4PlanCache(ctx, []expression.Expression{filter}) {
 				continue
 			}
 			matched = true

--- a/planner/util/path.go
+++ b/planner/util/path.go
@@ -73,13 +73,20 @@ func (path *AccessPath) IsTablePath() bool {
 }
 
 // SplitCorColAccessCondFromFilters move the necessary filter in the form of index_col = corrlated_col to access conditions.
+// The function consider the `idx_col_1 = const and index_col_2 = cor_col and index_col_3 = const` case.
+// It enables more index columns to be considered. The range will be rebuilt in 'ResolveCorrelatedColumns'.
 func (path *AccessPath) SplitCorColAccessCondFromFilters(ctx sessionctx.Context, eqOrInCount int) (access, remained []expression.Expression) {
+	// The plan cache do not support subquery now. So we skip this function when
+	// 'MaybeOverOptimized4PlanCache' function return true .
+	if expression.MaybeOverOptimized4PlanCache(ctx, path.TableFilters) {
+		return nil, path.TableFilters
+	}
 	access = make([]expression.Expression, len(path.IdxCols)-eqOrInCount)
 	used := make([]bool, len(path.TableFilters))
 	for i := eqOrInCount; i < len(path.IdxCols); i++ {
 		matched := false
 		for j, filter := range path.TableFilters {
-			if used[j] || !isColEqCorColOrConstant(ctx, filter, path.IdxCols[i]) || expression.MaybeOverOptimized4PlanCache(ctx, []expression.Expression{filter}) {
+			if used[j] || !isColEqCorColOrConstant(ctx, filter, path.IdxCols[i]) {
 				continue
 			}
 			matched = true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/29551

Problem Summary:
The condition `col1 = -3865356285544170443` will be added to access conditions in `dataSource.deriveIndexPathStats`. But this condition is not built the range for the index scan. So we lost the condition.

### What is changed and how it works?
Do not add the condition to access conditions in `dataSource.deriveIndexPathStats`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
