### PR TITLE
planner: Disable dynamic partition prune mode for all non-autocommit (#27532)

### DIFF
--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1021,7 +1021,7 @@ func (s *SessionVars) CheckAndGetTxnScope() string {
 
 // UseDynamicPartitionPrune indicates whether use new dynamic partition prune.
 func (s *SessionVars) UseDynamicPartitionPrune() bool {
-	if s.InTxn() {
+	if s.InTxn() || !s.GetStatusFlag(mysql.ServerStatusAutocommit) {
 		// UnionScan cannot get partition table IDs in dynamic-mode, this is a quick-fix for issues/26719,
 		// please see it for more details.
 		return false


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27532 

Problem Summary:
The real issue is that Dynamic prune mode is not fully supported and still have bugs, see #26876 / https://github.com/pingcap/tidb/issues/26719

This fix only hides the real issue and falls back to static prune mode implementation, as #26719 did.

### What is changed and how it works?
Also disable dynamic prune mode for autocommit=0, since it just has not started a transaction yet.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
