### PR TITLE
Add tidb_opt_prefer_range_scan to 4.0

### DIFF
--- a/cmd/explaintest/r/explain_complex_stats.result
+++ b/cmd/explaintest/r/explain_complex_stats.result
@@ -131,10 +131,10 @@ Projection_13	424.00	root		test.st.id, test.dd.id, test.st.aid, test.st.cm, test
     └─HashJoin_26	424.00	root		inner join, equal:[eq(test.st.aid, test.dd.aid) eq(test.st.ip, test.dd.ip)], other cond:gt(test.dd.t, test.st.t)
       ├─TableReader_29(Build)	424.00	root		data:Selection_28
       │ └─Selection_28	424.00	cop[tikv]		eq(test.st.bm, 0), eq(test.st.pt, "android"), gt(test.st.t, 1478143908), not(isnull(test.st.ip))
-      │   └─TableRangeScan_27	1999.00	cop[tikv]	table:gad	range:[0,+inf], keep order:false
+      │   └─TableFullScan_27	1999.00	cop[tikv]	table:gad	keep order:false
       └─TableReader_36(Probe)	455.80	root		data:Selection_35
         └─Selection_35	455.80	cop[tikv]		eq(test.dd.bm, 0), eq(test.dd.pt, "android"), gt(test.dd.t, 1478143908), not(isnull(test.dd.ip)), not(isnull(test.dd.t))
-          └─TableRangeScan_34	2000.00	cop[tikv]	table:dd	range:[0,+inf], keep order:false
+          └─TableFullScan_34	2000.00	cop[tikv]	table:dd	keep order:false
 explain select gad.id as gid,sdk.id as sid,gad.aid as aid,gad.cm as cm,sdk.dic as dic,sdk.ip as ip, sdk.t as t, gad.p1 as p1, gad.p2 as p2, gad.p3 as p3, gad.p4 as p4, gad.p5 as p5, gad.p6_md5 as p6, gad.p7_md5 as p7, gad.ext as ext from st gad join dd sdk on gad.aid = sdk.aid and gad.dic = sdk.mac and gad.t < sdk.t where gad.t > 1477971479 and gad.bm = 0 and gad.pt = 'ios' and gad.dit = 'mac' and sdk.t > 1477971479 and sdk.bm = 0 and sdk.pt = 'ios' limit 3000;
 id	estRows	task	access object	operator info
 Projection_10	170.34	root		test.st.id, test.dd.id, test.st.aid, test.st.cm, test.dd.dic, test.dd.ip, test.dd.t, test.st.p1, test.st.p2, test.st.p3, test.st.p4, test.st.p5, test.st.p6_md5, test.st.p7_md5, test.st.ext
@@ -142,7 +142,7 @@ Projection_10	170.34	root		test.st.id, test.dd.id, test.st.aid, test.st.cm, test
   └─IndexJoin_18	170.34	root		inner join, inner:IndexLookUp_17, outer key:test.st.aid, inner key:test.dd.aid, equal cond:eq(test.st.aid, test.dd.aid), eq(test.st.dic, test.dd.mac), other cond:lt(test.st.t, test.dd.t)
     ├─TableReader_25(Build)	170.34	root		data:Selection_24
     │ └─Selection_24	170.34	cop[tikv]		eq(test.st.bm, 0), eq(test.st.dit, "mac"), eq(test.st.pt, "ios"), gt(test.st.t, 1477971479), not(isnull(test.st.dic))
-    │   └─TableRangeScan_23	1999.00	cop[tikv]	table:gad	range:[0,+inf], keep order:false
+    │   └─TableFullScan_23	1999.00	cop[tikv]	table:gad	keep order:false
     └─IndexLookUp_17(Probe)	1.00	root		
       ├─IndexRangeScan_14(Build)	3.93	cop[tikv]	table:sdk, index:aid(aid, dic)	range: decided by [eq(test.dd.aid, test.st.aid)], keep order:false
       └─Selection_16(Probe)	1.00	cop[tikv]		eq(test.dd.bm, 0), eq(test.dd.pt, "ios"), gt(test.dd.t, 1477971479), not(isnull(test.dd.mac)), not(isnull(test.dd.t))
