### PR TITLE
table: set the datum collation correctly in CastValue()

### DIFF
--- a/executor/write_test.go
+++ b/executor/write_test.go
@@ -1096,6 +1096,20 @@ func TestReplace(t *testing.T) {
 	tk.MustExec("drop table t1, t2")
 }
 
+func TestReplaceWithCICollation(t *testing.T) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t (a varchar(20) charset utf8mb4 collate utf8mb4_general_ci primary key);")
+	tk.MustExec("replace into t(a) values (_binary'A '),(_binary'A');")
+	tk.MustQuery("select a from t use index(primary);").Check(testkit.Rows("A"))
+	tk.MustQuery("select a from t ignore index(primary);").Check(testkit.Rows("A"))
+}
+
 func TestGeneratedColumnForInsert(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/table/column.go
+++ b/table/column.go
@@ -363,18 +363,18 @@ func validateStringDatum(ctx sessionctx.Context, origin, casted *types.Datum, co
 		src := casted.GetBytes()
 		encBytes, err := enc.Transform(nil, src, charset.OpDecode)
 		if err != nil {
-			casted.SetBytesAsString(encBytes, charset.CollationUTF8MB4, 0)
+			casted.SetBytesAsString(encBytes, col.Collate, 0)
 			nSrc := charset.CountValidBytesDecode(enc, src)
 			return handleWrongCharsetValue(ctx, col, src, nSrc)
 		}
-		casted.SetBytesAsString(encBytes, charset.CollationUTF8MB4, 0)
+		casted.SetBytesAsString(encBytes, col.Collate, 0)
 		return nil
 	}
 	// Check if the string is valid in the given column charset.
 	str := casted.GetBytes()
 	if !charset.IsValid(enc, str) {
 		replace, _ := enc.Transform(nil, str, charset.OpReplace)
-		casted.SetBytesAsString(replace, charset.CollationUTF8MB4, 0)
+		casted.SetBytesAsString(replace, col.Collate, 0)
 		nSrc := charset.CountValidBytes(enc, str)
 		return handleWrongCharsetValue(ctx, col, str, nSrc)
 	}

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -304,7 +304,7 @@ func TestCastValue(t *testing.T) {
 	_, err = CastValue(ctx, types.NewDatum([]byte{0x32, 0xf0}), &colInfoS, false, true)
 	require.NoError(t, err)
 
-	colInfoS.Charset = charset.CharsetUTF8
+	colInfoS.Charset = charset.CharsetUTF8MB4
 	colInfoS.Collate = "utf8mb4_general_ci"
 	val, err = CastValue(ctx, types.NewBinaryLiteralDatum([]byte{0xE5, 0xA5, 0xBD}), &colInfoS, false, false)
 	require.NoError(t, err)

--- a/table/column_test.go
+++ b/table/column_test.go
@@ -303,6 +303,18 @@ func TestCastValue(t *testing.T) {
 	colInfoS.Charset = charset.CharsetASCII
 	_, err = CastValue(ctx, types.NewDatum([]byte{0x32, 0xf0}), &colInfoS, false, true)
 	require.NoError(t, err)
+
+	colInfoS.Charset = charset.CharsetUTF8
+	colInfoS.Collate = "utf8mb4_general_ci"
+	val, err = CastValue(ctx, types.NewBinaryLiteralDatum([]byte{0xE5, 0xA5, 0xBD}), &colInfoS, false, false)
+	require.NoError(t, err)
+	require.Equal(t, "utf8mb4_general_ci", val.Collation())
+	val, err = CastValue(ctx, types.NewBinaryLiteralDatum([]byte{0xE5, 0xA5, 0xBD, 0x81}), &colInfoS, false, false)
+	require.Error(t, err, "[table:1366]Incorrect string value '\\x81' for column ''")
+	require.Equal(t, "utf8mb4_general_ci", val.Collation())
+	val, err = CastValue(ctx, types.NewDatum([]byte{0xE5, 0xA5, 0xBD, 0x81}), &colInfoS, false, false)
+	require.Error(t, err, "[table:1366]Incorrect string value '\\x81' for column ''")
+	require.Equal(t, "utf8mb4_general_ci", val.Collation())
 }
 
 func TestGetDefaultValue(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #30930

### What is changed and how it works?

Even if the strings are transformed to UTF-8 charset, the collation in the datum should be unchanged.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
