### PR TITLE
server: Add uptime status var and statistics

### DIFF
--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -856,7 +856,7 @@ func getServerInfo(id string, serverIDGetter func() uint64) *ServerInfo {
 
 	failpoint.Inject("mockServerInfo", func(val failpoint.Value) {
 		if val.(bool) {
-			info.StartTimestamp = 1282967700000
+			info.StartTimestamp = 1282967700
 			info.Labels = map[string]string{
 				"foo": "bar",
 			}

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -72,7 +72,7 @@ func TestTopology(t *testing.T) {
 
 	topology, err := info.getTopologyFromEtcd(ctx)
 	require.NoError(t, err)
-	require.Equal(t, int64(1282967700000), topology.StartTimestamp)
+	require.Equal(t, int64(1282967700), topology.StartTimestamp)
 
 	v, ok := topology.Labels["foo"]
 	require.True(t, ok)
@@ -97,7 +97,7 @@ func TestTopology(t *testing.T) {
 
 	dir := path.Dir(s)
 	require.Equal(t, dir, topology.DeployPath)
-	require.Equal(t, int64(1282967700000), topology.StartTimestamp)
+	require.Equal(t, int64(1282967700), topology.StartTimestamp)
 	require.Equal(t, info.getTopologyInfo(), *topology)
 
 	// check ttl key

--- a/server/stat_test.go
+++ b/server/stat_test.go
@@ -1,0 +1,61 @@
+// Copyright 2021 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pingcap/failpoint"
+	"github.com/pingcap/tidb/domain/infosync"
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/store/mockstore"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUptime(t *testing.T) {
+	var err error
+
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/domain/infosync/mockServerInfo", "return(true)"))
+	defer func() {
+		err := failpoint.Disable("github.com/pingcap/tidb/domain/infosync/mockServerInfo")
+		require.NoError(t, err)
+	}()
+
+	store, err := mockstore.NewMockStore()
+	require.NoError(t, err)
+
+	dom, err := session.BootstrapSession(store)
+	defer func() {
+		dom.Close()
+		err := store.Close()
+		require.NoError(t, err)
+	}()
+	require.NoError(t, err)
+
+	_, err = infosync.GlobalInfoSyncerInit(context.Background(), dom.DDL().GetID(), dom.ServerID, dom.GetEtcdClient(), true)
+	require.NoError(t, err)
+
+	tidbdrv := NewTiDBDriver(store)
+	cfg := newTestConfig()
+	cfg.Socket = ""
+	server, err := NewServer(cfg, tidbdrv)
+	require.NoError(t, err)
+
+	stats, err := server.Stats(nil)
+	require.NoError(t, err)
+	require.GreaterOrEqual(t, stats[upTime].(int64), int64(time.Since(time.Unix(1282967700, 0)).Seconds()))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #8842

Problem Summary:

- The uptime in the `mysql.ComStatistics` was always 0
- There was no `Uptime` status var, causing compatibility issues with the status command in https://github.com/dbcli/mycli

<pre>mysql&gt; status
--------------
...
Uptime:			7 min 2 sec

Threads: 0  Questions: 0  Slow queries: 0  Opens: 0  Flush tables: 0  Open tables: 0  Queries per second avg: 0.000
--------------

mysql&gt; SHOW GLOBAL STATUS LIKE &apos;Uptime&apos;;
+---------------+-------+
| Variable_name | Value |
+---------------+-------+
| Uptime        | 423   |
+---------------+-------+
1 row in set (0.03 sec)
</pre>

And MySQL Shell:
```
sql> \status
MySQL Shell version 8.0.27

...
Uptime:                       21 min 34.0000 sec

Threads: 0  Questions: 0  Slow queries: 0  Opens: 0  Flush tables: 0  Open tables: 0  Queries per second avg: 0.000
```

(patched) MyCli:
```
MySQL root@127.1:(none)> status
--------------
mycli 1.24.1, running on CPython 3.10.0
...
| Uptime:              | 22 min 41 sec                                                                                                          |
+----------------------+------------------------------------------------------------------------------------------------------------------------+
--------------
Time: 0.031s
```

Related: https://github.com/dbcli/mycli/pull/1014

This matches the information in the HTTP status API (`/info`, `start_timestamp`) and the `information_schema.CLUSTER_INFO`. Note that *all* of these might report the current time instead of the real startup time if no PD/etcd is available.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
A global status variable for `Uptime` was added.
```
