### PR TITLE
executor/metrics: distinguish desc a table and explain a SQL on metrics

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -365,7 +365,13 @@ func GetStmtLabel(stmtNode ast.StmtNode) string {
 		}
 		return "DropTable"
 	case *ast.ExplainStmt:
-		return "Explain"
+		if _, ok := x.Stmt.(*ast.ShowStmt); ok {
+			return "DescTable"
+		}
+		if x.Analyze {
+			return "ExplainAnalyzeSQL"
+		}
+		return "ExplainSQL"
 	case *ast.InsertStmt:
 		if x.IsReplace {
 			return "Replace"

--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -189,14 +189,14 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "DROP SESSION BINDING FOR SELECT * FROM t1 WHERE a = 123",
 			stmtType: "DropBinding",
 		},
-		//{
+		// {
 		//	sql: "LOAD STATS '/tmp/stats.json'",
 		//	stmtType: "other",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "DROP STATS t",
 		//	stmtType: "other",
-		//},
+		// },
 		{
 			sql:      "RENAME TABLE t2 TO t5",
 			stmtType: "other",
@@ -209,18 +209,18 @@ func TestAuditLogNormal(t *testing.T) {
 			dbs:      "test",
 			tables:   "t1",
 		},
-		//{
+		// {
 		//	sql: "FLASHBACK TABLE t TO t1",
 		//	stmtType: "other",
 		//	dbs: "test",
 		//	tables: "t1",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "RECOVER TABLE t1",
 		//	stmtType: "other",
 		//	dbs: "test",
 		//	tables: "t1,t2",
-		//},
+		// },
 		{
 			sql:      "ALTER DATABASE test DEFAULT CHARACTER SET = utf8mb4",
 			stmtType: "other",
@@ -230,20 +230,20 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "ADMIN RELOAD opt_rule_blacklist",
 			stmtType: "other",
 		},
-		//{
+		// {
 		//	sql: "ADMIN PLUGINS ENABLE audit_test",
 		//	stmtType: "other",
-		//},
+		// },
 		{
 			sql:      "ADMIN FLUSH bindings",
 			stmtType: "other",
 		},
-		//{
+		// {
 		//	sql: "ADMIN REPAIR TABLE t1 CREATE TABLE (id int)",
 		//	stmtType: "other",
 		//	dbs: "test",
 		//	tables: "t1",
-		//},
+		// },
 		{
 			sql:      "ADMIN SHOW SLOW RECENT 10",
 			stmtType: "other",
@@ -252,27 +252,27 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "ADMIN SHOW DDL JOBS",
 			stmtType: "other",
 		},
-		//{
+		// {
 		//	sql: "ADMIN CANCEL DDL JOBS 1",
 		//	stmtType: "other",
-		//},
+		// },
 		{
 			sql:      "ADMIN CHECKSUM TABLE t1",
 			stmtType: "other",
-			//dbs: "test",
-			//tables: "t1",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "ADMIN CHECK TABLE t1",
 			stmtType: "other",
-			//dbs: "test",
-			//tables: "t1",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "ADMIN CHECK INDEX t1 a",
 			stmtType: "other",
-			//dbs: "test",
-			//tables: "t1",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "CREATE USER 'newuser' IDENTIFIED BY 'newuserpassword'",
@@ -316,10 +316,10 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "SET PASSWORD FOR 'newuser' = 'test'",
 			stmtType: "Set",
 		},
-		//{
+		// {
 		//	sql: "SET ROLE ALL",
 		//	stmtType: "other",
-		//},
+		// },
 		{
 			sql:      "DROP USER 'newuser'",
 			stmtType: "other",
@@ -333,26 +333,26 @@ func TestAuditLogNormal(t *testing.T) {
 		{
 			sql:      "SPLIT TABLE t1 BETWEEN (0) AND (1000000000) REGIONS 16",
 			stmtType: "other",
-			//dbs: "test",
-			//tables: "t1",
+			// dbs: "test",
+			// tables: "t1",
 		},
-		//{
+		// {
 		//	sql: "BACKUP DATABASE `test` TO '.'",
 		//	stmtType: "other",
 		//	dbs: "test",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "RESTORE DATABASE * FROM '.'",
 		//	stmtType: "other",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "CHANGE DRAINER TO NODE_STATE ='paused' FOR NODE_ID 'drainer1'",
 		//	stmtType: "other",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "CHANGE PUMP TO NODE_STATE ='paused' FOR NODE_ID 'pump1'",
 		//	stmtType: "other",
-		//},
+		// },
 		{
 			sql:      "BEGIN",
 			stmtType: "Begin",
@@ -369,30 +369,30 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "COMMIT",
 			stmtType: "Commit",
 		},
-		//{
+		// {
 		//	sql: "SHOW DRAINER STATUS",
 		//	stmtType: "Show",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "SHOW PUMP STATUS",
 		//	stmtType: "Show",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "SHOW GRANTS",
 		//	stmtType: "Show",
-		//},
+		// },
 		{
 			sql:      "SHOW PROCESSLIST",
 			stmtType: "Show",
 		},
-		//{
+		// {
 		//	sql: "SHOW BACKUPS",
 		//	stmtType: "Show",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "SHOW RESTORES",
 		//	stmtType: "Show",
-		//},
+		// },
 		{
 			sql:      "show analyze status",
 			stmtType: "Show",
@@ -421,10 +421,10 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "show fields from t1",
 			stmtType: "Show",
 		},
-		//{
+		// {
 		//	sql: "SHOW CONFIG",
 		//	stmtType: "Show",
-		//},
+		// },
 		{
 			sql:      "SHOW CREATE TABLE t1",
 			stmtType: "Show",
@@ -467,10 +467,10 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "SHOW PROFILES",
 			stmtType: "Show",
 		},
-		//{
+		// {
 		//	sql: "SHOW PUMP STATUS",
 		//	stmtType: "Show",
-		//},
+		// },
 		{
 			sql:      "SHOW SCHEMAS",
 			stmtType: "Show",
@@ -585,12 +585,12 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "DO 1",
 			stmtType: "other",
 		},
-		//{
+		// {
 		//	sql: "LOAD DATA LOCAL INFILE 'data.csv' INTO TABLE t1 FIELDS TERMINATED BY ',' ENCLOSED BY '\"' LINES TERMINATED BY '\r\n' IGNORE 1 LINES (id)",
 		//	stmtType: "LoadData",
 		//	dbs: "test",
 		//	tables: "t1",
-		//},
+		// },
 		{
 			sql:      "SELECT * FROM t1",
 			stmtType: "Select",
@@ -609,39 +609,39 @@ func TestAuditLogNormal(t *testing.T) {
 		},
 		{
 			sql:      "EXPLAIN ANALYZE SELECT * FROM t1 WHERE a = 1",
-			stmtType: "Explain",
-			//dbs: "test",
-			//tables: "t1",
+			stmtType: "ExplainAnalyzeSQL",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "EXPLAIN SELECT * FROM t1",
-			stmtType: "Explain",
-			//dbs: "test",
-			//tables: "t1",
+			stmtType: "ExplainSQL",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "EXPLAIN SELECT * FROM t1 WHERE a = 1",
-			stmtType: "Explain",
-			//dbs: "test",
-			//tables: "t1",
+			stmtType: "ExplainSQL",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "DESC SELECT * FROM t1 WHERE a = 1",
-			stmtType: "Explain",
-			//dbs: "test",
-			//tables: "t1",
+			stmtType: "ExplainSQL",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "DESCRIBE SELECT * FROM t1 WHERE a = 1",
-			stmtType: "Explain",
-			//dbs: "test",
-			//tables: "t1",
+			stmtType: "ExplainSQL",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "trace format='row' select * from t1",
 			stmtType: "Trace",
-			//dbs: "test",
-			//tables: "t1",
+			// dbs: "test",
+			// tables: "t1",
 		},
 		{
 			sql:      "flush status",
@@ -651,18 +651,18 @@ func TestAuditLogNormal(t *testing.T) {
 			sql:      "FLUSH TABLES",
 			stmtType: "other",
 		},
-		//{
+		// {
 		//	sql: "KILL TIDB 2",
 		//	stmtType: "other",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "SHUTDOWN",
 		//	stmtType: "Shutdow",
-		//},
-		//{
+		// },
+		// {
 		//	sql: "ALTER INSTANCE RELOAD TLS",
 		//	stmtType: "other",
-		//},
+		// },
 	}
 
 	testResults := make([]normalTest, 0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31115

Problem Summary:
SQL like desc/explain does two things, 
1. describes the table structure, many frameworks do this automatically, 
2. outputs the execution plan of the SQL. 
TiDB needs to distinguish them in metrics.

### What is changed and how it works?
Distinguish them by labels.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. start a cluster
1. run some desc table and then some explain SQL
1. check it on Grafana
![image](https://user-images.githubusercontent.com/4352397/147108030-94de04b9-80e4-49b7-a3bb-1b5cfbd75fbc.png)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