@@ -162,7 +162,7 @@ Projection_10	428.32	root		test.dt.id, test.dt.aid, test.dt.pt, test.dt.dic, tes
   └─IndexJoin_19	428.32	root		inner join, inner:IndexLookUp_18, outer key:test.dt.aid, test.dt.dic, inner key:test.rr.aid, test.rr.dic, equal cond:eq(test.dt.aid, test.rr.aid), eq(test.dt.dic, test.rr.dic)
     ├─TableReader_44(Build)	428.32	root		data:Selection_43
     │ └─Selection_43	428.32	cop[tikv]		eq(test.dt.bm, 0), eq(test.dt.pt, "ios"), gt(test.dt.t, 1478185592), not(isnull(test.dt.dic))
-    │   └─TableRangeScan_42	2000.00	cop[tikv]	table:dt	range:[0,+inf], keep order:false
+    │   └─TableFullScan_42	2000.00	cop[tikv]	table:dt	keep order:false
     └─IndexLookUp_18(Probe)	1.00	root		
       ├─IndexRangeScan_15(Build)	1.00	cop[tikv]	table:rr, index:PRIMARY(aid, dic)	range: decided by [eq(test.rr.aid, test.dt.aid) eq(test.rr.dic, test.dt.dic)], keep order:false
       └─Selection_17(Probe)	1.00	cop[tikv]		eq(test.rr.pt, "ios"), gt(test.rr.t, 1478185592)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -4957,7 +4957,7 @@ func (s *testSuiteP2) TestUnsignedFeedback(c *C) {
 	tk.MustQuery("select count(distinct b) from t").Check(testkit.Rows("2"))
 	result := tk.MustQuery("explain analyze select count(distinct b) from t")
 	c.Assert(result.Rows()[2][4], Equals, "table:t")
-	c.Assert(result.Rows()[2][6], Equals, "range:[0,+inf], keep order:false")
+	c.Assert(result.Rows()[2][6], Equals, "keep order:false")
 }
 
 func (s *testSuite) TestSummaryFailedUpdate(c *C) {

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -990,6 +990,16 @@ func (s *testSuite5) TestEnableNoopFunctionsVar(c *C) {
 	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("1"))
 	tk.MustExec(`set tidb_enable_noop_functions=0;`)
 	tk.MustQuery(`select @@tidb_enable_noop_functions;`).Check(testkit.Rows("0"))
+
+	tk.MustQuery("select @@tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
+	tk.MustExec("set global tidb_opt_prefer_range_scan = 1")
+	tk.MustQuery("select @@global.tidb_opt_prefer_range_scan").Check(testkit.Rows("1"))
+	tk.MustExec("set global tidb_opt_prefer_range_scan = 0")
+	tk.MustQuery("select @@global.tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
+	tk.MustExec("set session tidb_opt_prefer_range_scan = 1")
+	tk.MustQuery("select @@session.tidb_opt_prefer_range_scan").Check(testkit.Rows("1"))
+	tk.MustExec("set session tidb_opt_prefer_range_scan = 0")
+	tk.MustQuery("select @@session.tidb_opt_prefer_range_scan").Check(testkit.Rows("0"))
 }
 
 func (s *testSuite5) TestSetClusterConfig(c *C) {

--- a/planner/core/explain.go
+++ b/planner/core/explain.go
@@ -153,7 +153,7 @@ func (p *PhysicalIndexScan) isFullScan() bool {
 		return false
 	}
 	for _, ran := range p.Ranges {
-		if !ran.IsFullRange() {
+		if !ran.IsFullRange(false) {
 			return false
 		}
 	}
@@ -257,8 +257,14 @@ func (p *PhysicalTableScan) isFullScan() bool {
 	if len(p.rangeDecidedBy) > 0 || p.haveCorCol() {
 		return false
 	}
+	var unsignedIntHandle bool
+	if p.Table.PKIsHandle {
+		if pkColInfo := p.Table.GetPkColInfo(); pkColInfo != nil {
+			unsignedIntHandle = mysql.HasUnsignedFlag(pkColInfo.Flag)
+		}
+	}
 	for _, ran := range p.Ranges {
-		if !ran.IsFullRange() {
+		if !ran.IsFullRange(unsignedIntHandle) {
 			return false
 		}
 	}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -28,7 +28,9 @@ import (
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/planner/core"
+	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/statistics/handle"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/pingcap/tidb/util/testutil"
 )
@@ -2160,4 +2162,36 @@ func (s *testIntegrationSuite) TestIssues29711(c *C) {
 			"    └─TableRowIDScan_12 10000.00 cop[tikv] table:t29711 keep order:false, stats:pseudo",
 		))
 
+}
+
+func (s *testIntegrationSuite) TestPreferRangeScanForUnsignedIntHandle(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int unsigned primary key, b int, c int, index idx_b(b))")
+	tk.MustExec("insert into t values (1,2,3), (4,5,6), (7,8,9), (10,11,12), (13,14,15)")
+	do, _ := session.GetDomain(s.store)
+	c.Assert(do.StatsHandle().DumpStatsDeltaToKV(handle.DumpAll), IsNil)
+	tk.MustExec("analyze table t")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+		})
+		if strings.HasPrefix(tt, "set") {
+			tk.MustExec(tt)
+			continue
+		}
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+		})
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Plan...))
+	}
 }

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -1581,3 +1581,91 @@ func (s *testPlanSuite) TestIssue27233(c *C) {
 		tk.MustQuery(ts).Sort().Check(testkit.Rows(output[i].Result...))
 	}
 }
