### PR TITLE
executor: don't show default collate when charset is not utf8 in `show create table` statement

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5777,7 +5777,7 @@ func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 	tk.MustQuery("show create table t3").Check(testkit.Rows("t3 CREATE TABLE `t3` (\n" +
 		"  `a` char(10) DEFAULT NULL,\n" +
 		"  `b` char(10) DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci",
+		") ENGINE=InnoDB DEFAULT CHARSET=gbk",
 	))
 	tk.MustExec("create table t4(a char(10));")
 	tk.MustExec("alter table t4 add column b char(10) charset gbk;")
@@ -5792,7 +5792,7 @@ func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 	tk.MustExec("create table t1(a char(10));")
 	tk.MustQuery("show create table t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n" +
 		"  `a` char(10) DEFAULT NULL\n" +
-		") ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci",
+		") ENGINE=InnoDB DEFAULT CHARSET=gbk",
 	))
 }
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -1011,9 +1011,9 @@ func ConstructResultOfShowCreateTable(ctx sessionctx.Context, tableInfo *model.T
 	buf.WriteString(") ENGINE=InnoDB")
 	// We need to explicitly set the default charset and collation
 	// to make it work on MySQL server which has default collate utf8_general_ci.
-	if len(tblCollate) == 0 || tblCollate == "binary" {
+	if len(tblCollate) == 0 || (!mysql.IsUTF8Charset(tblCharset) && getDefaultCollate(tblCharset) == tblCollate) {
 		// If we can not find default collate for the given charset,
-		// or the collate is 'binary'(MySQL-5.7 compatibility, see #15633 for details),
+		// or the charset is not utf8 (MySQL compatibility, see #15633 and #30568 for details),
 		// do not show the collate part.
 		fmt.Fprintf(buf, " DEFAULT CHARSET=%s", tblCharset)
 	} else {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #30568 

Problem Summary: follow MySQL, don't show default collate in `show create table` statement with non utf8 charset

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Don't show default collate when charset is not utf8 in `show create table` statement
```
