### PR TITLE
fix #19150  pkg expression is changed

### DIFF
--- a/expression/builtin_time.go
+++ b/expression/builtin_time.go
@@ -20,6 +20,7 @@ package expression
 
 import (
 	"fmt"
+	"github.com/pingcap/tidb/util/parser"
 	"math"
 	"regexp"
 	"strconv"
@@ -5555,6 +5556,13 @@ func (b *builtinAddStringAndStringSig) evalString(row chunk.Row) (result string,
 			return "", true, nil
 		}
 		return "", true, err
+	}
+
+	check := arg1Str
+	_, check, _ = parser.Number(parser.Space0(check))
+	check, err = parser.Char(check, '-')
+	if strings.Compare(check, "") != 0 && err == nil {
+		return "", true, nil
 	}
 	if isDuration(arg0) {
 		result, err = strDurationAddDuration(sc, arg0, arg1)

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -939,6 +939,7 @@ func TestAddTimeSig(t *testing.T) {
 		{"2018-08-16 20:21:01", "00:00:00.000001", "2018-08-16 20:21:01.000001"},
 		{"1", "xxcvadfgasd", ""},
 		{"xxcvadfgasd", "1", ""},
+		{"2020-05-13 14:01:24", "2020-04-29 05:11:19", ""},
 	}
 	fc := funcs[ast.AddTime]
 	for _, c := range tbl {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #19150 

Problem Summary:

### What is changed and how it works?
After `ParseDuration` in `builtinAddStringAndStringSig.evalString` , format like `*-*` will be checked，if the `arg1Str`match this format, it will return `isNull`

### Check List

Tests <!-- At least one of them must be included. -->

- [×] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [×] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
