### PR TITLE
collation: make gbk default collation to `gbk_bin` if new collation is not enabled

### DIFF
--- a/cmd/explaintest/r/new_character_set.result
+++ b/cmd/explaintest/r/new_character_set.result
@@ -66,3 +66,24 @@ b	d
 select hex(b), hex(d) from t;
 hex(b)	hex(d)
 E4BDA0E5A5BD	7B22B2E2CAD4223A2022C4E3BAC3227D
+show charset;
+Charset	Description	Default collation	Maxlen
+ascii	US ASCII	ascii_bin	1
+binary	binary	binary	1
+gbk	Chinese Internal Code Specification	gbk_chinese_ci	2
+latin1	Latin1	latin1_bin	1
+utf8	UTF-8 Unicode	utf8_bin	3
+utf8mb4	UTF-8 Unicode	utf8mb4_bin	4
+show collation;
+Collation	Charset	Id	Default	Compiled	Sortlen
+ascii_bin	ascii	65	Yes	Yes	1
+binary	binary	63	Yes	Yes	1
+gbk_bin	gbk	87		Yes	1
+gbk_chinese_ci	gbk	28	Yes	Yes	1
+latin1_bin	latin1	47	Yes	Yes	1
+utf8_bin	utf8	83	Yes	Yes	1
+utf8_general_ci	utf8	33		Yes	1
+utf8_unicode_ci	utf8	192		Yes	1
+utf8mb4_bin	utf8mb4	46	Yes	Yes	1
+utf8mb4_general_ci	utf8mb4	45		Yes	1
+utf8mb4_unicode_ci	utf8mb4	224		Yes	1

--- a/cmd/explaintest/t/new_character_set.test
+++ b/cmd/explaintest/t/new_character_set.test
@@ -46,3 +46,5 @@ create table t (b blob, d json);
 insert into t values ('你好', '{"测试": "你好"}');
 select b, d from t;
 select hex(b), hex(d) from t;
