### PR TITLE
planner: regard NULL as point when accessing composite index (#30244)

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -683,6 +683,8 @@ func encodeIndexKey(sc *stmtctx.StatementContext, ran *ranger.Range) ([]byte, []
 		}
 	}
 
+	// NOTE: this is a hard-code operation to avoid wrong results when accessing unique index with NULL;
+	// Please see https://github.com/pingcap/tidb/issues/29650 for more details
 	if hasNull {
 		// Append 0 to make unique-key range [null, null] to be a scan rather than point-get.
 		high = kv.Key(high).Next()

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4041,7 +4041,7 @@ func buildRangesForIndexJoin(ctx sessionctx.Context, lookUpContents []*indexJoin
 		return retRanges, nil
 	}
 
-	return ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges, true)
+	return ranger.UnionRanges(ctx, tmpDatumRanges, true)
 }
 
 // buildKvRangesForIndexJoin builds kv ranges for index join when the inner plan is index scan plan.
@@ -4095,7 +4095,7 @@ func buildKvRangesForIndexJoin(ctx sessionctx.Context, tableID, indexID int64, l
 		return kvRanges, nil
 	}
 
-	tmpDatumRanges, err = ranger.UnionRanges(ctx.GetSessionVars().StmtCtx, tmpDatumRanges, true)
+	tmpDatumRanges, err = ranger.UnionRanges(ctx, tmpDatumRanges, true)
 	if err != nil {
 		return nil, err
 	}

--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -7188,11 +7188,21 @@ func CalAppropriateTime(minTime, maxTime, minSafeTime time.Time) time.Time {
 //   2. If t2 < t, we will use t2 as the result,
 //      and with it, a read request won't fail because it's bigger than the latest SafeTS.
 func calAppropriateTime(minTime, maxTime, minSafeTime time.Time) time.Time {
-	if minSafeTime.Before(minTime) {
-		return minTime
-	} else if minSafeTime.After(maxTime) {
-		return maxTime
+	if minSafeTime.Before(minTime) || minSafeTime.After(maxTime) {
+		logutil.BgLogger().Warn("calAppropriateTime",
+			zap.Time("minTime", minTime),
+			zap.Time("maxTime", maxTime),
+			zap.Time("minSafeTime", minSafeTime))
+		if minSafeTime.Before(minTime) {
+			return minTime
+		} else if minSafeTime.After(maxTime) {
+			return maxTime
+		}
 	}
+	logutil.BgLogger().Debug("calAppropriateTime",
+		zap.Time("minTime", minTime),
+		zap.Time("maxTime", maxTime),
+		zap.Time("minSafeTime", minSafeTime))
 	return minSafeTime
 }
 

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -606,7 +606,7 @@ func (e *Execute) rebuildRange(p Plan) error {
 					}
 				}
 				if pkCol != nil {
-					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx.GetSessionVars().StmtCtx, pkCol.RetType)
+					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType)
 					if err != nil {
 						return err
 					}
@@ -656,7 +656,7 @@ func (e *Execute) rebuildRange(p Plan) error {
 					}
 				}
 				if pkCol != nil {
-					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx.GetSessionVars().StmtCtx, pkCol.RetType)
+					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType)
 					if err != nil {
 						return err
 					}
