### PR TITLE
types, util: clean up compareDatum

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -552,7 +552,6 @@ func (d *Datum) SetValue(val interface{}, tp *types.FieldType) {
 
 // Compare compares datum to another datum.
 // Notes: don't rely on datum.collation to get the collator, it's tend to buggy.
-// TODO: use this function to replace CompareDatum. After we remove all of usage of CompareDatum, we can rename this function back to CompareDatum.
 func (d *Datum) Compare(sc *stmtctx.StatementContext, ad *Datum, comparer collate.Collator) (int, error) {
 	if d.k == KindMysqlJSON && ad.k != KindMysqlJSON {
 		cmp, err := ad.Compare(sc, d, comparer)
@@ -583,74 +582,19 @@ func (d *Datum) Compare(sc *stmtctx.StatementContext, ad *Datum, comparer collat
 	case KindFloat32, KindFloat64:
 		return d.compareFloat64(sc, ad.GetFloat64())
 	case KindString:
-		return d.compareStringNew(sc, ad.GetString(), comparer)
+		return d.compareString(sc, ad.GetString(), comparer)
 	case KindBytes:
-		return d.compareStringNew(sc, ad.GetString(), comparer)
+		return d.compareString(sc, ad.GetString(), comparer)
 	case KindMysqlDecimal:
 		return d.compareMysqlDecimal(sc, ad.GetMysqlDecimal())
 	case KindMysqlDuration:
 		return d.compareMysqlDuration(sc, ad.GetMysqlDuration())
 	case KindMysqlEnum:
-		return d.compareMysqlEnumNew(sc, ad.GetMysqlEnum(), comparer)
+		return d.compareMysqlEnum(sc, ad.GetMysqlEnum(), comparer)
 	case KindBinaryLiteral, KindMysqlBit:
-		return d.compareBinaryLiteralNew(sc, ad.GetBinaryLiteral4Cmp(), comparer)
+		return d.compareBinaryLiteral(sc, ad.GetBinaryLiteral4Cmp(), comparer)
 	case KindMysqlSet:
-		return d.compareMysqlSetNew(sc, ad.GetMysqlSet(), comparer)
-	case KindMysqlJSON:
-		return d.compareMysqlJSON(sc, ad.GetMysqlJSON())
-	case KindMysqlTime:
-		return d.compareMysqlTime(sc, ad.GetMysqlTime())
-	default:
-		return 0, nil
-	}
-}
-
-// CompareDatum compares datum to another datum.
-// Deprecated: will be replaced with Compare.
-// TODO: return error properly.
-func (d *Datum) CompareDatum(sc *stmtctx.StatementContext, ad *Datum) (int, error) {
-	if d.k == KindMysqlJSON && ad.k != KindMysqlJSON {
-		cmp, err := ad.CompareDatum(sc, d)
-		return cmp * -1, errors.Trace(err)
-	}
-	switch ad.k {
-	case KindNull:
-		if d.k == KindNull {
-			return 0, nil
-		}
-		return 1, nil
-	case KindMinNotNull:
-		if d.k == KindNull {
-			return -1, nil
-		} else if d.k == KindMinNotNull {
-			return 0, nil
-		}
-		return 1, nil
-	case KindMaxValue:
-		if d.k == KindMaxValue {
-			return 0, nil
-		}
-		return -1, nil
-	case KindInt64:
-		return d.compareInt64(sc, ad.GetInt64())
-	case KindUint64:
-		return d.compareUint64(sc, ad.GetUint64())
-	case KindFloat32, KindFloat64:
-		return d.compareFloat64(sc, ad.GetFloat64())
-	case KindString:
-		return d.compareString(sc, ad.GetString(), d.collation)
-	case KindBytes:
-		return d.compareBytes(sc, ad.GetBytes())
-	case KindMysqlDecimal:
-		return d.compareMysqlDecimal(sc, ad.GetMysqlDecimal())
-	case KindMysqlDuration:
-		return d.compareMysqlDuration(sc, ad.GetMysqlDuration())
-	case KindMysqlEnum:
-		return d.compareMysqlEnum(sc, ad.GetMysqlEnum())
-	case KindBinaryLiteral, KindMysqlBit:
-		return d.compareBinaryLiteral(sc, ad.GetBinaryLiteral4Cmp())
-	case KindMysqlSet:
-		return d.compareMysqlSet(sc, ad.GetMysqlSet())
+		return d.compareMysqlSet(sc, ad.GetMysqlSet(), comparer)
 	case KindMysqlJSON:
 		return d.compareMysqlJSON(sc, ad.GetMysqlJSON())
 	case KindMysqlTime:
@@ -731,7 +675,7 @@ func (d *Datum) compareFloat64(sc *stmtctx.StatementContext, f float64) (int, er
 	}
 }
 
-func (d *Datum) compareStringNew(sc *stmtctx.StatementContext, s string, comparer collate.Collator) (int, error) {
+func (d *Datum) compareString(sc *stmtctx.StatementContext, s string, comparer collate.Collator) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -762,44 +706,6 @@ func (d *Datum) compareStringNew(sc *stmtctx.StatementContext, s string, compare
 		}
 		return d.compareFloat64(sc, fVal)
 	}
-}
-
-func (d *Datum) compareString(sc *stmtctx.StatementContext, s string, retCollation string) (int, error) {
-	switch d.k {
-	case KindNull, KindMinNotNull:
-		return -1, nil
-	case KindMaxValue:
-		return 1, nil
-	case KindString, KindBytes:
-		return CompareString(d.GetString(), s, d.collation), nil
-	case KindMysqlDecimal:
-		dec := new(MyDecimal)
-		err := sc.HandleTruncate(dec.FromString(hack.Slice(s)))
-		return d.GetMysqlDecimal().Compare(dec), errors.Trace(err)
-	case KindMysqlTime:
-		dt, err := ParseDatetime(sc, s)
-		return d.GetMysqlTime().Compare(dt), errors.Trace(err)
-	case KindMysqlDuration:
-		dur, err := ParseDuration(sc, s, MaxFsp)
-		return d.GetMysqlDuration().Compare(dur), errors.Trace(err)
-	case KindMysqlSet:
-		return CompareString(d.GetMysqlSet().String(), s, d.collation), nil
-	case KindMysqlEnum:
-		return CompareString(d.GetMysqlEnum().String(), s, d.collation), nil
-	case KindBinaryLiteral, KindMysqlBit:
-		return CompareString(d.GetBinaryLiteral4Cmp().ToString(), s, d.collation), nil
-	default:
-		fVal, err := StrToFloat(sc, s, false)
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-		return d.compareFloat64(sc, fVal)
-	}
-}
-
-func (d *Datum) compareBytes(sc *stmtctx.StatementContext, b []byte) (int, error) {
-	str := string(hack.String(b))
-	return d.compareString(sc, str, d.collation)
 }
 
 func (d *Datum) compareMysqlDecimal(sc *stmtctx.StatementContext, dec *MyDecimal) (int, error) {
@@ -839,7 +745,7 @@ func (d *Datum) compareMysqlDuration(sc *stmtctx.StatementContext, dur Duration)
 	}
 }
 
-func (d *Datum) compareMysqlEnumNew(sc *stmtctx.StatementContext, enum Enum, comparer collate.Collator) (int, error) {
+func (d *Datum) compareMysqlEnum(sc *stmtctx.StatementContext, enum Enum, comparer collate.Collator) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -852,7 +758,7 @@ func (d *Datum) compareMysqlEnumNew(sc *stmtctx.StatementContext, enum Enum, com
 	}
 }
 
-func (d *Datum) compareBinaryLiteralNew(sc *stmtctx.StatementContext, b BinaryLiteral, comparer collate.Collator) (int, error) {
+func (d *Datum) compareBinaryLiteral(sc *stmtctx.StatementContext, b BinaryLiteral, comparer collate.Collator) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -872,7 +778,7 @@ func (d *Datum) compareBinaryLiteralNew(sc *stmtctx.StatementContext, b BinaryLi
 	}
 }
 
-func (d *Datum) compareMysqlSetNew(sc *stmtctx.StatementContext, set Set, comparer collate.Collator) (int, error) {
+func (d *Datum) compareMysqlSet(sc *stmtctx.StatementContext, set Set, comparer collate.Collator) (int, error) {
 	switch d.k {
 	case KindNull, KindMinNotNull:
 		return -1, nil
@@ -880,52 +786,6 @@ func (d *Datum) compareMysqlSetNew(sc *stmtctx.StatementContext, set Set, compar
 		return 1, nil
 	case KindString, KindBytes, KindMysqlEnum, KindMysqlSet:
 		return comparer.Compare(d.GetString(), set.String()), nil
-	default:
-		return d.compareFloat64(sc, set.ToNumber())
-	}
-}
-
-func (d *Datum) compareMysqlEnum(sc *stmtctx.StatementContext, enum Enum) (int, error) {
-	switch d.k {
-	case KindNull, KindMinNotNull:
-		return -1, nil
-	case KindMaxValue:
-		return 1, nil
-	case KindString, KindBytes, KindMysqlEnum, KindMysqlSet:
-		return CompareString(d.GetString(), enum.String(), d.collation), nil
-	default:
-		return d.compareFloat64(sc, enum.ToNumber())
-	}
-}
-
-func (d *Datum) compareBinaryLiteral(sc *stmtctx.StatementContext, b BinaryLiteral) (int, error) {
-	switch d.k {
-	case KindNull, KindMinNotNull:
-		return -1, nil
-	case KindMaxValue:
-		return 1, nil
-	case KindString, KindBytes:
-		fallthrough // in this case, d is converted to Binary and then compared with b
-	case KindBinaryLiteral, KindMysqlBit:
-		return CompareString(d.GetBinaryLiteral4Cmp().ToString(), b.ToString(), d.collation), nil
-	default:
-		val, err := b.ToInt(sc)
-		if err != nil {
-			return 0, errors.Trace(err)
-		}
-		result, err := d.compareFloat64(sc, float64(val))
-		return result, errors.Trace(err)
-	}
-}
-
-func (d *Datum) compareMysqlSet(sc *stmtctx.StatementContext, set Set) (int, error) {
-	switch d.k {
-	case KindNull, KindMinNotNull:
-		return -1, nil
-	case KindMaxValue:
-		return 1, nil
-	case KindString, KindBytes, KindMysqlEnum, KindMysqlSet:
-		return CompareString(d.GetString(), set.String(), d.collation), nil
 	default:
 		return d.compareFloat64(sc, set.ToNumber())
 	}

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -568,9 +568,6 @@ func (r *builder) buildFromIn(expr *expression.ScalarFunction) ([]*point, bool) 
 			hasNull = true
 			continue
 		}
-		if dt.Kind() == types.KindString || dt.Kind() == types.KindBinaryLiteral {
-			dt.SetString(dt.GetString(), colCollate)
-		}
 		if expr.GetArgs()[0].GetType().Tp == mysql.TypeEnum {
 			switch dt.Kind() {
 			case types.KindString, types.KindBytes, types.KindBinaryLiteral:


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #29867.

Remove compareDatum, it's not used any more.

### What is changed and how it works?

1. Remove compareDatum, it's not used any more.
2. Rename related function.
3. Remove some codes in point.go, since we support range collator in the last PR.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
