### PR TITLE
parser: add parser rules to support kill '1'

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -13346,28 +13346,28 @@ KillStmt:
 			TiDBExtension: $1.(bool),
 		}
 	}
-|   KillOrKillTiDB stringLit
-    {
-        $$ = &ast.KillStmt{
-            ConnectionID:  getUint64FromNUM($2),
-            TiDBExtension: $1.(bool),
-        }
-    }
-|   KillOrKillTiDB "CONNECTION" stringLit
-    {
-        $$ = &ast.KillStmt{
-            ConnectionID:  getUint64FromNUM($3),
-            TiDBExtension: $1.(bool),
-        }
-    }
-|   KillOrKillTiDB "QUERY" stringLit
-    {
-        $$ = &ast.KillStmt{
-            ConnectionID:  getUint64FromNUM($3),
-            Query:         true,
-            TiDBExtension: $1.(bool),
-        }
-    }
+|	KillOrKillTiDB stringLit
+	{
+		$$ = &ast.KillStmt{
+			ConnectionID:  getUint64FromNUM($2),
+			TiDBExtension: $1.(bool),
+		}
+	}
+|	KillOrKillTiDB "CONNECTION" stringLit
+	{
+		$$ = &ast.KillStmt{
+			ConnectionID:  getUint64FromNUM($3),
+			TiDBExtension: $1.(bool),
+		}
+	}
+|	KillOrKillTiDB "QUERY" stringLit
+	{
+		$$ = &ast.KillStmt{
+			ConnectionID:  getUint64FromNUM($3),
+			Query:         true,
+			TiDBExtension: $1.(bool),
+		}
+	}
 
 KillOrKillTiDB:
 	"KILL"

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -13346,6 +13346,28 @@ KillStmt:
 			TiDBExtension: $1.(bool),
 		}
 	}
+|   KillOrKillTiDB stringLit
+    {
+        $$ = &ast.KillStmt{
+            ConnectionID:  getUint64FromNUM($2),
+            TiDBExtension: $1.(bool),
+        }
+    }
+|   KillOrKillTiDB "CONNECTION" stringLit
+    {
+        $$ = &ast.KillStmt{
+            ConnectionID:  getUint64FromNUM($3),
+            TiDBExtension: $1.(bool),
+        }
+    }
+|   KillOrKillTiDB "QUERY" stringLit
+    {
+        $$ = &ast.KillStmt{
+            ConnectionID:  getUint64FromNUM($3),
+            Query:         true,
+            TiDBExtension: $1.(bool),
+        }
+    }
 
 KillOrKillTiDB:
 	"KILL"

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4989,6 +4989,7 @@ func TestSessionManage(t *testing.T) {
 		{"kill tidb '23123'", true, "KILL TIDB 23123"},
 		{"kill tidb connection '23123'", true, "KILL TIDB 23123"},
 		{"kill tidb query '23123'", true, "KILL TIDB QUERY 23123"},
+		{"kill 'asd'", true, "KILL 0"},
 	}
 	RunTest(t, table, false)
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -4983,6 +4983,12 @@ func TestSessionManage(t *testing.T) {
 		{"show full processlist", true, "SHOW FULL PROCESSLIST"},
 		{"shutdown", true, "SHUTDOWN"},
 		{"restart", true, "RESTART"},
+		{"kill '23123'", true, "KILL 23123"},
+		{"kill connection '23123'", true, "KILL 23123"},
+		{"kill query '23123'", true, "KILL QUERY 23123"},
+		{"kill tidb '23123'", true, "KILL TIDB 23123"},
+		{"kill tidb connection '23123'", true, "KILL TIDB 23123"},
+		{"kill tidb query '23123'", true, "KILL TIDB QUERY 23123"},
 	}
 	RunTest(t, table, false)
 }
@@ -5623,6 +5629,7 @@ func (wfc *windowFrameBoundChecker) Leave(inNode ast.Node) (node ast.Node, ok bo
 	return inNode, true
 }
 
+// TestVisitFrameBound
 // For issue #51
 // See https://github.com/pingcap/parser/pull/51 for details
 func TestVisitFrameBound(t *testing.T) {
@@ -5669,6 +5676,7 @@ func TestFieldText(t *testing.T) {
 	}
 }
 
