### PR TITLE
expression: fix data race in builtin_other_vec_generated_test.go

### DIFF
--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1118,8 +1118,6 @@ func genVecExprBenchCase(ctx sessionctx.Context, funcName string, testCase vecEx
 // testVectorizedEvalOneVec is used to verify that the vectorized
 // expression is evaluated correctly during projection
 func testVectorizedEvalOneVec(t *testing.T, vecExprCases vecExprBenchCases) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	for funcName, testCases := range vecExprCases {
 		for _, testCase := range testCases {
@@ -1321,8 +1319,6 @@ func removeTestOptions(args []string) []string {
 // testVectorizedBuiltinFunc is used to verify that the vectorized
 // expression is evaluated correctly
 func testVectorizedBuiltinFunc(t *testing.T, vecExprCases vecExprBenchCases) {
-	t.Parallel()
-
 	testFunc := make(map[string]bool)
 	argList := removeTestOptions(flag.Args())
 	testAll := len(argList) == 0


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #30502

Problem Summary:

### What is changed and how it works?

```testVectorizedEvalOneVec``` and ```testVectorizedBuiltinFunc``` are used by the wrong way. Many cases put global variable as parameters leading to data race.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
