### PR TITLE
server: fix authentication with MySQL 5.1 and older clients (#29732)

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -729,6 +729,20 @@ func (cc *clientConn) handleAuthPlugin(ctx context.Context, resp *handshakeRespo
 		}
 	} else {
 		logutil.Logger(ctx).Warn("Client without Auth Plugin support; Please upgrade client")
+		if cc.ctx == nil {
+			err := cc.openSession()
+			if err != nil {
+				return err
+			}
+		}
+		userplugin, err := cc.ctx.AuthPluginForUser(&auth.UserIdentity{Username: cc.user, Hostname: cc.peerHost})
+		if err != nil {
+			return err
+		}
+		if userplugin != mysql.AuthNativePassword && userplugin != "" {
+			return errNotSupportedAuthMode
+		}
+		resp.AuthPlugin = mysql.AuthNativePassword
 	}
 	return nil
 }

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -912,7 +912,9 @@ func TestHandleAuthPlugin(t *testing.T) {
 		pkt: &packetIO{
 			bufWriter: bufio.NewWriter(bytes.NewBuffer(nil)),
 		},
-		server: srv,
+		collation: mysql.DefaultCollationID,
+		server:    srv,
+		user:      "root",
 	}
 	ctx := context.Background()
 	resp := handshakeResponse41{

--- a/server/server.go
+++ b/server/server.go
@@ -102,6 +102,7 @@ var (
 	errSecureTransportRequired = dbterror.ClassServer.NewStd(errno.ErrSecureTransportRequired)
 	errMultiStatementDisabled  = dbterror.ClassServer.NewStd(errno.ErrMultiStatementDisabled)
 	errNewAbortingConnection   = dbterror.ClassServer.NewStd(errno.ErrNewAbortingConnection)
+	errNotSupportedAuthMode    = dbterror.ClassServer.NewStd(errno.ErrNotSupportedAuthMode)
 )
 
 // DefaultCapability is the capability of the server when it is created using the default configuration.


### PR DESCRIPTION
cherry-pick #29732 to release-5.3

------------------------------------------------------------

### What problem does this PR solve?

Issue Number: close #29725

Problem Summary:

`handleAuthPlugin` checks for the `ClientPluginAuth` capability but this didn't set the `AuthPlugin` causing `readOptionalSSLRequestAndHandshakeResponse` to return an error.

Note that this allows authentication for users that use `mysql_native_password` to work, but users using `caching_sha2_passwords` won't work.

This does now return a more specific error in case authentication with `caching_sha2_password` is used.
```
[dvaneeden@dve-carbon ~]$ ~/opt/mysql/5.1.73/bin/mysql -h 127.0.0.1 -u sha -P 4000 -psha
ERROR 1105 (HY000): ERROR 1251 (08004): Client does not support authentication protocol requested by server; consider upgrading MySQL client
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Verify the connection with MySQL client v5.1:
```
sh> mysql -u root -h 127.0.0.1 -P 4000
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
