### PR TITLE
planner, util/ranger: fix wrong optimize order by (#30273)

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -4359,3 +4359,16 @@ func (s *testIntegrationSuite) TestIssue27797(c *C) {
 	result = tk.MustQuery("select col2 from IDT_HP24172 where col1 = 8388607 and col1 in (select col1 from IDT_HP24172);")
 	result.Check(testkit.Rows("<nil>"))
 }
+
+func (s *testIntegrationSerialSuite) TestIssue30271(c *C) {
+	defer collate.SetNewCollationEnabledForTest(false)
+	collate.SetNewCollationEnabledForTest(true)
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a char(10), b char(10), c char(10), index (a, b, c)) collate utf8mb4_bin;")
+	tk.MustExec("insert into t values ('b', 'a', '1'), ('b', 'A', '2'), ('c', 'a', '3');")
+	tk.MustExec("set names utf8mb4 collate utf8mb4_general_ci;")
+	tk.MustQuery("select * from t where (a>'a' and b='a') or (b = 'A' and a < 'd') order by a,c;").Check(testkit.Rows("b a 1", "b A 2", "c a 3"))
+
+}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -14,6 +14,7 @@
 package ranger
 
 import (
+	"github.com/pingcap/parser/charset"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -704,7 +705,11 @@ func isSameValue(sc *stmtctx.StatementContext, lhs, rhs *valueInfo) (bool, error
 	if lhs == nil || rhs == nil || lhs.mutable || rhs.mutable || lhs.value.Kind() != rhs.value.Kind() {
 		return false, nil
 	}
+	collation := lhs.value.Collation()
+	// binary collator may not the best choice, but it can make sure the result is correct.
+	lhs.value.SetCollation(charset.CollationBin)
 	cmp, err := lhs.value.CompareDatum(sc, rhs.value)
+	lhs.value.SetCollation(collation)
 	if err != nil {
 		return false, err
 	}

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -14,11 +14,11 @@
 package ranger
 
 import (
-	"github.com/pingcap/parser/charset"
 	"math"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/parser/ast"
+	"github.com/pingcap/parser/charset"
 	"github.com/pingcap/parser/model"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/sessionctx"


### PR DESCRIPTION
cherry-pick #30273 to release-5.2

### What problem does this PR solve?

Issue Number: close #30271

Problem Summary:

`isSameValue` may use wrong collation.

### What is changed and how it works?

Use `CollationBin` for comparing datums in `isSameValue`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix a bug when reducing order by clause for the index which leads to the wrong result.
```
