### PR TITLE
expression: make built-in function ord() backward compatible

### DIFF
--- a/expression/builtin_convert_charset.go
+++ b/expression/builtin_convert_charset.go
@@ -272,7 +272,7 @@ func HandleBinaryLiteral(ctx sessionctx.Context, expr Expression, ec *ExprCollat
 			return BuildFromBinaryFunction(ctx, expr, ft)
 		}
 	case ast.Hex, ast.Length, ast.OctetLength, ast.ASCII, ast.ToBase64, ast.AesDecrypt, ast.Decode, ast.Encode,
-		ast.PasswordFunc, ast.MD5, ast.SHA, ast.SHA1, ast.SHA2, ast.Compress, ast.Ord:
+		ast.PasswordFunc, ast.MD5, ast.SHA, ast.SHA1, ast.SHA2, ast.Compress:
 		if _, err := charset.GetDefaultCollationLegacy(expr.GetType().Charset); err != nil {
 			return BuildToBinaryFunction(ctx, expr)
 		}

--- a/expression/builtin_convert_charset.go
+++ b/expression/builtin_convert_charset.go
@@ -66,7 +66,7 @@ func (c *tidbToBinaryFunctionClass) getFunction(ctx sessionctx.Context, args []E
 		}
 		bf.tp = args[0].GetType().Clone()
 		bf.tp.Charset, bf.tp.Collate = charset.CharsetBin, charset.CollationBin
-		sig = &builtinInternalToBinarySig{bf}
+		sig = &builtinInternalToBinarySig{baseBuiltinFunc: bf}
 		sig.setPbCode(tipb.ScalarFuncSig_ToBinary)
 	default:
 		return nil, fmt.Errorf("unexpected argTp: %d", argTp)
@@ -272,7 +272,7 @@ func HandleBinaryLiteral(ctx sessionctx.Context, expr Expression, ec *ExprCollat
 			return BuildFromBinaryFunction(ctx, expr, ft)
 		}
 	case ast.Hex, ast.Length, ast.OctetLength, ast.ASCII, ast.ToBase64, ast.AesDecrypt, ast.Decode, ast.Encode,
