### PR TITLE
server: Port missing in processlist

### DIFF
--- a/server/conn.go
+++ b/server/conn.go
@@ -888,7 +888,7 @@ func (cc *clientConn) checkAuthPlugin(ctx context.Context, resp *handshakeRespon
 
 func (cc *clientConn) PeerHost(hasPassword string) (host, port string, err error) {
 	if len(cc.peerHost) > 0 {
-		return cc.peerHost, "", nil
+		return cc.peerHost, cc.peerPort, nil
 	}
 	host = variable.DefHostname
 	if cc.isUnixSocket {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -779,7 +779,7 @@ func (cli *testServerClient) runTestLoadDataForListColumnPartition2(t *testing.T
 	})
 }
 
-func (cli *testServerClient) checkRows(t *testing.T, rows *sql.Rows, expectedRows ...string) {
+func (cli *testServerClient) Rows(t *testing.T, rows *sql.Rows) []string {
 	buf := bytes.NewBuffer(nil)
 	result := make([]string, 0, 2)
 	for rows.Next() {
@@ -806,7 +806,11 @@ func (cli *testServerClient) checkRows(t *testing.T, rows *sql.Rows, expectedRow
 		}
 		result = append(result, buf.String())
 	}
+	return result
+}
 
+func (cli *testServerClient) checkRows(t *testing.T, rows *sql.Rows, expectedRows ...string) {
+	result := cli.Rows(t, rows)
 	require.Equal(t, strings.Join(expectedRows, "\n"), strings.Join(result, "\n"))
 }
 

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -528,6 +528,9 @@ func TestSocketAndIp(t *testing.T) {
 			cli.checkRows(t, rows, "user1@127.0.0.1")
 			rows = dbt.MustQuery("show grants")
 			cli.checkRows(t, rows, "GRANT USAGE ON *.* TO 'user1'@'%'\nGRANT SELECT ON test.* TO 'user1'@'%'")
+			rows = dbt.MustQuery("select host from information_schema.processlist where user = 'user1'")
+			records := cli.Rows(t, rows)
+			require.Contains(t, records[0], ":", "Missing :<port> in is.processlist")
 		})
 	// Test with unix domain socket file connection with all hosts
 	cli.runTests(t, func(config *mysql.Config) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #30182

Problem Summary:
Regression, a second call of cc.PeerHost() was probably added, which made the port to be set to "".

### What is changed and how it works?
Fixed the return of the already set value.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fixed regression where the port part of the host in processlist disappeared
```