+show charset;
+show collation;

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -1164,6 +1164,8 @@ func (s *testColumnSuite) TestDropColumns(c *C) {
 }
 
 func TestModifyColumn(t *testing.T) {
+	collate.SetNewCollationEnabledForTest(true)
+	defer collate.SetNewCollationEnabledForTest(false)
 	collate.SetCharsetFeatEnabledForTest(true)
 	defer collate.SetCharsetFeatEnabledForTest(false)
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -5803,7 +5803,7 @@ func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 	tk.MustQuery("show charset").Check(testkit.Rows(
 		"ascii US ASCII ascii_bin 1",
 		"binary binary binary 1",
-		"gbk Chinese Internal Code Specification gbk_chinese_ci 2",
+		"gbk Chinese Internal Code Specification gbk_utf8mb4_bin 2",
 		"latin1 Latin1 latin1_bin 1",
 		"utf8 UTF-8 Unicode utf8_bin 3",
 		"utf8mb4 UTF-8 Unicode utf8mb4_bin 4",
@@ -5814,6 +5814,7 @@ func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 		"binary binary 63 Yes Yes 1",
 		"ascii_bin ascii 65 Yes Yes 1",
 		"utf8_bin utf8 83 Yes Yes 1",
+		"gbk_utf8mb4_bin gbk 0 Yes Yes 1",
 	))
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -108,6 +108,7 @@ var _ = Suite(&testSuiteP2{&baseTestSuite{}})
 var _ = Suite(&testSuite1{})
 var _ = SerialSuites(&testSerialSuite2{})
 var _ = SerialSuites(&testSuiteWithCliBaseCharset{})
+var _ = SerialSuites(&testSuiteWithCliBaseCharsetNoNewCollation{})
 var _ = Suite(&testSuite2{&baseTestSuite{}})
 var _ = Suite(&testSuite3{&baseTestSuite{}})
 var _ = Suite(&testSuite4{&baseTestSuite{}})
@@ -3441,11 +3442,27 @@ type testSuiteWithCliBaseCharset struct {
 }
 
 func (s *testSuiteWithCliBaseCharset) SetUpSuite(c *C) {
+	collate.SetNewCollationEnabledForTest(true)
 	collate.SetCharsetFeatEnabledForTest(true)
 	s.testSuiteWithCliBase.SetUpSuite(c)
 }
 
 func (s *testSuiteWithCliBaseCharset) TearDownSuite(c *C) {
+	s.testSuiteWithCliBase.TearDownSuite(c)
+	collate.SetNewCollationEnabledForTest(false)
+	collate.SetCharsetFeatEnabledForTest(false)
+}
+
+type testSuiteWithCliBaseCharsetNoNewCollation struct {
+	testSuiteWithCliBase
+}
+
+func (s *testSuiteWithCliBaseCharsetNoNewCollation) SetUpSuite(c *C) {
+	collate.SetCharsetFeatEnabledForTest(true)
+	s.testSuiteWithCliBase.SetUpSuite(c)
+}
+
+func (s *testSuiteWithCliBaseCharsetNoNewCollation) TearDownSuite(c *C) {
 	s.testSuiteWithCliBase.TearDownSuite(c)
 	collate.SetCharsetFeatEnabledForTest(false)
 }
@@ -5736,6 +5753,27 @@ func (s *testSerialSuite2) TestUnsignedFeedback(c *C) {
 	c.Assert(result.Rows()[2][6], Equals, "keep order:false")
 }
 
+func (s *testSuiteWithCliBaseCharsetNoNewCollation) TestCharsetFeature(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustQuery("show charset").Check(testkit.Rows(
+		"ascii US ASCII ascii_bin 1",
+		"binary binary binary 1",
+		"gbk Chinese Internal Code Specification gbk_bin 2",
+		"latin1 Latin1 latin1_bin 1",
+		"utf8 UTF-8 Unicode utf8_bin 3",
+		"utf8mb4 UTF-8 Unicode utf8mb4_bin 4",
+	))
+	tk.MustQuery("show collation").Check(testkit.Rows(
+		"utf8mb4_bin utf8mb4 46 Yes Yes 1",
+		"latin1_bin latin1 47 Yes Yes 1",
+		"binary binary 63 Yes Yes 1",
+		"ascii_bin ascii 65 Yes Yes 1",
+		"utf8_bin utf8 83 Yes Yes 1",
+		"gbk_bin gbk 87 Yes Yes 1",
+	))
+}
+
 func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")
@@ -5797,24 +5835,6 @@ func (s *testSuiteWithCliBaseCharset) TestCharsetFeature(c *C) {
 	tk.MustQuery("show create table t1").Check(testkit.Rows("t1 CREATE TABLE `t1` (\n" +
 		"  `a` char(10) DEFAULT NULL\n" +
 		") ENGINE=InnoDB DEFAULT CHARSET=gbk COLLATE=gbk_chinese_ci",
-	))
-
-	collate.SetNewCollationEnabledForTest(false)
-	tk.MustQuery("show charset").Check(testkit.Rows(
-		"ascii US ASCII ascii_bin 1",
-		"binary binary binary 1",
-		"gbk Chinese Internal Code Specification gbk_utf8mb4_bin 2",
-		"latin1 Latin1 latin1_bin 1",
-		"utf8 UTF-8 Unicode utf8_bin 3",
-		"utf8mb4 UTF-8 Unicode utf8mb4_bin 4",
-	))
-	tk.MustQuery("show collation").Check(testkit.Rows(
-		"utf8mb4_bin utf8mb4 46 Yes Yes 1",
-		"latin1_bin latin1 47 Yes Yes 1",
-		"binary binary 63 Yes Yes 1",
-		"ascii_bin ascii 65 Yes Yes 1",
-		"utf8_bin utf8 83 Yes Yes 1",
-		"gbk_utf8mb4_bin gbk 0 Yes Yes 1",
 	))
 }
 

--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -63,11 +63,12 @@ var charsetInfos = map[string]*Charset{
 
 // All the names supported collations should be in the following table.
 var supportedCollationNames = map[string]struct{}{
-	CollationUTF8:    {},
-	CollationUTF8MB4: {},
-	CollationASCII:   {},
-	CollationLatin1:  {},
-	CollationBin:     {},
+	CollationUTF8:     {},
+	CollationUTF8MB4:  {},
+	CollationASCII:    {},
+	CollationLatin1:   {},
+	CollationBin:      {},
+	"gbk_utf8mb4_bin": {},
 }
 
 // TiFlashSupportedCharsets is a map which contains TiFlash supports charsets.
@@ -212,7 +213,8 @@ const (
 	// CollationLatin1 is the default collation for CharsetLatin1.
 	CollationLatin1 = "latin1_bin"
 
-	CollationGBKBin = "gbk_bin"
+	CollationGBKBin       = "gbk_bin"
+	CollationGBKChineseCI = "gbk_chinese_ci"
 
 	CharsetARMSCII8 = "armscii8"
 	CharsetBig5     = "big5"

--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -63,12 +63,11 @@ var charsetInfos = map[string]*Charset{
 
 // All the names supported collations should be in the following table.
 var supportedCollationNames = map[string]struct{}{
-	CollationUTF8:     {},
-	CollationUTF8MB4:  {},
-	CollationASCII:    {},
-	CollationLatin1:   {},
-	CollationBin:      {},
-	"gbk_utf8mb4_bin": {},
+	CollationUTF8:    {},
+	CollationUTF8MB4: {},
+	CollationASCII:   {},
+	CollationLatin1:  {},
+	CollationBin:     {},
 }
 
 // TiFlashSupportedCharsets is a map which contains TiFlash supports charsets.
@@ -489,6 +488,11 @@ func AddCharset(c *Charset) {
 // Use only when adding a custom charset to the parser.
 func RemoveCharset(c string) {
 	delete(charsetInfos, c)
+	for i := range supportedCollations {
+		if supportedCollations[i].Name == c {
+			supportedCollations = append(supportedCollations[:i], supportedCollations[i+1:]...)
+		}
+	}
 }
 
 // AddCollation adds a new collation.
@@ -498,12 +502,18 @@ func AddCollation(c *Collation) {
 	collationsNameMap[c.Name] = c
 
 	if _, ok := supportedCollationNames[c.Name]; ok {
-		supportedCollations = append(supportedCollations, c)
+		AddSupportedCollation(c)
 	}
 
 	if charset, ok := charsetInfos[c.CharsetName]; ok {
 		charset.Collations[c.Name] = c
 	}
+}
+
+// AddSupportedCollation adds a new collation into supportedCollations.
+// Use only when adding a custom collation to the parser.
+func AddSupportedCollation(c *Collation) {
+	supportedCollations = append(supportedCollations, c)
 }
 
 // init method always puts to the end of file.

--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -485,7 +485,7 @@ func AddCharset(c *Charset) {
 }
 
 // RemoveCharset remove a charset.
-// Use only when adding a custom charset to the parser.
+// Use only when remove a custom charset to the parser.
 func RemoveCharset(c string) {
 	delete(charsetInfos, c)
 	for i := range supportedCollations {

--- a/parser/charset/encoding_gbk.go
+++ b/parser/charset/encoding_gbk.go
@@ -112,10 +112,7 @@ var GBKCase = unicode.SpecialCase{
 // customGBK is a simplifiedchinese.GBK wrapper.
 type customGBK struct{}
 
-func NewCustomGBKDecoder() *encoding.Decoder {
-	return customGBK{}.NewDecoder()
-}
-
+// NewCustomGBKEncoder return a custom GBK encoding.
 func NewCustomGBKEncoder() *encoding.Encoder {
 	return customGBK{}.NewEncoder()
 }

--- a/parser/charset/encoding_gbk.go
+++ b/parser/charset/encoding_gbk.go
@@ -112,6 +112,14 @@ var GBKCase = unicode.SpecialCase{
 // customGBK is a simplifiedchinese.GBK wrapper.
 type customGBK struct{}
 
+func NewCustomGBKDecoder() *encoding.Decoder {
+	return customGBK{}.NewDecoder()
+}
+
+func NewCustomGBKEncoder() *encoding.Encoder {
+	return customGBK{}.NewEncoder()
+}
+
 // NewDecoder returns simplifiedchinese.GBK.NewDecoder().
 func (c customGBK) NewDecoder() *encoding.Decoder {
 	return &encoding.Decoder{

--- a/util/collate/charset.go
+++ b/util/collate/charset.go
@@ -32,7 +32,6 @@ func EnableNewCharset() {
 // It will also enable or disable new collation.
 func SetCharsetFeatEnabledForTest(flag bool) {
 	enableCharsetFeat = flag
-	SetNewCollationEnabledForTest(flag)
 	if flag {
 		addCharset()
 	} else {
@@ -55,18 +54,16 @@ func addCharset() {
 		newCollatorMap[charset.CollationGBKChineseCI] = &gbkChineseCICollator{}
 		newCollatorIDMap[CollationName2ID(charset.CollationGBKChineseCI)] = &gbkChineseCICollator{}
 	} else {
-		charset.AddCharset(&charset.Charset{Name: charset.CharsetGBK, DefaultCollation: "gbk_utf8mb4_bin", Collations: make(map[string]*charset.Collation), Desc: "Chinese Internal Code Specification", Maxlen: 2})
-		charset.AddCollation(&charset.Collation{ID: 0, CharsetName: charset.CharsetGBK, Name: "gbk_utf8mb4_bin", IsDefault: true})
+		charset.AddCharset(&charset.Charset{Name: charset.CharsetGBK, DefaultCollation: charset.CollationGBKBin, Collations: make(map[string]*charset.Collation), Desc: "Chinese Internal Code Specification", Maxlen: 2})
+		charset.AddSupportedCollation(&charset.Collation{ID: 87, CharsetName: charset.CharsetGBK, Name: charset.CollationGBKBin, IsDefault: true})
 	}
 }
 
 func removeCharset() {
 	charset.RemoveCharset(charset.CharsetGBK)
-	if NewCollationEnabled() {
-		delete(newCollatorMap, charset.CollationGBKBin)
-		delete(newCollatorIDMap, CollationName2ID(charset.CollationGBKBin))
+	delete(newCollatorMap, charset.CollationGBKBin)
+	delete(newCollatorIDMap, CollationName2ID(charset.CollationGBKBin))
 
-		delete(newCollatorMap, charset.CollationGBKChineseCI)
-		delete(newCollatorIDMap, CollationName2ID(charset.CollationGBKChineseCI))
-	}
+	delete(newCollatorMap, charset.CollationGBKChineseCI)
+	delete(newCollatorIDMap, CollationName2ID(charset.CollationGBKChineseCI))
 }

--- a/util/collate/collate_test.go
+++ b/util/collate/collate_test.go
@@ -53,8 +53,10 @@ func testKeyTable(t *testing.T, collations []string, tests []keyTable) {
 }
 
 func TestUTF8CollatorCompare(t *testing.T) {
+	SetNewCollationEnabledForTest(true)
 	SetCharsetFeatEnabledForTest(true)
 	defer SetCharsetFeatEnabledForTest(false)
+	defer SetNewCollationEnabledForTest(false)
 	collations := []string{"binary", "utf8mb4_bin", "utf8mb4_general_ci", "utf8mb4_unicode_ci", "gbk_bin", "gbk_chinese_ci"}
 	tests := []compareTable{
 		{"a", "b", []int{-1, -1, -1, -1, -1, -1}},
@@ -75,8 +77,10 @@ func TestUTF8CollatorCompare(t *testing.T) {
 }
 
 func TestUTF8CollatorKey(t *testing.T) {
+	SetNewCollationEnabledForTest(true)
 	SetCharsetFeatEnabledForTest(true)
 	defer SetCharsetFeatEnabledForTest(false)
+	defer SetNewCollationEnabledForTest(false)
 	collations := []string{"binary", "utf8mb4_bin", "utf8mb4_general_ci", "utf8mb4_unicode_ci", "gbk_bin", "gbk_chinese_ci"}
 	tests := []keyTable{
 		{"a", [][]byte{{0x61}, {0x61}, {0x0, 0x41}, {0x0E, 0x33}, {0x61}, {0x41}}},
@@ -132,6 +136,7 @@ func TestRewriteAndRestoreCollationID(t *testing.T) {
 }
 
 func TestGetCollator(t *testing.T) {
+	SetCharsetFeatEnabledForTest(false)
 	SetNewCollationEnabledForTest(true)
 	defer SetNewCollationEnabledForTest(false)
 	require.IsType(t, &binCollator{}, GetCollator("binary"))
@@ -175,6 +180,8 @@ func TestGetCollator(t *testing.T) {
 	require.IsType(t, &binCollator{}, GetCollatorByID(2048))
 	require.IsType(t, &binCollator{}, GetCollatorByID(9999))
 
+	SetNewCollationEnabledForTest(true)
+	defer SetNewCollationEnabledForTest(false)
 	SetCharsetFeatEnabledForTest(true)
 	defer SetCharsetFeatEnabledForTest(false)
 	require.IsType(t, &gbkBinCollator{}, GetCollator("gbk_bin"))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--


Please create an issue first to describe the problem.


There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->


Issue Number: close  https://github.com/pingcap/tidb/issues/31221.

make gbk default collation to gbk_utf8mb4_bin if new collation is not enabled


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
