### PR TITLE
expression: fix truncate in CastStringAsDecimalSig

### DIFF
--- a/expression/builtin_cast.go
+++ b/expression/builtin_cast.go
@@ -1902,6 +1902,9 @@ func WrapWithCastAsDecimal(ctx sessionctx.Context, expr Expression) Expression {
 	if expr.GetType().EvalType() == types.ETInt {
 		tp.Flen = mysql.MaxIntWidth
 	}
+	if expr.GetType().EvalType() == types.ETString {
+		tp.Decimal = types.UnspecifiedLength
+	}
 	if tp.Flen == types.UnspecifiedLength || tp.Flen > mysql.MaxDecimalWidth {
 		tp.Flen = mysql.MaxDecimalWidth
 	}


### PR DESCRIPTION
Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>

### What problem does this PR solve?

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?
Avoid truncate in `CastStringAsDecimalSig` via setting `tp.Decimal=UnspecifiedLength`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
