### PR TITLE
table: don't compare different types of handles

### DIFF
--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -175,3 +175,14 @@ func buildTableInfo(t *testing.T, sql string) *model.TableInfo {
 	require.NoError(t, err)
 	return tblInfo
 }
+
+func TestIssue29520(t *testing.T) {
+	store, close := testkit.CreateMockStore(t)
+	defer close()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("set @@tidb_enable_mutation_checker=1")
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(c year, PRIMARY KEY (c) CLUSTERED, KEY i1(c))")
+	tk.MustExec("insert into t values('2020')")
+}

--- a/table/tables/mutation_checker.go
+++ b/table/tables/mutation_checker.go
@@ -136,7 +136,8 @@ func checkHandleConsistency(rowInsertion mutation, indexMutations []mutation, in
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if indexHandle.Compare(insertionHandle) != 0 {
+		// NOTE: handle type can be different, see issue 29520
+		if indexHandle.IsInt() == insertionHandle.IsInt() && indexHandle.Compare(insertionHandle) != 0 {
 			return errors.Errorf("inconsistent handles in row and index insertions. index handle = %v, "+
 				"row handle = %v, index = %+v, row = %+v",
 				indexHandle, insertionHandle, m, rowInsertion)


### PR DESCRIPTION
Signed-off-by: ekexium <ekexium@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29520 

Problem Summary:

### What is changed and how it works?

A workaround: just don't compare different types of handles.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
