### PR TITLE
planner: fix the issue that set wrong length and width for Decimal and Real when using plan-cache

### DIFF
--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -91,6 +91,7 @@ func numericContextResultType(ft *types.FieldType) types.EvalType {
 func setFlenDecimal4RealOrDecimal(ctx sessionctx.Context, retTp *types.FieldType, arg0, arg1 Expression, isReal bool, isMultiply bool) {
 	a, b := arg0.GetType(), arg1.GetType()
 	if MaybeOverOptimized4PlanCache(ctx, []Expression{arg0, arg1}) {
+		// set length and decimal to unspecified if arguments depend on parameters
 		retTp.Flen, retTp.Decimal = types.UnspecifiedLength, types.UnspecifiedLength
 		return
 	}

--- a/expression/builtin_arithmetic.go
+++ b/expression/builtin_arithmetic.go
@@ -88,7 +88,12 @@ func numericContextResultType(ft *types.FieldType) types.EvalType {
 
 // setFlenDecimal4RealOrDecimal is called to set proper `Flen` and `Decimal` of return
 // type according to the two input parameter's types.
-func setFlenDecimal4RealOrDecimal(retTp, a, b *types.FieldType, isReal bool, isMultiply bool) {
+func setFlenDecimal4RealOrDecimal(ctx sessionctx.Context, retTp *types.FieldType, arg0, arg1 Expression, isReal bool, isMultiply bool) {
+	a, b := arg0.GetType(), arg1.GetType()
+	if MaybeOverOptimized4PlanCache(ctx, []Expression{arg0, arg1}) {
+		retTp.Flen, retTp.Decimal = types.UnspecifiedLength, types.UnspecifiedLength
+		return
+	}
 	if a.Decimal != types.UnspecifiedLength && b.Decimal != types.UnspecifiedLength {
 		retTp.Decimal = a.Decimal + b.Decimal
 		if !isMultiply {
@@ -164,7 +169,7 @@ func (c *arithmeticPlusFunctionClass) getFunction(ctx sessionctx.Context, args [
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), true, false)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], true, false)
 		sig := &builtinArithmeticPlusRealSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_PlusReal)
 		return sig, nil
@@ -173,7 +178,7 @@ func (c *arithmeticPlusFunctionClass) getFunction(ctx sessionctx.Context, args [
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), false, false)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], false, false)
 		sig := &builtinArithmeticPlusDecimalSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_PlusDecimal)
 		return sig, nil
@@ -316,7 +321,7 @@ func (c *arithmeticMinusFunctionClass) getFunction(ctx sessionctx.Context, args 
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), true, false)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], true, false)
 		sig := &builtinArithmeticMinusRealSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MinusReal)
 		return sig, nil
@@ -325,7 +330,7 @@ func (c *arithmeticMinusFunctionClass) getFunction(ctx sessionctx.Context, args 
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), false, false)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], false, false)
 		sig := &builtinArithmeticMinusDecimalSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MinusDecimal)
 		return sig, nil
@@ -502,7 +507,7 @@ func (c *arithmeticMultiplyFunctionClass) getFunction(ctx sessionctx.Context, ar
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), true, true)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], true, true)
 		sig := &builtinArithmeticMultiplyRealSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MultiplyReal)
 		return sig, nil
@@ -511,7 +516,7 @@ func (c *arithmeticMultiplyFunctionClass) getFunction(ctx sessionctx.Context, ar
 		if err != nil {
 			return nil, err
 		}
-		setFlenDecimal4RealOrDecimal(bf.tp, args[0].GetType(), args[1].GetType(), false, true)
+		setFlenDecimal4RealOrDecimal(ctx, bf.tp, args[0], args[1], false, true)
 		sig := &builtinArithmeticMultiplyDecimalSig{bf}
 		sig.setPbCode(tipb.ScalarFuncSig_MultiplyDecimal)
 		return sig, nil

--- a/expression/builtin_arithmetic_test.go
+++ b/expression/builtin_arithmetic_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/testkit/trequire"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tipb/go-tipb"
 	"github.com/stretchr/testify/require"
 )
@@ -40,25 +41,25 @@ func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
 		Decimal: 0,
 		Flen:    2,
 	}
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, false)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, 6, ret.Flen)
 
 	b.Flen = 65
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, false)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, mysql.MaxRealWidth, ret.Flen)
-	setFlenDecimal4RealOrDecimal(ret, a, b, false, false)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, false, false)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, mysql.MaxDecimalWidth, ret.Flen)
 
 	b.Flen = types.UnspecifiedLength
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, false)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, types.UnspecifiedLength, ret.Flen)
 
 	b.Decimal = types.UnspecifiedLength
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, false)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, false)
 	require.Equal(t, types.UnspecifiedLength, ret.Decimal)
 	require.Equal(t, types.UnspecifiedLength, ret.Flen)
 
@@ -71,25 +72,25 @@ func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
 		Decimal: 0,
 		Flen:    2,
 	}
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, true)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, 8, ret.Flen)
 
 	b.Flen = 65
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, true)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, mysql.MaxRealWidth, ret.Flen)
-	setFlenDecimal4RealOrDecimal(ret, a, b, false, true)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, false, true)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, mysql.MaxDecimalWidth, ret.Flen)
 
 	b.Flen = types.UnspecifiedLength
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, true)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, 1, ret.Decimal)
 	require.Equal(t, types.UnspecifiedLength, ret.Flen)
 
 	b.Decimal = types.UnspecifiedLength
-	setFlenDecimal4RealOrDecimal(ret, a, b, true, true)
+	setFlenDecimal4RealOrDecimal(mock.NewContext(), ret, &Constant{RetType: a}, &Constant{RetType: b}, true, true)
 	require.Equal(t, types.UnspecifiedLength, ret.Decimal)
 	require.Equal(t, types.UnspecifiedLength, ret.Flen)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29565

Problem Summary: planner: fix the issue that set wrong length and width for Decimal and Real when using plan-cache

### What is changed and how it works?
Set the length and width to unspecified for Decimal and Real when they are parameters.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: fix the issue that set wrong length and width for Decimal and Real when using plan-cache
```
