### PR TITLE
expression: Use InEpsilon when comparing floating point numbers

### DIFF
--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -1020,8 +1020,10 @@ func TestTan(t *testing.T) {
 			require.NoError(t, err)
 			if c.isNil {
 				require.Equal(t, types.KindNull, d.Kind())
-			} else {
+			} else if c.expected == 0 {
 				require.Equal(t, c.expected, d.GetFloat64())
+			} else {
+				require.InEpsilon(t, c.expected, d.GetFloat64(), 1E-15)
 			}
 		}
 	}


### PR DESCRIPTION
### What problem does this PR solve?

Comparing floating point numbers with `require.Equal()` is not recommended because of the nature of floating point numbers.
They must be compared with possible delta/epsilon/error, i.e. with `require.InEpsilon()`.
The test fails consistently on Linux ARM64 architecture.

Problem Summary:

### What is changed and how it works?

Update the test to use `require.Equal()` only when comparing with zero. In all other cases it must use `require.InEpsilon()`

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
