### PR TITLE
br: fix wrong argument for splitSizeBytes on calling MergeFileRanges

### DIFF
--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -115,7 +115,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 	summary.CollectInt("restore files", len(files))
 
 	ranges, _, err := restore.MergeFileRanges(
-		files, cfg.MergeSmallRegionKeyCount, cfg.MergeSmallRegionKeyCount)
+		files, cfg.MergeSmallRegionSizeBytes, cfg.MergeSmallRegionKeyCount)
 	if err != nil {
 		return errors.Trace(err)
 	}


### PR DESCRIPTION
nothing just only fix a typo