### PR TITLE
planner: Introduce historical stats tables

### DIFF
--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -17,7 +17,6 @@ package executor_test
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/pingcap/tidb/path/pkg/mod/github.com/go-kit/kit@v0.9.0/transport/grpc"
 	"net"
 	"net/http/httptest"
 	"strconv"

--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -17,6 +17,7 @@ package executor_test
 import (
 	"crypto/tls"
 	"fmt"
+	"github.com/pingcap/tidb/path/pkg/mod/github.com/go-kit/kit@v0.9.0/transport/grpc"
 	"net"
 	"net/http/httptest"
 	"strconv"
@@ -918,7 +919,7 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 	tk.MustQuery("select TABLE_SCHEMA, sum(TABLE_SIZE) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'test' group by TABLE_SCHEMA;").Check(testkit.Rows(
 		"test 2",
 	))
-	c.Assert(len(tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()), Equals, 27)
+	c.Assert(len(tk.MustQuery("select TABLE_NAME from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql';").Rows()), Equals, 29)
 
 	// More tests about the privileges.
 	tk.MustExec("create user 'testuser'@'localhost'")
@@ -944,14 +945,14 @@ func (s *testInfoschemaClusterTableSuite) TestTableStorageStats(c *C) {
 		Hostname: "localhost",
 	}, nil, nil), Equals, true)
 
-	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("27"))
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("29"))
 
 	c.Assert(tk.Se.Auth(&auth.UserIdentity{
 		Username: "testuser3",
 		Hostname: "localhost",
 	}, nil, nil), Equals, true)
 
-	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("27"))
+	tk.MustQuery("select count(1) from information_schema.TABLE_STORAGE_STATS where TABLE_SCHEMA = 'mysql'").Check(testkit.Rows("29"))
 }
 
 func (s *testInfoschemaTableSuite) TestSequences(c *C) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -365,6 +365,24 @@ const (
 		oldReadLease bigint(20) NOT NULL DEFAULT 0,
 		PRIMARY KEY (tid)
 	);`
+	// CreateStatsHistory stores the historical stats.
+	CreateStatsHistory = `CREATE TABLE IF NOT EXISTS mysql.stats_history (
+		table_id bigint(64) NOT NULL,
+		stats_data longblob NOT NULL,
+		seq_no bigint(64) NOT NULL,
+		version bigint(64) NOT NULL,
+		create_time datetime(6) NOT NULL,
+		PRIMARY KEY(table_id)
+	);`
+	// CreateStatsMetaHistory stores the meta historical stats.
+	CreateStatsMetaHistory = `CREATE TABLE IF NOT EXISTS mysql.stats_meta_history (
+		table_id bigint(64) NOT NULL,
+		modify_count bigint(64) NOT NULL,
+		count bigint(64) NOT NULL,
+		version bigint(64) NOT NULL,
+		create_time datetime(6) NOT NULL,
+		PRIMARY KEY(table_id)
+	);`
 )
 
 // bootstrap initiates system DB for a store.
@@ -541,6 +559,8 @@ const (
 	// version80 fixes the issue https://github.com/pingcap/tidb/issues/25422.
 	// If the TiDB upgrading from the 4.x to a newer version, we keep the tidb_analyze_version to 1.
 	version80 = 80
+	// version81 adds the tables mysql.stats_history and mysql.stats_meta_history
+	version81 = 81
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
@@ -629,6 +649,7 @@ var (
 		upgradeToVer78,
 		upgradeToVer79,
 		upgradeToVer80,
+		upgradeToVer81,
 	}
 )
 
@@ -1654,6 +1675,13 @@ func upgradeToVer80(s Session, ver int64) {
 	mustExecute(s, "INSERT HIGH_PRIORITY IGNORE INTO %n.%n VALUES (%?, %?);",
 		mysql.SystemDB, mysql.GlobalVariablesTable, variable.TiDBAnalyzeVersion, 1)
 }
+func upgradeToVer81(s Session, ver int64) {
+	if ver >= version81 {
+		return
+	}
+	doReentrantDDL(s, CreateStatsHistory)
+	doReentrantDDL(s, CreateStatsMetaHistory)
+}
 
 func writeOOMAction(s Session) {
 	comment := "oom-action is `log` by default in v3.0.x, `cancel` by default in v4.0.11+"
@@ -1739,6 +1767,10 @@ func doDDLWorks(s Session) {
 	mustExecute(s, CreateColumnStatsUsageTable)
 	// Create table_cache_meta table.
 	mustExecute(s, CreateTableCacheMetaTable)
+	// Create stats_history table.
+	mustExecute(s, CreateStatsHistory)
+	// Create stats_meta_history table.
+	mustExecute(s, CreateStatsMetaHistory)
 }
 
 // doDMLWorks executes DML statements in bootstrap stage.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: #18745 

Problem Summary:
Introduce 2 internal tables (mysql.stats_history and mysql.stats_meta_history) to store historical statistics

### What is changed and how it works?
Add 2 new tables to store historical statistics:
* `mysql.stats_history`
* `mysql.stats_meta_history`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
