### PR TITLE
planner: regard NULL as point when accessing composite index

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -683,6 +683,8 @@ func encodeIndexKey(sc *stmtctx.StatementContext, ran *ranger.Range) ([]byte, []
 		}
 	}
 
+	// NOTE: this is a hard-code operation to avoid wrong results when accessing unique index with NULL;
+	// Please see https://github.com/pingcap/tidb/issues/29650 for more details
 	if hasNull {
 		// Append 0 to make unique-key range [null, null] to be a scan rather than point-get.
 		high = kv.Key(high).Next()

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1487,7 +1487,8 @@ func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bo
 		return indexScan.IsPointGetByUniqueKey(ctx.GetSessionVars().StmtCtx), nil
 	case *PhysicalTableReader:
 		tableScan := v.TablePlans[0].(*PhysicalTableScan)
-		isPointRange := len(tableScan.Ranges) == 1 && tableScan.Ranges[0].IsPoint(ctx.GetSessionVars().StmtCtx)
+		tableRangeIsPoint, _ := tableScan.Ranges[0].IsPoint(ctx.GetSessionVars().StmtCtx)
+		isPointRange := len(tableScan.Ranges) == 1 && tableRangeIsPoint
 		if !isPointRange {
 			return false, nil
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -860,7 +860,9 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		if canConvertPointGet {
 			allRangeIsPoint := true
 			for _, ran := range path.Ranges {
-				if !ran.IsPoint(ds.ctx.GetSessionVars().StmtCtx) {
+				isPoint, hasNull := ran.IsPoint(ds.ctx.GetSessionVars().StmtCtx)
+				if !isPoint || hasNull {
+					// unique indexes can have duplicated rows with NULL
 					allRangeIsPoint = false
 					break
 				}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1199,10 +1199,11 @@ func (p *PhysicalIndexScan) IsPartition() (bool, int64) {
 
 // IsPointGetByUniqueKey checks whether is a point get by unique key.
 func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sc *stmtctx.StatementContext) bool {
+	rangeIsPoint, _ := p.Ranges[0].IsPoint(sc)
 	return len(p.Ranges) == 1 &&
 		p.Index.Unique &&
 		len(p.Ranges[0].LowVal) == len(p.Index.Columns) &&
-		p.Ranges[0].IsPoint(sc)
+		rangeIsPoint
 }
 
 // PhysicalSelection represents a filter.

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -212,6 +212,22 @@ func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.Range) bool {
 		if len(rg.LowVal) != len(idx.Columns) {
 			return false
 		}
+		if !rg.LowExclude {
+			for _, v := range rg.LowVal {
+				if v.IsNull() {
+					// a unique index may have duplicated rows with NULLs, so we cannot set the unique attribute to true when the range has NULL
+					// please see https://github.com/pingcap/tidb/issues/29650 for more details
+					return false
+				}
+			}
+		}
+		if !rg.HighExclude {
+			for _, v := range rg.HighVal {
+				if v.IsNull() {
+					return false
+				}
+			}
+		}
 	}
 	return true
 }

--- a/planner/util/path.go
+++ b/planner/util/path.go
@@ -155,7 +155,7 @@ func (path *AccessPath) OnlyPointRange(sc *stmtctx.StatementContext) bool {
 	noIntervalRange := true
 	if path.IsIntHandlePath {
 		for _, ran := range path.Ranges {
-			if !ran.IsPoint(sc) {
+			if isPoint, _ := ran.IsPoint(sc); !isPoint {
 				noIntervalRange = false
 				break
 			}
@@ -165,7 +165,8 @@ func (path *AccessPath) OnlyPointRange(sc *stmtctx.StatementContext) bool {
 	haveNullVal := false
 	for _, ran := range path.Ranges {
 		// Not point or the not full matched.
-		if !ran.IsPoint(sc) || len(ran.HighVal) != len(path.Index.Columns) {
+		isPoint, _ := ran.IsPoint(sc)
+		if !isPoint || len(ran.HighVal) != len(path.Index.Columns) {
 			noIntervalRange = false
 			break
 		}

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -197,6 +197,9 @@ type StatementContext struct {
 	EnableOptimizeTrace bool
 	// LogicalOptimizeTrace indicates the trace for optimize
 	LogicalOptimizeTrace *tracing.LogicalOptimizeTracer
+
+	// RegardNULLAsPoint if regard NULL as Point
+	RegardNULLAsPoint bool
 }
 
 // StmtHints are SessionVars related sql hints.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1857,6 +1857,10 @@ var defaultSysVars = []*SysVar{
 		s.EnablePseudoForOutdatedStats = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRegardNULLAsPoint, Value: BoolToOnOff(DefTiDBRegardNULLAsPoint), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.StmtCtx.RegardNULLAsPoint = TiDBOptOn(val)
+		return nil
+	}},
 
 	{Scope: ScopeNone, Name: "version_compile_os", Value: runtime.GOOS},
 	{Scope: ScopeNone, Name: "version_compile_machine", Value: runtime.GOARCH},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -595,6 +595,9 @@ const (
 	// TiDBEnablePseudoForOutdatedStats indicates whether use pseudo for outdated stats
 	TiDBEnablePseudoForOutdatedStats = "tidb_enable_pseudo_for_outdated_stats"
 
+	// TiDBRegardNULLAsPoint indicates whether regard NULL as point when optimizing
+	TiDBRegardNULLAsPoint = "tidb_enable_regard_null_as_point"
+
 	// TiDBTmpTableMaxSize indicates the max memory size of temporary tables.
 	TiDBTmpTableMaxSize = "tidb_tmp_table_max_size"
 )
@@ -768,6 +771,7 @@ const (
 	DefTiDBEnableTSOFollowerProxy         = false
 	DefTiDBEnableOrderedResultMode        = false
 	DefTiDBEnablePseudoForOutdatedStats   = true
+	DefTiDBRegardNULLAsPoint              = true
 	DefEnablePlacementCheck               = true
 	DefTimestamp                          = "0"
 )

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -98,7 +98,7 @@ func detachColumnDNFConditions(sctx sessionctx.Context, conditions []expression.
 // in function which is `column in (constant list)`.
 // If so, it will return the offset of this column in the slice, otherwise return -1 for not found.
 // Since combining `x >= 2` and `x <= 2` can lead to an eq condition `x = 2`, we take le/ge/lt/gt into consideration.
-func getPotentialEqOrInColOffset(expr expression.Expression, cols []*expression.Column) int {
+func getPotentialEqOrInColOffset(sctx sessionctx.Context, expr expression.Expression, cols []*expression.Column) int {
 	f, ok := expr.(*expression.ScalarFunction)
 	if !ok {
 		return -1
@@ -109,7 +109,7 @@ func getPotentialEqOrInColOffset(expr expression.Expression, cols []*expression.
 		dnfItems := expression.FlattenDNFConditions(f)
 		offset := int(-1)
 		for _, dnfItem := range dnfItems {
-			curOffset := getPotentialEqOrInColOffset(dnfItem, cols)
+			curOffset := getPotentialEqOrInColOffset(sctx, dnfItem, cols)
 			if curOffset == -1 {
 				return -1
 			}
@@ -129,7 +129,7 @@ func getPotentialEqOrInColOffset(expr expression.Expression, cols []*expression.
 			}
 			if constVal, ok := f.GetArgs()[1].(*expression.Constant); ok {
 				val, err := constVal.Eval(chunk.Row{})
-				if err != nil || val.IsNull() {
+				if err != nil || (!sctx.GetSessionVars().StmtCtx.RegardNULLAsPoint && val.IsNull()) {
 					// treat col<=>null as range scan instead of point get to avoid incorrect results
 					// when nullable unique index has multiple matches for filter x is null
 					return -1
@@ -151,7 +151,7 @@ func getPotentialEqOrInColOffset(expr expression.Expression, cols []*expression.
 			}
 			if constVal, ok := f.GetArgs()[0].(*expression.Constant); ok {
 				val, err := constVal.Eval(chunk.Row{})
-				if err != nil || val.IsNull() {
+				if err != nil || (!sctx.GetSessionVars().StmtCtx.RegardNULLAsPoint && val.IsNull()) {
 					return -1
 				}
 				for i, col := range cols {
@@ -216,7 +216,7 @@ func extractIndexPointRangesForCNF(sctx sessionctx.Context, conds []expression.E
 		sameLens, allPoints := true, true
 		numCols := int(0)
 		for j, ran := range res.Ranges {
-			if !ran.IsPoint(sctx.GetSessionVars().StmtCtx) {
+			if isPoint, _ := ran.IsPoint(sctx.GetSessionVars().StmtCtx); !isPoint {
 				allPoints = false
 				break
 			}
@@ -517,7 +517,7 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 	columnValues := make([]*valueInfo, len(cols))
 	offsets := make([]int, len(conditions))
 	for i, cond := range conditions {
-		offset := getPotentialEqOrInColOffset(cond, cols)
+		offset := getPotentialEqOrInColOffset(sctx, cond, cols)
 		offsets[i] = offset
 		if offset == -1 {
 			continue

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -161,7 +161,7 @@ func appendPoints2Ranges(sc *stmtctx.StatementContext, origin []*Range, rangePoi
 	var newIndexRanges []*Range
 	for i := 0; i < len(origin); i++ {
 		oRange := origin[i]
-		if !oRange.IsPoint(sc) {
+		if isPoint, _ := oRange.IsPoint(sc); !isPoint {
 			newIndexRanges = append(newIndexRanges, oRange)
 		} else {
 			newRanges, err := appendPoints2IndexRange(sc, oRange, rangePoints, ft)

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -80,29 +80,34 @@ func (ran *Range) Clone() *Range {
 }
 
 // IsPoint returns if the range is a point.
-func (ran *Range) IsPoint(sc *stmtctx.StatementContext) bool {
+// Please notice that unique indexes can have duplicated NULL rows, hasNull indicates whether the Point Range has NULLs.
+func (ran *Range) IsPoint(sc *stmtctx.StatementContext) (isPoint bool, hasNull bool) {
 	if len(ran.LowVal) != len(ran.HighVal) {
-		return false
+		return false, false
 	}
 	for i := range ran.LowVal {
 		a := ran.LowVal[i]
 		b := ran.HighVal[i]
 		if a.Kind() == types.KindMinNotNull || b.Kind() == types.KindMaxValue {
-			return false
+			return false, false
 		}
 		cmp, err := a.CompareDatum(sc, &b)
 		if err != nil {
-			return false
+			return false, false
 		}
 		if cmp != 0 {
-			return false
+			if sc.RegardNULLAsPoint { // regard NULL as point and set hasNull=true
+				hasNull = true
+			} else { // regard NULL as range
+				return false, false
+			}
 		}
 
 		if a.IsNull() {
-			return false
+			return false, false
 		}
 	}
-	return !ran.LowExclude && !ran.HighExclude
+	return !ran.LowExclude && !ran.HighExclude, hasNull
 }
 
 // IsPointNullable returns if the range is a point.

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -125,8 +125,10 @@ func TestRange(t *testing.T) {
 		},
 	}
 	sc := new(stmtctx.StatementContext)
+	sc.RegardNULLAsPoint = false
 	for _, v := range isPointTests {
-		require.Equal(t, v.isPoint, v.ran.IsPoint(sc))
+		isPoint, _ := v.ran.IsPoint(sc)
+		require.Equal(t, v.isPoint, isPoint)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29650

Problem Summary: planner: regard NULL as point when accessing composite index

### What is changed and how it works?

planner: regard NULL as point when accessing composite index

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: regard NULL as point when accessing composite index
```