+
+func (s *testPlanSuite) TestPreferRangeScanOff(c *C) {
+	var (
+		input  []string
+		output []struct {
+			SQL    string
+			Plan   []string
+			Result []string
+		}
+	)
+	s.testData.GetTestCases(c, &input, &output)
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk := testkit.NewTestKit(c, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists test;")
+	tk.MustExec("create table test(`id` int(10) NOT NULL AUTO_INCREMENT,`name` varchar(50) NOT NULL DEFAULT 'tidb',`age` int(11) NOT NULL,`addr` varchar(50) DEFAULT 'The ocean of stars',PRIMARY KEY (`id`),KEY `idx_age` (`age`))")
+	tk.MustExec("insert into test(age) values(5);")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("analyze table test;")
+	tk.MustExec(fmt.Sprintf("set session tidb_opt_prefer_range_scan = %v", 0))
+
+	for i, ts := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = ts
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + ts).Rows())
+		})
+		tk.MustQuery("explain " + ts).Check(testkit.Rows(output[i].Plan...))
+	}
+}
+
+func (s *testPlanSuite) TestPreferRangeScanOn(c *C) {
+	var (
+		input  []string
+		output []struct {
+			SQL    string
+			Plan   []string
+			Result []string
+		}
+	)
+	s.testData.GetTestCases(c, &input, &output)
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	defer func() {
+		dom.Close()
+		store.Close()
+	}()
+	tk := testkit.NewTestKit(c, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists test;")
+	tk.MustExec("create table test(`id` int(10) NOT NULL AUTO_INCREMENT,`name` varchar(50) NOT NULL DEFAULT 'tidb',`age` int(11) NOT NULL,`addr` varchar(50) DEFAULT 'The ocean of stars',PRIMARY KEY (`id`),KEY `idx_age` (`age`))")
+	tk.MustExec("insert into test(age) values(5);")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("insert into test(name,age,addr) select name,age,addr from test;")
+	tk.MustExec("analyze table test;")
+	tk.MustExec(fmt.Sprintf("set session tidb_opt_prefer_range_scan = %v", 1))
+
+	for i, ts := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = ts
+			output[i].Plan = s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + ts).Rows())
+		})
+		tk.MustQuery("explain " + ts).Check(testkit.Rows(output[i].Plan...))
+	}
+}

--- a/planner/core/testdata/integration_suite_in.json
+++ b/planner/core/testdata/integration_suite_in.json
@@ -193,5 +193,18 @@
       "EXPLAIN SELECT t1.pk FROM t1 INNER JOIN t2 ON t1.col1 = t2.pk INNER JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'",
       "EXPLAIN SELECT t1.pk FROM t1 LEFT JOIN t2 ON t1.col1 = t2.pk LEFT JOIN t3 ON t1.col3 = t3.pk WHERE t2.col1 IN ('a' , 'b') AND t3.keycol = 'c' AND t1.col2 = 'a' AND t1.col1 != 'abcdef' AND t1.col1 != 'aaaaaa'"
     ]
