### PR TITLE
variable: change the error message for setting log_output

### DIFF
--- a/errno/errcode.go
+++ b/errno/errcode.go
@@ -908,6 +908,7 @@ const (
 	ErrFunctionalIndexDataIsTooLong                          = 3907
 	ErrFunctionalIndexNotApplicable                          = 3909
 	ErrDynamicPrivilegeNotRegistered                         = 3929
+	ErrGeneralLog                                            = 3930
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed         = 4030
 	ErrWrongPartitionTypeExpectedSystemTime = 4113

--- a/errno/errname.go
+++ b/errno/errname.go
@@ -911,6 +911,8 @@ var MySQLErrName = map[uint16]*mysql.ErrMessage{
 	ErrCTERecursiveForbiddenJoinOrder:                        mysql.Message("In recursive query block of Recursive Common Table Expression '%s', the recursive table must neither be in the right argument of a LEFT JOIN, nor be forced to be non-first with join order hints", nil),
 	ErrInvalidRequiresSingleReference:                        mysql.Message("In recursive query block of Recursive Common Table Expression '%s', the recursive table must be referenced only once, and not in any subquery", nil),
 	ErrCTEMaxRecursionDepth:                                  mysql.Message("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value", nil),
+	ErrGeneralLog:                                            mysql.Message("TiDB general log is implemented differently, and changes on the parameter '%s' will not be honored. Please check 'tidb_general_log' for details", nil),
+
 	// MariaDB errors.
 	ErrOnlyOneDefaultPartionAllowed:         mysql.Message("Only one DEFAULT partition allowed", nil),
 	ErrWrongPartitionTypeExpectedSystemTime: mysql.Message("Wrong partitioning type, expected type: `SYSTEM_TIME`", nil),

--- a/sessionctx/variable/error.go
+++ b/sessionctx/variable/error.go
@@ -43,4 +43,6 @@ var (
 	// It needs to be public for tests.
 	ErrFunctionsNoopImpl         = dbterror.ClassVariable.NewStdErr(mysql.ErrNotSupportedYet, pmysql.Message("function %s has only noop implementation in tidb now, use tidb_enable_noop_functions to enable these functions", nil))
 	ErrVariableNoLongerSupported = dbterror.ClassVariable.NewStd(mysql.ErrVariableNoLongerSupported)
+	// ErrGeneralLog is special tackling for mysql general log parameters
+	ErrGeneralLog = dbterror.ClassVariable.NewStd(mysql.ErrGeneralLog)
 )

--- a/sessionctx/variable/noop.go
+++ b/sessionctx/variable/noop.go
@@ -110,7 +110,9 @@ var noopSysVars = []*SysVar{
 	{Scope: ScopeGlobal, Name: InnodbCmpPerIndexEnabled, Value: Off, Type: TypeBool, AutoConvertNegativeBool: true},
 	{Scope: ScopeGlobal, Name: "innodb_ft_server_stopword_table", Value: ""},
 	{Scope: ScopeNone, Name: "performance_schema_max_file_instances", Value: "7693"},
-	{Scope: ScopeNone, Name: "log_output", Value: "FILE"},
+	{Scope: ScopeGlobal, Name: "log_output", Value: "FILE", Validation: func(vars *SessionVars, normalizedValue string, originalValue string, scope ScopeFlag) (string, error) {
+		return normalizedValue, ErrGeneralLog.GenWithStackByArgs("log_output")
+	}},
 	{Scope: ScopeGlobal, Name: "binlog_group_commit_sync_delay", Value: ""},
 	{Scope: ScopeGlobal, Name: "binlog_group_commit_sync_no_delay_count", Value: ""},
 	{Scope: ScopeNone, Name: "have_crypt", Value: "YES"},


### PR DESCRIPTION
Change the error message to make it more readable and intuitive for users

### What problem does this PR solve?

<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31100

Problem Summary:

While the TiDB general log works differently than the MySQL, related variables are still mostly modifiable with no clear message to the end users. 

There are three related variables:
general_log: modifiable with no restriction. doesn't take effect at all
general_log_file: modifiable with no restriction. doesn't take effect at all
log_output: changing this parameter will prompt a general "readonly" error message

In this PR, I'm only improving the error message for log_output. 
After this change, the message will look like the following:

tidb> SET global log_output = 'TABLE';
ERROR 3930 (HY000): TiDB general log is implemented differently, and changes on the parameter 'log_output' will not be honored. Please check 'tidb_general_log' for details

I believe we are safe to do the same for general_log and general_log_file.
However, such a change will anyway introduce a minor behavior change (to make the two parameters not modifiable).
So would need opinions - will use this PR to collect suggestions as well.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test : will add it separately
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

Improve the error message for setting log_output

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