@@ -750,7 +750,7 @@ func (e *Execute) buildRangeForTableScan(sctx sessionctx.Context, ts *PhysicalTa
 			}
 		}
 		if pkCol != nil {
-			ts.Ranges, err = ranger.BuildTableRange(ts.AccessCondition, sctx.GetSessionVars().StmtCtx, pkCol.RetType)
+			ts.Ranges, err = ranger.BuildTableRange(ts.AccessCondition, sctx, pkCol.RetType)
 			if err != nil {
 				return err
 			}
@@ -1460,10 +1460,10 @@ func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bo
 	switch v := p.(type) {
 	case *PhysicalIndexReader:
 		indexScan := v.IndexPlans[0].(*PhysicalIndexScan)
-		return indexScan.IsPointGetByUniqueKey(ctx.GetSessionVars().StmtCtx), nil
+		return indexScan.IsPointGetByUniqueKey(ctx), nil
 	case *PhysicalTableReader:
 		tableScan := v.TablePlans[0].(*PhysicalTableScan)
-		isPointRange := len(tableScan.Ranges) == 1 && tableScan.Ranges[0].IsPoint(ctx.GetSessionVars().StmtCtx)
+		isPointRange := len(tableScan.Ranges) == 1 && tableScan.Ranges[0].IsPoint(ctx)
 		if !isPointRange {
 			return false, nil
 		}

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1463,7 +1463,7 @@ func IsPointGetWithPKOrUniqueKeyByAutoCommit(ctx sessionctx.Context, p Plan) (bo
 		return indexScan.IsPointGetByUniqueKey(ctx), nil
 	case *PhysicalTableReader:
 		tableScan := v.TablePlans[0].(*PhysicalTableScan)
-		isPointRange := len(tableScan.Ranges) == 1 && tableScan.Ranges[0].IsPoint(ctx)
+		isPointRange := len(tableScan.Ranges) == 1 && tableScan.Ranges[0].IsPointNonNullable(ctx)
 		if !isPointRange {
 			return false, nil
 		}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1205,7 +1205,7 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx sessionctx.Context, row c
 		}
 		exprs = append(exprs, newExpr)
 	}
-	ranges, err := ranger.BuildColumnRange(exprs, ctx.GetSessionVars().StmtCtx, cwc.TargetCol.RetType, cwc.colLength)
+	ranges, err := ranger.BuildColumnRange(exprs, ctx, cwc.TargetCol.RetType, cwc.colLength)
 	if err != nil {
 		return nil, err
 	}
@@ -1449,7 +1449,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(path *util.AccessPath
 		var ranges, nextColRange []*ranger.Range
 		var err error
 		if len(colAccesses) > 0 {
-			nextColRange, err = ranger.BuildColumnRange(colAccesses, ijHelper.join.ctx.GetSessionVars().StmtCtx, lastPossibleCol.RetType, path.IdxColLens[lastColPos])
+			nextColRange, err = ranger.BuildColumnRange(colAccesses, ijHelper.join.ctx, lastPossibleCol.RetType, path.IdxColLens[lastColPos])
 			if err != nil {
 				return false, err
 			}
@@ -1551,14 +1551,13 @@ func (ijHelper *indexJoinBuildHelper) buildTemplateRange(matchedKeyCnt int, eqAn
 			HighVal: make([]types.Datum, pointLength),
 		})
 	}
-	sc := ijHelper.join.ctx.GetSessionVars().StmtCtx
 	for i, j := 0, 0; j < len(eqAndInFuncs); i++ {
 		// This position is occupied by join key.
 		if ijHelper.curIdxOff2KeyOff[i] != -1 {
 			continue
 		}
 		exprs := []expression.Expression{eqAndInFuncs[j]}
-		oneColumnRan, err := ranger.BuildColumnRange(exprs, sc, ijHelper.curNotUsedIndexCols[j].RetType, ijHelper.curNotUsedColLens[j])
+		oneColumnRan, err := ranger.BuildColumnRange(exprs, ijHelper.join.ctx, ijHelper.curNotUsedIndexCols[j].RetType, ijHelper.curNotUsedColLens[j])
 		if err != nil {
 			return nil, false, err
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -860,7 +860,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		if canConvertPointGet {
 			allRangeIsPoint := true
 			for _, ran := range path.Ranges {
-				if !ran.IsPoint(ds.ctx.GetSessionVars().StmtCtx) {
+				if !ran.IsPoint(ds.ctx) {
 					allRangeIsPoint = false
 					break
 				}
@@ -1581,7 +1581,7 @@ func (ds *DataSource) crossEstimateRowCount(path *util.AccessPath, conds []expre
 		return 0, false, corr
 	}
 	sc := ds.ctx.GetSessionVars().StmtCtx
-	ranges, err := ranger.BuildColumnRange(accessConds, sc, col.RetType, types.UnspecifiedLength)
+	ranges, err := ranger.BuildColumnRange(accessConds, ds.ctx, col.RetType, types.UnspecifiedLength)
 	if len(ranges) == 0 || err != nil {
 		return 0, err == nil, corr
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -860,7 +860,8 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		if canConvertPointGet {
 			allRangeIsPoint := true
 			for _, ran := range path.Ranges {
-				if !ran.IsPoint(ds.ctx) {
+				if !ran.IsPointNonNullable(ds.ctx) {
+					// unique indexes can have duplicated NULL rows so we cannot use PointGet if there is NULL
 					allRangeIsPoint = false
 					break
 				}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -4751,6 +4751,56 @@ func (s *testIntegrationSerialSuite) TestRejectSortForMPP(c *C) {
 	}
 }
 
+func (s *testIntegrationSerialSuite) TestRegardNULLAsPoint(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+
+	tk.MustExec("drop table if exists tpk")
+	tk.MustExec(`create table tuk (a int, b int, c int, unique key (a, b, c))`)
+	tk.MustExec(`create table tik (a int, b int, c int, key (a, b, c))`)
+	for _, va := range []string{"NULL", "1"} {
+		for _, vb := range []string{"NULL", "1"} {
+			for _, vc := range []string{"NULL", "1"} {
+				tk.MustExec(fmt.Sprintf(`insert into tuk values (%v, %v, %v)`, va, vb, vc))
+				tk.MustExec(fmt.Sprintf(`insert into tik values (%v, %v, %v)`, va, vb, vc))
+				if va == "1" && vb == "1" && vc == "1" {
+					continue
+				}
+				// duplicated NULL rows
+				tk.MustExec(fmt.Sprintf(`insert into tuk values (%v, %v, %v)`, va, vb, vc))
+				tk.MustExec(fmt.Sprintf(`insert into tik values (%v, %v, %v)`, va, vb, vc))
+			}
+		}
+	}
+
+	var input []string
+	var output []struct {
+		SQL          string
+		PlanEnabled  []string
+		PlanDisabled []string
+		Result       []string
+	}
+	s.testData.GetTestCases(c, &input, &output)
+	for i, tt := range input {
+		s.testData.OnRecord(func() {
+			output[i].SQL = tt
+			tk.MustExec(`set @@session.tidb_regard_null_as_point=true`)
+			output[i].PlanEnabled = s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + tt).Rows())
+			output[i].Result = s.testData.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+
+			tk.MustExec(`set @@session.tidb_regard_null_as_point=false`)
+			output[i].PlanDisabled = s.testData.ConvertRowsToStrings(tk.MustQuery("explain " + tt).Rows())
+		})
+		tk.MustExec(`set @@session.tidb_regard_null_as_point=true`)
+		tk.MustQuery("explain " + tt).Check(testkit.Rows(output[i].PlanEnabled...))
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
+
+		tk.MustExec(`set @@session.tidb_regard_null_as_point=false`)
+		tk.MustQuery("explain " + tt).Check(testkit.Rows(output[i].PlanDisabled...))
+		tk.MustQuery(tt).Check(testkit.Rows(output[i].Result...))
+	}
+}
+
 func (s *testIntegrationSuite) TestIssues29711(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -828,7 +828,7 @@ func (ds *DataSource) deriveTablePathStats(path *util.AccessPath, conds []expres
 		path.CountAfterAccess = 1
 		return nil
 	}
-	path.Ranges, err = ranger.BuildTableRange(path.AccessConds, sc, pkCol.RetType)
+	path.Ranges, err = ranger.BuildTableRange(path.AccessConds, ds.ctx, pkCol.RetType)
 	if err != nil {
 		return err
 	}

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -93,6 +93,7 @@ func (s *testPartitionPruneSuit) TestListPartitionPruner(c *C) {
 	tk.MustExec("use test_partition")
 	tk.Se.GetSessionVars().EnableClusteredIndex = variable.ClusteredIndexDefModeIntOnly
 	tk.MustExec("set @@session.tidb_enable_list_partition = ON")
+	tk.MustExec(`set @@session.tidb_regard_null_as_point=false`)
 	tk.MustExec("create table t1 (id int, a int, b int                 ) partition by list (    a    ) (partition p0 values in (1,2,3,4,5), partition p1 values in (6,7,8,9,10,null));")
 	tk.MustExec("create table t2 (a int, id int, b int) partition by list (a*3 + b - 2*a - b) (partition p0 values in (1,2,3,4,5), partition p1 values in (6,7,8,9,10,null));")
 	tk.MustExec("create table t3 (b int, id int, a int) partition by list columns (a) (partition p0 values in (1,2,3,4,5), partition p1 values in (6,7,8,9,10,null));")
@@ -169,6 +170,7 @@ func (s *testPartitionPruneSuit) TestListColumnsPartitionPruner(c *C) {
 	// tk1 use to test partition table with index.
 	tk1 := testkit.NewTestKit(c, s.store)
 	tk1.MustExec("drop database if exists test_partition_1;")
+	tk1.MustExec(`set @@session.tidb_regard_null_as_point=false`)
 	tk1.MustExec("create database test_partition_1")
 	tk1.MustExec("use test_partition_1")
 	tk1.MustExec("set @@session.tidb_enable_list_partition = ON")
@@ -180,6 +182,7 @@ func (s *testPartitionPruneSuit) TestListColumnsPartitionPruner(c *C) {
 	// tk2 use to compare the result with normal table.
 	tk2 := testkit.NewTestKit(c, s.store)
 	tk2.MustExec("drop database if exists test_partition_2;")
+	tk2.MustExec(`set @@session.tidb_regard_null_as_point=false`)
 	tk2.MustExec("create database test_partition_2")
 	tk2.MustExec("use test_partition_2")
 	tk2.MustExec("create table t1 (id int, a int, b int)")

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -28,7 +28,6 @@ import (
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/planner/util"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -548,7 +547,7 @@ func (ts *PhysicalTableScan) ResolveCorrelatedColumns() ([]*ranger.Range, error)
 	} else {
 		var err error
 		pkTP := ts.Table.GetPkColInfo().FieldType
-		ts.Ranges, err = ranger.BuildTableRange(access, ts.SCtx().GetSessionVars().StmtCtx, &pkTP)
+		ts.Ranges, err = ranger.BuildTableRange(access, ts.SCtx(), &pkTP)
 		if err != nil {
 			return nil, err
 		}
@@ -1196,11 +1195,11 @@ func (p *PhysicalIndexScan) IsPartition() (bool, int64) {
 }
 
 // IsPointGetByUniqueKey checks whether is a point get by unique key.
-func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sc *stmtctx.StatementContext) bool {
+func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sctx sessionctx.Context) bool {
 	return len(p.Ranges) == 1 &&
 		p.Index.Unique &&
 		len(p.Ranges[0].LowVal) == len(p.Index.Columns) &&
-		p.Ranges[0].IsPoint(sc)
+		p.Ranges[0].IsPoint(sctx)
 }
 
 // PhysicalSelection represents a filter.

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1199,7 +1199,7 @@ func (p *PhysicalIndexScan) IsPointGetByUniqueKey(sctx sessionctx.Context) bool 
 	return len(p.Ranges) == 1 &&
 		p.Index.Unique &&
 		len(p.Ranges[0].LowVal) == len(p.Index.Columns) &&
-		p.Ranges[0].IsPoint(sctx)
+		p.Ranges[0].IsPointNonNullable(sctx)
 }
 
 // PhysicalSelection represents a filter.

--- a/planner/core/plan_to_pb.go
+++ b/planner/core/plan_to_pb.go
@@ -212,6 +212,18 @@ func checkCoverIndex(idx *model.IndexInfo, ranges []*ranger.Range) bool {
 		if len(rg.LowVal) != len(idx.Columns) {
 			return false
 		}
+		for _, v := range rg.LowVal {
+			if v.IsNull() {
+				// a unique index may have duplicated rows with NULLs, so we cannot set the unique attribute to true when the range has NULL
+				// please see https://github.com/pingcap/tidb/issues/29650 for more details
+				return false
+			}
+		}
+		for _, v := range rg.HighVal {
+			if v.IsNull() {
+				return false
+			}
+		}
 	}
 	return true
 }

--- a/planner/core/rule_partition_processor.go
+++ b/planner/core/rule_partition_processor.go
@@ -139,7 +139,7 @@ func (s *partitionProcessor) findUsedPartitions(ctx sessionctx.Context, tbl tabl
 	ranges := detachedResult.Ranges
 	used := make([]int, 0, len(ranges))
 	for _, r := range ranges {
-		if r.IsPointNullable(ctx.GetSessionVars().StmtCtx) {
+		if r.IsPointNullable(ctx) {
 			if !r.HighVal[0].IsNull() {
 				if len(r.HighVal) != len(partIdx) {
 					used = []int{-1}
@@ -472,7 +472,7 @@ func (l *listPartitionPruner) locateColumnPartitionsByCondition(cond expression.
 			return nil, true, nil
 		}
 		var locations []tables.ListPartitionLocation
-		if r.IsPointNullable(sc) {
+		if r.IsPointNullable(l.ctx) {
 			location, err := colPrune.LocatePartition(sc, r.HighVal[0])
 			if types.ErrOverflow.Equal(err) {
 				return nil, true, nil // return full-scan if over-flow
@@ -554,7 +554,7 @@ func (l *listPartitionPruner) findUsedListPartitions(conds []expression.Expressi
 	}
 	used := make(map[int]struct{}, len(ranges))
 	for _, r := range ranges {
-		if r.IsPointNullable(l.ctx.GetSessionVars().StmtCtx) {
+		if r.IsPointNullable(l.ctx) {
 			if len(r.HighVal) != len(exprCols) {
 				return l.fullRange, nil
 			}

--- a/planner/core/testdata/integration_serial_suite_in.json
+++ b/planner/core/testdata/integration_serial_suite_in.json
@@ -30,6 +30,25 @@
 
   },
   {
+    "name": "TestRegardNULLAsPoint",
+    "cases": [
+      "select * from tuk where a<=>null and b=1",
+      "select * from tik where a<=>null and b=1",
+      "select * from tuk where a<=>null and b>0 and b<2",
+      "select * from tik where a<=>null and b>0 and b<2",
+      "select * from tuk where a<=>null and b>=1 and b<2",
+      "select * from tik where a<=>null and b>=1 and b<2",
+      "select * from tuk where a<=>null and b=1 and c=1",
+      "select * from tik where a<=>null and b=1 and c=1",
+      "select * from tuk where a=1 and b<=>null and c=1",
+      "select * from tik where a=1 and b<=>null and c=1",
+      "select * from tuk where a<=>null and b<=>null and c=1",
+      "select * from tik where a<=>null and b<=>null and c=1",
+      "select * from tuk where a<=>null and b<=>null and c<=>null",
+      "select * from tik where a<=>null and b<=>null and c<=>null"
+    ]
+  },
+  {
     "name": "TestPushDownToTiFlashWithKeepOrder",
     "cases": [
       "explain format = 'brief' select max(a) from t",

--- a/planner/core/testdata/integration_serial_suite_out.json
+++ b/planner/core/testdata/integration_serial_suite_out.json
@@ -221,6 +221,247 @@
     ]
   },
   {
+    "Name": "TestRegardNULLAsPoint",
+    "Cases": [
+      {
+        "SQL": "select * from tuk where a<=>null and b=1",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.01 root  index:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test.tuk.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b=1",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tik, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.01 root  index:Selection_6",
+          "└─Selection_6 0.01 cop[tikv]  eq(test.tik.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b>0 and b<2",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.25 root  index:Selection_6",
+          "└─Selection_6 0.25 cop[tikv]  eq(test.tuk.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b>0 and b<2",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tik, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.25 root  index:Selection_6",
+          "└─Selection_6 0.25 cop[tikv]  eq(test.tik.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b>=1 and b<2",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.25 root  index:Selection_6",
+          "└─Selection_6 0.25 cop[tikv]  eq(test.tuk.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b>=1 and b<2",
+        "PlanEnabled": [
+          "IndexReader_6 0.10 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.10 cop[tikv] table:tik, index:a(a, b, c) range:[NULL 1,NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.25 root  index:Selection_6",
+          "└─Selection_6 0.25 cop[tikv]  eq(test.tik.b, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 <nil>",
+          "<nil> 1 <nil>",
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b=1 and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 1.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 1.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL 1 1,NULL 1 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tuk.b, 1), eq(test.tuk.c, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b=1 and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 0.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL 1 1,NULL 1 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tik.b, 1), eq(test.tik.c, 1)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> 1 1",
+          "<nil> 1 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a=1 and b<=>null and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 1.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 1.00 cop[tikv] table:tuk, index:a(a, b, c) range:[1 NULL 1,1 NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tuk.c, 1)",
+          "  └─IndexRangeScan_5 0.10 cop[tikv] table:tuk, index:a(a, b, c) range:[1 NULL,1 NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 <nil> 1",
+          "1 <nil> 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a=1 and b<=>null and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 0.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.00 cop[tikv] table:tik, index:a(a, b, c) range:[1 NULL 1,1 NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tik.c, 1)",
+          "  └─IndexRangeScan_5 0.10 cop[tikv] table:tik, index:a(a, b, c) range:[1 NULL,1 NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "1 <nil> 1",
+          "1 <nil> 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b<=>null and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 1.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 1.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL NULL 1,NULL NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tuk.c, 1), nulleq(test.tuk.b, NULL)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> <nil> 1",
+          "<nil> <nil> 1"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b<=>null and c=1",
+        "PlanEnabled": [
+          "IndexReader_6 0.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL NULL 1,NULL NULL 1], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  eq(test.tik.c, 1), nulleq(test.tik.b, NULL)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> <nil> 1",
+          "<nil> <nil> 1"
+        ]
+      },
+      {
+        "SQL": "select * from tuk where a<=>null and b<=>null and c<=>null",
+        "PlanEnabled": [
+          "IndexReader_6 1.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 1.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL NULL NULL,NULL NULL NULL], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  nulleq(test.tuk.b, NULL), nulleq(test.tuk.c, NULL)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tuk, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> <nil> <nil>",
+          "<nil> <nil> <nil>"
+        ]
+      },
+      {
+        "SQL": "select * from tik where a<=>null and b<=>null and c<=>null",
+        "PlanEnabled": [
+          "IndexReader_6 0.00 root  index:IndexRangeScan_5",
+          "└─IndexRangeScan_5 0.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL NULL NULL,NULL NULL NULL], keep order:false, stats:pseudo"
+        ],
+        "PlanDisabled": [
+          "IndexReader_7 0.00 root  index:Selection_6",
+          "└─Selection_6 0.00 cop[tikv]  nulleq(test.tik.b, NULL), nulleq(test.tik.c, NULL)",
+          "  └─IndexRangeScan_5 10.00 cop[tikv] table:tik, index:a(a, b, c) range:[NULL,NULL], keep order:false, stats:pseudo"
+        ],
+        "Result": [
+          "<nil> <nil> <nil>",
+          "<nil> <nil> <nil>"
+        ]
+      }
+    ]
+  },
+  {
     "Name": "TestPushDownToTiFlashWithKeepOrder",
     "Cases": [
       {

--- a/planner/util/path.go
+++ b/planner/util/path.go
@@ -20,7 +20,6 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/ranger"
@@ -151,11 +150,11 @@ func isColEqCorColOrConstant(ctx sessionctx.Context, filter expression.Expressio
 }
 
 // OnlyPointRange checks whether each range is a point(no interval range exists).
-func (path *AccessPath) OnlyPointRange(sc *stmtctx.StatementContext) bool {
+func (path *AccessPath) OnlyPointRange(sctx sessionctx.Context) bool {
 	noIntervalRange := true
 	if path.IsIntHandlePath {
 		for _, ran := range path.Ranges {
-			if !ran.IsPoint(sc) {
+			if !ran.IsPoint(sctx) {
 				noIntervalRange = false
 				break
 			}
@@ -165,7 +164,7 @@ func (path *AccessPath) OnlyPointRange(sc *stmtctx.StatementContext) bool {
 	haveNullVal := false
 	for _, ran := range path.Ranges {
 		// Not point or the not full matched.
-		if !ran.IsPoint(sc) || len(ran.HighVal) != len(path.Index.Columns) {
+		if !ran.IsPoint(sctx) || len(ran.HighVal) != len(path.Index.Columns) {
 			noIntervalRange = false
 			break
 		}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -934,6 +934,9 @@ type SessionVars struct {
 	// EnablePseudoForOutdatedStats if using pseudo for outdated stats
 	EnablePseudoForOutdatedStats bool
 
+	// RegardNULLAsPoint if regard NULL as Point
+	RegardNULLAsPoint bool
+
 	// LocalTemporaryTables is *infoschema.LocalTemporaryTables, use interface to avoid circle dependency.
 	// It's nil if there is no local temporary table.
 	LocalTemporaryTables interface{}

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1840,6 +1840,10 @@ var defaultSysVars = []*SysVar{
 		s.EnablePseudoForOutdatedStats = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRegardNULLAsPoint, Value: BoolToOnOff(DefTiDBRegardNULLAsPoint), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.RegardNULLAsPoint = TiDBOptOn(val)
+		return nil
+	}},
 
 	{Scope: ScopeNone, Name: "version_compile_os", Value: runtime.GOOS},
 	{Scope: ScopeNone, Name: "version_compile_machine", Value: runtime.GOARCH},

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -595,6 +595,9 @@ const (
 	// TiDBEnablePseudoForOutdatedStats indicates whether use pseudo for outdated stats
 	TiDBEnablePseudoForOutdatedStats = "tidb_enable_pseudo_for_outdated_stats"
 
+	// TiDBRegardNULLAsPoint indicates whether regard NULL as point when optimizing
+	TiDBRegardNULLAsPoint = "tidb_regard_null_as_point"
+
 	// TiDBTmpTableMaxSize indicates the max memory size of temporary tables.
 	TiDBTmpTableMaxSize = "tidb_tmp_table_max_size"
 )
@@ -768,6 +771,7 @@ const (
 	DefTiDBEnableTSOFollowerProxy         = false
 	DefTiDBEnableOrderedResultMode        = false
 	DefTiDBEnablePseudoForOutdatedStats   = true
+	DefTiDBRegardNULLAsPoint              = true
 	DefEnablePlacementCheck               = true
 )
 

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -362,13 +362,12 @@ func (coll *HistColl) Selectivity(ctx sessionctx.Context, exprs []expression.Exp
 }
 
 func getMaskAndRanges(ctx sessionctx.Context, exprs []expression.Expression, rangeType ranger.RangeType, lengths []int, cachedPath *planutil.AccessPath, cols ...*expression.Column) (mask int64, ranges []*ranger.Range, partCover bool, err error) {
-	sc := ctx.GetSessionVars().StmtCtx
 	isDNF := false
 	var accessConds, remainedConds []expression.Expression
 	switch rangeType {
 	case ranger.ColumnRangeType:
 		accessConds = ranger.ExtractAccessConditionsForColumn(exprs, cols[0])
-		ranges, err = ranger.BuildColumnRange(accessConds, sc, cols[0].RetType, types.UnspecifiedLength)
+		ranges, err = ranger.BuildColumnRange(accessConds, ctx, cols[0].RetType, types.UnspecifiedLength)
 	case ranger.IndexRangeType:
 		if cachedPath != nil {
 			ranges, accessConds, remainedConds, isDNF = cachedPath.Ranges, cachedPath.AccessConds, cachedPath.TableFilters, cachedPath.IsDNFCond

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -216,7 +216,7 @@ func extractIndexPointRangesForCNF(sctx sessionctx.Context, conds []expression.E
 		sameLens, allPoints := true, true
 		numCols := int(0)
 		for j, ran := range res.Ranges {
-			if !ran.IsPoint(sctx.GetSessionVars().StmtCtx) {
+			if !ran.IsPoint(sctx) {
 				allPoints = false
 				break
 			}
@@ -610,13 +610,12 @@ func ExtractEqAndInCondition(sctx sessionctx.Context, conditions []expression.Ex
 // detachDNFCondAndBuildRangeForIndex will detach the index filters from table filters when it's a DNF.
 // We will detach the conditions of every DNF items, then compose them to a DNF.
 func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression.ScalarFunction, newTpSlice []*types.FieldType) ([]*Range, []expression.Expression, []*valueInfo, bool, error) {
-	sc := d.sctx.GetSessionVars().StmtCtx
 	firstColumnChecker := &conditionChecker{
 		checkerCol:    d.cols[0],
 		shouldReserve: d.lengths[0] != types.UnspecifiedLength,
 		length:        d.lengths[0],
 	}
-	rb := builder{sc: sc}
+	rb := builder{sc: d.sctx.GetSessionVars().StmtCtx}
 	dnfItems := expression.FlattenDNFConditions(condition)
 	newAccessItems := make([]expression.Expression, 0, len(dnfItems))
 	var totalRanges []*Range
@@ -666,7 +665,7 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression
 				firstColumnChecker.shouldReserve = d.lengths[0] != types.UnspecifiedLength
 			}
 			points := rb.build(item)
-			ranges, err := points2Ranges(sc, points, newTpSlice[0])
+			ranges, err := points2Ranges(d.sctx, points, newTpSlice[0])
 			if err != nil {
 				return nil, nil, nil, false, errors.Trace(err)
 			}
@@ -693,7 +692,7 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression
 	if hasPrefix(d.lengths) {
 		fixPrefixColRange(totalRanges, d.lengths, newTpSlice)
 	}
-	totalRanges, err := UnionRanges(sc, totalRanges, d.mergeConsecutive)
+	totalRanges, err := UnionRanges(d.sctx, totalRanges, d.mergeConsecutive)
 	if err != nil {
 		return nil, nil, nil, false, errors.Trace(err)
 	}

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -28,12 +28,12 @@ import (
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 )
 
-func validInterval(sc *stmtctx.StatementContext, low, high *point) (bool, error) {
+func validInterval(sctx sessionctx.Context, low, high *point) (bool, error) {
+	sc := sctx.GetSessionVars().StmtCtx
 	l, err := codec.EncodeKey(sc, nil, low.value)
 	if err != nil {
 		return false, errors.Trace(err)
@@ -53,18 +53,18 @@ func validInterval(sc *stmtctx.StatementContext, low, high *point) (bool, error)
 
 // points2Ranges build index ranges from range points.
 // Only one column is built there. If there're multiple columns, use appendPoints2Ranges.
-func points2Ranges(sc *stmtctx.StatementContext, rangePoints []*point, tp *types.FieldType) ([]*Range, error) {
+func points2Ranges(sctx sessionctx.Context, rangePoints []*point, tp *types.FieldType) ([]*Range, error) {
 	ranges := make([]*Range, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
-		startPoint, err := convertPoint(sc, rangePoints[i], tp)
+		startPoint, err := convertPoint(sctx, rangePoints[i], tp)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		endPoint, err := convertPoint(sc, rangePoints[i+1], tp)
+		endPoint, err := convertPoint(sctx, rangePoints[i+1], tp)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		less, err := validInterval(sc, startPoint, endPoint)
+		less, err := validInterval(sctx, startPoint, endPoint)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -87,7 +87,8 @@ func points2Ranges(sc *stmtctx.StatementContext, rangePoints []*point, tp *types
 	return ranges, nil
 }
 
-func convertPoint(sc *stmtctx.StatementContext, point *point, tp *types.FieldType) (*point, error) {
+func convertPoint(sctx sessionctx.Context, point *point, tp *types.FieldType) (*point, error) {
+	sc := sctx.GetSessionVars().StmtCtx
 	switch point.value.Kind() {
 	case types.KindMaxValue, types.KindMinNotNull:
 		return point, nil
@@ -156,15 +157,15 @@ func convertPoint(sc *stmtctx.StatementContext, point *point, tp *types.FieldTyp
 // The additional column ranges can only be appended to point ranges.
 // for example we have an index (a, b), if the condition is (a > 1 and b = 2)
 // then we can not build a conjunctive ranges for this index.
-func appendPoints2Ranges(sc *stmtctx.StatementContext, origin []*Range, rangePoints []*point,
+func appendPoints2Ranges(sctx sessionctx.Context, origin []*Range, rangePoints []*point,
 	ft *types.FieldType) ([]*Range, error) {
 	var newIndexRanges []*Range
 	for i := 0; i < len(origin); i++ {
 		oRange := origin[i]
-		if !oRange.IsPoint(sc) {
+		if !oRange.IsPoint(sctx) {
 			newIndexRanges = append(newIndexRanges, oRange)
 		} else {
-			newRanges, err := appendPoints2IndexRange(sc, oRange, rangePoints, ft)
+			newRanges, err := appendPoints2IndexRange(sctx, oRange, rangePoints, ft)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -174,19 +175,19 @@ func appendPoints2Ranges(sc *stmtctx.StatementContext, origin []*Range, rangePoi
 	return newIndexRanges, nil
 }
 
-func appendPoints2IndexRange(sc *stmtctx.StatementContext, origin *Range, rangePoints []*point,
+func appendPoints2IndexRange(sctx sessionctx.Context, origin *Range, rangePoints []*point,
 	ft *types.FieldType) ([]*Range, error) {
 	newRanges := make([]*Range, 0, len(rangePoints)/2)
 	for i := 0; i < len(rangePoints); i += 2 {
-		startPoint, err := convertPoint(sc, rangePoints[i], ft)
+		startPoint, err := convertPoint(sctx, rangePoints[i], ft)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		endPoint, err := convertPoint(sc, rangePoints[i+1], ft)
+		endPoint, err := convertPoint(sctx, rangePoints[i+1], ft)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
-		less, err := validInterval(sc, startPoint, endPoint)
+		less, err := validInterval(sctx, startPoint, endPoint)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -236,7 +237,7 @@ func appendRanges2PointRanges(pointRanges []*Range, ranges []*Range) []*Range {
 
 // points2TableRanges build ranges for table scan from range points.
 // It will remove the nil and convert MinNotNull and MaxValue to MinInt64 or MinUint64 and MaxInt64 or MaxUint64.
-func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []*point, tp *types.FieldType) ([]*Range, error) {
+func points2TableRanges(sctx sessionctx.Context, rangePoints []*point, tp *types.FieldType) ([]*Range, error) {
 	ranges := make([]*Range, 0, len(rangePoints)/2)
 	var minValueDatum, maxValueDatum types.Datum
 	// Currently, table's kv range cannot accept encoded value of MaxValueDatum. we need to convert it.
@@ -248,7 +249,7 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []*point, tp *
 		maxValueDatum.SetInt64(math.MaxInt64)
 	}
 	for i := 0; i < len(rangePoints); i += 2 {
-		startPoint, err := convertPoint(sc, rangePoints[i], tp)
+		startPoint, err := convertPoint(sctx, rangePoints[i], tp)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -258,7 +259,7 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []*point, tp *
 		} else if startPoint.value.Kind() == types.KindMinNotNull {
 			startPoint.value = minValueDatum
 		}
-		endPoint, err := convertPoint(sc, rangePoints[i+1], tp)
+		endPoint, err := convertPoint(sctx, rangePoints[i+1], tp)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -267,7 +268,7 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []*point, tp *
 		} else if endPoint.value.Kind() == types.KindNull {
 			continue
 		}
-		less, err := validInterval(sc, startPoint, endPoint)
+		less, err := validInterval(sctx, startPoint, endPoint)
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -286,8 +287,8 @@ func points2TableRanges(sc *stmtctx.StatementContext, rangePoints []*point, tp *
 }
 
 // buildColumnRange builds range from CNF conditions.
-func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType, tableRange bool, colLen int) (ranges []*Range, err error) {
-	rb := builder{sc: sc}
+func buildColumnRange(accessConditions []expression.Expression, sctx sessionctx.Context, tp *types.FieldType, tableRange bool, colLen int) (ranges []*Range, err error) {
+	rb := builder{sc: sctx.GetSessionVars().StmtCtx}
 	rangePoints := getFullRange()
 	for _, cond := range accessConditions {
 		rangePoints = rb.intersection(rangePoints, rb.build(cond))
@@ -297,9 +298,9 @@ func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.Stat
 	}
 	newTp := newFieldType(tp)
 	if tableRange {
-		ranges, err = points2TableRanges(sc, rangePoints, newTp)
+		ranges, err = points2TableRanges(sctx, rangePoints, newTp)
 	} else {
-		ranges, err = points2Ranges(sc, rangePoints, newTp)
+		ranges, err = points2Ranges(sctx, rangePoints, newTp)
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -316,7 +317,7 @@ func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.Stat
 				ran.HighExclude = false
 			}
 		}
-		ranges, err = UnionRanges(sc, ranges, true)
+		ranges, err = UnionRanges(sctx, ranges, true)
 		if err != nil {
 			return nil, err
 		}
@@ -325,23 +326,22 @@ func buildColumnRange(accessConditions []expression.Expression, sc *stmtctx.Stat
 }
 
 // BuildTableRange builds range of PK column for PhysicalTableScan.
-func BuildTableRange(accessConditions []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType) ([]*Range, error) {
-	return buildColumnRange(accessConditions, sc, tp, true, types.UnspecifiedLength)
+func BuildTableRange(accessConditions []expression.Expression, sctx sessionctx.Context, tp *types.FieldType) ([]*Range, error) {
+	return buildColumnRange(accessConditions, sctx, tp, true, types.UnspecifiedLength)
 }
 
 // BuildColumnRange builds range from access conditions for general columns.
-func BuildColumnRange(conds []expression.Expression, sc *stmtctx.StatementContext, tp *types.FieldType, colLen int) ([]*Range, error) {
+func BuildColumnRange(conds []expression.Expression, sctx sessionctx.Context, tp *types.FieldType, colLen int) ([]*Range, error) {
 	if len(conds) == 0 {
 		return []*Range{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}}}, nil
 	}
-	return buildColumnRange(conds, sc, tp, false, colLen)
+	return buildColumnRange(conds, sctx, tp, false, colLen)
 }
 
 // buildCNFIndexRange builds the range for index where the top layer is CNF.
 func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 	eqAndInCount int, accessCondition []expression.Expression) ([]*Range, error) {
-	sc := d.sctx.GetSessionVars().StmtCtx
-	rb := builder{sc: sc}
+	rb := builder{sc: d.sctx.GetSessionVars().StmtCtx}
 	var (
 		ranges []*Range
 		err    error
@@ -356,9 +356,9 @@ func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 			return nil, errors.Trace(rb.err)
 		}
 		if i == 0 {
-			ranges, err = points2Ranges(sc, point, newTp[i])
+			ranges, err = points2Ranges(d.sctx, point, newTp[i])
 		} else {
-			ranges, err = appendPoints2Ranges(sc, ranges, point, newTp[i])
+			ranges, err = appendPoints2Ranges(d.sctx, ranges, point, newTp[i])
 		}
 		if err != nil {
 			return nil, errors.Trace(err)
@@ -373,9 +373,9 @@ func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 		}
 	}
 	if eqAndInCount == 0 {
-		ranges, err = points2Ranges(sc, rangePoints, newTp[0])
+		ranges, err = points2Ranges(d.sctx, rangePoints, newTp[0])
 	} else if eqAndInCount < len(accessCondition) {
-		ranges, err = appendPoints2Ranges(sc, ranges, rangePoints, newTp[eqAndInCount])
+		ranges, err = appendPoints2Ranges(d.sctx, ranges, rangePoints, newTp[eqAndInCount])
 	}
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -384,7 +384,7 @@ func (d *rangeDetacher) buildCNFIndexRange(newTp []*types.FieldType,
 	// Take prefix index into consideration.
 	if hasPrefix(d.lengths) {
 		if fixPrefixColRange(ranges, d.lengths, newTp) {
-			ranges, err = UnionRanges(sc, ranges, d.mergeConsecutive)
+			ranges, err = UnionRanges(d.sctx, ranges, d.mergeConsecutive)
 			if err != nil {
 				return nil, errors.Trace(err)
 			}
@@ -404,7 +404,8 @@ type sortRange struct {
 // For two intervals [a, b], [c, d], we have guaranteed that a <= c. If b >= c. Then two intervals are overlapped.
 // And this two can be merged as [a, max(b, d)].
 // Otherwise they aren't overlapped.
-func UnionRanges(sc *stmtctx.StatementContext, ranges []*Range, mergeConsecutive bool) ([]*Range, error) {
+func UnionRanges(sctx sessionctx.Context, ranges []*Range, mergeConsecutive bool) ([]*Range, error) {
+	sc := sctx.GetSessionVars().StmtCtx
 	if len(ranges) == 0 {
 		return nil, nil
 	}

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -27,7 +27,6 @@ import (
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/sessionctx"
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/testkit"
@@ -300,7 +299,7 @@ func TestTableRange(t *testing.T) {
 			conds, filter = ranger.DetachCondsForColumn(sctx, conds, col)
 			require.Equal(t, tt.accessConds, fmt.Sprintf("%s", conds))
 			require.Equal(t, tt.filterConds, fmt.Sprintf("%s", filter))
-			result, err := ranger.BuildTableRange(conds, new(stmtctx.StatementContext), col.RetType)
+			result, err := ranger.BuildTableRange(conds, sctx, col.RetType)
 			require.NoError(t, err)
 			got := fmt.Sprintf("%v", result)
 			require.Equal(t, tt.resultStr, got)
@@ -1203,7 +1202,7 @@ func TestColumnRange(t *testing.T) {
 			require.NotNil(t, col)
 			conds = ranger.ExtractAccessConditionsForColumn(conds, col)
 			require.Equal(t, tt.accessConds, fmt.Sprintf("%s", conds))
-			result, err := ranger.BuildColumnRange(conds, new(stmtctx.StatementContext), col.RetType, tt.length)
+			result, err := ranger.BuildColumnRange(conds, sctx, col.RetType, tt.length)
 			require.NoError(t, err)
 			got := fmt.Sprintf("%v", result)
 			require.Equal(t, tt.resultStr, got)

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1308,6 +1308,7 @@ func TestCompIndexDNFMatch(t *testing.T) {
 	require.NoError(t, err)
 	testKit := testkit.NewTestKit(t, store)
 	testKit.MustExec("use test")
+	testKit.MustExec(`set @@session.tidb_regard_null_as_point=false`)
 	testKit.MustExec("drop table if exists t")
 	testKit.MustExec("create table t(a int, b int, c int, key(a,b,c));")
 	testKit.MustExec("insert into t values(1,2,2)")

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -82,7 +82,7 @@ func (ran *Range) Clone() *Range {
 
 // IsPoint returns if the range is a point.
 func (ran *Range) IsPoint(sctx sessionctx.Context) bool {
-	return ran.isPoint(sctx, false)
+	return ran.isPoint(sctx, sctx.GetSessionVars().RegardNULLAsPoint)
 }
 
 func (ran *Range) isPoint(sctx sessionctx.Context, regardNullAsPoint bool) bool {
@@ -110,6 +110,11 @@ func (ran *Range) isPoint(sctx sessionctx.Context, regardNullAsPoint bool) bool 
 		}
 	}
 	return !ran.LowExclude && !ran.HighExclude
+}
+
+// IsPointNonNullable returns if the range is a point without NULL.
+func (ran *Range) IsPointNonNullable(sctx sessionctx.Context) bool {
+	return ran.isPoint(sctx, false)
 }
 
 // IsPointNullable returns if the range is a point.

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -18,7 +18,7 @@ import (
 	"math"
 	"testing"
 
-	"github.com/pingcap/tidb/sessionctx/stmtctx"
+	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/ranger"
 	"github.com/stretchr/testify/require"
@@ -124,9 +124,8 @@ func TestRange(t *testing.T) {
 			isPoint: false,
 		},
 	}
-	sc := new(stmtctx.StatementContext)
 	for _, v := range isPointTests {
-		require.Equal(t, v.isPoint, v.ran.IsPoint(sc))
+		require.Equal(t, v.isPoint, v.ran.IsPoint(core.MockContext()))
 	}
 }
 


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/30244 https://github.com/pingcap/tidb/pull/29999 https://github.com/pingcap/tidb/pull/30340, no conflict

---

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29650

Problem Summary: planner: regard NULL as point when accessing composite index

### What is changed and how it works?

planner: regard NULL as point when accessing composite index

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: regard NULL as point when accessing composite index
```
