### PR TITLE
txn: fix the incorrect untouch used in optimistic transactions(#30447)

### DIFF
--- a/table/tables/index.go
+++ b/table/tables/index.go
@@ -172,8 +172,22 @@ func (c *index) Create(sctx sessionctx.Context, txn kv.Transaction, indexedValue
 		// should not overwrite the key with un-commit flag.
 		// So if the key exists, just do nothing and return.
 		v, err := txn.GetMemBuffer().Get(ctx, key)
-		if err == nil && len(v) != 0 {
-			return nil, nil
+		if err == nil {
+			if len(v) != 0 {
+				return nil, nil
+			}
+			// The key is marked as deleted in the memory buffer, as the existence check is done lazily
+			// for optimistic transactions by default. The "untouched" key could still exist in the store,
+			// it's needed to commit this key to do the existence check so unset the untouched flag.
+			if !txn.IsPessimistic() {
+				keyFlags, err := txn.GetMemBuffer().GetFlags(key)
+				if err != nil {
+					return nil, err
+				}
+				if keyFlags.HasPresumeKeyNotExists() {
+					opt.Untouched = false
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number:  ref #30410

Problem Summary:
When the optimistic transaction is used, the untouched key optimization is not compatible with lazy existence check and results in data inconsistency. Cherry-pick #30447 to release 5.0.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

Side effects


Documentation


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the data inconsistency caused by incorrect usage of lazy existence check and untouch key optimization.
```
