### PR TITLE
types: BIT to CHAR conversion should change to uint first

### DIFF
--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -2284,6 +2284,7 @@ func (s *testColumnTypeChangeSuite) TestChangeFromUnsignedIntToTime(c *C) {
 }
 
 // See https://github.com/pingcap/tidb/issues/25287.
+// Revised according to https://github.com/pingcap/tidb/pull/31031#issuecomment-1001404832.
 func (s *testColumnTypeChangeSuite) TestChangeFromBitToStringInvalidUtf8ErrMsg(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test;")
@@ -2291,8 +2292,8 @@ func (s *testColumnTypeChangeSuite) TestChangeFromBitToStringInvalidUtf8ErrMsg(c
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (a bit(45));")
 	tk.MustExec("insert into t values (1174717);")
-	errMsg := "[table:1366]Incorrect string value '\\xEC\\xBD' for column 'a'"
-	tk.MustGetErrMsg("alter table t modify column a varchar(31) collate utf8mb4_general_ci;", errMsg)
+	tk.MustExec("alter table t modify column a varchar(31) collate utf8mb4_general_ci;")
+	tk.MustQuery("select a from t;").Check(testkit.Rows("1174717"))
 }
 
 func (s *testColumnTypeChangeSuite) TestForIssue24621(c *C) {

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -837,7 +837,7 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromNumericToOthers(c *C
 	tk.MustExec("alter table t modify f32 blob")
 	tk.MustExec("alter table t modify f64 blob")
 	tk.MustExec("alter table t modify b blob")
-	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 21"))
 
 	// text
 	reset(tk)
@@ -850,7 +850,7 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromNumericToOthers(c *C
 	tk.MustExec("alter table t modify f32 text")
 	tk.MustExec("alter table t modify f64 text")
 	tk.MustExec("alter table t modify b text")
-	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 21"))
 
 	// enum
 	reset(tk)

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -797,7 +797,7 @@ func (s *testColumnTypeChangeSuite) TestColumnTypeChangeFromNumericToOthers(c *C
 	// MySQL will get "ERROR 1406 (22001): Data truncation: Data too long for column 'f64' at row 1".
 	tk.MustExec("alter table t modify f64 varchar(30)")
 	tk.MustExec("alter table t modify b varchar(30)")
-	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 \x15"))
+	tk.MustQuery("select * from t").Check(testkit.Rows("-258.1234500 333.33 2000000.20000002 323232323.32323235 -111.111115 -222222222222.22223 21"))
 
 	// binary
 	reset(tk)

--- a/types/datum.go
+++ b/types/datum.go
@@ -964,7 +964,7 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 	case KindBinaryLiteral:
 		s = d.GetBinaryLiteral().ToString()
 	case KindMysqlBit:
-		// https://github.com/pingcap/tidb/issues/25037.
+		// https://github.com/pingcap/tidb/issues/31124.
 		// Consider converting to uint first.
 		val, err := d.GetBinaryLiteral().ToInt(sc)
 		if err != nil {

--- a/types/datum.go
+++ b/types/datum.go
@@ -964,17 +964,13 @@ func (d *Datum) convertToString(sc *stmtctx.StatementContext, target *FieldType)
 	case KindBinaryLiteral:
 		s = d.GetBinaryLiteral().ToString()
 	case KindMysqlBit:
-		// issue #25037
-		// bit to binary/varbinary. should consider transferring to uint first.
-		if target.Tp == mysql.TypeString || (target.Tp == mysql.TypeVarchar && target.Collate == charset.CollationBin) {
-			val, err := d.GetBinaryLiteral().ToInt(sc)
-			if err != nil {
-				s = d.GetBinaryLiteral().ToString()
-			} else {
-				s = strconv.FormatUint(val, 10)
-			}
-		} else {
+		// https://github.com/pingcap/tidb/issues/25037.
+		// Consider converting to uint first.
+		val, err := d.GetBinaryLiteral().ToInt(sc)
+		if err != nil {
 			s = d.GetBinaryLiteral().ToString()
+		} else {
+			s = strconv.FormatUint(val, 10)
 		}
 	case KindMysqlJSON:
 		s = d.GetMysqlJSON().String()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31124

I try it on MySQL 5.7.36 and 8.0.27:
```sql
mysql> create table t (a bit(45));
Query OK, 0 rows affected (0.02 sec)

mysql> insert into t values (117471723421);
Query OK, 1 row affected (0.01 sec)

mysql> alter table t modify column a varchar(31) collate utf8mb4_general_ci;
Query OK, 1 row affected (0.05 sec)
Records: 1  Duplicates: 0  Warnings: 0

mysql> select * from t;
+--------------+
| a            |
+--------------+
| 117471723421 |
+--------------+
1 row in set (0.03 sec)
```

We can see that even if non-binary string, the `bit` type is changed to `int` first instead of `varchar` directly. This is conflict with https://github.com/pingcap/tidb/issues/25037#issuecomment-852985135:
> 2: when cast the bit to binary, we should consider to convert it to uint then cast uint to string, rather than takeing the bit to string directly.


### What is changed and how it works?

Always change to uint first.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