-		ast.PasswordFunc, ast.MD5, ast.SHA, ast.SHA1, ast.SHA2, ast.Compress:
+		ast.PasswordFunc, ast.MD5, ast.SHA, ast.SHA1, ast.SHA2, ast.Compress, ast.Ord:
 		if _, err := charset.GetDefaultCollationLegacy(expr.GetType().Charset); err != nil {
 			return BuildToBinaryFunction(ctx, expr)
 		}

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -30,6 +30,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestT(t *testing.T) {
+	CustomVerboseFlag = true
+	*CustomParallelSuiteFlag = true
+	TestingT(t)
+}
+
 func kindToFieldType(kind byte) types.FieldType {
 	ft := types.FieldType{}
 	switch kind {

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -802,7 +802,6 @@ func (s *testIntegrationSuite2) TestMathBuiltin(c *C) {
 }
 
 func (s *testIntegrationSuite2) TestStringBuiltin(c *C) {
-	c.Skip("it has been broken. Please fix it as soon as possible.")
 	defer s.cleanEnv(c)
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/parser/charset/encoding.go
+++ b/parser/charset/encoding.go
@@ -62,7 +62,8 @@ func (e *Encoding) Name() string {
 
 // CharLength returns the next character length in bytes.
 func (e *Encoding) CharLength(bs []byte) int {
-	return e.charLength(bs)
+	w := e.charLength(bs)
+	return mathutil.Min(w, len(bs))
 }
 
 // NewEncoding creates a new Encoding.
@@ -92,16 +93,6 @@ func (e *Encoding) EncodeString(src string) (string, error) {
 	}
 	bs, err := e.transform(e.enc.NewEncoder(), nil, Slice(src), false)
 	return string(bs), err
-}
-
-// EncodeFirstChar convert first code point of bytes from utf-8 charset to a specific charset.
-func (e *Encoding) EncodeFirstChar(dest, src []byte) ([]byte, error) {
-	srcNextLen := e.nextCharLenInSrc(src, false)
-	srcEnd := mathutil.Min(srcNextLen, len(src))
-	if !e.enabled() {
-		return src[:srcEnd], nil
-	}
-	return e.transform(e.enc.NewEncoder(), dest, src[:srcEnd], false)
 }
 
 // EncodeInternal convert bytes from utf-8 charset to a specific charset, we actually do not do the real convert, just find the inconvertible character and use ? replace.
@@ -161,17 +152,16 @@ func (e *Encoding) transform(transformer transform.Transformer, dest, src []byte
 	var destOffset, srcOffset int
 	var encodingErr error
 	for {
-		srcNextLen := e.nextCharLenInSrc(src[srcOffset:], isDecoding)
-		srcEnd := mathutil.Min(srcOffset+srcNextLen, len(src))
-		nDest, nSrc, err := transformer.Transform(dest[destOffset:], src[srcOffset:srcEnd], false)
+		w := e.nextCharLenInSrc(src[srcOffset:], isDecoding)
+		nDest, nSrc, err := transformer.Transform(dest[destOffset:], src[srcOffset:srcOffset+w], false)
 		if err == transform.ErrShortDst {
 			dest = enlargeCapacity(dest)
 		} else if err != nil || isDecoding && beginWithReplacementChar(dest[destOffset:destOffset+nDest]) {
 			if encodingErr == nil {
-				encodingErr = e.generateErr(src[srcOffset:], srcNextLen)
+				encodingErr = e.generateErr(src[srcOffset:], w)
 			}
 			dest[destOffset] = byte('?')
-			nDest, nSrc = 1, srcNextLen // skip the source bytes that cannot be decoded normally.
+			nDest, nSrc = 1, w // skip the source bytes that cannot be decoded normally.
 		}
 		destOffset += nDest
 		srcOffset += nSrc
@@ -185,7 +175,7 @@ func (e *Encoding) transform(transformer transform.Transformer, dest, src []byte
 func (e *Encoding) nextCharLenInSrc(srcRest []byte, isDecoding bool) int {
 	if isDecoding {
 		if e.charLength != nil {
-			return e.charLength(srcRest)
+			return e.CharLength(srcRest)
 		}
 		return len(srcRest)
 	}

--- a/parser/charset/encoding_table.go
+++ b/parser/charset/encoding_table.go
@@ -18,7 +18,6 @@ import (
 	go_unicode "unicode"
 	"unicode/utf8"
 
-	"github.com/cznic/mathutil"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/charmap"
 	"golang.org/x/text/encoding/japanese"
@@ -330,7 +329,6 @@ func (s StringValidatorASCII) Truncate(str string, strategy TruncateStrategy) (s
 			w = 1
 			if str[i] > go_unicode.MaxASCII {
 				w = UTF8Encoding.CharLength(Slice(str)[i:])
-				w = mathutil.Min(w, len(str)-i)
 				result = append(result, '?')
 				continue
 			}
@@ -425,7 +423,6 @@ func (s StringValidatorOther) Truncate(str string, strategy TruncateStrategy) (s
 	invalidPos := -1
 	for i, w := 0, 0; i < len(str); i += w {
 		w = UTF8Encoding.CharLength(strBytes[i:])
-		w = mathutil.Min(w, len(str)-i)
 		_, _, err := transformer.Transform(buf[:], strBytes[i:i+w], true)
 		if err != nil {
 			if invalidPos == -1 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Related to https://github.com/pingcap/tidb/pull/30156.

Problem Summary:

```sql
select ord(_latin1 '你');
```
should not return an encoding error.

Previous `ord()` implementation did not consider the backward compatibility. The test `TestStringBuiltin` was skipped due to the test framework refactoring. Now we add it back.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
