### PR TITLE
statistics: fix unstable test case TestTraceCE

### DIFF
--- a/statistics/trace_test.go
+++ b/statistics/trace_test.go
@@ -81,6 +81,6 @@ func TestTraceCE(t *testing.T) {
 			out[i].Expr = expr
 			out[i].Trace = sctx.GetSessionVars().StmtCtx.OptimizerCETrace
 		})
-		require.Equal(t, sctx.GetSessionVars().StmtCtx.OptimizerCETrace, out[i].Trace)
+		require.ElementsMatch(t, sctx.GetSessionVars().StmtCtx.OptimizerCETrace, out[i].Trace)
 	}
 }


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #30234

Problem Summary:

Please see the issue for details.

### What is changed and how it works?

Replace `require.Equal` with `require.ElementsMatch` to ignore the order when comparing two slices.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
