### PR TITLE
placement: fix majority schedule when primaryRegion and regions are same

### DIFF
--- a/ddl/placement/bundle_test.go
+++ b/ddl/placement/bundle_test.go
@@ -417,6 +417,21 @@ func (s *testBundleSuite) TestNewBundleFromOptions(c *C) {
 	})
 
 	tests = append(tests, TestCase{
+		name: "sugar syntax: normal case 2",
+		input: &model.PlacementSettings{
+			PrimaryRegion: "us",
+			Regions:       "us",
+			Schedule:      "majority_in_primary",
+		},
+		output: []*Rule{
+			NewRule(Voter, 2, NewConstraintsDirect(
+				NewConstraintDirect("region", In, "us"),
+			)),
+			NewRule(Follower, 1, NewConstraintsDirect()),
+		},
+	})
+
+	tests = append(tests, TestCase{
 		name: "sugar syntax: few followers",
 		input: &model.PlacementSettings{
 			PrimaryRegion: "us",


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31271

Problem Summary: When `primaryRegion` and `Regions` are same, and schedule is `majority_in_primary`, there will be an empty constraint `region in []{}`, which will break the validation of PD.

Either `region exists` or just no constraint will work. Here, we choose to remove the useless constraint, i.e. L189, if `if len(regions) > 0 {`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix bug when `SCHEDULE=majority_in_primary` and `PrimaryRegion` and `Regions` are same for placement rule
```
