### PR TITLE
server: try to make `TidbTestSuite` more stable

### DIFF
--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -95,14 +95,14 @@ func createTidbTestSuite(t *testing.T) (*tidbTestSuite, func()) {
 	ts.waitUntilServerOnline()
 
 	cleanup := func() {
-		if ts.store != nil {
-			ts.store.Close()
-		}
 		if ts.domain != nil {
 			ts.domain.Close()
 		}
 		if ts.server != nil {
 			ts.server.Close()
+		}
+		if ts.store != nil {
+			require.NoError(t, ts.store.Close())
 		}
 	}
 


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: this PR tries to close #30238, although I'm not 100% sure if the panic can be avoided.

Problem Summary:

### What is changed and how it works?

Firstly, the panic happens in other cases also: https://ci.pingcap.net/blue/organizations/jenkins/tidb_ghpr_check_2/detail/tidb_ghpr_check_2/50025/pipeline, I'm sure they happen for the same reason.

`panic: sync: WaitGroup is reused before previous Wait has returned` is reported when `wg.Add()` is called during the waiting of `wg.Wait()`.

I checked the code in `8550dbb21` and confirmed that:
- `KVStore.wg.Wait()` is called in `KVStore.Close()`, as shown in the error stack.
- `KVStore.wg.Add()` is called in basically 2 ways: the construct method of `KVStore` and some commit phase in `2pc.go`, like [this](https://github.com/tikv/client-go/blob/87c1c58064723255f777f60b8eb1fe13ae60a750/txnkv/transaction/2pc.go#L778):

```
	if actionIsCommit && !actionCommit.retry && !c.isAsyncCommit() {
		secondaryBo := retry.NewBackofferWithVars(c.store.Ctx(), CommitSecondaryMaxBackoff, c.txn.vars)
		c.store.WaitGroup().Add(1)
		go func() {
			defer c.store.WaitGroup().Done()
```

So probably, when the `KVStore.Close()` is called, there are some other goroutines trying to make the commit concurrently and caused this panic in our test. Since there is no asynchronize execution of the SQL statements in the test code of `TestLoadData`, I suspect that there are some background goroutine scheduled by the TiDB server, and this is possible(stats collector, DDL owner...).

I decide to change the order of 3 `Close()` in the test code to make sure `domain` and `server` close first to avoid those cases:

```
	cleanup := func() {
		if ts.store != nil {
			ts.store.Close()
		}
		if ts.domain != nil {
			ts.domain.Close()
		}
		if ts.server != nil {
			ts.server.Close()
		}
``` 

Also, I think it's better to avoid expose `KVStore.wg` in public by `KVStore.WaitGroup()` method by not trying to use it in the commit phase. I'm not sure if this is possible or easy.

### Check List

Tests <!-- At least one of them must be included. -->

- NA

Side effects

- None

Documentation

- None

### Release note

```release-note
None
```
