### PR TITLE
[logutil]: Fix MaxDays and MaxBackups not working for slow-query-logger

### DIFF
--- a/util/logutil/slow_query_logger.go
+++ b/util/logutil/slow_query_logger.go
@@ -15,14 +15,12 @@ var _pool = buffer.NewPool()
 
 func newSlowQueryLogger(cfg *LogConfig) (*zap.Logger, error) {
 
-	// reuse global config and override slow query log file
-	// if slow query log filename is empty, slow query log will behave the same as global log
+	// copy the global log config to slow log config
+	// if the filename of slow log config is empty, slow log will behave the same as global log.
 	sqConfig := &cfg.Config
 	if len(cfg.SlowQueryFile) != 0 {
-		sqConfig.File = log.FileLogConfig{
-			MaxSize:  cfg.File.MaxSize,
-			Filename: cfg.SlowQueryFile,
-		}
+		sqConfig.File = cfg.File
+		sqConfig.File.Filename = cfg.SlowQueryFile
 	}
 
 	// create the slow query logger


### PR DESCRIPTION
Signed-off-by: jyz0309 <45495947@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: fix #25716 

Problem Summary:
MaxDays and MaxBackups not working for slow-query-logger. This may causes unexpected disk usage.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix `MaxDays` and `MaxBackups` not working for slow log.
```
