### PR TITLE
topsql: deprecate single target

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -147,7 +147,6 @@ type Config struct {
 	DelayCleanTableLock uint64      `toml:"delay-clean-table-lock" json:"delay-clean-table-lock"`
 	SplitRegionMaxNum   uint64      `toml:"split-region-max-num" json:"split-region-max-num"`
 	StmtSummary         StmtSummary `toml:"stmt-summary" json:"stmt-summary"`
-	TopSQL              TopSQL      `toml:"top-sql" json:"top-sql"`
 	// RepairMode indicates that the TiDB is in the repair mode for table meta.
 	RepairMode      bool     `toml:"repair-mode" json:"repair-mode"`
 	RepairTableList []string `toml:"repair-table-list" json:"repair-table-list"`
@@ -603,12 +602,6 @@ type StmtSummary struct {
 	RefreshInterval int `toml:"refresh-interval" json:"refresh-interval"`
 	// The maximum history size of statement summary.
 	HistorySize int `toml:"history-size" json:"history-size"`
-}
-
-// TopSQL is the config for TopSQL.
-type TopSQL struct {
-	// The TopSQL's data receiver address.
-	ReceiverAddress string `toml:"receiver-address" json:"receiver-address"`
 }
 
 // IsolationRead is the config for isolation read.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -259,8 +259,6 @@ spilled-file-encryption-method = "plaintext"
 [pessimistic-txn]
 deadlock-history-capacity = 123
 deadlock-history-collect-retryable = true
-[top-sql]
-receiver-address = "127.0.0.1:10100"
 [status]
 grpc-keepalive-time = 20
 grpc-keepalive-timeout = 10
@@ -322,7 +320,6 @@ grpc-max-send-msg-size = 40960
 	require.Equal(t, uint(123), conf.PessimisticTxn.DeadlockHistoryCapacity)
 	require.True(t, conf.PessimisticTxn.DeadlockHistoryCollectRetryable)
 	require.False(t, conf.Experimental.EnableNewCharset)
-	require.Equal(t, "127.0.0.1:10100", conf.TopSQL.ReceiverAddress)
 	require.True(t, conf.Experimental.AllowsExpressionIndex)
 	require.Equal(t, uint(20), conf.Status.GRPCKeepAliveTime)
 	require.Equal(t, uint(10), conf.Status.GRPCKeepAliveTimeout)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -8766,9 +8766,7 @@ func (s *testResourceTagSuite) TestResourceGroupTag(c *C) {
 
 	// Enable Top SQL
 	topsqlstate.GlobalState.Enable.Store(true)
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TopSQL.ReceiverAddress = "mock-agent"
-	})
+	topsqlstate.GlobalState.ReceiverAddress.Store("mock-agent")
 
 	c.Assert(failpoint.Enable("github.com/pingcap/tidb/store/mockstore/unistore/unistoreRPCClientSendHook", `return(true)`), IsNil)
 	defer failpoint.Disable("github.com/pingcap/tidb/store/mockstore/unistore/unistoreRPCClientSendHook")

--- a/server/tidb_test.go
+++ b/server/tidb_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser"
@@ -1300,9 +1299,8 @@ func TestTopSQLCPUProfile(t *testing.T) {
 	dbt.MustExec("create table t1 (a int auto_increment, b int, unique index idx(a));")
 	dbt.MustExec("create table t2 (a int auto_increment, b int, unique index idx(a));")
 	dbt.MustExec("set @@global.tidb_enable_top_sql='On';")
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TopSQL.ReceiverAddress = "127.0.0.1:4001"
-	})
+	topsqlstate.GlobalState.ReceiverAddress.Store("127.0.0.1:4001")
+
 	dbt.MustExec("set @@global.tidb_top_sql_precision_seconds=1;")
 	dbt.MustExec("set @@global.tidb_txn_mode = 'pessimistic'")
 
@@ -1545,9 +1543,7 @@ func TestTopSQLStatementStats(t *testing.T) {
 
 	// Enable TopSQL
 	topsqlstate.GlobalState.Enable.Store(true)
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TopSQL.ReceiverAddress = "mock-agent"
-	})
+	topsqlstate.GlobalState.ReceiverAddress.Store("mock-agent")
 	dbt.MustExec("set @@global.tidb_enable_top_sql='On';")
 
 	const ExecCountPerSQL = 3