+  },
+  {
+    "name": "TestPreferRangeScanForUnsignedIntHandle",
+    "cases": [
+      "set tidb_opt_prefer_range_scan = 0",
+      "explain format = 'verbose' select * from t where b > 5",
+      "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+      "explain format = 'verbose' select * from t where b = 6 limit 1",
+      "set tidb_opt_prefer_range_scan = 1",
+      "explain format = 'verbose' select * from t where b > 5",
+      "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+      "explain format = 'verbose' select * from t where b = 6 limit 1"
+    ]
   }
 ]

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -1022,5 +1022,73 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestPreferRangeScanForUnsignedIntHandle",
+    "Cases": [
+      {
+        "SQL": "set tidb_opt_prefer_range_scan = 0",
+        "Plan": null
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b > 5",
+        "Plan": [
+          "TableReader_7 3.00 19.21 root  data:Selection_6",
+          "└─Selection_6 3.00 215.00 cop[tikv]  gt(test.t.b, 5)",
+          "  └─TableFullScan_5 5.00 200.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+        "Plan": [
+          "Limit_11 0.00 14.33 root  offset:0, count:1",
+          "└─TableReader_24 0.00 14.33 root  data:Limit_23",
+          "  └─Limit_23 0.00 215.00 cop[tikv]  offset:0, count:1",
+          "    └─Selection_22 0.00 215.00 cop[tikv]  eq(test.t.b, 6)",
+          "      └─TableFullScan_21 5.00 200.00 cop[tikv] table:t keep order:true"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 limit 1",
+        "Plan": [
+          "Limit_8 0.00 14.33 root  offset:0, count:1",
+          "└─TableReader_13 0.00 14.33 root  data:Limit_12",
+          "  └─Limit_12 0.00 215.00 cop[tikv]  offset:0, count:1",
+          "    └─Selection_11 0.00 215.00 cop[tikv]  eq(test.t.b, 6)",
+          "      └─TableFullScan_10 5.00 200.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "SQL": "set tidb_opt_prefer_range_scan = 1",
+        "Plan": null
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b > 5",
+        "Plan": [
+          "IndexLookUp_7 3.00 64.81 root  ",
+          "├─IndexRangeScan_5(Build) 3.00 191.00 cop[tikv] table:t, index:idx_b(b) range:(5,+inf], keep order:false",
+          "└─TableRowIDScan_6(Probe) 3.00 191.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 order by a limit 1",
+        "Plan": [
+          "TopN_9 0.00 19.34 root  test.t.a, offset:0, count:1",
+          "└─IndexLookUp_16 0.00 19.33 root  ",
+          "  ├─TopN_15(Build) 0.00 0.00 cop[tikv]  test.t.a, offset:0, count:1",
+          "  │ └─IndexRangeScan_13 0.00 20.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false",
+          "  └─TableRowIDScan_14(Probe) 0.00 20.00 cop[tikv] table:t keep order:false"
+        ]
+      },
+      {
+        "SQL": "explain format = 'verbose' select * from t where b = 6 limit 1",
+        "Plan": [
+          "IndexLookUp_13 0.00 19.33 root  limit embedded(offset:0, count:1)",
+          "├─Limit_12(Build) 0.00 20.00 cop[tikv]  offset:0, count:1",
+          "│ └─IndexRangeScan_10 0.00 20.00 cop[tikv] table:t, index:idx_b(b) range:[6,6], keep order:false",
+          "└─TableRowIDScan_11(Probe) 0.00 20.00 cop[tikv] table:t keep order:false"
+        ]
+      }
+    ]
   }
 ]

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -645,5 +645,17 @@
     "cases": [
       "SELECT col2 FROM PK_S_MULTI_31 AS T1 WHERE (SELECT count(DISTINCT COL1, COL2) FROM PK_S_MULTI_31 AS T2 WHERE T2.COL1>T1.COL1)>2 order by col2;"
     ]
+  },
+  {
+    "name": "TestPreferRangeScanOff",
+    "cases": [
+      "select * from test where age=5;"
+    ]
+  },
+  {
+    "name": "TestPreferRangeScanOn",
+    "cases": [
+      "select * from test where age=5;"
+    ]
   }
 ]

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -2141,5 +2141,31 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestPreferRangeScanOff",
+    "Cases": [
+      {
+        "SQL": "select * from test where age=5;",
+        "Plan": [
+          "TableReader_7 2048.00 root  data:Selection_6",
+          "└─Selection_6 2048.00 cop[tikv]  eq(test.test.age, 5)",
+          "  └─TableFullScan_5 2048.00 cop[tikv] table:test keep order:false"
+        ]
+      }
+    ]
+  },
+  {
+    "Name": "TestPreferRangeScanOn",
+    "Cases": [
+      {
+        "SQL": "select * from test where age=5;",
+        "Plan": [
+          "IndexLookUp_7 2048.00 root  ",
+          "├─IndexRangeScan_5(Build) 2048.00 cop[tikv] table:test, index:idx_age(age) range:[5,5], keep order:false",
+          "└─TableRowIDScan_6(Probe) 2048.00 cop[tikv] table:test keep order:false"
+        ]
+      }
+    ]
   }
 ]

