### PR TITLE
types: fix bug in ConvertFloatToUint function

### DIFF
--- a/types/convert.go
+++ b/types/convert.go
@@ -173,7 +173,7 @@ func ConvertFloatToUint(sc *stmtctx.StatementContext, fval float64, upperBound u
 	// so `float64(math.MaxUint64)` will make a num bigger than math.MaxUint64,
 	// which can not be represented by 64bit integer.
 	// So `uint64(float64(math.MaxUint64))` is undefined behavior.
-	if val == ubf {
+	if val == ubf && upperBound == math.MaxUint64 {
 		return math.MaxUint64, nil
 	}
 	if val > ubf {


### PR DESCRIPTION
when val == ubf && upperBound < math.MaxUint64, means tp is not 64 bits type. For example tinyint unsinged, and val == 255 and ubf == upperBound == 255 , which means client use doule to transmit data 255, then tidb try set it to database tinyint unsigned column but convert action failed here,  got math.MaxUint64)

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

1. create table：
DROP TABLE IF EXISTS mail;
CREATE TABLE mail (
	Id int unsigned NOT NULL default '',
	PackIndex tinyint unsigned NOT NULL default 0,
	PRIMARY KEY (Id, OwnerId)
)
DEFAULT CHARSET=latin1
ENGINE=InnoDB;

2. add data to table mail: INSERT INTO mail VALUES(1,0);
3. use mysql connector c：for example http://dev.mysql.com/get/Downloads/Connector-C/mysql-connector-c-6.1.6-src.tar.gz， other i think will also work.
```
double packindex = 255;
double id = 1;
char * m_szSql = "UPDATE mail SET	PackIndex = ? where Id = ?";  // !!! use this sql and bind params with MYSQL_TYPE_DOUBLE
my_bool*            m_aryParamIsNull;
MYSQL_BIND          m_aryParamBind[2];
// add connect and statement build code here.
...
// set praram use MYSQL_TYPE_DOUBLE, like below
void SetParamBuffer(uint32 uIndex, const void* pBuffer, uint32 uBufferSize, enum_field_types eFieldType)
{
		m_aryParamIsNull[uIndex] = (my_bool)false;
		m_aryParamBind[uIndex].buffer_type = eFieldType;
		m_aryParamBind[uIndex].is_null = m_aryParamIsNull + uIndex;
		m_aryParamBind[uIndex].buffer = const_cast<void*>(pBuffer);
		m_aryParamBind[uIndex].buffer_length = uBufferSize;
		m_aryParamBind[uIndex].length = m_aryParamLength + uIndex;
}

SetParamNumber(1, &packindex, MYSQL_TYPE_DOUBLE);
SetParamNumber(2, &id, MYSQL_TYPE_DOUBLE);

mysql_stmt_bind_param(m_pStmt, m_aryParamBind)
mysql_stmt_execute(m_pStmt)
```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
/cc @3pointer