### PR TITLE
[only 5.0]config: fix the bug that enforce-mpp config item is useless.

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1112,7 +1112,7 @@ func NewSessionVars() *SessionVars {
 
 	vars.AllowBatchCop = DefTiDBAllowBatchCop
 	vars.allowMPPExecution = DefTiDBAllowMPPExecution
-	vars.enforceMPPExecution = DefTiDBEnforceMPPExecution
+	vars.enforceMPPExecution = config.GetGlobalConfig().Performance.EnforceMPP
 	vars.MPPStoreFailTTL = DefTiDBMPPStoreFailTTL
 
 	var enableChunkRPC string

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -636,7 +636,6 @@ const (
 	DefTiDBOptimizerSelectivityLevel   = 0
 	DefTiDBAllowBatchCop               = 1
 	DefTiDBAllowMPPExecution           = true
-	DefTiDBEnforceMPPExecution         = false
 	DefTiDBMPPStoreFailTTL             = "60s"
 	DefTiDBTxnMode                     = ""
 	DefTiDBRowFormatV1                 = 1


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/29252

Problem Summary: Because the compatibility of the configuration framework is different, the configuration item of enforce-mpp is invalid when cherry-pick to 5.0.

### What is changed and how it works?

remove the problematic assignment.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```sql
set config:
[performance]
enforce-mpp=true

mysql> show variables like "tidb_enforce_mpp";
+------------------+-------+
| Variable_name    | Value |
+------------------+-------+
| tidb_enforce_mpp | ON    |
+------------------+-------+
1 row in set (0.01 sec)

mysql> select tidb_version();
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| tidb_version()                                                                                                                                                                                                                                                                                                                        |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Release Version: v5.0.4-20210918-2-g128b77ab5
Edition: Community
Git Commit Hash: 128b77ab5560dd24a5e22a88f25be724824b8e4f
Git Branch: bugfix/config-bug
UTC Build Time: 2021-11-10 07:58:36
GoVersion: go1.16.3
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false |
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)

create table t(a int);

mysql> explain select a+1 from t;
+-------------------------+----------+-----------+---------------+--------------------------------+
| id                      | estRows  | task      | access object | operator info                  |
+-------------------------+----------+-----------+---------------+--------------------------------+
| Projection_3            | 10000.00 | root      |               | plus(test.t.a, 1)->Column#3    |
| └─TableReader_5         | 10000.00 | root      |               | data:TableFullScan_4           |
|   └─TableFullScan_4     | 10000.00 | cop[tikv] | table:t       | keep order:false, stats:pseudo |
+-------------------------+----------+-----------+---------------+--------------------------------+
3 rows in set, 1 warning (0.00 sec)

mysql> show warnings;
+---------+------+-----------------------------------------------------------------------------+
| Level   | Code | Message                                                                     |
+---------+------+-----------------------------------------------------------------------------+
| Warning | 1105 | MPP mode may be blocked because there aren't tiflash replicas of table `t`. |
+---------+------+-----------------------------------------------------------------------------+
1 row in set (0.00 sec)

```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
config: fix the bug that enforce-mpp *config item* is useless in v5.0.4
```
