### PR TITLE
planner: check whether a predicate is from the underlying operator before pushing it down

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2680,6 +2680,20 @@ func (s *testIntegrationSuite) TestDeleteUsingJoin(c *C) {
 	tk.MustQuery("select * from t2").Check(testkit.Rows("2 2"))
 }
 
+func (s *testIntegrationSerialSuite) TestIssue28743(c *C) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
+
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec("set names utf8mb4")
+	tk.MustExec(`CREATE TABLE t (
+	  a char(1) COLLATE utf8mb4_general_ci DEFAULT NULL,
+	  b char(1) COLLATE utf8mb4_general_ci DEFAULT NULL
+	) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci`)
+	tk.MustQuery(`select t2.b from (select t.a as b from t union all select t.a as b from t) t2 where t2.b > 'a' collate utf8mb4_unicode_ci`).Check(testkit.Rows()) // no error
+}
+
 func (s *testIntegrationSerialSuite) Test19942(c *C) {
 	collate.SetNewCollationEnabledForTest(true)
 	defer collate.SetNewCollationEnabledForTest(false)

--- a/planner/core/rule_predicate_push_down.go
+++ b/planner/core/rule_predicate_push_down.go
@@ -391,7 +391,7 @@ func (p *LogicalProjection) PredicatePushDown(predicates []expression.Expression
 	}
 	for _, cond := range predicates {
 		newFilter := expression.ColumnSubstitute(cond, p.Schema(), p.Exprs)
-		if !expression.HasGetSetVarFunc(newFilter) {
+		if !expression.HasGetSetVarFunc(newFilter) && expression.ExprFromSchema(newFilter, p.Children()[0].Schema()) {
 			canBePushed = append(canBePushed, newFilter)
 		} else {
 			canNotBePushed = append(canNotBePushed, cond)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #28743, close #32160

Problem Summary:

### What is changed and how it works?

Due to the impact of new-collation, in `LogicalProjection.PredicatePushDown` some predicates not from the underlying operator are still pushed down, which causes some errors.
This PR lets it check whether a predicate is from the underlying operator before pushing it down.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
