### PR TITLE
domain: fix bug that after 'skip-grant-table', set password doesn't take effect immediately

### DIFF
--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1446,13 +1446,9 @@ const (
 // NotifyUpdatePrivilege updates privilege key in etcd, TiDB client that watches
 // the key will get notification.
 func (do *Domain) NotifyUpdatePrivilege() error {
-	// If skip-grant-table is configured, do not flush privileges.
-	// Because LoadPrivilegeLoop does not run and the privilege Handle is nil,
-	// the call to do.PrivilegeHandle().Update would panic.
-	if config.GetGlobalConfig().Security.SkipGrantTable {
-		return nil
-	}
-
+	// No matter skip-grant-table is configured or not, send etcd message is required.
+	// Because we need to tell other TiDB instances to update privilege data, say, we're change the
+	// password using a special TiDB instance and want the new password to take effect.
 	if do.etcdClient != nil {
 		row := do.etcdClient.KV
 		_, err := row.Put(context.Background(), privilegeKey, "")
@@ -1460,6 +1456,14 @@ func (do *Domain) NotifyUpdatePrivilege() error {
 			logutil.BgLogger().Warn("notify update privilege failed", zap.Error(err))
 		}
 	}
+
+	// If skip-grant-table is configured, do not flush privileges.
+	// Because LoadPrivilegeLoop does not run and the privilege Handle is nil,
+	// the call to do.PrivilegeHandle().Update would panic.
+	if config.GetGlobalConfig().Security.SkipGrantTable {
+		return nil
+	}
+
 	// update locally
 	sysSessionPool := do.SysSessionPool()
 	ctx, err := sysSessionPool.Get()

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -1446,8 +1446,8 @@ const (
 // NotifyUpdatePrivilege updates privilege key in etcd, TiDB client that watches
 // the key will get notification.
 func (do *Domain) NotifyUpdatePrivilege() error {
-	// No matter skip-grant-table is configured or not, send etcd message is required.
-	// Because we need to tell other TiDB instances to update privilege data, say, we're change the
+	// No matter skip-grant-table is configured or not, sending an etcd message is required.
+	// Because we need to tell other TiDB instances to update privilege data, say, we're changing the
 	// password using a special TiDB instance and want the new password to take effect.
 	if do.etcdClient != nil {
 		row := do.etcdClient.KV


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29653

Problem Summary:

### What is changed and how it works?

When `skip-grant-table` is configured, the changes of privilege data in one TiDB instance should still notify to other TiDB instance. Because without notification, set the password in a special TiDB instance will not take effect in the whole cluaster immediately.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

It's hard to write a unit test for this case.

I've test the change with those steps:

1. tiup playground
2. create user xxx@% identified by yyy
3. mysql -h 127.0.0.1 -u xxx -P -p , use password zzz, fail
4. use a `skip-grant-table` tidb node to connect to the cluster
5. set password for xxx@% = 'zzz'
6. mysql -h 127.0.0.1 -u xxx -P -p , use password zzz, success
 
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a bug that when 'skip-grant-table' is set, changing password doesn't take effect to the whole cluster immediately
```
