### PR TITLE
parser: parse gbk encoding SQL token by token instead of the whole SQL

### DIFF
--- a/br/pkg/lightning/restore/tidb_test.go
+++ b/br/pkg/lightning/restore/tidb_test.go
@@ -148,7 +148,7 @@ func (s *tidbSuite) TestCreateTableIfNotExistsStmt(c *C) {
 	c.Assert(
 		createTableIfNotExistsStmt("CREATE TABLE `\xcc\xcc\xcc`(`\xdd\xdd\xdd` TINYINT(1));", "\xcc\xcc\xcc"),
 		DeepEquals,
-		[]string{"CREATE TABLE IF NOT EXISTS `testdb`.`\xcc\xcc\xcc` (`ÝÝÝ` TINYINT(1));"},
+		[]string{"CREATE TABLE IF NOT EXISTS `testdb`.`\xcc\xcc\xcc` (`\xdd\xdd\xdd` TINYINT(1));"},
 	)
 
 	// renaming a table

--- a/executor/partition_table_test.go
+++ b/executor/partition_table_test.go
@@ -526,10 +526,10 @@ func (s *partitionTableSuite) TestDirectReadingwithIndexJoin(c *C) {
 	// hash and range partition
 	tk.MustExec("create table thash (a int, b int, c int, primary key(a), index idx_b(b)) partition by hash(a) partitions 4;")
 	tk.MustExec(`create table trange (a int, b int, c int, primary key(a), index idx_b(b)) partition by range(a) (
-		  partition p0 values less than(1000),
-		  partition p1 values less than(2000),
-		  partition p2 values less than(3000),
-		  partition p3 values less than(4000));`)
+		 partition p0 values less than(1000),
+		 partition p1 values less than(2000),
+		 partition p2 values less than(3000),
+		 partition p3 values less than(4000));`)
 
 	// regualr table
 	tk.MustExec(`create table tnormal (a int, b int, c int, primary key(a), index idx_b(b));`)

--- a/parser/ast/expressions_test.go
+++ b/parser/ast/expressions_test.go
@@ -380,7 +380,6 @@ func TestVariableExpr(t *testing.T) {
 		{"@``", "@``"},
 		{"@", "@``"},
 		{"@@``", "@@``"},
-		{"@@", "@@``"},
 		{"@@var", "@@`var`"},
 		{"@@global.b='foo'", "@@GLOBAL.`b`=_UTF8MB4'foo'"},
 		{"@@session.'C'", "@@SESSION.`c`"},

--- a/parser/charset/encoding.go
+++ b/parser/charset/encoding.go
@@ -68,6 +68,8 @@ type Encoding interface {
 	Tp() EncodingTp
 	// Peek returns the next char.
 	Peek(src []byte) []byte
+	// MbLen returns multiple byte length, if the next character is single byte, return 0.
+	MbLen(string) int
 	// IsValid checks whether the utf-8 bytes can be convert to valid string in current encoding.
 	IsValid(src []byte) bool
 	// Foreach iterates the characters in in current encoding.

--- a/parser/charset/encoding_base.go
+++ b/parser/charset/encoding_base.go
@@ -34,6 +34,10 @@ type encodingBase struct {
 	self Encoding
 }
 
+func (b encodingBase) MbLen(_ string) int {
+	return 0
+}
+
 func (b encodingBase) ToUpper(src string) string {
 	return strings.ToUpper(src)
 }

--- a/parser/charset/encoding_gbk.go
+++ b/parser/charset/encoding_gbk.go
@@ -60,7 +60,7 @@ func (e *encodingGBK) MbLen(bs string) int {
 		return 0
 	}
 
-	if 0x81 <= bs[0] && bs[0] <= 0xf4 {
+	if 0x81 <= bs[0] && bs[0] <= 0xfe {
 		if (0x40 <= bs[1] && bs[1] <= 0x7e) || (0x80 <= bs[1] && bs[1] <= 0xfe) {
 			return 2
 		}

--- a/parser/charset/encoding_gbk.go
+++ b/parser/charset/encoding_gbk.go
@@ -55,6 +55,20 @@ func (e *encodingGBK) Peek(src []byte) []byte {
 	return src
 }
 
+func (e *encodingGBK) MbLen(bs string) int {
+	if len(bs) < 2 {
+		return 0
+	}
+
+	if 0x81 <= bs[0] && bs[0] <= 0xf4 {
+		if (0x40 <= bs[1] && bs[1] <= 0x7e) || (0x80 <= bs[1] && bs[1] <= 0xfe) {
+			return 2
+		}
+	}
+
+	return 0
+}
+
 // ToUpper implements Encoding interface.
 func (e *encodingGBK) ToUpper(d string) string {
 	return strings.ToUpperSpecial(GBKCase, d)

--- a/parser/charset/encoding_utf8.go
+++ b/parser/charset/encoding_utf8.go
@@ -67,6 +67,14 @@ func (e *encodingUTF8) Peek(src []byte) []byte {
 	return src[:nextLen]
 }
 
+func (e *encodingUTF8) MbLen(bs string) int {
+	_, size := utf8.DecodeRuneInString(bs)
+	if size <= 1 {
+		return 0
+	}
+	return size
+}
+
 // IsValid implements Encoding interface.
 func (e *encodingUTF8) IsValid(src []byte) bool {
 	if utf8.Valid(src) {

--- a/parser/digester.go
+++ b/parser/digester.go
@@ -21,7 +21,6 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"unicode"
 	"unsafe"
 
 	"github.com/pingcap/tidb/parser/charset"
@@ -170,9 +169,6 @@ func (d *sqlDigester) normalize(sql string) {
 		if tok == invalid {
 			break
 		}
-		if tok == unicode.ReplacementChar && d.lexer.r.eof() {
-			break
-		}
 		if pos.Offset == len(sql) {
 			break
 		}
@@ -235,7 +231,7 @@ func (d *sqlDigester) reduceOptimizerHint(tok *token) (reduced bool) {
 			case "force", "use", "ignore":
 				for {
 					tok, _, lit := d.lexer.scan()
-					if tok == 0 || (tok == unicode.ReplacementChar && d.lexer.r.eof()) {
+					if (tok == 0 && d.lexer.r.eof()) || tok == invalid {
 						break
 					}
 					if lit == ")" {

--- a/parser/digester_test.go
+++ b/parser/digester_test.go
@@ -54,10 +54,10 @@ func TestNormalize(t *testing.T) {
 		{"select * from `table`", "select * from `table`"},
 		{"select * from `30`", "select * from `30`"},
 		{"select * from `select`", "select * from `select`"},
+		{"select * from 🥳", "select * from `🥳`"},
 		// test syntax error, it will be checked by parser, but it should not make normalize dead loop.
 		{"select * from t ignore index(", "select * from `t` ignore index"},
 		{"select /*+ ", "select "},
-		{"select * from 🥳", "select * from"},
 		{"select 1 / 2", "select ? / ?"},
 		{"select * from t where a = 40 limit ?, ?", "select * from `t` where `a` = ? limit ..."},
 		{"select * from t where a > ?", "select * from `t` where `a` > ?"},

--- a/parser/hintparser.go
+++ b/parser/hintparser.go
@@ -41,78 +41,79 @@ type yyhintXError struct {
 }
 
 const (
-	yyhintDefault             = 57415
+	yyhintDefault             = 57416
 	yyhintEOFCode             = 57344
 	yyhintErrCode             = 57345
-	hintAggToCop              = 57376
-	hintBCJoin                = 57389
-	hintBCJoinPreferLocal     = 57390
-	hintBKA                   = 57354
-	hintBNL                   = 57356
-	hintDupsWeedOut           = 57411
-	hintFalse                 = 57407
-	hintFirstMatch            = 57412
-	hintForceIndex            = 57401
-	hintGB                    = 57410
-	hintHashAgg               = 57378
-	hintHashJoin              = 57358
+	hintAggToCop              = 57377
+	hintBCJoin                = 57390
+	hintBCJoinPreferLocal     = 57391
+	hintBKA                   = 57355
+	hintBNL                   = 57357
+	hintDupsWeedOut           = 57412
+	hintFalse                 = 57408
+	hintFirstMatch            = 57413
+	hintForceIndex            = 57402
+	hintGB                    = 57411
+	hintHashAgg               = 57379
+	hintHashJoin              = 57359
 	hintIdentifier            = 57347
-	hintIgnoreIndex           = 57379
-	hintIgnorePlanCache       = 57377
-	hintIndexMerge            = 57362
-	hintInlHashJoin           = 57380
-	hintInlJoin               = 57381
-	hintInlMergeJoin          = 57382
+	hintIgnoreIndex           = 57380
+	hintIgnorePlanCache       = 57378
+	hintIndexMerge            = 57363
+	hintInlHashJoin           = 57381
+	hintInlJoin               = 57382
+	hintInlMergeJoin          = 57383
 	hintIntLit                = 57346
-	hintJoinFixedOrder        = 57350
-	hintJoinOrder             = 57351
-	hintJoinPrefix            = 57352
-	hintJoinSuffix            = 57353
-	hintLimitToCop            = 57400
-	hintLooseScan             = 57413
-	hintMB                    = 57409
-	hintMRR                   = 57364
-	hintMaterialization       = 57414
-	hintMaxExecutionTime      = 57372
-	hintMemoryQuota           = 57383
-	hintMerge                 = 57360
-	hintNoBKA                 = 57355
-	hintNoBNL                 = 57357
-	hintNoHashJoin            = 57359
-	hintNoICP                 = 57366
-	hintNoIndexMerge          = 57363
-	hintNoMRR                 = 57365
-	hintNoMerge               = 57361
-	hintNoRangeOptimization   = 57367
-	hintNoSemijoin            = 57371
-	hintNoSkipScan            = 57369
-	hintNoSwapJoinInputs      = 57384
-	hintNthPlan               = 57399
-	hintOLAP                  = 57402
-	hintOLTP                  = 57403
-	hintPartition             = 57404
-	hintQBName                = 57375
-	hintQueryType             = 57385
-	hintReadConsistentReplica = 57386
-	hintReadFromStorage       = 57387
-	hintResourceGroup         = 57374
-	hintSMJoin                = 57388
-	hintSemijoin              = 57370
-	hintSetVar                = 57373
-	hintSingleAtIdentifier    = 57348
-	hintSkipScan              = 57368
-	hintStreamAgg             = 57391
-	hintStringLit             = 57349
-	hintSwapJoinInputs        = 57392
-	hintTiFlash               = 57406
-	hintTiKV                  = 57405
-	hintTimeRange             = 57397
-	hintTrue                  = 57408
-	hintUseCascades           = 57398
-	hintUseIndex              = 57394
-	hintUseIndexMerge         = 57393
-	hintUsePlanCache          = 57395
-	hintUseToja               = 57396
+	hintInvalid               = 57348
+	hintJoinFixedOrder        = 57351
+	hintJoinOrder             = 57352
+	hintJoinPrefix            = 57353
+	hintJoinSuffix            = 57354
+	hintLimitToCop            = 57401
+	hintLooseScan             = 57414
+	hintMB                    = 57410
+	hintMRR                   = 57365
+	hintMaterialization       = 57415
+	hintMaxExecutionTime      = 57373
+	hintMemoryQuota           = 57384
+	hintMerge                 = 57361
+	hintNoBKA                 = 57356
+	hintNoBNL                 = 57358
+	hintNoHashJoin            = 57360
+	hintNoICP                 = 57367
+	hintNoIndexMerge          = 57364
+	hintNoMRR                 = 57366
+	hintNoMerge               = 57362
+	hintNoRangeOptimization   = 57368
+	hintNoSemijoin            = 57372
+	hintNoSkipScan            = 57370
+	hintNoSwapJoinInputs      = 57385
+	hintNthPlan               = 57400
+	hintOLAP                  = 57403
+	hintOLTP                  = 57404
+	hintPartition             = 57405
+	hintQBName                = 57376
+	hintQueryType             = 57386
+	hintReadConsistentReplica = 57387
+	hintReadFromStorage       = 57388
+	hintResourceGroup         = 57375
+	hintSMJoin                = 57389
+	hintSemijoin              = 57371
+	hintSetVar                = 57374
+	hintSingleAtIdentifier    = 57349
+	hintSkipScan              = 57369
+	hintStreamAgg             = 57392
+	hintStringLit             = 57350
+	hintSwapJoinInputs        = 57393
+	hintTiFlash               = 57407
+	hintTiKV                  = 57406
+	hintTimeRange             = 57398
+	hintTrue                  = 57409
+	hintUseCascades           = 57399
+	hintUseIndex              = 57395
+	hintUseIndexMerge         = 57394
+	hintUsePlanCache          = 57396
+	hintUseToja               = 57397
 
 	yyhintMaxDepth = 200
 	yyhintTabOfs   = -172
@@ -121,117 +122,118 @@ const (
 var (
 	yyhintXLAT = map[int]int{
 		41:    0,   // ')' (130x)
-		57376: 1,   // hintAggToCop (122x)
-		57389: 2,   // hintBCJoin (122x)
-		57390: 3,   // hintBCJoinPreferLocal (122x)
-		57354: 4,   // hintBKA (122x)
-		57356: 5,   // hintBNL (122x)
-		57401: 6,   // hintForceIndex (122x)
-		57378: 7,   // hintHashAgg (122x)
-		57358: 8,   // hintHashJoin (122x)
-		57379: 9,   // hintIgnoreIndex (122x)
-		57377: 10,  // hintIgnorePlanCache (122x)
-		57362: 11,  // hintIndexMerge (122x)
-		57380: 12,  // hintInlHashJoin (122x)
-		57381: 13,  // hintInlJoin (122x)
-		57382: 14,  // hintInlMergeJoin (122x)
-		57350: 15,  // hintJoinFixedOrder (122x)
-		57351: 16,  // hintJoinOrder (122x)
-		57352: 17,  // hintJoinPrefix (122x)
-		57353: 18,  // hintJoinSuffix (122x)
-		57400: 19,  // hintLimitToCop (122x)
-		57372: 20,  // hintMaxExecutionTime (122x)
-		57383: 21,  // hintMemoryQuota (122x)
-		57360: 22,  // hintMerge (122x)
-		57364: 23,  // hintMRR (122x)
-		57355: 24,  // hintNoBKA (122x)
-		57357: 25,  // hintNoBNL (122x)
-		57359: 26,  // hintNoHashJoin (122x)
-		57366: 27,  // hintNoICP (122x)
-		57363: 28,  // hintNoIndexMerge (122x)
-		57361: 29,  // hintNoMerge (122x)
-		57365: 30,  // hintNoMRR (122x)
-		57367: 31,  // hintNoRangeOptimization (122x)
-		57371: 32,  // hintNoSemijoin (122x)
-		57369: 33,  // hintNoSkipScan (122x)
-		57384: 34,  // hintNoSwapJoinInputs (122x)
-		57399: 35,  // hintNthPlan (122x)
-		57375: 36,  // hintQBName (122x)
-		57385: 37,  // hintQueryType (122x)
-		57386: 38,  // hintReadConsistentReplica (122x)
-		57387: 39,  // hintReadFromStorage (122x)
-		57374: 40,  // hintResourceGroup (122x)
-		57370: 41,  // hintSemijoin (122x)
-		57373: 42,  // hintSetVar (122x)
-		57368: 43,  // hintSkipScan (122x)
-		57388: 44,  // hintSMJoin (122x)
-		57391: 45,  // hintStreamAgg (122x)
-		57392: 46,  // hintSwapJoinInputs (122x)
-		57397: 47,  // hintTimeRange (122x)
-		57398: 48,  // hintUseCascades (122x)
-		57394: 49,  // hintUseIndex (122x)
-		57393: 50,  // hintUseIndexMerge (122x)
-		57395: 51,  // hintUsePlanCache (122x)
-		57396: 52,  // hintUseToja (122x)
+		57377: 1,   // hintAggToCop (122x)
+		57390: 2,   // hintBCJoin (122x)
+		57391: 3,   // hintBCJoinPreferLocal (122x)
+		57355: 4,   // hintBKA (122x)
+		57357: 5,   // hintBNL (122x)
+		57402: 6,   // hintForceIndex (122x)
+		57379: 7,   // hintHashAgg (122x)
+		57359: 8,   // hintHashJoin (122x)
+		57380: 9,   // hintIgnoreIndex (122x)
+		57378: 10,  // hintIgnorePlanCache (122x)
+		57363: 11,  // hintIndexMerge (122x)
+		57381: 12,  // hintInlHashJoin (122x)
+		57382: 13,  // hintInlJoin (122x)
+		57383: 14,  // hintInlMergeJoin (122x)
+		57351: 15,  // hintJoinFixedOrder (122x)
+		57352: 16,  // hintJoinOrder (122x)
+		57353: 17,  // hintJoinPrefix (122x)
+		57354: 18,  // hintJoinSuffix (122x)
+		57401: 19,  // hintLimitToCop (122x)
+		57373: 20,  // hintMaxExecutionTime (122x)
+		57384: 21,  // hintMemoryQuota (122x)
+		57361: 22,  // hintMerge (122x)
+		57365: 23,  // hintMRR (122x)
+		57356: 24,  // hintNoBKA (122x)
+		57358: 25,  // hintNoBNL (122x)
+		57360: 26,  // hintNoHashJoin (122x)
+		57367: 27,  // hintNoICP (122x)
+		57364: 28,  // hintNoIndexMerge (122x)
+		57362: 29,  // hintNoMerge (122x)
+		57366: 30,  // hintNoMRR (122x)
+		57368: 31,  // hintNoRangeOptimization (122x)
+		57372: 32,  // hintNoSemijoin (122x)
+		57370: 33,  // hintNoSkipScan (122x)
+		57385: 34,  // hintNoSwapJoinInputs (122x)
+		57400: 35,  // hintNthPlan (122x)
+		57376: 36,  // hintQBName (122x)
+		57386: 37,  // hintQueryType (122x)
+		57387: 38,  // hintReadConsistentReplica (122x)
+		57388: 39,  // hintReadFromStorage (122x)
+		57375: 40,  // hintResourceGroup (122x)
+		57371: 41,  // hintSemijoin (122x)
+		57374: 42,  // hintSetVar (122x)
+		57369: 43,  // hintSkipScan (122x)
+		57389: 44,  // hintSMJoin (122x)
+		57392: 45,  // hintStreamAgg (122x)
+		57393: 46,  // hintSwapJoinInputs (122x)
+		57398: 47,  // hintTimeRange (122x)
+		57399: 48,  // hintUseCascades (122x)
+		57395: 49,  // hintUseIndex (122x)
+		57394: 50,  // hintUseIndexMerge (122x)
+		57396: 51,  // hintUsePlanCache (122x)
+		57397: 52,  // hintUseToja (122x)
 		44:    53,  // ',' (120x)
-		57411: 54,  // hintDupsWeedOut (100x)
-		57412: 55,  // hintFirstMatch (100x)
-		57413: 56,  // hintLooseScan (100x)
-		57414: 57,  // hintMaterialization (100x)
-		57406: 58,  // hintTiFlash (100x)
-		57405: 59,  // hintTiKV (100x)
-		57407: 60,  // hintFalse (99x)
-		57402: 61,  // hintOLAP (99x)
-		57403: 62,  // hintOLTP (99x)
-		57408: 63,  // hintTrue (99x)
-		57410: 64,  // hintGB (98x)
-		57409: 65,  // hintMB (98x)
+		57412: 54,  // hintDupsWeedOut (100x)
+		57413: 55,  // hintFirstMatch (100x)
+		57414: 56,  // hintLooseScan (100x)
+		57415: 57,  // hintMaterialization (100x)
+		57407: 58,  // hintTiFlash (100x)
+		57406: 59,  // hintTiKV (100x)
+		57408: 60,  // hintFalse (99x)
+		57403: 61,  // hintOLAP (99x)
+		57404: 62,  // hintOLTP (99x)
+		57409: 63,  // hintTrue (99x)
+		57411: 64,  // hintGB (98x)
+		57410: 65,  // hintMB (98x)
 		57347: 66,  // hintIdentifier (97x)
-		57348: 67,  // hintSingleAtIdentifier (82x)
+		57349: 67,  // hintSingleAtIdentifier (82x)
 		93:    68,  // ']' (76x)
-		57404: 69,  // hintPartition (70x)
+		57405: 69,  // hintPartition (70x)
 		46:    70,  // '.' (66x)
 		61:    71,  // '=' (66x)
 		40:    72,  // '(' (61x)
 		57344: 73,  // $end (24x)
-		57435: 74,  // QueryBlockOpt (17x)
-		57427: 75,  // Identifier (13x)
+		57436: 74,  // QueryBlockOpt (17x)
+		57428: 75,  // Identifier (13x)
 		57346: 76,  // hintIntLit (8x)
-		57349: 77,  // hintStringLit (5x)
-		57417: 78,  // CommaOpt (4x)
-		57423: 79,  // HintTable (4x)
-		57424: 80,  // HintTableList (4x)
+		57350: 77,  // hintStringLit (5x)
+		57418: 78,  // CommaOpt (4x)
+		57424: 79,  // HintTable (4x)
+		57425: 80,  // HintTableList (4x)
 		91:    81,  // '[' (3x)
-		57416: 82,  // BooleanHintName (2x)
-		57418: 83,  // HintIndexList (2x)
-		57420: 84,  // HintStorageType (2x)
-		57421: 85,  // HintStorageTypeAndTable (2x)
-		57425: 86,  // HintTableListOpt (2x)
-		57430: 87,  // JoinOrderOptimizerHintName (2x)
-		57431: 88,  // NullaryHintName (2x)
-		57434: 89,  // PartitionListOpt (2x)
-		57437: 90,  // StorageOptimizerHintOpt (2x)
-		57438: 91,  // SubqueryOptimizerHintName (2x)
-		57441: 92,  // SubqueryStrategy (2x)
-		57442: 93,  // SupportedIndexLevelOptimizerHintName (2x)
-		57443: 94,  // SupportedTableLevelOptimizerHintName (2x)
-		57444: 95,  // TableOptimizerHintOpt (2x)
-		57446: 96,  // UnsupportedIndexLevelOptimizerHintName (2x)
-		57447: 97,  // UnsupportedTableLevelOptimizerHintName (2x)
-		57419: 98,  // HintQueryType (1x)
-		57422: 99,  // HintStorageTypeAndTableList (1x)
-		57426: 100, // HintTrueOrFalse (1x)
-		57428: 101, // IndexNameList (1x)
-		57429: 102, // IndexNameListOpt (1x)
-		57432: 103, // OptimizerHintList (1x)
-		57433: 104, // PartitionList (1x)
-		57436: 105, // Start (1x)
-		57439: 106, // SubqueryStrategies (1x)
-		57440: 107, // SubqueryStrategiesOpt (1x)
-		57445: 108, // UnitOfBytes (1x)
-		57448: 109, // Value (1x)
-		57415: 110, // $default (0x)
+		57417: 82,  // BooleanHintName (2x)
+		57419: 83,  // HintIndexList (2x)
+		57421: 84,  // HintStorageType (2x)
+		57422: 85,  // HintStorageTypeAndTable (2x)
+		57426: 86,  // HintTableListOpt (2x)
+		57431: 87,  // JoinOrderOptimizerHintName (2x)
+		57432: 88,  // NullaryHintName (2x)
+		57435: 89,  // PartitionListOpt (2x)
+		57438: 90,  // StorageOptimizerHintOpt (2x)
+		57439: 91,  // SubqueryOptimizerHintName (2x)
+		57442: 92,  // SubqueryStrategy (2x)
+		57443: 93,  // SupportedIndexLevelOptimizerHintName (2x)
+		57444: 94,  // SupportedTableLevelOptimizerHintName (2x)
+		57445: 95,  // TableOptimizerHintOpt (2x)
+		57447: 96,  // UnsupportedIndexLevelOptimizerHintName (2x)
+		57448: 97,  // UnsupportedTableLevelOptimizerHintName (2x)
+		57420: 98,  // HintQueryType (1x)
+		57423: 99,  // HintStorageTypeAndTableList (1x)
+		57427: 100, // HintTrueOrFalse (1x)
+		57429: 101, // IndexNameList (1x)
+		57430: 102, // IndexNameListOpt (1x)
+		57433: 103, // OptimizerHintList (1x)
+		57434: 104, // PartitionList (1x)
+		57437: 105, // Start (1x)
+		57440: 106, // SubqueryStrategies (1x)
+		57441: 107, // SubqueryStrategiesOpt (1x)
+		57446: 108, // UnitOfBytes (1x)
+		57449: 109, // Value (1x)
+		57416: 110, // $default (0x)
 		57345: 111, // error (0x)
+		57348: 112, // hintInvalid (0x)
 	}
 
 	yyhintSymNames = []string{
@@ -347,6 +349,7 @@ var (
 		"Value",
 		"$default",
 		"error",
+		"hintInvalid",
 	}
 
 	yyhintReductions = []struct{ xsym, components int }{

--- a/parser/hintparser.y
+++ b/parser/hintparser.y
@@ -43,6 +43,7 @@ import (
 
 	/*yy:token "%c" */
 	hintIdentifier
+	hintInvalid    "a special token never used by parser, used by lexer to indicate error"
 
 	/*yy:token "@%c" */
 	hintSingleAtIdentifier "identifier with single leading at"

--- a/parser/hintparserimpl.go
+++ b/parser/hintparserimpl.go
@@ -16,7 +16,6 @@ package parser
 import (
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -51,7 +50,7 @@ func (hs *hintScanner) Lex(lval *yyhintSymType) int {
 		n, e := strconv.ParseUint(lit, 10, 64)
 		if e != nil {
 			hs.AppendError(ErrWarnOptimizerHintInvalidInteger.GenWithStackByArgs(lit))
-			return int(unicode.ReplacementChar)
+			return hintInvalid
 		}
 		lval.number = n
 		return hintIntLit
@@ -108,7 +107,7 @@ func (hs *hintScanner) Lex(lval *yyhintSymType) int {
 	}
 
 	hs.AppendError(ErrWarnOptimizerHintInvalidToken.GenWithStackByArgs(errorTokenType, lit, tok))
-	return int(unicode.ReplacementChar)
+	return hintInvalid
 }
 
 type hintParser struct {

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -159,7 +159,11 @@ func (s *Scanner) convert2Connection(tok int, lit string) (int, string) {
 		}
 		s.lastErrorAsWarn()
 	}
-	utf8Lit, _ = s.connection.Transform(nil, utf8Lit, charset.OpReplace)
+
+	// It is definitely valid if `client` is the same with `connection`, so just transform if they are not the same.
+	if s.client.Tp() != s.connection.Tp() {
+		utf8Lit, _ = s.connection.Transform(nil, utf8Lit, charset.OpReplace)
+	}
 	return tok, string(utf8Lit)
 }
 

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -89,8 +89,8 @@ func (s *Scanner) Errors() (warns []error, errs []error) {
 
 // reset resets the sql string to be scanned.
 func (s *Scanner) reset(sql string) {
-	s.client = charset.EncodingUTF8Impl
-	s.connection = charset.EncodingUTF8Impl
+	s.client = charset.FindEncodingTakeUTF8AsNoop(mysql.DefaultCharset)
+	s.connection = charset.FindEncodingTakeUTF8AsNoop(mysql.DefaultCharset)
 	s.r = reader{s: sql, p: Pos{Line: 1}, l: len(sql)}
 	s.buf.Reset()
 	s.errs = s.errs[:0]

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
-	"unicode/utf8"
 
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -234,10 +233,6 @@ func (s *Scanner) Lex(v *yySymType) int {
 		s.identifierDot = s.r.peek() == '.'
 	}
 
-	if tok == unicode.ReplacementChar {
-		return invalid
-	}
-
 	return tok
 }
 
@@ -297,13 +292,15 @@ func (s *Scanner) handleIdent(lval *yySymType) int {
 	return underscoreCS
 }
 
-func (s *Scanner) skipWhitespace() rune {
-	return s.r.incAsLongAs(unicode.IsSpace)
+func (s *Scanner) skipWhitespace() byte {
+	return s.r.incAsLongAs(func(b byte) bool {
+		return unicode.IsSpace(rune(b))
+	})
 }
 
 func (s *Scanner) scan() (tok int, pos Pos, lit string) {
 	ch0 := s.r.peek()
-	if unicode.IsSpace(ch0) {
+	if unicode.IsSpace(rune(ch0)) {
 		ch0 = s.skipWhitespace()
 	}
 	pos = s.r.pos()
@@ -319,10 +316,7 @@ func (s *Scanner) scan() (tok int, pos Pos, lit string) {
 
 	// search a trie to get a token.
 	node := &ruleTable
-	for ch0 >= 0 && ch0 <= 255 {
-		if node.childs[ch0] == nil || s.r.eof() {
-			break
-		}
+	for !(node.childs[ch0] == nil || s.r.eof()) {
 		node = node.childs[ch0]
 		if node.fn != nil {
 			return node.fn(s)
@@ -345,7 +339,7 @@ func startWithXx(s *Scanner) (tok int, pos Pos, lit string) {
 			s.r.inc()
 			tok, lit = hexLit, s.r.data(&pos)
 		} else {
-			tok = unicode.ReplacementChar
+			tok = invalid
 		}
 		return
 	}
@@ -377,7 +371,7 @@ func startWithBb(s *Scanner) (tok int, pos Pos, lit string) {
 			s.r.inc()
 			tok, lit = bitLit, s.r.data(&pos)
 		} else {
-			tok = unicode.ReplacementChar
+			tok = invalid
 		}
 		return
 	}
@@ -386,7 +380,7 @@ func startWithBb(s *Scanner) (tok int, pos Pos, lit string) {
 }
 
 func startWithSharp(s *Scanner) (tok int, pos Pos, lit string) {
-	s.r.incAsLongAs(func(ch rune) bool {
+	s.r.incAsLongAs(func(ch byte) bool {
 		return ch != '\n'
 	})
 	return s.scan()
@@ -397,7 +391,7 @@ func startWithDash(s *Scanner) (tok int, pos Pos, lit string) {
 	if strings.HasPrefix(s.r.s[pos.Offset:], "--") {
 		remainLen := len(s.r.s[pos.Offset:])
 		if remainLen == 2 || (remainLen > 2 && unicode.IsSpace(rune(s.r.s[pos.Offset+2]))) {
-			s.r.incAsLongAs(func(ch rune) bool {
+			s.r.incAsLongAs(func(ch byte) bool {
 				return ch != '\n'
 			})
 			return s.scan()
@@ -483,7 +477,7 @@ func startWithSlash(s *Scanner) (tok int, pos Pos, lit string) {
 
 	// standard C-like comment. read until we see '*/' then drop it.
 	for {
-		if currentCharIsStar || s.r.incAsLongAs(func(ch rune) bool { return ch != '*' }) == '*' {
+		if currentCharIsStar || s.r.incAsLongAs(func(ch byte) bool { return ch != '*' }) == '*' {
 			switch s.r.readByte() {
 			case '/':
 				// Meets */, means comment end.
@@ -549,7 +543,7 @@ func startWithAt(s *Scanner) (tok int, pos Pos, lit string) {
 		case identifier:
 			tok, lit = doubleAtIdentifier, s.r.data(&pos)
 		}
-	case unicode.ReplacementChar:
+	case invalid:
 		break
 	default:
 		tok = singleAtIdentifier
@@ -591,12 +585,8 @@ func scanQuotedIdent(s *Scanner) (tok int, pos Pos, lit string) {
 	pos = s.r.pos()
 	s.r.inc()
 	s.buf.Reset()
-	for {
+	for !s.r.eof() {
 		ch := s.r.readByte()
-		if ch == unicode.ReplacementChar && s.r.eof() {
-			tok = unicode.ReplacementChar
-			return
-		}
 		if ch == '`' {
 			if s.r.peek() != '`' {
 				// don't return identifier in case that it's interpreted as keyword token later.
@@ -605,8 +595,10 @@ func scanQuotedIdent(s *Scanner) (tok int, pos Pos, lit string) {
 			}
 			s.r.inc()
 		}
-		s.buf.WriteRune(ch)
+		s.buf.WriteByte(ch)
 	}
