### PR TITLE
planner: fix `explain format = 'brief' for connection` index out of range

### DIFF
--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -4138,6 +4138,9 @@ func (b *PlanBuilder) buildExplainFor(explainFor *ast.ExplainForStmt) (Plan, err
 	if explainFor.Format == types.ExplainFormatROW {
 		explainRows = processInfo.PlanExplainRows
 	}
+	if explainFor.Format == types.ExplainFormatBrief {
+		return b.buildExplainPlan(targetPlan, explainFor.Format, explainRows, false, nil, nil)
+	}
 	return b.buildExplainPlan(targetPlan, explainFor.Format, explainRows, false, nil, processInfo.RuntimeStatsColl)
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #30594

Problem Summary:
```sql
tidb> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|               5 |
+-----------------+
1 row in set (0,00 sec)

tidb> create table t (a int);
Query OK, 0 rows affected (0,00 sec)

tidb> select * from t;
Empty set (0,01 sec)

tidb> explain format = 'brief' for connection 5;
ERROR 1105 (HY000): runtime error: index out of range [5] with length 5
```

### What is changed and how it works?

```sql
tidb> select connection_id();
+-----------------+
| connection_id() |
+-----------------+
|               5 |
+-----------------+
1 row in set (0,00 sec)

tidb> create table t (a int);
Query OK, 0 rows affected (0,00 sec)

tidb> select * from t;
Empty set (0,01 sec)

mysql> explain format = 'brief' for connection 5;
+-----------------------+---------+-----------+---------------+--------------------------------+
| id                    | estRows | task      | access object | operator info                  |
+-----------------------+---------+-----------+---------------+--------------------------------+
| TableReader_5         | 5.00    | root      |               | data:TableFullScan_4           |
| └─TableFullScan_4     | 5.00    | cop[tikv] | table:t       | keep order:false, stats:pseudo |
+-----------------------+---------+-----------+---------------+--------------------------------+
2 rows in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix `explain format = 'brief' for connection` index out of range
```
