### PR TITLE
planner: do not cache the tableDual plan

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -1167,7 +1167,7 @@ func TestPreparePlanCache4Function(t *testing.T) {
 	tk.MustExec("set @a = 0, @b = 1, @c = 2, @d = null;")
 	tk.MustQuery("execute stmt using @a, @b;").Check(testkit.Rows("<nil> 2", "0 0", "1 1", "2 2"))
 	tk.MustQuery("execute stmt using @c, @d;").Check(testkit.Rows("<nil> 1", "0 2", "1 2", "2 0"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
 }
 
 func TestPreparePlanCache4DifferentSystemVars(t *testing.T) {

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -937,9 +937,10 @@ func TestIssue28782(t *testing.T) {
 
 	tk.MustQuery("execute stmt using @a;").Check(testkit.Rows("1"))
 	tk.MustQuery("execute stmt using @b;").Check(testkit.Rows("0"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	// TODO(Reminiscent): Support cache more tableDual plan.
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 	tk.MustQuery("execute stmt using @c;").Check(testkit.Rows("0"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 }
 
 func TestIssue29101(t *testing.T) {
@@ -1157,7 +1158,7 @@ func TestPreparePlanCache4Function(t *testing.T) {
 	tk.MustExec("set @a = 1, @b = null;")
 	tk.MustQuery("execute stmt using @a;").Check(testkit.Rows("1"))
 	tk.MustQuery("execute stmt using @b;").Check(testkit.Rows("0"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t(a int);")
@@ -1166,7 +1167,7 @@ func TestPreparePlanCache4Function(t *testing.T) {
 	tk.MustExec("set @a = 0, @b = 1, @c = 2, @d = null;")
 	tk.MustQuery("execute stmt using @a, @b;").Check(testkit.Rows("<nil> 2", "0 0", "1 1", "2 2"))
 	tk.MustQuery("execute stmt using @c, @d;").Check(testkit.Rows("<nil> 1", "0 2", "1 2", "2 0"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 }
 
 func TestPreparePlanCache4DifferentSystemVars(t *testing.T) {

--- a/executor/testdata/prepare_suite_out.json
+++ b/executor/testdata/prepare_suite_out.json
@@ -63,7 +63,7 @@
               "Projection_3 1.00 root  10->Column#1, cba->Column#2",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "10 cba"
             ]
@@ -253,7 +253,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1234567"
             ]
@@ -270,7 +270,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1"
             ]
@@ -287,7 +287,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "99999"
             ]
@@ -304,7 +304,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:79)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-123456789"
             ]
@@ -321,7 +321,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1234567"
             ]
@@ -338,7 +338,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1"
             ]
@@ -355,7 +355,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-99999"
             ]
@@ -394,7 +394,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1234567"
             ]
@@ -411,7 +411,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1"
             ]
@@ -428,7 +428,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "99999"
             ]
@@ -445,7 +445,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:79)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-123456789"
             ]
@@ -462,7 +462,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1234567"
             ]
@@ -479,7 +479,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1"
             ]
@@ -496,7 +496,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(10,0) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-99999"
             ]
@@ -535,7 +535,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "9.9999"
             ]
@@ -552,7 +552,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1.0000"
             ]
@@ -569,7 +569,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "9.9999"
             ]
@@ -586,7 +586,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:78)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-9.9999"
             ]
@@ -603,7 +603,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-9.9999"
             ]
@@ -620,7 +620,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1.0000"
             ]
@@ -637,7 +637,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(5,4) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-9.9999"
             ]
@@ -676,7 +676,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1234567.123456700000000000000000000000"
             ]
@@ -693,7 +693,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "0.999990000000000000000000000000"
             ]
@@ -710,7 +710,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "99999.000000000000000000000000000000"
             ]
@@ -727,7 +727,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:80)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-123456789.012345678901234567890123456789"
             ]
@@ -744,7 +744,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1234567.123456700000000000000000000000"
             ]
@@ -761,7 +761,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.999990000000000000000000000000"
             ]
@@ -778,7 +778,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(64,30) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-99999.000000000000000000000000000000"
             ]
