### PR TITLE
test: make all the tests run in serial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ devgotest: failpoint-enable
 gotest: failpoint-enable
 	@echo "Running in native mode."
 	@export log_level=info; export TZ='Asia/Shanghai'; \
-	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' $(EXTRA_TEST_ARGS) -cover $(PACKAGES_TIDB_TESTS) -coverprofile=coverage.txt -check.p true > gotest.log || { $(FAILPOINT_DISABLE); cat 'gotest.log'; exit 1; }
+	$(GOTEST) -ldflags '$(TEST_LDFLAGS)' $(EXTRA_TEST_ARGS) -timeout 20m -cover $(PACKAGES_TIDB_TESTS) -coverprofile=coverage.txt -check.p true > gotest.log || { $(FAILPOINT_DISABLE); cat 'gotest.log'; exit 1; }
 	@$(FAILPOINT_DISABLE)
 
 gotest_in_verify_ci_part_1: failpoint-enable tools/bin/gotestsum tools/bin/gocov tools/bin/gocov-xml

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -165,8 +165,6 @@ func TestCheckStoresAlive(t *testing.T) {
 }
 
 func TestGetAllTiKVStores(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		stores         []*metapb.Store
 		storeBehavior  StoreBehavior
@@ -258,8 +256,6 @@ func TestGetAllTiKVStores(t *testing.T) {
 }
 
 func TestGetConnOnCanceledContext(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 

--- a/br/pkg/kv/checksum_test.go
+++ b/br/pkg/kv/checksum_test.go
@@ -25,8 +25,6 @@ import (
 func uint64NotEqual(a uint64, b uint64) bool { return a != b }
 
 func TestChecksum(t *testing.T) {
-	t.Parallel()
-
 	checksum := kv.NewKVChecksum(0)
 	require.Equal(t, uint64(0), checksum.Sum())
 
@@ -69,8 +67,6 @@ func TestChecksum(t *testing.T) {
 }
 
 func TestChecksumJSON(t *testing.T) {
-	t.Parallel()
-
 	testStruct := &struct {
 		Checksum kv.Checksum
 	}{

--- a/br/pkg/kv/kv_test.go
+++ b/br/pkg/kv/kv_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestMarshal(t *testing.T) {
-	t.Parallel()
-
 	dats := make([]types.Datum, 4)
 	dats[0].SetInt64(1)
 	dats[1].SetNull()
@@ -43,8 +41,6 @@ func TestMarshal(t *testing.T) {
 }
 
 func TestSimplePairIter(t *testing.T) {
-	t.Parallel()
-
 	pairs := []Pair{
 		{Key: []byte("1"), Val: []byte("a")},
 		{Key: []byte("2"), Val: []byte("b")},

--- a/br/pkg/kv/session_test.go
+++ b/br/pkg/kv/session_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestSession(t *testing.T) {
-	t.Parallel()
-
 	session := newSession(&SessionOptions{SQLMode: mysql.ModeNone, Timestamp: 1234567890, RowFormatVersion: "1"})
 	_, err := session.Txn(true)
 	require.NoError(t, err)

--- a/br/pkg/lightning/backend/backend_test.go
+++ b/br/pkg/lightning/backend/backend_test.go
@@ -39,7 +39,6 @@ func (s *backendSuite) tearDownTest() {
 }
 
 func TestOpenCloseImportCleanUpEngine(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 	ctx := context.Background()
@@ -72,7 +71,6 @@ func TestOpenCloseImportCleanUpEngine(t *testing.T) {
 }
 
 func TestUnsafeCloseEngine(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -94,7 +92,6 @@ func TestUnsafeCloseEngine(t *testing.T) {
 }
 
 func TestUnsafeCloseEngineWithUUID(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -116,7 +113,6 @@ func TestUnsafeCloseEngineWithUUID(t *testing.T) {
 }
 
 func TestWriteEngine(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -155,7 +151,6 @@ func TestWriteEngine(t *testing.T) {
 }
 
 func TestWriteToEngineWithNothing(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -179,7 +174,6 @@ func TestWriteToEngineWithNothing(t *testing.T) {
 }
 
 func TestOpenEngineFailed(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -193,7 +187,6 @@ func TestOpenEngineFailed(t *testing.T) {
 }
 
 func TestWriteEngineFailed(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -221,7 +214,6 @@ func TestWriteEngineFailed(t *testing.T) {
 }
 
 func TestWriteBatchSendFailedWithRetry(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -249,7 +241,6 @@ func TestWriteBatchSendFailedWithRetry(t *testing.T) {
 }
 
 func TestImportFailedNoRetry(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -268,7 +259,6 @@ func TestImportFailedNoRetry(t *testing.T) {
 }
 
 func TestImportFailedWithRetry(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -289,7 +279,6 @@ func TestImportFailedWithRetry(t *testing.T) {
 }
 
 func TestImportFailedRecovered(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -312,7 +301,6 @@ func TestImportFailedRecovered(t *testing.T) {
 
 //nolint:interfacer // change test case signature causes check panicking.
 func TestClose(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -322,7 +310,6 @@ func TestClose(t *testing.T) {
 }
 
 func TestMakeEmptyRows(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -332,7 +319,6 @@ func TestMakeEmptyRows(t *testing.T) {
 }
 
 func TestNewEncoder(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 
@@ -346,7 +332,6 @@ func TestNewEncoder(t *testing.T) {
 }
 
 func TestCheckDiskQuota(t *testing.T) {
-	t.Parallel()
 	s := createBackendSuite(t)
 	defer s.tearDownTest()
 

--- a/br/pkg/lightning/backend/importer/importer_test.go
+++ b/br/pkg/lightning/backend/importer/importer_test.go
@@ -79,7 +79,6 @@ func (s *importerSuite) tearDownTest() {
 }
 
 func TestWriteRows(t *testing.T) {
-	t.Parallel()
 	s := createImportSuite(t)
 	defer s.tearDownTest()
 
@@ -117,7 +116,6 @@ func TestWriteRows(t *testing.T) {
 }
 
 func TestWriteHeadSendFailed(t *testing.T) {
-	t.Parallel()
 	s := createImportSuite(t)
 	defer s.tearDownTest()
 
@@ -142,7 +140,6 @@ func TestWriteHeadSendFailed(t *testing.T) {
 }
 
 func TestWriteBatchSendFailed(t *testing.T) {
-	t.Parallel()
 	s := createImportSuite(t)
 	defer s.tearDownTest()
 
@@ -174,7 +171,6 @@ func TestWriteBatchSendFailed(t *testing.T) {
 }
 
 func TestWriteCloseFailed(t *testing.T) {
-	t.Parallel()
 	s := createImportSuite(t)
 	defer s.tearDownTest()
 
@@ -206,7 +202,6 @@ func TestWriteCloseFailed(t *testing.T) {
 }
 
 func TestCloseImportCleanupEngine(t *testing.T) {
-	t.Parallel()
 	s := createImportSuite(t)
 	defer s.tearDownTest()
 

--- a/br/pkg/lightning/backend/tidb/tidb_test.go
+++ b/br/pkg/lightning/backend/tidb/tidb_test.go
@@ -73,7 +73,6 @@ func (s *mysqlSuite) TearDownTest(t *testing.T) {
 }
 
 func TestWriteRowsReplaceOnDup(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.
@@ -132,7 +131,6 @@ func TestWriteRowsReplaceOnDup(t *testing.T) {
 }
 
 func TestWriteRowsIgnoreOnDup(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.
@@ -179,7 +177,6 @@ func TestWriteRowsIgnoreOnDup(t *testing.T) {
 }
 
 func TestWriteRowsErrorOnDup(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.
@@ -259,7 +256,6 @@ func testStrictMode(t *testing.T) {
 }
 
 func TestFetchRemoteTableModels_3_x(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.ExpectBegin()
@@ -294,7 +290,6 @@ func TestFetchRemoteTableModels_3_x(t *testing.T) {
 }
 
 func TestFetchRemoteTableModels_4_0(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.ExpectBegin()
@@ -332,7 +327,6 @@ func TestFetchRemoteTableModels_4_0(t *testing.T) {
 }
 
 func TestFetchRemoteTableModels_4_x_auto_increment(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.ExpectBegin()
@@ -370,7 +364,6 @@ func TestFetchRemoteTableModels_4_x_auto_increment(t *testing.T) {
 }
 
 func TestFetchRemoteTableModels_4_x_auto_random(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
 	s.mockDB.ExpectBegin()
@@ -410,7 +403,6 @@ func TestFetchRemoteTableModels_4_x_auto_random(t *testing.T) {
 }
 
 func TestWriteRowsErrorNoRetry(t *testing.T) {
-	t.Parallel()
 	nonRetryableError := sql.ErrNoRows
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
@@ -436,7 +428,6 @@ func TestWriteRowsErrorNoRetry(t *testing.T) {
 }
 
 func TestWriteRowsErrorDowngradingAll(t *testing.T) {
-	t.Parallel()
 	nonRetryableError := sql.ErrNoRows
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
@@ -503,7 +494,6 @@ func TestWriteRowsErrorDowngradingAll(t *testing.T) {
 }
 
 func TestWriteRowsErrorDowngradingExceedThreshold(t *testing.T) {
-	t.Parallel()
 	nonRetryableError := sql.ErrNoRows
 	s := createMysqlSuite(t)
 	defer s.TearDownTest(t)
@@ -608,7 +598,6 @@ func encodeRowsTiDB(t *testing.T, b backend.Backend, tbl table.Table) kv.Rows {
 }
 
 func TestEncodeRowForRecord(t *testing.T) {
-	t.Parallel()
 	s := createMysqlSuite(t)
 
 	// for a correct row, the will encode a correct result

--- a/br/pkg/logutil/logging_test.go
+++ b/br/pkg/logutil/logging_test.go
@@ -46,7 +46,6 @@ func newFile(j int) *backuppb.File {
 }
 
 func TestRater(t *testing.T) {
-	t.Parallel()
 	m := prometheus.NewCounter(prometheus.CounterOpts{
 		Namespace: "testing",
 		Name:      "rater",
@@ -65,13 +64,11 @@ func TestRater(t *testing.T) {
 }
 
 func TestFile(t *testing.T) {
-	t.Parallel()
 	assertTrimEqual(t, logutil.File(newFile(1)),
 		`{"file": {"name": "1", "CF": "write", "sha256": "31", "startKey": "31", "endKey": "32", "startVersion": 1, "endVersion": 2, "totalKvs": 1, "totalBytes": 1, "CRC64Xor": 1}}`)
 }
 
 func TestFiles(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		count  int
 		expect string
@@ -96,7 +93,6 @@ func TestFiles(t *testing.T) {
 }
 
 func TestKey(t *testing.T) {
-	t.Parallel()
 	encoder := zapcore.NewConsoleEncoder(zapcore.EncoderConfig{})
 	out, err := encoder.EncodeEntry(zapcore.Entry{}, []zap.Field{logutil.Key("test", []byte{0, 1, 2, 3})})
 	require.NoError(t, err)
@@ -104,7 +100,6 @@ func TestKey(t *testing.T) {
 }
 
 func TestKeys(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		count  int
 		expect string
@@ -129,7 +124,6 @@ func TestKeys(t *testing.T) {
 }
 
 func TestRewriteRule(t *testing.T) {
-	t.Parallel()
 	rule := &import_sstpb.RewriteRule{
 		OldKeyPrefix: []byte("old"),
 		NewKeyPrefix: []byte("new"),
@@ -143,7 +137,6 @@ func TestRewriteRule(t *testing.T) {
 }
 
 func TestRegion(t *testing.T) {
-	t.Parallel()
 	region := &metapb.Region{
 		Id:          1,
 		StartKey:    []byte{0x00, 0x01},
@@ -157,14 +150,12 @@ func TestRegion(t *testing.T) {
 }
 
 func TestLeader(t *testing.T) {
-	t.Parallel()
 	leader := &metapb.Peer{Id: 2, StoreId: 3}
 
 	assertTrimEqual(t, logutil.Leader(leader), `{"leader": "id:2 store_id:3 "}`)
 }
 
 func TestSSTMeta(t *testing.T) {
-	t.Parallel()
 	meta := &import_sstpb.SSTMeta{
 		Uuid: []byte("mock uuid"),
 		Range: &import_sstpb.Range{
@@ -183,14 +174,12 @@ func TestSSTMeta(t *testing.T) {
 }
 
 func TestShortError(t *testing.T) {
-	t.Parallel()
 	err := errors.Annotate(berrors.ErrInvalidArgument, "test")
 
 	assertTrimEqual(t, logutil.ShortError(err), `{"error": "test: [BR:Common:ErrInvalidArgument]invalid argument"}`)
 }
 
 func TestContextual(t *testing.T) {
-	t.Parallel()
 	testCore, logs := observer.New(zap.InfoLevel)
 	logutil.ResetGlobalLogger(zap.New(testCore))
 

--- a/br/pkg/membuf/buffer_test.go
+++ b/br/pkg/membuf/buffer_test.go
@@ -40,8 +40,6 @@ func (t *testAllocator) Free(_ []byte) {
 }
 
 func TestBufferPool(t *testing.T) {
-	t.Parallel()
-
 	allocator := &testAllocator{}
 	pool := NewPool(2, allocator)
 
@@ -69,8 +67,6 @@ func TestBufferPool(t *testing.T) {
 }
 
 func TestBufferIsolation(t *testing.T) {
-	t.Parallel()
-
 	bytesBuf := NewBuffer()
 	defer bytesBuf.Destroy()
 

--- a/br/pkg/metautil/metafile_test.go
+++ b/br/pkg/metautil/metafile_test.go
@@ -24,8 +24,6 @@ func checksum(m *backuppb.MetaFile) []byte {
 }
 
 func TestWalkMetaFileEmpty(t *testing.T) {
-	t.Parallel()
-
 	files := []*backuppb.MetaFile{}
 	collect := func(m *backuppb.MetaFile) { files = append(files, m) }
 	cipher := backuppb.CipherInfo{
@@ -46,8 +44,6 @@ func TestWalkMetaFileEmpty(t *testing.T) {
 }
 
 func TestWalkMetaFileLeaf(t *testing.T) {
-	t.Parallel()
-
 	leaf := &backuppb.MetaFile{Schemas: []*backuppb.Schema{
 		{Db: []byte("db"), Table: []byte("table")},
 	}}
@@ -64,8 +60,6 @@ func TestWalkMetaFileLeaf(t *testing.T) {
 }
 
 func TestWalkMetaFileInvalid(t *testing.T) {
-	t.Parallel()
-
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	mockStorage := mockstorage.NewMockExternalStorage(controller)
@@ -91,8 +85,6 @@ func TestWalkMetaFileInvalid(t *testing.T) {
 }
 
 func TestWalkMetaFile(t *testing.T) {
-	t.Parallel()
-
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 	mockStorage := mockstorage.NewMockExternalStorage(controller)
@@ -161,8 +153,6 @@ type encryptTest struct {
 }
 
 func TestEncryptAndDecrypt(t *testing.T) {
-	t.Parallel()
-
 	originalData := []byte("pingcap")
 	testCases := []encryptTest{
 		{

--- a/br/pkg/restore/split_test.go
+++ b/br/pkg/restore/split_test.go
@@ -237,7 +237,6 @@ func (b *assertRetryLessThanBackoffer) Attempt() int {
 }
 
 func TestScatterFinishInTime(t *testing.T) {
-	t.Parallel()
 	client := initTestClient()
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()
@@ -283,7 +282,6 @@ func TestScatterFinishInTime(t *testing.T) {
 //   [, aay), [aay, bba), [bba, bbf), [bbf, bbh), [bbh, bbj),
 //   [bbj, cca), [cca, xxe), [xxe, xxz), [xxz, )
 func TestSplitAndScatter(t *testing.T) {
-	t.Parallel()
 	client := initTestClient()
 	ranges := initRanges()
 	rewriteRules := initRewriteRules()

--- a/br/pkg/rtree/logging_test.go
+++ b/br/pkg/rtree/logging_test.go
@@ -15,7 +15,6 @@ import (
 )
 
 func TestLogRanges(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		count  int
 		expect string

--- a/br/pkg/rtree/rtree_test.go
+++ b/br/pkg/rtree/rtree_test.go
@@ -18,7 +18,6 @@ func newRange(start, end []byte) *rtree.Range {
 }
 
 func TestRangeTree(t *testing.T) {
-	t.Parallel()
 	rangeTree := rtree.NewRangeTree()
 	require.Nil(t, rangeTree.Get(newRange([]byte(""), []byte(""))))
 
@@ -123,7 +122,6 @@ func TestRangeTree(t *testing.T) {
 }
 
 func TestRangeIntersect(t *testing.T) {
-	t.Parallel()
 	rg := newRange([]byte("a"), []byte("c"))
 
 	start, end, isIntersect := rg.Intersect([]byte(""), []byte(""))

--- a/br/pkg/summary/collector_test.go
+++ b/br/pkg/summary/collector_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestSumDurationInt(t *testing.T) {
-	t.Parallel()
-
 	fields := []zap.Field{}
 	logger := func(msg string, fs ...zap.Field) {
 		fields = append(fields, fs...)

--- a/br/pkg/utils/backoff_test.go
+++ b/br/pkg/utils/backoff_test.go
@@ -16,8 +16,6 @@ import (
 )
 
 func TestBackoffWithSuccess(t *testing.T) {
-	t.Parallel()
-
 	var counter int
 	backoffer := utils.NewBackoffer(10, time.Nanosecond, time.Nanosecond)
 	err := utils.WithRetry(context.Background(), func() error {
@@ -37,8 +35,6 @@ func TestBackoffWithSuccess(t *testing.T) {
 }
 
 func TestBackoffWithFatalError(t *testing.T) {
-	t.Parallel()
-
 	var counter int
 	backoffer := utils.NewBackoffer(10, time.Nanosecond, time.Nanosecond)
 	gRPCError := status.Error(codes.Unavailable, "transport is closing")
@@ -66,8 +62,6 @@ func TestBackoffWithFatalError(t *testing.T) {
 }
 
 func TestBackoffWithFatalRawGRPCError(t *testing.T) {
-	t.Parallel()
-
 	var counter int
 	canceledError := status.Error(codes.Canceled, "context canceled")
 	backoffer := utils.NewBackoffer(10, time.Nanosecond, time.Nanosecond)
@@ -80,8 +74,6 @@ func TestBackoffWithFatalRawGRPCError(t *testing.T) {
 }
 
 func TestBackoffWithRetryableError(t *testing.T) {
-	t.Parallel()
-
 	var counter int
 	backoffer := utils.NewBackoffer(10, time.Nanosecond, time.Nanosecond)
 	err := utils.WithRetry(context.Background(), func() error {
@@ -104,8 +96,6 @@ func TestBackoffWithRetryableError(t *testing.T) {
 }
 
 func TestPdBackoffWithRetryableError(t *testing.T) {
-	t.Parallel()
-
 	var counter int
 	backoffer := utils.NewPDReqBackoffer()
 	gRPCError := status.Error(codes.Unavailable, "transport is closing")

--- a/br/pkg/utils/env_test.go
+++ b/br/pkg/utils/env_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestProxyFields(t *testing.T) {
-	t.Parallel()
-
 	revIndex := map[string]int{
 		"http_proxy":  0,
 		"https_proxy": 1,

--- a/br/pkg/utils/json_test.go
+++ b/br/pkg/utils/json_test.go
@@ -207,8 +207,6 @@ var testMetaJSONs = [][]byte{
 }
 
 func TestEncodeAndDecode(t *testing.T) {
-	t.Parallel()
-
 	for _, testMetaJSON := range testMetaJSONs {
 		meta, err := UnmarshalBackupMeta(testMetaJSON)
 		require.NoError(t, err)

--- a/br/pkg/utils/key_test.go
+++ b/br/pkg/utils/key_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestParseKey(t *testing.T) {
-	t.Parallel()
-
 	// test rawKey
 	testRawKey := []struct {
 		rawKey string
@@ -94,8 +92,6 @@ func TestParseKey(t *testing.T) {
 }
 
 func TestCompareEndKey(t *testing.T) {
-	t.Parallel()
-
 	// test endKey
 	testCase := []struct {
 		key1 []byte

--- a/br/pkg/utils/math_test.go
+++ b/br/pkg/utils/math_test.go
@@ -9,8 +9,6 @@ import (
 )
 
 func TestMinInt(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, 1, MinInt(1, 2))
 	require.Equal(t, 1, MinInt(2, 1))
 	require.Equal(t, 1, MinInt(4, 2, 1, 3))
@@ -18,8 +16,6 @@ func TestMinInt(t *testing.T) {
 }
 
 func TestMaxInt(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, 2, MaxInt(1, 2))
 	require.Equal(t, 2, MaxInt(2, 1))
 	require.Equal(t, 4, MaxInt(4, 2, 1, 3))
@@ -27,8 +23,6 @@ func TestMaxInt(t *testing.T) {
 }
 
 func TestClampInt(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, 3, ClampInt(100, 1, 3))
 	require.Equal(t, 2, ClampInt(2, 1, 3))
 	require.Equal(t, 1, ClampInt(0, 1, 3))
@@ -37,8 +31,6 @@ func TestClampInt(t *testing.T) {
 }
 
 func TestMinInt64(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, 1, MinInt(1, 2))
 	require.Equal(t, 1, MinInt(2, 1))
 	require.Equal(t, 1, MinInt(4, 2, 1, 3))
@@ -46,8 +38,6 @@ func TestMinInt64(t *testing.T) {
 }
 
 func TestNextPowerOfTwo(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, int64(1), NextPowerOfTwo(1))
 	require.Equal(t, int64(4), NextPowerOfTwo(3))
 	require.Equal(t, int64(256), NextPowerOfTwo(255))

--- a/br/pkg/utils/progress_test.go
+++ b/br/pkg/utils/progress_test.go
@@ -20,8 +20,6 @@ func (t *testWriter) Write(p []byte) (int, error) {
 }
 
 func TestProgress(t *testing.T) {
-	t.Parallel()
-
 	ctx, cancel := context.WithCancel(context.Background())
 
 	var p string

--- a/br/pkg/utils/retry_test.go
+++ b/br/pkg/utils/retry_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestIsRetryableError(t *testing.T) {
-	t.Parallel()
-
 	require.False(t, IsRetryableError(context.Canceled))
 	require.False(t, IsRetryableError(context.DeadlineExceeded))
 	require.False(t, IsRetryableError(io.EOF))

--- a/br/pkg/utils/safe_point_test.go
+++ b/br/pkg/utils/safe_point_test.go
@@ -13,8 +13,6 @@ import (
 )
 
 func TestCheckGCSafepoint(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	pdClient := &mockSafePoint{safepoint: 2333}
 	{
@@ -67,8 +65,6 @@ func (m *mockSafePoint) UpdateGCSafePoint(ctx context.Context, safePoint uint64)
 }
 
 func TestStartServiceSafePointKeeper(t *testing.T) {
-	t.Parallel()
-
 	pdClient := &mockSafePoint{safepoint: 2333}
 
 	cases := []struct {

--- a/br/pkg/utils/schema_test.go
+++ b/br/pkg/utils/schema_test.go
@@ -27,8 +27,6 @@ func mockBackupMeta(mockSchemas []*backuppb.Schema, mockFiles []*backuppb.File) 
 }
 
 func TestLoadBackupMeta(t *testing.T) {
-	t.Parallel()
-
 	testDir := t.TempDir()
 	store, err := storage.NewLocalStorage(testDir)
 	require.NoError(t, err)
@@ -105,8 +103,6 @@ func TestLoadBackupMeta(t *testing.T) {
 }
 
 func TestLoadBackupMetaPartionTable(t *testing.T) {
-	t.Parallel()
-
 	testDir := t.TempDir()
 	store, err := storage.NewLocalStorage(testDir)
 	require.NoError(t, err)

--- a/br/pkg/version/build/info_test.go
+++ b/br/pkg/version/build/info_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestInfo(t *testing.T) {
-	t.Parallel()
-
 	info := Info()
 	lines := strings.Split(info, "\n")
 	require.Regexp(t, "^Release Version", lines[0])

--- a/br/pkg/version/version_test.go
+++ b/br/pkg/version/version_test.go
@@ -168,8 +168,6 @@ func TestCheckClusterVersion(t *testing.T) {
 }
 
 func TestCompareVersion(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, -1, semver.New("4.0.0-rc").Compare(*semver.New("4.0.0-rc.2")))
 	require.Equal(t, -1, semver.New("4.0.0-beta.3").Compare(*semver.New("4.0.0-rc.2")))
 	require.Equal(t, -1, semver.New("4.0.0-rc.1").Compare(*semver.New("4.0.0")))
@@ -210,8 +208,6 @@ func TestNextMajorVersion(t *testing.T) {
 }
 
 func TestExtractTiDBVersion(t *testing.T) {
-	t.Parallel()
-
 	vers, err := ExtractTiDBVersion("5.7.10-TiDB-v2.1.0-rc.1-7-g38c939f")
 	require.NoError(t, err)
 	require.Equal(t, *semver.New("2.1.0-rc.1"), *vers)
@@ -257,8 +253,6 @@ func TestExtractTiDBVersion(t *testing.T) {
 }
 
 func TestCheckVersion(t *testing.T) {
-	t.Parallel()
-
 	err := CheckVersion("TiNB", *semver.New("2.3.5"), *semver.New("2.1.0"), *semver.New("3.0.0"))
 	require.NoError(t, err)
 
@@ -285,8 +279,6 @@ func versionEqualCheck(source *semver.Version, target *semver.Version) (result b
 }
 
 func TestNormalizeBackupVersion(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		target string
 		source string
@@ -307,7 +299,6 @@ func TestNormalizeBackupVersion(t *testing.T) {
 }
 
 func TestDetectServerInfo(t *testing.T) {
-	t.Parallel()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer db.Close()

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func TestAtomicBoolUnmarshal(t *testing.T) {
-	t.Parallel()
 	type data struct {
 		Ab AtomicBool `toml:"ab"`
 	}
@@ -59,8 +58,6 @@ func TestAtomicBoolUnmarshal(t *testing.T) {
 }
 
 func TestNullableBoolUnmarshal(t *testing.T) {
-	t.Parallel()
-
 	var nb = nullableBool{false, false}
 	data, err := json.Marshal(nb)
 	require.NoError(t, err)
@@ -480,8 +477,6 @@ xkNuJ2BlEGkwWLiRbKy1lNBBFUXKuhh3L/EIY10WTnr3TQzeL6H1
 }
 
 func TestOOMActionValid(t *testing.T) {
-	t.Parallel()
-
 	c1 := NewConfig()
 	tests := []struct {
 		oomAction string
@@ -500,8 +495,6 @@ func TestOOMActionValid(t *testing.T) {
 }
 
 func TestTxnTotalSizeLimitValid(t *testing.T) {
-	t.Parallel()
-
 	conf := NewConfig()
 	tests := []struct {
 		limit uint64
@@ -521,8 +514,6 @@ func TestTxnTotalSizeLimitValid(t *testing.T) {
 }
 
 func TestPreparePlanCacheValid(t *testing.T) {
-	t.Parallel()
-
 	conf := NewConfig()
 	tests := map[PreparedPlanCache]bool{
 		{Enabled: true, Capacity: 0}:                        false,
@@ -538,8 +529,6 @@ func TestPreparePlanCacheValid(t *testing.T) {
 }
 
 func TestMaxIndexLength(t *testing.T) {
-	t.Parallel()
-
 	conf := NewConfig()
 	checkValid := func(indexLen int, shouldBeValid bool) {
 		conf.MaxIndexLength = indexLen
@@ -552,8 +541,6 @@ func TestMaxIndexLength(t *testing.T) {
 }
 
 func TestIndexLimit(t *testing.T) {
-	t.Parallel()
-
 	conf := NewConfig()
 	checkValid := func(indexLimit int, shouldBeValid bool) {
 		conf.IndexLimit = indexLimit
@@ -566,8 +553,6 @@ func TestIndexLimit(t *testing.T) {
 }
 
 func TestTableColumnCountLimit(t *testing.T) {
-	t.Parallel()
-
 	conf := NewConfig()
 	checkValid := func(tableColumnLimit int, shouldBeValid bool) {
 		conf.TableColumnCountLimit = uint32(tableColumnLimit)
@@ -580,8 +565,6 @@ func TestTableColumnCountLimit(t *testing.T) {
 }
 
 func TestEncodeDefTempStorageDir(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		host       string
 		statusHost string
@@ -644,8 +627,6 @@ func TestModifyThroughLDFlags(t *testing.T) {
 }
 
 func TestSecurityValid(t *testing.T) {
-	t.Parallel()
-
 	c1 := NewConfig()
 	tests := []struct {
 		spilledFileEncryptionMethod string
@@ -664,8 +645,6 @@ func TestSecurityValid(t *testing.T) {
 }
 
 func TestTcpNoDelay(t *testing.T) {
-	t.Parallel()
-
 	c1 := NewConfig()
 	//check default value
 	require.True(t, c1.Performance.TCPNoDelay)

--- a/config/config_util_test.go
+++ b/config/config_util_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestCloneConf(t *testing.T) {
-	t.Parallel()
-
 	c1, err := CloneConf(&defaultConf)
 	require.NoError(t, err)
 	c2, err := CloneConf(c1)
@@ -44,8 +42,6 @@ func TestCloneConf(t *testing.T) {
 }
 
 func TestMergeConfigItems(t *testing.T) {
-	t.Parallel()
-
 	oriConf, _ := CloneConf(&defaultConf)
 	oldConf, _ := CloneConf(oriConf)
 	newConf, _ := CloneConf(oldConf)
@@ -96,8 +92,6 @@ func TestMergeConfigItems(t *testing.T) {
 }
 
 func TestFlattenConfig(t *testing.T) {
-	t.Parallel()
-
 	toJSONStr := func(v interface{}) string {
 		str, err := json.Marshal(v)
 		require.NoError(t, err)

--- a/ddl/db_cache_test.go
+++ b/ddl/db_cache_test.go
@@ -46,7 +46,6 @@ func testGetTableByNameT(t *testing.T, ctx sessionctx.Context, db, table string)
 }
 
 func TestAlterPartitionCache(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -77,7 +76,6 @@ func TestAlterPartitionCache(t *testing.T) {
 }
 
 func TestAlterViewTableCache(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -90,7 +88,6 @@ func TestAlterViewTableCache(t *testing.T) {
 }
 
 func TestAlterTableNoCache(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -115,7 +112,6 @@ func TestAlterTableNoCache(t *testing.T) {
 }
 
 func TestIndexOnCacheTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/ddl/label/attributes_test.go
+++ b/ddl/label/attributes_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestNewLabel(t *testing.T) {
-	t.Parallel()
-
 	type TestCase struct {
 		name  string
 		input string
@@ -58,8 +56,6 @@ func TestNewLabel(t *testing.T) {
 }
 
 func TestRestoreLabel(t *testing.T) {
-	t.Parallel()
-
 	type TestCase struct {
 		name   string
 		input  Label
@@ -94,8 +90,6 @@ func TestRestoreLabel(t *testing.T) {
 }
 
 func TestNewLabels(t *testing.T) {
-	t.Parallel()
-
 	labels, err := NewLabels(nil)
 	require.NoError(t, err)
 	require.Len(t, labels, 0)
@@ -128,8 +122,6 @@ func TestNewLabels(t *testing.T) {
 }
 
 func TestAddLabels(t *testing.T) {
-	t.Parallel()
-
 	type TestCase struct {
 		name   string
 		labels Labels
@@ -191,8 +183,6 @@ func TestAddLabels(t *testing.T) {
 }
 
 func TestRestoreLabels(t *testing.T) {
-	t.Parallel()
-
 	type TestCase struct {
 		name   string
 		input  Labels

--- a/ddl/label/rule_test.go
+++ b/ddl/label/rule_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestApplyAttributesSpec(t *testing.T) {
-	t.Parallel()
-
 	// valid case
 	spec := &ast.AttributesSpec{Attributes: "key=value,key1=value1"}
 	rule := NewRule()
@@ -51,8 +49,6 @@ func TestApplyAttributesSpec(t *testing.T) {
 }
 
 func TestDefaultOrEmpty(t *testing.T) {
-	t.Parallel()
-
 	specs := []*ast.AttributesSpec{{Attributes: ""}, {Default: true}}
 	for i := range specs {
 		rule := NewRule()
@@ -65,8 +61,6 @@ func TestDefaultOrEmpty(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	t.Parallel()
-
 	spec := &ast.AttributesSpec{Attributes: "key=value"}
 	rule := NewRule()
 	require.NoError(t, rule.ApplyAttributesSpec(spec))

--- a/ddl/options_test.go
+++ b/ddl/options_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestOptions(t *testing.T) {
-	t.Parallel()
-
 	client, err := clientv3.NewFromURL("test")
 	require.NoError(t, err)
 	callback := &ddl.BaseCallback{}

--- a/ddl/table_split_test.go
+++ b/ddl/table_split_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestTableSplit(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {

--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -43,7 +43,6 @@ import (
 )
 
 func TestSelectNormal(t *testing.T) {
-	t.Parallel()
 	response, colTypes := createSelectNormal(t, 1, 2, nil, nil)
 
 	// Test Next.
@@ -63,7 +62,6 @@ func TestSelectNormal(t *testing.T) {
 }
 
 func TestSelectMemTracker(t *testing.T) {
-	t.Parallel()
 	response, colTypes := createSelectNormal(t, 2, 6, nil, nil)
 
 	// Test Next.
@@ -76,7 +74,6 @@ func TestSelectMemTracker(t *testing.T) {
 }
 
 func TestSelectNormalChunkSize(t *testing.T) {
-	t.Parallel()
 	sctx := newMockSessionContext()
 	sctx.GetSessionVars().EnableChunkRPC = false
 	response, colTypes := createSelectNormal(t, 100, 1000000, nil, sctx)
@@ -86,7 +83,6 @@ func TestSelectNormalChunkSize(t *testing.T) {
 }
 
 func TestSelectWithRuntimeStats(t *testing.T) {
-	t.Parallel()
 	planIDs := []int{1, 2, 3}
 	response, colTypes := createSelectNormal(t, 1, 2, planIDs, nil)
 
@@ -111,7 +107,6 @@ func TestSelectWithRuntimeStats(t *testing.T) {
 }
 
 func TestSelectResultRuntimeStats(t *testing.T) {
-	t.Parallel()
 	basic := &execdetails.BasicRuntimeStats{}
 	basic.Record(time.Second, 20)
 	s1 := &selectResultRuntimeStats{
@@ -158,7 +153,6 @@ func TestSelectResultRuntimeStats(t *testing.T) {
 }
 
 func TestSelectStreaming(t *testing.T) {
-	t.Parallel()
 	response, colTypes := createSelectStreaming(t, 1, 2)
 	// Test Next.
 	chk := chunk.New(colTypes, 32, 32)
@@ -176,7 +170,6 @@ func TestSelectStreaming(t *testing.T) {
 }
 
 func TestSelectStreamingWithNextRaw(t *testing.T) {
-	t.Parallel()
 	response, _ := createSelectStreaming(t, 1, 2)
 	data, err := response.NextRaw(context.TODO())
 	require.NoError(t, err)
@@ -184,14 +177,12 @@ func TestSelectStreamingWithNextRaw(t *testing.T) {
 }
 
 func TestSelectStreamingChunkSize(t *testing.T) {
-	t.Parallel()
 	response, colTypes := createSelectStreaming(t, 100, 1000000)
 	testChunkSize(t, response, colTypes)
 	require.NoError(t, response.Close())
 }
 
 func TestAnalyze(t *testing.T) {
-	t.Parallel()
 	sctx := newMockSessionContext()
 	sctx.GetSessionVars().EnableChunkRPC = false
 	request, err := (&RequestBuilder{}).SetKeyRanges(nil).
@@ -217,7 +208,6 @@ func TestAnalyze(t *testing.T) {
 }
 
 func TestChecksum(t *testing.T) {
-	t.Parallel()
 	sctx := newMockSessionContext()
 	sctx.GetSessionVars().EnableChunkRPC = false
 	request, err := (&RequestBuilder{}).SetKeyRanges(nil).

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -38,7 +38,6 @@ type handleRange struct {
 }
 
 func TestTableHandlesToKVRanges(t *testing.T) {
-	t.Parallel()
 	handles := []kv.Handle{
 		kv.IntHandle(0),
 		kv.IntHandle(2),
@@ -71,7 +70,6 @@ func TestTableHandlesToKVRanges(t *testing.T) {
 }
 
 func TestTableRangesToKVRanges(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -129,7 +127,6 @@ func TestTableRangesToKVRanges(t *testing.T) {
 }
 
 func TestIndexRangesToKVRanges(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -189,7 +186,6 @@ func TestIndexRangesToKVRanges(t *testing.T) {
 }
 
 func TestRequestBuilder1(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -267,7 +263,6 @@ func TestRequestBuilder1(t *testing.T) {
 }
 
 func TestRequestBuilder2(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -345,7 +340,6 @@ func TestRequestBuilder2(t *testing.T) {
 }
 
 func TestRequestBuilder3(t *testing.T) {
-	t.Parallel()
 	handles := []kv.Handle{kv.IntHandle(0), kv.IntHandle(2), kv.IntHandle(3), kv.IntHandle(4),
 		kv.IntHandle(5), kv.IntHandle(10), kv.IntHandle(11), kv.IntHandle(100)}
 
@@ -394,7 +388,6 @@ func TestRequestBuilder3(t *testing.T) {
 }
 
 func TestRequestBuilder4(t *testing.T) {
-	t.Parallel()
 	keyRanges := []kv.KeyRange{
 		{
 			StartKey: kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -443,7 +436,6 @@ func TestRequestBuilder4(t *testing.T) {
 }
 
 func TestRequestBuilder5(t *testing.T) {
-	t.Parallel()
 	keyRanges := []kv.KeyRange{
 		{
 			StartKey: kv.Key{0x74, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0xf, 0x5f, 0x72, 0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0},
@@ -488,7 +480,6 @@ func TestRequestBuilder5(t *testing.T) {
 }
 
 func TestRequestBuilder6(t *testing.T) {
-	t.Parallel()
 	keyRanges := []kv.KeyRange{
 		{
 			StartKey: kv.Key{0x00, 0x01},
@@ -531,7 +522,6 @@ func TestRequestBuilder7(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		replicaRead := replicaRead
 		t.Run(replicaRead.src, func(t *testing.T) {
-			t.Parallel()
 			vars := variable.NewSessionVars()
 			vars.SetReplicaRead(replicaRead.replicaReadType)
 
@@ -561,7 +551,6 @@ func TestRequestBuilder7(t *testing.T) {
 }
 
 func TestRequestBuilder8(t *testing.T) {
-	t.Parallel()
 	sv := variable.NewSessionVars()
 	actual, err := (&RequestBuilder{}).
 		SetFromSessionVars(sv).
@@ -582,7 +571,6 @@ func TestRequestBuilder8(t *testing.T) {
 }
 
 func TestTableRangesToKVRangesWithFbs(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -604,7 +592,6 @@ func TestTableRangesToKVRangesWithFbs(t *testing.T) {
 }
 
 func TestIndexRangesToKVRangesWithFbs(t *testing.T) {
-	t.Parallel()
 	ranges := []*ranger.Range{
 		{
 			LowVal:  []types.Datum{types.NewIntDatum(1)},
@@ -641,7 +628,6 @@ func TestScanLimitConcurrency(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		tt := tt
 		t.Run(tt.src, func(t *testing.T) {
-			t.Parallel()
 			firstExec := &tipb.Executor{Tp: tt.tp}
 			switch tt.tp {
 			case tipb.ExecType_TypeTableScan:

--- a/distsql/select_result_test.go
+++ b/distsql/select_result_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestUpdateCopRuntimeStats(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx = new(stmtctx.StatementContext)
 	sr := selectResult{ctx: ctx, storeType: kv.TiKV}

--- a/domain/domain_utils_test.go
+++ b/domain/domain_utils_test.go
@@ -23,12 +23,10 @@ import (
 )
 
 func TestErrorCode(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, errno.ErrInfoSchemaExpired, int(terror.ToSQLError(ErrInfoSchemaExpired).Code))
 	require.Equal(t, errno.ErrInfoSchemaChanged, int(terror.ToSQLError(ErrInfoSchemaChanged).Code))
 }
 
 func TestServerIDConstant(t *testing.T) {
-	t.Parallel()
 	require.Less(t, lostConnectionToPDTimeout, serverIDTTL)
 }

--- a/domain/domainctx_test.go
+++ b/domain/domainctx_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestDomainCtx(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	require.NotEqual(t, "", domainKey.String())
 

--- a/domain/main_test.go
+++ b/domain/main_test.go
@@ -33,8 +33,6 @@ func TestMain(m *testing.M) {
 
 // TestDomainSerial handles tests in serial
 func TestDomainSerial(t *testing.T) {
-	t.Parallel()
-
 	// these tests should run in serial for failpoint is global
 	t.Run("info", SubTestInfo)
 	t.Run("domain", SubTestDomain)

--- a/domain/schema_checker_test.go
+++ b/domain/schema_checker_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestSchemaCheckerSimple(t *testing.T) {
-	t.Parallel()
-
 	lease := 5 * time.Millisecond
 	validator := NewSchemaValidator(lease, nil)
 	checker := &SchemaChecker{SchemaValidator: validator}

--- a/domain/schema_validator_test.go
+++ b/domain/schema_validator_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestSchemaValidator(t *testing.T) {
-	t.Parallel()
 	t.Run("general", subTestSchemaValidatorGeneral)
 	t.Run("enqueue", subTestEnqueue)
 	t.Run("enqueueActionType", subTestEnqueueActionType)

--- a/domain/session_pool_test.go
+++ b/domain/session_pool_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestSessionPool(t *testing.T) {
-	t.Parallel()
-
 	f := func() (pools.Resource, error) { return &testResource{}, nil }
 	pool := newSessionPool(1, f)
 	tr, err := pool.Get()

--- a/domain/topn_slow_query_test.go
+++ b/domain/topn_slow_query_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestPush(t *testing.T) {
-	t.Parallel()
-
 	slowQuery := newTopNSlowQueries(10, 0, 10)
 	// Insert data into the heap.
 	slowQuery.Append(&SlowQueryInfo{Duration: 300 * time.Millisecond})
@@ -70,8 +68,6 @@ func TestPush(t *testing.T) {
 }
 
 func TestRemoveExpired(t *testing.T) {
-	t.Parallel()
-
 	now := time.Now()
 	slowQuery := newTopNSlowQueries(6, 3*time.Second, 10)
 
@@ -99,8 +95,6 @@ func TestRemoveExpired(t *testing.T) {
 }
 
 func TestQueue(t *testing.T) {
-	t.Parallel()
-
 	q := newTopNSlowQueries(10, time.Minute, 5)
 	q.Append(&SlowQueryInfo{SQL: "aaa"})
 	q.Append(&SlowQueryInfo{SQL: "bbb"})

--- a/dumpling/export/block_allow_list_test.go
+++ b/dumpling/export/block_allow_list_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestFilterTables(t *testing.T) {
-	t.Parallel()
-
 	tctx := tcontext.Background().WithLogger(appLogger)
 	dbTables := DatabaseTables{}
 	expectedDBTables := DatabaseTables{}
@@ -49,8 +47,6 @@ func TestFilterTables(t *testing.T) {
 }
 
 func TestFilterDatabaseWithNoTable(t *testing.T) {
-	t.Parallel()
-
 	dbTables := DatabaseTables{}
 	expectedDBTables := DatabaseTables{}
 

--- a/dumpling/export/config_test.go
+++ b/dumpling/export/config_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestCreateExternalStorage(t *testing.T) {
-	t.Parallel()
 	mockConfig := defaultConfigForTest(t)
 	loc, err := mockConfig.createExternalStorage(tcontext.Background())
 	require.NoError(t, err)
@@ -20,7 +19,6 @@ func TestCreateExternalStorage(t *testing.T) {
 }
 
 func TestMatchMysqlBugVersion(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		serverInfo version.ServerInfo
 		expected   bool

--- a/dumpling/export/consistency_test.go
+++ b/dumpling/export/consistency_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestConsistencyController(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -74,8 +72,6 @@ func TestConsistencyController(t *testing.T) {
 }
 
 func TestConsistencyLockControllerRetry(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -112,8 +108,6 @@ func TestConsistencyLockControllerRetry(t *testing.T) {
 }
 
 func TestResolveAutoConsistency(t *testing.T) {
-	t.Parallel()
-
 	conf := defaultConfigForTest(t)
 	cases := []struct {
 		serverTp            version.ServerType
@@ -135,8 +129,6 @@ func TestResolveAutoConsistency(t *testing.T) {
 }
 
 func TestConsistencyControllerError(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -176,8 +168,6 @@ func TestConsistencyControllerError(t *testing.T) {
 }
 
 func TestConsistencyLockTiDBCheck(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {

--- a/dumpling/export/dump_test.go
+++ b/dumpling/export/dump_test.go
@@ -19,8 +19,6 @@ import (
 )
 
 func TestDumpBlock(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -65,8 +63,6 @@ func TestDumpBlock(t *testing.T) {
 }
 
 func TestDumpTableMeta(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -106,8 +102,6 @@ func TestDumpTableMeta(t *testing.T) {
 }
 
 func TestGetListTableTypeByConf(t *testing.T) {
-	t.Parallel()
-
 	conf := defaultConfigForTest(t)
 	cases := []struct {
 		serverInfo  version.ServerInfo
@@ -134,8 +128,6 @@ func TestGetListTableTypeByConf(t *testing.T) {
 }
 
 func TestAdjustDatabaseCollation(t *testing.T) {
-	t.Parallel()
-
 	tctx, cancel := tcontext.Background().WithLogger(appLogger).WithCancel()
 	defer cancel()
 	parser1 := parser.New()
@@ -158,8 +150,6 @@ func TestAdjustDatabaseCollation(t *testing.T) {
 }
 
 func TestAdjustTableCollation(t *testing.T) {
-	t.Parallel()
-
 	tctx, cancel := tcontext.Background().WithLogger(appLogger).WithCancel()
 	defer cancel()
 

--- a/dumpling/export/ir_impl_test.go
+++ b/dumpling/export/ir_impl_test.go
@@ -25,8 +25,6 @@ func (s *simpleRowReceiver) BindAddress(args []interface{}) {
 }
 
 func TestRowIter(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -66,8 +64,6 @@ func TestRowIter(t *testing.T) {
 }
 
 func TestChunkRowIter(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {

--- a/dumpling/export/metadata_test.go
+++ b/dumpling/export/metadata_test.go
@@ -24,8 +24,6 @@ const (
 )
 
 func TestMysqlMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -54,8 +52,6 @@ func TestMysqlMetaData(t *testing.T) {
 }
 
 func TestMetaDataAfterConn(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -95,8 +91,6 @@ func TestMetaDataAfterConn(t *testing.T) {
 }
 
 func TestMysqlWithFollowersMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -131,8 +125,6 @@ func TestMysqlWithFollowersMetaData(t *testing.T) {
 }
 
 func TestMysqlWithNullFollowersMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -160,8 +152,6 @@ func TestMysqlWithNullFollowersMetaData(t *testing.T) {
 }
 
 func TestMariaDBMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -187,8 +177,6 @@ func TestMariaDBMetaData(t *testing.T) {
 }
 
 func TestMariaDBWithFollowersMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -233,8 +221,6 @@ func TestMariaDBWithFollowersMetaData(t *testing.T) {
 }
 
 func TestEarlierMysqlMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -265,8 +251,6 @@ func TestEarlierMysqlMetaData(t *testing.T) {
 }
 
 func TestTiDBSnapshotMetaData(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -307,8 +291,6 @@ func TestTiDBSnapshotMetaData(t *testing.T) {
 }
 
 func TestNoPrivilege(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {

--- a/dumpling/export/prepare_test.go
+++ b/dumpling/export/prepare_test.go
@@ -15,8 +15,6 @@ import (
 )
 
 func TestPrepareDumpingDatabases(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -65,8 +63,6 @@ func TestPrepareDumpingDatabases(t *testing.T) {
 }
 
 func TestListAllTables(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -129,8 +125,6 @@ func TestListAllTables(t *testing.T) {
 }
 
 func TestListAllTablesByTableStatus(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -197,8 +191,6 @@ func TestListAllTablesByTableStatus(t *testing.T) {
 }
 
 func TestListAllTablesByShowFullTables(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -274,8 +266,6 @@ func TestListAllTablesByShowFullTables(t *testing.T) {
 }
 
 func TestConfigValidation(t *testing.T) {
-	t.Parallel()
-
 	conf := defaultConfigForTest(t)
 	conf.Where = "id < 5"
 	conf.SQL = "select * from t where id > 3"
@@ -309,8 +299,6 @@ func TestConfigValidation(t *testing.T) {
 }
 
 func TestValidateResolveAutoConsistency(t *testing.T) {
-	t.Parallel()
-
 	conf1 := defaultConfigForTest(t)
 	d := &Dumper{conf: conf1}
 	conf := d.conf

--- a/dumpling/export/sql_test.go
+++ b/dumpling/export/sql_test.go
@@ -51,8 +51,6 @@ const (
 )
 
 func TestBuildSelectAllQuery(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -174,8 +172,6 @@ func TestBuildSelectAllQuery(t *testing.T) {
 }
 
 func TestBuildOrderByClause(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -238,8 +234,6 @@ func TestBuildOrderByClause(t *testing.T) {
 }
 
 func TestBuildSelectField(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -286,8 +280,6 @@ func TestBuildSelectField(t *testing.T) {
 }
 
 func TestParseSnapshotToTSO(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -316,8 +308,6 @@ func TestParseSnapshotToTSO(t *testing.T) {
 }
 
 func TestShowCreateView(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -343,8 +333,6 @@ func TestShowCreateView(t *testing.T) {
 }
 
 func TestShowCreatePolicy(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -366,8 +354,6 @@ func TestShowCreatePolicy(t *testing.T) {
 }
 
 func TestListPolicyNames(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -396,8 +382,6 @@ func TestListPolicyNames(t *testing.T) {
 }
 
 func TestGetSuitableRows(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		avgRowLength uint64
 		expectedRows uint64
@@ -426,8 +410,6 @@ func TestGetSuitableRows(t *testing.T) {
 }
 
 func TestSelectTiDBRowID(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -463,8 +445,6 @@ func TestSelectTiDBRowID(t *testing.T) {
 }
 
 func TestBuildTableSampleQueries(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -782,8 +762,6 @@ func TestBuildTableSampleQueries(t *testing.T) {
 }
 
 func TestBuildPartitionClauses(t *testing.T) {
-	t.Parallel()
-
 	const (
 		dbName        = "test"
 		tbName        = "t"
@@ -842,8 +820,6 @@ func TestBuildPartitionClauses(t *testing.T) {
 }
 
 func TestBuildWhereCondition(t *testing.T) {
-	t.Parallel()
-
 	conf := DefaultConfig()
 	testCases := []struct {
 		confWhere     string
@@ -879,8 +855,6 @@ func TestBuildWhereCondition(t *testing.T) {
 }
 
 func TestBuildRegionQueriesWithoutPartition(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1040,8 +1014,6 @@ func TestBuildRegionQueriesWithoutPartition(t *testing.T) {
 }
 
 func TestBuildRegionQueriesWithPartitions(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1277,8 +1249,6 @@ func readRegionCsvDriverValues(t *testing.T) [][]driver.Value {
 }
 
 func TestBuildVersion3RegionQueries(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1554,8 +1524,6 @@ func TestBuildVersion3RegionQueries(t *testing.T) {
 }
 
 func TestCheckTiDBWithTiKV(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1603,8 +1571,6 @@ func TestCheckTiDBWithTiKV(t *testing.T) {
 }
 
 func TestPickupPossibleField(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1748,8 +1714,6 @@ func TestPickupPossibleField(t *testing.T) {
 }
 
 func TestCheckIfSeqExists(t *testing.T) {
-	t.Parallel()
-
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {
@@ -1777,7 +1741,6 @@ func TestCheckIfSeqExists(t *testing.T) {
 }
 
 func TestGetCharsetAndDefaultCollation(t *testing.T) {
-	t.Parallel()
 	db, mock, err := sqlmock.New()
 	require.NoError(t, err)
 	defer func() {

--- a/dumpling/export/sql_type_test.go
+++ b/dumpling/export/sql_type_test.go
@@ -10,8 +10,6 @@ import (
 )
 
 func TestEscape(t *testing.T) {
-	t.Parallel()
-
 	var bf bytes.Buffer
 	str := []byte(`MWQeWw""'\rNmtGxzGp`)
 	expectStrBackslash := `MWQeWw\"\"\'\\rNmtGxzGp`

--- a/dumpling/export/util_test.go
+++ b/dumpling/export/util_test.go
@@ -11,8 +11,6 @@ import (
 )
 
 func TestRepeatableRead(t *testing.T) {
-	t.Parallel()
-
 	data := [][]interface{}{
 		{version.ServerTypeUnknown, consistencyTypeNone, true},
 		{version.ServerTypeMySQL, consistencyTypeFlush, true},

--- a/dumpling/export/writer_test.go
+++ b/dumpling/export/writer_test.go
@@ -18,8 +18,6 @@ import (
 )
 
 func TestWriteDatabaseMeta(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -40,8 +38,6 @@ func TestWriteDatabaseMeta(t *testing.T) {
 }
 
 func TestWritePolicyMeta(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -62,8 +58,6 @@ func TestWritePolicyMeta(t *testing.T) {
 }
 
 func TestWriteTableMeta(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 
 	config := defaultConfigForTest(t)
@@ -83,8 +77,6 @@ func TestWriteTableMeta(t *testing.T) {
 }
 
 func TestWriteViewMeta(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -114,8 +106,6 @@ func TestWriteViewMeta(t *testing.T) {
 }
 
 func TestWriteTableData(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -155,8 +145,6 @@ func TestWriteTableData(t *testing.T) {
 }
 
 func TestWriteTableDataWithFileSize(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -207,8 +195,6 @@ func TestWriteTableDataWithFileSize(t *testing.T) {
 }
 
 func TestWriteTableDataWithFileSizeAndRows(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir
@@ -260,8 +246,6 @@ func TestWriteTableDataWithFileSizeAndRows(t *testing.T) {
 }
 
 func TestWriteTableDataWithStatementSize(t *testing.T) {
-	t.Parallel()
-
 	dir := t.TempDir()
 	config := defaultConfigForTest(t)
 	config.OutputDirPath = dir

--- a/errno/infoschema_test.go
+++ b/errno/infoschema_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestCopySafety(t *testing.T) {
-	t.Parallel()
-
 	IncrementError(123, "user", "host")
 	IncrementError(321, "user2", "host2")
 	IncrementWarning(123, "user", "host")

--- a/executor/adapter_test.go
+++ b/executor/adapter_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestQueryTime(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -36,8 +36,6 @@ import (
 )
 
 func TestAdminCheckIndexRange(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -58,8 +56,6 @@ func TestAdminCheckIndexRange(t *testing.T) {
 }
 
 func TestAdminCheckIndex(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -89,8 +85,6 @@ func TestAdminCheckIndex(t *testing.T) {
 }
 
 func TestAdminCheckIndexInTemporaryMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -123,8 +117,6 @@ func TestAdminCheckIndexInTemporaryMode(t *testing.T) {
 }
 
 func TestAdminCheckIndexInLocalTemporaryMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -149,8 +141,6 @@ func TestAdminCheckIndexInLocalTemporaryMode(t *testing.T) {
 }
 
 func TestAdminCheckIndexInCacheTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -186,8 +176,6 @@ func TestAdminCheckIndexInCacheTable(t *testing.T) {
 	tk.MustExec("drop table if exists cache_admin_table_with_index_test,cache_admin_table_without_index_test;")
 }
 func TestAdminRecoverIndex(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -305,8 +293,6 @@ func TestAdminRecoverIndex(t *testing.T) {
 }
 
 func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -353,8 +339,6 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 }
 
 func TestAdminRecoverPartitionTableIndex(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -428,8 +412,6 @@ func TestAdminRecoverPartitionTableIndex(t *testing.T) {
 }
 
 func TestAdminRecoverIndex1(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -485,8 +467,6 @@ func TestAdminRecoverIndex1(t *testing.T) {
 }
 
 func TestAdminCleanupIndex(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -569,8 +549,6 @@ func TestAdminCleanupIndex(t *testing.T) {
 }
 
 func TestAdminCleanupIndexForPartitionTable(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -654,8 +632,6 @@ func TestAdminCleanupIndexForPartitionTable(t *testing.T) {
 }
 
 func TestAdminCleanupIndexPKNotHandle(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -708,8 +684,6 @@ func TestAdminCleanupIndexPKNotHandle(t *testing.T) {
 }
 
 func TestAdminCleanupIndexMore(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -776,8 +750,6 @@ func TestAdminCleanupIndexMore(t *testing.T) {
 }
 
 func TestClusteredAdminCleanupIndex(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -857,8 +829,6 @@ func TestClusteredAdminCleanupIndex(t *testing.T) {
 }
 
 func TestAdminCheckPartitionTableFailed(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -960,8 +930,6 @@ func TestAdminCheckPartitionTableFailed(t *testing.T) {
 
 func TestAdminCheckTable(t *testing.T) {
 	// test NULL value.
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1081,8 +1049,6 @@ func TestAdminCheckTable(t *testing.T) {
 }
 
 func TestAdminCheckPrimaryIndex(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1094,8 +1060,6 @@ func TestAdminCheckPrimaryIndex(t *testing.T) {
 }
 
 func TestAdminCheckWithSnapshot(t *testing.T) {
-	t.Parallel()
-
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 

--- a/executor/aggfuncs/func_avg_test.go
+++ b/executor/aggfuncs/func_avg_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestMergePartialResult4Avg(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5, 2.0, 3.0, 2.375),
 		buildAggTester(ast.AggFuncAvg, mysql.TypeDouble, 5, 2.0, 3.0, 2.375),
@@ -37,8 +35,6 @@ func TestMergePartialResult4Avg(t *testing.T) {
 }
 
 func TestAvg(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5, nil, 2.0),
 		buildAggTester(ast.AggFuncAvg, mysql.TypeDouble, 5, nil, 2.0),
@@ -50,8 +46,6 @@ func TestAvg(t *testing.T) {
 }
 
 func TestMemAvg(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncAvg, mysql.TypeNewDecimal, 5,
 			aggfuncs.DefPartialResult4AvgDecimalSize, defaultUpdateMemDeltaGens, false),

--- a/executor/aggfuncs/func_bitfuncs_test.go
+++ b/executor/aggfuncs/func_bitfuncs_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMergePartialResult4BitFuncs(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncBitAnd, mysql.TypeLonglong, 5, 0, 0, 0),
 		buildAggTester(ast.AggFuncBitOr, mysql.TypeLonglong, 5, 7, 7, 7),
@@ -36,8 +34,6 @@ func TestMergePartialResult4BitFuncs(t *testing.T) {
 }
 
 func TestMemBitFunc(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncBitAnd, mysql.TypeLonglong, 5,
 			aggfuncs.DefPartialResult4BitFuncSize, defaultUpdateMemDeltaGens, false),

--- a/executor/aggfuncs/func_count_test.go
+++ b/executor/aggfuncs/func_count_test.go
@@ -42,8 +42,6 @@ func genApproxDistinctMergePartialResult(begin, end uint64) string {
 }
 
 func TestMergePartialResult4Count(t *testing.T) {
-	t.Parallel()
-
 	tester := buildAggTester(ast.AggFuncCount, mysql.TypeLonglong, 5, 5, 3, 8)
 	testMergePartialResult(t, tester)
 
@@ -52,8 +50,6 @@ func TestMergePartialResult4Count(t *testing.T) {
 }
 
 func TestCount(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncCount, mysql.TypeLonglong, 5, 0, 5),
 		buildAggTester(ast.AggFuncCount, mysql.TypeFloat, 5, 0, 5),
@@ -118,8 +114,6 @@ func TestCount(t *testing.T) {
 }
 
 func TestMemCount(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncCount, mysql.TypeLonglong, 5,
 			aggfuncs.DefPartialResult4CountSize, defaultUpdateMemDeltaGens, false),
@@ -164,8 +158,6 @@ func TestMemCount(t *testing.T) {
 }
 
 func TestWriteTime(t *testing.T) {
-	t.Parallel()
-
 	tt, err := types.ParseDate(&(stmtctx.StatementContext{}), "2020-11-11")
 	require.NoError(t, err)
 

--- a/executor/aggfuncs/func_cume_dist_test.go
+++ b/executor/aggfuncs/func_cume_dist_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMemCumeDist(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4CumeDistSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_first_row_test.go
+++ b/executor/aggfuncs/func_first_row_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMergePartialResult4FirstRow(t *testing.T) {
-	t.Parallel()
-
 	elems := []string{"e", "d", "c", "b", "a"}
 	enumC, _ := types.ParseEnumName(elems, "c", mysql.DefaultCollationName)
 	enumE, _ := types.ParseEnumName(elems, "e", mysql.DefaultCollationName)
@@ -54,8 +52,6 @@ func TestMergePartialResult4FirstRow(t *testing.T) {
 }
 
 func TestMemFirstRow(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncFirstRow, mysql.TypeLonglong, 5,
 			aggfuncs.DefPartialResult4FirstRowIntSize, defaultUpdateMemDeltaGens, false),

--- a/executor/aggfuncs/func_group_concat_test.go
+++ b/executor/aggfuncs/func_group_concat_test.go
@@ -34,15 +34,11 @@ import (
 )
 
 func TestMergePartialResult4GroupConcat(t *testing.T) {
-	t.Parallel()
-
 	test := buildAggTester(ast.AggFuncGroupConcat, mysql.TypeString, 5, "0 1 2 3 4", "2 3 4", "0 1 2 3 4 2 3 4")
 	testMergePartialResult(t, test)
 }
 
 func TestGroupConcat(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 
 	test := buildAggTester(ast.AggFuncGroupConcat, mysql.TypeString, 5, nil, "0 1 2 3 4")
@@ -67,8 +63,6 @@ func TestGroupConcat(t *testing.T) {
 }
 
 func TestMemGroupConcat(t *testing.T) {
-	t.Parallel()
-
 	multiArgsTest1 := buildMultiArgsAggMemTester(ast.AggFuncGroupConcat, []byte{mysql.TypeString, mysql.TypeString}, mysql.TypeString, 5,
 		aggfuncs.DefPartialResult4GroupConcatSize+aggfuncs.DefBytesBufferSize, groupConcatMultiArgsUpdateMemDeltaGens, false)
 	multiArgsTest2 := buildMultiArgsAggMemTester(ast.AggFuncGroupConcat, []byte{mysql.TypeString, mysql.TypeString}, mysql.TypeString, 5,

--- a/executor/aggfuncs/func_json_arrayagg_test.go
+++ b/executor/aggfuncs/func_json_arrayagg_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMergePartialResult4JsonArrayagg(t *testing.T) {
-	t.Parallel()
-
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON}
 
 	var tests []aggTest
@@ -66,8 +64,6 @@ func TestMergePartialResult4JsonArrayagg(t *testing.T) {
 }
 
 func TestJsonArrayagg(t *testing.T) {
-	t.Parallel()
-
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON}
 
 	var tests []aggTest
@@ -131,8 +127,6 @@ func jsonArrayaggMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (m
 }
 
 func TestMemJsonArrayagg(t *testing.T) {
-	t.Parallel()
-
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON}
 
 	var tests []aggMemTest

--- a/executor/aggfuncs/func_json_objectagg_test.go
+++ b/executor/aggfuncs/func_json_objectagg_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestMergePartialResult4JsonObjectagg(t *testing.T) {
-	t.Parallel()
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON}
 	var argCombines [][]byte
 	for i := 0; i < len(typeList); i++ {
@@ -73,7 +72,6 @@ func TestMergePartialResult4JsonObjectagg(t *testing.T) {
 }
 
 func TestJsonObjectagg(t *testing.T) {
-	t.Parallel()
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON}
 	var argCombines [][]byte
 	for i := 0; i < len(typeList); i++ {
@@ -112,7 +110,6 @@ func TestJsonObjectagg(t *testing.T) {
 }
 
 func TestMemJsonObjectagg(t *testing.T) {
-	t.Parallel()
 	typeList := []byte{mysql.TypeLonglong, mysql.TypeDouble, mysql.TypeString, mysql.TypeJSON, mysql.TypeDuration, mysql.TypeNewDecimal, mysql.TypeDate}
 	var argCombines [][]byte
 	for i := 0; i < len(typeList); i++ {

--- a/executor/aggfuncs/func_lead_lag_test.go
+++ b/executor/aggfuncs/func_lead_lag_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestLeadLag(t *testing.T) {
-	t.Parallel()
-
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{
@@ -120,8 +118,6 @@ func TestLeadLag(t *testing.T) {
 }
 
 func TestMemLeadLag(t *testing.T) {
-	t.Parallel()
-
 	zero := expression.NewZero()
 	one := expression.NewOne()
 	two := &expression.Constant{

--- a/executor/aggfuncs/func_max_min_test.go
+++ b/executor/aggfuncs/func_max_min_test.go
@@ -95,8 +95,6 @@ func minUpdateMemDeltaGens(srcChk *chunk.Chunk, dataType *types.FieldType) (memD
 }
 
 func TestMergePartialResult4MaxMin(t *testing.T) {
-	t.Parallel()
-
 	elems := []string{"e", "d", "c", "b", "a"}
 	enumA, _ := types.ParseEnum(elems, "a", mysql.DefaultCollationName)
 	enumC, _ := types.ParseEnum(elems, "c", mysql.DefaultCollationName)
@@ -135,15 +133,12 @@ func TestMergePartialResult4MaxMin(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.funcName, func(t *testing.T) {
-			t.Parallel()
 			testMergePartialResult(t, test)
 		})
 	}
 }
 
 func TestMaxMin(t *testing.T) {
-	t.Parallel()
-
 	unsignedType := types.NewFieldType(mysql.TypeLonglong)
 	unsignedType.Flag |= mysql.UnsignedFlag
 	tests := []aggTest{
@@ -170,15 +165,12 @@ func TestMaxMin(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.funcName, func(t *testing.T) {
-			t.Parallel()
 			testAggFunc(t, test)
 		})
 	}
 }
 
 func TestMemMaxMin(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncMax, mysql.TypeLonglong, 5,
 			aggfuncs.DefPartialResult4MaxMinIntSize, defaultUpdateMemDeltaGens, false),
@@ -229,7 +221,6 @@ func TestMemMaxMin(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.aggTest.funcName, func(t *testing.T) {
-			t.Parallel()
 			testAggMemFunc(t, test)
 		})
 	}
@@ -268,8 +259,6 @@ func testMaxSlidingWindow(tk *testkit.TestKit, tc maxSlidingWindowTestCase) {
 }
 
 func TestMaxSlidingWindow(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -348,8 +337,6 @@ func TestMaxSlidingWindow(t *testing.T) {
 }
 
 func TestDequeReset(t *testing.T) {
-	t.Parallel()
-
 	deque := aggfuncs.NewDeque(true, func(i, j interface{}) int {
 		return types.CompareInt64(i.(int64), j.(int64))
 	})
@@ -360,8 +347,6 @@ func TestDequeReset(t *testing.T) {
 }
 
 func TestDequePushPop(t *testing.T) {
-	t.Parallel()
-
 	deque := aggfuncs.NewDeque(true, func(i, j interface{}) int {
 		return types.CompareInt64(i.(int64), j.(int64))
 	})

--- a/executor/aggfuncs/func_ntile_test.go
+++ b/executor/aggfuncs/func_ntile_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMemNtile(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncNtile, mysql.TypeLonglong, 1, 1, 1,
 			aggfuncs.DefPartialResult4Ntile, defaultUpdateMemDeltaGens),

--- a/executor/aggfuncs/func_percent_rank_test.go
+++ b/executor/aggfuncs/func_percent_rank_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMemPercentRank(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncPercentRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_percentile_test.go
+++ b/executor/aggfuncs/func_percentile_test.go
@@ -33,8 +33,6 @@ func (a testSlice) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
 func (a testSlice) Less(i, j int) bool { return a[i] < a[j] }
 
 func TestPercentile(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncApproxPercentile, mysql.TypeLonglong, 5, nil, 2),
 		buildAggTester(ast.AggFuncApproxPercentile, mysql.TypeFloat, 5, nil, 2.0),

--- a/executor/aggfuncs/func_rank_test.go
+++ b/executor/aggfuncs/func_rank_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMemRank(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRank, mysql.TypeLonglong, 0, 1, 1,
 			aggfuncs.DefPartialResult4RankSize, rowMemDeltaGens),

--- a/executor/aggfuncs/func_stddevpop_test.go
+++ b/executor/aggfuncs/func_stddevpop_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestMergePartialResult4Stddevpop(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncStddevPop, mysql.TypeDouble, 5, 1.4142135623730951, 0.816496580927726, 1.3169567191065923),
 	}
@@ -33,8 +31,6 @@ func TestMergePartialResult4Stddevpop(t *testing.T) {
 }
 
 func TestStddevpop(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncStddevPop, mysql.TypeDouble, 5, nil, 1.4142135623730951),
 	}

--- a/executor/aggfuncs/func_stddevsamp_test.go
+++ b/executor/aggfuncs/func_stddevsamp_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestMergePartialResult4Stddevsamp(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncStddevSamp, mysql.TypeDouble, 5, 1.5811388300841898, 1, 1.407885953173359),
 	}
@@ -33,8 +31,6 @@ func TestMergePartialResult4Stddevsamp(t *testing.T) {
 }
 
 func TestStddevsamp(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncStddevSamp, mysql.TypeDouble, 5, nil, 1.5811388300841898),
 	}

--- a/executor/aggfuncs/func_sum_test.go
+++ b/executor/aggfuncs/func_sum_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestMergePartialResult4Sum(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncSum, mysql.TypeNewDecimal, 5, types.NewDecFromInt(10), types.NewDecFromInt(9), types.NewDecFromInt(19)),
 		buildAggTester(ast.AggFuncSum, mysql.TypeDouble, 5, 10.0, 9.0, 19.0),
@@ -41,8 +39,6 @@ func TestMergePartialResult4Sum(t *testing.T) {
 }
 
 func TestSum(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncSum, mysql.TypeNewDecimal, 5, nil, types.NewDecFromInt(10)),
 		buildAggTester(ast.AggFuncSum, mysql.TypeDouble, 5, nil, 10.0),
@@ -55,8 +51,6 @@ func TestSum(t *testing.T) {
 }
 
 func TestMemSum(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncSum, mysql.TypeDouble, 5,
 			aggfuncs.DefPartialResult4SumFloat64Size, defaultUpdateMemDeltaGens, false),

--- a/executor/aggfuncs/func_value_test.go
+++ b/executor/aggfuncs/func_value_test.go
@@ -61,8 +61,6 @@ func nthValueEvaluateRowUpdateMemDeltaGens(nth int) updateMemDeltaGens {
 }
 
 func TestMemValue(t *testing.T) {
-	t.Parallel()
-
 	firstMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(1)
 	secondMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(2)
 	fifthMemDeltaGens := nthValueEvaluateRowUpdateMemDeltaGens(5)

--- a/executor/aggfuncs/func_varpop_test.go
+++ b/executor/aggfuncs/func_varpop_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestMergePartialResult4Varpop(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncVarPop, mysql.TypeDouble, 5, types.NewFloat64Datum(float64(2)), types.NewFloat64Datum(float64(2)/float64(3)), types.NewFloat64Datum(float64(59)/float64(8)-float64(19*19)/float64(8*8))),
 	}
@@ -37,8 +35,6 @@ func TestMergePartialResult4Varpop(t *testing.T) {
 }
 
 func TestVarpop(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncVarPop, mysql.TypeDouble, 5, nil, types.NewFloat64Datum(float64(2))),
 	}
@@ -48,8 +44,6 @@ func TestVarpop(t *testing.T) {
 }
 
 func TestMemVarpop(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggMemTest{
 		buildAggMemTester(ast.AggFuncVarPop, mysql.TypeDouble, 5,
 			aggfuncs.DefPartialResult4VarPopFloat64Size, defaultUpdateMemDeltaGens, false),
@@ -59,7 +53,6 @@ func TestMemVarpop(t *testing.T) {
 	for n, test := range tests {
 		test := test
 		t.Run(fmt.Sprintf("%s_%d", test.aggTest.funcName, n), func(t *testing.T) {
-			t.Parallel()
 			testAggMemFunc(t, test)
 		})
 	}

--- a/executor/aggfuncs/func_varsamp_test.go
+++ b/executor/aggfuncs/func_varsamp_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestMergePartialResult4Varsamp(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncVarSamp, mysql.TypeDouble, 5, 2.5, 1, 1.9821428571428572),
 	}
@@ -33,8 +31,6 @@ func TestMergePartialResult4Varsamp(t *testing.T) {
 }
 
 func TestVarsamp(t *testing.T) {
-	t.Parallel()
-
 	tests := []aggTest{
 		buildAggTester(ast.AggFuncVarSamp, mysql.TypeDouble, 5, nil, 2.5),
 	}

--- a/executor/aggfuncs/row_number_test.go
+++ b/executor/aggfuncs/row_number_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMemRowNumber(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowMemTest{
 		buildWindowMemTester(ast.WindowFuncRowNumber, mysql.TypeLonglong, 0, 0, 4,
 			aggfuncs.DefPartialResult4RowNumberSize, defaultUpdateMemDeltaGens),

--- a/executor/aggfuncs/window_func_test.go
+++ b/executor/aggfuncs/window_func_test.go
@@ -171,8 +171,6 @@ func buildWindowMemTesterWithArgs(funcName string, tp byte, args []expression.Ex
 }
 
 func TestWindowFunctions(t *testing.T) {
-	t.Parallel()
-
 	tests := []windowTest{
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 1, 1, 1),
 		buildWindowTester(ast.WindowFuncCumeDist, mysql.TypeLonglong, 0, 0, 2, 1, 1),

--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestAggregation(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -477,7 +476,6 @@ func TestAggregation(t *testing.T) {
 }
 
 func TestAggPrune(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -505,7 +503,6 @@ func TestAggPrune(t *testing.T) {
 }
 
 func TestGroupConcatAggr(t *testing.T) {
-	t.Parallel()
 	var err error
 	// issue #5411
 	store, clean := testkit.CreateMockStore(t)
@@ -652,7 +649,6 @@ func TestGroupConcatAggr(t *testing.T) {
 }
 
 func TestSelectDistinct(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -667,7 +663,6 @@ func TestSelectDistinct(t *testing.T) {
 }
 
 func TestAggPushDown(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -698,7 +693,6 @@ func TestAggPushDown(t *testing.T) {
 }
 
 func TestOnlyFullGroupBy(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -813,7 +807,6 @@ func TestOnlyFullGroupBy(t *testing.T) {
 }
 
 func TestIssue16279(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -827,7 +820,6 @@ func TestIssue16279(t *testing.T) {
 }
 
 func TestIssue24676(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -845,7 +837,6 @@ func TestIssue24676(t *testing.T) {
 }
 
 func TestAggPushDownPartitionTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -880,7 +871,6 @@ func TestAggPushDownPartitionTable(t *testing.T) {
 }
 
 func TestIssue13652(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -897,7 +887,6 @@ func TestIssue13652(t *testing.T) {
 }
 
 func TestIssue14947(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -909,7 +898,6 @@ func TestIssue14947(t *testing.T) {
 }
 
 func TestHaving(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -937,7 +925,6 @@ func TestHaving(t *testing.T) {
 }
 
 func TestIssue26496(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -950,7 +937,6 @@ func TestIssue26496(t *testing.T) {
 }
 
 func TestAggEliminator(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -967,7 +953,6 @@ func TestAggEliminator(t *testing.T) {
 }
 
 func TestClusterIndexMaxMinEliminator(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -984,7 +969,6 @@ func TestClusterIndexMaxMinEliminator(t *testing.T) {
 }
 
 func TestMaxMinFloatScalaFunc(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -998,7 +982,6 @@ func TestMaxMinFloatScalaFunc(t *testing.T) {
 }
 
 func TestBuildProjBelowAgg(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1014,7 +997,6 @@ func TestBuildProjBelowAgg(t *testing.T) {
 }
 
 func TestInjectProjBelowTopN(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1036,7 +1018,6 @@ func TestInjectProjBelowTopN(t *testing.T) {
 }
 
 func TestFirstRowEnum(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1050,7 +1031,6 @@ func TestFirstRowEnum(t *testing.T) {
 }
 
 func TestAggJSON(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1103,7 +1083,6 @@ func TestAggJSON(t *testing.T) {
 }
 
 func TestIssue10099(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1116,7 +1095,6 @@ func TestIssue10099(t *testing.T) {
 }
 
 func TestIssue10098(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1128,7 +1106,6 @@ func TestIssue10098(t *testing.T) {
 }
 
 func TestIssue10608(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1144,8 +1121,6 @@ func TestIssue10608(t *testing.T) {
 }
 
 func TestIssue12759HashAggCalledByApply(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1176,7 +1151,6 @@ func TestIssue12759HashAggCalledByApply(t *testing.T) {
 }
 
 func TestPR15242ShallowCopy(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1194,7 +1168,6 @@ func TestPR15242ShallowCopy(t *testing.T) {
 }
 
 func TestIssue15690(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1248,7 +1221,6 @@ func TestIssue15690(t *testing.T) {
 }
 
 func TestIssue15958(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1262,7 +1234,6 @@ func TestIssue15958(t *testing.T) {
 }
 
 func TestIssue17216(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1277,7 +1248,6 @@ func TestIssue17216(t *testing.T) {
 }
 
 func TestHashAggRuntimeStat(t *testing.T) {
-	t.Parallel()
 	partialInfo := &executor.AggWorkerInfo{
 		Concurrency: 5,
 		WallTime:    int64(time.Second * 20),
@@ -1336,7 +1306,6 @@ func reconstructParallelGroupConcatResult(rows [][]interface{}) []string {
 }
 
 func TestParallelStreamAggGroupConcat(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1384,7 +1353,6 @@ func TestParallelStreamAggGroupConcat(t *testing.T) {
 }
 
 func TestIssue20658(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1461,7 +1429,6 @@ func TestIssue20658(t *testing.T) {
 }
 
 func TestIssue23277(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1495,7 +1462,6 @@ func TestIssue23277(t *testing.T) {
 }
 
 func TestAvgDecimal(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1518,7 +1484,6 @@ func TestAvgDecimal(t *testing.T) {
 
 // https://github.com/pingcap/tidb/issues/23314
 func TestIssue23314(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/executor/analyze_test.go
+++ b/executor/analyze_test.go
@@ -53,7 +53,6 @@ import (
 )
 
 func TestAnalyzePartition(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -121,7 +120,6 @@ PARTITION BY RANGE ( a ) (
 }
 
 func TestAnalyzeReplicaReadFollower(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -135,7 +133,6 @@ func TestAnalyzeReplicaReadFollower(t *testing.T) {
 }
 
 func TestClusterIndexAnalyze(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -168,7 +165,6 @@ func TestClusterIndexAnalyze(t *testing.T) {
 }
 
 func TestAnalyzeRestrict(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -182,7 +178,6 @@ func TestAnalyzeRestrict(t *testing.T) {
 }
 
 func TestAnalyzeParameters(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	dom, err := session.BootstrapSession(store)
@@ -244,7 +239,6 @@ func TestAnalyzeParameters(t *testing.T) {
 }
 
 func TestAnalyzeTooLongColumns(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	dom, err := session.BootstrapSession(store)
@@ -268,7 +262,6 @@ func TestAnalyzeTooLongColumns(t *testing.T) {
 }
 
 func TestAnalyzeIndexExtractTopN(t *testing.T) {
-	t.Parallel()
 	_ = checkHistogram
 	t.Skip("unstable, skip it and fix it before 20210618")
 	store, err := mockstore.NewMockStore()
@@ -318,7 +311,6 @@ func TestAnalyzeIndexExtractTopN(t *testing.T) {
 }
 
 func TestAnalyzeFastSample(t *testing.T) {
-	t.Parallel()
 	var cls testutils.Cluster
 	store, err := mockstore.NewMockStore(
 		mockstore.WithClusterInspector(func(c testutils.Cluster) {
@@ -426,7 +418,6 @@ func checkHistogram(sc *stmtctx.StatementContext, hg *statistics.Histogram) (boo
 }
 
 func TestFastAnalyze(t *testing.T) {
-	t.Parallel()
 	t.Skip("Skip this unstable test(#25782) and bring it back before 2021-07-29.")
 	var cls testutils.Cluster
 	store, err := mockstore.NewMockStore(
@@ -547,7 +538,6 @@ func TestFastAnalyze(t *testing.T) {
 }
 
 func TestIssue15993(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -561,7 +551,6 @@ func TestIssue15993(t *testing.T) {
 }
 
 func TestIssue15751(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -576,7 +565,6 @@ func TestIssue15751(t *testing.T) {
 }
 
 func TestIssue15752(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -615,7 +603,6 @@ func (c *regionProperityClient) SendRequest(ctx context.Context, addr string, re
 }
 
 func TestFastAnalyzeRetryRowCount(t *testing.T) {
-	t.Parallel()
 	cli := &regionProperityClient{}
 	hijackClient := func(c tikv.Client) tikv.Client {
 		cli.Client = c
@@ -663,7 +650,6 @@ func TestFastAnalyzeRetryRowCount(t *testing.T) {
 }
 
 func TestFailedAnalyzeRequest(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -679,7 +665,6 @@ func TestFailedAnalyzeRequest(t *testing.T) {
 }
 
 func TestExtractTopN(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	dom, err := session.BootstrapSession(store)
@@ -735,7 +720,6 @@ func TestExtractTopN(t *testing.T) {
 }
 
 func TestHashInTopN(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	dom, err := session.BootstrapSession(store)
@@ -778,7 +762,6 @@ func TestHashInTopN(t *testing.T) {
 }
 
 func TestNormalAnalyzeOnCommonHandle(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -831,7 +814,6 @@ func TestNormalAnalyzeOnCommonHandle(t *testing.T) {
 }
 
 func TestDefaultValForAnalyze(t *testing.T) {
-	t.Parallel()
 	t.Skip("skip race test")
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -870,7 +852,6 @@ func TestDefaultValForAnalyze(t *testing.T) {
 }
 
 func TestAnalyzeFullSamplingOnIndexWithVirtualColumnOrPrefixColumn(t *testing.T) {
-	t.Parallel()
 	t.Skip("unstable, skip it and fix it before 20210624")
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -904,7 +885,6 @@ func TestAnalyzeFullSamplingOnIndexWithVirtualColumnOrPrefixColumn(t *testing.T)
 }
 
 func TestSnapshotAnalyze(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -954,7 +934,6 @@ func TestSnapshotAnalyze(t *testing.T) {
 }
 
 func TestAdjustSampleRateNote(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/executor/batch_point_get_test.go
+++ b/executor/batch_point_get_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestBatchPointGetExec(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -80,8 +78,6 @@ func TestBatchPointGetExec(t *testing.T) {
 }
 
 func TestBatchPointGetInTxn(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -112,8 +108,6 @@ func TestBatchPointGetInTxn(t *testing.T) {
 }
 
 func TestBatchPointGetCache(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -128,8 +122,6 @@ func TestBatchPointGetCache(t *testing.T) {
 }
 
 func TestIssue18843(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -145,8 +137,6 @@ func TestIssue18843(t *testing.T) {
 }
 
 func TestIssue24562(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -160,8 +150,6 @@ func TestIssue24562(t *testing.T) {
 }
 
 func TestBatchPointGetUnsignedHandleWithSort(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -177,8 +165,6 @@ func TestBatchPointGetUnsignedHandleWithSort(t *testing.T) {
 }
 
 func TestBatchPointGetLockExistKey(t *testing.T) {
-	t.Parallel()
-
 	var wg sync.WaitGroup
 	errCh := make(chan error)
 	store, clean := testkit.CreateMockStore(t)
@@ -324,8 +310,6 @@ func TestBatchPointGetLockExistKey(t *testing.T) {
 }
 
 func TestBatchPointGetIssue25167(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/brie_test.go
+++ b/executor/brie_test.go
@@ -35,7 +35,6 @@ import (
 )
 
 func TestGlueGetVersion(t *testing.T) {
-	t.Parallel()
 	g := tidbGlueSession{}
 	version := g.GetVersion()
 	require.Contains(t, version, `Release Version`)
@@ -67,7 +66,6 @@ func fetchShowBRIEResult(t *testing.T, e *ShowExec, brieColTypes []*types.FieldT
 }
 
 func TestFetchShowBRIE(t *testing.T) {
-	t.Parallel()
 	// Compose a mocked session manager.
 	ps := make([]*util.ProcessInfo, 0, 1)
 	pi := &util.ProcessInfo{

--- a/executor/concurrent_map_test.go
+++ b/executor/concurrent_map_test.go
@@ -24,7 +24,6 @@ import (
 
 // TestConcurrentMap first inserts 1000 entries, then checks them
 func TestConcurrentMap(t *testing.T) {
-	t.Parallel()
 	m := newConcurrentMap()
 	const iterations = 1000
 	const mod = 111

--- a/executor/cte_test.go
+++ b/executor/cte_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestBasicCTE(t *testing.T) {
-	t.Parallel()
-
 	store, close := testkit.CreateMockStore(t)
 	defer close()
 
@@ -74,8 +72,6 @@ func TestBasicCTE(t *testing.T) {
 }
 
 func TestUnionDistinct(t *testing.T) {
-	t.Parallel()
-
 	store, close := testkit.CreateMockStore(t)
 	defer close()
 
@@ -103,8 +99,6 @@ func TestUnionDistinct(t *testing.T) {
 }
 
 func TestCTEMaxRecursionDepth(t *testing.T) {
-	t.Parallel()
-
 	store, close := testkit.CreateMockStore(t)
 	defer close()
 
@@ -146,8 +140,6 @@ func TestCTEMaxRecursionDepth(t *testing.T) {
 }
 
 func TestCTEWithLimit(t *testing.T) {
-	t.Parallel()
-
 	store, close := testkit.CreateMockStore(t)
 	defer close()
 

--- a/executor/delete_test.go
+++ b/executor/delete_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestDeleteLockKey(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -111,8 +109,6 @@ func TestDeleteLockKey(t *testing.T) {
 }
 
 func TestIssue21200(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -103,7 +103,6 @@ func TestExecutorPkg(t *testing.T) {
 }
 
 func SubTestShowProcessList(t *testing.T) {
-	t.Parallel()
 	// Compose schema.
 	names := []string{"Id", "User", "Host", "db", "Command", "Time", "State", "Info"}
 	ftypes := []byte{mysql.TypeLonglong, mysql.TypeVarchar, mysql.TypeVarchar,
@@ -177,7 +176,6 @@ func buildSchema(names []string, ftypes []byte) *expression.Schema {
 }
 
 func SubTestBuildKvRangesForIndexJoinWithoutCwc(t *testing.T) {
-	t.Parallel()
 	indexRanges := make([]*ranger.Range, 0, 6)
 	indexRanges = append(indexRanges, generateIndexRange(1, 1, 1, 1, 1))
 	indexRanges = append(indexRanges, generateIndexRange(1, 1, 2, 1, 1))
@@ -222,7 +220,6 @@ func generateDatumSlice(vals ...int64) []types.Datum {
 }
 
 func SubTestGetFieldsFromLine(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input    string
 		expected []string
@@ -281,7 +278,6 @@ func assertEqualStrings(t *testing.T, got []field, expect []string) {
 }
 
 func SubTestSlowQueryRuntimeStats(t *testing.T) {
-	t.Parallel()
 	stats := &slowQueryRuntimeStats{
 		totalFileNum: 2,
 		readFileNum:  2,
@@ -392,7 +388,6 @@ func getGrowing(m aggPartialResultMapper) bool {
 }
 
 func SubTestFilterTemporaryTableKeys(t *testing.T) {
-	t.Parallel()
 	vars := variable.NewSessionVars()
 	const tableID int64 = 3
 	vars.TxnCtx = &variable.TransactionContext{

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestGrantGlobal(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -71,8 +69,6 @@ func TestGrantGlobal(t *testing.T) {
 }
 
 func TestGrantDBScope(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -112,8 +108,6 @@ func TestGrantDBScope(t *testing.T) {
 }
 
 func TestWithGrantOption(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -138,8 +132,6 @@ func TestWithGrantOption(t *testing.T) {
 }
 
 func TestGrantTableScope(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -184,8 +176,6 @@ func TestGrantTableScope(t *testing.T) {
 }
 
 func TestGrantColumnScope(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -232,8 +222,6 @@ func TestGrantColumnScope(t *testing.T) {
 }
 
 func TestIssue2456(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -246,8 +234,6 @@ func TestIssue2456(t *testing.T) {
 }
 
 func TestNoAutoCreateUser(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -260,8 +246,6 @@ func TestNoAutoCreateUser(t *testing.T) {
 }
 
 func TestCreateUserWhenGrant(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -278,8 +262,6 @@ func TestCreateUserWhenGrant(t *testing.T) {
 }
 
 func TestGrantPrivilegeAtomic(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -334,8 +316,6 @@ func TestGrantPrivilegeAtomic(t *testing.T) {
 }
 
 func TestIssue2654(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -348,8 +328,6 @@ func TestIssue2654(t *testing.T) {
 }
 
 func TestGrantUnderANSIQuotes(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -364,8 +342,6 @@ func TestGrantUnderANSIQuotes(t *testing.T) {
 }
 
 func TestMaintainRequire(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -439,8 +415,6 @@ func TestMaintainRequire(t *testing.T) {
 }
 
 func TestMaintainAuthString(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -452,8 +426,6 @@ func TestMaintainAuthString(t *testing.T) {
 }
 
 func TestGrantOnNonExistTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -515,8 +487,6 @@ func TestGrantOnNonExistTable(t *testing.T) {
 }
 
 func TestIssue22721(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -531,8 +501,6 @@ func TestIssue22721(t *testing.T) {
 }
 
 func TestPerformanceSchemaPrivGrant(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -581,8 +549,6 @@ func TestPerformanceSchemaPrivGrant(t *testing.T) {
 }
 
 func TestGrantDynamicPrivs(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -617,8 +583,6 @@ func TestGrantDynamicPrivs(t *testing.T) {
 }
 
 func TestNonExistTableIllegalGrant(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/index_advise_test.go
+++ b/executor/index_advise_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestIndexAdvise(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/index_lookup_join_test.go
+++ b/executor/index_lookup_join_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestIndexLookupJoinHang(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -72,7 +71,6 @@ func TestIndexLookupJoinHang(t *testing.T) {
 }
 
 func TestIndexJoinUnionScan(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -127,7 +125,6 @@ func TestIndexJoinUnionScan(t *testing.T) {
 }
 
 func TestBatchIndexJoinUnionScanTest(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -150,7 +147,6 @@ func TestBatchIndexJoinUnionScanTest(t *testing.T) {
 }
 
 func TestInapplicableIndexJoinHint(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -194,7 +190,6 @@ func TestInapplicableIndexJoinHint(t *testing.T) {
 }
 
 func TestIndexJoinOverflow(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -210,7 +205,6 @@ func TestIndexJoinOverflow(t *testing.T) {
 }
 
 func TestIssue11061(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -225,7 +219,6 @@ func TestIssue11061(t *testing.T) {
 }
 
 func TestIndexJoinPartitionTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -240,7 +233,6 @@ func TestIndexJoinPartitionTable(t *testing.T) {
 }
 
 func TestIndexJoinMultiCondition(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -255,7 +247,6 @@ func TestIndexJoinMultiCondition(t *testing.T) {
 }
 
 func TestIssue16887(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -273,7 +264,6 @@ func TestIssue16887(t *testing.T) {
 }
 
 func TestIndexJoinEnumSetIssue19233(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -316,7 +306,6 @@ func TestIndexJoinEnumSetIssue19233(t *testing.T) {
 }
 
 func TestIssue19411(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -336,7 +325,6 @@ func TestIssue19411(t *testing.T) {
 }
 
 func TestIssue23653(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -352,7 +340,6 @@ func TestIssue23653(t *testing.T) {
 }
 
 func TestIssue23656(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -369,7 +356,6 @@ func TestIssue23656(t *testing.T) {
 }
 
 func TestIssue23722(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -406,7 +392,6 @@ func TestIssue23722(t *testing.T) {
 }
 
 func TestIssue24547(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -422,7 +407,6 @@ func TestIssue24547(t *testing.T) {
 }
 
 func TestIssue27138(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -471,7 +455,6 @@ PARTITIONS 1`)
 }
 
 func TestIssue27893(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -491,7 +474,6 @@ func TestPartitionTableIndexJoinAndIndexReader(t *testing.T) {
 	if israce.RaceEnabled {
 		t.Skip("exhaustive types test, skip race test")
 	}
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestPreparedNameResolver(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -47,7 +46,6 @@ func TestPreparedNameResolver(t *testing.T) {
 
 // a 'create table' DDL statement should be accepted if it has no parameters.
 func TestPreparedDDL(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -58,7 +56,6 @@ func TestPreparedDDL(t *testing.T) {
 
 // TestUnsupportedStmtForPrepare is related to https://github.com/pingcap/tidb/issues/17412
 func TestUnsupportedStmtForPrepare(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -70,7 +67,6 @@ func TestUnsupportedStmtForPrepare(t *testing.T) {
 }
 
 func TestIgnorePlanCache(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -123,7 +119,6 @@ func (sm *mockSessionManager2) ServerID() uint64 {
 }
 
 func TestPreparedStmtWithHint(t *testing.T) {
-	t.Parallel()
 	// see https://github.com/pingcap/tidb/issues/18535
 	store, dom, err := newStoreWithBootstrap()
 	require.NoError(t, err)

--- a/executor/show_stats_test.go
+++ b/executor/show_stats_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestShowStatsMeta(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -47,7 +46,6 @@ func TestShowStatsMeta(t *testing.T) {
 }
 
 func TestShowStatsHistograms(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -79,7 +77,6 @@ func TestShowStatsHistograms(t *testing.T) {
 }
 
 func TestShowStatsBuckets(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -126,7 +123,6 @@ func TestShowStatsBuckets(t *testing.T) {
 }
 
 func TestShowStatsHasNullValue(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -192,7 +188,6 @@ func TestShowStatsHasNullValue(t *testing.T) {
 }
 
 func TestShowPartitionStats(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -233,7 +228,6 @@ func TestShowPartitionStats(t *testing.T) {
 }
 
 func TestShowStatusSnapshot(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -262,7 +256,6 @@ func TestShowStatusSnapshot(t *testing.T) {
 }
 
 func TestShowStatsExtended(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -317,7 +310,6 @@ func TestShowStatsExtended(t *testing.T) {
 }
 
 func TestShowColumnStatsUsage(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -352,7 +344,6 @@ func TestShowColumnStatsUsage(t *testing.T) {
 }
 
 func TestShowHistogramsInFlight(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/shuffle_test.go
+++ b/executor/shuffle_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestPartitionRangeSplitter(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	concurrency := 2
 

--- a/executor/slow_query_test.go
+++ b/executor/slow_query_test.go
@@ -486,8 +486,6 @@ select 7;`
 }
 
 func TestSplitbyColon(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		line   string
 		fields []string

--- a/executor/union_scan_test.go
+++ b/executor/union_scan_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestDirtyTransaction(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -154,7 +153,6 @@ func TestDirtyTransaction(t *testing.T) {
 }
 
 func TestUnionScanWithCastCondition(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -170,7 +168,6 @@ func TestUnionScanWithCastCondition(t *testing.T) {
 }
 
 func TestUnionScanForMemBufferReader(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -309,7 +306,6 @@ func TestUnionScanForMemBufferReader(t *testing.T) {
 }
 
 func TestForUpdateUntouchedIndex(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -350,7 +346,6 @@ func TestForUpdateUntouchedIndex(t *testing.T) {
 }
 
 func TestUpdateScanningHandles(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -385,7 +380,6 @@ func TestUpdateScanningHandles(t *testing.T) {
 
 // See https://github.com/pingcap/tidb/issues/19136
 func TestForApplyAndUnionScan(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/executor/utils_test.go
+++ b/executor/utils_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestBatchRetrieverHelper(t *testing.T) {
-	t.Parallel()
-
 	rangeStarts := make([]int, 0)
 	rangeEnds := make([]int, 0)
 	collect := func(start, end int) error {

--- a/executor/write_concurrent_test.go
+++ b/executor/write_concurrent_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestBatchInsertWithOnDuplicate(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -42,7 +42,6 @@ import (
 )
 
 func TestInsert(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -326,7 +325,6 @@ func TestInsert(t *testing.T) {
 }
 
 func TestMultiBatch(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -341,7 +339,6 @@ func TestMultiBatch(t *testing.T) {
 }
 
 func TestInsertAutoInc(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -477,7 +474,6 @@ func TestInsertAutoInc(t *testing.T) {
 }
 
 func TestInsertIgnore(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	var cfg kv.InjectionConfig
@@ -598,7 +594,6 @@ commit;`
 }
 
 func TestInsertOnDup(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	var cfg kv.InjectionConfig
@@ -766,7 +761,6 @@ commit;`
 }
 
 func TestInsertIgnoreOnDup(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -821,7 +815,6 @@ func TestInsertIgnoreOnDup(t *testing.T) {
 }
 
 func TestInsertSetWithDefault(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -871,7 +864,6 @@ func TestInsertSetWithDefault(t *testing.T) {
 }
 
 func TestInsertOnDupUpdateDefault(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -919,7 +911,6 @@ func TestInsertOnDupUpdateDefault(t *testing.T) {
 }
 
 func TestReplace(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1103,7 +1094,6 @@ func TestReplace(t *testing.T) {
 }
 
 func TestGeneratedColumnForInsert(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1155,7 +1145,6 @@ func TestGeneratedColumnForInsert(t *testing.T) {
 }
 
 func TestPartitionedTableReplace(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1297,7 +1286,6 @@ func TestPartitionedTableReplace(t *testing.T) {
 }
 
 func TestHashPartitionedTableReplace(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1417,7 +1405,6 @@ func TestHashPartitionedTableReplace(t *testing.T) {
 }
 
 func TestPartitionedTableUpdate(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1527,7 +1514,6 @@ func TestPartitionedTableUpdate(t *testing.T) {
 
 // TestUpdateCastOnlyModifiedValues for issue #4514.
 func TestUpdateCastOnlyModifiedValues(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1576,7 +1562,6 @@ func fillMultiTableForUpdate(tk *testkit.TestKit) {
 }
 
 func TestMultipleTableUpdate(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1644,7 +1629,6 @@ func TestMultipleTableUpdate(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1702,7 +1686,6 @@ func TestPartitionedTableDelete(t *testing.T) {
 			  PARTITION p2 VALUES LESS THAN (16),
 			  PARTITION p3 VALUES LESS THAN (21))`
 
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1768,7 +1751,6 @@ func fillDataMultiTable(tk *testkit.TestKit) {
 }
 
 func TestMultiTableDelete(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1783,7 +1765,6 @@ func TestMultiTableDelete(t *testing.T) {
 }
 
 func TestQualifiedDelete(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1822,7 +1803,6 @@ func TestQualifiedDelete(t *testing.T) {
 }
 
 func TestLoadDataMissingColumn(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1864,7 +1844,6 @@ func TestLoadDataMissingColumn(t *testing.T) {
 }
 
 func TestIssue18681(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1900,7 +1879,6 @@ func TestIssue18681(t *testing.T) {
 
 func TestLoadData(t *testing.T) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2100,7 +2078,6 @@ func TestLoadData(t *testing.T) {
 
 func TestLoadDataEscape(t *testing.T) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2154,7 +2131,6 @@ func TestLoadDataWithLongContent(t *testing.T) {
 // TestLoadDataSpecifiedColumns reuse TestLoadDataEscape's test case :-)
 func TestLoadDataSpecifiedColumns(t *testing.T) {
 	trivialMsg := "Records: 1  Deleted: 0  Skipped: 0  Warnings: 0"
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2183,7 +2159,6 @@ func TestLoadDataSpecifiedColumns(t *testing.T) {
 }
 
 func TestLoadDataIgnoreLines(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2206,7 +2181,6 @@ func TestLoadDataIgnoreLines(t *testing.T) {
 
 // TestLoadDataOverflowBigintUnsigned related to issue 6360
 func TestLoadDataOverflowBigintUnsigned(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2228,7 +2202,6 @@ func TestLoadDataOverflowBigintUnsigned(t *testing.T) {
 }
 
 func TestLoadDataIntoPartitionedTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2256,7 +2229,6 @@ func TestLoadDataIntoPartitionedTable(t *testing.T) {
 }
 
 func TestNullDefault(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2271,7 +2243,6 @@ func TestNullDefault(t *testing.T) {
 }
 
 func TestNotNullDefault(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2343,7 +2314,6 @@ func TestLatch(t *testing.T) {
 
 // TestIssue4067 Test issue https://github.com/pingcap/tidb/issues/4067
 func TestIssue4067(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2360,7 +2330,6 @@ func TestIssue4067(t *testing.T) {
 }
 
 func TestInsertCalculatedValue(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2484,7 +2453,6 @@ func TestInsertCalculatedValue(t *testing.T) {
 }
 
 func TestDataTooLongErrMsg(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2500,7 +2468,6 @@ func TestDataTooLongErrMsg(t *testing.T) {
 }
 
 func TestUpdateSelect(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2515,7 +2482,6 @@ func TestUpdateSelect(t *testing.T) {
 }
 
 func TestUpdateDelete(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2538,7 +2504,6 @@ func TestUpdateDelete(t *testing.T) {
 }
 
 func TestUpdateAffectRowCnt(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2560,7 +2525,6 @@ func TestUpdateAffectRowCnt(t *testing.T) {
 }
 
 func TestReplaceLog(t *testing.T) {
-	t.Parallel()
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2596,7 +2560,6 @@ func TestReplaceLog(t *testing.T) {
 // There is no need to do the rebase when updating a record if the auto-increment ID not changed.
 // This could make the auto ID increasing speed slower.
 func TestRebaseIfNeeded(t *testing.T) {
-	t.Parallel()
 	store, domain, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2631,7 +2594,6 @@ func TestRebaseIfNeeded(t *testing.T) {
 }
 
 func TestDeferConstraintCheckForDelete(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2684,7 +2646,6 @@ func TestDeferConstraintCheckForDelete(t *testing.T) {
 }
 
 func TestDeferConstraintCheckForInsert(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2811,7 +2772,6 @@ func TestDeferConstraintCheckForInsert(t *testing.T) {
 }
 
 func TestPessimisticDeleteYourWrites(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2841,7 +2801,6 @@ func TestPessimisticDeleteYourWrites(t *testing.T) {
 }
 
 func TestDefEnumInsert(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2852,7 +2811,6 @@ func TestDefEnumInsert(t *testing.T) {
 }
 
 func TestIssue11059(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2865,7 +2823,6 @@ func TestIssue11059(t *testing.T) {
 }
 
 func TestSetWithRefGenCol(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2911,7 +2868,6 @@ func TestSetWithRefGenCol(t *testing.T) {
 }
 
 func TestSetWithCurrentTimestampAndNow(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2926,7 +2882,6 @@ func TestSetWithCurrentTimestampAndNow(t *testing.T) {
 }
 
 func TestApplyWithPointAndBatchPointGet(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -2970,7 +2925,6 @@ from t order by c_str;`).Check(testkit.Rows("10"))
 }
 
 func TestWriteListPartitionTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3021,7 +2975,6 @@ func TestWriteListPartitionTable(t *testing.T) {
 }
 
 func TestWriteListColumnsPartitionTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3073,7 +3026,6 @@ func TestWriteListColumnsPartitionTable(t *testing.T) {
 
 // TestWriteListPartitionTable1 test for write list partition when the partition expression is simple.
 func TestWriteListPartitionTable1(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3201,7 +3153,6 @@ func TestWriteListPartitionTable1(t *testing.T) {
 
 // TestWriteListPartitionTable2 test for write list partition when the partition expression is complicated and contain generated column.
 func TestWriteListPartitionTable2(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3329,7 +3280,6 @@ func TestWriteListPartitionTable2(t *testing.T) {
 }
 
 func TestWriteListColumnsPartitionTable1(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3458,7 +3408,6 @@ func TestWriteListColumnsPartitionTable1(t *testing.T) {
 
 // TestWriteListColumnsPartitionTable2 test for write list partition when the partition by multi-columns.
 func TestWriteListColumnsPartitionTable2(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3610,7 +3559,6 @@ func TestWriteListColumnsPartitionTable2(t *testing.T) {
 
 // TestWriteListColumnsPartitionTable2 test for write list partition when the partition by multi-columns.
 func TestWriteListPartitionTableIssue21437(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3623,7 +3571,6 @@ func TestWriteListPartitionTableIssue21437(t *testing.T) {
 }
 
 func TestListPartitionWithAutoRandom(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3649,7 +3596,6 @@ func TestListPartitionWithAutoRandom(t *testing.T) {
 }
 
 func TestListPartitionWithAutoIncrement(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3675,7 +3621,6 @@ func TestListPartitionWithAutoIncrement(t *testing.T) {
 }
 
 func TestListPartitionWithGeneratedColumn(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3723,7 +3668,6 @@ func TestListPartitionWithGeneratedColumn(t *testing.T) {
 }
 
 func TestListPartitionWithGeneratedColumn1(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3793,7 +3737,6 @@ func TestListPartitionWithGeneratedColumn1(t *testing.T) {
 }
 
 func TestListPartitionWithGeneratedColumn2(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3838,7 +3781,6 @@ func TestListPartitionWithGeneratedColumn2(t *testing.T) {
 }
 
 func TestListColumnsPartitionWithGeneratedColumn(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3865,7 +3807,6 @@ func TestListColumnsPartitionWithGeneratedColumn(t *testing.T) {
 }
 
 func TestIssue22496(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -3909,7 +3850,6 @@ func TestEqualDatumsAsBinary(t *testing.T) {
 }
 
 func TestIssue21232(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/expression/aggregation/agg_to_pb_test.go
+++ b/expression/aggregation/agg_to_pb_test.go
@@ -36,7 +36,6 @@ func genColumn(tp byte, id int64) *expression.Column {
 }
 
 func TestAggFunc2Pb(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	client := new(mock.Client)
 

--- a/expression/aggregation/aggregation_test.go
+++ b/expression/aggregation/aggregation_test.go
@@ -50,7 +50,6 @@ func createAggFuncSuite() (s *mockAggFuncSuite) {
 }
 
 func TestAvg(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -95,7 +94,6 @@ func TestAvg(t *testing.T) {
 }
 
 func TestAvgFinalMode(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	rows := make([][]types.Datum, 0, 100)
 	for i := 1; i <= 100; i++ {
@@ -126,7 +124,6 @@ func TestAvgFinalMode(t *testing.T) {
 }
 
 func TestSum(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -169,7 +166,6 @@ func TestSum(t *testing.T) {
 }
 
 func TestBitAnd(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -249,7 +245,6 @@ func TestBitAnd(t *testing.T) {
 }
 
 func TestBitOr(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -337,7 +332,6 @@ func TestBitOr(t *testing.T) {
 }
 
 func TestBitXor(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -417,7 +411,6 @@ func TestBitXor(t *testing.T) {
 }
 
 func TestCount(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -459,7 +452,6 @@ func TestCount(t *testing.T) {
 }
 
 func TestConcat(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -517,7 +509,6 @@ func TestConcat(t *testing.T) {
 }
 
 func TestFirstRow(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,
@@ -546,7 +537,6 @@ func TestFirstRow(t *testing.T) {
 }
 
 func TestMaxMin(t *testing.T) {
-	t.Parallel()
 	s := createAggFuncSuite()
 	col := &expression.Column{
 		Index:   0,

--- a/expression/aggregation/util_test.go
+++ b/expression/aggregation/util_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestDistinct(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	dc := createDistinctChecker(sc)
 	testCases := []struct {

--- a/expression/bench_test.go
+++ b/expression/bench_test.go
@@ -1502,8 +1502,6 @@ func testVectorizedBuiltinFunc(t *testing.T, vecExprCases vecExprBenchCases) {
 // testVectorizedBuiltinFuncForRand is used to verify that the vectorized
 // expression is evaluated correctly
 func testVectorizedBuiltinFuncForRand(t *testing.T, vecExprCases vecExprBenchCases) {
-	t.Parallel()
-
 	for funcName, testCases := range vecExprCases {
 		require.True(t, strings.EqualFold("rand", funcName))
 

--- a/expression/builtin_arithmetic_test.go
+++ b/expression/builtin_arithmetic_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
-	t.Parallel()
-
 	ret := &types.FieldType{}
 	a := &types.FieldType{
 		Decimal: 1,
@@ -96,7 +94,6 @@ func TestSetFlenDecimal4RealOrDecimal(t *testing.T) {
 }
 
 func TestArithmeticPlus(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// case: 1
 	args := []interface{}{int64(12), int64(1)}
@@ -193,7 +190,6 @@ func TestArithmeticPlus(t *testing.T) {
 }
 
 func TestArithmeticMinus(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// case: 1
 	args := []interface{}{int64(12), int64(1)}
@@ -272,7 +268,6 @@ func TestArithmeticMinus(t *testing.T) {
 }
 
 func TestArithmeticMultiply(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	testCases := []struct {
 		args   []interface{}
@@ -329,7 +324,6 @@ func TestArithmeticMultiply(t *testing.T) {
 }
 
 func TestArithmeticDivide(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	testCases := []struct {
@@ -399,7 +393,6 @@ func TestArithmeticDivide(t *testing.T) {
 }
 
 func TestArithmeticIntDivide(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	testCases := []struct {
 		args   []interface{}
@@ -515,7 +508,6 @@ func TestArithmeticIntDivide(t *testing.T) {
 }
 
 func TestArithmeticMod(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	testCases := []struct {
 		args   []interface{}
@@ -668,7 +660,6 @@ func TestArithmeticMod(t *testing.T) {
 }
 
 func TestDecimalErrOverflow(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	testCases := []struct {
 		args   []float64

--- a/expression/builtin_cast_test.go
+++ b/expression/builtin_cast_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestCastFunctions(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	sc := ctx.GetSessionVars().StmtCtx
@@ -310,7 +309,6 @@ var (
 )
 
 func TestCastFuncSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	sc := ctx.GetSessionVars().StmtCtx
@@ -1119,7 +1117,6 @@ func TestCastFuncSig(t *testing.T) {
 }
 
 func TestCastJSONAsDecimalSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	originIgnoreTruncate := sc.IgnoreTruncate
@@ -1166,7 +1163,6 @@ func TestCastJSONAsDecimalSig(t *testing.T) {
 
 // TestWrapWithCastAsTypesClasses tests WrapWithCastAsInt/Real/String/Decimal.
 func TestWrapWithCastAsTypesClasses(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	durationColumn0 := &Column{RetType: types.NewFieldType(mysql.TypeDuration), Index: 0}
@@ -1309,7 +1305,6 @@ func TestWrapWithCastAsTypesClasses(t *testing.T) {
 }
 
 func TestWrapWithCastAsTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	save := sc.TimeZone
@@ -1364,7 +1359,6 @@ func TestWrapWithCastAsTime(t *testing.T) {
 }
 
 func TestWrapWithCastAsDuration(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	cases := []struct {
@@ -1399,7 +1393,6 @@ func TestWrapWithCastAsDuration(t *testing.T) {
 }
 
 func TestWrapWithCastAsString(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	cases := []struct {
@@ -1430,7 +1423,6 @@ func TestWrapWithCastAsString(t *testing.T) {
 }
 
 func TestWrapWithCastAsJSON(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	input := &Column{RetType: &types.FieldType{Tp: mysql.TypeJSON}}
@@ -1442,8 +1434,6 @@ func TestWrapWithCastAsJSON(t *testing.T) {
 }
 
 func TestCastIntAsIntVec(t *testing.T) {
-	t.Parallel()
-
 	cast, input, result := genCastIntAsInt()
 	require.NoError(t, cast.vecEvalInt(input, result))
 	i64s := result.Int64s()
@@ -1472,8 +1462,6 @@ func TestCastIntAsIntVec(t *testing.T) {
 
 // for issue https://github.com/pingcap/tidb/issues/16825
 func TestCastStringAsDecimalSigWithUnsignedFlagInUnion(t *testing.T) {
-	t.Parallel()
-
 	col := &Column{RetType: types.NewFieldType(mysql.TypeString), Index: 0}
 	b, err := newBaseBuiltinFunc(mock.NewContext(), "", []Expression{col}, 0)
 	require.NoError(t, err)

--- a/expression/builtin_cast_vec_test.go
+++ b/expression/builtin_cast_vec_test.go
@@ -158,8 +158,6 @@ func TestVectorizedBuiltinCastFunc(t *testing.T) {
 }
 
 func TestVectorizedCastRealAsTime(t *testing.T) {
-	t.Parallel()
-
 	col := &Column{RetType: types.NewFieldType(mysql.TypeDouble), Index: 0}
 	baseFunc, err := newBaseBuiltinFunc(mock.NewContext(), "", []Expression{col}, 0)
 	if err != nil {
@@ -202,8 +200,6 @@ func genCastRealAsTime() *chunk.Chunk {
 
 // for issue https://github.com/pingcap/tidb/issues/16825
 func TestVectorizedCastStringAsDecimalWithUnsignedFlagInUnion(t *testing.T) {
-	t.Parallel()
-
 	col := &Column{RetType: types.NewFieldType(mysql.TypeString), Index: 0}
 	baseFunc, err := newBaseBuiltinFunc(mock.NewContext(), "", []Expression{col}, 0)
 	if err != nil {

--- a/expression/builtin_compare_test.go
+++ b/expression/builtin_compare_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestCompareFunctionWithRefine(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	tblInfo := newTestTableBuilder("").add("a", mysql.TypeLong, mysql.NotNullFlag).build()
@@ -84,7 +83,6 @@ func TestCompareFunctionWithRefine(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	intVal, uintVal, realVal, stringVal, decimalVal := 1, uint64(1), 1.1, "123", types.NewDecFromFloatForTest(123.123)
@@ -170,7 +168,6 @@ func TestCompare(t *testing.T) {
 }
 
 func TestCoalesce(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	cases := []struct {
@@ -216,7 +213,6 @@ func TestCoalesce(t *testing.T) {
 }
 
 func TestIntervalFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	sc := ctx.GetSessionVars().StmtCtx
@@ -274,7 +270,6 @@ func TestIntervalFunc(t *testing.T) {
 
 // greatest/least function is compatible with MySQL 8.0
 func TestGreatestLeastFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	originIgnoreTruncate := sc.IgnoreTruncate

--- a/expression/builtin_control_test.go
+++ b/expression/builtin_control_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestCaseWhen(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg []interface{}
@@ -60,7 +59,6 @@ func TestCaseWhen(t *testing.T) {
 }
 
 func TestIf(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -109,7 +107,6 @@ func TestIf(t *testing.T) {
 }
 
 func TestIfNull(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		arg1     interface{}

--- a/expression/builtin_encryption_test.go
+++ b/expression/builtin_encryption_test.go
@@ -55,7 +55,6 @@ var cryptTests = []struct {
 }
 
 func TestSQLDecode(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	for _, tt := range cryptTests {
 		err := ctx.GetSessionVars().SetSystemVar(variable.CharacterSetConnection, tt.chs)
@@ -75,7 +74,6 @@ func TestSQLDecode(t *testing.T) {
 }
 
 func TestSQLEncode(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	for _, test := range cryptTests {
 		err := ctx.GetSessionVars().SetSystemVar(variable.CharacterSetConnection, test.chs)
@@ -143,7 +141,6 @@ var aesTests = []struct {
 }
 
 func TestAESEncrypt(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	fc := funcs[ast.AesEncrypt]
@@ -208,7 +205,6 @@ func TestAESEncrypt(t *testing.T) {
 }
 
 func TestAESDecrypt(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	fc := funcs[ast.AesDecrypt]
@@ -339,7 +335,6 @@ func fromHex(str interface{}) (d types.Datum) {
 }
 
 func TestSha1Hash(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sha1Tests := []struct {
 		chs    string
@@ -378,7 +373,6 @@ func TestSha1Hash(t *testing.T) {
 }
 
 func TestSha2Hash(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sha2Tests := []struct {
 		chs        string
@@ -449,7 +443,6 @@ func TestSha2Hash(t *testing.T) {
 }
 
 func TestMD5Hash(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	cases := []struct {
@@ -497,7 +490,6 @@ func TestMD5Hash(t *testing.T) {
 }
 
 func TestRandomBytes(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 
 	fc := funcs[ast.RandomBytes]
@@ -536,7 +528,6 @@ func decodeHex(str string) []byte {
 }
 
 func TestCompress(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Compress]
 	tests := []struct {
@@ -569,7 +560,6 @@ func TestCompress(t *testing.T) {
 }
 
 func TestUncompress(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		in     interface{}
@@ -605,7 +595,6 @@ func TestUncompress(t *testing.T) {
 }
 
 func TestUncompressLength(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		in     interface{}
@@ -636,7 +625,6 @@ func TestUncompressLength(t *testing.T) {
 }
 
 func TestPassword(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}

--- a/expression/builtin_info_test.go
+++ b/expression/builtin_info_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestDatabase(t *testing.T) {
-	t.Parallel()
 	fc := funcs[ast.Database]
 	ctx := mock.NewContext()
 	f, err := fc.getFunction(ctx, nil)
@@ -58,7 +57,6 @@ func TestDatabase(t *testing.T) {
 }
 
 func TestFoundRows(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.LastFoundRows = 2
@@ -72,7 +70,6 @@ func TestFoundRows(t *testing.T) {
 }
 
 func TestUser(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.User = &auth.UserIdentity{Username: "root", Hostname: "localhost"}
@@ -87,7 +84,6 @@ func TestUser(t *testing.T) {
 }
 
 func TestCurrentUser(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.User = &auth.UserIdentity{Username: "root", Hostname: "localhost", AuthUsername: "root", AuthHostname: "localhost"}
@@ -102,7 +98,6 @@ func TestCurrentUser(t *testing.T) {
 }
 
 func TestCurrentRole(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	fc := funcs[ast.CurrentRole]
 	f, err := fc.getFunction(ctx, nil)
@@ -128,7 +123,6 @@ func TestCurrentRole(t *testing.T) {
 }
 
 func TestConnectionID(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.ConnectionID = uint64(1)
@@ -143,7 +137,6 @@ func TestConnectionID(t *testing.T) {
 }
 
 func TestVersion(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Version]
 	f, err := fc.getFunction(ctx, nil)
@@ -155,7 +148,6 @@ func TestVersion(t *testing.T) {
 }
 
 func TestBenchMark(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		LoopCount  int
@@ -197,7 +189,6 @@ func TestBenchMark(t *testing.T) {
 }
 
 func TestCharset(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Charset]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(nil)))
@@ -207,7 +198,6 @@ func TestCharset(t *testing.T) {
 }
 
 func TestCoercibility(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Coercibility]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(nil)))
@@ -216,7 +206,6 @@ func TestCoercibility(t *testing.T) {
 }
 
 func TestCollation(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Collation]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(nil)))
@@ -226,7 +215,6 @@ func TestCollation(t *testing.T) {
 }
 
 func TestRowCount(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 	sessionVars.StmtCtx.PrevAffectedRows = 10
@@ -246,7 +234,6 @@ func TestRowCount(t *testing.T) {
 
 // TestTiDBVersion for tidb_server().
 func TestTiDBVersion(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	f, err := newFunctionForTest(ctx, ast.TiDBVersion, primitiveValsToConstants(ctx, []interface{}{})...)
 	require.NoError(t, err)
@@ -256,7 +243,6 @@ func TestTiDBVersion(t *testing.T) {
 }
 
 func TestLastInsertID(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	maxUint64 := uint64(math.MaxUint64)
 	cases := []struct {
@@ -313,7 +299,6 @@ func TestLastInsertID(t *testing.T) {
 }
 
 func TestFormatBytes(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg interface{}
@@ -343,7 +328,6 @@ func TestFormatBytes(t *testing.T) {
 }
 
 func TestFormatNanoTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg interface{}

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestJSONType(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONType]
 	tbl := []struct {
@@ -55,7 +54,6 @@ func TestJSONType(t *testing.T) {
 }
 
 func TestJSONQuote(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONQuote]
 	tbl := []struct {
@@ -85,7 +83,6 @@ func TestJSONQuote(t *testing.T) {
 }
 
 func TestJSONUnquote(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONUnquote]
 	tbl := []struct {
@@ -126,7 +123,6 @@ func TestJSONUnquote(t *testing.T) {
 }
 
 func TestJSONExtract(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONExtract]
 	jstr := `{"a": [{"aa": [{"aaa": 1}]}], "aaa": 2}`
@@ -165,7 +161,6 @@ func TestJSONExtract(t *testing.T) {
 
 // TestJSONSetInsertReplace tests grammar of json_{set,insert,replace}.
 func TestJSONSetInsertReplace(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		fc           functionClass
@@ -212,7 +207,6 @@ func TestJSONSetInsertReplace(t *testing.T) {
 }
 
 func TestJSONMerge(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONMerge]
 	tbl := []struct {
@@ -244,7 +238,6 @@ func TestJSONMerge(t *testing.T) {
 }
 
 func TestJSONMergePreserve(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONMergePreserve]
 	tbl := []struct {
@@ -276,7 +269,6 @@ func TestJSONMergePreserve(t *testing.T) {
 }
 
 func TestJSONArray(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONArray]
 	tbl := []struct {
@@ -302,7 +294,6 @@ func TestJSONArray(t *testing.T) {
 }
 
 func TestJSONObject(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONObject]
 	tbl := []struct {
@@ -347,7 +338,6 @@ func TestJSONObject(t *testing.T) {
 }
 
 func TestJSONRemove(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONRemove]
 	tbl := []struct {
@@ -398,7 +388,6 @@ func TestJSONRemove(t *testing.T) {
 }
 
 func TestJSONContains(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONContains]
 	tbl := []struct {
@@ -479,7 +468,6 @@ func TestJSONContains(t *testing.T) {
 }
 
 func TestJSONContainsPath(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONContainsPath]
 	jsonString := `{"a": 1, "b": 2, "c": {"d": 4}}`
@@ -539,7 +527,6 @@ func TestJSONContainsPath(t *testing.T) {
 }
 
 func TestJSONLength(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONLength]
 	tbl := []struct {
@@ -612,7 +599,6 @@ func TestJSONLength(t *testing.T) {
 }
 
 func TestJSONKeys(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONKeys]
 	tbl := []struct {
@@ -684,7 +670,6 @@ func TestJSONKeys(t *testing.T) {
 }
 
 func TestJSONDepth(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONDepth]
 	tbl := []struct {
@@ -744,7 +729,6 @@ func TestJSONDepth(t *testing.T) {
 }
 
 func TestJSONArrayAppend(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sampleJSON, err := json.ParseBinaryFromString(`{"b": 2}`)
 	require.NoError(t, err)
@@ -824,7 +808,6 @@ func TestJSONArrayAppend(t *testing.T) {
 }
 
 func TestJSONSearch(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONSearch]
 	jsonString := `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`
@@ -900,7 +883,6 @@ func TestJSONSearch(t *testing.T) {
 }
 
 func TestJSONArrayInsert(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONArrayInsert]
 	tbl := []struct {
@@ -974,7 +956,6 @@ func TestJSONArrayInsert(t *testing.T) {
 }
 
 func TestJSONValid(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONValid]
 	tbl := []struct {
@@ -1006,7 +987,6 @@ func TestJSONValid(t *testing.T) {
 }
 
 func TestJSONStorageSize(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONStorageSize]
 	tbl := []struct {
@@ -1050,7 +1030,6 @@ func TestJSONStorageSize(t *testing.T) {
 }
 
 func TestJSONPretty(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONPretty]
 	tbl := []struct {
@@ -1125,7 +1104,6 @@ func TestJSONPretty(t *testing.T) {
 }
 
 func TestJSONMergePatch(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.JSONMergePatch]
 	tbl := []struct {

--- a/expression/builtin_like_test.go
+++ b/expression/builtin_like_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestLike(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		input   string
@@ -62,7 +61,6 @@ func TestLike(t *testing.T) {
 }
 
 func TestRegexp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		pattern string

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 func TestAbs(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg interface{}
@@ -59,7 +58,6 @@ func TestAbs(t *testing.T) {
 }
 
 func TestCeil(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	tmpIT := sc.IgnoreTruncate
@@ -125,7 +123,6 @@ func TestCeil(t *testing.T) {
 }
 
 func TestExp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       interface{}
@@ -177,7 +174,6 @@ func TestExp(t *testing.T) {
 }
 
 func TestFloor(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	tmpIT := sc.IgnoreTruncate
@@ -248,7 +244,6 @@ func TestFloor(t *testing.T) {
 }
 
 func TestLog(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args         []interface{}
@@ -292,7 +287,6 @@ func TestLog(t *testing.T) {
 }
 
 func TestLog2(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args         interface{}
@@ -331,7 +325,6 @@ func TestLog2(t *testing.T) {
 }
 
 func TestLog10(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args         interface{}
@@ -370,7 +363,6 @@ func TestLog10(t *testing.T) {
 }
 
 func TestRand(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Rand]
 	f, err := fc.getFunction(ctx, nil)
@@ -392,7 +384,6 @@ func TestRand(t *testing.T) {
 }
 
 func TestPow(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg []interface{}
@@ -440,7 +431,6 @@ func TestPow(t *testing.T) {
 }
 
 func TestRound(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	newDec := types.NewDecFromStringForTest
 	tbl := []struct {
@@ -495,7 +485,6 @@ func TestRound(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	newDec := types.NewDecFromStringForTest
 	tbl := []struct {
@@ -540,7 +529,6 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestCRC32(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg []interface{}
@@ -568,7 +556,6 @@ func TestCRC32(t *testing.T) {
 }
 
 func TestConv(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -633,7 +620,6 @@ func TestConv(t *testing.T) {
 }
 
 func TestSign(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	tmpIT := sc.IgnoreTruncate
@@ -669,7 +655,6 @@ func TestSign(t *testing.T) {
 }
 
 func TestDegrees(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreTruncate = false
@@ -713,7 +698,6 @@ func TestDegrees(t *testing.T) {
 }
 
 func TestSqrt(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg []interface{}
@@ -738,7 +722,6 @@ func TestSqrt(t *testing.T) {
 }
 
 func TestPi(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	f, err := funcs[ast.PI].getFunction(ctx, nil)
 	require.NoError(t, err)
@@ -749,7 +732,6 @@ func TestPi(t *testing.T) {
 }
 
 func TestRadians(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Arg interface{}
@@ -783,7 +765,6 @@ func TestRadians(t *testing.T) {
 }
 
 func TestSin(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args       interface{}
@@ -828,7 +809,6 @@ func TestSin(t *testing.T) {
 }
 
 func TestCos(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args       interface{}
@@ -870,7 +850,6 @@ func TestCos(t *testing.T) {
 }
 
 func TestAcos(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       interface{}
@@ -910,7 +889,6 @@ func TestAcos(t *testing.T) {
 }
 
 func TestAsin(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       interface{}
@@ -950,7 +928,6 @@ func TestAsin(t *testing.T) {
 }
 
 func TestAtan(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       []interface{}
@@ -990,7 +967,6 @@ func TestAtan(t *testing.T) {
 }
 
 func TestTan(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args       interface{}
@@ -1031,7 +1007,6 @@ func TestTan(t *testing.T) {
 }
 
 func TestCot(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args   interface{}

--- a/expression/builtin_miscellaneous_test.go
+++ b/expression/builtin_miscellaneous_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestInetAton(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Input    interface{}
@@ -62,7 +61,6 @@ func TestInetAton(t *testing.T) {
 }
 
 func TestIsIPv4(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     string
@@ -98,7 +96,6 @@ func TestIsIPv4(t *testing.T) {
 }
 
 func TestIsUUID(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		uuid   string
@@ -134,7 +131,6 @@ func TestIsUUID(t *testing.T) {
 }
 
 func TestUUID(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	f, err := newFunctionForTest(ctx, ast.UUID)
 	require.NoError(t, err)
@@ -161,7 +157,6 @@ func TestUUID(t *testing.T) {
 }
 
 func TestAnyValue(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		arg interface{}
@@ -184,7 +179,6 @@ func TestAnyValue(t *testing.T) {
 }
 
 func TestIsIPv6(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     string
@@ -214,7 +208,6 @@ func TestIsIPv6(t *testing.T) {
 }
 
 func TestInetNtoa(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     int
@@ -245,7 +238,6 @@ func TestInetNtoa(t *testing.T) {
 }
 
 func TestInet6NtoA(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     []byte
@@ -284,7 +276,6 @@ func TestInet6NtoA(t *testing.T) {
 }
 
 func TestInet6AtoN(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     string
@@ -316,7 +307,6 @@ func TestInet6AtoN(t *testing.T) {
 }
 
 func TestIsIPv4Mapped(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     []byte
@@ -346,7 +336,6 @@ func TestIsIPv4Mapped(t *testing.T) {
 }
 
 func TestIsIPv4Compat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		ip     []byte
@@ -377,7 +366,6 @@ func TestIsIPv4Compat(t *testing.T) {
 }
 
 func TestNameConst(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	dec := types.NewDecFromFloatForTest(123.123)
 	tm := types.NewTime(types.FromGoTime(time.Now()), mysql.TypeDatetime, 6)
@@ -421,7 +409,6 @@ func TestNameConst(t *testing.T) {
 }
 
 func TestUUIDToBin(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       []interface{}
@@ -521,7 +508,6 @@ func TestUUIDToBin(t *testing.T) {
 }
 
 func TestBinToUUID(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args       []interface{}

--- a/expression/builtin_op_test.go
+++ b/expression/builtin_op_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestUnary(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}
@@ -69,7 +68,6 @@ func TestUnary(t *testing.T) {
 }
 
 func TestLogicAnd(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -133,7 +131,6 @@ func TestLogicAnd(t *testing.T) {
 }
 
 func TestLeftShift(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -166,7 +163,6 @@ func TestLeftShift(t *testing.T) {
 }
 
 func TestRightShift(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -206,7 +202,6 @@ func TestRightShift(t *testing.T) {
 }
 
 func TestBitXor(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -246,7 +241,6 @@ func TestBitXor(t *testing.T) {
 }
 
 func TestBitOr(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -293,7 +287,6 @@ func TestBitOr(t *testing.T) {
 }
 
 func TestLogicOr(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -361,7 +354,6 @@ func TestLogicOr(t *testing.T) {
 }
 
 func TestBitAnd(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -401,7 +393,6 @@ func TestBitAnd(t *testing.T) {
 }
 
 func TestBitNeg(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -448,7 +439,6 @@ func TestBitNeg(t *testing.T) {
 }
 
 func TestUnaryNot(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -501,7 +491,6 @@ func TestUnaryNot(t *testing.T) {
 }
 
 func TestIsTrueOrFalse(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate
@@ -609,7 +598,6 @@ func TestIsTrueOrFalse(t *testing.T) {
 }
 
 func TestLogicXor(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	origin := sc.IgnoreTruncate

--- a/expression/builtin_op_vec_test.go
+++ b/expression/builtin_op_vec_test.go
@@ -161,7 +161,6 @@ func BenchmarkVectorizedBuiltinOpFunc(b *testing.B) {
 }
 
 func TestBuiltinUnaryMinusIntSig(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	ft := eType2FieldType(types.ETInt)
 	col0 := &Column{RetType: ft, Index: 0}

--- a/expression/builtin_other_test.go
+++ b/expression/builtin_other_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestBitCount(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -76,7 +75,6 @@ func TestBitCount(t *testing.T) {
 }
 
 func TestRowFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.RowFunc]
 	_, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums([]interface{}{"1", 1.2, true, 120}...)))
@@ -84,7 +82,6 @@ func TestRowFunc(t *testing.T) {
 }
 
 func TestSetVar(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.SetVar]
 	dec := types.NewDecFromInt(5)
@@ -120,7 +117,6 @@ func TestSetVar(t *testing.T) {
 }
 
 func TestGetVar(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	dec := types.NewDecFromInt(5)
 	timeDec := types.NewTime(types.FromGoTime(time.Now()), mysql.TypeTimestamp, 0)
@@ -175,7 +171,6 @@ func TestGetVar(t *testing.T) {
 }
 
 func TestValues(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := &valuesFunctionClass{baseFunctionClass{ast.Values, 0, 0}, 1, types.NewFieldType(mysql.TypeVarchar)}
 	_, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums("")))
@@ -205,7 +200,6 @@ func TestValues(t *testing.T) {
 }
 
 func TestSetVarFromColumn(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// Construct arguments.
 	argVarName := &Constant{

--- a/expression/builtin_other_vec_test.go
+++ b/expression/builtin_other_vec_test.go
@@ -63,7 +63,6 @@ func BenchmarkVectorizedBuiltinOtherFunc(b *testing.B) {
 }
 
 func TestInDecimal(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	ft := eType2FieldType(types.ETDecimal)
 	col0 := &Column{RetType: ft, Index: 0}

--- a/expression/builtin_regexp_vec_const_test.go
+++ b/expression/builtin_regexp_vec_const_test.go
@@ -61,7 +61,6 @@ func genVecBuiltinRegexpBenchCaseForConstants() (baseFunc builtinFunc, childrenF
 }
 
 func TestVectorizedBuiltinRegexpForConstants(t *testing.T) {
-	t.Parallel()
 	bf, childrenFieldTypes, input, output := genVecBuiltinRegexpBenchCaseForConstants()
 	err := bf.vecEvalInt(input, output)
 	require.NoError(t, err)

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -38,7 +38,6 @@ import (
 )
 
 func TestLengthAndOctetLength(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}
@@ -107,7 +106,6 @@ func TestLengthAndOctetLength(t *testing.T) {
 }
 
 func TestASCII(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}
@@ -168,7 +166,6 @@ func TestASCII(t *testing.T) {
 }
 
 func TestConcat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args    []interface{}
@@ -225,7 +222,6 @@ func TestConcat(t *testing.T) {
 }
 
 func TestConcatSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -271,7 +267,6 @@ func TestConcatSig(t *testing.T) {
 }
 
 func TestConcatWS(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -344,7 +339,6 @@ func TestConcatWS(t *testing.T) {
 }
 
 func TestConcatWSSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -393,7 +387,6 @@ func TestConcatWSSig(t *testing.T) {
 }
 
 func TestLeft(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -444,7 +437,6 @@ func TestLeft(t *testing.T) {
 }
 
 func TestRight(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -495,7 +487,6 @@ func TestRight(t *testing.T) {
 }
 
 func TestRepeat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	args := []interface{}{"a", int64(2)}
 	fc := funcs[ast.Repeat]
@@ -549,7 +540,6 @@ func TestRepeat(t *testing.T) {
 }
 
 func TestRepeatSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -596,7 +586,6 @@ func TestRepeatSig(t *testing.T) {
 }
 
 func TestLower(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -655,7 +644,6 @@ func TestLower(t *testing.T) {
 }
 
 func TestUpper(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -715,7 +703,6 @@ func TestUpper(t *testing.T) {
 }
 
 func TestReverse(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Reverse]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(nil)))
@@ -747,7 +734,6 @@ func TestReverse(t *testing.T) {
 }
 
 func TestStrcmp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -789,7 +775,6 @@ func TestStrcmp(t *testing.T) {
 }
 
 func TestReplace(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -831,7 +816,6 @@ func TestReplace(t *testing.T) {
 }
 
 func TestSubstring(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -880,7 +864,6 @@ func TestSubstring(t *testing.T) {
 }
 
 func TestConvert(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		str           interface{}
@@ -941,7 +924,6 @@ func TestConvert(t *testing.T) {
 }
 
 func TestSubstringIndex(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -989,7 +971,6 @@ func TestSubstringIndex(t *testing.T) {
 }
 
 func TestSpace(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -1036,7 +1017,6 @@ func TestSpace(t *testing.T) {
 }
 
 func TestSpaceSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeLonglong},
@@ -1065,7 +1045,6 @@ func TestSpaceSig(t *testing.T) {
 }
 
 func TestLocate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// 1. Test LOCATE without binary input.
 	tbl := []struct {
@@ -1138,7 +1117,6 @@ func TestLocate(t *testing.T) {
 }
 
 func TestTrim(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args   []interface{}
@@ -1191,7 +1169,6 @@ func TestTrim(t *testing.T) {
 }
 
 func TestLTrim(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		arg    interface{}
@@ -1234,7 +1211,6 @@ func TestLTrim(t *testing.T) {
 }
 
 func TestRTrim(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		arg    interface{}
@@ -1275,7 +1251,6 @@ func TestRTrim(t *testing.T) {
 }
 
 func TestHexFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		arg    interface{}
@@ -1346,7 +1321,6 @@ func TestHexFunc(t *testing.T) {
 }
 
 func TestUnhexFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		arg    interface{}
@@ -1387,7 +1361,6 @@ func TestUnhexFunc(t *testing.T) {
 }
 
 func TestBitLength(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}
@@ -1429,7 +1402,6 @@ func TestBitLength(t *testing.T) {
 }
 
 func TestChar(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -1473,7 +1445,6 @@ func TestChar(t *testing.T) {
 }
 
 func TestCharLength(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		input  interface{}
@@ -1523,7 +1494,6 @@ func TestCharLength(t *testing.T) {
 }
 
 func TestFindInSet(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	for _, c := range []struct {
 		str    interface{}
@@ -1552,7 +1522,6 @@ func TestFindInSet(t *testing.T) {
 }
 
 func TestField(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -1588,7 +1557,6 @@ func TestField(t *testing.T) {
 }
 
 func TestLpad(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		str    string
@@ -1625,7 +1593,6 @@ func TestLpad(t *testing.T) {
 }
 
 func TestRpad(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		str    string
@@ -1662,7 +1629,6 @@ func TestRpad(t *testing.T) {
 }
 
 func TestRpadSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -1705,7 +1671,6 @@ func TestRpadSig(t *testing.T) {
 }
 
 func TestInsertBinarySig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -1797,7 +1762,6 @@ func TestInsertBinarySig(t *testing.T) {
 }
 
 func TestInstr(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Args []interface{}
@@ -1843,7 +1807,6 @@ func TestInstr(t *testing.T) {
 }
 
 func TestLoadFile(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		arg    interface{}
@@ -1876,7 +1839,6 @@ func TestLoadFile(t *testing.T) {
 }
 
 func TestMakeSet(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		argList []interface{}
@@ -1903,7 +1865,6 @@ func TestMakeSet(t *testing.T) {
 }
 
 func TestOct(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	octTests := []struct {
 		origin interface{}
@@ -1953,7 +1914,6 @@ func TestOct(t *testing.T) {
 }
 
 func TestFormat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	formatTests := []struct {
 		number    interface{}
@@ -2083,7 +2043,6 @@ func TestFormat(t *testing.T) {
 }
 
 func TestFromBase64(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args   interface{}
@@ -2129,7 +2088,6 @@ func TestFromBase64(t *testing.T) {
 }
 
 func TestFromBase64Sig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -2183,7 +2141,6 @@ func TestFromBase64Sig(t *testing.T) {
 }
 
 func TestInsert(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args   []interface{}
@@ -2281,7 +2238,6 @@ func TestOrd(t *testing.T) {
 }
 
 func TestElt(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		argLst []interface{}
@@ -2305,7 +2261,6 @@ func TestElt(t *testing.T) {
 }
 
 func TestExportSet(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	estd := []struct {
 		argLst []interface{}
@@ -2336,7 +2291,6 @@ func TestExportSet(t *testing.T) {
 }
 
 func TestBin(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		Input    interface{}
 		Expected interface{}
@@ -2368,7 +2322,6 @@ func TestBin(t *testing.T) {
 }
 
 func TestQuote(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		arg interface{}
@@ -2398,7 +2351,6 @@ func TestQuote(t *testing.T) {
 }
 
 func TestToBase64(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		args   interface{}
@@ -2491,7 +2443,6 @@ func TestToBase64(t *testing.T) {
 }
 
 func TestToBase64Sig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	colTypes := []*types.FieldType{
 		{Tp: mysql.TypeVarchar},
@@ -2561,7 +2512,6 @@ func TestToBase64Sig(t *testing.T) {
 }
 
 func TestStringRight(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Right]
 	tests := []struct {
@@ -2594,7 +2544,6 @@ func TestStringRight(t *testing.T) {
 }
 
 func TestWeightString(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.WeightString]
 	tests := []struct {
@@ -2668,7 +2617,6 @@ func TestWeightString(t *testing.T) {
 }
 
 func TestTranslate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args  []interface{}

--- a/expression/builtin_test.go
+++ b/expression/builtin_test.go
@@ -122,7 +122,6 @@ func makeDatums(i interface{}) []types.Datum {
 }
 
 func TestIsNullFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.IsNull]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(1)))
@@ -139,7 +138,6 @@ func TestIsNullFunc(t *testing.T) {
 }
 
 func TestLock(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	lock := funcs[ast.GetLock]
 	f, err := lock.getFunction(ctx, datumsToConstants(types.MakeDatums(nil, 1)))
@@ -157,7 +155,6 @@ func TestLock(t *testing.T) {
 }
 
 func TestDisplayName(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, "=", GetDisplayName(ast.EQ))
 	require.Equal(t, "<=>", GetDisplayName(ast.NullEQ))
 	require.Equal(t, "IS TRUE", GetDisplayName(ast.IsTruthWithoutNull))

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -40,7 +40,6 @@ import (
 )
 
 func TestDate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tblDate := []struct {
 		Input  interface{}
@@ -418,7 +417,6 @@ func TestDate(t *testing.T) {
 }
 
 func TestMonthName(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -455,7 +453,6 @@ func TestMonthName(t *testing.T) {
 }
 
 func TestDayName(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -494,7 +491,6 @@ func TestDayName(t *testing.T) {
 }
 
 func TestDayOfWeek(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -531,7 +527,6 @@ func TestDayOfWeek(t *testing.T) {
 }
 
 func TestDayOfMonth(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -568,7 +563,6 @@ func TestDayOfMonth(t *testing.T) {
 }
 
 func TestDayOfYear(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -605,7 +599,6 @@ func TestDayOfYear(t *testing.T) {
 }
 
 func TestDateFormat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// Test case for https://github.com/pingcap/tidb/issues/2908
 	// SELECT DATE_FORMAT(null,'%Y-%M-%D')
@@ -652,7 +645,6 @@ func TestDateFormat(t *testing.T) {
 }
 
 func TestClock(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// test hour, minute, second, micro second
 
@@ -785,7 +777,6 @@ func TestClock(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     interface{}
@@ -832,7 +823,6 @@ func resetStmtContext(ctx sessionctx.Context) {
 }
 
 func TestNowAndUTCTimestamp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	gotime := func(typ types.Time, l *time.Location) time.Time {
 		tt, err := typ.GoTime(l)
@@ -899,7 +889,6 @@ func TestNowAndUTCTimestamp(t *testing.T) {
 }
 
 func TestIsDuration(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		Input  string
 		expect bool
@@ -921,7 +910,6 @@ func TestIsDuration(t *testing.T) {
 }
 
 func TestAddTimeSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Input         string
@@ -1037,7 +1025,6 @@ func TestAddTimeSig(t *testing.T) {
 }
 
 func TestSubTimeSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Input         string
@@ -1136,7 +1123,6 @@ func TestSubTimeSig(t *testing.T) {
 }
 
 func TestSysDate(t *testing.T) {
-	t.Parallel()
 	fc := funcs[ast.Sysdate]
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().StmtCtx.TimeZone = timeutil.SystemLocation()
@@ -1241,7 +1227,6 @@ func builtinDateFormat(ctx sessionctx.Context, args []types.Datum) (d types.Datu
 }
 
 func TestFromUnixTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		isDecimal      bool
@@ -1318,7 +1303,6 @@ func TestFromUnixTime(t *testing.T) {
 }
 
 func TestCurrentDate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	last := time.Now()
 	fc := funcs[ast.CurrentDate]
@@ -1332,7 +1316,6 @@ func TestCurrentDate(t *testing.T) {
 }
 
 func TestCurrentTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tfStr := "15:04:05"
 
@@ -1373,7 +1356,6 @@ func TestCurrentTime(t *testing.T) {
 }
 
 func TestUTCTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	last := time.Now().UTC()
 	tfStr := "00:00:00"
@@ -1415,7 +1397,6 @@ func TestUTCTime(t *testing.T) {
 }
 
 func TestUTCDate(t *testing.T) {
-	t.Parallel()
 	last := time.Now().UTC()
 	fc := funcs[ast.UTCDate]
 	f, err := fc.getFunction(mock.NewContext(), datumsToConstants(nil))
@@ -1428,7 +1409,6 @@ func TestUTCDate(t *testing.T) {
 }
 
 func TestStrToDate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// If you want to add test cases for `strToDate` but not the builtin function,
 	// adding cases in `types.format_test.go` `TestStrToDate` maybe more clear and easier
@@ -1501,7 +1481,6 @@ func TestStrToDate(t *testing.T) {
 }
 
 func TestFromDays(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -1563,7 +1542,6 @@ func TestFromDays(t *testing.T) {
 }
 
 func TestDateDiff(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// Test cases from https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_datediff
 	tests := []struct {
@@ -1617,7 +1595,6 @@ func TestDateDiff(t *testing.T) {
 }
 
 func TestTimeDiff(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -1667,7 +1644,6 @@ func TestTimeDiff(t *testing.T) {
 }
 
 func TestWeek(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// Test cases from https://dev.mysql.com/doc/refman/5.7/en/date-and-time-functions.html#function_week
 	tests := []struct {
@@ -1692,7 +1668,6 @@ func TestWeek(t *testing.T) {
 }
 
 func TestWeekWithoutModeSig(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		t      string
@@ -1723,7 +1698,6 @@ func TestWeekWithoutModeSig(t *testing.T) {
 	}
 }
 func TestYearWeek(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -1755,7 +1729,6 @@ func TestYearWeek(t *testing.T) {
 }
 
 func TestTimestampDiff(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		unit   string
@@ -1804,7 +1777,6 @@ func TestTimestampDiff(t *testing.T) {
 }
 
 func TestUnixTimestamp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// Test UNIX_TIMESTAMP().
 	fc := funcs[ast.UnixTimestamp]
@@ -1895,7 +1867,6 @@ func TestUnixTimestamp(t *testing.T) {
 }
 
 func TestDateArithFuncs(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	date := []string{"2016-12-31", "2017-01-01"}
 	fcAdd := funcs[ast.DateAdd]
@@ -2132,7 +2103,6 @@ func TestDateArithFuncs(t *testing.T) {
 }
 
 func TestTimestamp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		t      []types.Datum
@@ -2185,7 +2155,6 @@ func TestTimestamp(t *testing.T) {
 }
 
 func TestMakeDate(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	cases := []struct {
 		args     []interface{}
@@ -2240,7 +2209,6 @@ func TestMakeDate(t *testing.T) {
 }
 
 func TestMakeTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		Args []interface{}
@@ -2351,7 +2319,6 @@ func TestMakeTime(t *testing.T) {
 }
 
 func TestQuarter(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -2393,7 +2360,6 @@ func TestQuarter(t *testing.T) {
 }
 
 func TestGetFormat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		unit     string
@@ -2432,7 +2398,6 @@ func TestGetFormat(t *testing.T) {
 }
 
 func TestToSeconds(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -2474,7 +2439,6 @@ func TestToSeconds(t *testing.T) {
 }
 
 func TestToDays(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := ctx.GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
@@ -2517,7 +2481,6 @@ func TestToDays(t *testing.T) {
 }
 
 func TestTimestampAdd(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		unit     string
@@ -2544,7 +2507,6 @@ func TestTimestampAdd(t *testing.T) {
 }
 
 func TestPeriodAdd(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		Period  int64
@@ -2581,7 +2543,6 @@ func TestPeriodAdd(t *testing.T) {
 }
 
 func TestTimeFormat(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	// SELECT TIME_FORMAT(null,'%H %k %h %I %l')
 	args := []types.Datum{types.NewDatum(nil), types.NewStringDatum(`%H %k %h %I %l`)}
@@ -2620,7 +2581,6 @@ func TestTimeFormat(t *testing.T) {
 }
 
 func TestTimeToSec(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.TimeToSec]
 
@@ -2666,7 +2626,6 @@ func TestTimeToSec(t *testing.T) {
 }
 
 func TestSecToTime(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	stmtCtx := ctx.GetSessionVars().StmtCtx
 	origin := stmtCtx.IgnoreTruncate
@@ -2716,7 +2675,6 @@ func TestSecToTime(t *testing.T) {
 }
 
 func TestConvertTz(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	loc1, _ := time.LoadLocation("Europe/Tallinn")
 	loc2, _ := time.LoadLocation("Local")
@@ -2792,7 +2750,6 @@ func TestConvertTz(t *testing.T) {
 }
 
 func TestPeriodDiff(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		Period1 int64
@@ -2866,7 +2823,6 @@ func TestPeriodDiff(t *testing.T) {
 }
 
 func TestLastDay(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tests := []struct {
 		param  interface{}
@@ -2922,7 +2878,6 @@ func TestLastDay(t *testing.T) {
 }
 
 func TestWithTimeZone(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sv := ctx.GetSessionVars()
 	originTZ := sv.Location()
@@ -2967,7 +2922,6 @@ func TestWithTimeZone(t *testing.T) {
 }
 
 func TestTidbParseTso(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	ctx.GetSessionVars().TimeZone = time.UTC
 	tests := []struct {
@@ -3006,7 +2960,6 @@ func TestTidbParseTso(t *testing.T) {
 }
 
 func TestTiDBBoundedStaleness(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	t1, err := time.Parse(types.TimeFormat, "2015-09-21 09:53:04")
 	require.NoError(t, err)
@@ -3102,7 +3055,6 @@ func TestTiDBBoundedStaleness(t *testing.T) {
 }
 
 func TestGetIntervalFromDecimal(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	du := baseDateArithmetical{}
 

--- a/expression/builtin_time_vec_test.go
+++ b/expression/builtin_time_vec_test.go
@@ -589,7 +589,6 @@ func BenchmarkVectorizedBuiltinTimeFunc(b *testing.B) {
 }
 
 func TestVecMonth(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().SQLMode |= mysql.ModeNoZeroDate
 	ctx.GetSessionVars().StmtCtx.TruncateAsWarning = true

--- a/expression/collation_test.go
+++ b/expression/collation_test.go
@@ -34,8 +34,6 @@ func newExpression(coercibility Coercibility, repertoire Repertoire, chs, coll s
 }
 
 func TestInferCollation(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		exprs []Expression
 		err   bool
@@ -268,8 +266,6 @@ func newColInt(coercibility Coercibility) *Column {
 }
 
 func TestDeriveCollation(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	tests := []struct {
 		fcs    []string

--- a/expression/column_test.go
+++ b/expression/column_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestColumn(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	col := &Column{RetType: types.NewFieldType(mysql.TypeLonglong), UniqueID: 1}
 
@@ -100,8 +98,6 @@ func TestColumn(t *testing.T) {
 }
 
 func TestColumnHashCode(t *testing.T) {
-	t.Parallel()
-
 	col1 := &Column{
 		UniqueID: 12,
 	}
@@ -114,8 +110,6 @@ func TestColumnHashCode(t *testing.T) {
 }
 
 func TestColumn2Expr(t *testing.T) {
-	t.Parallel()
-
 	cols := make([]*Column, 0, 5)
 	for i := 0; i < 5; i++ {
 		cols = append(cols, &Column{UniqueID: int64(i)})
@@ -128,8 +122,6 @@ func TestColumn2Expr(t *testing.T) {
 }
 
 func TestColInfo2Col(t *testing.T) {
-	t.Parallel()
-
 	col0, col1 := &Column{ID: 0}, &Column{ID: 1}
 	cols := []*Column{col0, col1}
 	colInfo := &model.ColumnInfo{ID: 0}
@@ -142,8 +134,6 @@ func TestColInfo2Col(t *testing.T) {
 }
 
 func TestIndexInfo2Cols(t *testing.T) {
-	t.Parallel()
-
 	col0 := &Column{UniqueID: 0, ID: 0, RetType: types.NewFieldType(mysql.TypeLonglong)}
 	col1 := &Column{UniqueID: 1, ID: 1, RetType: types.NewFieldType(mysql.TypeLonglong)}
 	colInfo0 := &model.ColumnInfo{ID: 0, Name: model.NewCIStr("0")}
@@ -174,8 +164,6 @@ func TestIndexInfo2Cols(t *testing.T) {
 }
 
 func TestColHybird(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 
 	// bit

--- a/expression/constant_fold_test.go
+++ b/expression/constant_fold_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestFoldIfNull(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/expression/constant_propagation_test.go
+++ b/expression/constant_propagation_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestOuterJoinPropConst(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/expression/constant_test.go
+++ b/expression/constant_test.go
@@ -65,8 +65,6 @@ func newFunctionWithType(funcName string, tp *types.FieldType, args ...Expressio
 }
 
 func TestConstantPropagation(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		solver     []PropagateConstantSolver
 		conditions []Expression
@@ -193,8 +191,6 @@ func TestConstantPropagation(t *testing.T) {
 }
 
 func TestConstantFolding(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		condition Expression
 		result    string
@@ -231,7 +227,6 @@ func TestConstantFolding(t *testing.T) {
 }
 
 func TestConstantFoldingCharsetConvert(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		condition Expression
 		result    string
@@ -288,8 +283,6 @@ func TestConstantFoldingCharsetConvert(t *testing.T) {
 }
 
 func TestDeferredParamNotNull(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	testTime := time.Now()
 	ctx.GetSessionVars().PreparedParams = []types.Datum{
@@ -356,8 +349,6 @@ func TestDeferredParamNotNull(t *testing.T) {
 }
 
 func TestDeferredExprNotNull(t *testing.T) {
-	t.Parallel()
-
 	m := &MockExpr{}
 	ctx := mock.NewContext()
 	cst := &Constant{DeferredExpr: m, RetType: newIntFieldType()}
@@ -433,8 +424,6 @@ func TestDeferredExprNotNull(t *testing.T) {
 }
 
 func TestVectorizedConstant(t *testing.T) {
-	t.Parallel()
-
 	// fixed-length type with/without Sel
 	for _, cst := range []*Constant{
 		{RetType: newIntFieldType(), Value: types.NewIntDatum(2333)},
@@ -490,8 +479,6 @@ func TestVectorizedConstant(t *testing.T) {
 }
 
 func TestGetTypeThreadSafe(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().PreparedParams = []types.Datum{
 		types.NewIntDatum(1),

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestPBToExpr(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	fieldTps := make([]*types.FieldType, 1)
 	ds := []types.Datum{types.NewIntDatum(1), types.NewUintDatum(1), types.NewFloat64Datum(1),
@@ -86,7 +85,6 @@ func TestPBToExpr(t *testing.T) {
 
 // TestEval test expr.Eval().
 func TestEval(t *testing.T) {
-	t.Parallel()
 	row := chunk.MutRowFromDatums([]types.Datum{types.NewDatum(100)}).ToRow()
 	fieldTps := make([]*types.FieldType, 1)
 	fieldTps[0] = types.NewFieldType(mysql.TypeLonglong)

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -105,7 +105,6 @@ func primitiveValsToConstants(ctx sessionctx.Context, args []interface{}) []Expr
 }
 
 func TestSleep(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sessVars := ctx.GetSessionVars()
 
@@ -171,7 +170,6 @@ func TestSleep(t *testing.T) {
 }
 
 func TestBinopComparison(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		lhs    interface{}
 		op     string
@@ -250,7 +248,6 @@ func TestBinopComparison(t *testing.T) {
 }
 
 func TestBinopLogic(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		lhs interface{}
 		op  string
@@ -290,7 +287,6 @@ func TestBinopLogic(t *testing.T) {
 }
 
 func TestBinopBitop(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		lhs interface{}
 		op  string
@@ -328,7 +324,6 @@ func TestBinopBitop(t *testing.T) {
 }
 
 func TestBinopNumeric(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		lhs interface{}
 		op  string
@@ -472,7 +467,6 @@ func TestBinopNumeric(t *testing.T) {
 }
 
 func TestExtract(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	str := "2011-11-11 10:10:10.123456"
 	tbl := []struct {
@@ -519,7 +513,6 @@ func TestExtract(t *testing.T) {
 }
 
 func TestUnaryOp(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tbl := []struct {
 		arg    interface{}
@@ -588,7 +581,6 @@ func TestUnaryOp(t *testing.T) {
 }
 
 func TestMod(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	fc := funcs[ast.Mod]
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(234, 10)))

--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -39,7 +39,6 @@ func genColumn(tp byte, id int64) *Column {
 
 func TestConstant2Pb(t *testing.T) {
 	t.Skip("constant pb has changed")
-	t.Parallel()
 	var constExprs []Expression
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -123,7 +122,6 @@ func TestConstant2Pb(t *testing.T) {
 }
 
 func TestColumn2Pb(t *testing.T) {
-	t.Parallel()
 	var colExprs []Expression
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -215,7 +213,6 @@ func TestColumn2Pb(t *testing.T) {
 }
 
 func TestCompareFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var compareExprs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -252,7 +249,6 @@ func TestCompareFunc2Pb(t *testing.T) {
 }
 
 func TestLikeFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var likeFuncs []Expression
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -291,7 +287,6 @@ func TestLikeFunc2Pb(t *testing.T) {
 }
 
 func TestArithmeticalFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var arithmeticalFuncs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -339,7 +334,6 @@ func TestArithmeticalFunc2Pb(t *testing.T) {
 }
 
 func TestDateFunc2Pb(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -396,7 +390,6 @@ func TestLogicalFunc2Pb(t *testing.T) {
 }
 
 func TestBitwiseFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var bitwiseFuncs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -435,7 +428,6 @@ func TestBitwiseFunc2Pb(t *testing.T) {
 }
 
 func TestControlFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var controlFuncs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -477,7 +469,6 @@ func TestControlFunc2Pb(t *testing.T) {
 }
 
 func TestOtherFunc2Pb(t *testing.T) {
-	t.Parallel()
 	var otherFuncs = make([]Expression, 0)
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
@@ -508,7 +499,6 @@ func TestOtherFunc2Pb(t *testing.T) {
 }
 
 func TestExprPushDownToFlash(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -1004,7 +994,6 @@ func TestExprPushDownToFlash(t *testing.T) {
 
 func TestExprOnlyPushDownToFlash(t *testing.T) {
 	t.Skip("Skip this unstable test temporarily and bring it back before 2021-07-26")
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -1058,7 +1047,6 @@ func TestExprOnlyPushDownToFlash(t *testing.T) {
 }
 
 func TestExprPushDownToTiKV(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -1111,7 +1099,6 @@ func TestExprPushDownToTiKV(t *testing.T) {
 }
 
 func TestExprOnlyPushDownToTiKV(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -1138,7 +1125,6 @@ func TestExprOnlyPushDownToTiKV(t *testing.T) {
 }
 
 func TestGroupByItem2Pb(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 
@@ -1156,7 +1142,6 @@ func TestGroupByItem2Pb(t *testing.T) {
 }
 
 func TestSortByItem2Pb(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	client := new(mock.Client)
 

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestNewValuesFunc(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	res := NewValuesFunc(ctx, 0, types.NewFieldType(mysql.TypeLonglong))
 	require.Equal(t, "values", res.FuncName.O)
@@ -38,7 +37,6 @@ func TestNewValuesFunc(t *testing.T) {
 }
 
 func TestEvaluateExprWithNull(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong, 0).add("col1", mysql.TypeLonglong, 0).build()
 	schema := tableInfoToSchemaForTest(tblInfo)
@@ -59,7 +57,6 @@ func TestEvaluateExprWithNull(t *testing.T) {
 }
 
 func TestEvaluateExprWithNullAndParameters(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	tblInfo := newTestTableBuilder("").add("col0", mysql.TypeLonglong, 0).build()
 	schema := tableInfoToSchemaForTest(tblInfo)
@@ -83,7 +80,6 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 }
 
 func TestConstant(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	require.False(t, NewZero().IsCorrelated())
@@ -97,7 +93,6 @@ func TestConstant(t *testing.T) {
 }
 
 func TestIsBinaryLiteral(t *testing.T) {
-	t.Parallel()
 	col := &Column{RetType: types.NewFieldType(mysql.TypeEnum)}
 	require.False(t, IsBinaryLiteral(col))
 	col.RetType.Tp = mysql.TypeSet
@@ -114,7 +109,6 @@ func TestIsBinaryLiteral(t *testing.T) {
 }
 
 func TestConstItem(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	sf := newFunction(ast.Rand)
 	require.False(t, sf.ConstItem(ctx.GetSessionVars().StmtCtx))
@@ -127,7 +121,6 @@ func TestConstItem(t *testing.T) {
 }
 
 func TestVectorizable(t *testing.T) {
-	t.Parallel()
 	exprs := make([]Expression, 0, 4)
 	sf := newFunction(ast.Rand)
 	column := &Column{
@@ -227,7 +220,6 @@ func tableInfoToSchemaForTest(tableInfo *model.TableInfo) *Schema {
 }
 
 func TestEvalExpr(t *testing.T) {
-	t.Parallel()
 	ctx := createContext(t)
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
 	tNames := []string{"int", "real", "decimal", "string", "timestamp", "datetime", "duration"}

--- a/expression/flag_simplify_test.go
+++ b/expression/flag_simplify_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestSimplifyExpressionByFlag(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/expression/function_traits_test.go
+++ b/expression/function_traits_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestUnfoldableFuncs(t *testing.T) {
-	t.Parallel()
 	_, ok := unFoldableFunctions[ast.Sysdate]
 	require.True(t, ok)
 }

--- a/expression/helper_test.go
+++ b/expression/helper_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestGetTimeValue(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	v, err := GetTimeValue(ctx, "2012-12-12 00:00:00", mysql.TypeTimestamp, types.MinFsp)
 	require.NoError(t, err)
@@ -130,8 +128,6 @@ func TestGetTimeValue(t *testing.T) {
 }
 
 func TestIsCurrentTimestampExpr(t *testing.T) {
-	t.Parallel()
-
 	buildTimestampFuncCallExpr := func(i int64) *ast.FuncCallExpr {
 		var args []ast.ExprNode
 		if i != 0 {
@@ -157,8 +153,6 @@ func TestIsCurrentTimestampExpr(t *testing.T) {
 }
 
 func TestCurrentTimestampTimeZone(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	sessionVars := ctx.GetSessionVars()
 

--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -54,8 +54,6 @@ import (
 )
 
 func Test19654(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -104,8 +102,6 @@ func Test19654(t *testing.T) {
 }
 
 func Test19387(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -122,8 +118,6 @@ func Test19387(t *testing.T) {
 }
 
 func TestFuncREPEAT(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -161,8 +155,6 @@ func TestFuncREPEAT(t *testing.T) {
 }
 
 func TestFuncLpadAndRpad(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -187,8 +179,6 @@ func TestFuncLpadAndRpad(t *testing.T) {
 }
 
 func TestBuiltinFuncJsonPretty(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -259,8 +249,6 @@ func TestBuiltinFuncJsonPretty(t *testing.T) {
 }
 
 func TestMiscellaneousBuiltin(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -344,8 +332,6 @@ func TestMiscellaneousBuiltin(t *testing.T) {
 }
 
 func TestConvertToBit(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -392,8 +378,6 @@ func TestConvertToBit(t *testing.T) {
 }
 
 func TestStringBuiltin(t *testing.T) {
-	t.Parallel()
-
 	t.Skip("it has been broken. Please fix it as soon as possible.")
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -830,8 +814,6 @@ func TestStringBuiltin(t *testing.T) {
 }
 
 func TestEncryptionBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -999,8 +981,6 @@ func TestEncryptionBuiltin(t *testing.T) {
 }
 
 func TestOpBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1049,8 +1029,6 @@ func TestOpBuiltin(t *testing.T) {
 }
 
 func TestDatetimeOverflow(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1090,8 +1068,6 @@ func TestDatetimeOverflow(t *testing.T) {
 }
 
 func TestIssue11648(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1106,8 +1082,6 @@ func TestIssue11648(t *testing.T) {
 }
 
 func TestInfoBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1255,8 +1229,6 @@ func TestInfoBuiltin(t *testing.T) {
 }
 
 func TestControlBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1327,8 +1299,6 @@ func TestControlBuiltin(t *testing.T) {
 }
 
 func TestArithmeticBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1564,8 +1534,6 @@ func TestArithmeticBuiltin(t *testing.T) {
 }
 
 func TestGreatestTimeType(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1606,8 +1574,6 @@ func TestGreatestTimeType(t *testing.T) {
 }
 
 func TestCompareBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1815,8 +1781,6 @@ func TestCompareBuiltin(t *testing.T) {
 
 // #23157: make sure if Nullif expr is correct combined with IsNull expr.
 func TestNullifWithIsNull(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1830,8 +1794,6 @@ func TestNullifWithIsNull(t *testing.T) {
 }
 
 func TestAggregationBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1867,8 +1829,6 @@ func TestAggregationBuiltin(t *testing.T) {
 }
 
 func TestAggregationBuiltinBitOr(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1896,8 +1856,6 @@ func TestAggregationBuiltinBitOr(t *testing.T) {
 }
 
 func TestAggregationBuiltinBitXor(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1925,8 +1883,6 @@ func TestAggregationBuiltinBitXor(t *testing.T) {
 }
 
 func TestAggregationBuiltinBitAnd(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1954,8 +1910,6 @@ func TestAggregationBuiltinBitAnd(t *testing.T) {
 }
 
 func TestAggregationBuiltinGroupConcat(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1983,8 +1937,6 @@ func TestAggregationBuiltinGroupConcat(t *testing.T) {
 }
 
 func TestAggregationBuiltinJSONArrayagg(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2027,8 +1979,6 @@ func TestAggregationBuiltinJSONArrayagg(t *testing.T) {
 }
 
 func TestAggregationBuiltinJSONObjectAgg(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2069,8 +2019,6 @@ func TestAggregationBuiltinJSONObjectAgg(t *testing.T) {
 }
 
 func TestOtherBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2157,8 +2105,6 @@ func TestOtherBuiltin(t *testing.T) {
 }
 
 func TestDateBuiltin(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -2255,8 +2201,6 @@ func TestDateBuiltin(t *testing.T) {
 }
 
 func TestJSONBuiltin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2302,8 +2246,6 @@ func TestJSONBuiltin(t *testing.T) {
 }
 
 func TestTimeLiteral(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2355,8 +2297,6 @@ func TestTimeLiteral(t *testing.T) {
 }
 
 func TestIssue13822(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2366,8 +2306,6 @@ func TestIssue13822(t *testing.T) {
 }
 
 func TestTimestampLiteral(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2399,8 +2337,6 @@ func TestTimestampLiteral(t *testing.T) {
 }
 
 func TestLiterals(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2410,8 +2346,6 @@ func TestLiterals(t *testing.T) {
 }
 
 func TestFuncJSON(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2599,8 +2533,6 @@ func TestFuncJSON(t *testing.T) {
 }
 
 func TestColumnInfoModified(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2617,8 +2549,6 @@ func TestColumnInfoModified(t *testing.T) {
 }
 
 func TestIssues(t *testing.T) {
-	t.Parallel()
-
 	t.Skip("it has been broken. Please fix it as soon as possible.")
 	// for issue #4954
 	store, clean := testkit.CreateMockStore(t)
@@ -2681,8 +2611,6 @@ func TestIssues(t *testing.T) {
 }
 
 func TestInPredicate4UnsignedInt(t *testing.T) {
-	t.Parallel()
-
 	// for issue #6661
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -2708,8 +2636,6 @@ func TestInPredicate4UnsignedInt(t *testing.T) {
 }
 
 func TestFilterExtractFromDNF(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2771,8 +2697,6 @@ func TestFilterExtractFromDNF(t *testing.T) {
 }
 
 func TestTiDBIsOwnerFunc(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2788,8 +2712,6 @@ func TestTiDBIsOwnerFunc(t *testing.T) {
 }
 
 func TestTiDBDecodePlanFunc(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2827,8 +2749,6 @@ func TestTiDBDecodePlanFunc(t *testing.T) {
 }
 
 func TestTiDBDecodeKeyFunc(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2957,8 +2877,6 @@ func TestTiDBDecodeKeyFunc(t *testing.T) {
 }
 
 func TestTwoDecimalTruncate(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -2977,8 +2895,6 @@ func TestTwoDecimalTruncate(t *testing.T) {
 }
 
 func TestPrefixIndex(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3012,8 +2928,6 @@ func TestPrefixIndex(t *testing.T) {
 }
 
 func TestDecimalMul(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3026,8 +2940,6 @@ func TestDecimalMul(t *testing.T) {
 }
 
 func TestDecimalDiv(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3038,8 +2950,6 @@ func TestDecimalDiv(t *testing.T) {
 }
 
 func TestUnknowHintIgnore(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3053,8 +2963,6 @@ func TestUnknowHintIgnore(t *testing.T) {
 }
 
 func TestValuesInNonInsertStmt(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3068,8 +2976,6 @@ func TestValuesInNonInsertStmt(t *testing.T) {
 }
 
 func TestForeignKeyVar(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3080,8 +2986,6 @@ func TestForeignKeyVar(t *testing.T) {
 }
 
 func TestUserVarMockWindFunc(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3158,8 +3062,6 @@ func TestUserVarMockWindFunc(t *testing.T) {
 }
 
 func TestCastAsTime(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3193,8 +3095,6 @@ func TestCastAsTime(t *testing.T) {
 }
 
 func TestValuesFloat32(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3209,8 +3109,6 @@ func TestValuesFloat32(t *testing.T) {
 }
 
 func TestFuncNameConst(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3254,8 +3152,6 @@ func TestFuncNameConst(t *testing.T) {
 }
 
 func TestValuesEnum(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3270,8 +3166,6 @@ func TestValuesEnum(t *testing.T) {
 }
 
 func TestIssue9325(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3291,8 +3185,6 @@ func TestIssue9325(t *testing.T) {
 }
 
 func TestIssue9710(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3326,8 +3218,6 @@ func TestIssue9710(t *testing.T) {
 
 // TestDecimalConvertToTime for issue #9770
 func TestDecimalConvertToTime(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3341,8 +3231,6 @@ func TestDecimalConvertToTime(t *testing.T) {
 }
 
 func TestIssue9732(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3376,8 +3264,6 @@ monthname(str_to_date(1, '%m')), monthname(str_to_date(0, '%m'));`).Check(testki
 }
 
 func TestDaynameArithmetic(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3428,8 +3314,6 @@ func TestDaynameArithmetic(t *testing.T) {
 }
 
 func TestIssue10156(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3454,8 +3338,6 @@ where
 }
 
 func TestIssue9727(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3507,8 +3389,6 @@ func TestIssue9727(t *testing.T) {
 }
 
 func TestTimestampDatumEncode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3526,8 +3406,6 @@ func TestTimestampDatumEncode(t *testing.T) {
 }
 
 func TestDateTimeAddReal(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3552,8 +3430,6 @@ func TestDateTimeAddReal(t *testing.T) {
 }
 
 func TestIssue10181(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3566,8 +3442,6 @@ func TestIssue10181(t *testing.T) {
 }
 
 func TestExprPushdown(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3612,8 +3486,6 @@ func TestExprPushdown(t *testing.T) {
 	tk.MustQuery("select count(id) from t use index(key2) where substr(col2, 1, 1) = '5' and substr(col1, 1, 1) = '4'").Check(testkit.Rows("1"))
 }
 func TestIssue16973(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3642,8 +3514,6 @@ func TestIssue16973(t *testing.T) {
 }
 
 func TestExprPushdownBlacklist(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3694,8 +3564,6 @@ func TestExprPushdownBlacklist(t *testing.T) {
 }
 
 func TestOptRuleBlacklist(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3704,8 +3572,6 @@ func TestOptRuleBlacklist(t *testing.T) {
 }
 
 func TestIssue10804(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3719,8 +3585,6 @@ func TestIssue10804(t *testing.T) {
 }
 
 func TestInvalidEndingStatement(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3743,8 +3607,6 @@ func TestInvalidEndingStatement(t *testing.T) {
 }
 
 func TestIssue15613(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3756,8 +3618,6 @@ func TestIssue15613(t *testing.T) {
 }
 
 func TestIssue10675(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3791,8 +3651,6 @@ func TestIssue10675(t *testing.T) {
 }
 
 func TestDatetimeMicrosecond(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3947,8 +3805,6 @@ func TestDatetimeMicrosecond(t *testing.T) {
 }
 
 func TestFuncCaseWithLeftJoin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3966,8 +3822,6 @@ func TestFuncCaseWithLeftJoin(t *testing.T) {
 }
 
 func TestIssue11594(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3983,8 +3837,6 @@ func TestIssue11594(t *testing.T) {
 }
 
 func TestDefEnableVectorizedEvaluation(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -3994,8 +3846,6 @@ func TestDefEnableVectorizedEvaluation(t *testing.T) {
 }
 
 func TestIssue11309And11319(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4046,8 +3896,6 @@ func TestIssue11309And11319(t *testing.T) {
 }
 
 func TestIssue12301(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4059,8 +3907,6 @@ func TestIssue12301(t *testing.T) {
 }
 
 func TestIssue15315(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4071,7 +3917,6 @@ func TestIssue15315(t *testing.T) {
 }
 
 func TestNotExistFunc(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4099,8 +3944,6 @@ func TestNotExistFunc(t *testing.T) {
 }
 
 func TestDecodetoChunkReuse(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4151,8 +3994,6 @@ func TestDecodetoChunkReuse(t *testing.T) {
 }
 
 func TestInMeetsPrepareAndExecute(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4176,8 +4017,6 @@ func TestInMeetsPrepareAndExecute(t *testing.T) {
 }
 
 func TestCastStrToInt(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4201,8 +4040,6 @@ func TestCastStrToInt(t *testing.T) {
 }
 
 func TestValuesForBinaryLiteral(t *testing.T) {
-	t.Parallel()
-
 	// See issue #15310
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -4221,8 +4058,6 @@ func TestValuesForBinaryLiteral(t *testing.T) {
 }
 
 func TestIssue14159(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4235,8 +4070,6 @@ func TestIssue14159(t *testing.T) {
 }
 
 func TestIssue14146(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4249,8 +4082,6 @@ func TestIssue14146(t *testing.T) {
 }
 
 func TestIssue15346(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4261,8 +4092,6 @@ func TestIssue15346(t *testing.T) {
 }
 
 func TestOrderByFuncPlanCache(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4288,8 +4117,6 @@ func TestOrderByFuncPlanCache(t *testing.T) {
 }
 
 func TestSelectLimitPlanCache(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4325,8 +4152,6 @@ func TestSelectLimitPlanCache(t *testing.T) {
 }
 
 func TestCollation(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4393,8 +4218,6 @@ func TestCollation(t *testing.T) {
 }
 
 func TestCoercibility(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4436,8 +4259,6 @@ func TestCoercibility(t *testing.T) {
 }
 
 func TestIssue20071(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4455,8 +4276,6 @@ func TestIssue20071(t *testing.T) {
 }
 
 func TestVirtualGeneratedColumnAndLimit(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4470,8 +4289,6 @@ func TestVirtualGeneratedColumnAndLimit(t *testing.T) {
 }
 
 func TestIssue17791(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4490,8 +4307,6 @@ func TestIssue17791(t *testing.T) {
 }
 
 func TestIssue15986(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4526,8 +4341,6 @@ func TestIssue15986(t *testing.T) {
 }
 
 func TestNegativeZeroForHashJoin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4544,8 +4357,6 @@ func TestNegativeZeroForHashJoin(t *testing.T) {
 }
 
 func TestIssue1223(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4601,8 +4412,6 @@ func TestIssue1223(t *testing.T) {
 }
 
 func TestIssue15743(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4615,8 +4424,6 @@ func TestIssue15743(t *testing.T) {
 }
 
 func TestIssue15725(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4630,8 +4437,6 @@ func TestIssue15725(t *testing.T) {
 }
 
 func TestIssue15790(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4646,8 +4451,6 @@ func TestIssue15790(t *testing.T) {
 }
 
 func TestIssue15990(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4663,8 +4466,6 @@ func TestIssue15990(t *testing.T) {
 }
 
 func TestIssue15992(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4678,8 +4479,6 @@ func TestIssue15992(t *testing.T) {
 }
 
 func TestCTEWithDML(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4709,8 +4508,6 @@ func TestCTEWithDML(t *testing.T) {
 }
 
 func TestIssue16419(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4725,8 +4522,6 @@ func TestIssue16419(t *testing.T) {
 }
 
 func TestIssue16029(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4743,8 +4538,6 @@ func TestIssue16029(t *testing.T) {
 }
 
 func TestIssue16426(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4760,8 +4553,6 @@ func TestIssue16426(t *testing.T) {
 }
 
 func TestIssue16505(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4777,8 +4568,6 @@ func TestIssue16505(t *testing.T) {
 }
 
 func TestIssue20121(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4817,8 +4606,6 @@ func TestIssue20121(t *testing.T) {
 }
 
 func TestIssue16779(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4832,8 +4619,6 @@ func TestIssue16779(t *testing.T) {
 }
 
 func TestIssue16697(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4857,8 +4642,6 @@ func TestIssue16697(t *testing.T) {
 }
 
 func TestIssue17045(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4872,8 +4655,6 @@ func TestIssue17045(t *testing.T) {
 }
 
 func TestIssue17098(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4888,8 +4669,6 @@ func TestIssue17098(t *testing.T) {
 }
 
 func TestIssue17115(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4899,8 +4678,6 @@ func TestIssue17115(t *testing.T) {
 }
 
 func TestIndexedVirtualGeneratedColumnTruncate(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4935,8 +4712,6 @@ func TestIndexedVirtualGeneratedColumnTruncate(t *testing.T) {
 }
 
 func TestIssue17287(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4965,8 +4740,6 @@ func TestIssue17287(t *testing.T) {
 }
 
 func TestIssue26989(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4978,8 +4751,6 @@ func TestIssue26989(t *testing.T) {
 }
 
 func TestIssue17898(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -4993,8 +4764,6 @@ func TestIssue17898(t *testing.T) {
 }
 
 func TestIssue18515(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5006,8 +4775,6 @@ func TestIssue18515(t *testing.T) {
 }
 
 func TestIssue20223(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5028,8 +4795,6 @@ func TestIssue20223(t *testing.T) {
 }
 
 func TestIssue18525(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5045,8 +4810,6 @@ func TestIssue18525(t *testing.T) {
 }
 
 func TestSchemaDMLNotChange(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5064,8 +4827,6 @@ func TestSchemaDMLNotChange(t *testing.T) {
 }
 
 func TestIssue18850(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5087,8 +4848,6 @@ func TestIssue18850(t *testing.T) {
 }
 
 func TestIssue19504(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5107,8 +4866,6 @@ func TestIssue19504(t *testing.T) {
 }
 
 func TestIssue17767(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5127,8 +4884,6 @@ func TestIssue17767(t *testing.T) {
 }
 
 func TestIssue19596(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5143,8 +4898,6 @@ func TestIssue19596(t *testing.T) {
 }
 
 func TestIssue17476(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5171,8 +4924,6 @@ func TestIssue17476(t *testing.T) {
 }
 
 func TestIssue11645(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5190,8 +4941,6 @@ func TestIssue11645(t *testing.T) {
 }
 
 func TestIssue14349(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5207,8 +4956,6 @@ func TestIssue14349(t *testing.T) {
 }
 
 func TestIssue20180(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5231,8 +4978,6 @@ func TestIssue20180(t *testing.T) {
 }
 
 func TestIssue11755(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5245,8 +4990,6 @@ func TestIssue11755(t *testing.T) {
 }
 
 func TestIssue20369(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5260,8 +5003,6 @@ func TestIssue20369(t *testing.T) {
 }
 
 func TestIssue20730(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5275,8 +5016,6 @@ func TestIssue20730(t *testing.T) {
 }
 
 func TestIssue20860(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5289,8 +5028,6 @@ func TestIssue20860(t *testing.T) {
 }
 
 func TestIssue15847(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5303,8 +5040,6 @@ func TestIssue15847(t *testing.T) {
 }
 
 func TestIssue10462(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5345,8 +5080,6 @@ func TestIssue10462(t *testing.T) {
 }
 
 func TestIssue17868(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5360,8 +5093,6 @@ func TestIssue17868(t *testing.T) {
 }
 
 func TestIssue21619(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5375,8 +5106,6 @@ func TestIssue21619(t *testing.T) {
 }
 
 func TestIssue10467(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5405,8 +5134,6 @@ func TestIssue10467(t *testing.T) {
 }
 
 func TestIssue19892(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5648,8 +5375,6 @@ func TestIssue19892(t *testing.T) {
 
 // The actual results do not agree with the test results, It should be modified after the test suite is updated
 func TestIssue17726(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5664,8 +5389,6 @@ func TestIssue17726(t *testing.T) {
 }
 
 func TestDatetimeUserVariable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5678,8 +5401,6 @@ func TestDatetimeUserVariable(t *testing.T) {
 }
 
 func TestIssue12205(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5696,8 +5417,6 @@ func TestIssue12205(t *testing.T) {
 }
 
 func TestIssue21677(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5719,8 +5438,6 @@ func TestIssue21677(t *testing.T) {
 }
 
 func TestIssue11333(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5740,8 +5457,6 @@ func TestIssue11333(t *testing.T) {
 }
 
 func TestIssue12206(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5756,8 +5471,6 @@ func TestIssue12206(t *testing.T) {
 }
 
 func TestCastCoer(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5769,8 +5482,6 @@ func TestCastCoer(t *testing.T) {
 }
 
 func TestIssue12209(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5785,8 +5496,6 @@ func TestIssue12209(t *testing.T) {
 }
 
 func TestIssue22098(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5815,8 +5524,6 @@ func TestIssue22098(t *testing.T) {
 }
 
 func Test22717(t *testing.T) {
-	t.Parallel()
-
 	// For issue 22717
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -5841,8 +5548,6 @@ func Test22717(t *testing.T) {
 }
 
 func Test23262(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5856,8 +5561,6 @@ func Test23262(t *testing.T) {
 }
 
 func TestClusteredIndexCorCol(t *testing.T) {
-	t.Parallel()
-
 	// For issue 23076
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -5873,8 +5576,6 @@ func TestClusteredIndexCorCol(t *testing.T) {
 }
 
 func TestEnumPushDown(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -5979,8 +5680,6 @@ func TestEnumPushDown(t *testing.T) {
 }
 
 func TestJiraSetInnoDBDefaultRowFormat(t *testing.T) {
-	t.Parallel()
-
 	// For issue #23541
 	// JIRA needs to be able to set this to be happy.
 	// See: https://nova.moe/run-jira-on-tidb/
@@ -5998,8 +5697,6 @@ func TestJiraSetInnoDBDefaultRowFormat(t *testing.T) {
 }
 
 func TestIssue23623(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6012,8 +5709,6 @@ func TestIssue23623(t *testing.T) {
 }
 
 func TestApproximatePercentile(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6026,8 +5721,6 @@ func TestApproximatePercentile(t *testing.T) {
 }
 
 func TestIssue24429(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6042,8 +5735,6 @@ func TestIssue24429(t *testing.T) {
 }
 
 func TestVitessHash(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6075,8 +5766,6 @@ func TestVitessHash(t *testing.T) {
 }
 
 func TestVitessHashMatchesVitessShards(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6122,8 +5811,6 @@ func TestVitessHashMatchesVitessShards(t *testing.T) {
 }
 
 func TestSecurityEnhancedMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6138,8 +5825,6 @@ func TestSecurityEnhancedMode(t *testing.T) {
 }
 
 func TestIssue23925(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6158,8 +5843,6 @@ func TestIssue23925(t *testing.T) {
 }
 
 func TestCTEInvalidUsage(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6204,8 +5887,6 @@ func TestCTEInvalidUsage(t *testing.T) {
 }
 
 func TestIssue23889(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6222,8 +5903,6 @@ func TestIssue23889(t *testing.T) {
 }
 
 func TestRefineArgNullValues(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6240,8 +5919,6 @@ func TestRefineArgNullValues(t *testing.T) {
 }
 
 func TestEnumIndex(t *testing.T) {
-	t.Parallel()
-
 	elems := []string{"\"a\"", "\"b\"", "\"c\""}
 	rand.Shuffle(len(elems), func(i, j int) {
 		elems[i], elems[j] = elems[j], elems[i]
@@ -6338,8 +6015,6 @@ func TestEnumIndex(t *testing.T) {
 // Previously global values were cached. This is incorrect.
 // See: https://github.com/pingcap/tidb/issues/24368
 func TestGlobalCacheCorrectness(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6352,8 +6027,6 @@ func TestGlobalCacheCorrectness(t *testing.T) {
 }
 
 func TestRedundantColumnResolve(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6386,8 +6059,6 @@ func TestRedundantColumnResolve(t *testing.T) {
 }
 
 func TestControlFunctionWithEnumOrSet(t *testing.T) {
-	t.Parallel()
-
 	// issue 23114
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -6488,8 +6159,6 @@ func TestControlFunctionWithEnumOrSet(t *testing.T) {
 }
 
 func TestComplexShowVariables(t *testing.T) {
-	t.Parallel()
-
 	// This is an example SHOW VARIABLES from mysql-connector-java-5.1.34
 	// It returns 19 rows in MySQL 5.7 (the language sysvar no longer exists in 5.6+)
 	// and 16 rows in MySQL 8.0 (the aliases for tx_isolation is removed, along with query cache)
@@ -6510,8 +6179,6 @@ OR Variable_name = 'license' OR Variable_name = 'init_connect'`).Rows(), 19)
 }
 
 func TestBuiltinFuncJSONMergePatch_InColumn(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -6583,8 +6250,6 @@ func TestBuiltinFuncJSONMergePatch_InColumn(t *testing.T) {
 }
 
 func TestBuiltinFuncJSONMergePatch_InExpression(t *testing.T) {
-	t.Parallel()
-
 	ctx := context.Background()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -6706,8 +6371,6 @@ func TestBuiltinFuncJSONMergePatch_InExpression(t *testing.T) {
 }
 
 func TestFloat64Inf(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6719,8 +6382,6 @@ func TestFloat64Inf(t *testing.T) {
 }
 
 func TestCharsetErr(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6735,8 +6396,6 @@ func TestCharsetErr(t *testing.T) {
 }
 
 func TestIssue25591(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6759,8 +6418,6 @@ func TestIssue25591(t *testing.T) {
 }
 
 func TestIssue25526(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6777,8 +6434,6 @@ func TestIssue25526(t *testing.T) {
 }
 
 func TestTimestampIssue25093(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6796,8 +6451,6 @@ func TestTimestampIssue25093(t *testing.T) {
 }
 
 func TestIssue24953(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6812,8 +6465,6 @@ func TestIssue24953(t *testing.T) {
 
 // issue https://github.com/pingcap/tidb/issues/26111
 func TestRailsFKUsage(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6850,8 +6501,6 @@ func TestRailsFKUsage(t *testing.T) {
 }
 
 func TestTranslate(t *testing.T) {
-	t.Parallel()
-
 	cases := []string{"'ABC'", "'AABC'", "'A.B.C'", "'aaaaabbbbb'", "'abc'", "'aaa'", "NULL"}
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
@@ -6889,8 +6538,6 @@ func TestTranslate(t *testing.T) {
 }
 
 func TestIssue26958(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6907,8 +6554,6 @@ func TestIssue26958(t *testing.T) {
 }
 
 func TestConstPropNullFunctions(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6930,8 +6575,6 @@ func TestConstPropNullFunctions(t *testing.T) {
 }
 
 func TestIssue27233(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6945,8 +6588,6 @@ func TestIssue27233(t *testing.T) {
 }
 
 func TestIssue27236(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6963,8 +6604,6 @@ func TestIssue27236(t *testing.T) {
 }
 
 func TestIssue26977(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6974,8 +6613,6 @@ func TestIssue26977(t *testing.T) {
 }
 
 func TestIssue27610(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -6989,8 +6626,6 @@ func TestIssue27610(t *testing.T) {
 }
 
 func TestLastInsertId(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7008,8 +6643,6 @@ func TestLastInsertId(t *testing.T) {
 }
 
 func TestTimestamp(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7060,8 +6693,6 @@ func TestTimestamp(t *testing.T) {
 }
 
 func TestIdentity(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7079,8 +6710,6 @@ func TestIdentity(t *testing.T) {
 }
 
 func TestIssue28804(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7107,8 +6736,6 @@ PARTITION p20210909 VALUES LESS THAN (1631203200)
 }
 
 func TestIssue28643(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7125,8 +6752,6 @@ func TestIssue28643(t *testing.T) {
 }
 
 func TestIssue27831(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7144,8 +6769,6 @@ func TestIssue27831(t *testing.T) {
 }
 
 func TestIssue29434(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7167,8 +6790,6 @@ func TestIssue29434(t *testing.T) {
 }
 
 func TestIssue29417(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7181,8 +6802,6 @@ func TestIssue29417(t *testing.T) {
 }
 
 func TestIssue29244(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7199,8 +6818,6 @@ func TestIssue29244(t *testing.T) {
 }
 
 func TestIssue29513(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7217,8 +6834,6 @@ func TestIssue29513(t *testing.T) {
 }
 
 func TestIssue29755(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7234,8 +6849,6 @@ func TestIssue29755(t *testing.T) {
 }
 
 func TestIssue30101(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7248,8 +6861,6 @@ func TestIssue30101(t *testing.T) {
 }
 
 func TestIssue28739(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -7272,8 +6883,6 @@ func TestIssue28739(t *testing.T) {
 }
 
 func TestIssue30326(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/expression/scalar_function_test.go
+++ b/expression/scalar_function_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestScalarFunction(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	a := &Column{
 		UniqueID: 1,
@@ -57,8 +55,6 @@ func TestScalarFunction(t *testing.T) {
 }
 
 func TestIssue23309(t *testing.T) {
-	t.Parallel()
-
 	a := &Column{
 		UniqueID: 1,
 		RetType:  types.NewFieldType(mysql.TypeDouble),
@@ -74,8 +70,6 @@ func TestIssue23309(t *testing.T) {
 }
 
 func TestScalarFuncs2Exprs(t *testing.T) {
-	t.Parallel()
-
 	ctx := mock.NewContext()
 	a := &Column{
 		UniqueID: 1,

--- a/expression/schema_test.go
+++ b/expression/schema_test.go
@@ -48,7 +48,6 @@ func (s *schemaGenerator) generateSchema(colCount int) *Schema {
 }
 
 func TestSchemaString(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	require.Equal(t, "Column: [Column#1,Column#2,Column#3,Column#4,Column#5] Unique key: []", schema.String())
@@ -57,7 +56,6 @@ func TestSchemaString(t *testing.T) {
 }
 
 func TestSchemaRetrieveColumn(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	colOutSchema := &Column{
@@ -70,7 +68,6 @@ func TestSchemaRetrieveColumn(t *testing.T) {
 }
 
 func TestSchemaIsUniqueKey(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	generateKeys4Schema(schema)
@@ -88,7 +85,6 @@ func TestSchemaIsUniqueKey(t *testing.T) {
 }
 
 func TestSchemaContains(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	colOutSchema := &Column{
@@ -101,7 +97,6 @@ func TestSchemaContains(t *testing.T) {
 }
 
 func TestSchemaColumnsIndices(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	colOutSchema := &Column{
@@ -117,7 +112,6 @@ func TestSchemaColumnsIndices(t *testing.T) {
 }
 
 func TestSchemaColumnsByIndices(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	indices := []int{0, 1, 2, 3}
@@ -128,7 +122,6 @@ func TestSchemaColumnsByIndices(t *testing.T) {
 }
 
 func TestSchemaMergeSchema(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	lSchema := s.generateSchema(5)
 	generateKeys4Schema(lSchema)
@@ -150,7 +143,6 @@ func TestSchemaMergeSchema(t *testing.T) {
 }
 
 func TestGetUsedList(t *testing.T) {
-	t.Parallel()
 	s := &schemaGenerator{}
 	schema := s.generateSchema(5)
 	var usedCols []*Column

--- a/expression/typeinfer_test.go
+++ b/expression/typeinfer_test.go
@@ -34,8 +34,6 @@ import (
 )
 
 func TestInferType(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/expression/util_test.go
+++ b/expression/util_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func TestBaseBuiltin(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	bf, err := newBaseBuiltinFuncWithTp(ctx, "", nil, types.ETTimestamp)
 	require.NoError(t, err)
@@ -54,7 +53,6 @@ func TestBaseBuiltin(t *testing.T) {
 }
 
 func TestClone(t *testing.T) {
-	t.Parallel()
 	builtinFuncs := []builtinFunc{
 		&builtinArithmeticPlusRealSig{}, &builtinArithmeticPlusDecimalSig{}, &builtinArithmeticPlusIntSig{}, &builtinArithmeticMinusRealSig{}, &builtinArithmeticMinusDecimalSig{},
 		&builtinArithmeticMinusIntSig{}, &builtinArithmeticDivideRealSig{}, &builtinArithmeticDivideDecimalSig{}, &builtinArithmeticMultiplyRealSig{}, &builtinArithmeticMultiplyDecimalSig{},
@@ -161,7 +159,6 @@ func TestClone(t *testing.T) {
 }
 
 func TestGetUint64FromConstant(t *testing.T) {
-	t.Parallel()
 	con := &Constant{
 		Value: types.NewDatum(nil),
 	}
@@ -199,7 +196,6 @@ func TestGetUint64FromConstant(t *testing.T) {
 }
 
 func TestSetExprColumnInOperand(t *testing.T) {
-	t.Parallel()
 	col := &Column{RetType: newIntFieldType()}
 	require.True(t, setExprColumnInOperand(col).(*Column).InOperand)
 
@@ -211,7 +207,6 @@ func TestSetExprColumnInOperand(t *testing.T) {
 }
 
 func TestPopRowFirstArg(t *testing.T) {
-	t.Parallel()
 	c1, c2, c3 := &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}, &Column{RetType: newIntFieldType()}
 	f, err := funcs[ast.RowFunc].getFunction(mock.NewContext(), []Expression{c1, c2, c3})
 	require.NoError(t, err)
@@ -222,7 +217,6 @@ func TestPopRowFirstArg(t *testing.T) {
 }
 
 func TestGetStrIntFromConstant(t *testing.T) {
-	t.Parallel()
 	col := &Column{}
 	_, _, err := GetStringFromConstant(mock.NewContext(), col)
 	require.Error(t, err)
@@ -250,7 +244,6 @@ func TestGetStrIntFromConstant(t *testing.T) {
 }
 
 func TestSubstituteCorCol2Constant(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	corCol1 := &CorrelatedColumn{Data: &NewOne().Value}
 	corCol1.RetType = types.NewFieldType(mysql.TypeLonglong)
@@ -276,7 +269,6 @@ func TestSubstituteCorCol2Constant(t *testing.T) {
 }
 
 func TestPushDownNot(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	col := &Column{Index: 1, RetType: types.NewFieldType(mysql.TypeLonglong)}
 	// !((a=1||a=1)&&a=1)
@@ -322,7 +314,6 @@ func TestPushDownNot(t *testing.T) {
 }
 
 func TestFilter(t *testing.T) {
-	t.Parallel()
 	conditions := []Expression{
 		newFunction(ast.EQ, newColumn(0), newColumn(1)),
 		newFunction(ast.EQ, newColumn(1), newColumn(2)),
@@ -334,7 +325,6 @@ func TestFilter(t *testing.T) {
 }
 
 func TestFilterOutInPlace(t *testing.T) {
-	t.Parallel()
 	conditions := []Expression{
 		newFunction(ast.EQ, newColumn(0), newColumn(1)),
 		newFunction(ast.EQ, newColumn(1), newColumn(2)),
@@ -349,7 +339,6 @@ func TestFilterOutInPlace(t *testing.T) {
 }
 
 func TestHashGroupKey(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	eTypes := []types.EvalType{types.ETInt, types.ETReal, types.ETDecimal, types.ETString, types.ETTimestamp, types.ETDatetime, types.ETDuration}
@@ -392,7 +381,6 @@ func isLogicOrFunction(e Expression) bool {
 }
 
 func TestDisableParseJSONFlag4Expr(t *testing.T) {
-	t.Parallel()
 	var expr Expression
 	expr = &Column{RetType: newIntFieldType()}
 	ft := expr.GetType()
@@ -413,7 +401,6 @@ func TestDisableParseJSONFlag4Expr(t *testing.T) {
 }
 
 func TestSQLDigestTextRetriever(t *testing.T) {
-	t.Parallel()
 	// Create a fake session as the argument to the retriever, though it's actually not used when mock data is set.
 
 	r := NewSQLDigestTextRetriever()

--- a/infoschema/cache_test.go
+++ b/infoschema/cache_test.go
@@ -22,15 +22,11 @@ import (
 )
 
 func TestNewCache(t *testing.T) {
-	t.Parallel()
-
 	ic := infoschema.NewCache(16)
 	require.NotNil(t, ic)
 }
 
 func TestInsert(t *testing.T) {
-	t.Parallel()
-
 	ic := infoschema.NewCache(3)
 	require.NotNil(t, ic)
 
@@ -101,8 +97,6 @@ func TestInsert(t *testing.T) {
 }
 
 func TestGetByVersion(t *testing.T) {
-	t.Parallel()
-
 	ic := infoschema.NewCache(2)
 	require.NotNil(t, ic)
 	is1 := infoschema.MockInfoSchemaWithSchemaVer(nil, 1)
@@ -118,8 +112,6 @@ func TestGetByVersion(t *testing.T) {
 }
 
 func TestGetLatest(t *testing.T) {
-	t.Parallel()
-
 	ic := infoschema.NewCache(16)
 	require.NotNil(t, ic)
 	require.Nil(t, ic.GetLatest())

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -38,8 +38,6 @@ import (
 )
 
 func TestBasic(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -212,8 +210,6 @@ func TestBasic(t *testing.T) {
 }
 
 func TestMockInfoSchema(t *testing.T) {
-	t.Parallel()
-
 	tblID := int64(1234)
 	tblName := model.NewCIStr("tbl_m")
 	tableInfo := &model.TableInfo{
@@ -250,8 +246,6 @@ func checkApplyCreateNonExistsTableDoesNotPanic(t *testing.T, txn kv.Transaction
 
 // TestInfoTables makes sure that all tables of information_schema could be found in infoschema handle.
 func TestInfoTables(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -317,8 +311,6 @@ func genGlobalID(store kv.Storage) (int64, error) {
 }
 
 func TestGetBundle(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -394,8 +386,6 @@ func TestGetBundle(t *testing.T) {
 }
 
 func TestLocalTemporaryTables(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {

--- a/infoschema/metrics_schema_test.go
+++ b/infoschema/metrics_schema_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestMetricSchemaDef(t *testing.T) {
-	t.Parallel()
-
 	for name, def := range infoschema.MetricTableMap {
 		if strings.Contains(def.PromQL, "$QUANTILE") || strings.Contains(def.PromQL, "histogram_quantile") {
 			require.Greaterf(t, def.Quantile, float64(0), "the quantile of metric table %v should > 0", name)

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -28,14 +28,11 @@ import (
 )
 
 func TestPredefinedTables(t *testing.T) {
-	t.Parallel()
 	require.True(t, perfschema.IsPredefinedTable("EVENTS_statements_summary_by_digest"))
 	require.False(t, perfschema.IsPredefinedTable("statements"))
 }
 
 func TestPerfSchemaTables(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/kv/checker_test.go
+++ b/kv/checker_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestIsRequestTypeSupported(t *testing.T) {
-	t.Parallel()
-
 	checker := kv.RequestTypeSupportedChecker{}.IsRequestTypeSupported
 	assert.True(t, checker(kv.ReqTypeSelect, kv.ReqSubTypeGroupBy))
 	assert.True(t, checker(kv.ReqTypeDAG, kv.ReqSubTypeSignature))

--- a/kv/error_test.go
+++ b/kv/error_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestError(t *testing.T) {
-	t.Parallel()
-
 	kvErrs := []*terror.Error{
 		ErrNotExist,
 		ErrTxnRetryable,

--- a/kv/fault_injection_test.go
+++ b/kv/fault_injection_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestFaultInjectionBasic(t *testing.T) {
-	t.Parallel()
-
 	var cfg InjectionConfig
 	err1 := errors.New("foo")
 	cfg.SetGetError(err1)

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -30,8 +30,6 @@ import (
 )
 
 func TestPartialNext(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	// keyA represents a multi column index.
 	keyA, err := codec.EncodeValue(sc, nil, types.NewDatum("abc"), types.NewDatum("def"))
@@ -57,8 +55,6 @@ func TestPartialNext(t *testing.T) {
 }
 
 func TestIsPoint(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		start   []byte
 		end     []byte
@@ -111,16 +107,12 @@ func TestIsPoint(t *testing.T) {
 }
 
 func TestBasicFunc(t *testing.T) {
-	t.Parallel()
-
 	assert.False(t, IsTxnRetryableError(nil))
 	assert.True(t, IsTxnRetryableError(ErrTxnRetryable))
 	assert.False(t, IsTxnRetryableError(errors.New("test")))
 }
 
 func TestHandle(t *testing.T) {
-	t.Parallel()
-
 	ih := IntHandle(100)
 	assert.True(t, ih.IsInt())
 
@@ -153,8 +145,6 @@ func TestHandle(t *testing.T) {
 }
 
 func TestPaddingHandle(t *testing.T) {
-	t.Parallel()
-
 	dec := types.NewDecFromInt(1)
 	encoded, err := codec.EncodeKey(new(stmtctx.StatementContext), nil, types.NewDecimalDatum(dec))
 	assert.Nil(t, err)
@@ -171,8 +161,6 @@ func TestPaddingHandle(t *testing.T) {
 }
 
 func TestHandleMap(t *testing.T) {
-	t.Parallel()
-
 	m := NewHandleMap()
 	h := IntHandle(1)
 

--- a/kv/mock_test.go
+++ b/kv/mock_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestInterface(t *testing.T) {
-	t.Parallel()
-
 	storage := newMockStorage()
 	storage.GetClient()
 	storage.UUID()

--- a/kv/txn_test.go
+++ b/kv/txn_test.go
@@ -35,8 +35,6 @@ func mustBackOff(t *testing.T, cnt uint, sleep int) {
 }
 
 func TestRetryExceedCountError(t *testing.T) {
-	t.Parallel()
-
 	defer func(cnt uint) {
 		maxRetryCnt = cnt
 	}(maxRetryCnt)

--- a/kv/utils_test.go
+++ b/kv/utils_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestIncInt64(t *testing.T) {
-	t.Parallel()
-
 	mb := newMockMap()
 	key := Key("key")
 	v, err := IncInt64(mb, key, 1)
@@ -53,8 +51,6 @@ func TestIncInt64(t *testing.T) {
 }
 
 func TestGetInt64(t *testing.T) {
-	t.Parallel()
-
 	mb := newMockMap()
 	key := Key("key")
 	v, err := GetInt64(context.TODO(), mb, key)

--- a/kv/version_test.go
+++ b/kv/version_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestVersion(t *testing.T) {
-	t.Parallel()
-
 	le := NewVersion(42).Cmp(NewVersion(43))
 	gt := NewVersion(42).Cmp(NewVersion(41))
 	eq := NewVersion(42).Cmp(NewVersion(42))

--- a/meta/autoid/autoid_test.go
+++ b/meta/autoid/autoid_test.go
@@ -529,7 +529,6 @@ func TestRollbackAlloc(t *testing.T) {
 
 // TestNextStep tests generate next auto id step.
 func TestNextStep(t *testing.T) {
-	t.Parallel()
 	nextStep := autoid.NextStep(2000000, 1*time.Nanosecond)
 	require.Equal(t, int64(2000000), nextStep)
 	nextStep = autoid.NextStep(678910, 10*time.Second)

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestPlacementPolicy(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 
@@ -105,8 +103,6 @@ func TestPlacementPolicy(t *testing.T) {
 }
 
 func TestBackupAndRestoreAutoIDs(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -154,8 +150,6 @@ func TestBackupAndRestoreAutoIDs(t *testing.T) {
 }
 
 func TestMeta(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 
@@ -389,7 +383,6 @@ func TestMeta(t *testing.T) {
 }
 
 func TestSnapshot(t *testing.T) {
-	t.Parallel()
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -427,7 +420,6 @@ func TestSnapshot(t *testing.T) {
 }
 
 func TestElement(t *testing.T) {
-	t.Parallel()
 	checkElement := func(key []byte, resErr error) {
 		e := &meta.Element{ID: 123, TypeKey: key}
 		eBytes := e.EncodeElement()
@@ -453,8 +445,6 @@ func TestElement(t *testing.T) {
 }
 
 func TestDDL(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		desc        string
 		startHandle kv.Handle
@@ -476,7 +466,6 @@ func TestDDL(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		tc := tc
 		t.Run(tc.desc, func(t *testing.T) {
-			t.Parallel()
 			store, err := mockstore.NewMockStore()
 			require.NoError(t, err)
 			defer func() {
@@ -619,8 +608,6 @@ func TestDDL(t *testing.T) {
 }
 
 func TestAddIndexJob(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {

--- a/parser/ast/ddl_test.go
+++ b/parser/ast/ddl_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestDDLVisitorCover(t *testing.T) {
-	t.Parallel()
 	ce := &checkExpr{}
 	constraint := &Constraint{Keys: []*IndexPartSpecification{{Column: &ColumnName{}}, {Column: &ColumnName{}}}, Refer: &ReferenceDef{}, Option: &IndexOption{}}
 
@@ -68,7 +67,6 @@ func TestDDLVisitorCover(t *testing.T) {
 }
 
 func TestDDLIndexColNameRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"(a + 1)", "(`a`+1)"},
 		{"(1 * 1 + (1 + 1))", "(1*1+(1+1))"},
@@ -81,7 +79,6 @@ func TestDDLIndexColNameRestore(t *testing.T) {
 }
 
 func TestDDLIndexExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"world", "`world`"},
 		{"world(2)", "`world`(2)"},
@@ -93,7 +90,6 @@ func TestDDLIndexExprRestore(t *testing.T) {
 }
 
 func TestDDLOnDeleteRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"on delete restrict", "ON DELETE RESTRICT"},
 		{"on delete CASCADE", "ON DELETE CASCADE"},
@@ -109,7 +105,6 @@ func TestDDLOnDeleteRestore(t *testing.T) {
 }
 
 func TestDDLOnUpdateRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ON UPDATE RESTRICT", "ON UPDATE RESTRICT"},
 		{"on update CASCADE", "ON UPDATE CASCADE"},
@@ -125,7 +120,6 @@ func TestDDLOnUpdateRestore(t *testing.T) {
 }
 
 func TestDDLIndexOption(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"key_block_size=16", "KEY_BLOCK_SIZE=16"},
 		{"USING HASH", "USING HASH"},
@@ -144,7 +138,6 @@ func TestDDLIndexOption(t *testing.T) {
 }
 
 func TestTableToTableRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"t1 to t2", "`t1` TO `t2`"},
 	}
@@ -155,7 +148,6 @@ func TestTableToTableRestore(t *testing.T) {
 }
 
 func TestDDLReferenceDefRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"REFERENCES parent(id) ON DELETE CASCADE ON UPDATE RESTRICT", "REFERENCES `parent`(`id`) ON DELETE CASCADE ON UPDATE RESTRICT"},
 		{"REFERENCES parent(id) ON DELETE CASCADE", "REFERENCES `parent`(`id`) ON DELETE CASCADE"},
@@ -172,7 +164,6 @@ func TestDDLReferenceDefRestore(t *testing.T) {
 }
 
 func TestDDLConstraintRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"INDEX par_ind (parent_id)", "INDEX `par_ind`(`parent_id`)"},
 		{"INDEX par_ind (parent_id(6))", "INDEX `par_ind`(`parent_id`(6))"},
@@ -225,7 +216,6 @@ func TestDDLConstraintRestore(t *testing.T) {
 }
 
 func TestDDLColumnOptionRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"primary key", "PRIMARY KEY"},
 		{"not null", "NOT NULL"},
@@ -260,7 +250,6 @@ func TestDDLColumnOptionRestore(t *testing.T) {
 }
 
 func TestDDLColumnDefRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		// for type
 		{"id json", "`id` JSON"},
@@ -385,7 +374,6 @@ func TestDDLColumnDefRestore(t *testing.T) {
 }
 
 func TestDDLTruncateTableStmtRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"truncate t1", "TRUNCATE TABLE `t1`"},
 		{"truncate table t1", "TRUNCATE TABLE `t1`"},
@@ -398,7 +386,6 @@ func TestDDLTruncateTableStmtRestore(t *testing.T) {
 }
 
 func TestDDLDropTableStmtRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"drop table t1", "DROP TABLE `t1`"},
 		{"drop table if exists t1", "DROP TABLE IF EXISTS `t1`"},
@@ -413,7 +400,6 @@ func TestDDLDropTableStmtRestore(t *testing.T) {
 }
 
 func TestColumnPositionRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"", ""},
 		{"first", "FIRST"},
@@ -426,7 +412,6 @@ func TestColumnPositionRestore(t *testing.T) {
 }
 
 func TestAlterTableSpecRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ENGINE innodb", "ENGINE = innodb"},
 		{"ENGINE = innodb", "ENGINE = innodb"},
@@ -556,7 +541,6 @@ func TestAlterTableSpecRestore(t *testing.T) {
 }
 
 func TestAlterTableOptionRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ALTER TABLE t ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 8", "ALTER TABLE `t` ROW_FORMAT = COMPRESSED KEY_BLOCK_SIZE = 8"},
 		{"ALTER TABLE t ROW_FORMAT = COMPRESSED, KEY_BLOCK_SIZE = 8", "ALTER TABLE `t` ROW_FORMAT = COMPRESSED, KEY_BLOCK_SIZE = 8"},
@@ -568,7 +552,6 @@ func TestAlterTableOptionRestore(t *testing.T) {
 }
 
 func TestAdminRepairTableRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ADMIN REPAIR TABLE t CREATE TABLE t (a int)", "ADMIN REPAIR TABLE `t` CREATE TABLE `t` (`a` INT)"},
 		{"ADMIN REPAIR TABLE t CREATE TABLE t (a char(1), b int)", "ADMIN REPAIR TABLE `t` CREATE TABLE `t` (`a` CHAR(1),`b` INT)"},
@@ -581,7 +564,6 @@ func TestAdminRepairTableRestore(t *testing.T) {
 }
 
 func TestSequenceRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"create sequence seq", "CREATE SEQUENCE `seq`"},
 		{"create sequence if not exists seq", "CREATE SEQUENCE IF NOT EXISTS `seq`"},
@@ -626,7 +608,6 @@ func TestSequenceRestore(t *testing.T) {
 }
 
 func TestDropIndexRestore(t *testing.T) {
-	t.Parallel()
 	sourceSQL := "drop index if exists idx on t"
 	cases := []struct {
 		flags     format.RestoreFlags

--- a/parser/ast/dml_test.go
+++ b/parser/ast/dml_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestDMLVisitorCover(t *testing.T) {
-	t.Parallel()
 	ce := &checkExpr{}
 
 	tableRefsClause := &TableRefsClause{TableRefs: &Join{Left: &TableSource{Source: &TableName{}}, On: &OnCondition{Expr: ce}}}
@@ -72,7 +71,6 @@ func TestDMLVisitorCover(t *testing.T) {
 }
 
 func TestTableNameRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"dbb.`tbb1`", "`dbb`.`tbb1`"},
 		{"`tbb2`", "`tbb2`"},
@@ -88,7 +86,6 @@ func TestTableNameRestore(t *testing.T) {
 }
 
 func TestTableNameIndexHintsRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"t use index (hello)", "`t` USE INDEX (`hello`)"},
 		{"t use index (hello, world)", "`t` USE INDEX (`hello`, `world`)"},
@@ -131,7 +128,6 @@ func TestTableNameIndexHintsRestore(t *testing.T) {
 }
 
 func TestLimitRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"limit 10", "LIMIT 10"},
 		{"limit 10,20", "LIMIT 10,20"},
@@ -144,7 +140,6 @@ func TestLimitRestore(t *testing.T) {
 }
 
 func TestWildCardFieldRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"*", "*"},
 		{"t.*", "`t`.*"},
@@ -157,7 +152,6 @@ func TestWildCardFieldRestore(t *testing.T) {
 }
 
 func TestSelectFieldRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"*", "*"},
 		{"t.*", "`t`.*"},
@@ -172,7 +166,6 @@ func TestSelectFieldRestore(t *testing.T) {
 }
 
 func TestFieldListRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"*", "*"},
 		{"t.*", "`t`.*"},
@@ -187,7 +180,6 @@ func TestFieldListRestore(t *testing.T) {
 }
 
 func TestTableSourceRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"tbl", "`tbl`"},
 		{"tbl as t", "`tbl` AS `t`"},
@@ -201,7 +193,6 @@ func TestTableSourceRestore(t *testing.T) {
 }
 
 func TestOnConditionRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"on t1.a=t2.a", "ON `t1`.`a`=`t2`.`a`"},
 		{"on t1.a=t2.a and t1.b=t2.b", "ON `t1`.`a`=`t2`.`a` AND `t1`.`b`=`t2`.`b`"},
@@ -213,7 +204,6 @@ func TestOnConditionRestore(t *testing.T) {
 }
 
 func TestJoinRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"t1 natural join t2", "`t1` NATURAL JOIN `t2`"},
 		{"t1 natural left join t2", "`t1` NATURAL LEFT JOIN `t2`"},
@@ -252,7 +242,6 @@ func TestJoinRestore(t *testing.T) {
 }
 
 func TestTableRefsClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"t", "`t`"},
 		{"t1 join t2", "`t1` JOIN `t2`"},
@@ -265,7 +254,6 @@ func TestTableRefsClauseRestore(t *testing.T) {
 }
 
 func TestDeleteTableListRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"t1,t2", "`t1`,`t2`"},
 	}
@@ -277,7 +265,6 @@ func TestDeleteTableListRestore(t *testing.T) {
 }
 
 func TestDeleteTableIndexHintRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"DELETE FROM t1 USE key (`fld1`) WHERE fld=1",
 			"DELETE FROM `t1` USE INDEX (`fld1`) WHERE `fld`=1"},
@@ -292,7 +279,6 @@ func TestDeleteTableIndexHintRestore(t *testing.T) {
 }
 
 func TestByItemRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a", "`a`"},
 		{"a desc", "`a` DESC"},
@@ -305,7 +291,6 @@ func TestByItemRestore(t *testing.T) {
 }
 
 func TestGroupByClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"GROUP BY a,b desc", "GROUP BY `a`,`b` DESC"},
 		{"GROUP BY 1 desc,b", "GROUP BY 1 DESC,`b`"},
@@ -317,7 +302,6 @@ func TestGroupByClauseRestore(t *testing.T) {
 }
 
 func TestOrderByClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ORDER BY a", "ORDER BY `a`"},
 		{"ORDER BY a,b", "ORDER BY `a`,`b`"},
@@ -334,7 +318,6 @@ func TestOrderByClauseRestore(t *testing.T) {
 }
 
 func TestAssignmentRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a=1", "`a`=1"},
 		{"b=1+2", "`b`=1+2"},
@@ -346,7 +329,6 @@ func TestAssignmentRestore(t *testing.T) {
 }
 
 func TestHavingClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"HAVING a", "HAVING `a`"},
 		{"HAVING NULL", "HAVING NULL"},
@@ -359,7 +341,6 @@ func TestHavingClauseRestore(t *testing.T) {
 }
 
 func TestFrameBoundRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"CURRENT ROW", "CURRENT ROW"},
 		{"UNBOUNDED PRECEDING", "UNBOUNDED PRECEDING"},
@@ -378,7 +359,6 @@ func TestFrameBoundRestore(t *testing.T) {
 }
 
 func TestFrameClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"ROWS CURRENT ROW", "ROWS BETWEEN CURRENT ROW AND CURRENT ROW"},
 		{"ROWS UNBOUNDED PRECEDING", "ROWS BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW"},
@@ -393,7 +373,6 @@ func TestFrameClauseRestore(t *testing.T) {
 }
 
 func TestPartitionByClauseRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"PARTITION BY a", "PARTITION BY `a`"},
 		{"PARTITION BY NULL", "PARTITION BY NULL"},
@@ -406,7 +385,6 @@ func TestPartitionByClauseRestore(t *testing.T) {
 }
 
 func TestWindowSpecRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"w as ()", "`w` AS ()"},
 		{"w as (w1)", "`w` AS (`w1`)"},
@@ -432,7 +410,6 @@ func TestWindowSpecRestore(t *testing.T) {
 }
 
 func TestFulltextSearchModifier(t *testing.T) {
-	t.Parallel()
 	require.False(t, FulltextSearchModifier(FulltextSearchModifierNaturalLanguageMode).IsBooleanMode())
 	require.True(t, FulltextSearchModifier(FulltextSearchModifierNaturalLanguageMode).IsNaturalLanguageMode())
 	require.False(t, FulltextSearchModifier(FulltextSearchModifierNaturalLanguageMode).WithQueryExpansion())

--- a/parser/ast/expressions_test.go
+++ b/parser/ast/expressions_test.go
@@ -61,7 +61,6 @@ func (n *checkExpr) reset() {
 }
 
 func TestExpresionsVisitorCover(t *testing.T) {
-	t.Parallel()
 	ce := &checkExpr{}
 	stmts :=
 		[]struct {
@@ -102,7 +101,6 @@ func TestExpresionsVisitorCover(t *testing.T) {
 }
 
 func TestUnaryOperationExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"++1", "++1"},
 		{"--1", "--1"},
@@ -119,7 +117,6 @@ func TestUnaryOperationExprRestore(t *testing.T) {
 }
 
 func TestColumnNameExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"abc", "`abc`"},
 		{"`abc`", "`abc`"},
@@ -136,7 +133,6 @@ func TestColumnNameExprRestore(t *testing.T) {
 }
 
 func TestIsNullExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a is null", "`a` IS NULL"},
 		{"a is not null", "`a` IS NOT NULL"},
@@ -148,7 +144,6 @@ func TestIsNullExprRestore(t *testing.T) {
 }
 
 func TestIsTruthRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a is true", "`a` IS TRUE"},
 		{"a is not true", "`a` IS NOT TRUE"},
@@ -162,7 +157,6 @@ func TestIsTruthRestore(t *testing.T) {
 }
 
 func TestBetweenExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"b between 1 and 2", "`b` BETWEEN 1 AND 2"},
 		{"b not between 1 and 2", "`b` NOT BETWEEN 1 AND 2"},
@@ -177,7 +171,6 @@ func TestBetweenExprRestore(t *testing.T) {
 }
 
 func TestCaseExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"case when 1 then 2 end", "CASE WHEN 1 THEN 2 END"},
 		{"case when 1 then 'a' when 2 then 'b' end", "CASE WHEN 1 THEN _UTF8MB4'a' WHEN 2 THEN _UTF8MB4'b' END"},
@@ -192,7 +185,6 @@ func TestCaseExpr(t *testing.T) {
 }
 
 func TestBinaryOperationExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"'a'!=1", "_UTF8MB4'a'!=1"},
 		{"a!=1", "`a`!=1"},
@@ -220,7 +212,6 @@ func TestBinaryOperationExpr(t *testing.T) {
 }
 
 func TestBinaryOperationExprWithFlags(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"'a'!=1", "_UTF8MB4'a' != 1"},
 		{"a!=1", "`a` != 1"},
@@ -239,7 +230,6 @@ func TestBinaryOperationExprWithFlags(t *testing.T) {
 }
 
 func TestParenthesesExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"(1+2)*3", "(1+2)*3"},
 		{"1+2*3", "1+2*3"},
@@ -251,7 +241,6 @@ func TestParenthesesExpr(t *testing.T) {
 }
 
 func TestWhenClause(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"when 1 then 2", "WHEN 1 THEN 2"},
 		{"when 1 then 'a'", "WHEN 1 THEN _UTF8MB4'a'"},
@@ -264,7 +253,6 @@ func TestWhenClause(t *testing.T) {
 }
 
 func TestDefaultExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"default", "DEFAULT"},
 		{"default(i)", "DEFAULT(`i`)"},
@@ -276,7 +264,6 @@ func TestDefaultExpr(t *testing.T) {
 }
 
 func TestPatternInExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"'a' in ('b')", "_UTF8MB4'a' IN (_UTF8MB4'b')"},
 		{"2 in (0,3,7)", "2 IN (0,3,7)"},
@@ -291,7 +278,6 @@ func TestPatternInExprRestore(t *testing.T) {
 }
 
 func TestPatternLikeExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a like 't1'", "`a` LIKE _UTF8MB4't1'"},
 		{"a like 't1%'", "`a` LIKE _UTF8MB4't1%'"},
@@ -309,7 +295,6 @@ func TestPatternLikeExprRestore(t *testing.T) {
 }
 
 func TestValuesExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"values(a)", "VALUES(`a`)"},
 		{"values(a)+values(b)", "VALUES(`a`)+VALUES(`b`)"},
@@ -321,7 +306,6 @@ func TestValuesExpr(t *testing.T) {
 }
 
 func TestPatternRegexpExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"a regexp 't1'", "`a` REGEXP _UTF8MB4't1'"},
 		{"a regexp '^[abc][0-9]{11}|ok$'", "`a` REGEXP _UTF8MB4'^[abc][0-9]{11}|ok$'"},
@@ -339,7 +323,6 @@ func TestPatternRegexpExprRestore(t *testing.T) {
 }
 
 func TestRowExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"(1,2)", "ROW(1,2)"},
 		{"(col1,col2)", "ROW(`col1`,`col2`)"},
@@ -353,7 +336,6 @@ func TestRowExprRestore(t *testing.T) {
 }
 
 func TestMaxValueExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"maxvalue", "MAXVALUE"},
 	}
@@ -364,7 +346,6 @@ func TestMaxValueExprRestore(t *testing.T) {
 }
 
 func TestPositionExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"1", "1"},
 	}
@@ -376,7 +357,6 @@ func TestPositionExprRestore(t *testing.T) {
 }
 
 func TestExistsSubqueryExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"EXISTS (SELECT 2)", "EXISTS (SELECT 2)"},
 		{"NOT EXISTS (SELECT 2)", "NOT EXISTS (SELECT 2)"},
@@ -390,7 +370,6 @@ func TestExistsSubqueryExprRestore(t *testing.T) {
 }
 
 func TestVariableExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"@a>1", "@`a`>1"},
 		{"@`aB`+1", "@`aB`+1"},
@@ -414,7 +393,6 @@ func TestVariableExpr(t *testing.T) {
 }
 
 func TestMatchAgainstExpr(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{`MATCH(content, title) AGAINST ('search for')`, "MATCH (`content`,`title`) AGAINST (_UTF8MB4'search for')"},
 		{`MATCH(content) AGAINST ('search for' IN BOOLEAN MODE)`, "MATCH (`content`) AGAINST (_UTF8MB4'search for' IN BOOLEAN MODE)"},

--- a/parser/ast/flag_test.go
+++ b/parser/ast/flag_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestHasAggFlag(t *testing.T) {
-	t.Parallel()
 	expr := &ast.BetweenExpr{}
 	flagTests := []struct {
 		flag   uint64
@@ -39,7 +38,6 @@ func TestHasAggFlag(t *testing.T) {
 }
 
 func TestFlag(t *testing.T) {
-	t.Parallel()
 	flagTests := []struct {
 		expr string
 		flag uint64

--- a/parser/ast/format_test.go
+++ b/parser/ast/format_test.go
@@ -15,7 +15,6 @@ func getDefaultCharsetAndCollate() (string, string) {
 }
 
 func TestAstFormat(t *testing.T) {
-	t.Parallel()
 	var testcases = []struct {
 		input  string
 		output string

--- a/parser/ast/functions_test.go
+++ b/parser/ast/functions_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestFunctionsVisitorCover(t *testing.T) {
-	t.Parallel()
 	valueExpr := NewValueExpr(42, mysql.DefaultCharset, mysql.DefaultCollationName)
 	stmts := []Node{
 		&AggregateFuncExpr{Args: []ExprNode{valueExpr}},
@@ -40,7 +39,6 @@ func TestFunctionsVisitorCover(t *testing.T) {
 }
 
 func TestFuncCallExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"JSON_ARRAYAGG(attribute)", "JSON_ARRAYAGG(`attribute`)"},
 		{"JSON_OBJECTAGG(attribute, value)", "JSON_OBJECTAGG(`attribute`, `value`)"},
@@ -155,7 +153,6 @@ func TestAggregateFuncExprRestore(t *testing.T) {
 }
 
 func TestConvert(t *testing.T) {
-	t.Parallel()
 	// Test case for CONVERT(expr USING transcoding_name).
 	cases := []struct {
 		SQL          string
@@ -185,7 +182,6 @@ func TestConvert(t *testing.T) {
 }
 
 func TestChar(t *testing.T) {
-	t.Parallel()
 	// Test case for CHAR(N USING charset_name)
 	cases := []struct {
 		SQL          string
@@ -215,7 +211,6 @@ func TestChar(t *testing.T) {
 }
 
 func TestWindowFuncExprRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"RANK() OVER w", "RANK() OVER `w`"},
 		{"RANK() OVER (PARTITION BY a)", "RANK() OVER (PARTITION BY `a`)"},
@@ -235,7 +230,6 @@ func TestWindowFuncExprRestore(t *testing.T) {
 }
 
 func TestGenericFuncRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"s.a()", "`s`.`a`()"},
 		{"`s`.`a`()", "`s`.`a`()"},

--- a/parser/ast/misc_test.go
+++ b/parser/ast/misc_test.go
@@ -43,7 +43,6 @@ func (visitor1) Enter(in ast.Node) (ast.Node, bool) {
 }
 
 func TestMiscVisitorCover(t *testing.T) {
-	t.Parallel()
 	valueExpr := ast.NewValueExpr(42, mysql.DefaultCharset, mysql.DefaultCollationName)
 	stmts := []ast.Node{
 		&ast.AdminStmt{},
@@ -86,7 +85,6 @@ func TestMiscVisitorCover(t *testing.T) {
 }
 
 func TestDDLVisitorCoverMisc(t *testing.T) {
-	t.Parallel()
 	sql := `
 create table t (c1 smallint unsigned, c2 int unsigned);
 alter table t add column a smallint unsigned after b;
@@ -112,7 +110,6 @@ constraint foreign key (jobabbr) references ffxi_jobtype (jobabbr) on delete cas
 }
 
 func TestDMLVistorCover(t *testing.T) {
-	t.Parallel()
 	sql := `delete from somelog where user = 'jcole' order by timestamp_column limit 1;
 delete t1, t2 from t1 inner join t2 inner join t3 where t1.id=t2.id and t2.id=t3.id;
 select * from t where exists(select * from t k where t.c = k.c having sum(c) = 1);
@@ -133,7 +130,6 @@ load data infile '/tmp/t.csv' into table t fields terminated by 'ab' enclosed by
 
 // test Change Pump or drainer status sql parser
 func TestChangeStmt(t *testing.T) {
-	t.Parallel()
 	sql := `change pump to node_state='paused' for node_id '127.0.0.1:8249';
 change drainer to node_state='paused' for node_id '127.0.0.1:8249';
 shutdown;`
@@ -148,7 +144,6 @@ shutdown;`
 }
 
 func TestSensitiveStatement(t *testing.T) {
-	t.Parallel()
 	positive := []ast.StmtNode{
 		&ast.SetPwdStmt{},
 		&ast.CreateUserStmt{},
@@ -180,7 +175,6 @@ func TestSensitiveStatement(t *testing.T) {
 }
 
 func TestUserSpec(t *testing.T) {
-	t.Parallel()
 	hashString := "*3D56A309CD04FA2EEF181462E59011F075C89548"
 	u := ast.UserSpec{
 		User: &auth.UserIdentity{
@@ -212,7 +206,6 @@ func TestUserSpec(t *testing.T) {
 }
 
 func TestTableOptimizerHintRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"USE_INDEX(t1 c1)", "USE_INDEX(`t1` `c1`)"},
 		{"USE_INDEX(test.t1 c1)", "USE_INDEX(`test`.`t1` `c1`)"},
@@ -288,7 +281,6 @@ func TestTableOptimizerHintRestore(t *testing.T) {
 }
 
 func TestChangeStmtRestore(t *testing.T) {
-	t.Parallel()
 	testCases := []NodeRestoreTestCase{
 		{"CHANGE PUMP TO NODE_STATE ='paused' FOR NODE_ID '127.0.0.1:9090'", "CHANGE PUMP TO NODE_STATE ='paused' FOR NODE_ID '127.0.0.1:9090'"},
 		{"CHANGE DRAINER TO NODE_STATE ='paused' FOR NODE_ID '127.0.0.1:9090'", "CHANGE DRAINER TO NODE_STATE ='paused' FOR NODE_ID '127.0.0.1:9090'"},
@@ -300,7 +292,6 @@ func TestChangeStmtRestore(t *testing.T) {
 }
 
 func TestBRIESecureText(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		input   string
 		secured string

--- a/parser/ast/util_test.go
+++ b/parser/ast/util_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestCacheable(t *testing.T) {
-	t.Parallel()
 	// test non-SelectStmt
 	var stmt Node = &DeleteStmt{}
 	require.False(t, IsReadOnly(stmt))
@@ -76,7 +75,6 @@ func TestCacheable(t *testing.T) {
 }
 
 func TestUnionReadOnly(t *testing.T) {
-	t.Parallel()
 	selectReadOnly := &SelectStmt{}
 	selectForUpdate := &SelectStmt{
 		LockInfo: &SelectLockInfo{LockType: SelectLockForUpdate},

--- a/parser/auth/caching_sha2_test.go
+++ b/parser/auth/caching_sha2_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestCheckShaPasswordGood(t *testing.T) {
-	t.Parallel()
 	pwd := "foobar"
 	pwhash, _ := hex.DecodeString("24412430303524031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
 	r, err := CheckShaPassword(pwhash, pwd)
@@ -30,7 +29,6 @@ func TestCheckShaPasswordGood(t *testing.T) {
 }
 
 func TestCheckShaPasswordBad(t *testing.T) {
-	t.Parallel()
 	pwd := "not_foobar"
 	pwhash, _ := hex.DecodeString("24412430303524031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
 	r, err := CheckShaPassword(pwhash, pwd)
@@ -39,7 +37,6 @@ func TestCheckShaPasswordBad(t *testing.T) {
 }
 
 func TestCheckShaPasswordShort(t *testing.T) {
-	t.Parallel()
 	pwd := "not_foobar"
 	pwhash, _ := hex.DecodeString("aaaaaaaa")
 	_, err := CheckShaPassword(pwhash, pwd)
@@ -47,7 +44,6 @@ func TestCheckShaPasswordShort(t *testing.T) {
 }
 
 func TestCheckShaPasswordDigetTypeIncompatible(t *testing.T) {
-	t.Parallel()
 	pwd := "not_foobar"
 	pwhash, _ := hex.DecodeString("24422430303524031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
 	_, err := CheckShaPassword(pwhash, pwd)
@@ -55,7 +51,6 @@ func TestCheckShaPasswordDigetTypeIncompatible(t *testing.T) {
 }
 
 func TestCheckShaPasswordIterationsInvalid(t *testing.T) {
-	t.Parallel()
 	pwd := "not_foobar"
 	pwhash, _ := hex.DecodeString("24412430304124031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
 	_, err := CheckShaPassword(pwhash, pwd)
@@ -65,7 +60,6 @@ func TestCheckShaPasswordIterationsInvalid(t *testing.T) {
 // The output from NewSha2Password is not stable as the hash is based on the genrated salt.
 // This is why CheckShaPassword is used here.
 func TestNewSha2Password(t *testing.T) {
-	t.Parallel()
 	pwd := "testpwd"
 	pwhash := NewSha2Password(pwd)
 	r, err := CheckShaPassword([]byte(pwhash), pwd)

--- a/parser/auth/mysql_native_password_test.go
+++ b/parser/auth/mysql_native_password_test.go
@@ -20,21 +20,18 @@ import (
 )
 
 func TestEncodePassword(t *testing.T) {
-	t.Parallel()
 	pwd := "123"
 	require.Equal(t, "*23AE809DDACAF96AF0FD78ED04B6A265E05AA257", EncodePassword(pwd))
 	require.Equal(t, EncodePasswordBytes([]byte(pwd)), EncodePassword(pwd))
 }
 
 func TestDecodePassword(t *testing.T) {
-	t.Parallel()
 	x, err := DecodePassword(EncodePassword("123"))
 	require.NoError(t, err)
 	require.Equal(t, Sha1Hash(Sha1Hash([]byte("123"))), x)
 }
 
 func TestCheckScramble(t *testing.T) {
-	t.Parallel()
 	pwd := "abc"
 	salt := []byte{85, 92, 45, 22, 58, 79, 107, 6, 122, 125, 58, 80, 12, 90, 103, 32, 90, 10, 74, 82}
 	auth := []byte{24, 180, 183, 225, 166, 6, 81, 102, 70, 248, 199, 143, 91, 204, 169, 9, 161, 171, 203, 33}

--- a/parser/charset/charset_test.go
+++ b/parser/charset/charset_test.go
@@ -26,7 +26,6 @@ func testValidCharset(t *testing.T, charset string, collation string, expect boo
 }
 
 func TestValidCharset(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		cs   string
 		co   string
@@ -61,7 +60,6 @@ func testGetDefaultCollation(t *testing.T, charset string, expectCollation strin
 }
 
 func TestGetDefaultCollation(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		cs   string
 		co   string
@@ -94,7 +92,6 @@ func TestGetDefaultCollation(t *testing.T) {
 }
 
 func TestSupportedCollations(t *testing.T) {
-	t.Parallel()
 	// All supportedCollation are defined from their names
 	require.Equal(t, len(supportedCollationNames), len(supportedCollationNames))
 
@@ -112,7 +109,6 @@ func TestSupportedCollations(t *testing.T) {
 }
 
 func TestGetCharsetDesc(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		cs     string
 		result string
@@ -138,7 +134,6 @@ func TestGetCharsetDesc(t *testing.T) {
 }
 
 func TestGetCollationByName(t *testing.T) {
-	t.Parallel()
 	for _, collation := range collations {
 		coll, err := GetCollationByName(collation.Name)
 		require.NoError(t, err)

--- a/parser/charset/encoding_test.go
+++ b/parser/charset/encoding_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestEncoding(t *testing.T) {
-	t.Parallel()
 	enc := charset.NewEncoding(charset.CharsetGBK)
 	require.Equal(t, charset.CharsetGBK, enc.Name())
 

--- a/parser/consistent_test.go
+++ b/parser/consistent_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestKeywordConsistent(t *testing.T) {
-	t.Parallel()
-
 	_, filename, _, _ := runtime.Caller(0)
 	parserFilename := path.Join(path.Dir(filename), "parser.y")
 	parserFile, err := os.Open(parserFilename)

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestNormalize(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  string
 		expect string
@@ -78,8 +76,6 @@ func TestNormalize(t *testing.T) {
 }
 
 func TestNormalizeDigest(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		sql        string
 		normalized string
@@ -100,8 +96,6 @@ func TestNormalizeDigest(t *testing.T) {
 }
 
 func TestDigestHashEqForSimpleSQL(t *testing.T) {
-	t.Parallel()
-
 	sqlGroups := [][]string{
 		{"select * from b where id = 1", "select * from b where id = '1'", "select * from b where id =2"},
 		{"select 2 from b, c where c.id > 1", "select 4 from b, c where c.id > 23"},
@@ -121,8 +115,6 @@ func TestDigestHashEqForSimpleSQL(t *testing.T) {
 }
 
 func TestDigestHashNotEqForSimpleSQL(t *testing.T) {
-	t.Parallel()
-
 	sqlGroups := [][]string{
 		{"select * from b where id = 1", "select a from b where id = 1", "select * from d where bid =1"},
 	}
@@ -140,8 +132,6 @@ func TestDigestHashNotEqForSimpleSQL(t *testing.T) {
 }
 
 func TestGenDigest(t *testing.T) {
-	t.Parallel()
-
 	hash := genRandDigest("abc")
 	digest := parser.NewDigest(hash)
 	require.Equal(t, fmt.Sprintf("%x", hash), digest.String())

--- a/parser/format/format_test.go
+++ b/parser/format/format_test.go
@@ -31,7 +31,6 @@ func checkFormat(t *testing.T, f Formatter, buf *bytes.Buffer, str, expect strin
 }
 
 func TestFormat(t *testing.T) {
-	t.Parallel()
 	str := "abc%d%%e%i\nx\ny\n%uz\n"
 	buf := &bytes.Buffer{}
 	f := IndentFormatter(buf, "\t")
@@ -50,7 +49,6 @@ z
 }
 
 func TestRestoreCtx(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		flag   RestoreFlags
 		expect string
@@ -85,7 +83,6 @@ func TestRestoreCtx(t *testing.T) {
 }
 
 func TestRestoreSpecialComment(t *testing.T) {
-	t.Parallel()
 	var sb strings.Builder
 	sb.Reset()
 	ctx := NewRestoreCtx(RestoreTiDBSpecialComment, &sb)

--- a/parser/hintparser_test.go
+++ b/parser/hintparser_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestParseHint(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		input  string
 		mode   mysql.SQLMode

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestTokenID(t *testing.T) {
-	t.Parallel()
-
 	for str, tok := range tokenMap {
 		l := NewScanner(str)
 		var v yySymType
@@ -34,8 +32,6 @@ func TestTokenID(t *testing.T) {
 }
 
 func TestSingleChar(t *testing.T) {
-	t.Parallel()
-
 	table := []byte{'|', '&', '-', '+', '*', '/', '%', '^', '~', '(', ',', ')'}
 	for _, tok := range table {
 		l := NewScanner(string(tok))
@@ -56,8 +52,6 @@ type testLiteralValue struct {
 }
 
 func TestSingleCharOther(t *testing.T) {
-	t.Parallel()
-
 	table := []testCaseItem{
 		{"AT", identifier},
 		{"?", paramMarker},
@@ -69,8 +63,6 @@ func TestSingleCharOther(t *testing.T) {
 }
 
 func TestAtLeadingIdentifier(t *testing.T) {
-	t.Parallel()
-
 	table := []testCaseItem{
 		{"@", singleAtIdentifier},
 		{"@''", singleAtIdentifier},
@@ -96,8 +88,6 @@ func TestAtLeadingIdentifier(t *testing.T) {
 }
 
 func TestUnderscoreCS(t *testing.T) {
-	t.Parallel()
-
 	var v yySymType
 	scanner := NewScanner(`_utf8"string"`)
 	tok := scanner.Lex(&v)
@@ -113,8 +103,6 @@ func TestUnderscoreCS(t *testing.T) {
 }
 
 func TestLiteral(t *testing.T) {
-	t.Parallel()
-
 	table := []testCaseItem{
 		{`'''a'''`, stringLit},
 		{`''a''`, stringLit},
@@ -163,8 +151,6 @@ func TestLiteral(t *testing.T) {
 }
 
 func TestLiteralValue(t *testing.T) {
-	t.Parallel()
-
 	table := []testLiteralValue{
 		{`'''a'''`, `'a'`},
 		{`''a''`, ``},
@@ -239,8 +225,6 @@ func runLiteralTest(t *testing.T, table []testLiteralValue) {
 }
 
 func TestComment(t *testing.T) {
-	t.Parallel()
-
 	table := []testCaseItem{
 		{"-- select --\n1", intLit},
 		{"/*!40101 SET character_set_client = utf8 */;", set},
@@ -266,8 +250,6 @@ SELECT`, selectKwd},
 }
 
 func TestScanQuotedIdent(t *testing.T) {
-	t.Parallel()
-
 	l := NewScanner("`fk`")
 	l.r.peek()
 	tok, pos, lit := scanQuotedIdent(l)
@@ -277,8 +259,6 @@ func TestScanQuotedIdent(t *testing.T) {
 }
 
 func TestScanString(t *testing.T) {
-	t.Parallel()
-
 	table := []struct {
 		raw    string
 		expect string
@@ -314,8 +294,6 @@ func TestScanString(t *testing.T) {
 }
 
 func TestIdentifier(t *testing.T) {
-	t.Parallel()
-
 	replacementString := string(unicode.ReplacementChar) + "xxx"
 	table := [][2]string{
 		{`哈哈`, "哈哈"},
@@ -347,8 +325,6 @@ func TestIdentifier(t *testing.T) {
 }
 
 func TestSpecialComment(t *testing.T) {
-	t.Parallel()
-
 	l := NewScanner("/*!40101 select\n5*/")
 	tok, pos, lit := l.scan()
 	requires.Equal(t, identifier, tok)
@@ -362,8 +338,6 @@ func TestSpecialComment(t *testing.T) {
 }
 
 func TestFeatureIDsComment(t *testing.T) {
-	t.Parallel()
-
 	l := NewScanner("/*T![auto_rand] auto_random(5) */")
 	tok, pos, lit := l.scan()
 	requires.Equal(t, identifier, tok)
@@ -383,8 +357,6 @@ func TestFeatureIDsComment(t *testing.T) {
 }
 
 func TestOptimizerHint(t *testing.T) {
-	t.Parallel()
-
 	l := NewScanner("SELECT /*+ BKA(t1) */ 0;")
 	tokens := []struct {
 		tok   int
@@ -409,8 +381,6 @@ func TestOptimizerHint(t *testing.T) {
 }
 
 func TestOptimizerHintAfterCertainKeywordOnly(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  string
 		tokens []int
@@ -491,8 +461,6 @@ func TestOptimizerHintAfterCertainKeywordOnly(t *testing.T) {
 }
 
 func TestInt(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  string
 		expect uint64
@@ -522,8 +490,6 @@ func TestInt(t *testing.T) {
 }
 
 func TestSQLModeANSIQuotes(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input string
 		tok   int
@@ -556,8 +522,6 @@ func TestSQLModeANSIQuotes(t *testing.T) {
 }
 
 func TestIllegal(t *testing.T) {
-	t.Parallel()
-
 	table := []testCaseItem{
 		{"'", invalid},
 		{"'fu", invalid},
@@ -576,8 +540,6 @@ func TestIllegal(t *testing.T) {
 }
 
 func TestVersionDigits(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input    string
 		min      int
@@ -656,8 +618,6 @@ func TestVersionDigits(t *testing.T) {
 }
 
 func TestFeatureIDs(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input      string
 		featureIDs []string

--- a/parser/model/model_test.go
+++ b/parser/model/model_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestT(t *testing.T) {
-	t.Parallel()
 	abc := NewCIStr("aBC")
 	require.Equal(t, "aBC", abc.O)
 	require.Equal(t, "abc", abc.L)
@@ -34,7 +33,6 @@ func TestT(t *testing.T) {
 }
 
 func TestModelBasic(t *testing.T) {
-	t.Parallel()
 	column := &ColumnInfo{
 		ID:           1,
 		Name:         NewCIStr("c"),
@@ -140,7 +138,6 @@ func TestModelBasic(t *testing.T) {
 }
 
 func TestJobStartTime(t *testing.T) {
-	t.Parallel()
 	job := &Job{
 		ID:         123,
 		BinlogInfo: &HistoryInfo{},
@@ -150,7 +147,6 @@ func TestJobStartTime(t *testing.T) {
 }
 
 func TestJobCodec(t *testing.T) {
-	t.Parallel()
 	type A struct {
 		Name string
 	}
@@ -247,7 +243,6 @@ func TestJobCodec(t *testing.T) {
 }
 
 func TestState(t *testing.T) {
-	t.Parallel()
 	schemaTbl := []SchemaState{
 		StateDeleteOnly,
 		StateWriteOnly,
@@ -276,7 +271,6 @@ func TestState(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
-	t.Parallel()
 	acts := []struct {
 		act    ActionType
 		result string
@@ -313,7 +307,6 @@ func TestString(t *testing.T) {
 }
 
 func TestUnmarshalCIStr(t *testing.T) {
-	t.Parallel()
 	var ci CIStr
 
 	// Test unmarshal CIStr from a single string.
@@ -333,7 +326,6 @@ func TestUnmarshalCIStr(t *testing.T) {
 }
 
 func TestDefaultValue(t *testing.T) {
-	t.Parallel()
 	srcCol := &ColumnInfo{
 		ID: 1,
 	}
@@ -411,8 +403,6 @@ func TestDefaultValue(t *testing.T) {
 }
 
 func TestPlacementSettingsString(t *testing.T) {
-	t.Parallel()
-
 	settings := &PlacementSettings{
 		PrimaryRegion: "us-east-1",
 		Regions:       "us-east-1,us-east-2",

--- a/parser/mysql/const_test.go
+++ b/parser/mysql/const_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestSQLMode(t *testing.T) {
-	t.Parallel()
 	// ref https://dev.mysql.com/doc/internals/en/query-event.html#q-sql-mode-code,
 	hardCode := []struct {
 		code  SQLMode

--- a/parser/mysql/error_test.go
+++ b/parser/mysql/error_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestSQLError(t *testing.T) {
-	t.Parallel()
 	e := NewErrf(ErrNoDB, "no db error", nil)
 	require.Greater(t, len(e.Error()), 0)
 

--- a/parser/mysql/privs_test.go
+++ b/parser/mysql/privs_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestPrivString(t *testing.T) {
-	t.Parallel()
 	for i := 0; ; i++ {
 		p := PrivilegeType(1 << i)
 		if p > AllPriv {
@@ -31,7 +30,6 @@ func TestPrivString(t *testing.T) {
 }
 
 func TestPrivColumn(t *testing.T) {
-	t.Parallel()
 	for _, p := range AllGlobalPrivs {
 		require.NotEmptyf(t, p.ColumnString(), "%s", p)
 		np, ok := NewPrivFromColumn(p.ColumnString())
@@ -53,7 +51,6 @@ func TestPrivColumn(t *testing.T) {
 }
 
 func TestPrivSetString(t *testing.T) {
-	t.Parallel()
 	for _, p := range AllTablePrivs {
 		require.NotEmptyf(t, p.SetString(), "%s", p)
 		np, ok := NewPrivFromSetEnum(p.SetString())
@@ -69,7 +66,6 @@ func TestPrivSetString(t *testing.T) {
 }
 
 func TestPrivsHas(t *testing.T) {
-	t.Parallel()
 	// it is a simple helper, does not handle all&dynamic privs
 	privs := Privileges{AllPriv}
 	require.True(t, privs.Has(AllPriv))
@@ -83,7 +79,6 @@ func TestPrivsHas(t *testing.T) {
 }
 
 func TestPrivAllConsistency(t *testing.T) {
-	t.Parallel()
 	// AllPriv in mysql.user columns.
 	for priv := CreatePriv; priv != AllPriv; priv = priv << 1 {
 		_, ok := Priv2UserCol[priv]

--- a/parser/mysql/type_test.go
+++ b/parser/mysql/type_test.go
@@ -20,7 +20,6 @@ import (
 )
 
 func TestFlags(t *testing.T) {
-	t.Parallel()
 	require.True(t, HasNotNullFlag(NotNullFlag))
 	require.True(t, HasUniKeyFlag(UniqueKeyFlag))
 	require.True(t, HasNotNullFlag(NotNullFlag))

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -33,8 +33,6 @@ import (
 )
 
 func TestSimple(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 
 	reservedKws := []string{
@@ -312,8 +310,6 @@ func TestSimple(t *testing.T) {
 }
 
 func TestSpecialComments(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 
 	// 1. Make sure /*! ... */ respects the same SQL mode.
@@ -462,8 +458,6 @@ func RunErrMsgTest(t *testing.T, table []testErrMsgCase) {
 }
 
 func TestDMLStmt(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"", true, ""},
 		{";", true, ""},
@@ -1032,8 +1026,6 @@ AAAAAAAAAAAA5gm5Mg==
 }
 
 func TestDBAStmt(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for SHOW statement
 		{"SHOW VARIABLES LIKE 'character_set_results'", true, "SHOW SESSION VARIABLES LIKE _UTF8MB4'character_set_results'"},
@@ -1287,8 +1279,6 @@ func TestDBAStmt(t *testing.T) {
 }
 
 func TestSetVariable(t *testing.T) {
-	t.Parallel()
-
 	table := []struct {
 		Input    string
 		Name     string
@@ -1332,8 +1322,6 @@ func TestSetVariable(t *testing.T) {
 }
 
 func TestFlushTable(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	stmt, _, err := p.Parse("flush local tables tbl1,tbl2 with read lock", "", "")
 	require.NoError(t, err)
@@ -1346,8 +1334,6 @@ func TestFlushTable(t *testing.T) {
 }
 
 func TestFlushPrivileges(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	stmt, _, err := p.Parse("flush privileges", "", "")
 	require.NoError(t, err)
@@ -1356,8 +1342,6 @@ func TestFlushPrivileges(t *testing.T) {
 }
 
 func TestExpression(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// sign expression
 		{"SELECT ++1", true, "SELECT ++1"},
@@ -1414,8 +1398,6 @@ func TestExpression(t *testing.T) {
 }
 
 func TestBuiltin(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for builtin functions
 		{"SELECT POW(1, 2)", true, "SELECT POW(1, 2)"},
@@ -2152,8 +2134,6 @@ func TestBuiltin(t *testing.T) {
 }
 
 func TestIdentifier(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for quote identifier
 		{"select `a`, `a.b`, `a b` from t", true, "SELECT `a`,`a.b`,`a b` FROM `t`"},
@@ -2209,8 +2189,6 @@ func TestIdentifier(t *testing.T) {
 }
 
 func TestDDL(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"CREATE", false, ""},
 		{"CREATE TABLE", false, ""},
@@ -3462,8 +3440,6 @@ func TestDDL(t *testing.T) {
 }
 
 func TestHintError(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	stmt, warns, err := p.Parse("select /*+ tidb_unknown(T1,t2) */ c1, c2 from t1, t2 where t1.c1 = t2.c1", "", "")
 	require.NoError(t, err)
@@ -3502,8 +3478,6 @@ func TestHintError(t *testing.T) {
 }
 
 func TestErrorMsg(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	_, _, err := p.Parse("select1 1", "", "")
 	require.EqualError(t, err, "line 1 column 7 near \"select1 1\" ")
@@ -3602,8 +3576,6 @@ func TestErrorMsg(t *testing.T) {
 }
 
 func TestOptimizerHints(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	// Test USE_INDEX
 	stmt, _, err := p.Parse("select /*+ USE_INDEX(T1,T2), use_index(t3,t4) */ c1, c2 from t1, t2 where t1.c1 = t2.c1", "", "")
@@ -4073,8 +4045,6 @@ func TestOptimizerHints(t *testing.T) {
 }
 
 func TestType(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for time fsp
 		{"CREATE TABLE t( c1 TIME(2), c2 DATETIME(2), c3 TIMESTAMP(2) );", true, "CREATE TABLE `t` (`c1` TIME(2),`c2` DATETIME(2),`c3` TIMESTAMP(2))"},
@@ -4257,8 +4227,6 @@ func TestPrivilege(t *testing.T) {
 }
 
 func TestComment(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"create table t (c int comment 'comment')", true, "CREATE TABLE `t` (`c` INT COMMENT 'comment')"},
 		{"create table t (c int) comment = 'comment'", true, "CREATE TABLE `t` (`c` INT) COMMENT = 'comment'"},
@@ -4285,8 +4253,6 @@ func TestComment(t *testing.T) {
 }
 
 func TestParserErrMsg(t *testing.T) {
-	t.Parallel()
-
 	commentMsgCases := []testErrMsgCase{
 		{"delete from t where a = 7 or 1=1/*' and b = 'p'", errors.New("near '/*' and b = 'p'' at line 1")},
 		{"delete from t where a = 7 or\n 1=1/*' and b = 'p'", errors.New("near '/*' and b = 'p'' at line 2")},
@@ -4321,8 +4287,6 @@ func (sc *subqueryChecker) Leave(inNode ast.Node) (node ast.Node, ok bool) {
 }
 
 func TestSubquery(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for compare subquery
 		{"SELECT 1 > (select 1)", true, "SELECT 1>(SELECT 1)"},
@@ -4374,8 +4338,6 @@ func TestSubquery(t *testing.T) {
 }
 
 func TestSetOperator(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// union and union all
 		{"select c1 from t1 union select c2 from t2", true, "SELECT `c1` FROM `t1` UNION SELECT `c2` FROM `t2`"},
@@ -4501,8 +4463,6 @@ func checkOrderBy(t *testing.T, s ast.Node, hasOrderBy []bool, i int) int {
 }
 
 func TestUnionOrderBy(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	p.EnableWindowFunc(false)
 
@@ -4536,8 +4496,6 @@ func TestUnionOrderBy(t *testing.T) {
 }
 
 func TestLikeEscape(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		// for like escape
 		{`select "abc_" like "abc\\_" escape ''`, true, "SELECT _UTF8MB4'abc_' LIKE _UTF8MB4'abc\\_'"},
@@ -4551,8 +4509,6 @@ func TestLikeEscape(t *testing.T) {
 }
 
 func TestLockUnlockTables(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`UNLOCK TABLES;`, true, "UNLOCK TABLES"},
 		{`LOCK TABLES t1 READ;`, true, "LOCK TABLES `t1` READ"},
@@ -4586,8 +4542,6 @@ func TestLockUnlockTables(t *testing.T) {
 }
 
 func TestIndexHint(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`select * from t use index (primary)`, true, "SELECT * FROM `t` USE INDEX (`primary`)"},
 		{"select * from t use index (`primary`)", true, "SELECT * FROM `t` USE INDEX (`primary`)"},
@@ -4605,8 +4559,6 @@ func TestIndexHint(t *testing.T) {
 }
 
 func TestPriority(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`select high_priority * from t`, true, "SELECT HIGH_PRIORITY * FROM `t`"},
 		{`select low_priority * from t`, true, "SELECT LOW_PRIORITY * FROM `t`"},
@@ -4634,8 +4586,6 @@ func TestPriority(t *testing.T) {
 }
 
 func TestSQLResult(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`select SQL_BIG_RESULT c1 from t group by c1`, true, "SELECT SQL_BIG_RESULT `c1` FROM `t` GROUP BY `c1`"},
 		{`select SQL_SMALL_RESULT c1 from t group by c1`, true, "SELECT SQL_SMALL_RESULT `c1` FROM `t` GROUP BY `c1`"},
@@ -4649,8 +4599,6 @@ func TestSQLResult(t *testing.T) {
 }
 
 func TestSQLNoCache(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`select SQL_NO_CACHE * from t`, false, ""},
 		{`select SQL_CACHE * from t`, true, "SELECT * FROM `t`"},
@@ -4668,8 +4616,6 @@ func TestSQLNoCache(t *testing.T) {
 }
 
 func TestEscape(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{`select """;`, false, ""},
 		{`select """";`, true, "SELECT _UTF8MB4'\"'"},
@@ -4683,8 +4629,6 @@ func TestEscape(t *testing.T) {
 }
 
 func TestExplain(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"explain select c1 from t1", true, "EXPLAIN FORMAT = 'row' SELECT `c1` FROM `t1`"},
 		{"explain delete t1, t2 from t1 inner join t2 inner join t3 where t1.id=t2.id and t2.id=t3.id;", true, "EXPLAIN FORMAT = 'row' DELETE `t1`,`t2` FROM (`t1` JOIN `t2`) JOIN `t3` WHERE `t1`.`id`=`t2`.`id` AND `t2`.`id`=`t3`.`id`"},
@@ -4732,7 +4676,6 @@ func TestExplain(t *testing.T) {
 }
 
 func TestPrepare(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"PREPARE pname FROM 'SELECT ?'", true, "PREPARE `pname` FROM 'SELECT ?'"},
 		{"PREPARE pname FROM @test", true, "PREPARE `pname` FROM @`test`"},
@@ -4742,7 +4685,6 @@ func TestPrepare(t *testing.T) {
 }
 
 func TestDeallocate(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"DEALLOCATE PREPARE test", true, "DEALLOCATE PREPARE `test`"},
 		{"DEALLOCATE PREPARE ``", true, "DEALLOCATE PREPARE ``"},
@@ -4751,7 +4693,6 @@ func TestDeallocate(t *testing.T) {
 }
 
 func TestExecute(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"EXECUTE test", true, "EXECUTE `test`"},
 		{"EXECUTE test USING @var1,@var2", true, "EXECUTE `test` USING @`var1`,@`var2`"},
@@ -4761,7 +4702,6 @@ func TestExecute(t *testing.T) {
 }
 
 func TestTrace(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"trace begin", true, "TRACE START TRANSACTION"},
 		{"trace commit", true, "TRACE COMMIT"},
@@ -4783,7 +4723,6 @@ func TestTrace(t *testing.T) {
 }
 
 func TestBinding(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"create global binding for select * from t using select * from t use index(a)", true, "CREATE GLOBAL BINDING FOR SELECT * FROM `t` USING SELECT * FROM `t` USE INDEX (`a`)"},
 		{"create session binding for select * from t using select * from t use index(a)", true, "CREATE SESSION BINDING FOR SELECT * FROM `t` USING SELECT * FROM `t` USE INDEX (`a`)"},
@@ -4857,7 +4796,6 @@ func TestBinding(t *testing.T) {
 }
 
 func TestView(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"create view v as select * from t", true, "CREATE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `v` AS SELECT * FROM `t`"},
 		{"create or replace view v as select * from t", true, "CREATE OR REPLACE ALGORITHM = UNDEFINED DEFINER = CURRENT_USER SQL SECURITY DEFINER VIEW `v` AS SELECT * FROM `t`"},
@@ -4964,7 +4902,6 @@ func TestView(t *testing.T) {
 }
 
 func TestTimestampDiffUnit(t *testing.T) {
-	t.Parallel()
 	// Test case for timestampdiff unit.
 	// TimeUnit should be unified to upper case.
 	p := parser.New()
@@ -5001,7 +4938,6 @@ func TestTimestampDiffUnit(t *testing.T) {
 }
 
 func TestFuncCallExprOffset(t *testing.T) {
-	t.Parallel()
 	// Test case for offset field on func call expr.
 	p := parser.New()
 	stmt, _, err := p.Parse("SELECT s.a(), b();", "", "")
@@ -5028,7 +4964,6 @@ func TestFuncCallExprOffset(t *testing.T) {
 }
 
 func TestSessionManage(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		// Kill statement.
 		// See https://dev.mysql.com/doc/refman/5.7/en/kill.html
@@ -5047,7 +4982,6 @@ func TestSessionManage(t *testing.T) {
 }
 
 func TestParseShowOpenTables(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"SHOW OPEN TABLES", true, "SHOW OPEN TABLES"},
 		{"SHOW OPEN TABLES IN test", true, "SHOW OPEN TABLES IN `test`"},
@@ -5057,7 +4991,6 @@ func TestParseShowOpenTables(t *testing.T) {
 }
 
 func TestSQLModeANSIQuotes(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 	p.SetSQLMode(mysql.ModeANSIQuotes)
 	tests := []string{
@@ -5071,7 +5004,6 @@ func TestSQLModeANSIQuotes(t *testing.T) {
 }
 
 func TestDDLStatements(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 	// Tests that whatever the charset it is define, we always assign utf8 charset and utf8_bin collate.
 	createTableStr := `CREATE TABLE t (
@@ -5151,7 +5083,6 @@ func TestDDLStatements(t *testing.T) {
 }
 
 func TestAnalyze(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"analyze table t1", true, "ANALYZE TABLE `t1`"},
 		{"analyze table t1.*", false, ""},
@@ -5202,7 +5133,6 @@ func TestAnalyze(t *testing.T) {
 }
 
 func TestTableSample(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		// positive test cases
 		{"select * from tbl tablesample system (50);", true, "SELECT * FROM `tbl` TABLESAMPLE SYSTEM (50)"},
@@ -5260,7 +5190,6 @@ func TestTableSample(t *testing.T) {
 }
 
 func TestGeneratedColumn(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input string
 		ok    bool
@@ -5290,7 +5219,6 @@ func TestGeneratedColumn(t *testing.T) {
 }
 
 func TestSetTransaction(t *testing.T) {
-	t.Parallel()
 	// Set transaction is equivalent to setting the global or session value of tx_isolation.
 	// For example:
 	// SET SESSION TRANSACTION ISOLATION LEVEL READ COMMITTED
@@ -5323,7 +5251,6 @@ func TestSetTransaction(t *testing.T) {
 }
 
 func TestSideEffect(t *testing.T) {
-	t.Parallel()
 	// This test cover a bug that parse an error SQL doesn't leave the parser in a
 	// clean state, cause the following SQL parse fail.
 	p := parser.New()
@@ -5335,8 +5262,6 @@ func TestSideEffect(t *testing.T) {
 }
 
 func TestTablePartition(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"ALTER TABLE t1 TRUNCATE PARTITION p0", true, "ALTER TABLE `t1` TRUNCATE PARTITION `p0`"},
 		{"ALTER TABLE t1 TRUNCATE PARTITION p0, p1", true, "ALTER TABLE `t1` TRUNCATE PARTITION `p0`,`p1`"},
@@ -5537,7 +5462,6 @@ ENGINE=INNODB PARTITION BY LINEAR HASH (a) PARTITIONS 1;`, true, "CREATE TABLE `
 }
 
 func TestTablePartitionNameList(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{`select * from t partition (p0,p1)`, true, ""},
 	}
@@ -5559,7 +5483,6 @@ func TestTablePartitionNameList(t *testing.T) {
 }
 
 func TestNotExistsSubquery(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{`select * from t1 where not exists (select * from t2 where t1.a = t2.a)`, true, ""},
 	}
@@ -5577,7 +5500,6 @@ func TestNotExistsSubquery(t *testing.T) {
 }
 
 func TestWindowFunctionIdentifier(t *testing.T) {
-	t.Parallel()
 	var table []testCase
 	for key := range parser.WindowFuncTokenMapForTest {
 		table = append(table, testCase{fmt.Sprintf("select 1 %s", key), false, fmt.Sprintf("SELECT 1 AS `%s`", key)})
@@ -5591,7 +5513,6 @@ func TestWindowFunctionIdentifier(t *testing.T) {
 }
 
 func TestWindowFunctions(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		// For window function descriptions.
 		// See https://dev.mysql.com/doc/refman/8.0/en/window-function-descriptions.html
@@ -5699,8 +5620,6 @@ func (wfc *windowFrameBoundChecker) Leave(inNode ast.Node) (node ast.Node, ok bo
 // For issue #51
 // See https://github.com/pingcap/parser/pull/51 for details
 func TestVisitFrameBound(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	p.EnableWindowFunc(true)
 	table := []struct {
@@ -5724,7 +5643,6 @@ func TestVisitFrameBound(t *testing.T) {
 }
 
 func TestFieldText(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 	stmts, _, err := p.Parse("select a from t", "", "")
 	require.NoError(t, err)
@@ -5747,7 +5665,6 @@ func TestFieldText(t *testing.T) {
 
 // See https://github.com/pingcap/parser/issue/94
 func TestQuotedSystemVariables(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 
 	st, err := p.ParseOneStmt(
@@ -5809,8 +5726,6 @@ func TestQuotedSystemVariables(t *testing.T) {
 
 // See https://github.com/pingcap/parser/issue/95
 func TestQuotedVariableColumnName(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 
 	st, err := p.ParseOneStmt(
@@ -5841,8 +5756,6 @@ func TestQuotedVariableColumnName(t *testing.T) {
 }
 
 func TestCharset(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 
 	st, err := p.ParseOneStmt("ALTER SCHEMA GLOBAL DEFAULT CHAR SET utf8mb4", "", "")
@@ -5857,8 +5770,6 @@ func TestCharset(t *testing.T) {
 }
 
 func TestFulltextSearch(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 
 	st, err := p.ParseOneStmt("SELECT * FROM fulltext_test WHERE MATCH(content) AGAINST('search')", "", "")
@@ -5904,8 +5815,6 @@ func TestFulltextSearch(t *testing.T) {
 }
 
 func TestStartTransaction(t *testing.T) {
-	t.Parallel()
-
 	cases := []testCase{
 		{"START TRANSACTION READ WRITE", true, "START TRANSACTION"},
 		{"START TRANSACTION WITH CONSISTENT SNAPSHOT", true, "START TRANSACTION"},
@@ -5923,8 +5832,6 @@ func TestStartTransaction(t *testing.T) {
 }
 
 func TestSignedInt64OutOfRange(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	cases := []string{
 		"recover table by job 18446744073709551612",
@@ -6034,8 +5941,6 @@ func (checker *nodeTextCleaner) Leave(in ast.Node) (out ast.Node, ok bool) {
 
 // For index advisor
 func TestIndexAdviseStmt(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"INDEX ADVISE INFILE '/tmp/t.sql'", true, "INDEX ADVISE INFILE '/tmp/t.sql'"},
 		{"INDEX ADVISE LOCAL INFILE '/tmp/t.sql'", true, "INDEX ADVISE LOCAL INFILE '/tmp/t.sql'"},
@@ -6096,8 +6001,6 @@ func TestIndexAdviseStmt(t *testing.T) {
 
 // For BRIE
 func TestBRIE(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"BACKUP DATABASE a TO 'local:///tmp/archive01/'", true, "BACKUP DATABASE `a` TO 'local:///tmp/archive01/'"},
 		{"BACKUP SCHEMA a TO 'local:///tmp/archive01/'", true, "BACKUP DATABASE `a` TO 'local:///tmp/archive01/'"},
@@ -6209,8 +6112,6 @@ func TestAsyncImport(t *testing.T) {
 }
 
 func TestStatisticsOps(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"create statistics stats1 (cardinality) on t(a,b,c)", true, "CREATE STATISTICS `stats1` (CARDINALITY) ON `t`(`a`, `b`, `c`)"},
 		{"create statistics stats2 (dependency) on t(a,b)", true, "CREATE STATISTICS `stats2` (DEPENDENCY) ON `t`(`a`, `b`)"},
@@ -6241,8 +6142,6 @@ func TestStatisticsOps(t *testing.T) {
 }
 
 func TestHighNotPrecedenceMode(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	var sb strings.Builder
 
@@ -6287,8 +6186,6 @@ func TestHighNotPrecedenceMode(t *testing.T) {
 
 // For CTE
 func TestCTE(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"WITH `cte` AS (SELECT 1,2) SELECT `col1`,`col2` FROM `cte`", true, "WITH `cte` AS (SELECT 1,2) SELECT `col1`,`col2` FROM `cte`"},
 		{"WITH `cte` (col1, col2) AS (SELECT 1,2 UNION ALL SELECT 3,4) SELECT col1, col2 FROM cte;", true, "WITH `cte` (`col1`, `col2`) AS (SELECT 1,2 UNION ALL SELECT 3,4) SELECT `col1`,`col2` FROM `cte`"},
@@ -6313,7 +6210,6 @@ func TestCTE(t *testing.T) {
 }
 
 func TestAsOfClause(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"SELECT * FROM `t` AS /* comment */ a;", true, "SELECT * FROM `t` AS `a`"},
 		{"SELECT * FROM `t` AS OF TIMESTAMP TIDB_BOUNDED_STALENESS(DATE_SUB(NOW(), INTERVAL 3 SECOND), NOW());", true, "SELECT * FROM `t` AS OF TIMESTAMP TIDB_BOUNDED_STALENESS(DATE_SUB(NOW(), INTERVAL 3 SECOND), NOW())"},
@@ -6331,8 +6227,6 @@ func TestAsOfClause(t *testing.T) {
 
 // For `PARTITION BY [LINEAR] KEY ALGORITHM` syntax
 func TestPartitionKeyAlgorithm(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"CREATE TABLE t  (c1 integer ,c2 integer) PARTITION BY LINEAR KEY ALGORITHM = 1 (c1,c2) PARTITIONS 4", true, "CREATE TABLE `t` (`c1` INT,`c2` INT) PARTITION BY LINEAR KEY ALGORITHM = 1 (`c1`,`c2`) PARTITIONS 4"},
 		{"CREATE TABLE t  (c1 integer ,c2 integer) PARTITION BY LINEAR KEY ALGORITHM = -1 (c1,c2) PARTITIONS 4", false, ""},
@@ -6345,8 +6239,6 @@ func TestPartitionKeyAlgorithm(t *testing.T) {
 
 // server side help syntax
 func TestHelp(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"HELP 'select'", true, "HELP 'select'"},
 	}
@@ -6355,8 +6247,6 @@ func TestHelp(t *testing.T) {
 }
 
 func TestRestoreBinOpWithBrackets(t *testing.T) {
-	t.Parallel()
-
 	cases := []testCase{
 		{"select mod(a+b, 4)+1", true, "SELECT (((`a` + `b`) % 4) + 1)"},
 		{"select mod( year(a) - abs(weekday(a) + dayofweek(a)), 4) + 1", true, "SELECT (((year(`a`) - abs((weekday(`a`) + dayofweek(`a`)))) % 4) + 1)"},
@@ -6400,8 +6290,6 @@ func TestRestoreBinOpWithBrackets(t *testing.T) {
 
 // For CTE bindings.
 func TestCTEBindings(t *testing.T) {
-	t.Parallel()
-
 	table := []testCase{
 		{"WITH `cte` AS (SELECT * from t) SELECT `col1`,`col2` FROM `cte`", true, "WITH `cte` AS (SELECT * FROM `test`.`t`) SELECT `col1`,`col2` FROM `cte`"},
 		{"WITH `cte` (col1, col2) AS (SELECT * from t UNION ALL SELECT 3,4) SELECT col1, col2 FROM cte;", true, "WITH `cte` (`col1`, `col2`) AS (SELECT * FROM `test`.`t` UNION ALL SELECT 3,4) SELECT `col1`,`col2` FROM `cte`"},
@@ -6459,7 +6347,6 @@ func TestCTEBindings(t *testing.T) {
 }
 
 func TestPlanReplayer(t *testing.T) {
-	t.Parallel()
 	table := []testCase{
 		{"PLAN REPLAYER DUMP EXPLAIN SELECT a FROM t", true, "PLAN REPLAYER DUMP EXPLAIN SELECT `a` FROM `t`"},
 		{"PLAN REPLAYER DUMP EXPLAIN SELECT * FROM t WHERE a > 10", true, "PLAN REPLAYER DUMP EXPLAIN SELECT * FROM `t` WHERE `a`>10"},
@@ -6493,7 +6380,6 @@ func TestPlanReplayer(t *testing.T) {
 }
 
 func TestGBKEncoding(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 	gbkEncoding, _ := charset.Lookup("gbk")
 	encoder := gbkEncoding.NewEncoder()

--- a/parser/types/field_type_test.go
+++ b/parser/types/field_type_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestFieldType(t *testing.T) {
-	t.Parallel()
 	ft := NewFieldType(mysql.TypeDuration)
 	require.Equal(t, UnspecifiedLength, ft.Flen)
 	require.Equal(t, UnspecifiedLength, ft.Decimal)
@@ -197,7 +196,6 @@ func TestFieldType(t *testing.T) {
 }
 
 func TestHasCharsetFromStmt(t *testing.T) {
-	t.Parallel()
 	template := "CREATE TABLE t(a %s)"
 
 	types := []struct {
@@ -246,7 +244,6 @@ func TestHasCharsetFromStmt(t *testing.T) {
 }
 
 func TestEnumSetFlen(t *testing.T) {
-	t.Parallel()
 	p := parser.New()
 	cases := []struct {
 		sql string
@@ -279,7 +276,6 @@ func TestEnumSetFlen(t *testing.T) {
 }
 
 func TestFieldTypeEqual(t *testing.T) {
-	t.Parallel()
 	// Tp not equal
 	ft1 := NewFieldType(mysql.TypeDouble)
 	ft2 := NewFieldType(mysql.TypeFloat)

--- a/planner/cascades/enforcer_rules_test.go
+++ b/planner/cascades/enforcer_rules_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestGetEnforcerRules(t *testing.T) {
-	t.Parallel()
-
 	prop := &property.PhysicalProperty{}
 	group := memo.NewGroupWithSchema(nil, expression.NewSchema())
 	enforcers := GetEnforcerRules(group, prop)
@@ -42,7 +40,6 @@ func TestGetEnforcerRules(t *testing.T) {
 }
 
 func TestNewProperties(t *testing.T) {
-	t.Parallel()
 	prop := &property.PhysicalProperty{}
 	col := &expression.Column{}
 	group := memo.NewGroupWithSchema(nil, expression.NewSchema())

--- a/planner/cascades/integration_test.go
+++ b/planner/cascades/integration_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestSimpleProjDual(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -40,8 +38,6 @@ func TestSimpleProjDual(t *testing.T) {
 }
 
 func TestPKIsHandleRangeScan(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -72,8 +68,6 @@ func TestPKIsHandleRangeScan(t *testing.T) {
 }
 
 func TestIndexScan(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -104,8 +98,6 @@ func TestIndexScan(t *testing.T) {
 }
 
 func TestBasicShow(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -121,8 +113,6 @@ func TestBasicShow(t *testing.T) {
 }
 
 func TestSort(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -152,8 +142,6 @@ func TestSort(t *testing.T) {
 }
 
 func TestAggregation(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -186,8 +174,6 @@ func TestAggregation(t *testing.T) {
 }
 
 func TestPushdownDistinctEnable(t *testing.T) {
-	t.Parallel()
-
 	var input []string
 	var output []struct {
 		SQL    string
@@ -203,8 +189,6 @@ func TestPushdownDistinctEnable(t *testing.T) {
 }
 
 func TestPushdownDistinctDisable(t *testing.T) {
-	t.Parallel()
-
 	var input []string
 	var output []struct {
 		SQL    string
@@ -253,8 +237,6 @@ func doTestPushdownDistinct(t *testing.T, vars, input []string, output []struct 
 }
 
 func TestSimplePlans(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -284,8 +266,6 @@ func TestSimplePlans(t *testing.T) {
 }
 
 func TestJoin(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -321,8 +301,6 @@ func TestJoin(t *testing.T) {
 }
 
 func TestApply(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -354,8 +332,6 @@ func TestApply(t *testing.T) {
 }
 
 func TestMemTableScan(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -382,8 +358,6 @@ func TestMemTableScan(t *testing.T) {
 }
 
 func TestTopN(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -413,8 +387,6 @@ func TestTopN(t *testing.T) {
 }
 
 func TestCascadePlannerHashedPartTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -449,8 +421,6 @@ func TestCascadePlannerHashedPartTable(t *testing.T) {
 }
 
 func TestInlineProjection(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/planner/cascades/optimize_test.go
+++ b/planner/cascades/optimize_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestImplGroupZeroCost(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
@@ -57,8 +55,6 @@ func TestImplGroupZeroCost(t *testing.T) {
 }
 
 func TestInitGroupSchema(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
@@ -81,8 +77,6 @@ func TestInitGroupSchema(t *testing.T) {
 }
 
 func TestFillGroupStats(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
@@ -104,8 +98,6 @@ func TestFillGroupStats(t *testing.T) {
 }
 
 func TestPreparePossibleProperties(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
@@ -198,8 +190,6 @@ func (rule *fakeTransformation) OnTransform(old *memo.ExprIter) (newExprs []*mem
 }
 
 func TestAppliedRuleSet(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})

--- a/planner/cascades/stringer_test.go
+++ b/planner/cascades/stringer_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestGroupStringer(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandSelection: {

--- a/planner/cascades/transformation_rules_test.go
+++ b/planner/cascades/transformation_rules_test.go
@@ -62,8 +62,6 @@ func testGroupToString(t *testing.T, input []string, output []struct {
 }
 
 func TestAggPushDownGather(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		memo.OperandAggregation: {
@@ -116,8 +114,6 @@ func TestAggPushDownGather(t *testing.T) {
 }
 
 func TestPredicatePushDown(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(
 		TransformationRuleBatch{ // TiDB layer
@@ -159,8 +155,6 @@ func TestPredicatePushDown(t *testing.T) {
 }
 
 func TestTopNRules(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(
 		TransformationRuleBatch{ // TiDB layer
@@ -200,8 +194,6 @@ func TestTopNRules(t *testing.T) {
 }
 
 func TestProjectionElimination(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		memo.OperandProjection: {
@@ -222,8 +214,6 @@ func TestProjectionElimination(t *testing.T) {
 }
 
 func TestEliminateMaxMin(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandAggregation: {
@@ -243,8 +233,6 @@ func TestEliminateMaxMin(t *testing.T) {
 }
 
 func TestMergeAggregationProjection(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandAggregation: {
@@ -264,8 +252,6 @@ func TestMergeAggregationProjection(t *testing.T) {
 }
 
 func TestMergeAdjacentTopN(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandLimit: {
@@ -292,8 +278,6 @@ func TestMergeAdjacentTopN(t *testing.T) {
 }
 
 func TestMergeAdjacentLimit(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		memo.OperandLimit: {
@@ -314,8 +298,6 @@ func TestMergeAdjacentLimit(t *testing.T) {
 }
 
 func TestTransformLimitToTableDual(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		memo.OperandLimit: {
@@ -335,8 +317,6 @@ func TestTransformLimitToTableDual(t *testing.T) {
 }
 
 func TestPostTransformationRules(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(TransformationRuleBatch{
 		memo.OperandLimit: {
@@ -356,8 +336,6 @@ func TestPostTransformationRules(t *testing.T) {
 }
 
 func TestPushLimitDownTiKVSingleGather(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandLimit: {
@@ -383,8 +361,6 @@ func TestPushLimitDownTiKVSingleGather(t *testing.T) {
 }
 
 func TestEliminateOuterJoin(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandAggregation: {
@@ -407,8 +383,6 @@ func TestEliminateOuterJoin(t *testing.T) {
 }
 
 func TestTransformAggregateCaseToSelection(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandAggregation: {
@@ -428,8 +402,6 @@ func TestTransformAggregateCaseToSelection(t *testing.T) {
 }
 
 func TestTransformAggToProj(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandAggregation: {
@@ -452,8 +424,6 @@ func TestTransformAggToProj(t *testing.T) {
 }
 
 func TestDecorrelate(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandApply: {
@@ -474,8 +444,6 @@ func TestDecorrelate(t *testing.T) {
 }
 
 func TestInjectProj(t *testing.T) {
-	t.Parallel()
-
 	optimizer := NewOptimizer()
 	optimizer.ResetTransformationRules(map[memo.Operand][]Transformation{
 		memo.OperandLimit: {

--- a/planner/core/cache_test.go
+++ b/planner/core/cache_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestCacheKey(t *testing.T) {
-	t.Parallel()
 	ctx := MockContext()
 	ctx.GetSessionVars().SnapshotTS = 0
 	ctx.GetSessionVars().SQLMode = mysql.ModeNone

--- a/planner/core/cacheable_checker_test.go
+++ b/planner/core/cacheable_checker_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestCacheable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/planner/core/collect_column_stats_usage_test.go
+++ b/planner/core/collect_column_stats_usage_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestCollectPredicateColumns(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/planner/core/exhaust_physical_plans_test.go
+++ b/planner/core/exhaust_physical_plans_test.go
@@ -47,7 +47,6 @@ func rewriteSimpleExpr(ctx sessionctx.Context, str string, schema *expression.Sc
 }
 
 func TestIndexJoinAnalyzeLookUpFilters(t *testing.T) {
-	t.Parallel()
 	ctx := MockContext()
 
 	ctx.GetSessionVars().PlanID = -1

--- a/planner/core/expression_test.go
+++ b/planner/core/expression_test.go
@@ -52,7 +52,6 @@ func runTests(t *testing.T, tests []testCase) {
 }
 
 func TestBetween(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{exprStr: "1 between 2 and 3", resultStr: "0"},
 		{exprStr: "1 not between 2 and 3", resultStr: "1"},
@@ -64,7 +63,6 @@ func TestBetween(t *testing.T) {
 }
 
 func TestCaseWhen(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{
 			exprStr:   "case 1 when 1 then 'str1' when 2 then 'str2' end",
@@ -103,7 +101,6 @@ func TestCaseWhen(t *testing.T) {
 }
 
 func TestCast(t *testing.T) {
-	t.Parallel()
 	f := types.NewFieldType(mysql.TypeLonglong)
 
 	expr := &ast.FuncCastExpr{
@@ -142,7 +139,6 @@ func TestCast(t *testing.T) {
 }
 
 func TestPatternIn(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{
 			exprStr:   "1 not in (1, 2, 3)",
@@ -189,7 +185,6 @@ func TestPatternIn(t *testing.T) {
 }
 
 func TestIsNull(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{
 			exprStr:   "1 IS NULL",
@@ -212,7 +207,6 @@ func TestIsNull(t *testing.T) {
 }
 
 func TestCompareRow(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{
 			exprStr:   "row(1,2,3)=row(1,2,3)",
@@ -255,7 +249,6 @@ func TestCompareRow(t *testing.T) {
 }
 
 func TestIsTruth(t *testing.T) {
-	t.Parallel()
 	tests := []testCase{
 		{
 			exprStr:   "1 IS TRUE",

--- a/planner/core/indexmerge_test.go
+++ b/planner/core/indexmerge_test.go
@@ -58,7 +58,6 @@ func getIndexMergePathDigest(paths []*util.AccessPath, startIndex int) string {
 }
 
 func TestIndexMergePathGeneration(t *testing.T) {
-	t.Parallel()
 	var input, output []string
 	indexMergeSuiteData.GetTestCases(t, &input, &output)
 	ctx := context.TODO()

--- a/planner/core/integration_partition_test.go
+++ b/planner/core/integration_partition_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestListPartitionPushDown(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -64,7 +63,6 @@ func TestListPartitionPushDown(t *testing.T) {
 }
 
 func TestListColVariousTypes(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -107,7 +105,6 @@ func TestListColVariousTypes(t *testing.T) {
 }
 
 func TestListPartitionPruning(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -151,7 +148,6 @@ func TestListPartitionPruning(t *testing.T) {
 }
 
 func TestListPartitionFunctions(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -190,7 +186,6 @@ func TestListPartitionOrderLimit(t *testing.T) {
 		t.Skip("skip race test")
 	}
 
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -254,7 +249,6 @@ func TestListPartitionAgg(t *testing.T) {
 		t.Skip("skip race test")
 	}
 
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -314,7 +308,6 @@ func TestListPartitionAgg(t *testing.T) {
 }
 
 func TestListPartitionDML(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -376,7 +369,6 @@ func TestListPartitionDML(t *testing.T) {
 }
 
 func TestListPartitionCreation(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -440,7 +432,6 @@ func TestListPartitionCreation(t *testing.T) {
 }
 
 func TestListPartitionDDL(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -495,7 +486,6 @@ func TestListPartitionDDL(t *testing.T) {
 }
 
 func TestListPartitionOperations(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -583,7 +573,6 @@ func TestListPartitionOperations(t *testing.T) {
 }
 
 func TestListPartitionPrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -623,7 +612,6 @@ func TestListPartitionPrivilege(t *testing.T) {
 }
 
 func TestListPartitionShardBits(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -655,7 +643,6 @@ func TestListPartitionShardBits(t *testing.T) {
 }
 
 func TestListPartitionSplitRegion(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -689,7 +676,6 @@ func TestListPartitionSplitRegion(t *testing.T) {
 }
 
 func TestListPartitionView(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -734,7 +720,6 @@ func TestListPartitionView(t *testing.T) {
 }
 
 func TestListPartitionAutoIncre(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -780,7 +765,6 @@ func TestListPartitionAutoIncre(t *testing.T) {
 }
 
 func TestListPartitionAutoRandom(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -816,7 +800,6 @@ func TestListPartitionAutoRandom(t *testing.T) {
 }
 
 func TestListPartitionInvisibleIdx(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -836,7 +819,6 @@ func TestListPartitionInvisibleIdx(t *testing.T) {
 }
 
 func TestListPartitionCTE(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -864,7 +846,6 @@ func TestListPartitionCTE(t *testing.T) {
 }
 
 func TestListPartitionTempTable(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -882,7 +863,6 @@ func TestListPartitionTempTable(t *testing.T) {
 }
 
 func TestListPartitionAlterPK(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -917,7 +897,6 @@ func TestListPartitionRandomTransaction(t *testing.T) {
 		t.Skip("skip race test")
 	}
 
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -971,7 +950,6 @@ func TestListPartitionRandomTransaction(t *testing.T) {
 }
 
 func TestIssue27018(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -999,7 +977,6 @@ PARTITION BY LIST COLUMNS(col1) (
 }
 
 func TestIssue27017(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1029,7 +1006,6 @@ PARTITION BY LIST COLUMNS(col1) (
 }
 
 func TestIssue27544(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1047,7 +1023,6 @@ func TestIssue27544(t *testing.T) {
 }
 
 func TestIssue27012(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1078,7 +1053,6 @@ PARTITION BY LIST COLUMNS(col1) (
 }
 
 func TestIssue27030(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1101,7 +1075,6 @@ PARTITION BY LIST COLUMNS(col1) (
 }
 
 func TestIssue27070(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1113,7 +1086,6 @@ func TestIssue27070(t *testing.T) {
 }
 
 func TestIssue27031(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1132,7 +1104,6 @@ PARTITION BY LIST COLUMNS(col1) (
 }
 
 func TestIssue27493(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1162,7 +1133,6 @@ func genListPartition(begin, end int) string {
 }
 
 func TestIssue27532(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/planner/memo/expr_iterator_test.go
+++ b/planner/memo/expr_iterator_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestNewExprIterFromGroupElem(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	schema := expression.NewSchema()
 
@@ -67,8 +65,6 @@ func TestNewExprIterFromGroupElem(t *testing.T) {
 }
 
 func TestExprIterNext(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	schema := expression.NewSchema()
 
@@ -116,8 +112,6 @@ func TestExprIterNext(t *testing.T) {
 }
 
 func TestExprIterReset(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	schema := expression.NewSchema()
 
@@ -190,8 +184,6 @@ func TestExprIterReset(t *testing.T) {
 }
 
 func TestExprIterWithEngineType(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	schema := expression.NewSchema()
 

--- a/planner/memo/group_expr_test.go
+++ b/planner/memo/group_expr_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestNewGroupExpr(t *testing.T) {
-	t.Parallel()
 	p := &plannercore.LogicalLimit{}
 	expr := NewGroupExpr(p)
 	require.Equal(t, p, expr.ExprNode)
@@ -34,7 +33,6 @@ func TestNewGroupExpr(t *testing.T) {
 }
 
 func TestGroupExprFingerprint(t *testing.T) {
-	t.Parallel()
 	p := &plannercore.LogicalLimit{Count: 3}
 	expr := NewGroupExpr(p)
 	childGroup := NewGroupWithSchema(nil, expression.NewSchema())

--- a/planner/memo/group_test.go
+++ b/planner/memo/group_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestNewGroup(t *testing.T) {
-	t.Parallel()
-
 	p := &plannercore.LogicalLimit{}
 	expr := NewGroupExpr(p)
 	g := NewGroupWithSchema(expr, expression.NewSchema())
@@ -42,7 +40,6 @@ func TestNewGroup(t *testing.T) {
 }
 
 func TestGroupInsert(t *testing.T) {
-	t.Parallel()
 	p := &plannercore.LogicalLimit{}
 	expr := NewGroupExpr(p)
 	g := NewGroupWithSchema(expr, expression.NewSchema())
@@ -52,8 +49,6 @@ func TestGroupInsert(t *testing.T) {
 }
 
 func TestGroupDelete(t *testing.T) {
-	t.Parallel()
-
 	p := &plannercore.LogicalLimit{}
 	expr := NewGroupExpr(p)
 	g := NewGroupWithSchema(expr, expression.NewSchema())
@@ -67,8 +62,6 @@ func TestGroupDelete(t *testing.T) {
 }
 
 func TestGroupDeleteAll(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	expr := NewGroupExpr(plannercore.LogicalSelection{}.Init(ctx, 0))
 	g := NewGroupWithSchema(expr, expression.NewSchema())
@@ -85,8 +78,6 @@ func TestGroupDeleteAll(t *testing.T) {
 }
 
 func TestGroupExists(t *testing.T) {
-	t.Parallel()
-
 	p := &plannercore.LogicalLimit{}
 	expr := NewGroupExpr(p)
 	g := NewGroupWithSchema(expr, expression.NewSchema())
@@ -97,8 +88,6 @@ func TestGroupExists(t *testing.T) {
 }
 
 func TestGroupFingerPrint(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	stmt1, err := p.ParseOneStmt("select * from t where a > 1 and a < 100", "", "")
 	require.NoError(t, err)
@@ -154,8 +143,6 @@ func TestGroupFingerPrint(t *testing.T) {
 }
 
 func TestGroupGetFirstElem(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	expr0 := NewGroupExpr(plannercore.LogicalProjection{}.Init(ctx, 0))
 	expr1 := NewGroupExpr(plannercore.LogicalLimit{}.Init(ctx, 0))
@@ -186,8 +173,6 @@ func (impl *fakeImpl) AttachChildren(...Implementation) Implementation { return 
 func (impl *fakeImpl) GetCostLimit(float64, ...Implementation) float64 { return 0 }
 
 func TestGetInsertGroupImpl(t *testing.T) {
-	t.Parallel()
-
 	g := NewGroupWithSchema(NewGroupExpr(plannercore.LogicalLimit{}.Init(plannercore.MockContext(), 0)), expression.NewSchema())
 	emptyProp := &property.PhysicalProperty{}
 	require.Nil(t, g.GetImpl(emptyProp))
@@ -201,8 +186,6 @@ func TestGetInsertGroupImpl(t *testing.T) {
 }
 
 func TestEngineTypeSet(t *testing.T) {
-	t.Parallel()
-
 	require.True(t, EngineAll.Contains(EngineTiDB))
 	require.True(t, EngineAll.Contains(EngineTiKV))
 	require.True(t, EngineAll.Contains(EngineTiFlash))
@@ -225,8 +208,6 @@ func TestEngineTypeSet(t *testing.T) {
 }
 
 func TestFirstElemAfterDelete(t *testing.T) {
-	t.Parallel()
-
 	ctx := plannercore.MockContext()
 	oldExpr := NewGroupExpr(plannercore.LogicalLimit{Count: 10}.Init(ctx, 0))
 	g := NewGroupWithSchema(oldExpr, expression.NewSchema())
@@ -242,8 +223,6 @@ func TestFirstElemAfterDelete(t *testing.T) {
 }
 
 func TestBuildKeyInfo(t *testing.T) {
-	t.Parallel()
-
 	p := parser.New()
 	ctx := plannercore.MockContext()
 	is := infoschema.MockInfoSchema([]*model.TableInfo{plannercore.MockSignedTable()})
@@ -291,8 +270,6 @@ func TestBuildKeyInfo(t *testing.T) {
 }
 
 func TestExploreMark(t *testing.T) {
-	t.Parallel()
-
 	mark := ExploreMark(0)
 	require.False(t, mark.Explored(0))
 	require.False(t, mark.Explored(1))

--- a/planner/memo/pattern_test.go
+++ b/planner/memo/pattern_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestGetOperand(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, OperandJoin, GetOperand(&plannercore.LogicalJoin{}))
 	require.Equal(t, OperandAggregation, GetOperand(&plannercore.LogicalAggregation{}))
 	require.Equal(t, OperandProjection, GetOperand(&plannercore.LogicalProjection{}))
@@ -40,8 +39,6 @@ func TestGetOperand(t *testing.T) {
 }
 
 func TestOperandMatch(t *testing.T) {
-	t.Parallel()
-
 	require.True(t, OperandAny.Match(OperandLimit))
 	require.True(t, OperandAny.Match(OperandSelection))
 	require.True(t, OperandAny.Match(OperandJoin))
@@ -66,8 +63,6 @@ func TestOperandMatch(t *testing.T) {
 }
 
 func TestNewPattern(t *testing.T) {
-	t.Parallel()
-
 	p := NewPattern(OperandAny, EngineAll)
 	require.Equal(t, OperandAny, p.Operand)
 	require.Nil(t, p.Children)
@@ -78,8 +73,6 @@ func TestNewPattern(t *testing.T) {
 }
 
 func TestPatternSetChildren(t *testing.T) {
-	t.Parallel()
-
 	p := NewPattern(OperandAny, EngineAll)
 	p.SetChildren(NewPattern(OperandLimit, EngineAll))
 	require.Len(t, p.Children, 1)

--- a/planner/util/path_test.go
+++ b/planner/util/path_test.go
@@ -77,7 +77,6 @@ func TestCompareCol2Len(t *testing.T) {
 }
 
 func TestOnlyPointRange(t *testing.T) {
-	t.Parallel()
 	sctx := core.MockContext()
 	nullDatum := types.MinNotNullDatum()
 	nullDatum.SetNull()

--- a/plugin/const_test.go
+++ b/plugin/const_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestConstToString(t *testing.T) {
-	t.Parallel()
 	kinds := map[fmt.Stringer]string{
 		Audit:                     "Audit",
 		Authentication:            "Authentication",

--- a/plugin/helper_test.go
+++ b/plugin/helper_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestPluginDeclare(t *testing.T) {
-	t.Parallel()
 	auditRaw := &AuditManifest{Manifest: Manifest{}}
 	auditExport := ExportManifest(auditRaw)
 	audit2 := DeclareAuditManifest(auditExport)
@@ -44,7 +43,6 @@ func TestPluginDeclare(t *testing.T) {
 }
 
 func TestDecode(t *testing.T) {
-	t.Parallel()
 	failID := ID("fail")
 	_, _, err := failID.Decode()
 	require.Error(t, err)

--- a/plugin/spi_test.go
+++ b/plugin/spi_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestExportManifest(t *testing.T) {
-	t.Parallel()
 	callRecorder := struct {
 		OnInitCalled      bool
 		NotifyEventCalled bool

--- a/privilege/privileges/cache_test.go
+++ b/privilege/privileges/cache_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestLoadUserTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -63,7 +62,6 @@ func TestLoadUserTable(t *testing.T) {
 }
 
 func TestLoadGlobalPrivTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -91,7 +89,6 @@ func TestLoadGlobalPrivTable(t *testing.T) {
 }
 
 func TestLoadDBTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -114,7 +111,6 @@ func TestLoadDBTable(t *testing.T) {
 }
 
 func TestLoadTablesPrivTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -140,7 +136,6 @@ func TestLoadTablesPrivTable(t *testing.T) {
 }
 
 func TestLoadColumnsPrivTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -166,7 +161,6 @@ func TestLoadColumnsPrivTable(t *testing.T) {
 }
 
 func TestLoadDefaultRoleTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -189,7 +183,6 @@ func TestLoadDefaultRoleTable(t *testing.T) {
 }
 
 func TestPatternMatch(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -230,7 +223,6 @@ func TestPatternMatch(t *testing.T) {
 }
 
 func TestHostMatch(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -288,7 +280,6 @@ func TestHostMatch(t *testing.T) {
 }
 
 func TestCaseInsensitive(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -310,7 +301,6 @@ func TestCaseInsensitive(t *testing.T) {
 }
 
 func TestLoadRoleGraph(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -344,7 +334,6 @@ func TestLoadRoleGraph(t *testing.T) {
 }
 
 func TestRoleGraphBFS(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -382,7 +371,6 @@ func TestRoleGraphBFS(t *testing.T) {
 }
 
 func TestFindAllUserEffectiveRoles(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -422,7 +410,6 @@ func TestFindAllUserEffectiveRoles(t *testing.T) {
 }
 
 func TestAbnormalMySQLTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -501,7 +488,6 @@ func TestAbnormalMySQLTable(t *testing.T) {
 }
 
 func TestSortUserTable(t *testing.T) {
-	t.Parallel()
 	var p privileges.MySQLPrivilege
 	p.User = []privileges.UserRecord{
 		privileges.NewUserRecord(`%`, "root"),
@@ -542,7 +528,6 @@ func TestSortUserTable(t *testing.T) {
 }
 
 func TestGlobalPrivValueRequireStr(t *testing.T) {
-	t.Parallel()
 	var (
 		none  = privileges.GlobalPrivValue{SSLType: privileges.SslTypeNone}
 		tls   = privileges.GlobalPrivValue{SSLType: privileges.SslTypeAny}
@@ -570,7 +555,6 @@ func checkUserRecord(t *testing.T, x, y []privileges.UserRecord) {
 }
 
 func TestDBIsVisible(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -50,7 +50,6 @@ import (
 const dbName = "test"
 
 func TestCheckDBPrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	rootSe := newSession(t, store, dbName)
@@ -80,7 +79,6 @@ func TestCheckDBPrivilege(t *testing.T) {
 }
 
 func TestCheckPointGetDBPrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	rootSe := newSession(t, store, dbName)
@@ -100,7 +98,6 @@ func TestCheckPointGetDBPrivilege(t *testing.T) {
 }
 
 func TestIssue22946(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	rootSe := newSession(t, store, dbName)
@@ -127,7 +124,6 @@ func TestIssue22946(t *testing.T) {
 }
 
 func TestCheckTablePrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -164,7 +160,6 @@ func TestCheckTablePrivilege(t *testing.T) {
 }
 
 func TestCheckViewPrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	rootSe := newSession(t, store, dbName)
@@ -187,7 +182,6 @@ func TestCheckViewPrivilege(t *testing.T) {
 }
 
 func TestCheckPrivilegeWithRoles(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	rootSe := newSession(t, store, dbName)
@@ -222,7 +216,6 @@ func TestCheckPrivilegeWithRoles(t *testing.T) {
 }
 
 func TestShowGrants(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -377,7 +370,6 @@ func TestShowGrants(t *testing.T) {
 // identity from mysql.user. In TiDB we now use the identity from mysql.user in error messages
 // for consistency.
 func TestErrorMessage(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -402,7 +394,6 @@ func TestErrorMessage(t *testing.T) {
 }
 
 func TestShowColumnGrants(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	se := newSession(t, store, dbName)
@@ -418,7 +409,6 @@ func TestShowColumnGrants(t *testing.T) {
 }
 
 func TestDropTablePrivileges(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -446,7 +436,6 @@ func TestDropTablePrivileges(t *testing.T) {
 }
 
 func TestSetPasswdStmt(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	se := newSession(t, store, dbName)
@@ -567,7 +556,6 @@ func TestAlterUserStmt(t *testing.T) {
 }
 
 func TestSelectViewSecurity(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -594,7 +582,6 @@ func TestSelectViewSecurity(t *testing.T) {
 }
 
 func TestShowViewPriv(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -691,7 +678,6 @@ func TestShowViewPriv(t *testing.T) {
 }
 
 func TestRoleAdminSecurity(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -714,7 +700,6 @@ func TestRoleAdminSecurity(t *testing.T) {
 }
 
 func TestCheckCertBasedAuth(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -951,7 +936,6 @@ func connectionState(issuer, subject pkix.Name, cipher uint16, opt ...func(c *x5
 }
 
 func TestCheckAuthenticate(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -994,7 +978,6 @@ func TestCheckAuthenticate(t *testing.T) {
 }
 
 func TestUseDB(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1041,7 +1024,6 @@ func TestUseDB(t *testing.T) {
 }
 
 func TestRevokePrivileges(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1069,7 +1051,6 @@ func TestRevokePrivileges(t *testing.T) {
 }
 
 func TestSetGlobal(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	se := newSession(t, store, dbName)
@@ -1086,7 +1067,6 @@ func TestSetGlobal(t *testing.T) {
 }
 
 func TestCreateDropUser(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1115,7 +1095,6 @@ func TestCreateDropUser(t *testing.T) {
 }
 
 func TestConfigPrivilege(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1142,7 +1121,6 @@ func TestConfigPrivilege(t *testing.T) {
 }
 
 func TestShowCreateTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1161,7 +1139,6 @@ func TestShowCreateTable(t *testing.T) {
 }
 
 func TestReplaceAndInsertOnDuplicate(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1204,7 +1181,6 @@ func TestReplaceAndInsertOnDuplicate(t *testing.T) {
 }
 
 func TestAnalyzeTable(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1245,7 +1221,6 @@ func TestAnalyzeTable(t *testing.T) {
 }
 
 func TestSystemSchema(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1283,7 +1258,6 @@ func TestSystemSchema(t *testing.T) {
 }
 
 func TestPerformanceSchema(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1318,7 +1292,6 @@ func TestPerformanceSchema(t *testing.T) {
 }
 
 func TestMetricsSchema(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1430,7 +1403,6 @@ func TestMetricsSchema(t *testing.T) {
 }
 
 func TestAdminCommand(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1453,7 +1425,6 @@ func TestAdminCommand(t *testing.T) {
 }
 
 func TestTableNotExistNoPermissions(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1502,7 +1473,6 @@ func TestTableNotExistNoPermissions(t *testing.T) {
 }
 
 func TestLoadDataPrivilege(t *testing.T) {
-	t.Parallel()
 	// Create file.
 	path := "/tmp/load_data_priv.csv"
 	fp, err := os.Create(path)
@@ -1537,7 +1507,6 @@ func TestLoadDataPrivilege(t *testing.T) {
 }
 
 func TestSelectIntoNoPermissions(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1550,7 +1519,6 @@ func TestSelectIntoNoPermissions(t *testing.T) {
 }
 
 func TestGetEncodedPassword(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1561,7 +1529,6 @@ func TestGetEncodedPassword(t *testing.T) {
 }
 
 func TestAuthHost(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1583,7 +1550,6 @@ func TestAuthHost(t *testing.T) {
 }
 
 func TestDefaultRoles(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1608,7 +1574,6 @@ func TestDefaultRoles(t *testing.T) {
 }
 
 func TestUserTableConsistency(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1638,7 +1603,6 @@ func TestUserTableConsistency(t *testing.T) {
 }
 
 func TestFieldList(t *testing.T) { // Issue #14237 List fields RPC
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -1681,7 +1645,6 @@ func newSession(t *testing.T, store kv.Storage, dbName string) session.Session {
 }
 
 func TestDynamicPrivs(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1728,7 +1691,6 @@ func TestDynamicPrivs(t *testing.T) {
 }
 
 func TestDynamicGrantOption(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1818,7 +1780,6 @@ func TestSecurityEnhancedModeInfoschema(t *testing.T) {
 }
 
 func TestClusterConfigInfoschema(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -1906,7 +1867,6 @@ func TestSecurityEnhancedModeStatusVars(t *testing.T) {
 	// So we can only test that the dynamic privilege is grantable.
 	// We will have to use an integration test to run SHOW STATUS LIKE 'tidb_gc_leader_desc'
 	// and verify if it appears.
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -1963,7 +1923,6 @@ func TestSecurityEnhancedLocalBackupRestore(t *testing.T) {
 }
 
 func TestRenameUser(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2075,7 +2034,6 @@ func TestSecurityEnhancedModeSysVars(t *testing.T) {
 // TestViewDefiner tests that default roles are correctly applied in the algorithm definer
 // See: https://github.com/pingcap/tidb/issues/24414
 func TestViewDefiner(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2153,7 +2111,6 @@ func TestSecurityEnhancedModeRestrictedUsers(t *testing.T) {
 }
 
 func TestDynamicPrivsRegistration(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2196,7 +2153,6 @@ func TestDynamicPrivsRegistration(t *testing.T) {
 func TestInfoSchemaUserPrivileges(t *testing.T) {
 	// Being able to read all privileges from information_schema.user_privileges requires a very specific set of permissions.
 	// SUPER user is not sufficient. It was observed in MySQL to require SELECT on mysql.*
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2255,7 +2211,6 @@ func TestInfoSchemaUserPrivileges(t *testing.T) {
 
 // Issues https://github.com/pingcap/tidb/issues/25972 and https://github.com/pingcap/tidb/issues/26451
 func TestGrantOptionAndRevoke(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2333,7 +2288,6 @@ func tearDownTest(t *testing.T, store kv.Storage, dbName string) {
 }
 
 func TestGrantReferences(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2359,7 +2313,6 @@ func TestGrantReferences(t *testing.T) {
 }
 
 func TestDashboardClientDynamicPriv(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2404,8 +2357,6 @@ func TestDashboardClientDynamicPriv(t *testing.T) {
 
 // https://github.com/pingcap/tidb/issues/27213
 func TestShowGrantsWithRolesAndDynamicPrivs(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2494,7 +2445,6 @@ func TestShowGrantsWithRolesAndDynamicPrivs(t *testing.T) {
 }
 
 func TestGrantLockTables(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2519,8 +2469,6 @@ func TestGrantLockTables(t *testing.T) {
 
 // https://github.com/pingcap/tidb/issues/27560
 func TestShowGrantsForCurrentUserUsingRole(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2572,7 +2520,6 @@ func TestShowGrantsForCurrentUserUsingRole(t *testing.T) {
 }
 
 func TestGrantPlacementAdminDynamicPriv(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2632,7 +2579,6 @@ func TestDBNameCaseSensitivityInTableLevel(t *testing.T) {
 }
 
 func TestInformationSchemaPlacmentRulesPrivileges(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2686,7 +2632,6 @@ func TestInformationSchemaPlacmentRulesPrivileges(t *testing.T) {
 }
 
 func TestGrantCreateTmpTables(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2711,7 +2656,6 @@ func TestGrantCreateTmpTables(t *testing.T) {
 }
 
 func TestCreateTmpTablesPriv(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2869,7 +2813,6 @@ func TestCreateTmpTablesPriv(t *testing.T) {
 }
 
 func TestRevokeSecondSyntax(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2886,7 +2829,6 @@ func TestRevokeSecondSyntax(t *testing.T) {
 }
 
 func TestGrantEvent(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2910,7 +2852,6 @@ func TestGrantEvent(t *testing.T) {
 }
 
 func TestGrantRoutine(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -2936,7 +2877,6 @@ func TestGrantRoutine(t *testing.T) {
 }
 
 func TestIssue28675(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 
@@ -3002,7 +2942,6 @@ func TestSkipGrantTable(t *testing.T) {
 }
 
 func TestIssue29823(t *testing.T) {
-	t.Parallel()
 	store, clean := newStore(t)
 	defer clean()
 

--- a/server/column_test.go
+++ b/server/column_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestDumpColumn(t *testing.T) {
-	t.Parallel()
-
 	info := ColumnInfo{
 		Schema:             "testSchema",
 		Table:              "testTable",
@@ -52,8 +50,6 @@ func TestDumpColumn(t *testing.T) {
 }
 
 func TestColumnNameLimit(t *testing.T) {
-	t.Parallel()
-
 	aLongName := make([]byte, 0, 300)
 	for i := 0; i < 300; i++ {
 		aLongName = append(aLongName, 'a')

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -44,7 +44,6 @@ import (
 )
 
 func TestMalformHandshakeHeader(t *testing.T) {
-	t.Parallel()
 	data := []byte{0x00}
 	var p handshakeResponse41
 	_, err := parseHandshakeResponseHeader(context.Background(), &p, data)
@@ -52,7 +51,6 @@ func TestMalformHandshakeHeader(t *testing.T) {
 }
 
 func TestParseHandshakeResponse(t *testing.T) {
-	t.Parallel()
 	// test data from http://dev.mysql.com/doc/internals/en/connection-phase-packets.html#packet-Protocol::HandshakeResponse41
 	data := []byte{
 		0x85, 0xa2, 0x1e, 0x00, 0x00, 0x00, 0x00, 0x40, 0x08, 0x00, 0x00, 0x00,
@@ -120,7 +118,6 @@ func TestParseHandshakeResponse(t *testing.T) {
 }
 
 func TestIssue1768(t *testing.T) {
-	t.Parallel()
 	// this data is from captured handshake packet, using mysql client.
 	// TiDB should handle authorization correctly, even mysql client set
 	// the ClientPluginAuthLenencClientData capability.
@@ -147,7 +144,6 @@ func TestIssue1768(t *testing.T) {
 }
 
 func TestAuthSwitchRequest(t *testing.T) {
-	t.Parallel()
 	// this data is from a MySQL 8.0 client
 	data := []byte{
 		0x85, 0xa6, 0xff, 0x1, 0x0, 0x0, 0x0, 0x1, 0x21, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0,
@@ -173,8 +169,6 @@ func TestAuthSwitchRequest(t *testing.T) {
 }
 
 func TestInitialHandshake(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -227,8 +221,6 @@ type dispatchInput struct {
 }
 
 func TestDispatch(t *testing.T) {
-	t.Parallel()
-
 	userData := append([]byte("root"), 0x0, 0x0)
 	userData = append(userData, []byte("test")...)
 	userData = append(userData, 0x0)
@@ -348,8 +340,6 @@ func TestDispatch(t *testing.T) {
 }
 
 func TestDispatchClientProtocol41(t *testing.T) {
-	t.Parallel()
-
 	userData := append([]byte("root"), 0x0, 0x0)
 	userData = append(userData, []byte("test")...)
 	userData = append(userData, 0x0)
@@ -524,8 +514,6 @@ func testDispatch(t *testing.T, inputs []dispatchInput, capability uint32) {
 }
 
 func TestGetSessionVarsWaitTimeout(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -560,8 +548,6 @@ func mapBelong(m1, m2 map[string]string) bool {
 }
 
 func TestConnExecutionTimeout(t *testing.T) {
-	t.Parallel()
-
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 
@@ -637,8 +623,6 @@ func TestConnExecutionTimeout(t *testing.T) {
 }
 
 func TestShutDown(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -654,8 +638,6 @@ func TestShutDown(t *testing.T) {
 }
 
 func TestShutdownOrNotify(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	se, err := session.CreateSession4Test(store)
@@ -686,8 +668,6 @@ type snapshotCache interface {
 }
 
 func TestPrefetchPointKeys(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -749,8 +729,6 @@ func testGetTableByName(t *testing.T, ctx sessionctx.Context, db, table string) 
 }
 
 func TestTiFlashFallback(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t,
 		mockstore.WithClusterInspector(func(c testutils.Cluster) {
 			mockCluster := c.(*unistore.Cluster)
@@ -881,8 +859,6 @@ func testFallbackWork(t *testing.T, tk *testkit.TestKit, cc *clientConn, sql str
 
 // For issue https://github.com/pingcap/tidb/issues/25069
 func TestShowErrors(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	cc := &clientConn{

--- a/server/driver_tidb_test.go
+++ b/server/driver_tidb_test.go
@@ -42,8 +42,6 @@ func createColumnByTypeAndLen(tp byte, len uint32) *ColumnInfo {
 	}
 }
 func TestConvertColumnInfo(t *testing.T) {
-	t.Parallel()
-
 	// Test "mysql.TypeBit", for: https://github.com/pingcap/tidb/issues/5405.
 	resultField := ast.ResultField{
 		Column: &model.ColumnInfo{

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -72,7 +72,6 @@ func createBasicHTTPHandlerTestSuite() *basicHTTPHandlerTestSuite {
 }
 
 func TestRegionIndexRange(t *testing.T) {
-	t.Parallel()
 	sTableID := int64(3)
 	sIndex := int64(11)
 	eTableID := int64(9)
@@ -143,7 +142,6 @@ func TestRegionIndexRange(t *testing.T) {
 }
 
 func TestRegionCommonHandleRange(t *testing.T) {
-	t.Parallel()
 	sTableID := int64(3)
 	indexValues := []types.Datum{
 		types.NewIntDatum(100),
@@ -179,7 +177,6 @@ func TestRegionCommonHandleRange(t *testing.T) {
 }
 
 func TestRegionIndexRangeWithEndNoLimit(t *testing.T) {
-	t.Parallel()
 	sTableID := int64(15)
 	startKey := tablecodec.GenTableRecordPrefix(sTableID)
 	endKey := []byte("z_aaaaafdfd")
@@ -197,7 +194,6 @@ func TestRegionIndexRangeWithEndNoLimit(t *testing.T) {
 }
 
 func TestRegionIndexRangeWithStartNoLimit(t *testing.T) {
-	t.Parallel()
 	eTableID := int64(9)
 	startKey := []byte("m_aaaaafdfd")
 	endKey := tablecodec.GenTableRecordPrefix(eTableID)
@@ -215,7 +211,6 @@ func TestRegionIndexRangeWithStartNoLimit(t *testing.T) {
 }
 
 func TestRegionsAPI(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -238,7 +233,6 @@ func TestRegionsAPI(t *testing.T) {
 }
 
 func TestRegionsAPIForClusterIndex(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -274,7 +268,6 @@ func TestRegionsAPIForClusterIndex(t *testing.T) {
 }
 
 func TestRangesAPI(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -314,7 +307,6 @@ func (ts *basicHTTPHandlerTestSuite) regionContainsTable(t *testing.T, regionID 
 }
 
 func TestListTableRegions(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -341,7 +333,6 @@ func TestListTableRegions(t *testing.T) {
 }
 
 func TestListTableRanges(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -367,7 +358,6 @@ func TestListTableRanges(t *testing.T) {
 }
 
 func TestGetRegionByIDWithError(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -378,7 +368,6 @@ func TestGetRegionByIDWithError(t *testing.T) {
 }
 
 func TestBinlogRecover(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -558,7 +547,6 @@ func decodeKeyMvcc(closer io.ReadCloser, t *testing.T, valid bool) {
 }
 
 func TestGetTableMVCC(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -657,7 +645,6 @@ func TestGetTableMVCC(t *testing.T) {
 }
 
 func TestGetMVCCNotFound(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -675,7 +662,6 @@ func TestGetMVCCNotFound(t *testing.T) {
 }
 
 func TestDecodeColumnValue(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -742,7 +728,6 @@ func TestDecodeColumnValue(t *testing.T) {
 }
 
 func TestGetIndexMVCC(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -821,7 +806,6 @@ func TestGetIndexMVCC(t *testing.T) {
 }
 
 func TestGetSettings(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -843,7 +827,6 @@ func TestGetSettings(t *testing.T) {
 }
 
 func TestGetSchema(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -959,7 +942,6 @@ func TestGetSchema(t *testing.T) {
 }
 
 func TestAllHistory(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	ts.prepareData(t)
@@ -996,7 +978,6 @@ func dummyRecord() *deadlockhistory.DeadlockRecord {
 }
 
 func TestPprof(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -1016,7 +997,6 @@ func TestPprof(t *testing.T) {
 }
 
 func TestHotRegionInfo(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -1027,7 +1007,6 @@ func TestHotRegionInfo(t *testing.T) {
 }
 
 func TestDebugZip(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 	ts.startServer(t)
 	defer ts.stopServer(t)
@@ -1041,7 +1020,6 @@ func TestDebugZip(t *testing.T) {
 }
 
 func TestCheckCN(t *testing.T) {
-	t.Parallel()
 	s := &Server{cfg: &config.Config{Security: config.Security{ClusterVerifyCN: []string{"a ", "b", "c"}}}}
 	tlsConfig := &tls.Config{}
 	s.setCNChecker(tlsConfig)
@@ -1055,7 +1033,6 @@ func TestCheckCN(t *testing.T) {
 }
 
 func TestDDLHookHandler(t *testing.T) {
-	t.Parallel()
 	ts := createBasicHTTPHandlerTestSuite()
 
 	ts.startServer(t)

--- a/server/mock_conn_test.go
+++ b/server/mock_conn_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestMockConn(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	server := CreateMockServer(t, store)

--- a/server/packetio_test.go
+++ b/server/packetio_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestPacketIOWrite(t *testing.T) {
-	t.Parallel()
-
 	// Test write one packet
 	var outBuffer bytes.Buffer
 	pkt := &packetIO{bufWriter: bufio.NewWriter(&outBuffer)}
@@ -53,8 +51,6 @@ func TestPacketIOWrite(t *testing.T) {
 }
 
 func TestPacketIORead(t *testing.T) {
-	t.Parallel()
-
 	var inBuffer bytes.Buffer
 	_, err := inBuffer.Write([]byte{0x01, 0x00, 0x00, 0x00, 0x01})
 	require.NoError(t, err)

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -140,13 +140,11 @@ func TestRegression(t *testing.T) {
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 	if regression {
-		t.Parallel()
 		ts.runTestRegression(t, nil, "Regression")
 	}
 }
 
 func TestUint64(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -154,7 +152,6 @@ func TestUint64(t *testing.T) {
 }
 
 func TestSpecialType(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -162,7 +159,6 @@ func TestSpecialType(t *testing.T) {
 }
 
 func TestPreparedString(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -170,7 +166,6 @@ func TestPreparedString(t *testing.T) {
 }
 
 func TestPreparedTimestamp(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -178,7 +173,6 @@ func TestPreparedTimestamp(t *testing.T) {
 }
 
 func TestConcurrentUpdate(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -186,7 +180,6 @@ func TestConcurrentUpdate(t *testing.T) {
 }
 
 func TestErrorCode(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -194,7 +187,6 @@ func TestErrorCode(t *testing.T) {
 }
 
 func TestAuth(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -203,7 +195,6 @@ func TestAuth(t *testing.T) {
 }
 
 func TestIssues(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -213,14 +204,12 @@ func TestIssues(t *testing.T) {
 }
 
 func TestDBNameEscape(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 	ts.runTestDBNameEscape(t)
 }
 
 func TestResultFieldTableIsNull(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -228,7 +217,6 @@ func TestResultFieldTableIsNull(t *testing.T) {
 }
 
 func TestStatusAPI(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -236,7 +224,6 @@ func TestStatusAPI(t *testing.T) {
 }
 
 func TestStatusPort(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -252,7 +239,6 @@ func TestStatusPort(t *testing.T) {
 }
 
 func TestStatusAPIWithTLS(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -298,7 +284,6 @@ func TestStatusAPIWithTLS(t *testing.T) {
 }
 
 func TestStatusAPIWithTLSCNCheck(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -377,7 +362,6 @@ func newTLSHttpClient(t *testing.T, caFile, certFile, keyFile string) *http.Clie
 }
 
 func TestMultiStatements(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -386,7 +370,6 @@ func TestMultiStatements(t *testing.T) {
 }
 
 func TestSocketForwarding(t *testing.T) {
-	t.Parallel()
 	osTempDir := os.TempDir()
 	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	require.NoError(t, err)
@@ -423,7 +406,6 @@ func TestSocketForwarding(t *testing.T) {
 }
 
 func TestSocket(t *testing.T) {
-	t.Parallel()
 	osTempDir := os.TempDir()
 	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	require.NoError(t, err)
@@ -463,7 +445,6 @@ func TestSocket(t *testing.T) {
 }
 
 func TestSocketAndIp(t *testing.T) {
-	t.Parallel()
 	osTempDir := os.TempDir()
 	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	require.NoError(t, err)
@@ -633,7 +614,6 @@ func TestSocketAndIp(t *testing.T) {
 
 // TestOnlySocket for server configuration without network interface for mysql clients
 func TestOnlySocket(t *testing.T) {
-	t.Parallel()
 	osTempDir := os.TempDir()
 	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	require.NoError(t, err)
@@ -895,7 +875,6 @@ func registerTLSConfig(configName string, caCertPath string, clientCertPath stri
 }
 
 func TestSystemTimeZone(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -912,7 +891,6 @@ func TestSystemTimeZone(t *testing.T) {
 }
 
 func TestClientWithCollation(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -920,7 +898,6 @@ func TestClientWithCollation(t *testing.T) {
 }
 
 func TestCreateTableFlen(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -994,7 +971,6 @@ func Execute(ctx context.Context, qc *TiDBContext, sql string) (ResultSet, error
 }
 
 func TestShowTablesFlen(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1026,7 +1002,6 @@ func checkColNames(t *testing.T, columns []*ColumnInfo, names ...string) {
 }
 
 func TestFieldList(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1109,28 +1084,24 @@ func TestFieldList(t *testing.T) {
 }
 
 func TestClientErrors(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 	ts.runTestInfoschemaClientErrors(t)
 }
 
 func TestInitConnect(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 	ts.runTestInitConnect(t)
 }
 
 func TestSumAvg(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 	ts.runTestSumAvg(t)
 }
 
 func TestNullFlag(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1199,7 +1170,6 @@ func TestNullFlag(t *testing.T) {
 }
 
 func TestNO_DEFAULT_VALUEFlag(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1223,7 +1193,6 @@ func TestNO_DEFAULT_VALUEFlag(t *testing.T) {
 }
 
 func TestGracefulShutdown(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1265,7 +1234,6 @@ func TestGracefulShutdown(t *testing.T) {
 }
 
 func TestPessimisticInsertSelectForUpdate(t *testing.T) {
-	t.Parallel()
 	ts, cleanup := createTidbTestSuite(t)
 	defer cleanup()
 
@@ -1692,7 +1660,6 @@ func (ts *tidbTestTopSQLSuite) loopExec(ctx context.Context, t *testing.T, fn fu
 }
 
 func TestLocalhostClientMapping(t *testing.T) {
-	t.Parallel()
 	osTempDir := os.TempDir()
 	tempDir, err := os.MkdirTemp(osTempDir, "tidb-test.*.socket")
 	require.NoError(t, err)

--- a/server/util_test.go
+++ b/server/util_test.go
@@ -31,8 +31,6 @@ import (
 )
 
 func TestDumpBinaryTime(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	parsedTime, err := types.ParseTimestamp(sc, "0000-00-00 00:00:00.000000")
 	require.NoError(t, err)
@@ -88,7 +86,6 @@ func TestDumpBinaryTime(t *testing.T) {
 }
 
 func TestResultEncoder(t *testing.T) {
-	t.Parallel()
 	// Encode bytes to utf-8.
 	d := newResultEncoder("utf-8")
 	src := []byte("test_string")
@@ -107,8 +104,6 @@ func TestResultEncoder(t *testing.T) {
 }
 
 func TestDumpTextValue(t *testing.T) {
-	t.Parallel()
-
 	columns := []*ColumnInfo{{
 		Type:    mysql.TypeLonglong,
 		Decimal: mysql.NotFixedDec,
@@ -256,8 +251,6 @@ func mustDecodeStr(t *testing.T, b []byte) string {
 }
 
 func TestAppendFormatFloat(t *testing.T) {
-	t.Parallel()
-
 	infVal, _ := strconv.ParseFloat("+Inf", 64)
 	tests := []struct {
 		fVal    float64
@@ -440,8 +433,6 @@ func TestAppendFormatFloat(t *testing.T) {
 }
 
 func TestDumpLengthEncodedInt(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		num    uint64
 		buffer []byte
@@ -470,8 +461,6 @@ func TestDumpLengthEncodedInt(t *testing.T) {
 }
 
 func TestParseLengthEncodedInt(t *testing.T) {
-	t.Parallel()
-
 	testCases := []struct {
 		buffer []byte
 		num    uint64
@@ -520,8 +509,6 @@ func TestParseLengthEncodedInt(t *testing.T) {
 }
 
 func TestDumpUint(t *testing.T) {
-	t.Parallel()
-
 	testCases := []uint64{
 		0,
 		1,
@@ -540,8 +527,6 @@ func TestDumpUint(t *testing.T) {
 }
 
 func TestParseLengthEncodedBytes(t *testing.T) {
-	t.Parallel()
-
 	buffer := []byte{'\xfb'}
 	b, isNull, n, err := parseLengthEncodedBytes(buffer)
 	require.Nil(t, b)
@@ -565,8 +550,6 @@ func TestParseLengthEncodedBytes(t *testing.T) {
 }
 
 func TestParseNullTermString(t *testing.T) {
-	t.Parallel()
-
 	for _, tc := range []struct {
 		input  string
 		str    string

--- a/session/clustered_index_test.go
+++ b/session/clustered_index_test.go
@@ -34,8 +34,6 @@ func createTestKit(t *testing.T, store kv.Storage) *testkit.TestKit {
 }
 
 func TestClusteredUnionScan(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -59,8 +57,6 @@ func TestClusteredUnionScan(t *testing.T) {
 }
 
 func TestClusteredPrefixColumn(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -134,8 +130,6 @@ func TestClusteredPrefixColumn(t *testing.T) {
 }
 
 func TestClusteredUnionScanIndexLookup(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -155,8 +149,6 @@ func TestClusteredUnionScanIndexLookup(t *testing.T) {
 }
 
 func TestClusteredIndexLookUp(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -169,8 +161,6 @@ func TestClusteredIndexLookUp(t *testing.T) {
 }
 
 func TestClusteredIndexLookUp2(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -197,8 +187,6 @@ SELECT c_balance, c_first, c_middle, c_id FROM c3 use index (idx) WHERE c_w_id =
 }
 
 func TestClusteredTopN(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -219,8 +207,6 @@ func TestClusteredTopN(t *testing.T) {
 }
 
 func TestClusteredHint(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -231,8 +217,6 @@ func TestClusteredHint(t *testing.T) {
 }
 
 func TestClusteredBatchPointGet(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -249,8 +233,6 @@ type SnapCacheSizeGetter interface {
 }
 
 func TestClusteredInsertIgnoreBatchGetKeyCount(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -270,8 +252,6 @@ func TestClusteredInsertIgnoreBatchGetKeyCount(t *testing.T) {
 }
 
 func TestClusteredPrefixingPrimaryKey(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -350,8 +330,6 @@ func TestClusteredPrefixingPrimaryKey(t *testing.T) {
 }
 
 func TestClusteredWithOldRowFormat(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -405,8 +383,6 @@ func TestClusteredWithOldRowFormat(t *testing.T) {
 }
 
 func TestIssue20002(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -423,8 +399,6 @@ func TestIssue20002(t *testing.T) {
 
 // https://github.com/pingcap/tidb/issues/20727
 func TestClusteredIndexSplitAndAddIndex(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -439,8 +413,6 @@ func TestClusteredIndexSplitAndAddIndex(t *testing.T) {
 }
 
 func TestClusteredIndexSelectWhereInNull(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestSysSessionPoolGoroutineLeak(t *testing.T) {
-	t.Parallel()
-
 	store, dom := createStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()
 	defer dom.Close()
@@ -58,8 +56,6 @@ func TestSysSessionPoolGoroutineLeak(t *testing.T) {
 }
 
 func TestParseErrorWarn(t *testing.T) {
-	t.Parallel()
-
 	ctx := core.MockContext()
 
 	nodes, err := Parse(ctx, "select /*+ adf */ 1")
@@ -72,8 +68,6 @@ func TestParseErrorWarn(t *testing.T) {
 }
 
 func TestKeysNeedLock(t *testing.T) {
-	t.Parallel()
-
 	rowKey := tablecodec.EncodeRowKeyWithHandle(1, kv.IntHandle(1))
 	indexKey := tablecodec.EncodeIndexSeekKey(1, 1, []byte{1})
 	uniqueValue := make([]byte, 8)

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -61,7 +61,6 @@ func TestSetSystemVariable(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		tc := tc
 		t.Run(tc.key, func(t *testing.T) {
-			t.Parallel()
 			mtx.Lock()
 			err := variable.SetSessionSystemVar(v, tc.key, tc.value)
 			mtx.Unlock()

--- a/sessionctx/variable/varsutil_test.go
+++ b/sessionctx/variable/varsutil_test.go
@@ -593,7 +593,6 @@ func TestValidate(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.key, func(t *testing.T) {
-			t.Parallel()
 			_, err := GetSysVar(tc.key).Validate(v, tc.value, ScopeGlobal)
 			if tc.error {
 				require.Errorf(t, err, "%v got err=%v", tc, err)
@@ -622,7 +621,6 @@ func TestValidate(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		tc := tc
 		t.Run(tc.key, func(t *testing.T) {
-			t.Parallel()
 			_, err := GetSysVar(tc.key).Validate(v, tc.value, ScopeSession)
 			if tc.error {
 				require.Errorf(t, err, "%v got err=%v", tc, err)
@@ -681,7 +679,6 @@ func TestValidateStmtSummary(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		tc := tc
 		t.Run(tc.key, func(t *testing.T) {
-			t.Parallel()
 			_, err := GetSysVar(tc.key).Validate(v, tc.value, tc.scope)
 			if tc.error {
 				require.Errorf(t, err, "%v got err=%v", tc, err)

--- a/statistics/cmsketch_test.go
+++ b/statistics/cmsketch_test.go
@@ -107,7 +107,6 @@ func averageAbsoluteError(cms *CMSketch, topN *TopN, mp map[int64]uint32) (uint6
 }
 
 func TestCMSketch(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		zipfFactor float64
 		avgError   uint64
@@ -152,7 +151,6 @@ func TestCMSketch(t *testing.T) {
 }
 
 func TestCMSketchCoding(t *testing.T) {
-	t.Parallel()
 	lSketch := NewCMSketch(5, 2048)
 	lSketch.count = 2048 * math.MaxUint32
 	for i := range lSketch.table {
@@ -169,7 +167,6 @@ func TestCMSketchCoding(t *testing.T) {
 }
 
 func TestCMSketchTopN(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		zipfFactor float64
 		avgError   uint64
@@ -208,7 +205,6 @@ func TestCMSketchTopN(t *testing.T) {
 }
 
 func TestMergeCMSketch4IncrementalAnalyze(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		zipfFactor float64
 		avgError   uint64
@@ -259,7 +255,6 @@ func TestMergeCMSketch4IncrementalAnalyze(t *testing.T) {
 }
 
 func TestCMSketchTopNUniqueData(t *testing.T) {
-	t.Parallel()
 	d, w := int32(5), int32(2048)
 	total := uint64(1000000)
 	mp := make(map[int64]uint32)
@@ -281,7 +276,6 @@ func TestCMSketchTopNUniqueData(t *testing.T) {
 }
 
 func TestCMSketchCodingTopN(t *testing.T) {
-	t.Parallel()
 	lSketch := NewCMSketch(5, 2048)
 	lSketch.count = 2048 * (math.MaxUint32)
 	for i := range lSketch.table {

--- a/statistics/feedback_test.go
+++ b/statistics/feedback_test.go
@@ -55,7 +55,6 @@ func genHistogram() *Histogram {
 }
 
 func TestUpdateHistogram(t *testing.T) {
-	t.Parallel()
 	feedbacks := []Feedback{
 		newFeedback(0, 1, 10000, 1),
 		newFeedback(1, 2, 1, 1),
@@ -80,7 +79,6 @@ func TestUpdateHistogram(t *testing.T) {
 }
 
 func TestSplitBuckets(t *testing.T) {
-	t.Parallel()
 	// test bucket split
 	feedbacks := []Feedback{newFeedback(0, 1, 1, 1)}
 	for i := 0; i < 100; i++ {
@@ -190,7 +188,6 @@ func TestSplitBuckets(t *testing.T) {
 }
 
 func TestMergeBuckets(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		points       []int64
 		counts       []int64
@@ -252,7 +249,6 @@ func encodeInt(v int64) *types.Datum {
 }
 
 func TestFeedbackEncoding(t *testing.T) {
-	t.Parallel()
 	hist := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeLong), 0, 0)
 	q := &QueryFeedback{Hist: hist, Tp: PkType}
 	q.Feedback = append(q.Feedback, Feedback{encodeInt(0), encodeInt(3), 1, 0, 1})

--- a/statistics/fmsketch_test.go
+++ b/statistics/fmsketch_test.go
@@ -35,7 +35,6 @@ func extractSampleItemsDatums(items []*SampleItem) []types.Datum {
 
 func SubTestSketch() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		sc := &stmtctx.StatementContext{TimeZone: time.Local}
 		maxSize := 1000
@@ -67,7 +66,6 @@ func SubTestSketch() func(*testing.T) {
 
 func SubTestSketchProtoConversion() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		sc := &stmtctx.StatementContext{TimeZone: time.Local}
 		maxSize := 1000
@@ -86,7 +84,6 @@ func SubTestSketchProtoConversion() func(*testing.T) {
 
 func SubTestFMSketchCoding() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		sc := &stmtctx.StatementContext{TimeZone: time.Local}
 		maxSize := 1000

--- a/statistics/handle/update_list_test.go
+++ b/statistics/handle/update_list_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestInsertAndDelete(t *testing.T) {
-	t.Parallel()
 	h := Handle{
 		listHead: &SessionStatsCollector{mapper: make(tableDeltaMap)},
 		feedback: statistics.NewQueryFeedbackMap(),

--- a/statistics/histogram_test.go
+++ b/statistics/histogram_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 func TestNewHistogramBySelectivity(t *testing.T) {
-	t.Parallel()
 	coll := &HistColl{
 		Count:   330,
 		Columns: make(map[int64]*Column),
@@ -125,7 +124,6 @@ num: 30 lower_bound: 12 upper_bound: 14 repeats: 10 ndv: 0`
 }
 
 func TestTruncateHistogram(t *testing.T) {
-	t.Parallel()
 	hist := NewHistogram(0, 0, 0, 0, types.NewFieldType(mysql.TypeLonglong), 1, 0)
 	low, high := types.NewIntDatum(0), types.NewIntDatum(1)
 	hist.AppendBucket(&low, &high, 0, 1)
@@ -136,7 +134,6 @@ func TestTruncateHistogram(t *testing.T) {
 }
 
 func TestValueToString4InvalidKey(t *testing.T) {
-	t.Parallel()
 	bytes, err := codec.EncodeKey(nil, nil, types.NewDatum(1), types.NewDatum(0.5))
 	require.NoError(t, err)
 	// Append invalid flag.
@@ -174,7 +171,6 @@ func genHist4Test(t *testing.T, buckets []*bucket4Test, totColSize int64) *Histo
 }
 
 func TestMergePartitionLevelHist(t *testing.T) {
-	t.Parallel()
 	type testCase struct {
 		partitionHists  [][]*bucket4Test
 		totColSize      []int64
@@ -428,7 +424,6 @@ func genBucket4Merging4Test(lower, upper, ndv, disjointNDV int64) bucket4Merging
 }
 
 func TestMergeBucketNDV(t *testing.T) {
-	t.Parallel()
 	type testData struct {
 		left   bucket4Merging
 		right  bucket4Merging

--- a/statistics/integration_test.go
+++ b/statistics/integration_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestChangeVerTo2Behavior(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -103,7 +102,6 @@ func TestChangeVerTo2Behavior(t *testing.T) {
 }
 
 func TestFastAnalyzeOnVer2(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -152,7 +150,6 @@ func TestFastAnalyzeOnVer2(t *testing.T) {
 }
 
 func TestIncAnalyzeOnVer2(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -180,7 +177,6 @@ func TestIncAnalyzeOnVer2(t *testing.T) {
 }
 
 func TestExpBackoffEstimation(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -217,7 +213,6 @@ func TestExpBackoffEstimation(t *testing.T) {
 }
 
 func TestGlobalStats(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -314,7 +309,6 @@ func TestGlobalStats(t *testing.T) {
 }
 
 func TestNULLOnFullSampling(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -350,7 +344,6 @@ func TestNULLOnFullSampling(t *testing.T) {
 }
 
 func TestAnalyzeSnapshot(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -380,7 +373,6 @@ func TestAnalyzeSnapshot(t *testing.T) {
 }
 
 func TestHistogramsWithSameTxnTS(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -402,7 +394,6 @@ func TestHistogramsWithSameTxnTS(t *testing.T) {
 }
 
 func TestAnalyzeLongString(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/statistics/sample_test.go
+++ b/statistics/sample_test.go
@@ -56,7 +56,6 @@ func recordSetForDistributedSamplingTest(size, batch int) []*recordSet {
 }
 
 func TestWeightedSampling(t *testing.T) {
-	t.Parallel()
 	sampleNum := int64(20)
 	rowNum := 100
 	loopCnt := 1000
@@ -95,7 +94,6 @@ func TestWeightedSampling(t *testing.T) {
 }
 
 func TestDistributedWeightedSampling(t *testing.T) {
-	t.Parallel()
 	sampleNum := int64(10)
 	rowNum := 100
 	loopCnt := 1500
@@ -139,7 +137,6 @@ func TestDistributedWeightedSampling(t *testing.T) {
 }
 
 func TestBuildStatsOnRowSample(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	sketch := NewFMSketch(1000)
 	data := make([]*SampleItem, 0, 8)

--- a/statistics/scalar_test.go
+++ b/statistics/scalar_test.go
@@ -61,8 +61,6 @@ func getUnsignedFieldType() *types.FieldType {
 }
 
 func TestCalcFraction(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		lower    types.Datum
 		upper    types.Datum
@@ -179,8 +177,6 @@ func TestCalcFraction(t *testing.T) {
 }
 
 func TestEnumRangeValues(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		low         types.Datum
 		high        types.Datum

--- a/statistics/selectivity_test.go
+++ b/statistics/selectivity_test.go
@@ -130,7 +130,6 @@ func getRange(start, end int64) []*ranger.Range {
 }
 
 func TestSelectivityGreedyAlgo(t *testing.T) {
-	t.Parallel()
 	nodes := make([]*statistics.StatsNode, 3)
 	nodes[0] = statistics.MockStatsNode(1, 3, 2)
 	nodes[1] = statistics.MockStatsNode(2, 5, 2)

--- a/statistics/statistics_test.go
+++ b/statistics/statistics_test.go
@@ -134,7 +134,6 @@ func mockHistogram(lower, num int64) *Histogram {
 }
 
 func TestMergeHistogram(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		leftLower  int64
 		leftNum    int64
@@ -190,7 +189,6 @@ func TestMergeHistogram(t *testing.T) {
 }
 
 func TestPseudoTable(t *testing.T) {
-	t.Parallel()
 	ti := &model.TableInfo{}
 	colInfo := &model.ColumnInfo{
 		ID:        1,
@@ -233,7 +231,6 @@ func buildCMSketch(values []types.Datum) *CMSketch {
 
 func SubTestColumnRange() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		bucketCount := int64(256)
 		ctx := mock.NewContext()
@@ -312,7 +309,6 @@ func SubTestColumnRange() func(*testing.T) {
 
 func SubTestIntColumnRanges() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		bucketCount := int64(256)
 		ctx := mock.NewContext()
@@ -407,7 +403,6 @@ func SubTestIntColumnRanges() func(*testing.T) {
 
 func SubTestIndexRanges() func(*testing.T) {
 	return func(t *testing.T) {
-		t.Parallel()
 		s := createTestStatisticsSamples(t)
 		bucketCount := int64(256)
 		ctx := mock.NewContext()

--- a/store/copr/batch_coprocessor_test.go
+++ b/store/copr/batch_coprocessor_test.go
@@ -94,8 +94,6 @@ func calcReginCount(tasks []*batchCopTask) int {
 }
 
 func TestBalanceBatchCopTaskWithContinuity(t *testing.T) {
-	t.Parallel()
-
 	for replicaNum := 1; replicaNum < 6; replicaNum++ {
 		storeCount := 10
 		regionCount := 100000

--- a/store/copr/coprocessor_cache_test.go
+++ b/store/copr/coprocessor_cache_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestBuildCacheKey(t *testing.T) {
-	t.Parallel()
 	req := coprocessor.Request{
 		Tp:      0xAB,
 		StartTs: 0xAABBCC,
@@ -70,7 +69,6 @@ func TestBuildCacheKey(t *testing.T) {
 }
 
 func TestDisable(t *testing.T) {
-	t.Parallel()
 	cache, err := newCoprCache(&config.CoprocessorCache{CapacityMB: 0})
 	require.NoError(t, err)
 	require.Nil(t, cache)
@@ -95,7 +93,6 @@ func TestDisable(t *testing.T) {
 }
 
 func TestAdmission(t *testing.T) {
-	t.Parallel()
 	cache, err := newCoprCache(&config.CoprocessorCache{AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
 	require.NoError(t, err)
 	require.NotNil(t, cache)
@@ -153,7 +150,6 @@ func TestAdmission(t *testing.T) {
 }
 
 func TestCacheValueLen(t *testing.T) {
-	t.Parallel()
 	v := coprCacheValue{
 		TimeStamp:         0x123,
 		RegionID:          0x1,
@@ -173,7 +169,6 @@ func TestCacheValueLen(t *testing.T) {
 }
 
 func TestGetSet(t *testing.T) {
-	t.Parallel()
 	cache, err := newCoprCache(&config.CoprocessorCache{AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: 1})
 	require.NoError(t, err)
 	require.NotNil(t, cache)
@@ -200,7 +195,6 @@ func TestGetSet(t *testing.T) {
 }
 
 func TestIssue24118(t *testing.T) {
-	t.Parallel()
 	_, err := newCoprCache(&config.CoprocessorCache{AdmissionMinProcessMs: 5, AdmissionMaxResultMB: 1, CapacityMB: -1})
 	require.EqualError(t, err, "Capacity must be > 0 to enable the cache")
 }

--- a/store/copr/coprocessor_test.go
+++ b/store/copr/coprocessor_test.go
@@ -27,7 +27,6 @@ import (
 )
 
 func TestBuildTasks(t *testing.T) {
-	t.Parallel()
 	// nil --- 'g' --- 'n' --- 't' --- nil
 	// <-  0  -> <- 1 -> <- 2 -> <- 3 ->
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
@@ -155,7 +154,6 @@ func TestBuildTasks(t *testing.T) {
 }
 
 func TestSplitRegionRanges(t *testing.T) {
-	t.Parallel()
 	// nil --- 'g' --- 'n' --- 't' --- nil
 	// <-  0  -> <- 1 -> <- 2 -> <- 3 ->
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
@@ -218,7 +216,6 @@ func TestSplitRegionRanges(t *testing.T) {
 }
 
 func TestRebuild(t *testing.T) {
-	t.Parallel()
 	// nil --- 'm' --- nil
 	// <-  0  -> <- 1 ->
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
@@ -292,7 +289,6 @@ func rangeEqual(t *testing.T, ranges []kv.KeyRange, keys ...string) {
 }
 
 func TestBuildPagingTasks(t *testing.T) {
-	t.Parallel()
 	// nil --- 'g' --- 'n' --- 't' --- nil
 	// <-  0  -> <- 1 -> <- 2 -> <- 3 ->
 	mockClient, cluster, pdClient, err := testutils.NewMockTiKV("", nil)
@@ -345,7 +341,6 @@ func toRange(r *KeyRanges) []kv.KeyRange {
 }
 
 func TestCalculateRetry(t *testing.T) {
-	t.Parallel()
 	worker := copIteratorWorker{}
 
 	// split in one range
@@ -404,7 +399,6 @@ func TestCalculateRetry(t *testing.T) {
 }
 
 func TestCalculateRemain(t *testing.T) {
-	t.Parallel()
 	worker := copIteratorWorker{}
 
 	// split in one range

--- a/store/copr/key_ranges_test.go
+++ b/store/copr/key_ranges_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestCopRanges(t *testing.T) {
-	t.Parallel()
 	ranges := []kv.KeyRange{
 		{StartKey: []byte("a"), EndKey: []byte("b")},
 		{StartKey: []byte("c"), EndKey: []byte("d")},
@@ -36,7 +35,6 @@ func TestCopRanges(t *testing.T) {
 }
 
 func TestCopRangeSplit(t *testing.T) {
-	t.Parallel()
 	first := &kv.KeyRange{StartKey: []byte("a"), EndKey: []byte("b")}
 	mid := []kv.KeyRange{
 		{StartKey: []byte("c"), EndKey: []byte("d")},

--- a/store/driver/txn/batch_getter_test.go
+++ b/store/driver/txn/batch_getter_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestBufferBatchGetter(t *testing.T) {
-	t.Parallel()
-
 	snap := newMockStore()
 	ka := []byte("a")
 	kb := []byte("b")

--- a/store/driver/txn/driver_test.go
+++ b/store/driver/txn/driver_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestLockNotFoundPrint(t *testing.T) {
-	t.Parallel()
 	msg := "Txn(Mvcc(TxnLockNotFound { start_ts: 408090278408224772, commit_ts: 408090279311835140, " +
 		"key: [116, 128, 0, 0, 0, 0, 0, 50, 137, 95, 105, 128, 0, 0, 0, 0,0 ,0, 1, 1, 67, 49, 57, 48, 57, 50, 57, 48, 255, 48, 48, 48, 48, 48, 52, 56, 54, 255, 50, 53, 53, 50, 51, 0, 0, 0, 252] }))"
 	key := prettyLockNotFoundKey(msg)
@@ -31,7 +30,6 @@ func TestLockNotFoundPrint(t *testing.T) {
 }
 
 func TestWriteConflictPrettyFormat(t *testing.T) {
-	t.Parallel()
 	conflict := &kvrpcpb.WriteConflict{
 		StartTs:          399402937522847774,
 		ConflictTs:       399402937719455772,

--- a/store/driver/txn/union_iter_test.go
+++ b/store/driver/txn/union_iter_test.go
@@ -34,7 +34,6 @@ func r(key, value string) *kv.Entry {
 }
 
 func TestUnionIter(t *testing.T) {
-	t.Parallel()
 	// test iter normal cases, snap iter become invalid before dirty iter
 	snapRecords := []*kv.Entry{
 		r("k00", "v0"),
@@ -115,7 +114,6 @@ func TestUnionIter(t *testing.T) {
 }
 
 func TestUnionIterErrors(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		dirty                     []*kv.Entry
 		snap                      []*kv.Entry

--- a/store/helper/helper_test.go
+++ b/store/helper/helper_test.go
@@ -34,8 +34,6 @@ import (
 )
 
 func TestHotRegion(t *testing.T) {
-	t.Parallel()
-
 	store, clean := createMockStore(t)
 	defer clean()
 
@@ -71,8 +69,6 @@ func TestHotRegion(t *testing.T) {
 }
 
 func TestGetRegionsTableInfo(t *testing.T) {
-	t.Parallel()
-
 	store, clean := createMockStore(t)
 	defer clean()
 
@@ -84,8 +80,6 @@ func TestGetRegionsTableInfo(t *testing.T) {
 }
 
 func TestTiKVRegionsInfo(t *testing.T) {
-	t.Parallel()
-
 	store, clean := createMockStore(t)
 	defer clean()
 
@@ -99,8 +93,6 @@ func TestTiKVRegionsInfo(t *testing.T) {
 }
 
 func TestTiKVStoresStat(t *testing.T) {
-	t.Parallel()
-
 	store, clean := createMockStore(t)
 	defer clean()
 

--- a/store/mockstore/mockcopr/cop_handler_dag_test.go
+++ b/store/mockstore/mockcopr/cop_handler_dag_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestConstructTimezone(t *testing.T) {
-	t.Parallel()
-
 	secondsEastOfUTC := int((8 * time.Hour).Seconds())
 	loc, err := constructTimeZone("", secondsEastOfUTC)
 	require.NoError(t, err)

--- a/store/mockstore/mockcopr/executor_test.go
+++ b/store/mockstore/mockcopr/executor_test.go
@@ -37,8 +37,6 @@ import (
 // This test checks the resolve lock functionality. When a txn meets the lock of a large transaction,
 // it should not block by the lock.
 func TestResolvedLargeTxnLocks(t *testing.T) {
-	t.Parallel()
-
 	rpcClient, cluster, pdClient, err := testutils.NewMockTiKV("", mockcopr.NewCoprRPCHandler())
 	require.NoError(t, err)
 
@@ -105,8 +103,6 @@ func TestResolvedLargeTxnLocks(t *testing.T) {
 }
 
 func TestIssue15662(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/store/mockstore/unistore/cophandler/cop_handler_test.go
+++ b/store/mockstore/unistore/cophandler/cop_handler_test.go
@@ -279,8 +279,6 @@ func (dagBuilder *dagBuilder) build() *tipb.DAGRequest {
 
 // see tikv/src/coprocessor/util.rs for more detail
 func TestIsPrefixNext(t *testing.T) {
-	t.Parallel()
-
 	require.True(t, isPrefixNext([]byte{}, []byte{0}))
 	require.True(t, isPrefixNext([]byte{0}, []byte{1}))
 	require.True(t, isPrefixNext([]byte{1}, []byte{2}))
@@ -295,8 +293,6 @@ func TestIsPrefixNext(t *testing.T) {
 }
 
 func TestPointGet(t *testing.T) {
-	t.Parallel()
-
 	// here would build mvccStore and server, and prepare
 	// three rows data, just like the test data of table_scan.rs.
 	// then init the store with the generated data.
@@ -349,8 +345,6 @@ func TestPointGet(t *testing.T) {
 }
 
 func TestClosureExecutor(t *testing.T) {
-	t.Parallel()
-
 	data := prepareTestTableData(t, keyNumber, tableID)
 	store, clean := newTestStore(t, "cop_handler_test_db", "cop_handler_test_log")
 	defer clean()

--- a/store/mockstore/unistore/lockstore/lockstore_test.go
+++ b/store/mockstore/unistore/lockstore/lockstore_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestMemStore(t *testing.T) {
-	t.Parallel()
-
 	prefix := "ls"
 	n := 30000
 	ls := NewMemStore(1 << 10)
@@ -80,8 +78,6 @@ func deleteMemStore(t *testing.T, ls *MemStore, prefix string, n int) {
 }
 
 func TestIterator(t *testing.T) {
-	t.Parallel()
-
 	_ = checkKey
 	t.Skip("Skip this unstable test(#26235) and bring it back before 2021-07-29.")
 	ls := NewMemStore(1 << 10)
@@ -133,8 +129,6 @@ func numToKey(n int) []byte {
 }
 
 func TestReplace(t *testing.T) {
-	t.Parallel()
-
 	prefix := "ls"
 	n := 30000
 	ls := NewMemStore(1 << 10)

--- a/store/mockstore/unistore/raw_handler_test.go
+++ b/store/mockstore/unistore/raw_handler_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestRawHandler(t *testing.T) {
-	t.Parallel()
-
 	h := newRawHandler()
 	ctx := context.Background()
 	keys := make([][]byte, 10)

--- a/store/mockstore/unistore/tikv/detector_test.go
+++ b/store/mockstore/unistore/tikv/detector_test.go
@@ -36,8 +36,6 @@ import (
 )
 
 func TestDeadlock(t *testing.T) {
-	t.Parallel()
-
 	makeDiagCtx := func(key string, resourceGroupTag string) diagnosticContext {
 		return diagnosticContext{
 			key:              []byte(key),

--- a/store/mockstore/unistore/tikv/mvcc_test.go
+++ b/store/mockstore/unistore/tikv/mvcc_test.go
@@ -483,7 +483,6 @@ func MustGetRollback(key []byte, ts uint64, store *TestStore) {
 }
 
 func TestBasicOptimistic(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -498,7 +497,6 @@ func TestBasicOptimistic(t *testing.T) {
 }
 
 func TestPessimiticTxnTTL(t *testing.T) {
-	t.Parallel()
 	var err error
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
@@ -528,7 +526,6 @@ func TestPessimiticTxnTTL(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -563,7 +560,6 @@ func TestRollback(t *testing.T) {
 }
 
 func TestOverwritePessimisitcLock(t *testing.T) {
-	t.Parallel()
 	var err error
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
@@ -592,7 +588,6 @@ func TestOverwritePessimisitcLock(t *testing.T) {
 }
 
 func TestCheckTxnStatus(t *testing.T) {
-	t.Parallel()
 	var err error
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
@@ -695,7 +690,6 @@ func TestCheckTxnStatus(t *testing.T) {
 }
 
 func TestCheckSecondaryLocksStatus(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -762,7 +756,6 @@ func TestCheckSecondaryLocksStatus(t *testing.T) {
 }
 
 func TestMvccGet(t *testing.T) {
-	t.Parallel()
 	var err error
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
@@ -877,7 +870,6 @@ func TestMvccGet(t *testing.T) {
 }
 
 func TestPrimaryKeyOpLock(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -929,7 +921,6 @@ func TestPrimaryKeyOpLock(t *testing.T) {
 }
 
 func TestMvccTxnRead(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1001,7 +992,6 @@ func TestMvccTxnRead(t *testing.T) {
 }
 
 func TestTxnPrewrite(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1037,7 +1027,6 @@ func TestTxnPrewrite(t *testing.T) {
 }
 
 func TestPrewriteInsert(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1074,7 +1063,6 @@ func TestPrewriteInsert(t *testing.T) {
 }
 
 func TestRollbackKey(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1100,7 +1088,6 @@ func TestRollbackKey(t *testing.T) {
 }
 
 func TestCleanup(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1123,7 +1110,6 @@ func TestCleanup(t *testing.T) {
 }
 
 func TestCommit(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1175,7 +1161,6 @@ func TestCommit(t *testing.T) {
 }
 
 func TestMinCommitTs(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1197,7 +1182,6 @@ func TestMinCommitTs(t *testing.T) {
 }
 
 func TestPessimisticLock(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1363,7 +1347,6 @@ func TestPessimisticLock(t *testing.T) {
 }
 
 func TestResolveCommit(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1429,7 +1412,6 @@ func MustLoad(startTS, commitTS uint64, store *TestStore, pairs ...string) {
 }
 
 func TestBatchGet(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 	MustLoad(100, 101, store, "ta:1", "tb:2", "tc:3")
@@ -1443,7 +1425,6 @@ func TestBatchGet(t *testing.T) {
 }
 
 func TestCommitPessimisticLock(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 	k := []byte("ta")
@@ -1454,7 +1435,6 @@ func TestCommitPessimisticLock(t *testing.T) {
 }
 
 func TestOpCheckNotExist(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1472,7 +1452,6 @@ func TestOpCheckNotExist(t *testing.T) {
 }
 
 func TestPessimisticLockForce(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1490,7 +1469,6 @@ func TestPessimisticLockForce(t *testing.T) {
 }
 
 func TestScanSampleStep(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 	for i := 0; i < 1000; i++ {
@@ -1524,7 +1502,6 @@ func genScanSampleStepKey(i int) []byte {
 }
 
 func TestAsyncCommitPrewrite(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 
@@ -1554,7 +1531,6 @@ func TestAsyncCommitPrewrite(t *testing.T) {
 }
 
 func TestAccessCommittedLocks(t *testing.T) {
-	t.Parallel()
 	store, close := NewTestStore("basic_optimistic_db", "basic_optimistic_log", t)
 	defer close()
 

--- a/store/mockstore/unistore/util/lockwaiter/lockwaiter_test.go
+++ b/store/mockstore/unistore/util/lockwaiter/lockwaiter_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestLockwaiterBasic(t *testing.T) {
-	t.Parallel()
-
 	mgr := NewManager(&config.DefaultConf)
 
 	keyHash := uint64(100)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -141,8 +141,6 @@ func TestNew(t *testing.T) {
 }
 
 func TestGetSet(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -198,8 +196,6 @@ func TestSeek(t *testing.T) {
 }
 
 func TestInc(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -240,8 +236,6 @@ func TestInc(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -287,8 +281,6 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDelete2(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -329,8 +321,6 @@ func TestDelete2(t *testing.T) {
 }
 
 func TestSetNil(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -347,8 +337,6 @@ func TestSetNil(t *testing.T) {
 }
 
 func TestBasicSeek(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -373,8 +361,6 @@ func TestBasicSeek(t *testing.T) {
 }
 
 func TestBasicTable(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -431,8 +417,6 @@ func TestBasicTable(t *testing.T) {
 }
 
 func TestRollback(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -468,8 +452,6 @@ func TestRollback(t *testing.T) {
 }
 
 func TestSeekMin(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -510,8 +492,6 @@ func TestSeekMin(t *testing.T) {
 }
 
 func TestConditionIfNotExist(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -552,8 +532,6 @@ func TestConditionIfNotExist(t *testing.T) {
 }
 
 func TestConditionIfEqual(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -599,8 +577,6 @@ func TestConditionIfEqual(t *testing.T) {
 }
 
 func TestConditionUpdate(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -659,8 +635,6 @@ func TestDBClose(t *testing.T) {
 }
 
 func TestIsolationInc(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -707,8 +681,6 @@ func TestIsolationInc(t *testing.T) {
 }
 
 func TestIsolationMultiInc(t *testing.T) {
-	t.Parallel()
-
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	defer func() {
@@ -763,7 +735,6 @@ func TestIsolationMultiInc(t *testing.T) {
 }
 
 func TestRetryOpenStore(t *testing.T) {
-	t.Parallel()
 	begin := time.Now()
 	require.NoError(t, Register("dummy", &brokenStore{}))
 	store, err := newStoreWithRetry("dummy://dummy-store", 3)
@@ -778,7 +749,6 @@ func TestRetryOpenStore(t *testing.T) {
 }
 
 func TestOpenStore(t *testing.T) {
-	t.Parallel()
 	require.NoError(t, Register("open", &brokenStore{}))
 	store, err := newStoreWithRetry(":", 3)
 	if store != nil {
@@ -790,7 +760,6 @@ func TestOpenStore(t *testing.T) {
 }
 
 func TestRegister(t *testing.T) {
-	t.Parallel()
 	err := Register("retry", &brokenStore{})
 	require.NoError(t, err)
 	err = Register("retry", &brokenStore{})

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 func TestString(t *testing.T) {
-	t.Parallel()
 	col := ToColumn(&model.ColumnInfo{
 		FieldType: *types.NewFieldType(mysql.TypeTiny),
 		State:     model.StatePublic,
@@ -84,7 +83,6 @@ func TestString(t *testing.T) {
 }
 
 func TestFind(t *testing.T) {
-	t.Parallel()
 	cols := []*Column{
 		newCol("a"),
 		newCol("b"),
@@ -104,7 +102,6 @@ func TestFind(t *testing.T) {
 }
 
 func TestCheck(t *testing.T) {
-	t.Parallel()
 	col := newCol("a")
 	col.Flag = mysql.AutoIncrementFlag
 	cols := []*Column{col, col}
@@ -121,7 +118,6 @@ func TestCheck(t *testing.T) {
 }
 
 func TestHandleBadNull(t *testing.T) {
-	t.Parallel()
 	col := newCol("a")
 	sc := new(stmtctx.StatementContext)
 	d := types.Datum{}
@@ -141,7 +137,6 @@ func TestHandleBadNull(t *testing.T) {
 }
 
 func TestDesc(t *testing.T) {
-	t.Parallel()
 	col := newCol("a")
 	col.Flag = mysql.AutoIncrementFlag | mysql.NotNullFlag | mysql.PriKeyFlag
 	NewColDesc(col)
@@ -252,7 +247,6 @@ func TestGetZeroValue(t *testing.T) {
 	sc := new(stmtctx.StatementContext)
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%+v", tt.ft), func(t *testing.T) {
-			t.Parallel()
 			colInfo := &model.ColumnInfo{FieldType: *tt.ft}
 			zv := GetZeroValue(colInfo)
 			require.Equal(t, tt.value.Kind(), zv.Kind())
@@ -264,7 +258,6 @@ func TestGetZeroValue(t *testing.T) {
 }
 
 func TestCastValue(t *testing.T) {
-	t.Parallel()
 	ctx := mock.NewContext()
 	colInfo := model.ColumnInfo{
 		FieldType: *types.NewFieldType(mysql.TypeLong),
@@ -313,7 +306,6 @@ func TestCastValue(t *testing.T) {
 }
 
 func TestGetDefaultValue(t *testing.T) {
-	t.Parallel()
 	var nilDt types.Datum
 	nilDt.SetNull()
 	ctx := mock.NewContext()

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestErrorCode(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, mysql.ErrBadNull, int(terror.ToSQLError(ErrColumnCantNull).Code))
 	require.Equal(t, mysql.ErrBadField, int(terror.ToSQLError(ErrUnknownColumn).Code))
 	require.Equal(t, mysql.ErrFieldSpecifiedTwice, int(terror.ToSQLError(errDuplicateColumn).Code))

--- a/table/tables/index_test.go
+++ b/table/tables/index_test.go
@@ -34,7 +34,6 @@ import (
 )
 
 func TestSingleColumnCommonHandle(t *testing.T) {
-	t.Parallel()
 	tblInfo := buildTableInfo(t, "create table t (a varchar(255) primary key, u int unique, nu int, index nu (nu))")
 	var idxUnique, idxNonUnique table.Index
 	for _, idxInfo := range tblInfo.Indices {

--- a/table/tables/partition_test.go
+++ b/table/tables/partition_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestPartitionBasic(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -63,7 +62,6 @@ PARTITION BY RANGE COLUMNS ( id ) (
 }
 
 func TestPartitionAddRecord(t *testing.T) {
-	t.Parallel()
 	createTable1 := `CREATE TABLE test.t1 (id int(11), index(id))
 PARTITION BY RANGE ( id ) (
 		PARTITION p0 VALUES LESS THAN (6),
@@ -166,7 +164,6 @@ PARTITION BY RANGE ( id ) (
 }
 
 func TestHashPartitionAddRecord(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -236,7 +233,6 @@ func TestHashPartitionAddRecord(t *testing.T) {
 
 // TestPartitionGetPhysicalID tests partition.GetPhysicalID().
 func TestPartitionGetPhysicalID(t *testing.T) {
-	t.Parallel()
 	createTable1 := `CREATE TABLE test.t1 (id int(11), index(id))
 PARTITION BY RANGE ( id ) (
 		PARTITION p0 VALUES LESS THAN (6),
@@ -264,7 +260,6 @@ PARTITION BY RANGE ( id ) (
 }
 
 func TestGeneratePartitionExpr(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -298,7 +293,6 @@ func TestGeneratePartitionExpr(t *testing.T) {
 }
 
 func TestLocateRangeColumnPartitionErr(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -317,7 +311,6 @@ func TestLocateRangeColumnPartitionErr(t *testing.T) {
 }
 
 func TestLocateRangePartitionErr(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -336,7 +329,6 @@ func TestLocateRangePartitionErr(t *testing.T) {
 }
 
 func TestLocatePartitionWithExtraHandle(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -356,7 +348,6 @@ func TestLocatePartitionWithExtraHandle(t *testing.T) {
 }
 
 func TestMultiTableUpdate(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -380,7 +371,6 @@ func TestMultiTableUpdate(t *testing.T) {
 }
 
 func TestLocatePartitionSingleColumn(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -411,7 +401,6 @@ func TestLocatePartitionSingleColumn(t *testing.T) {
 }
 
 func TestTimeZoneChange(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -471,7 +460,6 @@ func TestTimeZoneChange(t *testing.T) {
 }
 
 func TestCreatePartitionTableNotSupport(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -487,7 +475,6 @@ func TestCreatePartitionTableNotSupport(t *testing.T) {
 }
 
 func TestRangePartitionUnderNoUnsigned(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -513,7 +500,6 @@ func TestRangePartitionUnderNoUnsigned(t *testing.T) {
 }
 
 func TestIntUint(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -550,7 +536,6 @@ partition p4 values less than (9223372036854775806))`)
 }
 
 func TestHashPartitionAndConditionConflict(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -576,7 +561,6 @@ func TestHashPartitionAndConditionConflict(t *testing.T) {
 }
 
 func TestHashPartitionInsertValue(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -595,7 +579,6 @@ func TestHashPartitionInsertValue(t *testing.T) {
 }
 
 func TestIssue21574(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -609,7 +592,6 @@ func TestIssue21574(t *testing.T) {
 }
 
 func TestIssue24746(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/table/tables/state_remote_test.go
+++ b/table/tables/state_remote_test.go
@@ -46,7 +46,6 @@ func initRow(ctx context.Context, exec session.Session, tid int) error {
 }
 
 func TestStateRemote(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -82,7 +82,6 @@ func (m mockPumpClient) PullBinlogs(ctx context.Context, in *binlog.PullBinlogRe
 }
 
 func TestBasic(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -183,7 +182,6 @@ func countEntriesWithPrefix(ctx sessionctx.Context, prefix []byte) (int, error) 
 }
 
 func TestTypes(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
@@ -237,7 +235,6 @@ func TestTypes(t *testing.T) {
 }
 
 func TestUniqueIndexMultipleNullEntries(t *testing.T) {
-	t.Parallel()
 	ctx := context.Background()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
@@ -279,7 +276,6 @@ func TestUniqueIndexMultipleNullEntries(t *testing.T) {
 }
 
 func TestRowKeyCodec(t *testing.T) {
-	t.Parallel()
 	tableVal := []struct {
 		tableID int64
 		h       int64
@@ -321,7 +317,6 @@ func TestRowKeyCodec(t *testing.T) {
 }
 
 func TestUnsignedPK(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -346,7 +341,6 @@ func TestUnsignedPK(t *testing.T) {
 }
 
 func TestIterRecords(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -373,7 +367,6 @@ func TestIterRecords(t *testing.T) {
 }
 
 func TestTableFromMeta(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -427,7 +420,6 @@ func TestTableFromMeta(t *testing.T) {
 }
 
 func TestShardRowIDBitsStep(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -447,7 +439,6 @@ func TestShardRowIDBitsStep(t *testing.T) {
 }
 
 func TestHiddenColumn(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -615,7 +606,6 @@ func TestHiddenColumn(t *testing.T) {
 }
 
 func TestAddRecordWithCtx(t *testing.T) {
-	t.Parallel()
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
@@ -662,7 +652,6 @@ func TestAddRecordWithCtx(t *testing.T) {
 }
 
 func TestConstraintCheckForUniqueIndex(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 
 	tk := testkit.NewTestKit(t, store)
@@ -718,7 +707,6 @@ func TestConstraintCheckForUniqueIndex(t *testing.T) {
 }
 
 func TestViewColumns(t *testing.T) {
-	t.Parallel()
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)

--- a/table/temptable/ddl_test.go
+++ b/table/temptable/ddl_test.go
@@ -45,8 +45,6 @@ func createTestSuite(t *testing.T) (sessionctx.Context, *temporaryTableDDL, func
 }
 
 func TestAddLocalTemporaryTable(t *testing.T) {
-	t.Parallel()
-
 	sctx, ddl, clean := createTestSuite(t)
 	defer clean()
 
@@ -110,8 +108,6 @@ func TestAddLocalTemporaryTable(t *testing.T) {
 }
 
 func TestRemoveLocalTemporaryTable(t *testing.T) {
-	t.Parallel()
-
 	sctx, ddl, clean := createTestSuite(t)
 	defer clean()
 
@@ -159,8 +155,6 @@ func TestRemoveLocalTemporaryTable(t *testing.T) {
 }
 
 func TestTruncateLocalTemporaryTable(t *testing.T) {
-	t.Parallel()
-
 	sctx, ddl, clean := createTestSuite(t)
 	defer clean()
 

--- a/table/temptable/interceptor_test.go
+++ b/table/temptable/interceptor_test.go
@@ -49,7 +49,6 @@ func encodeTableKey(tblID int64, suffix ...byte) kv.Key {
 }
 
 func TestGetKeyAccessedTableID(t *testing.T) {
-	t.Parallel()
 	tbPrefix := tablecodec.TablePrefix()
 	prefix0 := encodeTableKey(0)
 	prefixMax := encodeTableKey(math.MaxInt64)
@@ -114,7 +113,6 @@ func TestGetKeyAccessedTableID(t *testing.T) {
 }
 
 func TestGetRangeAccessedTableID(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		start kv.Key
 		end   kv.Key
@@ -219,7 +217,6 @@ func TestGetRangeAccessedTableID(t *testing.T) {
 }
 
 func TestNotTableRange(t *testing.T) {
-	t.Parallel()
 	falseCases := [][]kv.Key{
 		{nil, nil},
 		{nil, encodeTableKey(1, 0)},
@@ -254,7 +251,6 @@ func TestNotTableRange(t *testing.T) {
 }
 
 func TestGetSessionTemporaryTableKey(t *testing.T) {
-	t.Parallel()
 	localTempTableData := []*kv.Entry{
 		{Key: encodeTableKey(5), Value: []byte("v5")},
 		{Key: encodeTableKey(5, 0), Value: []byte("v50")},
@@ -331,7 +327,6 @@ func TestGetSessionTemporaryTableKey(t *testing.T) {
 }
 
 func TestInterceptorTemporaryTableInfoByID(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1, 5).
 		AddTable(model.TempTableGlobal, 2, 6).
@@ -381,7 +376,6 @@ func TestInterceptorTemporaryTableInfoByID(t *testing.T) {
 }
 
 func TestInterceptorOnGet(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1).
 		AddTable(model.TempTableGlobal, 3).
@@ -528,7 +522,6 @@ func TestInterceptorOnGet(t *testing.T) {
 }
 
 func TestInterceptorBatchGetTemporaryTableKeys(t *testing.T) {
-	t.Parallel()
 	localTempTableData := []*kv.Entry{
 		{Key: encodeTableKey(5), Value: []byte("v5")},
 		{Key: encodeTableKey(5, 0), Value: []byte("v50")},
@@ -712,7 +705,6 @@ func TestInterceptorBatchGetTemporaryTableKeys(t *testing.T) {
 }
 
 func TestInterceptorOnBatchGet(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1).
 		AddTable(model.TempTableGlobal, 3).
@@ -914,7 +906,6 @@ func TestInterceptorOnBatchGet(t *testing.T) {
 }
 
 func TestCreateUnionIter(t *testing.T) {
-	t.Parallel()
 	retriever := newMockedRetriever(t).SetData([]*kv.Entry{
 		{Key: kv.Key("k1"), Value: []byte("v1")},
 		{Key: kv.Key("k10"), Value: []byte("")},
@@ -1055,7 +1046,6 @@ func TestCreateUnionIter(t *testing.T) {
 }
 
 func TestErrorCreateUnionIter(t *testing.T) {
-	t.Parallel()
 	retriever := newMockedRetriever(t).SetAllowedMethod("Iter", "IterReverse").SetData([]*kv.Entry{
 		{Key: kv.Key("k1"), Value: []byte("")},
 	})
@@ -1193,7 +1183,6 @@ func checkCreatedIterClosed(t *testing.T, retriever *mockedRetriever, snap *mock
 }
 
 func TestIterTable(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1).
 		AddTable(model.TempTableGlobal, 3).
@@ -1346,7 +1335,6 @@ func TestIterTable(t *testing.T) {
 }
 
 func TestOnIter(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1).
 		AddTable(model.TempTableGlobal, 3).
@@ -1556,7 +1544,6 @@ func TestOnIter(t *testing.T) {
 }
 
 func TestOnIterReverse(t *testing.T) {
-	t.Parallel()
 	is := newMockedInfoSchema(t).
 		AddTable(model.TempTableNone, 1).
 		AddTable(model.TempTableGlobal, 3).

--- a/tablecodec/tablecodec_test.go
+++ b/tablecodec/tablecodec_test.go
@@ -35,7 +35,6 @@ import (
 // TestTableCodec  tests some functions in package tablecodec
 // TODO: add more tests.
 func TestTableCodec(t *testing.T) {
-	t.Parallel()
 	key := EncodeRowKey(1, codec.EncodeInt(nil, 2))
 	h, err := DecodeRowKey(key)
 	require.NoError(t, err)
@@ -68,7 +67,6 @@ type column struct {
 }
 
 func TestRowCodec(t *testing.T) {
-	t.Parallel()
 	c1 := &column{id: 1, tp: types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &column{id: 2, tp: types.NewFieldType(mysql.TypeVarchar)}
 	c3 := &column{id: 3, tp: types.NewFieldType(mysql.TypeNewDecimal)}
@@ -156,7 +154,6 @@ func TestRowCodec(t *testing.T) {
 }
 
 func TestDecodeColumnValue(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 
 	// test timestamp
@@ -221,7 +218,6 @@ func TestDecodeColumnValue(t *testing.T) {
 }
 
 func TestUnflattenDatums(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	input := types.MakeDatums(int64(1))
 	tps := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
@@ -243,7 +239,6 @@ func TestUnflattenDatums(t *testing.T) {
 }
 
 func TestTimeCodec(t *testing.T) {
-	t.Parallel()
 	c1 := &column{id: 1, tp: types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &column{id: 2, tp: types.NewFieldType(mysql.TypeVarchar)}
 	c3 := &column{id: 3, tp: types.NewFieldType(mysql.TypeTimestamp)}
@@ -293,7 +288,6 @@ func TestTimeCodec(t *testing.T) {
 }
 
 func TestCutRow(t *testing.T) {
-	t.Parallel()
 	var err error
 	c1 := &column{id: 1, tp: types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &column{id: 2, tp: types.NewFieldType(mysql.TypeVarchar)}
@@ -346,7 +340,6 @@ func TestCutRow(t *testing.T) {
 }
 
 func TestCutKeyNew(t *testing.T) {
-	t.Parallel()
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
 	handle := types.NewIntDatum(100)
 	values = append(values, handle)
@@ -369,7 +362,6 @@ func TestCutKeyNew(t *testing.T) {
 }
 
 func TestCutKey(t *testing.T) {
-	t.Parallel()
 	colIDs := []int64{1, 2, 3}
 	values := []types.Datum{types.NewIntDatum(1), types.NewBytesDatum([]byte("abc")), types.NewFloat64Datum(5.5)}
 	handle := types.NewIntDatum(100)
@@ -406,7 +398,6 @@ func TestDecodeBadDecical(t *testing.T) {
 }
 
 func TestIndexKey(t *testing.T) {
-	t.Parallel()
 	tableID := int64(4)
 	indexID := int64(5)
 	indexKey := EncodeIndexSeekKey(tableID, indexID, []byte{})
@@ -418,7 +409,6 @@ func TestIndexKey(t *testing.T) {
 }
 
 func TestRecordKey(t *testing.T) {
-	t.Parallel()
 	tableID := int64(55)
 	tableKey := EncodeRowKeyWithHandle(tableID, kv.IntHandle(math.MaxUint32))
 	tTableID, _, isRecordKey, err := DecodeKeyHead(tableKey)
@@ -446,7 +436,6 @@ func TestRecordKey(t *testing.T) {
 }
 
 func TestPrefix(t *testing.T) {
-	t.Parallel()
 	const tableID int64 = 66
 	key := EncodeTablePrefix(tableID)
 	tTableID := DecodeTableID(key)
@@ -472,7 +461,6 @@ func TestPrefix(t *testing.T) {
 }
 
 func TestDecodeIndexKey(t *testing.T) {
-	t.Parallel()
 	tableID := int64(4)
 	indexID := int64(5)
 	values := []types.Datum{
@@ -507,7 +495,6 @@ func TestDecodeIndexKey(t *testing.T) {
 }
 
 func TestCutPrefix(t *testing.T) {
-	t.Parallel()
 	key := EncodeTableIndexPrefix(42, 666)
 	res := CutRowKeyPrefix(key)
 	require.Equal(t, []byte{0x80, 0x0, 0x0, 0x0, 0x0, 0x0, 0x2, 0x9a}, res)
@@ -516,7 +503,6 @@ func TestCutPrefix(t *testing.T) {
 }
 
 func TestRange(t *testing.T) {
-	t.Parallel()
 	s1, e1 := GetTableHandleKeyRange(22)
 	s2, e2 := GetTableHandleKeyRange(23)
 	require.Less(t, string(s1), string(e1))
@@ -531,7 +517,6 @@ func TestRange(t *testing.T) {
 }
 
 func TestDecodeAutoIDMeta(t *testing.T) {
-	t.Parallel()
 	keyBytes := []byte{0x6d, 0x44, 0x42, 0x3a, 0x35, 0x36, 0x0, 0x0, 0x0, 0xfc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x68, 0x54, 0x49, 0x44, 0x3a, 0x31, 0x30, 0x38, 0x0, 0xfe}
 	key, field, err := DecodeMetaKey(keyBytes)
 	require.NoError(t, err)
@@ -578,7 +563,6 @@ func BenchmarkEncodeValue(b *testing.B) {
 }
 
 func TestError(t *testing.T) {
-	t.Parallel()
 	kvErrs := []*terror.Error{
 		errInvalidKey,
 		errInvalidRecordKey,
@@ -592,7 +576,6 @@ func TestError(t *testing.T) {
 }
 
 func TestUntouchedIndexKValue(t *testing.T) {
-	t.Parallel()
 	untouchedIndexKey := []byte("t00000001_i000000001")
 	untouchedIndexValue := []byte{0, 0, 0, 0, 0, 0, 0, 1, 49}
 	require.True(t, IsUntouchedIndexKValue(untouchedIndexKey, untouchedIndexValue))

--- a/telemetry/cte_test/cte_test.go
+++ b/telemetry/cte_test/cte_test.go
@@ -49,8 +49,6 @@ func TestCTEPreviewAndReport(t *testing.T) {
 		t.Skip("integration.NewClusterV3 will create file contains a colon which is not allowed on Windows")
 	}
 
-	t.Parallel()
-
 	s := newSuite(t)
 	defer s.close()
 

--- a/telemetry/data_cluster_hardware_test.go
+++ b/telemetry/data_cluster_hardware_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestNormalizeDiskName(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		diskName string
 		expected string
@@ -39,8 +37,6 @@ func TestNormalizeDiskName(t *testing.T) {
 }
 
 func TestIsNormalizedDiskNameAllowed(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		diskName string
 	}{
@@ -66,8 +62,6 @@ func TestIsNormalizedDiskNameAllowed(t *testing.T) {
 }
 
 func TestIsNormalizedDiskNameNotAllowed(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		diskName string
 	}{
@@ -84,8 +78,6 @@ func TestIsNormalizedDiskNameNotAllowed(t *testing.T) {
 }
 
 func TestNormalizeFieldName(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		fileName string
 		expected string

--- a/telemetry/data_feature_usage_test.go
+++ b/telemetry/data_feature_usage_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestTxnUsageInfo(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -70,8 +68,6 @@ func TestTxnUsageInfo(t *testing.T) {
 }
 
 func TestTemporaryTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -89,8 +85,6 @@ func TestTemporaryTable(t *testing.T) {
 }
 
 func TestCachedTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/telemetry/telemetry_test.go
+++ b/telemetry/telemetry_test.go
@@ -33,8 +33,6 @@ func TestTrackingID(t *testing.T) {
 		t.Skip("integration.NewClusterV3 will create file contains a colon which is not allowed on Windows")
 	}
 
-	t.Parallel()
-
 	etcdCluster := integration.NewClusterV3(t, &integration.ClusterConfig{Size: 1})
 	defer etcdCluster.Terminate(t)
 

--- a/telemetry/util_test.go
+++ b/telemetry/util_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestHashString(t *testing.T) {
-	t.Parallel()
-
 	actual, err := hashString("127.0.0.1")
 	require.NoError(t, err)
 	require.Equal(t, "4b84b15bff6ee5796152495a230e45e3d7e947d9", actual)
@@ -50,8 +48,6 @@ func TestParseAddress(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.src, func(t *testing.T) {
-			t.Parallel()
-
 			host, port, err := parseAddressAndHash(test.src)
 			require.NoError(t, err)
 

--- a/types/binary_literal_test.go
+++ b/types/binary_literal_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestBinaryLiteral(t *testing.T) {
 	t.Run("TestTrimLeadingZeroBytes", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    []byte
 			Expected []byte
@@ -46,7 +45,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestParseBitStr", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    string
 			Expected []byte
@@ -108,7 +106,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestParseBitStr", func(t *testing.T) {
-		t.Parallel()
 		b, err := ParseBitStr("")
 		require.Nil(t, b)
 		require.Error(t, err)
@@ -116,7 +113,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestParseHexStr", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    string
 			Expected []byte
@@ -149,7 +145,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestParseHexStr", func(t *testing.T) {
-		t.Parallel()
 		b, err := ParseBitStr("")
 		require.Nil(t, b)
 		require.Error(t, err)
@@ -157,7 +152,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestString", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    BinaryLiteral
 			Expected string
@@ -174,7 +168,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestToBitLiteralString", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input           BinaryLiteral
 			TrimLeadingZero bool
@@ -200,7 +193,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestToInt", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    string
 			Expected uint64
@@ -230,7 +222,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestNewBinaryLiteralFromUint", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			Input    uint64
 			ByteSize int
@@ -267,7 +258,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestCompare", func(t *testing.T) {
-		t.Parallel()
 		tbl := []struct {
 			a   BinaryLiteral
 			b   BinaryLiteral
@@ -284,7 +274,6 @@ func TestBinaryLiteral(t *testing.T) {
 	})
 
 	t.Run("TestToString", func(t *testing.T) {
-		t.Parallel()
 		h, _ := NewHexLiteral("x'3A3B'")
 		str := h.ToString()
 		require.Equal(t, str, ":;")

--- a/types/compare_test.go
+++ b/types/compare_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestCompare(t *testing.T) {
-	t.Parallel()
-
 	cmpTbl := []struct {
 		lhs interface{}
 		rhs interface{}
@@ -156,8 +154,6 @@ func compareForTest(a, b interface{}) (int, error) {
 }
 
 func TestCompareDatum(t *testing.T) {
-	t.Parallel()
-
 	cmpTbl := []struct {
 		lhs Datum
 		rhs Datum
@@ -186,8 +182,6 @@ func TestCompareDatum(t *testing.T) {
 }
 
 func TestVecCompareIntAndUint(t *testing.T) {
-	t.Parallel()
-
 	cmpTblUU := []struct {
 		lhs []uint64
 		rhs []uint64

--- a/types/const_test.go
+++ b/types/const_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestGetSQLMode(t *testing.T) {
-	t.Parallel()
-
 	positiveCases := []struct {
 		arg string
 	}{
@@ -59,8 +57,6 @@ func TestGetSQLMode(t *testing.T) {
 }
 
 func TestSQLMode(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		arg                           string
 		hasNoZeroDateMode             bool
@@ -87,8 +83,6 @@ func TestSQLMode(t *testing.T) {
 }
 
 func TestRealAsFloatMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -111,8 +105,6 @@ func TestRealAsFloatMode(t *testing.T) {
 }
 
 func TestPipesAsConcatMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -123,8 +115,6 @@ func TestPipesAsConcatMode(t *testing.T) {
 }
 
 func TestIssue22387(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -138,8 +128,6 @@ func TestIssue22387(t *testing.T) {
 }
 
 func TestIssue22389(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -157,8 +145,6 @@ func TestIssue22389(t *testing.T) {
 }
 
 func TestIssue22390(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -177,8 +163,6 @@ func TestIssue22390(t *testing.T) {
 }
 
 func TestIssue22442(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -191,8 +175,6 @@ func TestIssue22442(t *testing.T) {
 }
 
 func TestIssue22444(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -205,8 +187,6 @@ func TestIssue22444(t *testing.T) {
 }
 
 func TestIssue22445(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -220,8 +200,6 @@ func TestIssue22445(t *testing.T) {
 }
 
 func TestIssue22446(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -234,8 +212,6 @@ func TestIssue22446(t *testing.T) {
 }
 
 func TestIssue22447(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -250,8 +226,6 @@ func TestIssue22447(t *testing.T) {
 }
 
 func TestNoUnsignedSubtractionMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -338,8 +312,6 @@ func TestNoUnsignedSubtractionMode(t *testing.T) {
 }
 
 func TestHighNotPrecedenceMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -360,8 +332,6 @@ func TestHighNotPrecedenceMode(t *testing.T) {
 }
 
 func TestIgnoreSpaceMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -426,8 +396,6 @@ func TestIgnoreSpaceMode(t *testing.T) {
 }
 
 func TestNoBackslashEscapesMode(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -441,8 +409,6 @@ func TestNoBackslashEscapesMode(t *testing.T) {
 }
 
 func TestServerStatus(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		arg            uint16
 		IsCursorExists bool

--- a/types/convert_test.go
+++ b/types/convert_test.go
@@ -46,7 +46,6 @@ func Convert(val interface{}, target *FieldType) (v interface{}, err error) {
 }
 
 func TestConvertType(t *testing.T) {
-	t.Parallel()
 	ft := NewFieldType(mysql.TypeBlob)
 	ft.Flen = 4
 	ft.Charset = "utf8"
@@ -334,7 +333,6 @@ func testToString(t *testing.T, val interface{}, expect string) {
 }
 
 func TestConvertToString(t *testing.T) {
-	t.Parallel()
 	testToString(t, "0", "0")
 	testToString(t, true, "1")
 	testToString(t, "false", "false")
@@ -436,7 +434,6 @@ func testStrToFloat(t *testing.T, str string, expect float64, truncateAsErr bool
 }
 
 func TestStrToNum(t *testing.T) {
-	t.Parallel()
 	testStrToInt(t, "0", 0, true, nil)
 	testStrToInt(t, "-1", -1, true, nil)
 	testStrToInt(t, "100", 100, true, nil)
@@ -515,7 +512,6 @@ func testSelectUpdateDeleteEmptyStringError(t *testing.T) {
 }
 
 func TestFieldTypeToStr(t *testing.T) {
-	t.Parallel()
 	v := TypeToStr(mysql.TypeUnspecified, "not binary")
 	require.Equal(t, TypeStr(mysql.TypeUnspecified), v)
 	v = TypeToStr(mysql.TypeBlob, charset.CharsetBin)
@@ -583,7 +579,6 @@ func strvalue(v interface{}) string {
 }
 
 func TestConvert(t *testing.T) {
-	t.Parallel()
 	// integer ranges
 	signedDeny(t, mysql.TypeTiny, -129, "-128")
 	signedAccept(t, mysql.TypeTiny, -128, "-128")
@@ -775,7 +770,6 @@ func TestConvert(t *testing.T) {
 }
 
 func TestRoundIntStr(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		a string
 		b byte
@@ -791,7 +785,6 @@ func TestRoundIntStr(t *testing.T) {
 }
 
 func TestGetValidInt(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		origin  string
 		valid   string
@@ -872,7 +865,6 @@ func TestGetValidInt(t *testing.T) {
 }
 
 func TestGetValidFloat(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		origin string
 		valid  string
@@ -933,7 +925,6 @@ func TestGetValidFloat(t *testing.T) {
 // time conversion is complicated including Date/Datetime/Time/Timestamp etc,
 // Timestamp may involving timezone.
 func TestConvertTime(t *testing.T) {
-	t.Parallel()
 	timezones := []*time.Location{
 		time.UTC,
 		time.FixedZone("", 3*3600),
@@ -989,7 +980,6 @@ func testConvertTimeTimeZone(t *testing.T, sc *stmtctx.StatementContext) {
 }
 
 func TestConvertJSONToInt(t *testing.T) {
-	t.Parallel()
 	var tests = []struct {
 		in  string
 		out int64
@@ -1022,7 +1012,6 @@ func TestConvertJSONToInt(t *testing.T) {
 }
 
 func TestConvertJSONToFloat(t *testing.T) {
-	t.Parallel()
 	var tests = []struct {
 		in  interface{}
 		out float64
@@ -1056,7 +1045,6 @@ func TestConvertJSONToFloat(t *testing.T) {
 }
 
 func TestConvertJSONToDecimal(t *testing.T) {
-	t.Parallel()
 	var tests = []struct {
 		in  string
 		out *MyDecimal
@@ -1086,7 +1074,6 @@ func TestConvertJSONToDecimal(t *testing.T) {
 }
 
 func TestNumberToDuration(t *testing.T) {
-	t.Parallel()
 	var testCases = []struct {
 		number int64
 		fsp    int
@@ -1138,7 +1125,6 @@ func TestNumberToDuration(t *testing.T) {
 }
 
 func TestStrToDuration(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	var tests = []struct {
 		str        string
@@ -1158,7 +1144,6 @@ func TestStrToDuration(t *testing.T) {
 }
 
 func TestConvertScientificNotation(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		input  string
 		output string
@@ -1194,7 +1179,6 @@ func TestConvertScientificNotation(t *testing.T) {
 }
 
 func TestConvertDecimalStrToUint(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		input  string
 		result uint64

--- a/types/core_time_test.go
+++ b/types/core_time_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestWeekBehaviour(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, weekBehaviour(1), weekBehaviourMondayFirst)
 	require.Equal(t, weekBehaviour(2), weekBehaviourYear)
 	require.Equal(t, weekBehaviour(4), weekBehaviourFirstWeekday)
@@ -34,8 +32,6 @@ func TestWeekBehaviour(t *testing.T) {
 }
 
 func TestWeek(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		Input  CoreTime
 		Mode   int
@@ -53,8 +49,6 @@ func TestWeek(t *testing.T) {
 }
 
 func TestCalcDaynr(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, 0, calcDaynr(0, 0, 0))
 	require.Equal(t, 3652424, calcDaynr(9999, 12, 31))
 	require.Equal(t, 719528, calcDaynr(1970, 1, 1))
@@ -64,8 +58,6 @@ func TestCalcDaynr(t *testing.T) {
 }
 
 func TestCalcTimeTimeDiff(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		T1           CoreTime
 		T2           CoreTime
@@ -105,8 +97,6 @@ func TestCalcTimeTimeDiff(t *testing.T) {
 }
 
 func TestCompareTime(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		T1     CoreTime
 		T2     CoreTime
@@ -126,8 +116,6 @@ func TestCompareTime(t *testing.T) {
 }
 
 func TestGetDateFromDaynr(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		daynr uint
 		year  uint
@@ -157,8 +145,6 @@ func TestGetDateFromDaynr(t *testing.T) {
 }
 
 func TestMixDateAndTime(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		date   CoreTime
 		dur    Duration
@@ -208,8 +194,6 @@ func TestMixDateAndTime(t *testing.T) {
 }
 
 func TestIsLeapYear(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		T      CoreTime
 		Expect bool
@@ -234,8 +218,6 @@ func TestIsLeapYear(t *testing.T) {
 	}
 }
 func TestGetLastDay(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		year        int
 		month       int
@@ -255,8 +237,6 @@ func TestGetLastDay(t *testing.T) {
 }
 
 func TestGetFixDays(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		year        int
 		month       int
@@ -278,8 +258,6 @@ func TestGetFixDays(t *testing.T) {
 }
 
 func TestAddDate(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		year  int
 		month int
@@ -300,8 +278,6 @@ func TestAddDate(t *testing.T) {
 }
 
 func TestWeekday(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		Input  CoreTime
 		Expect string
@@ -318,7 +294,6 @@ func TestWeekday(t *testing.T) {
 }
 
 func TestFindZoneTransition(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		TZ      string
 		dt      string
@@ -358,7 +333,6 @@ func TestFindZoneTransition(t *testing.T) {
 }
 
 func TestAdjustedGoTime(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		TZ      string
 		dt      CoreTime

--- a/types/datum_test.go
+++ b/types/datum_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestDatum(t *testing.T) {
-	t.Parallel()
 	values := []interface{}{
 		int64(1),
 		uint64(1),
@@ -62,7 +61,6 @@ func testDatumToBool(t *testing.T, in interface{}, res int) {
 }
 
 func TestToBool(t *testing.T) {
-	t.Parallel()
 	testDatumToBool(t, 0, 0)
 	testDatumToBool(t, int64(0), 0)
 	testDatumToBool(t, uint64(0), 0)
@@ -123,7 +121,6 @@ func testDatumToInt64(t *testing.T, val interface{}, expect int64) {
 }
 
 func TestToInt64(t *testing.T) {
-	t.Parallel()
 	testDatumToInt64(t, "0", int64(0))
 	testDatumToInt64(t, 0, int64(0))
 	testDatumToInt64(t, int64(0), int64(0))
@@ -153,7 +150,6 @@ func TestToInt64(t *testing.T) {
 }
 
 func TestConvertToFloat(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		d      Datum
 		tp     byte
@@ -206,7 +202,6 @@ func mustParseTimeIntoDatum(s string, tp byte, fsp int8) (d Datum) {
 }
 
 func TestToJSON(t *testing.T) {
-	t.Parallel()
 	ft := NewFieldType(mysql.TypeJSON)
 	sc := new(stmtctx.StatementContext)
 	tests := []struct {
@@ -246,7 +241,6 @@ func TestToJSON(t *testing.T) {
 }
 
 func TestIsNull(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		data   interface{}
 		isnull bool
@@ -269,7 +263,6 @@ func testIsNull(t *testing.T, data interface{}, isnull bool) {
 }
 
 func TestToBytes(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		a   Datum
 		out []byte
@@ -290,7 +283,6 @@ func TestToBytes(t *testing.T) {
 }
 
 func TestComputePlusAndMinus(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	tests := []struct {
 		a      Datum
@@ -319,7 +311,6 @@ func TestComputePlusAndMinus(t *testing.T) {
 }
 
 func TestCloneDatum(t *testing.T) {
-	t.Parallel()
 	var raw Datum
 	raw.b = []byte("raw")
 	raw.k = KindRaw
@@ -366,7 +357,6 @@ func newRetTypeWithFlenDecimal(tp byte, flen int, decimal int) *FieldType {
 }
 
 func TestEstimatedMemUsage(t *testing.T) {
-	t.Parallel()
 	b := []byte{'a', 'b', 'c', 'd'}
 	enum := Enum{Name: "a", Value: 1}
 	datumArray := []Datum{
@@ -386,7 +376,6 @@ func TestEstimatedMemUsage(t *testing.T) {
 }
 
 func TestChangeReverseResultByUpperLowerBound(t *testing.T) {
-	t.Parallel()
 	sc := new(stmtctx.StatementContext)
 	sc.IgnoreTruncate = true
 	sc.OverflowAsWarning = true
@@ -501,7 +490,6 @@ func prepareCompareDatums() ([]Datum, []Datum) {
 }
 
 func TestStringToMysqlBit(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		a   Datum
 		out []byte

--- a/types/errors_test.go
+++ b/types/errors_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestError(t *testing.T) {
-	t.Parallel()
-
 	kvErrs := []*terror.Error{
 		ErrInvalidDefault,
 		ErrDataTooLong,

--- a/types/etc_test.go
+++ b/types/etc_test.go
@@ -36,8 +36,6 @@ func testIsTypeChar(t *testing.T, tp byte, expect bool) {
 }
 
 func TestIsType(t *testing.T) {
-	t.Parallel()
-
 	testIsTypeBlob(t, mysql.TypeTinyBlob, true)
 	testIsTypeBlob(t, mysql.TypeMediumBlob, true)
 	testIsTypeBlob(t, mysql.TypeBlob, true)
@@ -60,8 +58,6 @@ func testTypeToStr(t *testing.T, tp byte, charset string, expect string) {
 }
 
 func TestTypeToStr(t *testing.T) {
-	t.Parallel()
-
 	testTypeStr(t, mysql.TypeYear, "year")
 	testTypeStr(t, 0xdd, "")
 
@@ -98,8 +94,6 @@ func TestTypeToStr(t *testing.T) {
 }
 
 func TestEOFAsNil(t *testing.T) {
-	t.Parallel()
-
 	err := EOFAsNil(io.EOF)
 	require.NoError(t, err)
 	err = EOFAsNil(errors.New("test"))
@@ -107,8 +101,6 @@ func TestEOFAsNil(t *testing.T) {
 }
 
 func TestMaxFloat(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		flen    int
 		decimal int
@@ -126,8 +118,6 @@ func TestMaxFloat(t *testing.T) {
 }
 
 func TestRoundFloat(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  float64
 		expect float64
@@ -149,8 +139,6 @@ func TestRoundFloat(t *testing.T) {
 }
 
 func TestRound(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  float64
 		dec    int
@@ -170,8 +158,6 @@ func TestRound(t *testing.T) {
 }
 
 func TestTruncateFloat(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input   float64
 		flen    int
@@ -194,8 +180,6 @@ func TestTruncateFloat(t *testing.T) {
 }
 
 func TestIsTypeTemporal(t *testing.T) {
-	t.Parallel()
-
 	res := IsTypeTemporal(mysql.TypeDuration)
 	require.True(t, res)
 	res = IsTypeTemporal(mysql.TypeDatetime)
@@ -211,8 +195,6 @@ func TestIsTypeTemporal(t *testing.T) {
 }
 
 func TestIsBinaryStr(t *testing.T) {
-	t.Parallel()
-
 	in := FieldType{
 		Tp:      mysql.TypeBit,
 		Flag:    mysql.UnsignedFlag,
@@ -235,8 +217,6 @@ func TestIsBinaryStr(t *testing.T) {
 }
 
 func TestIsNonBinaryStr(t *testing.T) {
-	t.Parallel()
-
 	in := FieldType{
 		Tp:      mysql.TypeBit,
 		Flag:    mysql.UnsignedFlag,
@@ -260,8 +240,6 @@ func TestIsNonBinaryStr(t *testing.T) {
 }
 
 func TestIsTemporalWithDate(t *testing.T) {
-	t.Parallel()
-
 	res := IsTemporalWithDate(mysql.TypeDatetime)
 	require.True(t, res)
 
@@ -276,8 +254,6 @@ func TestIsTemporalWithDate(t *testing.T) {
 }
 
 func TestIsTypePrefixable(t *testing.T) {
-	t.Parallel()
-
 	res := IsTypePrefixable('t')
 	require.False(t, res)
 
@@ -286,8 +262,6 @@ func TestIsTypePrefixable(t *testing.T) {
 }
 
 func TestIsTypeFractionable(t *testing.T) {
-	t.Parallel()
-
 	res := IsTypeFractionable(mysql.TypeDatetime)
 	require.True(t, res)
 
@@ -302,8 +276,6 @@ func TestIsTypeFractionable(t *testing.T) {
 }
 
 func TestIsTypeNumeric(t *testing.T) {
-	t.Parallel()
-
 	res := IsTypeNumeric(mysql.TypeBit)
 	require.True(t, res)
 

--- a/types/field_type_test.go
+++ b/types/field_type_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestFieldType(t *testing.T) {
-	t.Parallel()
-
 	ft := NewFieldType(mysql.TypeDuration)
 	require.Equal(t, UnspecifiedLength, ft.Flen)
 	require.Equal(t, UnspecifiedLength, ft.Decimal)
@@ -158,8 +156,6 @@ func TestFieldType(t *testing.T) {
 }
 
 func TestDefaultTypeForValue(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		value     interface{}
 		tp        byte
@@ -210,8 +206,6 @@ func TestDefaultTypeForValue(t *testing.T) {
 }
 
 func TestAggFieldType(t *testing.T) {
-	t.Parallel()
-
 	fts := []*FieldType{
 		NewFieldType(mysql.TypeUnspecified),
 		NewFieldType(mysql.TypeTiny),
@@ -306,8 +300,6 @@ func TestAggFieldType(t *testing.T) {
 }
 
 func TestAggFieldTypeForTypeFlag(t *testing.T) {
-	t.Parallel()
-
 	types := []*FieldType{
 		NewFieldType(mysql.TypeLonglong),
 		NewFieldType(mysql.TypeLonglong),
@@ -335,8 +327,6 @@ func TestAggFieldTypeForTypeFlag(t *testing.T) {
 }
 
 func TestAggFieldTypeForIntegralPromotion(t *testing.T) {
-	t.Parallel()
-
 	fts := []*FieldType{
 		NewFieldType(mysql.TypeTiny),
 		NewFieldType(mysql.TypeShort),
@@ -375,8 +365,6 @@ func TestAggFieldTypeForIntegralPromotion(t *testing.T) {
 }
 
 func TestAggregateEvalType(t *testing.T) {
-	t.Parallel()
-
 	fts := []*FieldType{
 		NewFieldType(mysql.TypeUnspecified),
 		NewFieldType(mysql.TypeTiny),

--- a/types/format_test.go
+++ b/types/format_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestTimeFormatMethod(t *testing.T) {
-	t.Parallel()
-
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	tblDate := []struct {
@@ -81,8 +79,6 @@ func TestTimeFormatMethod(t *testing.T) {
 }
 
 func TestStrToDate(t *testing.T) {
-	t.Parallel()
-
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	tests := []struct {

--- a/types/fsp_test.go
+++ b/types/fsp_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestCheckFsp(t *testing.T) {
-	t.Parallel()
 	obtained, err := CheckFsp(int(UnspecifiedFsp))
 	require.Equal(t, DefaultFsp, obtained)
 	require.NoError(t, err)
@@ -62,7 +61,6 @@ func TestCheckFsp(t *testing.T) {
 }
 
 func TestParseFrac(t *testing.T) {
-	t.Parallel()
 	obtained, overflow, err := ParseFrac("", 5)
 	require.Equal(t, 0, obtained)
 	require.False(t, overflow)
@@ -121,7 +119,6 @@ func TestParseFrac(t *testing.T) {
 }
 
 func TestAlignFrac(t *testing.T) {
-	t.Parallel()
 	obtained := alignFrac("100", 6)
 	require.Equal(t, "100000", obtained)
 	obtained = alignFrac("10000000000", 6)

--- a/types/helper_test.go
+++ b/types/helper_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestStrToInt(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		input  string
 		output string
@@ -45,8 +43,6 @@ func TestStrToInt(t *testing.T) {
 }
 
 func TestTruncate(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		f        float64
 		dec      int
@@ -64,8 +60,6 @@ func TestTruncate(t *testing.T) {
 }
 
 func TestTruncateFloatToString(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		f        float64
 		dec      int

--- a/types/json/binary_functions_test.go
+++ b/types/json/binary_functions_test.go
@@ -20,8 +20,6 @@ import (
 )
 
 func TestDecodeEscapedUnicode(t *testing.T) {
-	t.Parallel()
-
 	in := "597d"
 	r, size, err := decodeEscapedUnicode([]byte(in))
 	require.NoError(t, err)

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestBinaryJSONMarshalUnmarshal(t *testing.T) {
-	t.Parallel()
-
 	expectedList := []string{
 		`{"a": [1, "2", {"aa": "bb"}, 4, null], "b": true, "c": null}`,
 		`{"aaaaaaaaaaa": [1, "2", {"aa": "bb"}, 4.1], "bbbbbbbbbb": true, "ccccccccc": "d"}`,
@@ -40,8 +38,6 @@ func TestBinaryJSONMarshalUnmarshal(t *testing.T) {
 }
 
 func TestBinaryJSONExtract(t *testing.T) {
-	t.Parallel()
-
 	bj1 := mustParseBinaryFromString(t, `{"\"hello\"": "world", "a": [1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}], "b": true, "c": ["d"]}`)
 	bj2 := mustParseBinaryFromString(t, `[{"a": 1, "b": true}, 3, 3.5, "hello, world", null, true]`)
 
@@ -86,8 +82,6 @@ func TestBinaryJSONExtract(t *testing.T) {
 }
 
 func TestBinaryJSONType(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		in  string
 		out string
@@ -111,8 +105,6 @@ func TestBinaryJSONType(t *testing.T) {
 }
 
 func TestBinaryJSONUnquote(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		json     string
 		unquoted string
@@ -139,8 +131,6 @@ func TestBinaryJSONUnquote(t *testing.T) {
 }
 
 func TestQuoteString(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		raw    string
 		quoted string
@@ -163,8 +153,6 @@ func TestQuoteString(t *testing.T) {
 }
 
 func TestBinaryJSONModify(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		base     string
 		setField string
@@ -219,8 +207,6 @@ func TestBinaryJSONModify(t *testing.T) {
 }
 
 func TestBinaryJSONRemove(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		base     string
 		path     string
@@ -257,8 +243,6 @@ func TestBinaryJSONRemove(t *testing.T) {
 }
 
 func TestCompareBinary(t *testing.T) {
-	t.Parallel()
-
 	jNull := mustParseBinaryFromString(t, `null`)
 	jBoolTrue := mustParseBinaryFromString(t, `true`)
 	jBoolFalse := mustParseBinaryFromString(t, `false`)
@@ -323,8 +307,6 @@ func TestCompareBinary(t *testing.T) {
 }
 
 func TestBinaryJSONMerge(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		suffixes []string
 		expected string
@@ -368,8 +350,6 @@ func BenchmarkBinaryMarshal(b *testing.B) {
 }
 
 func TestBinaryJSONContains(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		input    string
 		target   string
@@ -401,8 +381,6 @@ func TestBinaryJSONContains(t *testing.T) {
 }
 
 func TestBinaryJSONCopy(t *testing.T) {
-	t.Parallel()
-
 	expectedList := []string{
 		`{"a": [1, "2", {"aa": "bb"}, 4, null], "b": true, "c": null}`,
 		`{"aaaaaaaaaaa": [1, "2", {"aa": "bb"}, 4.1], "bbbbbbbbbb": true, "ccccccccc": "d"}`,
@@ -415,8 +393,6 @@ func TestBinaryJSONCopy(t *testing.T) {
 }
 
 func TestGetKeys(t *testing.T) {
-	t.Parallel()
-
 	parsedBJ := mustParseBinaryFromString(t, "[]")
 	require.Equal(t, "[]", parsedBJ.GetKeys().String())
 	parsedBJ = mustParseBinaryFromString(t, "{}")
@@ -434,8 +410,6 @@ func TestGetKeys(t *testing.T) {
 }
 
 func TestBinaryJSONDepth(t *testing.T) {
-	t.Parallel()
-
 	var tests = []struct {
 		input    string
 		expected int
@@ -456,8 +430,6 @@ func TestBinaryJSONDepth(t *testing.T) {
 }
 
 func TestParseBinaryFromString(t *testing.T) {
-	t.Parallel()
-
 	obj, err := ParseBinaryFromString("")
 	require.Error(t, err)
 	require.Equal(t, "", obj.String())
@@ -470,8 +442,6 @@ func TestParseBinaryFromString(t *testing.T) {
 }
 
 func TestCreateBinary(t *testing.T) {
-	t.Parallel()
-
 	bj := CreateBinary(int64(1 << 62))
 	require.Equal(t, TypeCodeInt64, bj.TypeCode)
 	require.NotNil(t, bj.Value)
@@ -502,8 +472,6 @@ func TestCreateBinary(t *testing.T) {
 }
 
 func TestFunctions(t *testing.T) {
-	t.Parallel()
-
 	testByte := []byte{'\\', 'b', 'f', 'n', 'r', 't', 'u', 'z', '0'}
 	testOutput, err := unquoteString(string(testByte))
 	require.Equal(t, "\bfnrtuz0", testOutput)
@@ -519,8 +487,6 @@ func TestFunctions(t *testing.T) {
 }
 
 func TestBinaryJSONExtractCallback(t *testing.T) {
-	t.Parallel()
-
 	bj1 := mustParseBinaryFromString(t, `{"\"hello\"": "world", "a": [1, "2", {"aa": "bb"}, 4.0, {"aa": "cc"}], "b": true, "c": ["d"]}`)
 	bj2 := mustParseBinaryFromString(t, `[{"a": 1, "b": true}, 3, 3.5, "hello, world", null, true]`)
 
@@ -590,8 +556,6 @@ func TestBinaryJSONExtractCallback(t *testing.T) {
 }
 
 func TestBinaryJSONWalk(t *testing.T) {
-	t.Parallel()
-
 	bj1 := mustParseBinaryFromString(t, `["abc", [{"k": "10"}, "def"], {"x":"abc"}, {"y":"bcd"}]`)
 	bj2 := mustParseBinaryFromString(t, `{}`)
 

--- a/types/json/path_expr_test.go
+++ b/types/json/path_expr_test.go
@@ -35,7 +35,6 @@ func TestContainsAnyAsterisk(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.expression, func(t *testing.T) {
-			t.Parallel()
 			pe, err := ParseJSONPathExpr(test.expression)
 			require.NoError(t, err)
 			require.Equal(t, test.containsAsterisks, pe.flags.containsAnyAsterisk())
@@ -65,7 +64,6 @@ func TestValidatePathExpr(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.expression, func(t *testing.T) {
-			t.Parallel()
 			pe, err := ParseJSONPathExpr(test.expression)
 			if test.success {
 				require.NoError(t, err)
@@ -91,7 +89,6 @@ func TestPathExprToString(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.expression, func(t *testing.T) {
-			t.Parallel()
 			pe, err := ParseJSONPathExpr(test.expression)
 			require.NoError(t, err)
 			require.Equal(t, test.expression, pe.String())
@@ -118,7 +115,6 @@ func TestPushBackOneIndexLeg(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.expression, func(t *testing.T) {
-			t.Parallel()
 			pe, err := ParseJSONPathExpr(test.expression)
 			require.NoError(t, err)
 

--- a/types/mydecimal_test.go
+++ b/types/mydecimal_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestFromInt(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  int64
 		output string
@@ -42,7 +41,6 @@ func TestFromInt(t *testing.T) {
 }
 
 func TestFromUint(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  uint64
 		output string
@@ -60,7 +58,6 @@ func TestFromUint(t *testing.T) {
 }
 
 func TestToInt(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  string
 		output int64
@@ -86,7 +83,6 @@ func TestToInt(t *testing.T) {
 }
 
 func TestToUint(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  string
 		output uint64
@@ -112,7 +108,6 @@ func TestToUint(t *testing.T) {
 }
 
 func TestFromFloat(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		s string
 		f float64
@@ -131,7 +126,6 @@ func TestFromFloat(t *testing.T) {
 }
 
 func TestToFloat(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		in  string
 		out string
@@ -189,7 +183,6 @@ func TestToFloat(t *testing.T) {
 }
 
 func TestToHashKey(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		numbers []string
 	}{
@@ -267,7 +260,6 @@ func TestToHashKey(t *testing.T) {
 }
 
 func TestRemoveTrailingZeros(t *testing.T) {
-	t.Parallel()
 	tests := []string{
 		"0", "0.0", ".0", ".00000000", "0.0000", "0000", "0000.0", "0000.000",
 		"-0", "-0.0", "-.0", "-.00000000", "-0.0000", "-0000", "-0000.0", "-0000.000",
@@ -301,7 +293,6 @@ func TestRemoveTrailingZeros(t *testing.T) {
 }
 
 func TestRoundWithHalfEven(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  string
 		scale  int
@@ -338,7 +329,6 @@ func TestRoundWithHalfEven(t *testing.T) {
 }
 
 func TestRoundWithTruncate(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  string
 		scale  int
@@ -374,7 +364,6 @@ func TestRoundWithTruncate(t *testing.T) {
 }
 
 func TestRoundWithCeil(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		input  string
 		scale  int
@@ -411,7 +400,6 @@ func TestRoundWithCeil(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		input  string
 		output string
@@ -431,7 +419,6 @@ func TestToString(t *testing.T) {
 }
 
 func TestToBinFromBin(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		input     string
 		precision int
@@ -502,7 +489,6 @@ func TestToBinFromBin(t *testing.T) {
 }
 
 func TestCompareMyDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		a   string
 		b   string
@@ -532,7 +518,6 @@ func TestCompareMyDecimal(t *testing.T) {
 }
 
 func TestMaxDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		prec   int
 		frac   int
@@ -564,7 +549,6 @@ func TestMaxDecimal(t *testing.T) {
 }
 
 func TestNegMyDecimal(t *testing.T) {
-	t.Parallel()
 	type testCase struct {
 		a      string
 		result string
@@ -583,7 +567,6 @@ func TestNegMyDecimal(t *testing.T) {
 }
 
 func TestAddMyDecimal(t *testing.T) {
-	t.Parallel()
 	type testCase struct {
 		a      string
 		b      string
@@ -620,7 +603,6 @@ func TestAddMyDecimal(t *testing.T) {
 }
 
 func TestSubMyDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		a      string
 		b      string
@@ -658,7 +640,6 @@ func TestSubMyDecimal(t *testing.T) {
 }
 
 func TestMulMyDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		a      string
 		b      string
@@ -693,7 +674,6 @@ func TestMulMyDecimal(t *testing.T) {
 }
 
 func TestDivModMyDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		a      string
 		b      string
@@ -801,7 +781,6 @@ func TestDivModMyDecimal(t *testing.T) {
 }
 
 func TestMaxOrMinMyDecimal(t *testing.T) {
-	t.Parallel()
 	type tcase struct {
 		neg    bool
 		prec   int
@@ -822,7 +801,6 @@ func TestMaxOrMinMyDecimal(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
-	t.Parallel()
 	var x1, y1, z1 MyDecimal
 	require.NoError(t, x1.FromString([]byte("38520.130741106671")))
 	require.NoError(t, y1.FromString([]byte("9863.944799797851")))

--- a/types/overflow_test.go
+++ b/types/overflow_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestAdd(t *testing.T) {
-	t.Parallel()
-
 	tblUint64 := []struct {
 		lsh      uint64
 		rsh      uint64
@@ -100,8 +98,6 @@ func TestAdd(t *testing.T) {
 }
 
 func TestSub(t *testing.T) {
-	t.Parallel()
-
 	tblUint64 := []struct {
 		lsh      uint64
 		rsh      uint64
@@ -200,8 +196,6 @@ func TestSub(t *testing.T) {
 }
 
 func TestMul(t *testing.T) {
-	t.Parallel()
-
 	tblUint64 := []struct {
 		lsh      uint64
 		rsh      uint64
@@ -275,8 +269,6 @@ func TestMul(t *testing.T) {
 }
 
 func TestDiv(t *testing.T) {
-	t.Parallel()
-
 	tblInt64 := []struct {
 		lsh      int64
 		rsh      int64

--- a/types/parser_driver/value_expr_test.go
+++ b/types/parser_driver/value_expr_test.go
@@ -47,7 +47,6 @@ func TestValueExprRestore(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		test := test
 		t.Run(test.expect, func(t *testing.T) {
-			t.Parallel()
 			var sb strings.Builder
 			expr := &ValueExpr{Datum: test.datum}
 			err := expr.Restore(format.NewRestoreCtx(format.DefaultRestoreFlags, &sb))

--- a/types/time_test.go
+++ b/types/time_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 func TestTimeEncoding(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		Year, Month, Day, Hour, Minute, Second, Microsecond int
 		Type                                                uint8
@@ -61,7 +60,6 @@ func TestTimeEncoding(t *testing.T) {
 }
 
 func TestDateTime(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -182,7 +180,6 @@ func TestDateTime(t *testing.T) {
 }
 
 func TestTimestamp(t *testing.T) {
-	t.Parallel()
 	table := []struct {
 		Input  string
 		Expect string
@@ -208,7 +205,6 @@ func TestTimestamp(t *testing.T) {
 }
 
 func TestDate(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -304,7 +300,6 @@ func TestDate(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -399,7 +394,6 @@ func TestTime(t *testing.T) {
 }
 
 func TestDurationAdd(t *testing.T) {
-	t.Parallel()
 	table := []struct {
 		Input    string
 		Fsp      int8
@@ -436,7 +430,6 @@ func TestDurationAdd(t *testing.T) {
 }
 
 func TestDurationSub(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -461,7 +454,6 @@ func TestDurationSub(t *testing.T) {
 }
 
 func TestTimeFsp(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -501,7 +493,6 @@ func TestTimeFsp(t *testing.T) {
 }
 
 func TestYear(t *testing.T) {
-	t.Parallel()
 	table := []struct {
 		Input  string
 		Expect int16
@@ -563,7 +554,6 @@ func TestYear(t *testing.T) {
 }
 
 func TestCodec(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 
 	// MySQL timestamp value doesn't allow month=0 or day=0.
@@ -621,7 +611,6 @@ func TestCodec(t *testing.T) {
 }
 
 func TestParseTimeFromNum(t *testing.T) {
-	t.Parallel()
 	table := []struct {
 		Input                int64
 		ExpectDateTimeError  bool
@@ -695,7 +684,6 @@ func TestParseTimeFromNum(t *testing.T) {
 }
 
 func TestToNumber(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	losAngelesTz, err := time.LoadLocation("America/Los_Angeles")
@@ -772,7 +760,6 @@ func TestToNumber(t *testing.T) {
 }
 
 func TestParseTimeFromFloatString(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -805,7 +792,6 @@ func TestParseTimeFromFloatString(t *testing.T) {
 }
 
 func TestParseFrac(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		S        string
 		Fsp      int8
@@ -842,7 +828,6 @@ func TestParseFrac(t *testing.T) {
 }
 
 func TestRoundFrac(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	sc.TimeZone = time.UTC
@@ -935,7 +920,6 @@ func TestRoundFrac(t *testing.T) {
 }
 
 func TestConvert(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	losAngelesTz, _ := time.LoadLocation("America/Los_Angeles")
@@ -986,7 +970,6 @@ func TestConvert(t *testing.T) {
 }
 
 func TestCompare(t *testing.T) {
-	t.Parallel()
 	sc := &stmtctx.StatementContext{TimeZone: time.UTC}
 	tbl := []struct {
 		Arg1 string
@@ -1036,7 +1019,6 @@ func TestCompare(t *testing.T) {
 }
 
 func TestDurationClock(t *testing.T) {
-	t.Parallel()
 	// test hour, minute, second and micro second
 	tbl := []struct {
 		Input       string
@@ -1061,7 +1043,6 @@ func TestDurationClock(t *testing.T) {
 }
 
 func TestParseDateFormat(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		Input  string
 		Result []string
@@ -1085,7 +1066,6 @@ func TestParseDateFormat(t *testing.T) {
 }
 
 func TestTimestampDiff(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		unit   string
 		t1     types.CoreTime
@@ -1109,7 +1089,6 @@ func TestTimestampDiff(t *testing.T) {
 }
 
 func TestDateFSP(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		date   string
 		expect int
@@ -1126,7 +1105,6 @@ func TestDateFSP(t *testing.T) {
 }
 
 func TestConvertTimeZone(t *testing.T) {
-	t.Parallel()
 	loc, _ := time.LoadLocation("Asia/Shanghai")
 	tests := []struct {
 		input  types.CoreTime
@@ -1148,7 +1126,6 @@ func TestConvertTimeZone(t *testing.T) {
 }
 
 func TestTimeAdd(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		Arg1 string
 		Arg2 string
@@ -1179,7 +1156,6 @@ func TestTimeAdd(t *testing.T) {
 }
 
 func TestTruncateOverflowMySQLTime(t *testing.T) {
-	t.Parallel()
 	v := types.MaxTime + 1
 	res, err := types.TruncateOverflowMySQLTime(v)
 	require.True(t, types.ErrTruncatedWrongVal.Equal(err))
@@ -1212,8 +1188,6 @@ func TestTruncateOverflowMySQLTime(t *testing.T) {
 }
 
 func TestCheckTimestamp(t *testing.T) {
-	t.Parallel()
-
 	shanghaiTz, _ := time.LoadLocation("Asia/Shanghai")
 
 	tests := []struct {
@@ -1323,7 +1297,6 @@ func TestCheckTimestamp(t *testing.T) {
 }
 
 func TestExtractDurationValue(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		unit   string
 		format string
@@ -1464,14 +1437,12 @@ func TestExtractDurationValue(t *testing.T) {
 }
 
 func TestCurrentTime(t *testing.T) {
-	t.Parallel()
 	res := types.CurrentTime(mysql.TypeTimestamp)
 	require.Equal(t, mysql.TypeTimestamp, res.Type())
 	require.Equal(t, int8(0), res.Fsp())
 }
 
 func TestInvalidZero(t *testing.T) {
-	t.Parallel()
 	in := types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp)
 	require.True(t, in.InvalidZero())
 	in.SetCoreTime(types.FromDate(2019, 00, 00, 00, 00, 00, 00))
@@ -1481,7 +1452,6 @@ func TestInvalidZero(t *testing.T) {
 }
 
 func TestGetFsp(t *testing.T) {
-	t.Parallel()
 	res := types.GetFsp("2019:04:12 14:00:00.123456")
 	require.Equal(t, int8(6), res)
 
@@ -1496,7 +1466,6 @@ func TestGetFsp(t *testing.T) {
 }
 
 func TestExtractDatetimeNum(t *testing.T) {
-	t.Parallel()
 	in := types.NewTime(types.FromDate(2019, 04, 12, 14, 00, 00, 0000), mysql.TypeTimestamp, types.DefaultFsp)
 
 	res, err := types.ExtractDatetimeNum(&in, "day")
@@ -1568,7 +1537,6 @@ func TestExtractDatetimeNum(t *testing.T) {
 }
 
 func TestExtractDurationNum(t *testing.T) {
-	t.Parallel()
 	type resultTbl struct {
 		unit   string
 		expect int64
@@ -1634,7 +1602,6 @@ func TestExtractDurationNum(t *testing.T) {
 }
 
 func TestParseDurationValue(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		format string
 		unit   string
@@ -1691,7 +1658,6 @@ func TestParseDurationValue(t *testing.T) {
 }
 
 func TestIsClockUnit(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		input    string
 		expected bool
@@ -1719,7 +1685,6 @@ func TestIsClockUnit(t *testing.T) {
 }
 
 func TestIsDateFormat(t *testing.T) {
-	t.Parallel()
 	input := "1234:321"
 	output := types.IsDateFormat(input)
 	require.False(t, output)
@@ -1734,7 +1699,6 @@ func TestIsDateFormat(t *testing.T) {
 }
 
 func TestParseTimeFromInt64(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 
@@ -1753,7 +1717,6 @@ func TestParseTimeFromInt64(t *testing.T) {
 }
 
 func TestGetFormatType(t *testing.T) {
-	t.Parallel()
 	input := "TEST"
 	isDuration, isDate := types.GetFormatType(input)
 	require.False(t, isDuration)
@@ -1771,7 +1734,6 @@ func TestGetFormatType(t *testing.T) {
 }
 
 func TestGetFracIndex(t *testing.T) {
-	t.Parallel()
 	testCases := []struct {
 		str         string
 		expectIndex int
@@ -1787,7 +1749,6 @@ func TestGetFracIndex(t *testing.T) {
 }
 
 func TestTimeOverflow(t *testing.T) {
-	t.Parallel()
 	sc := mock.NewContext().GetSessionVars().StmtCtx
 	sc.IgnoreZeroInDate = true
 	table := []struct {
@@ -1821,7 +1782,6 @@ func TestTimeOverflow(t *testing.T) {
 }
 
 func TestTruncateFrac(t *testing.T) {
-	t.Parallel()
 	cols := []struct {
 		input  time.Time
 		fsp    int8
@@ -1839,7 +1799,6 @@ func TestTruncateFrac(t *testing.T) {
 }
 
 func TestTimeSub(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		Arg1 string
 		Arg2 string
@@ -1866,7 +1825,6 @@ func TestTimeSub(t *testing.T) {
 }
 
 func TestCheckMonthDay(t *testing.T) {
-	t.Parallel()
 	dates := []struct {
 		date        types.CoreTime
 		isValidDate bool
@@ -1903,7 +1861,6 @@ func TestCheckMonthDay(t *testing.T) {
 }
 
 func TestFormatIntWidthN(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		num    int
 		width  int
@@ -1926,7 +1883,6 @@ func TestFormatIntWidthN(t *testing.T) {
 }
 
 func TestFromGoTime(t *testing.T) {
-	t.Parallel()
 	// Test rounding of nanosecond to millisecond.
 	cases := []struct {
 		input string
@@ -1956,7 +1912,6 @@ func TestFromGoTime(t *testing.T) {
 }
 
 func TestGetTimezone(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		input    string
 		idx      int
@@ -1985,7 +1940,6 @@ func TestGetTimezone(t *testing.T) {
 }
 
 func TestParseWithTimezone(t *testing.T) {
-	t.Parallel()
 	getTZ := func(tzSign string, tzHour, tzMinue int) *time.Location {
 		offset := tzHour*60*60 + tzMinue*60
 		if tzSign == "-" {

--- a/util/admin/admin_integration_test.go
+++ b/util/admin/admin_integration_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestAdminCheckTable(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
@@ -77,8 +75,6 @@ func TestAdminCheckTable(t *testing.T) {
 }
 
 func TestAdminCheckTableClusterIndex(t *testing.T) {
-	t.Parallel()
-
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestGetDDLInfo(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 
@@ -79,8 +77,6 @@ func TestGetDDLInfo(t *testing.T) {
 }
 
 func TestGetDDLJobs(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 
@@ -134,8 +130,6 @@ func TestGetDDLJobs(t *testing.T) {
 }
 
 func TestGetDDLJobsIsSort(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 
@@ -165,8 +159,6 @@ func TestGetDDLJobsIsSort(t *testing.T) {
 }
 
 func TestCancelJobs(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 
@@ -280,8 +272,6 @@ func TestCancelJobs(t *testing.T) {
 }
 
 func TestGetHistoryDDLJobs(t *testing.T) {
-	t.Parallel()
-
 	store, clean := newMockStore(t)
 	defer clean()
 
@@ -340,8 +330,6 @@ func TestGetHistoryDDLJobs(t *testing.T) {
 }
 
 func TestIsJobRollbackable(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		tp     model.ActionType
 		state  model.SchemaState
@@ -364,8 +352,6 @@ func TestIsJobRollbackable(t *testing.T) {
 }
 
 func TestError(t *testing.T) {
-	t.Parallel()
-
 	kvErrs := []*terror.Error{
 		ErrDataInConsistent,
 		ErrDDLJobNotFound,

--- a/util/arena/arena_test.go
+++ b/util/arena/arena_test.go
@@ -28,8 +28,6 @@ const (
 )
 
 func TestSimpleArenaAllocator(t *testing.T) {
-	t.Parallel()
-
 	arena := NewAllocator(arenaCap)
 	slice := arena.Alloc(allocCapSmall)
 	assert.Equal(t, allocCapSmall, arena.off)
@@ -57,7 +55,6 @@ func TestSimpleArenaAllocator(t *testing.T) {
 }
 
 func TestStdAllocator(t *testing.T) {
-	t.Parallel()
 	slice := StdAllocator.Alloc(allocCapMedium)
 	assert.Len(t, slice, 0)
 	assert.Equal(t, allocCapMedium, cap(slice))

--- a/util/bitmap/concurrent_test.go
+++ b/util/bitmap/concurrent_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestConcurrentBitmapSet(t *testing.T) {
-	t.Parallel()
-
 	const loopCount = 1000
 	const interval = 2
 
@@ -51,8 +49,6 @@ func TestConcurrentBitmapSet(t *testing.T) {
 // TestConcurrentBitmapUniqueSetter checks if isSetter is unique everytime
 // when a bit is set.
 func TestConcurrentBitmapUniqueSetter(t *testing.T) {
-	t.Parallel()
-
 	const loopCount = 10000
 	const competitorsPerSet = 50
 

--- a/util/checksum/checksum_test.go
+++ b/util/checksum/checksum_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestChecksumReadAt(t *testing.T) {
-	t.Parallel()
 	f := newFakeFile()
 
 	w := newTestBuff("0123456789", 510)
@@ -56,11 +55,9 @@ func TestChecksumReadAt(t *testing.T) {
 // both the current block and the following block have errors.
 func TestAddOneByte(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testAddOneByte(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testAddOneByte(t, true)
 	})
 }
@@ -99,11 +96,9 @@ func testAddOneByte(t *testing.T, encrypt bool) {
 // both the current block and the following block have errors.
 func TestDeleteOneByte(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testDeleteOneByte(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testDeleteOneByte(t, true)
 	})
 }
@@ -142,11 +137,9 @@ func testDeleteOneByte(t *testing.T, encrypt bool) {
 // only the current block has error.
 func TestModifyOneByte(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testModifyOneByte(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testModifyOneByte(t, true)
 	})
 }
@@ -184,11 +177,9 @@ func testModifyOneByte(t *testing.T, encrypt bool) {
 // TestReadEmptyFile ensures that whether encrypted or not, no error will occur.
 func TestReadEmptyFile(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testReadEmptyFile(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testReadEmptyFile(t, true)
 	})
 }
@@ -221,11 +212,9 @@ func testReadEmptyFile(t *testing.T, encrypt bool) {
 // only the current block has error.
 func TestModifyThreeBytes(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testModifyThreeBytes(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testModifyThreeBytes(t, true)
 	})
 }
@@ -270,11 +259,9 @@ func testModifyThreeBytes(t *testing.T, encrypt bool) {
 // 2. Read all data at once.
 func TestReadDifferentBlockSize(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testReadDifferentBlockSize(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testReadDifferentBlockSize(t, true)
 	})
 }
@@ -328,11 +315,9 @@ func testReadDifferentBlockSize(t *testing.T, encrypt bool) {
 // 2. Write some block and append some block.
 func TestWriteDifferentBlockSize(t *testing.T) {
 	t.Run("unencrypted", func(t *testing.T) {
-		t.Parallel()
 		testWriteDifferentBlockSize(t, false)
 	})
 	t.Run("encrypted", func(t *testing.T) {
-		t.Parallel()
 		testWriteDifferentBlockSize(t, true)
 	})
 }
@@ -393,7 +378,6 @@ func testWriteDifferentBlockSize(t *testing.T, encrypt bool) {
 }
 
 func TestChecksumWriter(t *testing.T) {
-	t.Parallel()
 	f := newFakeFile()
 
 	buf := newTestBuff("0123456789", 100)
@@ -413,7 +397,6 @@ func TestChecksumWriter(t *testing.T) {
 }
 
 func TestChecksumWriterAutoFlush(t *testing.T) {
-	t.Parallel()
 	f := newFakeFile()
 
 	buf := newTestBuff("0123456789", 102)

--- a/util/chunk/chunk_test.go
+++ b/util/chunk/chunk_test.go
@@ -32,8 +32,6 @@ import (
 )
 
 func TestAppendRow(t *testing.T) {
-	t.Parallel()
-
 	numCols := 6
 	numRows := 10
 	chk := newChunk(8, 8, 0, 0, 40, 0)
@@ -142,8 +140,6 @@ func TestAppendRow(t *testing.T) {
 }
 
 func TestAppendChunk(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 3)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeVarchar})
@@ -202,8 +198,6 @@ func TestAppendChunk(t *testing.T) {
 }
 
 func TestTruncateTo(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 3)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeVarchar})
@@ -397,8 +391,6 @@ var allTypes = []*types.FieldType{
 }
 
 func TestCompare(t *testing.T) {
-	t.Parallel()
-
 	chunk := NewChunkWithCapacity(allTypes, 32)
 	for i := 0; i < len(allTypes); i++ {
 		chunk.AppendNull(i)
@@ -485,8 +477,6 @@ func TestCompare(t *testing.T) {
 }
 
 func TestCopyTo(t *testing.T) {
-	t.Parallel()
-
 	chunk := NewChunkWithCapacity(allTypes, 101)
 	for i := 0; i < len(allTypes); i++ {
 		chunk.AppendNull(i)
@@ -541,8 +531,6 @@ func TestCopyTo(t *testing.T) {
 }
 
 func TestGetDecimalDatum(t *testing.T) {
-	t.Parallel()
-
 	datum := types.NewDatum(1.01)
 	decType := types.NewFieldType(mysql.TypeNewDecimal)
 	decType.Flen = 4
@@ -559,8 +547,6 @@ func TestGetDecimalDatum(t *testing.T) {
 }
 
 func TestChunkMemoryUsage(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 5)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeVarchar})
@@ -617,8 +603,6 @@ func TestChunkMemoryUsage(t *testing.T) {
 }
 
 func TestSwapColumn(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 2)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
@@ -671,8 +655,6 @@ func TestSwapColumn(t *testing.T) {
 }
 
 func TestAppendSel(t *testing.T) {
-	t.Parallel()
-
 	tll := &types.FieldType{Tp: mysql.TypeLonglong}
 	chk := NewChunkWithCapacity([]*types.FieldType{tll}, 1024)
 	sel := make([]int, 0, 1024/2)
@@ -691,8 +673,6 @@ func TestAppendSel(t *testing.T) {
 }
 
 func TestMakeRefTo(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 2)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
@@ -713,8 +693,6 @@ func TestMakeRefTo(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 4)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeDouble})
@@ -1013,8 +991,6 @@ func benchmarkChunkGrow(t benchChunkGrowCase) func(b *testing.B) {
 }
 
 func TestAppendRows(t *testing.T) {
-	t.Parallel()
-
 	numCols := 6
 	numRows := 10
 	chk := newChunk(8, 8, 0, 0, 40, 0)

--- a/util/chunk/chunk_util_test.go
+++ b/util/chunk/chunk_util_test.go
@@ -53,8 +53,6 @@ func getChk(isLast3ColTheSame bool) (*Chunk, *Chunk, []bool) {
 }
 
 func TestCopySelectedJoinRows(t *testing.T) {
-	t.Parallel()
-
 	srcChk, dstChk, selected := getChk(true)
 	numRows := srcChk.NumRows()
 	for i := 0; i < numRows; i++ {
@@ -80,8 +78,6 @@ func TestCopySelectedJoinRows(t *testing.T) {
 }
 
 func TestCopySelectedJoinRowsWithoutSameOuters(t *testing.T) {
-	t.Parallel()
-
 	srcChk, dstChk, selected := getChk(false)
 	numRows := srcChk.NumRows()
 	for i := 0; i < numRows; i++ {
@@ -107,8 +103,6 @@ func TestCopySelectedJoinRowsWithoutSameOuters(t *testing.T) {
 }
 
 func TestCopySelectedJoinRowsDirect(t *testing.T) {
-	t.Parallel()
-
 	srcChk, dstChk, selected := getChk(false)
 	numRows := srcChk.NumRows()
 	for i := 0; i < numRows; i++ {
@@ -138,8 +132,6 @@ func TestCopySelectedJoinRowsDirect(t *testing.T) {
 }
 
 func TestCopySelectedVirtualNum(t *testing.T) {
-	t.Parallel()
-
 	// srcChk does not contain columns
 	srcChk := newChunk()
 	srcChk.TruncateTo(3)

--- a/util/chunk/codec_test.go
+++ b/util/chunk/codec_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestCodec(t *testing.T) {
-	t.Parallel()
-
 	numCols := 6
 	numRows := 10
 
@@ -77,8 +75,6 @@ func TestCodec(t *testing.T) {
 }
 
 func TestEstimateTypeWidth(t *testing.T) {
-	t.Parallel()
-
 	var colType *types.FieldType
 
 	colType = &types.FieldType{Tp: mysql.TypeLonglong}

--- a/util/chunk/column_test.go
+++ b/util/chunk/column_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestColumnCopy(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(8, 10)
 	for i := 0; i < 10; i++ {
 		col.AppendInt64(int64(i))
@@ -44,8 +42,6 @@ func TestColumnCopy(t *testing.T) {
 }
 
 func TestColumnCopyReconstructFixedLen(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
 	results := make([]int64, 0, 1024)
 	nulls := make([]bool, 0, 1024)
@@ -102,8 +98,6 @@ func TestColumnCopyReconstructFixedLen(t *testing.T) {
 }
 
 func TestColumnCopyReconstructVarLen(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
 	results := make([]string, 0, 1024)
 	nulls := make([]bool, 0, 1024)
@@ -160,8 +154,6 @@ func TestColumnCopyReconstructVarLen(t *testing.T) {
 }
 
 func TestLargeStringColumnOffset(t *testing.T) {
-	t.Parallel()
-
 	numRows := 1
 	col := newVarLenColumn(numRows)
 	// The max-length of a string field can be 6M, a typical batch size for Chunk is 1024, which is 1K.
@@ -171,8 +163,6 @@ func TestLargeStringColumnOffset(t *testing.T) {
 }
 
 func TestI64Column(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -195,8 +185,6 @@ func TestI64Column(t *testing.T) {
 }
 
 func TestF64Column(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDouble)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -219,8 +207,6 @@ func TestF64Column(t *testing.T) {
 }
 
 func TestF32Column(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeFloat)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -243,8 +229,6 @@ func TestF32Column(t *testing.T) {
 }
 
 func TestDurationSliceColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDuration)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -269,8 +253,6 @@ func TestDurationSliceColumn(t *testing.T) {
 }
 
 func TestMyDecimal(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeNewDecimal)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -312,8 +294,6 @@ func TestMyDecimal(t *testing.T) {
 }
 
 func TestStringColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeVarString)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -330,8 +310,6 @@ func TestStringColumn(t *testing.T) {
 }
 
 func TestSetColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeSet)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -352,8 +330,6 @@ func TestSetColumn(t *testing.T) {
 }
 
 func TestJSONColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeJSON)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -374,8 +350,6 @@ func TestJSONColumn(t *testing.T) {
 }
 
 func TestTimeColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDatetime)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -397,8 +371,6 @@ func TestTimeColumn(t *testing.T) {
 }
 
 func TestDurationColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeDuration)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -416,8 +388,6 @@ func TestDurationColumn(t *testing.T) {
 }
 
 func TestEnumColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeEnum)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -438,8 +408,6 @@ func TestEnumColumn(t *testing.T) {
 }
 
 func TestNullsColumn(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -464,8 +432,6 @@ func TestNullsColumn(t *testing.T) {
 }
 
 func TestReconstructFixedLen(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
 	results := make([]int64, 0, 1024)
 	nulls := make([]bool, 0, 1024)
@@ -522,8 +488,6 @@ func TestReconstructFixedLen(t *testing.T) {
 }
 
 func TestReconstructVarLen(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeVarString), 1024)
 	results := make([]string, 0, 1024)
 	nulls := make([]bool, 0, 1024)
@@ -580,8 +544,6 @@ func TestReconstructVarLen(t *testing.T) {
 }
 
 func TestPreAllocInt64(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 128)
 	col.ResizeInt64(256, true)
 	i64s := col.Int64s()
@@ -596,8 +558,6 @@ func TestPreAllocInt64(t *testing.T) {
 }
 
 func TestPreAllocUint64(t *testing.T) {
-	t.Parallel()
-
 	tll := types.NewFieldType(mysql.TypeLonglong)
 	tll.Flag |= mysql.UnsignedFlag
 	col := NewColumn(tll, 128)
@@ -614,8 +574,6 @@ func TestPreAllocUint64(t *testing.T) {
 }
 
 func TestPreAllocFloat32(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeFloat32, 128)
 	col.ResizeFloat32(256, true)
 	f32s := col.Float32s()
@@ -630,8 +588,6 @@ func TestPreAllocFloat32(t *testing.T) {
 }
 
 func TestPreAllocFloat64(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeFloat64, 128)
 	col.ResizeFloat64(256, true)
 	f64s := col.Float64s()
@@ -646,8 +602,6 @@ func TestPreAllocFloat64(t *testing.T) {
 }
 
 func TestPreAllocDecimal(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeMyDecimal, 128)
 	col.ResizeDecimal(256, true)
 	ds := col.Decimals()
@@ -661,8 +615,6 @@ func TestPreAllocDecimal(t *testing.T) {
 }
 
 func TestPreAllocTime(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeTime, 128)
 	col.ResizeTime(256, true)
 	ds := col.Times()
@@ -676,8 +628,6 @@ func TestPreAllocTime(t *testing.T) {
 }
 
 func TestNull(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeFloat64, 32)
 	col.ResizeFloat64(1024, true)
 	require.Equal(t, 1024, col.nullCount())
@@ -710,8 +660,6 @@ func TestNull(t *testing.T) {
 }
 
 func TestSetNulls(t *testing.T) {
-	t.Parallel()
-
 	col := newFixedLenColumn(sizeFloat64, 32)
 	col.ResizeFloat64(1024, true)
 	require.Equal(t, 1024, col.nullCount())
@@ -740,8 +688,6 @@ func TestSetNulls(t *testing.T) {
 }
 
 func TestResizeReserve(t *testing.T) {
-	t.Parallel()
-
 	cI64s := newFixedLenColumn(sizeInt64, 0)
 	require.Zero(t, cI64s.length)
 	for i := 0; i < 100; i++ {
@@ -765,8 +711,6 @@ func TestResizeReserve(t *testing.T) {
 }
 
 func TestGetRaw(t *testing.T) {
-	t.Parallel()
-
 	chk := NewChunkWithCapacity([]*types.FieldType{types.NewFieldType(mysql.TypeFloat)}, 1024)
 	col := chk.Column(0)
 	for i := 0; i < 1024; i++ {
@@ -797,8 +741,6 @@ func TestGetRaw(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	t.Parallel()
-
 	col := NewColumn(types.NewFieldType(mysql.TypeLonglong), 1024)
 	for i := 0; i < 1024; i++ {
 		col.AppendInt64(int64(i))
@@ -979,8 +921,6 @@ func genNullCols(n int) []*Column {
 }
 
 func TestVectorizedNulls(t *testing.T) {
-	t.Parallel()
-
 	for i := 0; i < 256; i++ {
 		cols := genNullCols(4)
 		lCol, rCol := cols[0], cols[1]
@@ -999,8 +939,6 @@ func TestVectorizedNulls(t *testing.T) {
 }
 
 func TestResetColumn(t *testing.T) {
-	t.Parallel()
-
 	col0 := NewColumn(types.NewFieldType(mysql.TypeVarString), 0)
 	col1 := NewColumn(types.NewFieldType(mysql.TypeLonglong), 0)
 

--- a/util/chunk/disk_test.go
+++ b/util/chunk/disk_test.go
@@ -66,8 +66,6 @@ func initChunks(numChk, numRow int) ([]*Chunk, []*types.FieldType) {
 }
 
 func TestListInDisk(t *testing.T) {
-	t.Parallel()
-
 	numChk, numRow := 2, 2
 	chks, fields := initChunks(numChk, numRow)
 	l := NewListInDisk(fields)
@@ -185,8 +183,6 @@ func checkRow(t *testing.T, row1, row2 Row) {
 }
 
 func testListInDisk(t *testing.T) {
-	t.Parallel()
-
 	numChk, numRow := 10, 1000
 	chks, fields := initChunks(numChk, numRow)
 	lChecksum := NewListInDisk(fields)
@@ -256,8 +252,6 @@ func TestListInDiskWithChecksumAndEncrypt(t *testing.T) {
 // |      |                                          | |                             |
 // +------+------------------------------------------+ +-----------------------------+
 func testReaderWithCache(t *testing.T) {
-	t.Parallel()
-
 	testData := "0123456789"
 	buf := bytes.NewBuffer(nil)
 	for i := 0; i < 102; i++ {
@@ -337,8 +331,6 @@ func testReaderWithCache(t *testing.T) {
 
 // Here we test situations where size of data is small, so no data is flushed to disk.
 func testReaderWithCacheNoFlush(t *testing.T) {
-	t.Parallel()
-
 	testData := "0123456789"
 
 	field := []*types.FieldType{types.NewFieldType(mysql.TypeString)}

--- a/util/chunk/iterator_test.go
+++ b/util/chunk/iterator_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestIteratorOnSel(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	chk := New(fields, 32, 1024)
 	sel := make([]int, 0, 1024)
@@ -52,8 +50,6 @@ func checkEqual(it Iterator, exp []int64, t *testing.T) {
 }
 
 func TestMultiIterator(t *testing.T) {
-	t.Parallel()
-
 	it := NewMultiIterator(NewIterator4Chunk(new(Chunk)))
 	require.Equal(t, it.End(), it.Begin())
 
@@ -97,8 +93,6 @@ func TestMultiIterator(t *testing.T) {
 }
 
 func TestIterator(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	chk := New(fields, 32, 1024)
 	n := 10

--- a/util/chunk/list_test.go
+++ b/util/chunk/list_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestList(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{
 		types.NewFieldType(mysql.TypeLonglong),
 	}
@@ -85,8 +83,6 @@ func TestList(t *testing.T) {
 }
 
 func TestListMemoryUsage(t *testing.T) {
-	t.Parallel()
-
 	fieldTypes := make([]*types.FieldType, 0, 5)
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeFloat})
 	fieldTypes = append(fieldTypes, &types.FieldType{Tp: mysql.TypeVarchar})

--- a/util/chunk/mutrow_test.go
+++ b/util/chunk/mutrow_test.go
@@ -27,8 +27,6 @@ import (
 )
 
 func TestMutRow(t *testing.T) {
-	t.Parallel()
-
 	mutRow := MutRowFromTypes(allTypes)
 	row := mutRow.ToRow()
 	sc := new(stmtctx.StatementContext)
@@ -92,8 +90,6 @@ func TestMutRow(t *testing.T) {
 }
 
 func TestIssue29947(t *testing.T) {
-	t.Parallel()
-
 	mutRow := MutRowFromTypes(allTypes)
 	nilDatum := types.NewDatum(nil)
 
@@ -171,8 +167,6 @@ func BenchmarkMutRowFromValues(b *testing.B) {
 }
 
 func TestMutRowShallowCopyPartialRow(t *testing.T) {
-	t.Parallel()
-
 	colTypes := make([]*types.FieldType, 0, 3)
 	colTypes = append(colTypes, &types.FieldType{Tp: mysql.TypeVarString})
 	colTypes = append(colTypes, &types.FieldType{Tp: mysql.TypeLonglong})

--- a/util/chunk/pool_test.go
+++ b/util/chunk/pool_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestNewPool(t *testing.T) {
-	t.Parallel()
-
 	pool := NewPool(1024)
 	require.Equal(t, 1024, pool.initCap)
 	require.NotNil(t, pool.varLenColPool)
@@ -35,8 +33,6 @@ func TestNewPool(t *testing.T) {
 }
 
 func TestPoolGetChunk(t *testing.T) {
-	t.Parallel()
-
 	initCap := 1024
 	pool := NewPool(initCap)
 
@@ -72,8 +68,6 @@ func TestPoolGetChunk(t *testing.T) {
 }
 
 func TestPoolPutChunk(t *testing.T) {
-	t.Parallel()
-
 	initCap := 1024
 	pool := NewPool(initCap)
 

--- a/util/chunk/row_container_test.go
+++ b/util/chunk/row_container_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestNewRowContainer(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	rc := NewRowContainer(fields, 1024)
 	require.NotNil(t, rc)
@@ -33,8 +31,6 @@ func TestNewRowContainer(t *testing.T) {
 }
 
 func TestSel(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	sz := 4
 	rc := NewRowContainer(fields, sz)
@@ -85,8 +81,6 @@ func TestSel(t *testing.T) {
 }
 
 func TestSpillAction(t *testing.T) {
-	t.Parallel()
-
 	sz := 4
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	rc := NewRowContainer(fields, sz)
@@ -139,8 +133,6 @@ func TestSpillAction(t *testing.T) {
 }
 
 func TestNewSortedRowContainer(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	rc := NewSortedRowContainer(fields, 1024, nil, nil, nil)
 	require.NotNil(t, rc)
@@ -148,8 +140,6 @@ func TestNewSortedRowContainer(t *testing.T) {
 }
 
 func TestSortedRowContainerSortSpillAction(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	byItemsDesc := []bool{false}
 	keyColumns := []int{0}
@@ -193,8 +183,6 @@ func TestSortedRowContainerSortSpillAction(t *testing.T) {
 }
 
 func TestRowContainerResetAndAction(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLonglong)}
 	sz := 20
 	rc := NewRowContainer(fields, sz)

--- a/util/codec/bytes_test.go
+++ b/util/codec/bytes_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestFastSlowFastReverse(t *testing.T) {
-	t.Parallel()
-
 	if !supportsUnaligned {
 		return
 	}
@@ -35,8 +33,6 @@ func TestFastSlowFastReverse(t *testing.T) {
 }
 
 func TestBytesCodec(t *testing.T) {
-	t.Parallel()
-
 	inputs := []struct {
 		enc  []byte
 		dec  []byte

--- a/util/codec/codec_test.go
+++ b/util/codec/codec_test.go
@@ -35,8 +35,6 @@ import (
 )
 
 func TestCodecKey(t *testing.T) {
-	t.Parallel()
-
 	table := []struct {
 		Input  []types.Datum
 		Expect []types.Datum
@@ -116,8 +114,6 @@ func estimateValuesSize(sc *stmtctx.StatementContext, vals []types.Datum) (int, 
 }
 
 func TestCodecKeyCompare(t *testing.T) {
-	t.Parallel()
-
 	table := []struct {
 		Left   []types.Datum
 		Right  []types.Datum
@@ -233,8 +229,6 @@ func TestCodecKeyCompare(t *testing.T) {
 }
 
 func TestNumberCodec(t *testing.T) {
-	t.Parallel()
-
 	tblInt64 := []int64{
 		math.MinInt64,
 		math.MinInt32,
@@ -335,8 +329,6 @@ func TestNumberCodec(t *testing.T) {
 }
 
 func TestNumberOrder(t *testing.T) {
-	t.Parallel()
-
 	tblInt64 := []struct {
 		Arg1 int64
 		Arg2 int64
@@ -405,8 +397,6 @@ func TestNumberOrder(t *testing.T) {
 }
 
 func TestFloatCodec(t *testing.T) {
-	t.Parallel()
-
 	tblFloat := []float64{
 		-1,
 		0,
@@ -465,8 +455,6 @@ func TestFloatCodec(t *testing.T) {
 }
 
 func TestBytes(t *testing.T) {
-	t.Parallel()
-
 	tblBytes := [][]byte{
 		{},
 		{0x00, 0x01},
@@ -545,8 +533,6 @@ func parseDuration(t *testing.T, s string) types.Duration {
 }
 
 func TestTime(t *testing.T) {
-	t.Parallel()
-
 	tbl := []string{
 		"2011-01-01 00:00:00",
 		"2011-01-01 00:00:00",
@@ -594,8 +580,6 @@ func TestTime(t *testing.T) {
 }
 
 func TestDuration(t *testing.T) {
-	t.Parallel()
-
 	tbl := []string{
 		"11:11:11",
 		"00:00:00",
@@ -638,8 +622,6 @@ func TestDuration(t *testing.T) {
 }
 
 func TestDecimal(t *testing.T) {
-	t.Parallel()
-
 	tbl := []string{
 		"1234.00",
 		"1234",
@@ -812,8 +794,6 @@ func TestDecimal(t *testing.T) {
 }
 
 func TestJSON(t *testing.T) {
-	t.Parallel()
-
 	tbl := []string{
 		"1234.00",
 		`{"a": "b"}`,
@@ -843,8 +823,6 @@ func TestJSON(t *testing.T) {
 }
 
 func TestCut(t *testing.T) {
-	t.Parallel()
-
 	table := []struct {
 		Input  []types.Datum
 		Expect []types.Datum
@@ -940,8 +918,6 @@ func TestCut(t *testing.T) {
 }
 
 func TestCutOneError(t *testing.T) {
-	t.Parallel()
-
 	var b []byte
 	_, _, err := CutOne(b)
 	require.Error(t, err)
@@ -954,8 +930,6 @@ func TestCutOneError(t *testing.T) {
 }
 
 func TestSetRawValues(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	datums := types.MakeDatums(1, "abc", 1.1, []byte("def"))
 	rowData, err := EncodeValue(sc, nil, datums...)
@@ -974,8 +948,6 @@ func TestSetRawValues(t *testing.T) {
 }
 
 func TestDecodeOneToChunk(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	datums, tps := datumsForTest(sc)
 	rowCount := 3
@@ -1000,8 +972,6 @@ func TestDecodeOneToChunk(t *testing.T) {
 }
 
 func TestHashGroup(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	tp := types.NewFieldType(mysql.TypeNewDecimal)
 	tps := []*types.FieldType{tp}
@@ -1099,8 +1069,6 @@ func chunkForTest(t *testing.T, sc *stmtctx.StatementContext, datums []types.Dat
 }
 
 func TestDecodeRange(t *testing.T) {
-	t.Parallel()
-
 	_, _, err := DecodeRange(nil, 0, nil, nil)
 	require.Error(t, err)
 
@@ -1167,8 +1135,6 @@ func testHashChunkRowEqual(t *testing.T, a, b interface{}, equal bool) {
 }
 
 func TestHashChunkRow(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	buf := make([]byte, 1)
 	datums, tps := datumsForTest(sc)
@@ -1213,8 +1179,6 @@ func TestHashChunkRow(t *testing.T) {
 }
 
 func TestValueSizeOfSignedInt(t *testing.T) {
-	t.Parallel()
-
 	testCase := []int64{64, 8192, 1048576, 134217728, 17179869184, 2199023255552, 281474976710656, 36028797018963968, 4611686018427387904}
 	var b []byte
 	for _, v := range testCase {
@@ -1240,8 +1204,6 @@ func TestValueSizeOfSignedInt(t *testing.T) {
 }
 
 func TestValueSizeOfUnsignedInt(t *testing.T) {
-	t.Parallel()
-
 	testCase := []uint64{128, 16384, 2097152, 268435456, 34359738368, 4398046511104, 562949953421312, 72057594037927936, 9223372036854775808}
 	var b []byte
 	for _, v := range testCase {
@@ -1257,8 +1219,6 @@ func TestValueSizeOfUnsignedInt(t *testing.T) {
 }
 
 func TestHashChunkColumns(t *testing.T) {
-	t.Parallel()
-
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}
 	buf := make([]byte, 1)
 	datums, tps := datumsForTest(sc)

--- a/util/codec/decimal_test.go
+++ b/util/codec/decimal_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestDecimalCodec(t *testing.T) {
-	t.Parallel()
-
 	inputs := []struct {
 		Input float64
 	}{
@@ -63,8 +61,6 @@ func TestDecimalCodec(t *testing.T) {
 }
 
 func TestFrac(t *testing.T) {
-	t.Parallel()
-
 	inputs := []struct {
 		Input *types.MyDecimal
 	}{

--- a/util/cteutil/storage_test.go
+++ b/util/cteutil/storage_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestStorageBasic(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 1
 	storage := NewStorageRowContainer(fields, chkSize)
@@ -59,8 +57,6 @@ func TestStorageBasic(t *testing.T) {
 }
 
 func TestOpenAndClose(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 1
 	storage := NewStorageRowContainer(fields, chkSize)
@@ -82,8 +78,6 @@ func TestOpenAndClose(t *testing.T) {
 }
 
 func TestAddAndGetChunk(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 10
 
@@ -112,8 +106,6 @@ func TestAddAndGetChunk(t *testing.T) {
 }
 
 func TestSpillToDisk(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 10
 	storage := NewStorageRowContainer(fields, chkSize)
@@ -169,8 +161,6 @@ func TestSpillToDisk(t *testing.T) {
 }
 
 func TestReopen(t *testing.T) {
-	t.Parallel()
-
 	fields := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 10
 	storage := NewStorageRowContainer(fields, chkSize)
@@ -214,8 +204,6 @@ func TestReopen(t *testing.T) {
 }
 
 func TestSwapData(t *testing.T) {
-	t.Parallel()
-
 	tp1 := []*types.FieldType{types.NewFieldType(mysql.TypeLong)}
 	chkSize := 10
 	storage1 := NewStorageRowContainer(tp1, chkSize)

--- a/util/dbterror/terror_test.go
+++ b/util/dbterror/terror_test.go
@@ -28,8 +28,6 @@ func genErrMsg(pattern string, a ...interface{}) string {
 }
 
 func TestErrorRedact(t *testing.T) {
-	t.Parallel()
-
 	original := errors.RedactLogEnabled.Load()
 	errors.RedactLogEnabled.Store(true)
 	defer func() { errors.RedactLogEnabled.Store(original) }()

--- a/util/encrypt/aes_layer_test.go
+++ b/util/encrypt/aes_layer_test.go
@@ -73,7 +73,6 @@ func testReadAtWithCase(t *testing.T, testCase readAtTestCase) {
 }
 
 func TestReadAt(t *testing.T) {
-	t.Parallel()
 	ctrCipher1, err := NewCtrCipher()
 	require.NoError(t, err)
 	ctrCipher2, err := NewCtrCipher()

--- a/util/encrypt/aes_test.go
+++ b/util/encrypt/aes_test.go
@@ -28,7 +28,6 @@ func toHex(buf []byte) string {
 }
 
 func TestPad(t *testing.T) {
-	t.Parallel()
 	p := []byte{0x0A, 0x0B, 0x0C, 0x0D}
 	p, err := PKCS7Pad(p, 8)
 	require.NoError(t, err)
@@ -46,7 +45,6 @@ func TestPad(t *testing.T) {
 }
 
 func TestUnpad(t *testing.T) {
-	t.Parallel()
 	// Valid paddings.
 	p := []byte{0x0A, 0x0B, 0x0C, 0x0D, 0x04, 0x04, 0x04, 0x04}
 	p, err := PKCS7Unpad(p, 8)
@@ -112,7 +110,6 @@ func TestUnpad(t *testing.T) {
 }
 
 func TestAESECB(t *testing.T) {
-	t.Parallel()
 	var commonInput = []byte{
 		0x6b, 0xc1, 0xbe, 0xe2, 0x2e, 0x40, 0x9f, 0x96, 0xe9, 0x3d, 0x7e, 0x11, 0x73, 0x93, 0x17, 0x2a,
 		0xae, 0x2d, 0x8a, 0x57, 0x1e, 0x03, 0xac, 0x9c, 0x9e, 0xb7, 0x6f, 0xac, 0x45, 0xaf, 0x8e, 0x51,
@@ -189,7 +186,6 @@ func TestAESECB(t *testing.T) {
 }
 
 func TestAESEncryptWithECB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -222,7 +218,6 @@ func TestAESEncryptWithECB(t *testing.T) {
 }
 
 func TestAESDecryptWithECB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		expect      string
 		key         string
@@ -258,7 +253,6 @@ func TestAESDecryptWithECB(t *testing.T) {
 }
 
 func TestAESEncryptWithCBC(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -293,7 +287,6 @@ func TestAESEncryptWithCBC(t *testing.T) {
 }
 
 func TestAESEncryptWithOFB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -328,7 +321,6 @@ func TestAESEncryptWithOFB(t *testing.T) {
 }
 
 func TestAESDecryptWithOFB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -362,7 +354,6 @@ func TestAESDecryptWithOFB(t *testing.T) {
 }
 
 func TestAESEncryptWithCTR(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -397,7 +388,6 @@ func TestAESEncryptWithCTR(t *testing.T) {
 }
 
 func TestAESDecryptWithCTR(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -431,7 +421,6 @@ func TestAESDecryptWithCTR(t *testing.T) {
 }
 
 func TestAESDecryptWithCBC(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		expect      string
 		key         string
@@ -469,7 +458,6 @@ func TestAESDecryptWithCBC(t *testing.T) {
 }
 
 func TestAESEncryptWithCFB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -504,7 +492,6 @@ func TestAESEncryptWithCFB(t *testing.T) {
 }
 
 func TestAESDecryptWithCFB(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		key     string
@@ -538,7 +525,6 @@ func TestAESDecryptWithCFB(t *testing.T) {
 }
 
 func TestDeriveKeyMySQL(t *testing.T) {
-	t.Parallel()
 	p := []byte("MySQL=insecure! MySQL=insecure! ")
 	p = DeriveKeyMySQL(p, 16)
 	require.Equal(t, "00000000000000000000000000000000", toHex(p))

--- a/util/encrypt/crypt_test.go
+++ b/util/encrypt/crypt_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestSQLDecode(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		passwd  string
@@ -53,7 +52,6 @@ func TestSQLDecode(t *testing.T) {
 }
 
 func TestSQLEncode(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		str     string
 		passwd  string

--- a/util/execdetails/execdetails_test.go
+++ b/util/execdetails/execdetails_test.go
@@ -26,7 +26,6 @@ import (
 )
 
 func TestString(t *testing.T) {
-	t.Parallel()
 	detail := &ExecDetails{
 		CopTime:      time.Second + 3*time.Millisecond,
 		BackoffTime:  time.Second,
@@ -87,7 +86,6 @@ func mockExecutorExecutionSummaryForTiFlash(TimeProcessedNs, NumProducedRows, Nu
 }
 
 func TestCopRuntimeStats(t *testing.T) {
-	t.Parallel()
 	stats := NewRuntimeStatsColl(nil)
 	tableScanID := 1
 	aggID := 2
@@ -140,7 +138,6 @@ func TestCopRuntimeStats(t *testing.T) {
 }
 
 func TestCopRuntimeStatsForTiFlash(t *testing.T) {
-	t.Parallel()
 	stats := NewRuntimeStatsColl(nil)
 	tableScanID := 1
 	aggID := 2
@@ -179,7 +176,6 @@ func TestCopRuntimeStatsForTiFlash(t *testing.T) {
 }
 
 func TestRuntimeStatsWithCommit(t *testing.T) {
-	t.Parallel()
 	commitDetail := &util.CommitDetails{
 		GetCommitTsTime: time.Second,
 		PrewriteTime:    time.Second,
@@ -230,7 +226,6 @@ func TestRuntimeStatsWithCommit(t *testing.T) {
 }
 
 func TestRootRuntimeStats(t *testing.T) {
-	t.Parallel()
 	basic1 := &BasicRuntimeStats{}
 	basic2 := &BasicRuntimeStats{}
 	basic1.Record(time.Second, 20)
@@ -260,7 +255,6 @@ func TestRootRuntimeStats(t *testing.T) {
 }
 
 func TestFormatDurationForExplain(t *testing.T) {
-	t.Parallel()
 	cases := []struct {
 		t string
 		s string

--- a/util/expensivequery/expensivequerey_test.go
+++ b/util/expensivequery/expensivequerey_test.go
@@ -32,8 +32,6 @@ func TestMain(m *testing.M) {
 }
 
 func TestLogFormat(t *testing.T) {
-	t.Parallel()
-
 	mem := new(memory.Tracker)
 	mem.Consume(1<<30 + 1<<29 + 1<<28 + 1<<27)
 	info := &util.ProcessInfo{

--- a/util/fastrand/random_test.go
+++ b/util/fastrand/random_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestRand(t *testing.T) {
-	t.Parallel()
-
 	x := Uint32N(1024)
 	require.Less(t, x, uint32(1024))
 	y := Uint64N(1 << 63)

--- a/util/format/format_test.go
+++ b/util/format/format_test.go
@@ -31,8 +31,6 @@ func checkFormat(t *testing.T, f Formatter, buf *bytes.Buffer, str, expect strin
 }
 
 func TestFormat(t *testing.T) {
-	t.Parallel()
-
 	str := "abc%d%%e%i\nx\ny\n%uz\n"
 	buf := &bytes.Buffer{}
 	f := IndentFormatter(buf, "\t")

--- a/util/generatedexpr/gen_expr_test.go
+++ b/util/generatedexpr/gen_expr_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestParseExpression(t *testing.T) {
-	t.Parallel()
-
 	node, err := ParseExpression("json_extract(a, '$.a')")
 	require.NoError(t, err)
 	require.Equal(t, "json_extract", node.(*ast.FuncCallExpr).FnName.L)

--- a/util/kvcache/simple_lru_test.go
+++ b/util/kvcache/simple_lru_test.go
@@ -46,8 +46,6 @@ func newMockHashKey(key int64) *mockCacheKey {
 }
 
 func TestPut(t *testing.T) {
-	t.Parallel()
-
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -121,7 +119,6 @@ func TestPut(t *testing.T) {
 }
 
 func TestZeroQuota(t *testing.T) {
-	t.Parallel()
 	lru := NewSimpleLRUCache(100, 0, 0)
 	require.Equal(t, uint(100), lru.capacity)
 
@@ -138,7 +135,6 @@ func TestZeroQuota(t *testing.T) {
 }
 
 func TestOOMGuard(t *testing.T) {
-	t.Parallel()
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -164,7 +160,6 @@ func TestOOMGuard(t *testing.T) {
 }
 
 func TestGet(t *testing.T) {
-	t.Parallel()
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -208,7 +203,6 @@ func TestGet(t *testing.T) {
 }
 
 func TestDelete(t *testing.T) {
-	t.Parallel()
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -238,7 +232,6 @@ func TestDelete(t *testing.T) {
 }
 
 func TestDeleteAll(t *testing.T) {
-	t.Parallel()
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -265,7 +258,6 @@ func TestDeleteAll(t *testing.T) {
 }
 
 func TestValues(t *testing.T) {
-	t.Parallel()
 	maxMem, err := memory.MemTotal()
 	require.NoError(t, err)
 
@@ -288,7 +280,6 @@ func TestValues(t *testing.T) {
 }
 
 func TestPutProfileName(t *testing.T) {
-	t.Parallel()
 	lru := NewSimpleLRUCache(3, 0, 10)
 	require.Equal(t, uint(3), lru.capacity)
 	tem := reflect.TypeOf(*lru)

--- a/util/math/math_test.go
+++ b/util/math/math_test.go
@@ -24,7 +24,6 @@ import (
 
 func TestStrLenOfUint64Fast(t *testing.T) {
 	t.Run("RandomInput", func(t *testing.T) {
-		t.Parallel()
 		for i := 0; i < 1000000; i++ {
 			num := rand.Uint64()
 			expected := len(strconv.FormatUint(num, 10))
@@ -34,7 +33,6 @@ func TestStrLenOfUint64Fast(t *testing.T) {
 	})
 
 	t.Run("ManualInput", func(t *testing.T) {
-		t.Parallel()
 		nums := [22]uint64{0,
 			1, 12, 123, 1234, 12345,
 			123456, 1234567, 12345678, 123456789, 1234567890,

--- a/util/math/rand_test.go
+++ b/util/math/rand_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestRandWithTime(t *testing.T) {
-	t.Parallel()
-
 	rng1 := NewWithTime()
 	// NOTE: On windows platform, this Sleep is necessary. Because time.Now() is
 	// imprecise, calling UnixNano() twice returns the same value. We have to make
@@ -42,8 +40,6 @@ func TestRandWithTime(t *testing.T) {
 }
 
 func TestRandWithSeed(t *testing.T) {
-	t.Parallel()
-
 	tests := [4]struct {
 		seed  int64
 		once  float64
@@ -62,8 +58,6 @@ func TestRandWithSeed(t *testing.T) {
 }
 
 func TestRandWithSeed1AndSeed2(t *testing.T) {
-	t.Parallel()
-
 	seed1 := uint32(10000000)
 	seed2 := uint32(1000000)
 

--- a/util/memory/tracker_test.go
+++ b/util/memory/tracker_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestSetLabel(t *testing.T) {
-	t.Parallel()
-
 	tracker := NewTracker(1, -1)
 	require.Equal(t, 1, tracker.label)
 	require.Equal(t, int64(0), tracker.BytesConsumed())
@@ -73,8 +71,6 @@ func TestConsume(t *testing.T) {
 }
 
 func TestOOMAction(t *testing.T) {
-	t.Parallel()
-
 	tracker := NewTracker(1, 100)
 	// make sure no panic here.
 	tracker.Consume(10000)
@@ -144,8 +140,6 @@ func (a *mockAction) GetPriority() int64 {
 }
 
 func TestAttachTo(t *testing.T) {
-	t.Parallel()
-
 	oldParent := NewTracker(1, -1)
 	newParent := NewTracker(2, -1)
 	child := NewTracker(3, -1)
@@ -168,8 +162,6 @@ func TestAttachTo(t *testing.T) {
 }
 
 func TestDetach(t *testing.T) {
-	t.Parallel()
-
 	parent := NewTracker(1, -1)
 	child := NewTracker(2, -1)
 	child.Consume(100)
@@ -187,8 +179,6 @@ func TestDetach(t *testing.T) {
 }
 
 func TestReplaceChild(t *testing.T) {
-	t.Parallel()
-
 	oldChild := NewTracker(1, -1)
 	oldChild.Consume(100)
 	newChild := NewTracker(2, -1)
@@ -231,8 +221,6 @@ func TestReplaceChild(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	t.Parallel()
-
 	parent := NewTracker(1, -1)
 	child1 := NewTracker(2, 1000)
 	child2 := NewTracker(3, -1)
@@ -270,8 +258,6 @@ func TestToString(t *testing.T) {
 }
 
 func TestMaxConsumed(t *testing.T) {
-	t.Parallel()
-
 	r := NewTracker(1, -1)
 	c1 := NewTracker(2, -1)
 	c2 := NewTracker(3, -1)
@@ -299,8 +285,6 @@ func TestMaxConsumed(t *testing.T) {
 }
 
 func TestGlobalTracker(t *testing.T) {
-	t.Parallel()
-
 	r := NewGlobalTracker(1, -1)
 	c1 := NewTracker(2, -1)
 	c2 := NewTracker(3, -1)
@@ -388,8 +372,6 @@ func parseByte(str string) (int64, error) {
 }
 
 func TestFormatBytesWithPrune(t *testing.T) {
-	t.Parallel()
-
 	cases := []struct {
 		b string
 		s string
@@ -435,14 +417,10 @@ func TestFormatBytesWithPrune(t *testing.T) {
 }
 
 func TestErrorCode(t *testing.T) {
-	t.Parallel()
-
 	require.Equal(t, errno.ErrMemExceedThreshold, int(terror.ToSQLError(errMemExceedThreshold).Code))
 }
 
 func TestOOMActionPriority(t *testing.T) {
-	t.Parallel()
-
 	tracker := NewTracker(1, 100)
 	// make sure no panic here.
 	tracker.Consume(10000)

--- a/util/misc_test.go
+++ b/util/misc_test.go
@@ -34,7 +34,6 @@ import (
 
 func TestRunWithRetry(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
-		t.Parallel()
 		cnt := 0
 		err := RunWithRetry(3, 1, func() (bool, error) {
 			cnt++
@@ -48,7 +47,6 @@ func TestRunWithRetry(t *testing.T) {
 	})
 
 	t.Run("retry exceeds", func(t *testing.T) {
-		t.Parallel()
 		cnt := 0
 		err := RunWithRetry(3, 1, func() (bool, error) {
 			cnt++
@@ -62,7 +60,6 @@ func TestRunWithRetry(t *testing.T) {
 	})
 
 	t.Run("failed result", func(t *testing.T) {
-		t.Parallel()
 		cnt := 0
 		err := RunWithRetry(3, 1, func() (bool, error) {
 			cnt++
@@ -77,8 +74,6 @@ func TestRunWithRetry(t *testing.T) {
 }
 
 func TestX509NameParseMatch(t *testing.T) {
-	t.Parallel()
-
 	assert.Equal(t, "", X509NameOnline(pkix.Name{}))
 
 	check := pkix.Name{
@@ -97,13 +92,11 @@ func TestX509NameParseMatch(t *testing.T) {
 }
 
 func TestBasicFuncGetStack(t *testing.T) {
-	t.Parallel()
 	b := GetStack()
 	assert.Less(t, len(b), 4096)
 }
 
 func TestBasicFuncWithRecovery(t *testing.T) {
-	t.Parallel()
 	var recovery interface{}
 	WithRecovery(func() {
 		panic("test")
@@ -114,20 +107,17 @@ func TestBasicFuncWithRecovery(t *testing.T) {
 }
 
 func TestBasicFuncSyntaxError(t *testing.T) {
-	t.Parallel()
 	assert.Nil(t, SyntaxError(nil))
 	assert.True(t, terror.ErrorEqual(SyntaxError(errors.New("test")), parser.ErrParse))
 	assert.True(t, terror.ErrorEqual(SyntaxError(parser.ErrSyntax.GenWithStackByArgs()), parser.ErrSyntax))
 }
 
 func TestBasicFuncSyntaxWarn(t *testing.T) {
-	t.Parallel()
 	assert.Nil(t, SyntaxWarn(nil))
 	assert.True(t, terror.ErrorEqual(SyntaxWarn(errors.New("test")), parser.ErrParse))
 }
 
 func TestBasicFuncProcessInfo(t *testing.T) {
-	t.Parallel()
 	pi := ProcessInfo{
 		ID:      1,
 		User:    "test",
@@ -161,7 +151,6 @@ func TestBasicFuncProcessInfo(t *testing.T) {
 }
 
 func TestBasicFuncRandomBuf(t *testing.T) {
-	t.Parallel()
 	buf := fastrand.Buf(5)
 	assert.Len(t, buf, 5)
 	assert.False(t, bytes.Contains(buf, []byte("$")))
@@ -169,7 +158,6 @@ func TestBasicFuncRandomBuf(t *testing.T) {
 }
 
 func TestToPB(t *testing.T) {
-	t.Parallel()
 	column := &model.ColumnInfo{
 		ID:           1,
 		Name:         model.NewCIStr("c"),
@@ -195,7 +183,6 @@ func TestToPB(t *testing.T) {
 }
 
 func TestComposeURL(t *testing.T) {
-	t.Parallel()
 	// TODO Setup config for TLS and verify https protocol output
 	assert.Equal(t, ComposeURL("server.example.com", ""), "http://server.example.com")
 	assert.Equal(t, ComposeURL("httpserver.example.com", ""), "http://httpserver.example.com")

--- a/util/mock/mock_test.go
+++ b/util/mock/mock_test.go
@@ -29,8 +29,6 @@ func (k contextKeyType) String() string {
 const contextKey contextKeyType = 0
 
 func TestContext(t *testing.T) {
-	t.Parallel()
-
 	ctx := NewContext()
 
 	ctx.SetValue(contextKey, 1)

--- a/util/mvmap/mvmap_test.go
+++ b/util/mvmap/mvmap_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestMVMap(t *testing.T) {
-	t.Parallel()
-
 	m := NewMVMap()
 	m.Put([]byte("abc"), []byte("abc1"))
 	m.Put([]byte("abc"), []byte("abc2"))
@@ -52,8 +50,6 @@ func TestMVMap(t *testing.T) {
 }
 
 func TestFNVHash(t *testing.T) {
-	t.Parallel()
-
 	b := []byte{0xcb, 0xf2, 0x9c, 0xe4, 0x84, 0x22, 0x23, 0x25}
 	sum1 := fnvHash64(b)
 	hash := fnv.New64()

--- a/util/parser/ast_test.go
+++ b/util/parser/ast_test.go
@@ -24,8 +24,6 @@ import (
 )
 
 func TestSimpleCases(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		sql string
 		db  string

--- a/util/parser/parser_test.go
+++ b/util/parser/parser_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 func TestSpace(t *testing.T) {
-	t.Parallel()
-
 	okTable := []struct {
 		Times    int
 		Input    string
@@ -57,8 +55,6 @@ func TestSpace(t *testing.T) {
 }
 
 func TestDigit(t *testing.T) {
-	t.Parallel()
-
 	okTable := []struct {
 		Times          int
 		Input          string
@@ -98,8 +94,6 @@ func TestDigit(t *testing.T) {
 }
 
 func TestNumber(t *testing.T) {
-	t.Parallel()
-
 	okTable := []struct {
 		Input        string
 		ExpectedNum  int
@@ -136,8 +130,6 @@ func TestNumber(t *testing.T) {
 }
 
 func TestCharAndAnyChar(t *testing.T) {
-	t.Parallel()
-
 	okTable := []struct {
 		Char     byte
 		Input    string

--- a/util/plancodec/codec_test.go
+++ b/util/plancodec/codec_test.go
@@ -29,7 +29,6 @@ type encodeTaskTypeCase struct {
 }
 
 func TestEncodeTaskType(t *testing.T) {
-	t.Parallel()
 	cases := []encodeTaskTypeCase{
 		{true, kv.UnSpecified, "0", "root"},
 		{false, kv.TiKV, "1_0", "cop[tikv]"},
@@ -52,8 +51,6 @@ func TestEncodeTaskType(t *testing.T) {
 }
 
 func TestDecodeDiscardPlan(t *testing.T) {
-	t.Parallel()
-
 	plan, err := DecodePlan(PlanDiscardedEncoded)
 	require.NoError(t, err)
 	require.Equal(t, planDiscardedDecoded, plan)

--- a/util/plancodec/id_test.go
+++ b/util/plancodec/id_test.go
@@ -22,7 +22,6 @@ import (
 
 func TestPlanIDChanged(t *testing.T) {
 	// Attention: for compatibility, shouldn't modify the below test, you can only add test when add new plan ID.
-	t.Parallel()
 	testCases := []struct {
 		Value    int
 		Expected int

--- a/util/prefix_helper_test.go
+++ b/util/prefix_helper_test.go
@@ -34,7 +34,6 @@ const (
 )
 
 func TestPrefix(t *testing.T) {
-	t.Parallel()
 	s, err := mockstore.NewMockStore()
 	require.Nil(t, err)
 	defer func() {
@@ -75,7 +74,6 @@ func TestPrefix(t *testing.T) {
 }
 
 func TestPrefixFilter(t *testing.T) {
-	t.Parallel()
 	rowKey := []byte(`test@#$%l(le[0]..prefix) 2uio`)
 	rowKey[8] = 0x00
 	rowKey[9] = 0x00

--- a/util/printer/printer_test.go
+++ b/util/printer/printer_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestPrintResult(t *testing.T) {
-	t.Parallel()
 	cols := []string{"col1", "col2", "col3"}
 	datas := [][]string{{"11"}, {"21", "22", "23"}}
 	result, ok := GetPrintResult(cols, datas)

--- a/util/processinfo_test.go
+++ b/util/processinfo_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 func TestGlobalConnID(t *testing.T) {
-	t.Parallel()
 	originCfg := config.GetGlobalConfig()
 	newCfg := *originCfg
 	newCfg.Experimental.EnableGlobalKill = true

--- a/util/profile/flamegraph_test.go
+++ b/util/profile/flamegraph_test.go
@@ -26,8 +26,6 @@ import (
 )
 
 func TestProfileToDatum(t *testing.T) {
-	t.Parallel()
-
 	file, err := os.Open("testdata/test.pprof")
 	require.Nil(t, err)
 	defer func() {

--- a/util/profile/profile_test.go
+++ b/util/profile/profile_test.go
@@ -28,7 +28,6 @@ import (
 )
 
 func TestProfiles(t *testing.T) {
-	t.Parallel()
 	var err error
 	var store kv.Storage
 	var dom *domain.Domain

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -48,7 +48,6 @@ func newDomainStoreWithBootstrap(t *testing.T) (*domain.Domain, kv.Storage, erro
 }
 
 func TestTableRange(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -307,7 +306,6 @@ func TestTableRange(t *testing.T) {
 
 // for issue #6661
 func TestIndexRangeForUnsignedAndOverflow(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -864,7 +862,6 @@ func TestColumnRange(t *testing.T) {
 }
 
 func TestIndexRangeEliminatedProjection(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -921,7 +918,6 @@ func TestCompIndexInExprCorrCol(t *testing.T) {
 }
 
 func TestIndexStringIsTrueRange(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -952,7 +948,6 @@ func TestIndexStringIsTrueRange(t *testing.T) {
 }
 
 func TestCompIndexDNFMatch(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -985,7 +980,6 @@ func TestCompIndexDNFMatch(t *testing.T) {
 }
 
 func TestCompIndexMultiColDNF1(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1019,7 +1013,6 @@ func TestCompIndexMultiColDNF1(t *testing.T) {
 }
 
 func TestCompIndexMultiColDNF2(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1053,7 +1046,6 @@ func TestCompIndexMultiColDNF2(t *testing.T) {
 }
 
 func TestPrefixIndexMultiColDNF(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1089,7 +1081,6 @@ func TestPrefixIndexMultiColDNF(t *testing.T) {
 }
 
 func TestIndexRangeForBit(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1128,7 +1119,6 @@ func TestIndexRangeForBit(t *testing.T) {
 }
 
 func TestIndexRangeForYear(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1291,7 +1281,6 @@ func TestIndexRangeForYear(t *testing.T) {
 
 // For https://github.com/pingcap/tidb/issues/22032
 func TestPrefixIndexRangeScan(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1363,7 +1352,6 @@ func TestPrefixIndexRangeScan(t *testing.T) {
 }
 
 func TestIndexRangeForDecimal(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()
@@ -1397,7 +1385,6 @@ func TestIndexRangeForDecimal(t *testing.T) {
 }
 
 func TestPrefixIndexAppendPointRanges(t *testing.T) {
-	t.Parallel()
 	dom, store, err := newDomainStoreWithBootstrap(t)
 	defer func() {
 		dom.Close()

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func TestRange(t *testing.T) {
-	t.Parallel()
 	simpleTests := []struct {
 		ran ranger.Range
 		str string
@@ -130,7 +129,6 @@ func TestRange(t *testing.T) {
 }
 
 func TestIsFullRange(t *testing.T) {
-	t.Parallel()
 	nullDatum := types.MinNotNullDatum()
 	nullDatum.SetNull()
 	isFullRangeTests := []struct {

--- a/util/resourcegrouptag/resource_group_tag_test.go
+++ b/util/resourcegrouptag/resource_group_tag_test.go
@@ -29,8 +29,6 @@ import (
 )
 
 func TestResourceGroupTagEncoding(t *testing.T) {
-	t.Parallel()
-
 	sqlDigest := parser.NewDigest(nil)
 	tag := EncodeResourceGroupTag(sqlDigest, nil, tipb.ResourceGroupTagLabel_ResourceGroupTagLabelUnknown)
 	require.Len(t, tag, 2)
@@ -62,8 +60,6 @@ func TestResourceGroupTagEncoding(t *testing.T) {
 }
 
 func TestResourceGroupTagEncodingPB(t *testing.T) {
-	t.Parallel()
-
 	digest1 := genDigest("abc")
 	digest2 := genDigest("abcdefg")
 	// Test for protobuf

--- a/util/rowDecoder/decoder_test.go
+++ b/util/rowDecoder/decoder_test.go
@@ -36,7 +36,6 @@ import (
 )
 
 func TestRowDecoder(t *testing.T) {
-	t.Parallel()
 	c1 := &model.ColumnInfo{ID: 1, Name: model.NewCIStr("c1"), State: model.StatePublic, Offset: 0, FieldType: *types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &model.ColumnInfo{ID: 2, Name: model.NewCIStr("c2"), State: model.StatePublic, Offset: 1, FieldType: *types.NewFieldType(mysql.TypeVarchar)}
 	c3 := &model.ColumnInfo{ID: 3, Name: model.NewCIStr("c3"), State: model.StatePublic, Offset: 2, FieldType: *types.NewFieldType(mysql.TypeNewDecimal)}
@@ -152,7 +151,6 @@ func TestRowDecoder(t *testing.T) {
 }
 
 func TestClusterIndexRowDecoder(t *testing.T) {
-	t.Parallel()
 	c1 := &model.ColumnInfo{ID: 1, Name: model.NewCIStr("c1"), State: model.StatePublic, Offset: 0, FieldType: *types.NewFieldType(mysql.TypeLonglong)}
 	c2 := &model.ColumnInfo{ID: 2, Name: model.NewCIStr("c2"), State: model.StatePublic, Offset: 1, FieldType: *types.NewFieldType(mysql.TypeVarchar)}
 	c3 := &model.ColumnInfo{ID: 3, Name: model.NewCIStr("c3"), State: model.StatePublic, Offset: 2, FieldType: *types.NewFieldType(mysql.TypeNewDecimal)}

--- a/util/rowcodec/rowcodec_test.go
+++ b/util/rowcodec/rowcodec_test.go
@@ -43,8 +43,6 @@ type testData struct {
 }
 
 func TestEncodeLargeSmallReuseBug(t *testing.T) {
-	t.Parallel()
-
 	// reuse one rowcodec.Encoder.
 	var encoder rowcodec.Encoder
 	colFt := types.NewFieldType(mysql.TypeString)
@@ -83,8 +81,6 @@ func TestEncodeLargeSmallReuseBug(t *testing.T) {
 }
 
 func TestDecodeRowWithHandle(t *testing.T) {
-	t.Parallel()
-
 	handleID := int64(-1)
 	handleValue := int64(10000)
 
@@ -223,8 +219,6 @@ func TestDecodeRowWithHandle(t *testing.T) {
 }
 
 func TestEncodeKindNullDatum(t *testing.T) {
-	t.Parallel()
-
 	var encoder rowcodec.Encoder
 	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = time.UTC
@@ -251,8 +245,6 @@ func TestEncodeKindNullDatum(t *testing.T) {
 }
 
 func TestDecodeDecimalFspNotMatch(t *testing.T) {
-	t.Parallel()
-
 	var encoder rowcodec.Encoder
 	sc := new(stmtctx.StatementContext)
 	sc.TimeZone = time.UTC
@@ -287,8 +279,6 @@ func TestDecodeDecimalFspNotMatch(t *testing.T) {
 }
 
 func TestTypesNewRowCodec(t *testing.T) {
-	t.Parallel()
-
 	getJSONDatum := func(value string) types.Datum {
 		j, err := json.ParseBinaryFromString(value)
 		require.NoError(t, err)
@@ -563,8 +553,6 @@ func TestTypesNewRowCodec(t *testing.T) {
 }
 
 func TestNilAndDefault(t *testing.T) {
-	t.Parallel()
-
 	td := []testData{
 		{
 			1,
@@ -696,8 +684,6 @@ func TestNilAndDefault(t *testing.T) {
 }
 
 func TestVarintCompatibility(t *testing.T) {
-	t.Parallel()
-
 	td := []testData{
 		{
 			1,
@@ -755,8 +741,6 @@ func TestVarintCompatibility(t *testing.T) {
 }
 
 func TestCodecUtil(t *testing.T) {
-	t.Parallel()
-
 	colIDs := []int64{1, 2, 3, 4}
 	tps := make([]*types.FieldType, 4)
 	for i := 0; i < 3; i++ {
@@ -807,8 +791,6 @@ func TestCodecUtil(t *testing.T) {
 }
 
 func TestOldRowCodec(t *testing.T) {
-	t.Parallel()
-
 	colIDs := []int64{1, 2, 3, 4}
 	tps := make([]*types.FieldType, 4)
 	for i := 0; i < 3; i++ {
@@ -844,8 +826,6 @@ func TestOldRowCodec(t *testing.T) {
 }
 
 func Test65535Bug(t *testing.T) {
-	t.Parallel()
-
 	colIds := []int64{1}
 	tps := make([]*types.FieldType, 1)
 	tps[0] = types.NewFieldType(mysql.TypeString)

--- a/util/selection/selection_test.go
+++ b/util/selection/selection_test.go
@@ -50,14 +50,12 @@ func init() {
 }
 
 func TestSelection(t *testing.T) {
-	t.Parallel()
 	data := testSlice{1, 2, 3, 4, 5}
 	index := Select(data, 3)
 	require.Equal(t, 3, data[index])
 }
 
 func TestSelectionWithDuplicate(t *testing.T) {
-	t.Parallel()
 	data := testSlice{1, 2, 3, 3, 5}
 	index := Select(data, 3)
 	require.Equal(t, 3, data[index])
@@ -66,7 +64,6 @@ func TestSelectionWithDuplicate(t *testing.T) {
 }
 
 func TestSelectionWithRandomCase(t *testing.T) {
-	t.Parallel()
 	data := randomTestCase(1000000)
 	index := Select(data, 500000)
 	actual := data[index]
@@ -76,7 +73,6 @@ func TestSelectionWithRandomCase(t *testing.T) {
 }
 
 func TestSelectionWithSerialCase(t *testing.T) {
-	t.Parallel()
 	data := serialTestCase(1000000)
 	sort.Sort(sort.Reverse(data))
 	index := Select(data, 500000)

--- a/util/sem/sem_test.go
+++ b/util/sem/sem_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestInvisibleSchema(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	assert.True(IsInvisibleSchema(metricsSchema))
@@ -35,7 +34,6 @@ func TestInvisibleSchema(t *testing.T) {
 }
 
 func TestIsInvisibleTable(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	mysqlTbls := []string{exprPushdownBlacklist, gcDeleteRange, gcDeleteRangeDone, optRuleBlacklist, tidb, globalVariables}
@@ -61,7 +59,6 @@ func TestIsInvisibleTable(t *testing.T) {
 }
 
 func TestIsRestrictedPrivilege(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	assert.True(IsRestrictedPrivilege("RESTRICTED_TABLES_ADMIN"))
@@ -72,7 +69,6 @@ func TestIsRestrictedPrivilege(t *testing.T) {
 }
 
 func TestIsInvisibleStatusVar(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	assert.True(IsInvisibleStatusVar(tidbGCLeaderDesc))
@@ -82,7 +78,6 @@ func TestIsInvisibleStatusVar(t *testing.T) {
 }
 
 func TestIsInvisibleSysVar(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	assert.False(IsInvisibleSysVar(variable.Hostname))                   // changes the value to default, but is not invisible

--- a/util/set/float64_set_test.go
+++ b/util/set/float64_set_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestFloat64Set(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	set := NewFloat64Set()

--- a/util/set/int_set_test.go
+++ b/util/set/int_set_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestIntSet(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	set := NewIntSet()
@@ -44,7 +43,6 @@ func TestIntSet(t *testing.T) {
 }
 
 func TestInt64Set(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	set := NewInt64Set()

--- a/util/set/string_set_test.go
+++ b/util/set/string_set_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestStringSet(t *testing.T) {
-	t.Parallel()
 	assert := assert.New(t)
 
 	set := NewStringSet()

--- a/util/slice/slice_test.go
+++ b/util/slice/slice_test.go
@@ -36,7 +36,6 @@ func TestSlice(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprint(test.a), func(t *testing.T) {
-			t.Parallel()
 			even := func(i int) bool { return test.a[i]%2 == 0 }
 			require.Equal(t, test.anyOf, AnyOf(test.a, even))
 			require.Equal(t, test.noneOf, NoneOf(test.a, even))

--- a/util/sqlexec/utils_test.go
+++ b/util/sqlexec/utils_test.go
@@ -24,7 +24,6 @@ import (
 )
 
 func TestReserveBuffer(t *testing.T) {
-	t.Parallel()
 	res0 := reserveBuffer(nil, 0)
 	require.Len(t, res0, 0)
 
@@ -100,7 +99,6 @@ func TestEscapeBackslash(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		v := v
 		t.Run(v.name, func(t *testing.T) {
-			t.Parallel()
 			require.Equal(t, v.output, escapeBytesBackslash(nil, v.input))
 			require.Equal(t, v.output, escapeStringBackslash(nil, string(v.input)))
 		})
@@ -392,7 +390,6 @@ func TestEscapeSQL(t *testing.T) {
 		// copy iterator variable into a new variable, see issue #27779
 		v := v
 		t.Run(v.name, func(t *testing.T) {
-			t.Parallel()
 			r3 := new(strings.Builder)
 			r1, e1 := escapeSQL(v.input, v.params...)
 			r2, e2 := EscapeSQL(v.input, v.params...)
@@ -418,7 +415,6 @@ func TestEscapeSQL(t *testing.T) {
 }
 
 func TestMustUtils(t *testing.T) {
-	t.Parallel()
 	require.PanicsWithError(t, "missing arguments, need 1-th arg, but only got 0 args", func() {
 		MustEscapeSQL("%?")
 	})

--- a/util/stmtsummary/evicted_test.go
+++ b/util/stmtsummary/evicted_test.go
@@ -58,7 +58,6 @@ func generateStmtSummaryByDigestKeyValue(schema string, beginTime int64, endTime
 
 // Test stmtSummaryByDigestMap.ToEvictedCountDatum
 func TestMapToEvictedCountDatum(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	ssMap.Clear()
 	now := time.Now().Unix()
@@ -143,7 +142,6 @@ func TestMapToEvictedCountDatum(t *testing.T) {
 
 // Test stmtSummaryByDigestEvicted
 func TestSimpleStmtSummaryByDigestEvicted(t *testing.T) {
-	t.Parallel()
 	ssbde := newStmtSummaryByDigestEvicted()
 	evictedKey, evictedValue := generateStmtSummaryByDigestKeyValue("a", 1, 2)
 
@@ -221,7 +219,6 @@ func TestSimpleStmtSummaryByDigestEvicted(t *testing.T) {
 
 // Test stmtSummaryByDigestEvictedElement.ToEvictedCountDatum
 func TestStmtSummaryByDigestEvictedElement(t *testing.T) {
-	t.Parallel()
 	record := newStmtSummaryByDigestEvictedElement(0, 1)
 	evictedKey, evictedValue := generateStmtSummaryByDigestKeyValue("alpha", 0, 1)
 	digestValue := evictedValue.history.Back().Value.(*stmtSummaryByDigestElement)
@@ -250,7 +247,6 @@ func TestStmtSummaryByDigestEvictedElement(t *testing.T) {
 // test stmtSummaryByDigestEvicted.addEvicted
 // test stmtSummaryByDigestEvicted.toEvictedCountDatum (single and multiple intervals)
 func TestEvictedCountDetailed(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	ssMap.Clear()
 	err := ssMap.SetRefreshInterval("60", false)
@@ -314,7 +310,6 @@ func TestEvictedCountDetailed(t *testing.T) {
 }
 
 func TestNewStmtSummaryByDigestEvictedElement(t *testing.T) {
-	t.Parallel()
 	now := time.Now().Unix()
 	end := now + 60
 	stmtEvictedElement := newStmtSummaryByDigestEvictedElement(now, end)
@@ -324,14 +319,12 @@ func TestNewStmtSummaryByDigestEvictedElement(t *testing.T) {
 }
 
 func TestStmtSummaryByDigestEvicted(t *testing.T) {
-	t.Parallel()
 	stmtEvicted := newStmtSummaryByDigestEvicted()
 	require.Equal(t, 0, stmtEvicted.history.Len())
 }
 
 // test addInfo function
 func TestAddInfo(t *testing.T) {
-	t.Parallel()
 	now := time.Now().Unix()
 	addTo := stmtSummaryByDigestElement{
 		// user

--- a/util/stmtsummary/statement_summary_test.go
+++ b/util/stmtsummary/statement_summary_test.go
@@ -44,7 +44,6 @@ func fakePlanDigestGenerator() string {
 }
 
 func TestSetUp(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	err := ssMap.SetEnabled("1", false)
 	require.NoError(t, err)
@@ -60,7 +59,6 @@ const (
 
 // Test stmtSummaryByDigest.AddStatement.
 func TestAddStatement(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	ssMap.beginTimeForCurInterval = now + 60
@@ -751,7 +749,6 @@ func newStmtSummaryReaderForTest(ssMap *stmtSummaryByDigestMap) *stmtSummaryRead
 
 // Test stmtSummaryByDigest.ToDatum.
 func TestToDatum(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -849,7 +846,6 @@ func TestToDatum(t *testing.T) {
 
 // Test AddStatement and ToDatum parallel.
 func TestAddStatementParallel(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -887,7 +883,6 @@ func TestAddStatementParallel(t *testing.T) {
 
 // Test max number of statement count.
 func TestMaxStmtCount(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -947,7 +942,6 @@ func TestMaxStmtCount(t *testing.T) {
 
 // Test max length of normalized and sample SQL.
 func TestMaxSQLLength(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -991,7 +985,6 @@ func TestMaxSQLLength(t *testing.T) {
 
 // Test AddStatement and SetMaxStmtCount parallel.
 func TestSetMaxStmtCountParallel(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -1039,7 +1032,6 @@ func TestSetMaxStmtCountParallel(t *testing.T) {
 
 // Test setting EnableStmtSummary to 0.
 func TestDisableStmtSummary(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 
@@ -1098,7 +1090,6 @@ func TestDisableStmtSummary(t *testing.T) {
 
 // Test disable and enable statement summary concurrently with adding statements.
 func TestEnableSummaryParallel(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 
 	threads := 8
@@ -1136,7 +1127,6 @@ func TestEnableSummaryParallel(t *testing.T) {
 
 // Test GetMoreThanCntBindableStmt.
 func TestGetMoreThanCntBindableStmt(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 
 	stmtExecInfo1 := generateAnyExecInfo()
@@ -1161,7 +1151,6 @@ func TestGetMoreThanCntBindableStmt(t *testing.T) {
 
 // Test `formatBackoffTypes`.
 func TestFormatBackoffTypes(t *testing.T) {
-	t.Parallel()
 	backoffMap := make(map[string]int)
 	require.Nil(t, formatBackoffTypes(backoffMap))
 	bo1 := "pdrpc"
@@ -1175,7 +1164,6 @@ func TestFormatBackoffTypes(t *testing.T) {
 
 // Test refreshing current statement summary periodically.
 func TestRefreshCurrentSummary(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 
@@ -1215,7 +1203,6 @@ func TestRefreshCurrentSummary(t *testing.T) {
 
 // Test expiring statement summary to history.
 func TestSummaryHistory(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	err := ssMap.SetRefreshInterval("10", false)
@@ -1295,7 +1282,6 @@ func TestSummaryHistory(t *testing.T) {
 
 // Test summary when PrevSQL is not empty.
 func TestPrevSQL(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	// to disable expiration
@@ -1331,7 +1317,6 @@ func TestPrevSQL(t *testing.T) {
 }
 
 func TestEndTime(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	ssMap.beginTimeForCurInterval = now - 100
@@ -1379,7 +1364,6 @@ func TestEndTime(t *testing.T) {
 }
 
 func TestPointGet(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 	now := time.Now().Unix()
 	ssMap.beginTimeForCurInterval = now - 100
@@ -1405,7 +1389,6 @@ func TestPointGet(t *testing.T) {
 }
 
 func TestAccessPrivilege(t *testing.T) {
-	t.Parallel()
 	ssMap := newStmtSummaryByDigestMap()
 
 	loops := 32

--- a/util/stmtsummary/variables_test.go
+++ b/util/stmtsummary/variables_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestSetInVariable(t *testing.T) {
-	t.Parallel()
 	sv := newSysVars()
 	st := sv.getVariable(typeMaxStmtCount)
 	require.Equal(t, int64(config.GetGlobalConfig().StmtSummary.MaxStmtCount), st)
@@ -58,7 +57,6 @@ func TestSetInVariable(t *testing.T) {
 }
 
 func TestSetBoolVariable(t *testing.T) {
-	t.Parallel()
 	sv := newSysVars()
 	en := sv.getVariable(typeEnable)
 	require.Equal(t, config.GetGlobalConfig().StmtSummary.Enable, en > 0)
@@ -98,7 +96,6 @@ func TestSetBoolVariable(t *testing.T) {
 }
 
 func TestMinValue(t *testing.T) {
-	t.Parallel()
 	sv := newSysVars()
 	err := sv.setVariable(typeMaxStmtCount, "0", false)
 	require.NoError(t, err)

--- a/util/stringutil/string_util_test.go
+++ b/util/stringutil/string_util_test.go
@@ -21,7 +21,6 @@ import (
 )
 
 func TestUnquote(t *testing.T) {
-	t.Parallel()
 	table := []struct {
 		str    string
 		expect string
@@ -67,7 +66,6 @@ func TestUnquote(t *testing.T) {
 }
 
 func TestPatternMatch(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		pattern string
 		input   string
@@ -111,7 +109,6 @@ func TestPatternMatch(t *testing.T) {
 }
 
 func TestCompileLike2Regexp(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		pattern string
 		regexp  string
@@ -139,7 +136,6 @@ func TestCompileLike2Regexp(t *testing.T) {
 }
 
 func TestIsExactMatch(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		pattern    string
 		escape     byte
@@ -167,7 +163,6 @@ func TestIsExactMatch(t *testing.T) {
 }
 
 func TestBuildStringFromLabels(t *testing.T) {
-	t.Parallel()
 	tbl := []struct {
 		name     string
 		labels   map[string]string

--- a/util/sys/linux/sys_test.go
+++ b/util/sys/linux/sys_test.go
@@ -21,8 +21,6 @@ import (
 )
 
 func TestGetOSVersion(t *testing.T) {
-	t.Parallel()
-
 	osRelease, err := OSVersion()
 	require.NoError(t, err)
 	require.NotEmpty(t, osRelease)

--- a/util/sys/storage/sys_test.go
+++ b/util/sys/storage/sys_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestGetTargetDirectoryCapacity(t *testing.T) {
-	t.Parallel()
 	r, err := storage.GetTargetDirectoryCapacity(".")
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, r, uint64(1), "couldn't get capacity")

--- a/util/systimemon/systime_mon_test.go
+++ b/util/systimemon/systime_mon_test.go
@@ -23,8 +23,6 @@ import (
 )
 
 func TestSystimeMonitor(t *testing.T) {
-	t.Parallel()
-
 	errTriggered := atomic.NewBool(false)
 	nowTriggered := atomic.NewBool(false)
 	go StartMonitor(

--- a/util/texttree/texttree_test.go
+++ b/util/texttree/texttree_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestPrettyIdentifier(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, "test", texttree.PrettyIdentifier("test", "", false))
 	require.Equal(t, "  ├ ─test", texttree.PrettyIdentifier("test", "  │  ", false))
 	require.Equal(t, "\t\t├\t─test", texttree.PrettyIdentifier("test", "\t\t│\t\t", false))
@@ -31,7 +30,6 @@ func TestPrettyIdentifier(t *testing.T) {
 }
 
 func TestIndent4Child(t *testing.T) {
-	t.Parallel()
 	require.Equal(t, "    │ ", texttree.Indent4Child("    ", false))
 	require.Equal(t, "    │ ", texttree.Indent4Child("    ", true))
 	require.Equal(t, "     │ ", texttree.Indent4Child("   │ ", true))

--- a/util/timeutil/time_test.go
+++ b/util/timeutil/time_test.go
@@ -28,8 +28,6 @@ import (
 )
 
 func TestGetTZNameFromFileName(t *testing.T) {
-	t.Parallel()
-
 	tz, err := inferTZNameFromFileName("/usr/share/zoneinfo/Asia/Shanghai")
 
 	require.NoError(t, err)
@@ -42,8 +40,6 @@ func TestGetTZNameFromFileName(t *testing.T) {
 }
 
 func TestLocal(t *testing.T) {
-	t.Parallel()
-
 	os.Setenv("TZ", "Asia/Shanghai")
 	systemTZ.Store(InferSystemTZ())
 	loc := SystemLocation()
@@ -65,8 +61,6 @@ func TestLocal(t *testing.T) {
 }
 
 func TestInferOneStepLinkForPath(t *testing.T) {
-	t.Parallel()
-
 	os.Remove(filepath.Join(os.TempDir(), "testlink1"))
 	os.Remove(filepath.Join(os.TempDir(), "testlink2"))
 	os.Remove(filepath.Join(os.TempDir(), "testlink3"))

--- a/util/vitess/vitess_hash_test.go
+++ b/util/vitess/vitess_hash_test.go
@@ -25,8 +25,6 @@ import (
 )
 
 func TestVitessHash(t *testing.T) {
-	t.Parallel()
-
 	hashed, err := HashUint64(30375298039)
 	require.NoError(t, err)
 	require.Equal(t, "031265661E5F1133", toHex(hashed))

--- a/util/wait_group_wrapper_test.go
+++ b/util/wait_group_wrapper_test.go
@@ -22,7 +22,6 @@ import (
 )
 
 func TestWaitGroupWrapperRun(t *testing.T) {
-	t.Parallel()
 	var expect int32 = 4
 	var val atomic.Int32
 	var wg WaitGroupWrapper
@@ -36,7 +35,6 @@ func TestWaitGroupWrapperRun(t *testing.T) {
 }
 
 func TestWaitGroupWrapperRunWithRecover(t *testing.T) {
-	t.Parallel()
 	var expect int32 = 2
 	var val atomic.Int32
 	var wg WaitGroupWrapper


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Problem Summary: 

For now, the CI is extremely unstable because some parallel tests access the global variable. Since there are too many of such tests, we try to make all the tests run in serial first, and then parallelize them later as an optimization. 

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
