### PR TITLE
br: fix S3 backup endpoint suffix /

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -189,6 +189,7 @@ func (options *S3BackendOptions) parseFromFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
+	options.Endpoint = strings.Trim(options.Endpoint, "/")
 	options.Region, err = flags.GetString(s3RegionOption)
 	if err != nil {
 		return errors.Trace(err)

--- a/ddl/options_test.go
+++ b/ddl/options_test.go
@@ -15,22 +15,21 @@
 package ddl_test
 
 import (
+	"github.com/stretchr/testify/require"
+	"testing"
 	"time"
 
-	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/util/mock"
 	"go.etcd.io/etcd/clientv3"
 )
 
-type ddlOptionsSuite struct{}
+func TestOptions(t *testing.T) {
+	t.Parallel()
 
-var _ = Suite(&ddlOptionsSuite{})
-
-func (s *ddlOptionsSuite) TestOptions(c *C) {
 	client, err := clientv3.NewFromURL("test")
-	c.Assert(err, IsNil)
+	require.NoError(t, err)
 	callback := &ddl.BaseCallback{}
 	lease := time.Second * 3
 	store := &mock.Store{}
@@ -49,9 +48,9 @@ func (s *ddlOptionsSuite) TestOptions(c *C) {
 		o(opt)
 	}
 
-	c.Assert(opt.EtcdCli, Equals, client)
-	c.Assert(opt.Hook, Equals, callback)
-	c.Assert(opt.Lease, Equals, lease)
-	c.Assert(opt.Store, Equals, store)
-	c.Assert(opt.InfoCache, Equals, infoHandle)
+	require.Equal(t, client, opt.EtcdCli)
+	require.Equal(t, callback, opt.Hook)
+	require.Equal(t, lease, opt.Lease)
+	require.Equal(t, store, opt.Store)
+	require.Equal(t, infoHandle, opt.InfoCache)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. tidb/br/pkg/storage/s3.go
2. *: what's changed

when Endpoint end have ”/“ , An error occurs during S3 backup
-->

### What problem does this PR solve?

Issue Number: close #30128 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```