### PR TITLE
planner, ddl: convert large varchar for create table in non strict mode

### DIFF
--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -1193,8 +1193,8 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 		{"decimal(2,1)", "bigint", nil},
 	}
 	for _, tt := range tests {
-		ftA := s.colDefStrToFieldType(c, tt.origin)
-		ftB := s.colDefStrToFieldType(c, tt.to)
+		ftA := s.colDefStrToFieldType(c, tt.origin, ctx)
+		ftB := s.colDefStrToFieldType(c, tt.to, ctx)
 		err := checkModifyTypes(ctx, ftA, ftB, false)
 		if err == nil {
 			c.Assert(tt.err, IsNil, Commentf("origin:%v, to:%v", tt.origin, tt.to))
@@ -1204,13 +1204,13 @@ func (s *testColumnSuite) TestModifyColumn(c *C) {
 	}
 }
 
-func (s *testColumnSuite) colDefStrToFieldType(c *C, str string) *types.FieldType {
+func (s *testColumnSuite) colDefStrToFieldType(c *C, str string, ctx sessionctx.Context) *types.FieldType {
 	sqlA := "alter table t modify column a " + str
 	stmt, err := parser.New().ParseOneStmt(sqlA, "", "")
 	c.Assert(err, IsNil)
 	colDef := stmt.(*ast.AlterTableStmt).Specs[0].NewColumns[0]
 	chs, coll := charset.GetDefaultCharsetAndCollate()
-	col, _, err := buildColumnAndConstraint(nil, 0, colDef, nil, chs, coll)
+	col, _, err := buildColumnAndConstraint(ctx, 0, colDef, nil, chs, coll)
 	c.Assert(err, IsNil)
 	return &col.FieldType
 }

--- a/ddl/error.go
+++ b/ddl/error.go
@@ -310,4 +310,7 @@ var (
 	errDependentByFunctionalIndex = dbterror.ClassDDL.NewStd(mysql.ErrDependentByFunctionalIndex)
 	// errFunctionalIndexOnBlob when the expression of expression index returns blob or text.
 	errFunctionalIndexOnBlob = dbterror.ClassDDL.NewStd(mysql.ErrFunctionalIndexOnBlob)
+
+	// ErrAutoConvert is returned when auto convert happens
+	ErrAutoConvert = dbterror.ClassDDL.NewStd(mysql.ErrAutoConvert)
 )

--- a/errors.toml
+++ b/errors.toml
@@ -361,6 +361,11 @@ error = '''
 Incorrect usage of %s and %s
 '''
 
+["ddl:1246"]
+error = '''
+Converting column '%s' from %s to %s
+'''
+
 ["ddl:1248"]
 error = '''
 Every derived table must have its own alias

--- a/planner/core/preprocess_test.go
+++ b/planner/core/preprocess_test.go
@@ -364,3 +364,18 @@ func (s *testValidatorSuite) TestDropGlobalTempTable(c *C) {
 	s.runSQL(c, "drop global temporary table temp, ltemp1", false, core.ErrDropTableOnTemporaryTable)
 	s.runSQL(c, "drop global temporary table test2.temp2, temp1", false, nil)
 }
+
+// For issue 30328
+func (s *testValidatorSuite) TestLargeVarcharAutoConv(c *C) {
+	_, err := s.se.Execute(context.Background(), "use test")
+	c.Assert(err, IsNil)
+	s.runSQL(c, "CREATE TABLE t1(a varbinary(70000), b varchar(70000000))", false,
+		errors.New("[types:1074]Column length too big for column 'a' (max = 65535); use BLOB or TEXT instead"))
+
+	_, err = s.se.Execute(context.Background(), "SET sql_mode = 'NO_ENGINE_SUBSTITUTION'")
+	c.Assert(err, IsNil)
+	s.runSQL(c, "CREATE TABLE t1(a varbinary(70000), b varchar(70000000));", false, nil)
+	s.runSQL(c, "CREATE TABLE t1(a varbinary(70000), b varchar(70000000) charset utf8mb4);", false, nil)
+	_, err = s.se.Execute(context.Background(), "SET sql_mode = 'STRICT_TRANS_TABLES,NO_ENGINE_SUBSTITUTION'")
+	c.Assert(err, IsNil)
+}


### PR DESCRIPTION
Signed-off-by: unconsolable <chenzhipeng2012@gmail.com>

### What problem does this PR solve?

Issue Number: close #30328 

Problem Summary:

### What is changed and how it works?
- In non strict mode, auto convert varchar with large length to TEXT or BLOB, and append warnings.
- Fix a nil pointer dereference in test case due to changes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
