### PR TITLE
*: fix invalid year value cast incorrect

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8031,6 +8031,18 @@ func (s *testSuite) TestIssue20305(c *C) {
 	tk.MustQuery("SELECT * FROM `t3` where y <= a").Check(testkit.Rows("2155 2156"))
 }
 
+func (s *testSuite) TestIssue25993(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t1")
+	tk.MustExec("create table t1 (a int, y YEAR)")
+	tk.MustExec("insert ignore t1 values (1, 1900), (2, 2156), (3, '1900'), (4, '2156')")
+	tk.MustQuery("SELECT * FROM `t1`  where a = 1").Check(testkit.Rows("1 0"))
+	tk.MustQuery("SELECT * FROM `t1`  where a = 2").Check(testkit.Rows("2 0"))
+	tk.MustQuery("SELECT * FROM `t1`  where a = 3").Check(testkit.Rows("3 0"))
+	tk.MustQuery("SELECT * FROM `t1`  where a = 4").Check(testkit.Rows("4 0"))
+}
+
 func (s *testSuite) TestIssue22817(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")

--- a/expression/builtin_compare.go
+++ b/expression/builtin_compare.go
@@ -1532,7 +1532,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	}
 	// int constant [cmp] year type
 	if arg0IsCon && arg0IsInt && arg1Type.Tp == mysql.TypeYear && !arg0.Value.IsNull() {
-		adjusted, failed := types.AdjustYear(arg0.Value.GetInt64(), false)
+		adjusted, failed := types.CompareYear(arg0.Value.GetInt64(), false)
 		if failed == nil {
 			arg0.Value.SetInt64(adjusted)
 			finalArg0 = arg0
@@ -1540,7 +1540,7 @@ func (c *compareFunctionClass) refineArgs(ctx sessionctx.Context, args []Express
 	}
 	// year type [cmp] int constant
 	if arg1IsCon && arg1IsInt && arg0Type.Tp == mysql.TypeYear && !arg1.Value.IsNull() {
-		adjusted, failed := types.AdjustYear(arg1.Value.GetInt64(), false)
+		adjusted, failed := types.CompareYear(arg1.Value.GetInt64(), false)
 		if failed == nil {
 			arg1.Value.SetInt64(adjusted)
 			finalArg1 = arg1

--- a/types/datum.go
+++ b/types/datum.go
@@ -1434,7 +1434,7 @@ func (d *Datum) ConvertToMysqlYear(sc *stmtctx.StatementContext, target *FieldTy
 		}
 		y = ret.GetInt64()
 	}
-	y, err = AdjustYear(y, adjust)
+	y, err = CompareYear(y, adjust)
 	ret.SetInt64(y)
 	return ret, errors.Trace(err)
 }

--- a/types/time.go
+++ b/types/time.go
@@ -1248,8 +1248,8 @@ func adjustYear(y int) int {
 	return y
 }
 
-// AdjustYear is used for adjusting year and checking its validation.
-func AdjustYear(y int64, adjustZero bool) (int64, error) {
+// CompareYear is used for comparing year.
+func CompareYear(y int64, adjustZero bool) (int64, error) {
 	if y == 0 && !adjustZero {
 		return y, nil
 	}
@@ -1262,6 +1262,19 @@ func AdjustYear(y int64, adjustZero bool) (int64, error) {
 	}
 	if y > int64(MaxYear) {
 		return int64(MaxYear), errors.Trace(ErrWarnDataOutOfRange)
+	}
+
+	return y, nil
+}
+
+// AdjustYear is used for adjusting year and checking its validation.
+func AdjustYear(y int64, adjustZero bool) (int64, error) {
+	if y == 0 && !adjustZero {
+		return y, nil
+	}
+	y = int64(adjustYear(int(y)))
+	if y < int64(MinYear) || y > int64(MaxYear) {
+		return 0, errors.Trace(ErrWarnDataOutOfRange)
 	}
 
 	return y, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #25993

Problem Summary:

```sql
mysql> use test
Database changed

mysql> CREATE TABLE t1 (a int, y YEAR);
Query OK, 0 rows affected (0.01 sec)

mysql> insert ignore t1 values (1, 1900), (2, 2156), (3, '1900'), (4, '2156');
Query OK, 4 rows affected, 4 warnings (0.00 sec)
Records: 4  Duplicates: 0  Warnings: 4

mysql> SELECT * FROM `t1`;
+------+------+
| a    | y    |
+------+------+
|    1 | 1901 |
|    2 | 2155 |
|    3 | 1901 |
|    4 | 2155 |
+------+------+
4 rows in set (0.00 sec)
```

### What is changed and how it works?
```sql
mysql> use test
Database changed

mysql> CREATE TABLE t1 (a int, y YEAR);
Query OK, 0 rows affected (0.01 sec)

mysql> insert ignore t1 values (1, 1900), (2, 2156), (3, '1900'), (4, '2156');
Query OK, 4 rows affected, 4 warnings (0.00 sec)
Records: 4  Duplicates: 0  Warnings: 4

mysql> SELECT * FROM `t1`;
+------+------+
| a    | y    |
+------+------+
|    1 | 0000 |
|    2 | 0000 |
|    3 | 0000 |
|    4 | 0000 |
+------+------+
4 rows in set (0.00 sec)
```
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix `invalid year value cast incorrect`
```
