### PR TITLE
planner: rename duplicated anonymous columns when creating view

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -3619,3 +3619,109 @@ func (s *testIntegrationSuite3) TestIssue29282(c *C) {
 		c.Fail()
 	}
 }
+
+func (s *testIntegrationSuite3) TestIssue29326(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (id int)")
+	tk.MustExec("insert into t1 values(1)")
+	defer tk.MustExec("drop table t1")
+
+	tk.MustExec("drop table if exists t2")
+	tk.MustExec("create table t2 (id int)")
+	tk.MustExec("insert into t2 values(1)")
+	defer tk.MustExec("drop table t2")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create view v1 as select 1,1")
+	rs, err := tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("1 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "1")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "Name_exp_1")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create view v1 as select 1, 2, 1, 2, 1, 2, 1, 2")
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("1 2 1 2 1 2 1 2"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "1")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "2")
+	c.Assert(rs.Fields()[2].Column.Name.O, Equals, "Name_exp_1")
+	c.Assert(rs.Fields()[3].Column.Name.O, Equals, "Name_exp_2")
+	c.Assert(rs.Fields()[4].Column.Name.O, Equals, "Name_exp_1_1")
+	c.Assert(rs.Fields()[5].Column.Name.O, Equals, "Name_exp_1_2")
+	c.Assert(rs.Fields()[6].Column.Name.O, Equals, "Name_exp_2_1")
+	c.Assert(rs.Fields()[7].Column.Name.O, Equals, "Name_exp_2_2")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create view v1 as select 't', 't', 1 as t")
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("t t 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "Name_exp_t")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "Name_exp_1_t")
+	c.Assert(rs.Fields()[2].Column.Name.O, Equals, "t")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create definer=`root`@`127.0.0.1` view v1 as select 1, 1 union all select 1, 1")
+	tk.MustQuery("show create view v1").Check(testkit.Rows("v1 CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`127.0.0.1` " +
+		"SQL SECURITY DEFINER VIEW `v1` (`1`, `Name_exp_1`) " +
+		"AS SELECT 1 AS `1`,1 AS `Name_exp_1` UNION ALL SELECT 1 AS `1`,1 AS `1` " +
+		"utf8mb4 utf8mb4_bin"))
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("1 1", "1 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "1")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "Name_exp_1")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create definer=`root`@`127.0.0.1` view v1 as select 'id', id from t1")
+	tk.MustQuery("show create view v1").Check(testkit.Rows("v1 CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`127.0.0.1` " +
+		"SQL SECURITY DEFINER VIEW `v1` (`Name_exp_id`, `id`) " +
+		"AS SELECT _UTF8MB4'id' AS `Name_exp_id`,`id` AS `id` FROM `test`.`t1` " +
+		"utf8mb4 utf8mb4_bin"))
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("id 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "Name_exp_id")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "id")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create definer=`root`@`127.0.0.1` view v1 as select 1, (select id from t1 where t1.id=t2.id) as '1' from t2")
+	tk.MustQuery("show create view v1").Check(testkit.Rows("v1 CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`127.0.0.1` " +
+		"SQL SECURITY DEFINER VIEW `v1` (`Name_exp_1`, `1`) " +
+		"AS SELECT 1 AS `Name_exp_1`,(SELECT `id` AS `id` FROM `test`.`t1` WHERE `t1`.`id`=`t2`.`id`) AS `1` FROM `test`.`t2` " +
+		"utf8mb4 utf8mb4_bin"))
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("1 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "Name_exp_1")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "1")
+
+	tk.MustExec("drop view if exists v1")
+	tk.MustExec("create definer=`root`@`127.0.0.1` view v1 as select 1 as 'abs(t1.id)', abs(t1.id) from t1")
+	tk.MustQuery("show create view v1").Check(testkit.Rows("v1 CREATE ALGORITHM=UNDEFINED DEFINER=`root`@`127.0.0.1` " +
+		"SQL SECURITY DEFINER VIEW `v1` (`abs(t1.id)`, `Name_exp_abs(t1.id)`) " +
+		"AS SELECT 1 AS `abs(t1.id)`,ABS(`t1`.`id`) AS `Name_exp_abs(t1.id)` FROM `test`.`t1` " +
+		"utf8mb4 utf8mb4_bin"))
+	rs, err = tk.Exec("select * from v1")
+	c.Assert(err, IsNil)
+	tk.ResultSetToResult(rs, Commentf("%v", rs)).Check(testkit.Rows("1 1"))
+	c.Assert(rs.Fields()[0].Column.Name.O, Equals, "abs(t1.id)")
+	c.Assert(rs.Fields()[1].Column.Name.O, Equals, "Name_exp_abs(t1.id)")
+
+	tk.MustExec("drop view if exists v1")
+	err = tk.ExecToErr("create definer=`root`@`127.0.0.1` view v1 as select 1 as t,1 as t")
+	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
+
+	tk.MustExec("drop view if exists v1")
+	err = tk.ExecToErr("create definer=`root`@`127.0.0.1` view v1 as select * from t1 left join t2 on t1.id=t2.id")
+	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
+
+	tk.MustExec("drop view if exists v1")
+	err = tk.ExecToErr("create definer=`root`@`127.0.0.1` view v1 as select t1.id, t2.id from t1,t2 where t1.id=t2.id")
+	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
+}

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -3635,6 +3635,8 @@ func (s *testIntegrationSuite3) TestIssue29326(c *C) {
 	defer tk.MustExec("drop table t2")
 
 	tk.MustExec("drop view if exists v1")
+	defer tk.MustExec("drop view if exists v1")
+
 	tk.MustExec("create view v1 as select 1,1")
 	rs, err := tk.Exec("select * from v1")
 	c.Assert(err, IsNil)

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -3718,6 +3718,10 @@ func (s *testIntegrationSuite3) TestIssue29326(c *C) {
 	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
 
 	tk.MustExec("drop view if exists v1")
+	err = tk.ExecToErr("create definer=`root`@`127.0.0.1` view v1 as select 1 as id, id from t1")
+	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
+
+	tk.MustExec("drop view if exists v1")
 	err = tk.ExecToErr("create definer=`root`@`127.0.0.1` view v1 as select * from t1 left join t2 on t1.id=t2.id")
 	c.Assert(infoschema.ErrColumnExists.Equal(err), IsTrue)
 

--- a/parser/ast/dml.go
+++ b/parser/ast/dml.go
@@ -1100,6 +1100,8 @@ type SelectStmt struct {
 	// Lists is filled only when Kind == SelectStmtKindValues
 	Lists []*RowExpr
 	With  *WithClause
+	// AsViewSchema indicates if this stmt provides the schema for the view. It is only used when creating the view
+	AsViewSchema bool
 }
 
 func (*SelectStmt) resultSet() {}

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -3907,6 +3907,11 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (Plan, err
 			b.capFlag &= ^renameView
 			b.isCreateView = false
 		}()
+
+		if stmt := findStmtAsViewSchema(v); stmt != nil {
+			stmt.AsViewSchema = true
+		}
+
 		plan, err := b.Build(ctx, v.Select)
 		if err != nil {
 			return nil, err
@@ -4401,4 +4406,20 @@ func adjustOverlongViewColname(plan LogicalPlan) {
 			outputNames[i].ColName = model.NewCIStr(fmt.Sprintf("name_exp_%d", i+1))
 		}
 	}
+}
+
+// findStmtAsViewSchema finds the first SelectStmt as the schema for the view
+func findStmtAsViewSchema(stmt ast.Node) *ast.SelectStmt {
+	switch x := stmt.(type) {
+	case *ast.CreateViewStmt:
+		return findStmtAsViewSchema(x.Select)
+	case *ast.SetOprStmt:
+		return findStmtAsViewSchema(x.SelectList)
+	case *ast.SetOprSelectList:
+		return findStmtAsViewSchema(x.Selects[0])
+	case *ast.SelectStmt:
+		return x
+	}
+
+	return nil
 }

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -4420,6 +4420,5 @@ func findStmtAsViewSchema(stmt ast.Node) *ast.SelectStmt {
 	case *ast.SelectStmt:
 		return x
 	}
-
 	return nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29326

Problem Summary:

To make a compatibility with mysql, create view should not fail when the result contains some duplicated names. For example:

```
mysql> create view v as select 3, 4, 3, 4, 3, 4, 3, 4;
Query OK, 0 rows affected (0.01 sec)

mysql> select * from v \G
*************************** 1. row ***************************
           3: 3
           4: 4
  Name_exp_3: 3
  Name_exp_4: 4
Name_exp_1_3: 3
Name_exp_1_4: 4
Name_exp_2_3: 3
Name_exp_2_4: 4
1 row in set (0.00 sec)
```

By the way, a table column or a column name specified with `as` should not be renamed even if it is duplicated:

```
mysql> create table t(id int);
Query OK, 0 rows affected (0.03 sec)

mysql> create view v as select id, 1 as id from t;
ERROR 1060 (42S21): Duplicate column name 'id'
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Support rename duplicated column names when creating view
```
