### PR TITLE
expression: null is incorrect arguments in nth_value

### DIFF
--- a/executor/window_test.go
+++ b/executor/window_test.go
@@ -152,8 +152,8 @@ func doTestWindowFunctions(tk *testkit.TestKit) {
 	result = tk.MustQuery("select a, b, cume_dist() over(order by a, b) from t")
 	result.Check(testkit.Rows("1 1 0.25", "1 2 0.5", "2 1 0.75", "2 2 1"))
 
-	result = tk.MustQuery("select a, nth_value(a, null) over() from t")
-	result.Check(testkit.Rows("1 <nil>", "1 <nil>", "2 <nil>", "2 <nil>"))
+	tk.MustGetErrCode("select a, nth_value(a, null) over() from t", 1210)
+	tk.MustGetErrCode("select a, nth_value(a, 0) over() from t", 1210)
 	result = tk.MustQuery("select a, nth_value(a, 1) over() from t")
 	result.Check(testkit.Rows("1 1", "1 1", "2 1", "2 1"))
 	result = tk.MustQuery("select a, nth_value(a, 4) over() from t")

--- a/expression/aggregation/window_func.go
+++ b/expression/aggregation/window_func.go
@@ -32,8 +32,8 @@ func NewWindowFuncDesc(ctx sessionctx.Context, name string, args []expression.Ex
 	switch strings.ToLower(name) {
 	case ast.WindowFuncNthValue:
 		val, isNull, ok := expression.GetUint64FromConstant(args[1])
-		// nth_value does not allow `0`, but allows `null`.
-		if !ok || (val == 0 && !isNull) {
+		// nth_value does not allow `0` and `null`.
+		if !ok || val == 0 || isNull {
 			return nil, nil
 		}
 	case ast.WindowFuncNtile:


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #30893

Problem Summary:

```sql
mysql> SELECT id, NTH_VALUE(id, NULL) OVER () FROM t1;
+------+-----------------------------+
| id   | NTH_VALUE(id, NULL) OVER () |
+------+-----------------------------+
|   12 |                        NULL |
|   13 |                        NULL |
|   14 |                        NULL |
+------+-----------------------------+
3 rows in set (0.01 sec)
```

In `MySQL`, `NULL` is incorrect arguments in `nth_value`.

### What is changed and how it works?

```sql
mysql> SELECT id,NTH_VALUE(id,null) OVER () FROM t1;
ERROR 1210 (HY000): Incorrect arguments to nth_value
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
In `MySQL`, `NULL` is incorrect arguments in `nth_value`.
```