+	tok = invalid
+	return
 }
 
 func startString(s *Scanner) (tok int, pos Pos, lit string) {
@@ -655,59 +647,76 @@ func (mb *lazyBuf) data() string {
 
 func (s *Scanner) scanString() (tok int, pos Pos, lit string) {
 	tok, pos = stringLit, s.r.pos()
-	mb := lazyBuf{false, &s.r, &s.buf, &pos}
 	ending := s.r.readByte()
-	ch0 := s.r.peek()
+	foundEscape := false
 	for !s.r.eof() {
+		ch0 := s.r.readByte()
 		if ch0 == ending {
-			s.r.inc()
-			if s.r.peek() != ending {
-				lit = mb.data()
+			if s.r.peek() == ending {
+				s.r.inc()
+				foundEscape = true
+				continue
+			}
+			str := s.r.data(&pos)
+			if foundEscape {
+				lit = handleEscape(str[1:len(str)-1], ending)
 				return
 			}
-			str := mb.r.data(&pos)
-			mb.setUseBuf(str[1 : len(str)-1])
+			lit = str[1 : len(str)-1]
+			return
 		} else if ch0 == '\\' && !s.sqlMode.HasNoBackslashEscapesMode() {
-			mb.setUseBuf(mb.r.data(&pos)[1:])
-			ch0 = handleEscape(s)
-		}
-		mb.writeRune(ch0, s.r.w)
-		if !s.r.eof() {
+			if s.r.eof() {
+				break
+			}
 			s.r.inc()
-			ch0 = s.r.peek()
+			foundEscape = true
 		}
 	}
 
-	tok = unicode.ReplacementChar
+	tok = invalid
 	return
 }
 
 // handleEscape handles the case in scanString when previous char is '\'.
-func handleEscape(s *Scanner) rune {
-	s.r.inc()
-	ch0 := s.r.peek()
-	/*
-		\" \' \\ \n \0 \b \Z \r \t ==> escape to one char
-		\% \_ ==> preserve both char
-		other ==> remove \
-	*/
-	switch ch0 {
-	case 'n':
-		ch0 = '\n'
-	case '0':
-		ch0 = 0
-	case 'b':
-		ch0 = 8
-	case 'Z':
-		ch0 = 26
-	case 'r':
-		ch0 = '\r'
-	case 't':
-		ch0 = '\t'
-	case '%', '_':
-		s.buf.WriteByte('\\')
+func handleEscape(s string, sep byte) string {
+	var buf bytes.Buffer
+	var ch0 byte
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\\' {
+			switch s[i+1] {
+			/*
+				\" \' \\ \n \0 \b \Z \r \t ==> escape to one char
+				\% \_ ==> preserve both char
+				other ==> remove \
+			*/
+			case 'n':
+				ch0 = '\n'
+			case '0':
+				ch0 = 0
+			case 'b':
+				ch0 = 8
+			case 'Z':
+				ch0 = 26
+			case 'r':
+				ch0 = '\r'
+			case 't':
+				ch0 = '\t'
+			case '%', '_':
+				buf.WriteByte('\\')
+				ch0 = s[i+1]
+			default:
+				ch0 = s[i+1]
+			}
+			buf.WriteByte(ch0)
+			i++
+		} else if s[i] == sep {
+			buf.WriteByte(s[i])
+			i++
+		} else {
+			buf.WriteByte(s[i])
+		}
 	}
-	return ch0
+	return buf.String()
 }
 
 func startWithNumber(s *Scanner) (tok int, pos Pos, lit string) {
@@ -787,13 +796,13 @@ func startWithDot(s *Scanner) (tok int, pos Pos, lit string) {
 }
 
 func (s *Scanner) scanOct() {
-	s.r.incAsLongAs(func(ch rune) bool {
+	s.r.incAsLongAs(func(ch byte) bool {
 		return ch >= '0' && ch <= '7'
 	})
 }
 
 func (s *Scanner) scanHex() {
-	s.r.incAsLongAs(func(ch rune) bool {
+	s.r.incAsLongAs(func(ch byte) bool {
 		return ch >= '0' && ch <= '9' ||
 			ch >= 'a' && ch <= 'f' ||
 			ch >= 'A' && ch <= 'F'
@@ -801,7 +810,7 @@ func (s *Scanner) scanHex() {
 }
 
 func (s *Scanner) scanBit() {
-	s.r.incAsLongAs(func(ch rune) bool {
+	s.r.incAsLongAs(func(ch byte) bool {
 		return ch == '0' || ch == '1'
 	})
 }
@@ -881,7 +890,7 @@ func (s *Scanner) scanFeatureIDs() (featureIDs []string) {
 			return nil
 		case expectChar:
 			if isIdentChar(ch) {
-				b.WriteRune(ch)
+				b.WriteByte(ch)
 				state = obtainChar
 				break
 			}
@@ -889,7 +898,7 @@ func (s *Scanner) scanFeatureIDs() (featureIDs []string) {
 			return nil
 		case obtainChar:
 			if isIdentChar(ch) {
-				b.WriteRune(ch)
+				b.WriteByte(ch)
 				state = obtainChar
 				break
 			} else if ch == ',' {
@@ -921,9 +930,6 @@ type reader struct {
 	s string
 	p Pos
 	w int
-
-	peekRune        rune
-	peekRuneUpdated bool
 }
 
 var eof = Pos{-1, -1, -1}
@@ -933,26 +939,14 @@ func (r *reader) eof() bool {
 }
 
 // peek() peeks a rune from underlying reader.
-// if reader meets EOF, it will return unicode.ReplacementChar. to distinguish from
-// the real unicode.ReplacementChar, the caller should call r.eof() again to check.
-func (r *reader) peek() rune {
-	if r.peekRuneUpdated {
-		return r.peekRune
-	}
+// if reader meets EOF, it will return 0. to distinguish from
+// the real 0, the caller should call r.eof() again to check.
+func (r *reader) peek() byte {
 	if r.eof() {
-		return unicode.ReplacementChar
+		return 0
 	}
-	v, w := rune(r.s[r.p.Offset]), 1
-	if v >= 0x80 {
-		v, w = utf8.DecodeRuneInString(r.s[r.p.Offset:])
-		if v == utf8.RuneError && w == 1 {
-			v = rune(r.s[r.p.Offset]) // illegal encoding
-		}
-	}
-	r.w = w
-	r.peekRune = v
-	r.peekRuneUpdated = true
-	return v
+	r.w = 1
+	return r.s[r.p.Offset]
 }
 
 // inc increase the position offset of the reader.
@@ -964,7 +958,6 @@ func (r *reader) inc() {
 	}
 	r.p.Offset += r.w
 	r.p.Col++
-	r.peekRuneUpdated = false
 }
 
 func (r *reader) incN(n int) {
@@ -973,9 +966,9 @@ func (r *reader) incN(n int) {
 	}
 }
 
-func (r *reader) readByte() (ch rune) {
+func (r *reader) readByte() (ch byte) {
 	ch = r.peek()
-	if ch == unicode.ReplacementChar && r.eof() {
+	if r.eof() {
 		return
 	}
 	r.inc()
@@ -987,9 +980,6 @@ func (r *reader) pos() Pos {
 }
 
 func (r *reader) updatePos(pos Pos) {
-	if r.p.Offset != pos.Offset {
-		r.peekRuneUpdated = false
-	}
 	r.p = pos
 }
 
@@ -997,13 +987,13 @@ func (r *reader) data(from *Pos) string {
 	return r.s[from.Offset:r.p.Offset]
 }
 
-func (r *reader) incAsLongAs(fn func(rune) bool) rune {
+func (r *reader) incAsLongAs(fn func(b byte) bool) byte {
 	for {
 		ch := r.peek()
 		if !fn(ch) {
 			return ch
 		}
-		if ch == unicode.ReplacementChar && r.eof() {
+		if r.eof() {
 			return 0
 		}
 		r.inc()

--- a/parser/lexer.go
+++ b/parser/lexer.go
@@ -89,8 +89,8 @@ func (s *Scanner) Errors() (warns []error, errs []error) {
 
 // reset resets the sql string to be scanned.
 func (s *Scanner) reset(sql string) {
-	s.client = charset.FindEncodingTakeUTF8AsNoop(mysql.DefaultCharset)
-	s.connection = charset.FindEncodingTakeUTF8AsNoop(mysql.DefaultCharset)
+	s.client = charset.FindEncoding(mysql.DefaultCharset)
+	s.connection = charset.FindEncoding(mysql.DefaultCharset)
 	s.r = reader{s: sql, p: Pos{Line: 1}, l: len(sql)}
 	s.buf.Reset()
 	s.errs = s.errs[:0]

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -328,12 +328,12 @@ func TestSpecialComment(t *testing.T) {
 	tok, pos, lit := l.scan()
 	requires.Equal(t, identifier, tok)
 	requires.Equal(t, "select", lit)
-	requires.Equal(t, Pos{0, 9, 9}, pos)
+	requires.Equal(t, Pos{1, 9, 9}, pos)
 
 	tok, pos, lit = l.scan()
 	requires.Equal(t, intLit, tok)
 	requires.Equal(t, "5", lit)
-	requires.Equal(t, Pos{1, 1, 16}, pos)
+	requires.Equal(t, Pos{2, 1, 16}, pos)
 }
 
 func TestFeatureIDsComment(t *testing.T) {
@@ -341,12 +341,12 @@ func TestFeatureIDsComment(t *testing.T) {
 	tok, pos, lit := l.scan()
 	requires.Equal(t, identifier, tok)
 	requires.Equal(t, "auto_random", lit)
-	requires.Equal(t, Pos{0, 16, 16}, pos)
+	requires.Equal(t, Pos{1, 16, 16}, pos)
 	tok, pos, _ = l.scan()
 	requires.Equal(t, int('('), tok)
 	_, pos, lit = l.scan()
 	requires.Equal(t, "5", lit)
-	requires.Equal(t, Pos{0, 28, 28}, pos)
+	requires.Equal(t, Pos{1, 28, 28}, pos)
 	tok, pos, _ = l.scan()
 	requires.Equal(t, int(')'), tok)
 

--- a/parser/lexer_test.go
+++ b/parser/lexer_test.go
@@ -213,13 +213,13 @@ func runLiteralTest(t *testing.T, table []testLiteralValue) {
 		val := l.LexLiteral()
 		switch val.(type) {
 		case int64:
-			requires.Equal(t, val, v.val, v.str)
+			requires.Equal(t, v.val, val, v.str)
 		case float64:
-			requires.Equal(t, val, v.val, v.str)
+			requires.Equal(t, v.val, val, v.str)
 		case string:
-			requires.Equal(t, val, v.val, v.str)
+			requires.Equal(t, v.val, val, v.str)
 		default:
-			requires.Equal(t, fmt.Sprint(val), v.val, v.str)
+			requires.Equal(t, v.val, fmt.Sprint(val), v.str)
 		}
 	}
 }
@@ -294,7 +294,6 @@ func TestScanString(t *testing.T) {
 }
 
 func TestIdentifier(t *testing.T) {
-	replacementString := string(unicode.ReplacementChar) + "xxx"
 	table := [][2]string{
 		{`哈哈`, "哈哈"},
 		{"`numeric`", "numeric"},
@@ -302,7 +301,7 @@ func TestIdentifier(t *testing.T) {
 		{`5number`, `5number`},
 		{"1_x", "1_x"},
 		{"0_x", "0_x"},
-		{replacementString, replacementString},
+		{string(unicode.ReplacementChar) + "xxx", string(unicode.ReplacementChar) + "xxx"},
 		{"9e", "9e"},
 		{"0b", "0b"},
 		{"0b123", "0b123"},
@@ -319,8 +318,8 @@ func TestIdentifier(t *testing.T) {
 		l.reset(item[0])
 		var v yySymType
 		tok := l.Lex(&v)
-		requires.Equal(t, identifier, tok)
-		requires.Equal(t, item[1], v.ident)
+		requires.Equal(t, identifier, tok, item)
+		requires.Equal(t, item[1], v.ident, item)
 	}
 }
 
@@ -544,13 +543,13 @@ func TestVersionDigits(t *testing.T) {
 		input    string
 		min      int
 		max      int
-		nextChar rune
+		nextChar byte
 	}{
 		{
 			input:    "12345",
 			min:      5,
 			max:      5,
-			nextChar: unicode.ReplacementChar,
+			nextChar: 0,
 		},
 		{
 			input:    "12345xyz",
@@ -580,7 +579,7 @@ func TestVersionDigits(t *testing.T) {
 			input:    "",
 			min:      5,
 			max:      5,
-			nextChar: unicode.ReplacementChar,
+			nextChar: 0,
 		},
 		{
 			input:    "1234567xyz",
@@ -598,7 +597,7 @@ func TestVersionDigits(t *testing.T) {
 			input:    "12345",
 			min:      5,
 			max:      6,
-			nextChar: unicode.ReplacementChar,
+			nextChar: 0,
 		},
 		{
 			input:    "1234xyz",
@@ -621,12 +620,12 @@ func TestFeatureIDs(t *testing.T) {
 	tests := []struct {
 		input      string
 		featureIDs []string
-		nextChar   rune
+		nextChar   byte
 	}{
 		{
 			input:      "[feature]",
 			featureIDs: []string{"feature"},
-			nextChar:   unicode.ReplacementChar,
+			nextChar:   0,
 		},
 		{
 			input:      "[feature] xx",
@@ -636,17 +635,17 @@ func TestFeatureIDs(t *testing.T) {
 		{
 			input:      "[feature1,feature2]",
 			featureIDs: []string{"feature1", "feature2"},
-			nextChar:   unicode.ReplacementChar,
+			nextChar:   0,
 		},
 		{
 			input:      "[feature1,feature2,feature3]",
 			featureIDs: []string{"feature1", "feature2", "feature3"},
-			nextChar:   unicode.ReplacementChar,
+			nextChar:   0,
 		},
 		{
 			input:      "[id_en_ti_fier]",
 			featureIDs: []string{"id_en_ti_fier"},
-			nextChar:   unicode.ReplacementChar,
+			nextChar:   0,
 		},
 		{
 			input:      "[invalid,    whitespace]",

--- a/parser/misc.go
+++ b/parser/misc.go
@@ -13,23 +13,23 @@
 
 package parser
 
-func isLetter(ch rune) bool {
+func isLetter(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
 }
 
-func isDigit(ch rune) bool {
+func isDigit(ch byte) bool {
 	return ch >= '0' && ch <= '9'
 }
 
-func isIdentChar(ch rune) bool {
+func isIdentChar(ch byte) bool {
 	return isLetter(ch) || isDigit(ch) || ch == '_' || ch == '$' || isIdentExtend(ch)
 }
 
-func isIdentExtend(ch rune) bool {
-	return ch >= 0x80 && ch <= '\uffff'
+func isIdentExtend(ch byte) bool {
+	return ch >= 0x80
 }
 
-func isUserVarChar(ch rune) bool {
+func isUserVarChar(ch byte) bool {
 	return isLetter(ch) || isDigit(ch) || ch == '_' || ch == '$' || ch == '.' || isIdentExtend(ch)
 }
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -6428,6 +6428,7 @@ func TestGBKEncoding(t *testing.T) {
 		{"select '\xa5\x5c'", false},
 		{"select '''\xa5\x5c'", false},
 		{"select ```\xa5\x5c`", false},
+		{"select '\x65\x5c'", true},
 	} {
 		_, _, err = p.ParseSQL(test.sql, gbkOpt)
 		if test.err {

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -258,7 +258,7 @@ func toInt(l yyLexer, lval *yySymType, str string) int {
 			return toDecimal(l, lval, str)
 		}
 		l.AppendError(l.Errorf("integer literal: %v", err))
-		return int(unicode.ReplacementChar)
+		return invalid
 	}
 
 	switch {
@@ -293,7 +293,7 @@ func toFloat(l yyLexer, lval *yySymType, str string) int {
 			return int(unicode.ReplacementChar)
 		}
 		l.AppendError(l.Errorf("float literal: %v", err))
-		return int(unicode.ReplacementChar)
+		return invalid
 	}
 
 	lval.item = n
@@ -305,7 +305,7 @@ func toHex(l yyLexer, lval *yySymType, str string) int {
 	h, err := ast.NewHexLiteral(str)
 	if err != nil {
 		l.AppendError(l.Errorf("hex literal: %v", err))
-		return int(unicode.ReplacementChar)
+		return invalid
 	}
 	lval.item = h
 	return hexLit
@@ -316,7 +316,7 @@ func toBit(l yyLexer, lval *yySymType, str string) int {
 	b, err := ast.NewBitLiteral(str)
 	if err != nil {
 		l.AppendError(l.Errorf("bit literal: %v", err))
-		return int(unicode.ReplacementChar)
+		return invalid
 	}
 	lval.item = b
 	return bitLit

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -412,7 +412,7 @@ func (c CharsetConnection) ApplyOn(p *Parser) error {
 	} else {
 		p.charset = string(c)
 	}
-	p.lexer.connection = charset.FindEncoding(p.charset)
+	p.lexer.connection = charset.FindEncodingTakeUTF8AsNoop(string(c))
 	return nil
 }
 

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -412,7 +412,7 @@ func (c CharsetConnection) ApplyOn(p *Parser) error {
 	} else {
 		p.charset = string(c)
 	}
-	p.lexer.connection = charset.FindEncodingTakeUTF8AsNoop(string(c))
+	p.lexer.connection = charset.FindEncoding(string(c))
 	return nil
 }
 
@@ -435,6 +435,6 @@ type CharsetClient string
 
 // ApplyOn implements ParseParam interface.
 func (c CharsetClient) ApplyOn(p *Parser) error {
-	p.lexer.client = charset.FindEncodingTakeUTF8AsNoop(string(c))
+	p.lexer.client = charset.FindEncoding(string(c))
 	return nil
 }

--- a/parser/yy_parser.go
+++ b/parser/yy_parser.go
@@ -289,7 +289,7 @@ func toFloat(l yyLexer, lval *yySymType, str string) int {
 		e := err.(*strconv.NumError)
 		if e.Err == strconv.ErrRange {
 			l.AppendError(types.ErrIllegalValueForType.GenWithStackByArgs("double", str))
-			return int(unicode.ReplacementChar)
+			return invalid
 		}
 		l.AppendError(l.Errorf("float literal: %v", err))
 		return invalid


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/30765
close https://github.com/pingcap/tidb/issues/29382

this pr is based on https://github.com/pingcap/tidb/pull/29573. please only review the second commit.
It will make the parser compatible with MySQL in parsing gbk encoding characters.

```go
// benchcode
func BenchmarkParser(b *testing.B) {
	p := parser.New()
	sql := "select '" + strings.Repeat("这是一个测试", 10000) + "' as " + strings.Repeat("aaaaa", 10000)
	b.ResetTimer()
	for i := 0; i < b.N; i++ {
		_, _, err := p.ParseSQL(sql)
		require.NoError(b, err)
	}
}
```

`client=utf8 & connection=utf8`
```
before                       after
876	   1410416 ns/op     775	   1497224 ns/op
829	   1427232 ns/op     831	   1486620 ns/op
686	   1570810 ns/op     660	   1678825 ns/op
747	   1512891 ns/op     622	   1718708 ns/op
781	   1512988 ns/op     706	   1662557 ns/op
```
![image](https://user-images.githubusercontent.com/20839912/147526848-c9e2c5ec-42f9-4cf4-be86-0e9fc3f3e1fd.png)

`client=gbk & connection=utf8`
`client=gbk & connection=gbk`
```
240	   5076879 ns/op
237	   5216370 ns/op
232	   5058759 ns/op
234	   5134991 ns/op
234	   5142602 ns/op
```
![image](https://user-images.githubusercontent.com/20839912/147526757-d1fb8f4c-edf7-4cfa-a262-05518ed217a4.png)

we need optimize `convert2Connection` function
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