--- a/session/session.go
+++ b/session/session.go
@@ -2182,6 +2182,7 @@ var builtinGlobalVariable = []string{
 	variable.TiDBDDLReorgBatchSize,
 	variable.TiDBDDLErrorCountLimit,
 	variable.TiDBOptInSubqToJoinAndAgg,
+	variable.TiDBOptPreferRangeScan,
 	variable.TiDBOptCorrelationThreshold,
 	variable.TiDBOptCorrelationExpFactor,
 	variable.TiDBOptCPUFactor,

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -614,6 +614,9 @@ type SessionVars struct {
 	// allowInSubqToJoinAndAgg can be set to false to forbid rewriting the semi join to inner join with agg.
 	allowInSubqToJoinAndAgg bool
 
+	// preferRangeScan allows optimizer to always prefer range scan over full scan.
+	preferRangeScan bool
+
 	// EnableIndexMerge enables the generation of IndexMergePath.
 	enableIndexMerge bool
 
@@ -736,6 +739,7 @@ func NewSessionVars() *SessionVars {
 		DisableTxnAutoRetry:         DefTiDBDisableTxnAutoRetry,
 		DDLReorgPriority:            kv.PriorityLow,
 		allowInSubqToJoinAndAgg:     DefOptInSubqToJoinAndAgg,
+		preferRangeScan:             DefOptPreferRangeScan,
 		CorrelationThreshold:        DefOptCorrelationThreshold,
 		CorrelationExpFactor:        DefOptCorrelationExpFactor,
 		CPUFactor:                   DefOptCPUFactor,
@@ -852,6 +856,16 @@ func (s *SessionVars) GetAllowInSubqToJoinAndAgg() bool {
 // SetAllowInSubqToJoinAndAgg set SessionVars.allowInSubqToJoinAndAgg.
 func (s *SessionVars) SetAllowInSubqToJoinAndAgg(val bool) {
 	s.allowInSubqToJoinAndAgg = val
+}
+
+// GetAllowPreferRangeScan get preferRangeScan from SessionVars.preferRangeScan.
+func (s *SessionVars) GetAllowPreferRangeScan() bool {
+	return s.preferRangeScan
+}
+
+// SetAllowPreferRangeScan set SessionVars.preferRangeScan.
+func (s *SessionVars) SetAllowPreferRangeScan(val bool) {
+	s.preferRangeScan = val
 }
 
 // GetEnableCascadesPlanner get EnableCascadesPlanner from sql hints and SessionVars.EnableCascadesPlanner.
@@ -1165,6 +1179,8 @@ func (s *SessionVars) SetSystemVar(name string, val string) error {
 		s.AllowWriteRowID = TiDBOptOn(val)
 	case TiDBOptInSubqToJoinAndAgg:
 		s.SetAllowInSubqToJoinAndAgg(TiDBOptOn(val))
+	case TiDBOptPreferRangeScan:
+		s.SetAllowPreferRangeScan(TiDBOptOn(val))
 	case TiDBOptCorrelationThreshold:
 		s.CorrelationThreshold = tidbOptFloat64(val, DefOptCorrelationThreshold)
 	case TiDBOptCorrelationExpFactor:

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -629,6 +629,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeSession, TiDBChecksumTableConcurrency, strconv.Itoa(DefChecksumTableConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBDistSQLScanConcurrency, strconv.Itoa(DefDistSQLScanConcurrency)},
 	{ScopeGlobal | ScopeSession, TiDBOptInSubqToJoinAndAgg, BoolToIntStr(DefOptInSubqToJoinAndAgg)},
+	{ScopeGlobal | ScopeSession, TiDBOptPreferRangeScan, BoolToIntStr(DefOptPreferRangeScan)},
 	{ScopeGlobal | ScopeSession, TiDBOptCorrelationThreshold, strconv.FormatFloat(DefOptCorrelationThreshold, 'f', -1, 64)},
 	{ScopeGlobal | ScopeSession, TiDBOptCorrelationExpFactor, strconv.Itoa(DefOptCorrelationExpFactor)},
 	{ScopeGlobal | ScopeSession, TiDBOptCPUFactor, strconv.FormatFloat(DefOptCPUFactor, 'f', -1, 64)},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -206,6 +206,9 @@ const (
 	// tidb_opt_insubquery_to_join_and_agg is used to enable/disable the optimizer rule of rewriting IN subquery.
 	TiDBOptInSubqToJoinAndAgg = "tidb_opt_insubq_to_join_and_agg"
 
+	// tidb_opt_prefer_range_scan is used to enable/disable the optimizer to always prefer range scan over full scan, ignoring their costs.
+	TiDBOptPreferRangeScan = "tidb_opt_prefer_range_scan"
+
 	// tidb_opt_correlation_threshold is a guard to enable row count estimation using column order correlation.
 	TiDBOptCorrelationThreshold = "tidb_opt_correlation_threshold"
 
@@ -473,6 +476,7 @@ const (
 	DefOptDiskFactor                   = 1.5
 	DefOptConcurrencyFactor            = 3.0
 	DefOptInSubqToJoinAndAgg           = true
+	DefOptPreferRangeScan              = false
 	DefBatchInsert                     = false
 	DefBatchDelete                     = false
 	DefBatchCommit                     = false

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -458,7 +458,7 @@ func ValidateSetSystemVar(vars *SessionVars, name string, value string, scope Sc
 		}
 		return value, nil
 	case TiDBSkipUTF8Check, TiDBOptAggPushDown, TiDBOptDistinctAggPushDown,
-		TiDBOptInSubqToJoinAndAgg, TiDBEnableFastAnalyze,
+		TiDBOptInSubqToJoinAndAgg, TiDBOptPreferRangeScan, TiDBEnableFastAnalyze,
 		TiDBBatchInsert, TiDBDisableTxnAutoRetry, TiDBEnableStreaming, TiDBEnableChunkRPC,
 		TiDBBatchDelete, TiDBBatchCommit, TiDBEnableCascadesPlanner, TiDBEnableWindowFunction, TiDBPProfSQLCPU,
 		TiDBLowResolutionTSO, TiDBEnableIndexMerge, TiDBEnableNoopFuncs,

--- a/util/ranger/testdata/ranger_suite_out.json
+++ b/util/ranger/testdata/ranger_suite_out.json
@@ -120,7 +120,7 @@
         "Plan": [
           "TableReader_7 1.00 root  data:Selection_6",
           "└─Selection_6 1.00 cop[tikv]  eq(test.t2.t, \"aaaa\")",
-          "  └─TableRangeScan_5 2.00 cop[tikv] table:t2 range:[0,+inf], keep order:false"
+          "  └─TableFullScan_5 2.00 cop[tikv] table:t2 keep order:false"
         ],
         "Result": [
           "1 aaaa"
@@ -131,7 +131,7 @@
         "Plan": [
           "TableReader_7 1.60 root  data:Selection_6",
           "└─Selection_6 1.60 cop[tikv]  or(eq(test.t2.t, \"aaaa\"), eq(test.t2.t, \"a\"))",
-          "  └─TableRangeScan_5 2.00 cop[tikv] table:t2 range:[0,+inf], keep order:false"
+          "  └─TableFullScan_5 2.00 cop[tikv] table:t2 keep order:false"
         ],
         "Result": [
           "1 aaaa",

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -78,7 +78,15 @@ func (ran *Range) IsPoint(sc *stmtctx.StatementContext) bool {
 }
 
 //IsFullRange check if the range is full scan range
-func (ran *Range) IsFullRange() bool {
+func (ran *Range) IsFullRange(unsignedIntHandle bool) bool {
+	if unsignedIntHandle {
+		if len(ran.LowVal) != 1 || len(ran.HighVal) != 1 {
+			return false
+		}
+		lowValRawString := formatDatum(ran.LowVal[0], true)
+		highValRawString := formatDatum(ran.HighVal[0], false)
+		return lowValRawString == "0" && highValRawString == "+inf"
+	}
 	if len(ran.LowVal) != len(ran.HighVal) {
 		return false
 	}
@@ -91,6 +99,16 @@ func (ran *Range) IsFullRange() bool {
 		}
 	}
 	return true
+}
+
+// HasFullRange checks if any range in the slice is a full range.
+func HasFullRange(ranges []*Range, unsignedIntHandle bool) bool {
+	for _, ran := range ranges {
+		if ran.IsFullRange(unsignedIntHandle) {
+			return true
+		}
+	}
+	return false
 }
 
 // String implements the Stringer interface.

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -14,12 +14,11 @@
 package ranger_test
 
 import (
-	"math"
-
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/ranger"
+	"math"
 )
 
 var _ = Suite(&testRangeSuite{})
@@ -136,53 +135,68 @@ func (s *testRangeSuite) TestIsFullRange(c *C) {
 	nullDatum := types.MinNotNullDatum()
 	nullDatum.SetNull()
 	isFullRangeTests := []struct {
-		ran         ranger.Range
-		isFullRange bool
+		ran               ranger.Range
+		unsignedIntHandle bool
+		isFullRange       bool
 	}{
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(math.MinInt64)},
 				HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)},
 			},
-			isFullRange: true,
+			unsignedIntHandle: false,
+			isFullRange:       true,
 		},
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(math.MaxInt64)},
 				HighVal: []types.Datum{types.NewIntDatum(math.MinInt64)},
 			},
-			isFullRange: false,
+			unsignedIntHandle: false,
+			isFullRange:       false,
 		},
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{types.NewIntDatum(1)},
 				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 			},
-			isFullRange: false,
+			unsignedIntHandle: false,
+			isFullRange:       false,
 		},
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{*nullDatum.Clone()},
 				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
 			},