+// TestQuotedSystemVariables
 // See https://github.com/pingcap/parser/issue/94
 func TestQuotedSystemVariables(t *testing.T) {
 	p := parser.New()
@@ -5730,6 +5738,7 @@ func TestQuotedSystemVariables(t *testing.T) {
 	}
 }
 
+// TestQuotedVariableColumnName
 // See https://github.com/pingcap/parser/issue/95
 func TestQuotedVariableColumnName(t *testing.T) {
 	p := parser.New()
@@ -5945,6 +5954,7 @@ func (checker *nodeTextCleaner) Leave(in ast.Node) (out ast.Node, ok bool) {
 	return in, true
 }
 
+// TestIndexAdviseStmt
 // For index advisor
 func TestIndexAdviseStmt(t *testing.T) {
 	table := []testCase{
@@ -6005,6 +6015,7 @@ func TestIndexAdviseStmt(t *testing.T) {
 	RunTest(t, table, false)
 }
 
+// TestBRIE
 // For BRIE
 func TestBRIE(t *testing.T) {
 	table := []testCase{
@@ -6190,6 +6201,7 @@ func TestHighNotPrecedenceMode(t *testing.T) {
 	require.Equal(t, "SELECT !1 BETWEEN -5 AND 5", restoreSQL)
 }
 
+// TestCTE
 // For CTE
 func TestCTE(t *testing.T) {
 	table := []testCase{
@@ -6231,6 +6243,7 @@ func TestAsOfClause(t *testing.T) {
 	RunTest(t, table, false)
 }
 
+// TestPartitionKeyAlgorithm
 // For `PARTITION BY [LINEAR] KEY ALGORITHM` syntax
 func TestPartitionKeyAlgorithm(t *testing.T) {
 	table := []testCase{
@@ -6243,6 +6256,7 @@ func TestPartitionKeyAlgorithm(t *testing.T) {
 	RunTest(t, table, false)
 }
 
+// TestHelp
 // server side help syntax
 func TestHelp(t *testing.T) {
 	table := []testCase{
@@ -6294,6 +6308,7 @@ func TestRestoreBinOpWithBrackets(t *testing.T) {
 	}
 }
 
+// TestCTEBindings
 // For CTE bindings.
 func TestCTEBindings(t *testing.T) {
 	table := []testCase{

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -88,6 +88,7 @@ type Parser struct {
 	explicitCharset       bool
 	strictDoubleFieldType bool
 
+	// cache
 	// the following fields are used by yyParse to reduce allocation.
 	cache  []yySymType
 	yylval yySymType
@@ -210,6 +211,7 @@ func ParseErrorWith(errstr string, lineno int) error {
 	return fmt.Errorf("near '%-.80s' at line %d", errstr, lineno)
 }
 
+// setLastSelectFieldText
 // The select statement is not at the end of the whole statement, if the last
 // field text was set from its offset to the end of the src string, update
 // the last field text.
@@ -300,6 +302,7 @@ func toFloat(l yyLexer, lval *yySymType, str string) int {
 	return floatLit
 }
 
+// toHex
 // See https://dev.mysql.com/doc/refman/5.7/en/hexadecimal-literals.html
 func toHex(l yyLexer, lval *yySymType, str string) int {
 	h, err := ast.NewHexLiteral(str)
@@ -311,6 +314,7 @@ func toHex(l yyLexer, lval *yySymType, str string) int {
 	return hexLit
 }
 
+// toBit
 // See https://dev.mysql.com/doc/refman/5.7/en/bit-type.html
 func toBit(l yyLexer, lval *yySymType, str string) int {
 	b, err := ast.NewBitLiteral(str)
@@ -328,6 +332,12 @@ func getUint64FromNUM(num interface{}) uint64 {
 		return uint64(v)
 	case uint64:
 		return v
+	case string:
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			return 0
+		}
+		return uint64(n)
 	}
 	return 0
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #27932 

Problem Summary:
add support for kill '1' , before this we just support kill 1
modify rules in parser.y , if it's '1' , use  strconv.Atoi() to convert '1' to 1.
If we input kill 'asd' ,strconv.Atoi() wil err and we just return 0 , it's consistent with mysql 8.0.

This is result in mysql 8.0.18
`mysql> kill '1';
ERROR 1094 (HY000): Unknown thread id: 1

mysql> kill 'asd';
ERROR 1094 (HY000): Unknown thread id: 0`
**From this we can see , mysql will convert 'asd' to 0.**

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
