### PR TITLE
session: show actual error in TestPessimisticLockNonExistsKey

### DIFF
--- a/session/pessimistic_test.go
+++ b/session/pessimistic_test.go
@@ -1164,11 +1164,11 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err := tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue, Commentf("got %v", err))
 	err = tk1.ExecToErr("select * from t where k = 4 for update nowait")
-	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue, Commentf("got %v", err))
 	err = tk1.ExecToErr("select * from t where k = 7 for update nowait")
-	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue, Commentf("got %v", err))
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 
@@ -1180,9 +1180,9 @@ func (s *testPessimisticSuite) TestPessimisticLockNonExistsKey(c *C) {
 
 	tk1.MustExec("begin pessimistic")
 	err = tk1.ExecToErr("select * from t where k = 2 for update nowait")
-	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue, Commentf("got %v", err))
 	err = tk1.ExecToErr("select * from t where k = 6 for update nowait")
-	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue)
+	c.Check(storeerr.ErrLockAcquireFailAndNoWaitSet.Equal(err), IsTrue, Commentf("got %v", err))
 	tk.MustExec("rollback")
 	tk1.MustExec("rollback")
 }


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close nothing

Problem Summary:

`TestPessimisticLockNonExistsKey` is unstable (https://github.com/pingcap/tidb/issues/30677), however we don't known what happened. This PR print the actual error if the test fails again to help investigate the problem.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