--- a/util/topsql/reporter/reporter_test.go
+++ b/util/topsql/reporter/reporter_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/util/topsql/collector"
 	"github.com/pingcap/tidb/util/topsql/reporter/mock"
 	topsqlstate "github.com/pingcap/tidb/util/topsql/state"
@@ -86,9 +85,7 @@ func setupRemoteTopSQLReporter(maxStatementsNum, interval int, addr string) (*Re
 	topsqlstate.GlobalState.MaxStatementCount.Store(int64(maxStatementsNum))
 	topsqlstate.GlobalState.MaxCollect.Store(10000)
 	topsqlstate.GlobalState.ReportIntervalSeconds.Store(int64(interval))
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TopSQL.ReceiverAddress = addr
-	})
+	topsqlstate.GlobalState.ReceiverAddress.Store(addr)
 
 	topsqlstate.EnableTopSQL()
 	ts := NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc)

--- a/util/topsql/state/state.go
+++ b/util/topsql/state/state.go
@@ -23,6 +23,15 @@ const (
 	DefTiDBTopSQLMaxStatementCount     = 200
 	DefTiDBTopSQLMaxCollect            = 5000
 	DefTiDBTopSQLReportIntervalSeconds = 60
+
+	// DefTiDBTopSQLReceiverAddress is temporary for testing
+	//
+	// Deprecated
+	//
+	// TiDB has deprecated the single target reporting mode. However, since TopSQL tests rely heavily
+	// on single target, this global variable is introduced to make the tests work properly before
+	// refactoring them. This variable will be removed later after refactoring is totally done.
+	DefTiDBTopSQLReceiverAddress = ""
 )
 
 // GlobalState is the global Top-SQL state.
@@ -32,6 +41,13 @@ var GlobalState = State{
 	MaxStatementCount:     atomic.NewInt64(DefTiDBTopSQLMaxStatementCount),
 	MaxCollect:            atomic.NewInt64(DefTiDBTopSQLMaxCollect),
 	ReportIntervalSeconds: atomic.NewInt64(DefTiDBTopSQLReportIntervalSeconds),
+
+	// Deprecated
+	//
+	// TiDB has deprecated the single target reporting mode. However, since TopSQL tests rely heavily
+	// on single target, this global variable is introduced to make the tests work properly before
+	// refactoring them. This variable will be removed later after refactoring is totally done.
+	ReceiverAddress: atomic.NewString(DefTiDBTopSQLReceiverAddress),
 }
 
 // State is the state for control top sql feature.
@@ -46,6 +62,13 @@ type State struct {
 	MaxCollect *atomic.Int64
 	// The report data interval of top-sql.
 	ReportIntervalSeconds *atomic.Int64
+
+	// Deprecated
+	//
+	// TiDB has deprecated the single target reporting mode. However, since TopSQL tests rely heavily
+	// on single target, this global variable is introduced to make the tests work properly before
+	// refactoring them. This variable will be removed later after refactoring is totally done.
+	ReceiverAddress *atomic.String
 }
 
 // EnableTopSQL enables the top SQL feature.

--- a/util/topsql/topsql_test.go
+++ b/util/topsql/topsql_test.go
@@ -19,7 +19,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/util/cpuprofile"
 	"github.com/pingcap/tidb/util/topsql"
@@ -92,9 +91,7 @@ func TestTopSQLReporter(t *testing.T) {
 	require.NoError(t, err)
 	topsqlstate.GlobalState.MaxStatementCount.Store(200)
 	topsqlstate.GlobalState.ReportIntervalSeconds.Store(1)
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.TopSQL.ReceiverAddress = server.Address()
-	})
+	topsqlstate.GlobalState.ReceiverAddress.Store(server.Address())
 
 	topsqlstate.EnableTopSQL()
 	report := reporter.NewRemoteTopSQLReporter(mockPlanBinaryDecoderFunc)


### PR DESCRIPTION
Signed-off-by: Zhenchi <zhongzc_arch@outlook.com>

Issue Number: close #31211

Problem Summary:

### What is changed and how it works?

* Remove TopSQL config

### Release note

```release-note
None
```
