### PR TITLE
planner: fix data race

### DIFF
--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -4195,18 +4195,18 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 			us.SetChildren(ds)
 			result = us
 		} else {
-			go func() {
-				defer func() {
-					if r := recover(); r != nil {
-					}
-				}()
-				if !b.inUpdateStmt && !b.inDeleteStmt && !b.ctx.GetSessionVars().StmtCtx.InExplainStmt {
+			if !b.inUpdateStmt && !b.inDeleteStmt && !sessionVars.StmtCtx.InExplainStmt {
+				go func() {
+					defer func() {
+						if r := recover(); r != nil {
+						}
+					}()
 					err := cachedTable.UpdateLockForRead(b.ctx.GetStore(), txn.StartTS())
 					if err != nil {
 						log.Warn("Update Lock Info Error")
 					}
-				}
-			}()
+				}()
+			}
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29961

Problem Summary:

### What is changed and how it works?

```
WARNING: DATA RACE
Write at 0x00c001fa0280 by goroutine 88:
  github.com/pingcap/tidb/executor.ResetContextOfStmt()
      /home/jenkins/agent/workspace/atom-ut/tidb/executor/executor.go:1848 +0x11b2
  github.com/pingcap/tidb/session.(*session).ExecuteStmt()
      /home/jenkins/agent/workspace/atom-ut/tidb/session/session.go:1534 +0x204
  github.com/pingcap/tidb/testkit.(*TestKit).Exec()
      /home/jenkins/agent/workspace/atom-ut/tidb/testkit/testkit.go:145 +0x2dc
  github.com/pingcap/tidb/testkit.(*TestKit).MustQuery()
      /home/jenkins/agent/workspace/atom-ut/tidb/testkit/testkit.go:90 +0x176
  github.com/pingcap/tidb/testkit.(*TestKit).HasPlan()
      /home/jenkins/agent/workspace/atom-ut/tidb/testkit/testkit.go:122 +0xb3
  github.com/pingcap/tidb/table/tables_test.TestCacheCondition()
      /home/jenkins/agent/workspace/atom-ut/tidb/table/tables/cache_test.go:160 +0x270
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202

Previous read at 0x00c001fa0280 by goroutine 79:
  github.com/pingcap/tidb/planner/core.(*PlanBuilder).buildDataSource.func1()
      /home/jenkins/agent/workspace/atom-ut/tidb/planner/core/logical_plan_builder.go:4203 +0x1fd

Goroutine 88 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1238 +0x5d7
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:1511 +0xa6
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1193 +0x202
  testing.runTests()
      /usr/local/go/src/testing/testing.go:1509 +0x612
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:1417 +0x3b3
  go.uber.org/goleak.VerifyTestMain()
      /nfs/cache/mod/go.uber.org/goleak@v1.1.11-0.20210813005559-691160354723/testmain.go:53 +0x5e
  github.com/pingcap/tidb/table/tables_test.TestMain()
      /home/jenkins/agent/workspace/atom-ut/tidb/table/tables/main_test.go:31 +0x130
  main.main()
      _testmain.go:183 +0x371
```

https://ci.pingcap.net/job/atom-ut/1406/testReport/github/com_pingcap_tidb_table_tables/TestCacheCondition/

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
