### PR TITLE
executor: buildWindow cannot call typeInfer twice

### DIFF
--- a/executor/aggregate_test.go
+++ b/executor/aggregate_test.go
@@ -1483,6 +1483,7 @@ func TestAvgDecimal(t *testing.T) {
 	tk.MustExec("insert into td values (0,29815);")
 	tk.MustExec("insert into td values (10017,-32661);")
 	tk.MustQuery(" SELECT AVG( col_bigint / col_smallint) AS field1 FROM td;").Sort().Check(testkit.Rows("25769363061037.62077260"))
+	tk.MustQuery(" SELECT AVG(col_bigint) OVER (PARTITION BY col_smallint) as field2 FROM td where col_smallint = -23828;").Sort().Check(testkit.Rows("4.0000"))
 	tk.MustExec("drop table td;")
 }
 

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4192,11 +4192,7 @@ func (b *executorBuilder) buildWindow(v *plannercore.PhysicalWindow) Executor {
 	partialResults := make([]aggfuncs.PartialResult, 0, len(v.WindowFuncDescs))
 	resultColIdx := v.Schema().Len() - len(v.WindowFuncDescs)
 	for _, desc := range v.WindowFuncDescs {
-		aggDesc, err := aggregation.NewAggFuncDesc(b.ctx, desc.Name, desc.Args, false)
-		if err != nil {
-			b.err = err
-			return nil
-		}
+		aggDesc:= aggregation.NewAggFuncDescForWindowFunc(desc,false)
 		agg := aggfuncs.BuildWindowFunctions(b.ctx, aggDesc, resultColIdx, orderByCols)
 		windowFuncs = append(windowFuncs, agg)
 		partialResult, _ := agg.AllocPartialResult()

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4192,7 +4192,7 @@ func (b *executorBuilder) buildWindow(v *plannercore.PhysicalWindow) Executor {
 	partialResults := make([]aggfuncs.PartialResult, 0, len(v.WindowFuncDescs))
 	resultColIdx := v.Schema().Len() - len(v.WindowFuncDescs)
 	for _, desc := range v.WindowFuncDescs {
-		aggDesc:= aggregation.NewAggFuncDescForWindowFunc(desc,false)
+		aggDesc := aggregation.NewAggFuncDescForWindowFunc(desc, false)
 		agg := aggfuncs.BuildWindowFunctions(b.ctx, aggDesc, resultColIdx, orderByCols)
 		windowFuncs = append(windowFuncs, agg)
 		partialResult, _ := agg.AllocPartialResult()

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4192,7 +4192,11 @@ func (b *executorBuilder) buildWindow(v *plannercore.PhysicalWindow) Executor {
 	partialResults := make([]aggfuncs.PartialResult, 0, len(v.WindowFuncDescs))
 	resultColIdx := v.Schema().Len() - len(v.WindowFuncDescs)
 	for _, desc := range v.WindowFuncDescs {
-		aggDesc := aggregation.NewAggFuncDescForWindowFunc(desc, false)
+		aggDesc, err := aggregation.NewAggFuncDescForWindowFunc(b.ctx, desc, false)
+		if err != nil {
+			b.err = err
+			return nil
+		}
 		agg := aggfuncs.BuildWindowFunctions(b.ctx, aggDesc, resultColIdx, orderByCols)
 		windowFuncs = append(windowFuncs, agg)
 		partialResult, _ := agg.AllocPartialResult()

--- a/executor/tiflash_test.go
+++ b/executor/tiflash_test.go
@@ -829,6 +829,7 @@ func (s *tiflashTestSuite) TestAvgOverflow(c *C) {
 	tk.MustExec("set @@session.tidb_isolation_read_engines=\"tiflash\"")
 	tk.MustExec("set @@session.tidb_enforce_mpp=ON")
 	tk.MustQuery(" SELECT AVG( col_bigint / col_smallint) AS field1 FROM td;").Sort().Check(testkit.Rows("25769363061037.62077260"))
+	tk.MustQuery(" SELECT AVG(col_bigint) OVER (PARTITION BY col_smallint) as field2 FROM td where col_smallint = -23828;").Sort().Check(testkit.Rows("4.0000"))
 	tk.MustExec("drop table if exists td;")
 }
 

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -52,7 +52,7 @@ func NewAggFuncDesc(ctx sessionctx.Context, name string, args []expression.Expre
 	return &AggFuncDesc{baseFuncDesc: b, HasDistinct: hasDistinct}, nil
 }
 
-// NewAggFuncDescForWindowFunc creates an aggregation function from window functions, where baseFuncDesc is ready.
+// NewAggFuncDescForWindowFunc creates an aggregation function from window functions, where baseFuncDesc may be ready.
 func NewAggFuncDescForWindowFunc(ctx sessionctx.Context, Desc *WindowFuncDesc, hasDistinct bool) (*AggFuncDesc, error) {
 	if Desc.RetTp == nil { // safety check
 		return NewAggFuncDesc(ctx, Desc.Name, Desc.Args, hasDistinct)

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -43,12 +43,18 @@ type AggFuncDesc struct {
 }
 
 // NewAggFuncDesc creates an aggregation function signature descriptor.
+// this func cannot be called twice as the TypeInfer will change return type.
 func NewAggFuncDesc(ctx sessionctx.Context, name string, args []expression.Expression, hasDistinct bool) (*AggFuncDesc, error) {
 	b, err := newBaseFuncDesc(ctx, name, args)
 	if err != nil {
 		return nil, err
 	}
 	return &AggFuncDesc{baseFuncDesc: b, HasDistinct: hasDistinct}, nil
+}
+
+// NewAggFuncDescForWindowFunc creates an aggregation function from window functions, where baseFuncDesc is ready.
+func NewAggFuncDescForWindowFunc(Desc *WindowFuncDesc, hasDistinct bool) *AggFuncDesc {
+	return &AggFuncDesc{baseFuncDesc: baseFuncDesc{Desc.Name, Desc.Args, Desc.RetTp}, HasDistinct: hasDistinct}
 }
 
 // String implements the fmt.Stringer interface.

--- a/expression/aggregation/descriptor.go
+++ b/expression/aggregation/descriptor.go
@@ -43,7 +43,7 @@ type AggFuncDesc struct {
 }
 
 // NewAggFuncDesc creates an aggregation function signature descriptor.
-// this func cannot be called twice as the TypeInfer will change return type.
+// this func cannot be called twice as the TypeInfer has changed the type of args in the first time.
 func NewAggFuncDesc(ctx sessionctx.Context, name string, args []expression.Expression, hasDistinct bool) (*AggFuncDesc, error) {
 	b, err := newBaseFuncDesc(ctx, name, args)
 	if err != nil {
@@ -53,8 +53,11 @@ func NewAggFuncDesc(ctx sessionctx.Context, name string, args []expression.Expre
 }
 
 // NewAggFuncDescForWindowFunc creates an aggregation function from window functions, where baseFuncDesc is ready.
-func NewAggFuncDescForWindowFunc(Desc *WindowFuncDesc, hasDistinct bool) *AggFuncDesc {
-	return &AggFuncDesc{baseFuncDesc: baseFuncDesc{Desc.Name, Desc.Args, Desc.RetTp}, HasDistinct: hasDistinct}
+func NewAggFuncDescForWindowFunc(ctx sessionctx.Context, Desc *WindowFuncDesc, hasDistinct bool) (*AggFuncDesc, error) {
+	if Desc.RetTp == nil { // safety check
+		return NewAggFuncDesc(ctx, Desc.Name, Desc.Args, hasDistinct)
+	}
+	return &AggFuncDesc{baseFuncDesc: baseFuncDesc{Desc.Name, Desc.Args, Desc.RetTp}, HasDistinct: hasDistinct}, nil
 }
 
 // String implements the fmt.Stringer interface.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/30402

Problem Summary: build window desc call TypeInfer twice, which change the return type incorrectly. For example, avg() in window func, a int type is first inferred to decimal(15,4), then inferred to decimal(19,8), which breaks compatibility with mysql.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
