### PR TITLE
ddl: null is not allowed to create an expression index

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2386,6 +2386,15 @@ func (s *testSerialDBSuite1) TestCreateExpressionIndexError(c *C) {
 
 	tk.MustGetErrCode("create table t1 (col1 int, index ((concat(''))));", errno.ErrWrongKeyColumnFunctionalIndex)
 	tk.MustGetErrCode("create table t1 (col1 int, index c((null)));", errno.ErrWrongKeyColumnFunctionalIndex)
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Experimental.AllowsExpressionIndex = false
+	})
+	tk.MustGetErrMsg("create table tt1 (col1 int, index c((concat(null,'3'))));", "[ddl:8200]Unsupported creating expression index containing unsafe functions without allow-expression-index in config")
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.Experimental.AllowsExpressionIndex = true
+	})
+	tk.MustExec("create table tt (col1 int, index c((concat(null,'3'))));")
+	tk.MustExec("create table tt2(col1 int, index c((md5(null))));")
 	tk.MustGetErrCode("CREATE TABLE t1 (col1 INT, PRIMARY KEY ((ABS(col1))) NONCLUSTERED);", errno.ErrFunctionalIndexPrimaryKey)
 
 	// For issue 26349

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2385,6 +2385,7 @@ func (s *testSerialDBSuite1) TestCreateExpressionIndexError(c *C) {
 	tk.MustExec("create table t (j json, key k ((j+1),(j+1)))")
 
 	tk.MustGetErrCode("create table t1 (col1 int, index ((concat(''))));", errno.ErrWrongKeyColumnFunctionalIndex)
+	tk.MustGetErrCode("create table t1 (col1 int, index c((null)));", errno.ErrWrongKeyColumnFunctionalIndex)
 	tk.MustGetErrCode("CREATE TABLE t1 (col1 INT, PRIMARY KEY ((ABS(col1))) NONCLUSTERED);", errno.ErrFunctionalIndexPrimaryKey)
 
 	// For issue 26349

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5350,6 +5350,11 @@ func buildHiddenColumnInfo(ctx sessionctx.Context, indexPartSpecifications []*as
 		if _, ok := expr.(*expression.Column); ok {
 			return nil, ErrFunctionalIndexOnField
 		}
+		if r, ok := expr.(*expression.Constant); ok {
+			if r.Value.Kind() == types.KindNull {
+				return nil, errors.Trace(errWrongKeyColumnFunctionalIndex.GenWithStackByArgs("NULL"))
+			}
+		}
 
 		colInfo := &model.ColumnInfo{
 			Name:                idxPart.Column.Name,

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5350,11 +5350,6 @@ func buildHiddenColumnInfo(ctx sessionctx.Context, indexPartSpecifications []*as
 		if _, ok := expr.(*expression.Column); ok {
 			return nil, ErrFunctionalIndexOnField
 		}
-		if r, ok := expr.(*expression.Constant); ok {
-			if r.Value.Kind() == types.KindNull {
-				return nil, errors.Trace(errWrongKeyColumnFunctionalIndex.GenWithStackByArgs("NULL"))
-			}
-		}
 
 		colInfo := &model.ColumnInfo{
 			Name:                idxPart.Column.Name,

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -298,7 +298,7 @@ func (c *illegalFunctionChecker) Enter(inNode ast.Node) (outNode ast.Node, skipC
 		}
 	case *driver.ValueExpr:
 		if node.Datum.Kind() == types.KindNull {
-			c.otherErr = errWrongKeyColumnFunctionalIndex
+			c.otherErr = errors.Trace(errWrongKeyColumnFunctionalIndex.GenWithStackByArgs("NULL"))
 			return inNode, true
 		}
 	case *ast.SubqueryExpr, *ast.ValuesExpr, *ast.VariableExpr:
@@ -368,7 +368,7 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 				case "concat", "md5":
 					return nil
 				default:
-					return errors.Trace(errWrongKeyColumnFunctionalIndex.GenWithStackByArgs("NULL"))
+					return c.otherErr
 				}
 			}
 		}

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -16,7 +16,6 @@ package ddl
 
 import (
 	"fmt"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
@@ -26,6 +25,8 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
+	"github.com/pingcap/tidb/types"
+	driver "github.com/pingcap/tidb/types/parser_driver"
 )
 
 // columnGenerationInDDL is a struct for validating generated columns in DDL.
@@ -353,6 +354,9 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 	}
 	if genType == typeIndex && c.hasNotGAFunc4ExprIdx && !config.GetGlobalConfig().Experimental.AllowsExpressionIndex {
 		return ErrUnsupportedExpressionIndex
+	}
+	if expr.(*driver.ValueExpr).Datum.Kind() == types.KindNull {
+		return errors.Trace(errWrongKeyColumnFunctionalIndex.GenWithStackByArgs("NULL"))
 	}
 	return nil
 }

--- a/ddl/generated_column.go
+++ b/ddl/generated_column.go
@@ -16,12 +16,14 @@ package ddl
 
 import (
 	"fmt"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
+	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/table"
@@ -355,6 +357,9 @@ func checkIllegalFn4Generated(name string, genType int, expr ast.ExprNode) error
 		return errWindowInvalidWindowFuncUse.GenWithStackByArgs(name)
 	}
 	if c.otherErr != nil {
+		if terror.ErrorEqual(c.otherErr, errWrongKeyColumnFunctionalIndex) && genType == typeColumn {
+			return nil
+		}
 		return c.otherErr
 	}
 	if genType == typeIndex && c.hasNotGAFunc4ExprIdx && !config.GetGlobalConfig().Experimental.AllowsExpressionIndex {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31149

Problem Summary:

### What is changed and how it works?

TiDB

```mysql
mysql> CREATE TABLE t(a INT, b INT, INDEX c((null)));
Query OK, 0 rows affected (0.07 sec)

mysql> show create table t;
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                              |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) DEFAULT NULL,
  `b` int(11) DEFAULT NULL,
  KEY `c` ((null))
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+-----------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

mysql

```mysql
mysql> CREATE TABLE t(a INT, b INT, INDEX c((null)));
ERROR 3761 (HY000): The used storage engine cannot index the expression 'NULL'.
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