@@ -817,7 +817,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "1234567.12346"
             ]
@@ -834,7 +834,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "0.99999"
             ]
@@ -851,7 +851,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "99999.00000"
             ]
@@ -868,7 +868,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:79)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-123456789.01235"
             ]
@@ -885,7 +885,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-1234567.12346"
             ]
@@ -902,7 +902,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.99999"
             ]
@@ -919,7 +919,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(15,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-99999.00000"
             ]
@@ -958,7 +958,7 @@
               "Projection_3 1.00 root  cast(1234567.1234567, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "0.99999"
             ]
@@ -975,7 +975,7 @@
               "Projection_3 1.00 root  cast(0.99999, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "0.99999"
             ]
@@ -992,7 +992,7 @@
               "Projection_3 1.00 root  cast(99999.0, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "0.99999"
             ]
@@ -1009,7 +1009,7 @@
               "Projection_3 1.00 root  cast(-123456789.0123456789012345678901234567890123456789, decima(len:78)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.99999"
             ]
@@ -1026,7 +1026,7 @@
               "Projection_3 1.00 root  cast(-1234567.1234567, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.99999"
             ]
@@ -1043,7 +1043,7 @@
               "Projection_3 1.00 root  cast(-0.99999, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.99999"
             ]
@@ -1060,7 +1060,7 @@
               "Projection_3 1.00 root  cast(-99999.0, decimal(5,5) BINARY)->Column#1",
               "└─TableDual_4 1.00 root  rows:1"
             ],
-            "LastPlanUseCache": "1",
+            "LastPlanUseCache": "0",
             "Result": [
               "-0.99999"
             ]

--- a/expression/integration_serial_test.go
+++ b/expression/integration_serial_test.go
@@ -78,7 +78,7 @@ func TestIssue17727(t *testing.T) {
 
 	tk.MustExec("set @a = '2020-06-12 13:47:58';")
 	tk.MustQuery("execute stmt using @a;").Check(testkit.Rows("1591940878"))
-	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@last_plan_from_cache;").Check(testkit.Rows("0"))
 }
 
 func TestIssue17891(t *testing.T) {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -555,8 +555,9 @@ REBUILD:
 	}
 	e.names = names
 	e.Plan = p