-			isFullRange: true,
+			unsignedIntHandle: false,
+			isFullRange:       true,
 		},
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{*nullDatum.Clone()},
 				HighVal: []types.Datum{*nullDatum.Clone()},
 			},
-			isFullRange: true,
+			unsignedIntHandle: false,
+			isFullRange:       false,
 		},
 		{
 			ran: ranger.Range{
 				LowVal:  []types.Datum{types.MinNotNullDatum()},
 				HighVal: []types.Datum{types.MaxValueDatum()},
 			},
-			isFullRange: true,
+			unsignedIntHandle: false,
+			isFullRange:       true,
+		},
+		{
+			ran: ranger.Range{
+				LowVal:  []types.Datum{types.NewUintDatum(0)},
+				HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)},
+			},
+			unsignedIntHandle: true,
+			isFullRange:       true,
 		},
 	}
 	for _, t := range isFullRangeTests {
-		c.Assert(t.ran.IsFullRange(), Equals, t.isFullRange)
+		c.Assert(t.ran.IsFullRange(t.unsignedIntHandle), Equals, t.isFullRange)
 	}
 }


### PR DESCRIPTION
### What problem does this PR solve?

Problem Summary:
Turning on `tidb_opt_prefer_range_scan` can prevent from choosing full table scan when range index scan exists, which is a way to avoid terrible plan. We can backport it to 4.0.

### What is changed and how it works?

The pr cherry picks #18996, #20672, #27123

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Add tidb_opt_prefer_range_scan
```