-	containTableDual := containTableDual(p)
-	if !containTableDual && varsNum > 0 && prepared.UseCache && !stmtCtx.SkipPlanCache {
+	// We only cache the tableDual plan when the number of vars are zero.
+	cacheTableDual := containTableDual(p) && varsNum == 0
+	if !cacheTableDual && prepared.UseCache && !stmtCtx.SkipPlanCache {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -556,8 +556,10 @@ REBUILD:
 	e.names = names
 	e.Plan = p
 	// We only cache the tableDual plan when the number of vars are zero.
-	cacheTableDual := containTableDual(p) && varsNum == 0
-	if !cacheTableDual && prepared.UseCache && !stmtCtx.SkipPlanCache {
+	if containTableDual(p) && varsNum > 0 {
+		stmtCtx.SkipPlanCache = true
+	}
+	if prepared.UseCache && !stmtCtx.SkipPlanCache {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -449,6 +449,7 @@ func (e *Execute) getPhysicalPlan(ctx context.Context, sctx sessionctx.Context, 
 		cacheKey = NewPlanCacheKey(sctx.GetSessionVars(), e.ExecID, prepared.SchemaVersion)
 	}
 	tps := make([]*types.FieldType, len(e.UsingVars))
+	varsNum := len(e.UsingVars)
 	for i, param := range e.UsingVars {
 		name := param.(*expression.ScalarFunction).GetArgs()[0].String()
 		tps[i] = sctx.GetSessionVars().UserVarTypes[name]
@@ -554,8 +555,8 @@ REBUILD:
 	}
 	e.names = names
 	e.Plan = p
-	_, isTableDual := p.(*PhysicalTableDual)
-	if !isTableDual && prepared.UseCache && !stmtCtx.SkipPlanCache {
+	containTableDual := containTableDual(p)
+	if !containTableDual && varsNum > 0 && prepared.UseCache && !stmtCtx.SkipPlanCache {
 		// rebuild key to exclude kv.TiFlash when stmt is not read only
 		if _, isolationReadContainTiFlash := sessVars.IsolationReadEngines[kv.TiFlash]; isolationReadContainTiFlash && !IsReadOnly(stmt, sessVars) {
 			delete(sessVars.IsolationReadEngines, kv.TiFlash)
@@ -584,6 +585,21 @@ REBUILD:
 	}
 	err = e.setFoundInPlanCache(sctx, false)
 	return err
+}
+
+func containTableDual(p Plan) bool {
+	_, isTableDual := p.(*PhysicalTableDual)
+	if isTableDual {
+		return true
+	}
+	physicalPlan, ok := p.(PhysicalPlan)
+	if !ok {
+		return false
+	}
+	for _, child := range physicalPlan.Children() {
+		return containTableDual(child)
+	}
+	return false
 }
 
 // tryCachePointPlan will try to cache point execution plan, there may be some

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -886,6 +886,54 @@ func (s *testPrepareSerialSuite) TestPrepareCachePointGetInsert(c *C) {
 	tk.MustQuery("select * from t2 order by a").Check(testkit.Rows("1 1", "2 2", "3 3"))
 }
 
+func (s *testPrepareSerialSuite) TestIssue31280(c *C) {
+	defer testleak.AfterTest(c)()
+	store, dom, err := newStoreWithBootstrap()
+	c.Assert(err, IsNil)
+	tk := testkit.NewTestKit(c, store)
+	orgEnable := core.PreparedPlanCacheEnabled()
+	defer func() {
+		dom.Close()
+		err = store.Close()
+		c.Assert(err, IsNil)
+		core.SetPreparedPlanCache(orgEnable)
+	}()
+	core.SetPreparedPlanCache(true)
+	tk.Se, err = session.CreateSession4TestWithOpt(store, &session.Opt{
+		PreparedPlanCache: kvcache.NewSimpleLRUCache(100, 0.1, math.MaxUint64),
+	})
+	c.Assert(err, IsNil)
+
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists UK_MU15569;")
+	tk.MustExec("CREATE TABLE `UK_MU15569` (" +
+		"`COL1` varbinary(20) DEFAULT NULL," +
+		"`COL2` bit(16) DEFAULT NULL," +
+		"`COL3` time DEFAULT NULL," +
+		"`COL4` int(11) DEFAULT NULL," +
+		"UNIQUE KEY `U_M_COL4` (`COL1`(10),`COL2`)," +
+		"UNIQUE KEY `U_M_COL5` (`COL3`,`COL2`)" +
+		") ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;")
+	tk.MustExec("insert into UK_MU15569  values(0x1C4FDBA09B42D999AC3019B6A9C0C787FBA08446, 0xCA74, '-836:46:08', 735655453);")
+
+	tk.MustExec(`prepare stmt from 'select * from UK_MU15569 where col2 >= ? and col1 is not null and col3 = ?;';`)
+
+	tk.MustExec("set @a=-32373, @b='45:50:46.85487';")
+	res := tk.MustQuery("execute stmt using @a,@b;")
+	c.Assert(len(res.Rows()), Equals, 0)
+
+	tk.MustExec("set @a=-27225, @b='-836:46:08';")
+	res = tk.MustQuery("execute stmt using @a,@b;")
+	c.Assert(len(res.Rows()), Equals, 1)
+	// The tableDual plan will not be cached.
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("0"))
+	tk.MustQuery("execute stmt using @a,@b;")
+	tk.MustQuery(`select @@last_plan_from_cache`).Check(testkit.Rows("1"))
+
+	res1 := tk.MustQuery("select * from UK_MU15569 where col2 >= -27225 and col1 is not null and col3 = '-836:46:08';")
+	c.Assert(res.Rows(), DeepEquals, res1.Rows())
+}
+
 // nolint:unused
 func readGaugeInt(g prometheus.Gauge) int {
 	ch := make(chan prometheus.Metric, 1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/31280

Problem Summary:
Some tableDual will be cached previous.

### What is changed and how it works?
Do not cache those tableDual plans.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
