### PR TITLE
ddl: Wrap TiFlash and its pd rule management into InfoSyncer

### DIFF
--- a/ddl/placement/common.go
+++ b/ddl/placement/common.go
@@ -35,6 +35,8 @@ const (
 	RuleIndexTable = 40
 	// RuleIndexPartition is the index for a rule of partition.
 	RuleIndexPartition = 80
+	// RuleIndexTiFlash is the index for a rule of TiFlash.
+	RuleIndexTiFlash = 120
 )
 
 const (

--- a/ddl/placement/rule.go
+++ b/ddl/placement/rule.go
@@ -49,6 +49,18 @@ type Rule struct {
 	Constraints Constraints  `json:"label_constraints,omitempty"`
 }
 
+type TiFlashRule struct {
+	GroupID     string       `json:"group_id"`
+	ID          string       `json:"id"`
+	Index       int          `json:"index,omitempty"`
+	Override    bool         `json:"override,omitempty"`
+	StartKeyHex string       `json:"start_key"`
+	EndKeyHex   string       `json:"end_key"`
+	Role        PeerRoleType `json:"role"`
+	Count       int          `json:"count"`
+	Constraints Constraints  `json:"label_constraints,omitempty"`
+}
+
 // NewRule constructs *Rule from role, count, and constraints. It is here to
 // consistent the behavior of creating new rules.
 func NewRule(role PeerRoleType, replicas uint64, cnst Constraints) *Rule {

--- a/ddl/placement/rule.go
+++ b/ddl/placement/rule.go
@@ -49,16 +49,19 @@ type Rule struct {
 	Constraints Constraints  `json:"label_constraints,omitempty"`
 }
 
+// TiFlashRule extends Rule with other necessary fields.
 type TiFlashRule struct {
-	GroupID     string       `json:"group_id"`
-	ID          string       `json:"id"`
-	Index       int          `json:"index,omitempty"`
-	Override    bool         `json:"override,omitempty"`
-	StartKeyHex string       `json:"start_key"`
-	EndKeyHex   string       `json:"end_key"`
-	Role        PeerRoleType `json:"role"`
-	Count       int          `json:"count"`
-	Constraints Constraints  `json:"label_constraints,omitempty"`
+	GroupID        string       `json:"group_id"`
+	ID             string       `json:"id"`
+	Index          int          `json:"index,omitempty"`
+	Override       bool         `json:"override,omitempty"`
+	StartKeyHex    string       `json:"start_key"`
+	EndKeyHex      string       `json:"end_key"`
+	Role           PeerRoleType `json:"role"`
+	Count          int          `json:"count"`
+	Constraints    Constraints  `json:"label_constraints,omitempty"`
+	LocationLabels []string     `json:"location_labels,omitempty"`
+	IsolationLevel string       `json:"isolation_level,omitempty"`
 }
 
 // NewRule constructs *Rule from role, count, and constraints. It is here to

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -236,7 +236,6 @@ func initPlacementManager(addrs []string) PlacementManager {
 func initTiFlashPlacementManager(addrs []string) TiFlashPlacementManager {
 	if len(addrs) == 0 {
 		m := mockTiFlashPlacementManager{}
-		//m.tiflash = NewMockTiFlash()
 		return &m
 	}
 	return &TiFlashPDPlacementManager{addrs: addrs}

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -966,8 +966,8 @@ func GetLabelRules(ctx context.Context, ruleIDs []string) (map[string]*label.Rul
 	return is.labelRuleManager.GetLabelRules(ctx, ruleIDs)
 }
 
-// SetPlacementRule is a helper function to set placement rule.
-func SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
+// SetTiFlashPlacementRule is a helper function to set placement rule.
+func SetTiFlashPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return errors.Trace(err)
@@ -975,8 +975,8 @@ func SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	return is.tiflashPlacementManager.SetPlacementRule(ctx, rule)
 }
 
-// DeletePlacementRule is to delete placement rule for certain group.
-func DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
+// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
+func DeleteTiFlashPlacementRule(ctx context.Context, group string, ruleID string) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return errors.Trace(err)
@@ -984,8 +984,8 @@ func DeletePlacementRule(ctx context.Context, group string, ruleID string) error
 	return is.tiflashPlacementManager.DeletePlacementRule(ctx, group, ruleID)
 }
 
-// GetGroupRules to get all placement rule in a certain group.
-func GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
+// GetTiFlashGroupRules to get all placement rule in a certain group.
+func GetTiFlashGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -993,8 +993,8 @@ func GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, 
 	return is.tiflashPlacementManager.GetGroupRules(ctx, group)
 }
 
-// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
-func PostAccelerateSchedule(ctx context.Context, tableID int64) error {
+// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
+func PostTiFlashAccelerateSchedule(ctx context.Context, tableID int64) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return errors.Trace(err)
@@ -1002,8 +1002,8 @@ func PostAccelerateSchedule(ctx context.Context, tableID int64) error {
 	return is.tiflashPlacementManager.PostAccelerateSchedule(ctx, tableID)
 }
 
-// GetPDRegionRecordStats is a helper function calling `/stats/region`.
-func GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
+// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
+func GetTiFlashPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return errors.Trace(err)
@@ -1011,8 +1011,8 @@ func GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PD
 	return is.tiflashPlacementManager.GetPDRegionRecordStats(ctx, tableID, stats)
 }
 
-// GetStoresStat gets the TiKV store information by accessing PD's api.
-func GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
+// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
+func GetTiFlashStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -1029,6 +1029,7 @@ func CloseTiFlashManager(ctx context.Context) {
 	is.tiflashPlacementManager.Close(ctx)
 }
 
+// ConfigureTiFlashPDForTable configures pd rule for unpartitioned tables.
 func ConfigureTiFlashPDForTable(id int64, count uint64, locationLabels *[]string) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
@@ -1043,6 +1044,7 @@ func ConfigureTiFlashPDForTable(id int64, count uint64, locationLabels *[]string
 	return nil
 }
 
+// ConfigureTiFlashPDForPartitions configures pd rule for all partition in partitioned tables.
 func ConfigureTiFlashPDForPartitions(accel bool, definitions *[]model.PartitionDefinition, count uint64, locationLabels *[]string) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -19,8 +19,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/tidb/parser/model"
-	"github.com/pingcap/tidb/store/helper"
 	"io"
 	"net/http"
 	"os"
@@ -40,9 +38,11 @@ import (
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/owner"
+	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/binloginfo"
+	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/types"
 	util2 "github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/dbterror"
@@ -93,18 +93,18 @@ var ErrPrometheusAddrIsNotSet = dbterror.ClassDomain.NewStd(errno.ErrPrometheusA
 
 // InfoSyncer stores server info to etcd when the tidb-server starts and delete when tidb-server shuts down.
 type InfoSyncer struct {
-	etcdCli          *clientv3.Client
-	info             *ServerInfo
-	serverInfoPath   string
-	minStartTS       uint64
-	minStartTSPath   string
-	manager          util2.SessionManager
-	session          *concurrency.Session
-	topologySession  *concurrency.Session
-	prometheusAddr   string
-	modifyTime       time.Time
-	labelRuleManager LabelRuleManager
-	placementManager PlacementManager
+	etcdCli                 *clientv3.Client
+	info                    *ServerInfo
+	serverInfoPath          string
+	minStartTS              uint64
+	minStartTSPath          string
+	manager                 util2.SessionManager
+	session                 *concurrency.Session
+	topologySession         *concurrency.Session
+	prometheusAddr          string
+	modifyTime              time.Time
+	labelRuleManager        LabelRuleManager
+	placementManager        PlacementManager
 	tiflashPlacementManager TiFlashPlacementManager
 }
 
@@ -255,7 +255,6 @@ func GetMockTiFlash() *MockTiFlash {
 	}
 	return nil
 }
-
 
 // SetMockTiFlash can only be used in tests to set MockTiFlash
 func SetMockTiFlash(tiflash *MockTiFlash) {

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -969,7 +969,7 @@ func GetLabelRules(ctx context.Context, ruleIDs []string) (map[string]*label.Rul
 }
 
 // SetPlacementRule is a helper function to set placement rule.
-func SetPlacementRule(ctx context.Context, rule placement.Rule) error {
+func SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return errors.Trace(err)
@@ -987,7 +987,7 @@ func DeletePlacementRule(ctx context.Context, group string, ruleID string) error
 }
 
 // GetGroupRules to get all placement rule in a certain group.
-func GetGroupRules(ctx context.Context, group string) ([]placement.Rule, error) {
+func GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	is, err := getGlobalInfoSyncer()
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -210,3 +210,65 @@ func TestPutBundlesRetry(t *testing.T) {
 		require.True(t, got.IsEmpty())
 	})
 }
+
+func TestTiFlashManager(t *testing.T) {
+	ctx := context.Background()
+	_, err := GlobalInfoSyncerInit(ctx, "test", func() uint64 { return 1 }, nil, false)
+	tiflash := NewMockTiFlash()
+	SetMockTiFlash(tiflash)
+
+	require.NoError(t, err)
+
+	// SetPlacementRule/GetGroupRules
+	rule := MakeNewRule(1, 2, []string{"a"})
+	require.NoError(t, SetPlacementRule(ctx, *rule))
+	rules, err := GetGroupRules(ctx, "tiflash")
+	require.Nil(t, err)
+	require.Equal(t, 1, len(rules))
+	require.Equal(t, "table-1-r", rules[0].ID)
+	require.Equal(t, 2, rules[0].Count)
+	require.Equal(t, []string{"a"}, rules[0].LocationLabels)
+	require.Equal(t, false, rules[0].Override, false)
+	require.Equal(t, placement.RuleIndexTiFlash, rules[0].Index)
+
+	// PostAccelerateSchedule
+	require.Nil(t, PostAccelerateSchedule(ctx, 1))
+	z, ok := tiflash.SyncStatus[1]
+	require.Equal(t, true, ok)
+	require.Equal(t, true, z.Accel)
+
+	// GetStoresStat
+	stats, err := GetStoresStat(ctx)
+	require.Nil(t, err)
+	require.Equal(t, 1, stats.Count)
+
+	// DeletePlacementRule
+	require.NoError(t, DeletePlacementRule(ctx, "tiflash", rule.ID))
+	rules, err = GetGroupRules(ctx, "tiflash")
+	require.Nil(t, err)
+	require.Equal(t, 0, len(rules))
+
+	// ConfigureTiFlashPDForTable
+	require.Nil(t, ConfigureTiFlashPDForTable(1, 2, &[]string{"a"}))
+	rules, err = GetGroupRules(ctx, "tiflash")
+	require.Nil(t, err)
+	require.Equal(t, 1, len(rules))
+
+	// ConfigureTiFlashPDForPartitions
+	ConfigureTiFlashPDForPartitions(true, &[]model.PartitionDefinition{
+		model.PartitionDefinition {
+			ID: 2,
+			Name: model.NewCIStr("p"),
+			LessThan: []string{},
+		},
+	}, 3, &[]string{})
+	rules, err = GetGroupRules(ctx, "tiflash")
+	require.Nil(t, err)
+	// Have table 1 and 2
+	require.Equal(t, 2, len(rules))
+	z, ok = tiflash.SyncStatus[2]
+	require.Equal(t, true, ok)
+	require.Equal(t, true, z.Accel)
+
+	CloseTiFlashManager(ctx)
+}

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -256,9 +256,9 @@ func TestTiFlashManager(t *testing.T) {
 
 	// ConfigureTiFlashPDForPartitions
 	ConfigureTiFlashPDForPartitions(true, &[]model.PartitionDefinition{
-		model.PartitionDefinition {
-			ID: 2,
-			Name: model.NewCIStr("p"),
+		model.PartitionDefinition{
+			ID:       2,
+			Name:     model.NewCIStr("p"),
 			LessThan: []string{},
 		},
 	}, 3, &[]string{})

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -256,7 +256,7 @@ func TestTiFlashManager(t *testing.T) {
 
 	// ConfigureTiFlashPDForPartitions
 	ConfigureTiFlashPDForPartitions(true, &[]model.PartitionDefinition{
-		model.PartitionDefinition{
+		{
 			ID:       2,
 			Name:     model.NewCIStr("p"),
 			LessThan: []string{},

--- a/domain/infosync/info_test.go
+++ b/domain/infosync/info_test.go
@@ -219,10 +219,10 @@ func TestTiFlashManager(t *testing.T) {
 
 	require.NoError(t, err)
 
-	// SetPlacementRule/GetGroupRules
+	// SetTiFlashPlacementRule/GetTiFlashGroupRules
 	rule := MakeNewRule(1, 2, []string{"a"})
-	require.NoError(t, SetPlacementRule(ctx, *rule))
-	rules, err := GetGroupRules(ctx, "tiflash")
+	require.NoError(t, SetTiFlashPlacementRule(ctx, *rule))
+	rules, err := GetTiFlashGroupRules(ctx, "tiflash")
 	require.Nil(t, err)
 	require.Equal(t, 1, len(rules))
 	require.Equal(t, "table-1-r", rules[0].ID)
@@ -231,26 +231,26 @@ func TestTiFlashManager(t *testing.T) {
 	require.Equal(t, false, rules[0].Override, false)
 	require.Equal(t, placement.RuleIndexTiFlash, rules[0].Index)
 
-	// PostAccelerateSchedule
-	require.Nil(t, PostAccelerateSchedule(ctx, 1))
+	// PostTiFlashAccelerateSchedule
+	require.Nil(t, PostTiFlashAccelerateSchedule(ctx, 1))
 	z, ok := tiflash.SyncStatus[1]
 	require.Equal(t, true, ok)
 	require.Equal(t, true, z.Accel)
 
-	// GetStoresStat
-	stats, err := GetStoresStat(ctx)
+	// GetTiFlashStoresStat
+	stats, err := GetTiFlashStoresStat(ctx)
 	require.Nil(t, err)
 	require.Equal(t, 1, stats.Count)
 
-	// DeletePlacementRule
-	require.NoError(t, DeletePlacementRule(ctx, "tiflash", rule.ID))
-	rules, err = GetGroupRules(ctx, "tiflash")
+	// DeleteTiFlashPlacementRule
+	require.NoError(t, DeleteTiFlashPlacementRule(ctx, "tiflash", rule.ID))
+	rules, err = GetTiFlashGroupRules(ctx, "tiflash")
 	require.Nil(t, err)
 	require.Equal(t, 0, len(rules))
 
 	// ConfigureTiFlashPDForTable
 	require.Nil(t, ConfigureTiFlashPDForTable(1, 2, &[]string{"a"}))
-	rules, err = GetGroupRules(ctx, "tiflash")
+	rules, err = GetTiFlashGroupRules(ctx, "tiflash")
 	require.Nil(t, err)
 	require.Equal(t, 1, len(rules))
 
@@ -262,7 +262,7 @@ func TestTiFlashManager(t *testing.T) {
 			LessThan: []string{},
 		},
 	}, 3, &[]string{})
-	rules, err = GetGroupRules(ctx, "tiflash")
+	rules, err = GetTiFlashGroupRules(ctx, "tiflash")
 	require.Nil(t, err)
 	// Have table 1 and 2
 	require.Equal(t, 2, len(rules))

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/placement"
 	"github.com/pingcap/tidb/store/helper"
@@ -37,7 +38,6 @@ import (
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/pdapi"
 	"go.uber.org/zap"
-	"github.com/gorilla/mux"
 )
 
 // TiFlashPlacementManager manages placement settings for TiFlash.

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -184,7 +184,6 @@ func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.
 
 type mockTiFlashPlacementManager struct {
 	sync.Mutex
-	addrs   []string
 	tiflash *MockTiFlash
 }
 

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -69,7 +69,7 @@ func (m *TiFlashPDPlacementManager) Close(ctx context.Context) {
 }
 
 // SetTiFlashPlacementRule is a helper function to set placement rule.
-func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
+func (m *TiFlashPDPlacementManager) SetTiFlashPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	j, _ := json.Marshal(rule)
 	buf := bytes.NewBuffer(j)
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule"), "POST", buf)
@@ -83,7 +83,7 @@ func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule p
 }
 
 // DeleteTiFlashPlacementRule is to delete placement rule for certain group.
-func (m *TiFlashPDPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
+func (m *TiFlashPDPlacementManager) DeleteTiFlashPlacementRule(ctx context.Context, group string, ruleID string) error {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule", group, ruleID), "DELETE", nil)
 	if err != nil {
 		return errors.Trace(err)
@@ -95,7 +95,7 @@ func (m *TiFlashPDPlacementManager) DeletePlacementRule(ctx context.Context, gro
 }
 
 // GetTiFlashGroupRules to get all placement rule in a certain group.
-func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
+func (m *TiFlashPDPlacementManager) GetTiFlashGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rules", "group", group), "GET", nil)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -114,7 +114,7 @@ func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group str
 }
 
 // PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
-func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
+func (m *TiFlashPDPlacementManager) PostTiFlashAccelerateSchedule(ctx context.Context, tableID int64) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	startKey = codec.EncodeBytes([]byte{}, startKey)
@@ -140,7 +140,7 @@ func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, 
 }
 
 // GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
-func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
+func (m *TiFlashPDPlacementManager) GetTiFlashPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	startKey = codec.EncodeBytes([]byte{}, startKey)
@@ -165,7 +165,7 @@ func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, 
 }
 
 // GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
-func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
+func (m *TiFlashPDPlacementManager) GetTiFlashStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	var storesStat helper.StoresStat
 	res, err := doRequest(ctx, m.addrs, pdapi.Stores, "GET", nil)
 	if err != nil {

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -373,8 +373,8 @@ func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
 
 // HandleGetPDRegionRecordStats is mock function for GetPDRegionRecordStats.
 // It currently always returns 1 Region for convenience.
-func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) *helper.PDRegionStats {
-	return &helper.PDRegionStats{
+func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) helper.PDRegionStats {
+	return helper.PDRegionStats{
 		Count:            1,
 		EmptyCount:       1,
 		StorageSize:      1,
@@ -460,7 +460,7 @@ func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context
 	if m.tiflash == nil {
 		return errors.New("MockTiFlash is not accessible")
 	}
-	*stats = *m.tiflash.HandleGetPDRegionRecordStats(tableID)
+	*stats = m.tiflash.HandleGetPDRegionRecordStats(tableID)
 	return nil
 }
 

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -42,17 +42,17 @@ import (
 
 // TiFlashPlacementManager manages placement settings for TiFlash.
 type TiFlashPlacementManager interface {
-	// SetPlacementRule is a helper function to set placement rule.
+	// SetTiFlashPlacementRule is a helper function to set placement rule.
 	SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error
-	// DeletePlacementRule is to delete placement rule for certain group.
+	// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
 	DeletePlacementRule(ctx context.Context, group string, ruleID string) error
-	// GetGroupRules to get all placement rule in a certain group.
+	// GetTiFlashGroupRules to get all placement rule in a certain group.
 	GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error)
-	// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+	// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
 	PostAccelerateSchedule(ctx context.Context, tableID int64) error
-	// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+	// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
 	GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error
-	// GetStoresStat gets the TiKV store information by accessing PD's api.
+	// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
 	GetStoresStat(ctx context.Context) (*helper.StoresStat, error)
 	// Close is to close TiFlashPlacementManager
 	Close(ctx context.Context)
@@ -68,7 +68,7 @@ func (m *TiFlashPDPlacementManager) Close(ctx context.Context) {
 
 }
 
-// SetPlacementRule is a helper function to set placement rule.
+// SetTiFlashPlacementRule is a helper function to set placement rule.
 func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	j, _ := json.Marshal(rule)
 	buf := bytes.NewBuffer(j)
@@ -77,31 +77,31 @@ func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule p
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in SetPlacementRule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in SetTiFlashPlacementRule")
 	}
 	return nil
 }
 
-// DeletePlacementRule is to delete placement rule for certain group.
+// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
 func (m *TiFlashPDPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule", group, ruleID), "DELETE", nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in DeletePlacementRule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in DeleteTiFlashPlacementRule")
 	}
 	return nil
 }
 
-// GetGroupRules to get all placement rule in a certain group.
+// GetTiFlashGroupRules to get all placement rule in a certain group.
 func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rules", "group", group), "GET", nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if res == nil {
-		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetGroupRules")
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashGroupRules")
 	}
 
 	var rules []placement.TiFlashRule
@@ -113,7 +113,7 @@ func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group str
 	return rules, nil
 }
 
-// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
 func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
@@ -134,12 +134,12 @@ func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, 
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in PostAccelerateSchedule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in PostTiFlashAccelerateSchedule")
 	}
 	return nil
 }
 
-// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
 func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
@@ -154,7 +154,7 @@ func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, 
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in GetPDRegionRecordStats")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashPDRegionRecordStats")
 	}
 
 	err = json.Unmarshal(res, stats)
@@ -164,7 +164,7 @@ func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, 
 	return nil
 }
 
-// GetStoresStat gets the TiKV store information by accessing PD's api.
+// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
 func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	var storesStat helper.StoresStat
 	res, err := doRequest(ctx, m.addrs, pdapi.Stores, "GET", nil)
@@ -172,7 +172,7 @@ func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.
 		return nil, errors.Trace(err)
 	}
 	if res == nil {
-		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetStoresStat")
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashStoresStat")
 	}
 
 	err = json.Unmarshal(res, &storesStat)
@@ -300,7 +300,7 @@ func NewMockTiFlash() *MockTiFlash {
 	return tiflash
 }
 
-// HandleSetPlacementRule is mock function for SetPlacementRule.
+// HandleSetPlacementRule is mock function for SetTiFlashPlacementRule.
 func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.TiFlashRule) error {
 	if !tiflash.PdEnabled {
 		return errors.New("pd server is manually disabled, just quit")
@@ -337,12 +337,12 @@ func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.TiFlashRule) e
 	return nil
 }
 
-// HandleDeletePlacementRule is mock function for DeletePlacementRule.
+// HandleDeletePlacementRule is mock function for DeleteTiFlashPlacementRule.
 func (tiflash *MockTiFlash) HandleDeletePlacementRule(group string, ruleID string) {
 	delete(tiflash.GlobalTiFlashPlacementRules, ruleID)
 }
 
-// HandleGetGroupRules is mock function for GetGroupRules.
+// HandleGetGroupRules is mock function for GetTiFlashGroupRules.
 func (tiflash *MockTiFlash) HandleGetGroupRules(group string) ([]placement.TiFlashRule, error) {
 	var result = make([]placement.TiFlashRule, 0)
 	for _, item := range tiflash.GlobalTiFlashPlacementRules {
@@ -351,7 +351,7 @@ func (tiflash *MockTiFlash) HandleGetGroupRules(group string) ([]placement.TiFla
 	return result, nil
 }
 
-// HandlePostAccelerateSchedule is mock function for PostAccelerateSchedule.
+// HandlePostAccelerateSchedule is mock function for PostTiFlashAccelerateSchedule.
 func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
 	tableID := helper.GetTiFlashTableIDFromEndKey(endKey)
 
@@ -368,7 +368,7 @@ func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
 	return nil
 }
 
-// HandleGetPDRegionRecordStats is mock function for GetPDRegionRecordStats.
+// HandleGetPDRegionRecordStats is mock function for GetTiFlashPDRegionRecordStats.
 // It currently always returns 1 Region for convenience.
 func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) helper.PDRegionStats {
 	return helper.PDRegionStats{
@@ -381,7 +381,7 @@ func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) helper.PDRegio
 	}
 }
 
-// HandleGetStoresStat is mock function for GetStoresStat.
+// HandleGetStoresStat is mock function for GetTiFlashStoresStat.
 // It returns address of our mocked TiFlash server.
 func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	return &helper.StoresStat{
@@ -407,7 +407,7 @@ func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	}
 }
 
-// SetPlacementRule is a helper function to set placement rule.
+// SetTiFlashPlacementRule is a helper function to set placement rule.
 func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	m.Lock()
 	defer m.Unlock()
@@ -417,7 +417,7 @@ func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule
 	return m.tiflash.HandleSetPlacementRule(rule)
 }
 
-// DeletePlacementRule is to delete placement rule for certain group.
+// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
 func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
 	m.Lock()
 	defer m.Unlock()
@@ -428,7 +428,7 @@ func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, g
 	return nil
 }
 
-// GetGroupRules to get all placement rule in a certain group.
+// GetTiFlashGroupRules to get all placement rule in a certain group.
 func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -438,7 +438,7 @@ func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group s
 	return m.tiflash.HandleGetGroupRules(group)
 }
 
-// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
 func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
 	m.Lock()
 	defer m.Unlock()
@@ -450,7 +450,7 @@ func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context
 	return m.tiflash.HandlePostAccelerateSchedule(hex.EncodeToString(endKey))
 }
 
-// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
 func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	m.Lock()
 	defer m.Unlock()
@@ -461,7 +461,7 @@ func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context
 	return nil
 }
 
-// GetStoresStat gets the TiKV store information by accessing PD's api.
+// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
 func (m *mockTiFlashPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	m.Lock()
 	defer m.Unlock()

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -269,19 +269,17 @@ func (tiflash *MockTiFlash) setUpMockTiFlashHTTPServer() (*httptest.Server, stri
 		table, ok := tiflash.SyncStatus[tableID]
 		logutil.BgLogger().Info("Mock TiFlash returns", zap.Bool("ok", ok), zap.Int("tableID", tableID))
 		if !ok {
-			b := []byte("0\n\n")
 			w.WriteHeader(http.StatusOK)
-			w.Write(b)
+			_, _ = w.Write([]byte("0\n\n"))
 			return
 		}
-		sync := table.String()
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(sync))
+		_, _ = w.Write([]byte(table.String()))
 	})
 	router.HandleFunc("/config", func(w http.ResponseWriter, req *http.Request) {
 		s := fmt.Sprintf("{\n    \"engine-store\": {\n        \"http_port\": %v\n    }\n}", statusPort)
 		w.WriteHeader(http.StatusOK)
-		w.Write([]byte(s))
+		_, _ = w.Write([]byte(s))
 	})
 	return server, statusAddr
 }

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -42,17 +42,17 @@ import (
 
 // TiFlashPlacementManager manages placement settings for TiFlash.
 type TiFlashPlacementManager interface {
-	// SetTiFlashPlacementRule is a helper function to set placement rule.
+	// SetPlacementRule is a helper function to set placement rule.
 	SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error
-	// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
+	// DeletePlacementRule is to delete placement rule for certain group.
 	DeletePlacementRule(ctx context.Context, group string, ruleID string) error
-	// GetTiFlashGroupRules to get all placement rule in a certain group.
+	// GetGroupRules to get all placement rule in a certain group.
 	GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error)
-	// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
+	// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
 	PostAccelerateSchedule(ctx context.Context, tableID int64) error
-	// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
+	// GetPDRegionRecordStats is a helper function calling `/stats/region`.
 	GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error
-	// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
+	// GetStoresStat gets the TiKV store information by accessing PD's api.
 	GetStoresStat(ctx context.Context) (*helper.StoresStat, error)
 	// Close is to close TiFlashPlacementManager
 	Close(ctx context.Context)
@@ -68,8 +68,8 @@ func (m *TiFlashPDPlacementManager) Close(ctx context.Context) {
 
 }
 
-// SetTiFlashPlacementRule is a helper function to set placement rule.
-func (m *TiFlashPDPlacementManager) SetTiFlashPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
+// SetPlacementRule is a helper function to set placement rule.
+func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	j, _ := json.Marshal(rule)
 	buf := bytes.NewBuffer(j)
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule"), "POST", buf)
@@ -77,31 +77,31 @@ func (m *TiFlashPDPlacementManager) SetTiFlashPlacementRule(ctx context.Context,
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in SetTiFlashPlacementRule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in SetPlacementRule")
 	}
 	return nil
 }
 
-// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
-func (m *TiFlashPDPlacementManager) DeleteTiFlashPlacementRule(ctx context.Context, group string, ruleID string) error {
+// DeletePlacementRule is to delete placement rule for certain group.
+func (m *TiFlashPDPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule", group, ruleID), "DELETE", nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in DeleteTiFlashPlacementRule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in DeletePlacementRule")
 	}
 	return nil
 }
 
-// GetTiFlashGroupRules to get all placement rule in a certain group.
-func (m *TiFlashPDPlacementManager) GetTiFlashGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
+// GetGroupRules to get all placement rule in a certain group.
+func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rules", "group", group), "GET", nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if res == nil {
-		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashGroupRules")
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetGroupRules")
 	}
 
 	var rules []placement.TiFlashRule
@@ -113,8 +113,8 @@ func (m *TiFlashPDPlacementManager) GetTiFlashGroupRules(ctx context.Context, gr
 	return rules, nil
 }
 
-// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
-func (m *TiFlashPDPlacementManager) PostTiFlashAccelerateSchedule(ctx context.Context, tableID int64) error {
+// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	startKey = codec.EncodeBytes([]byte{}, startKey)
@@ -134,13 +134,13 @@ func (m *TiFlashPDPlacementManager) PostTiFlashAccelerateSchedule(ctx context.Co
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in PostTiFlashAccelerateSchedule")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in PostAccelerateSchedule")
 	}
 	return nil
 }
 
-// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
-func (m *TiFlashPDPlacementManager) GetTiFlashPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
+// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	startKey := tablecodec.GenTableRecordPrefix(tableID)
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	startKey = codec.EncodeBytes([]byte{}, startKey)
@@ -154,7 +154,7 @@ func (m *TiFlashPDPlacementManager) GetTiFlashPDRegionRecordStats(ctx context.Co
 		return errors.Trace(err)
 	}
 	if res == nil {
-		return fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashPDRegionRecordStats")
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in GetPDRegionRecordStats")
 	}
 
 	err = json.Unmarshal(res, stats)
@@ -164,15 +164,15 @@ func (m *TiFlashPDPlacementManager) GetTiFlashPDRegionRecordStats(ctx context.Co
 	return nil
 }
 
-// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
-func (m *TiFlashPDPlacementManager) GetTiFlashStoresStat(ctx context.Context) (*helper.StoresStat, error) {
+// GetStoresStat gets the TiKV store information by accessing PD's api.
+func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	var storesStat helper.StoresStat
 	res, err := doRequest(ctx, m.addrs, pdapi.Stores, "GET", nil)
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
 	if res == nil {
-		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetTiFlashStoresStat")
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetStoresStat")
 	}
 
 	err = json.Unmarshal(res, &storesStat)
@@ -351,7 +351,7 @@ func (tiflash *MockTiFlash) HandleGetGroupRules(group string) ([]placement.TiFla
 	return result, nil
 }
 
-// HandlePostAccelerateSchedule is mock function for PostTiFlashAccelerateSchedule.
+// HandlePostAccelerateSchedule is mock function for PostAccelerateSchedule.
 func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
 	tableID := helper.GetTiFlashTableIDFromEndKey(endKey)
 
@@ -368,7 +368,7 @@ func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
 	return nil
 }
 
-// HandleGetPDRegionRecordStats is mock function for GetTiFlashPDRegionRecordStats.
+// HandleGetPDRegionRecordStats is mock function for GetPDRegionRecordStats.
 // It currently always returns 1 Region for convenience.
 func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) helper.PDRegionStats {
 	return helper.PDRegionStats{
@@ -381,7 +381,7 @@ func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) helper.PDRegio
 	}
 }
 
-// HandleGetStoresStat is mock function for GetTiFlashStoresStat.
+// HandleGetStoresStat is mock function for GetStoresStat.
 // It returns address of our mocked TiFlash server.
 func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	return &helper.StoresStat{
@@ -407,7 +407,7 @@ func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	}
 }
 
-// SetTiFlashPlacementRule is a helper function to set placement rule.
+// SetPlacementRule is a helper function to set placement rule.
 func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
 	m.Lock()
 	defer m.Unlock()
@@ -417,7 +417,7 @@ func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule
 	return m.tiflash.HandleSetPlacementRule(rule)
 }
 
-// DeleteTiFlashPlacementRule is to delete placement rule for certain group.
+// DeletePlacementRule is to delete placement rule for certain group.
 func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
 	m.Lock()
 	defer m.Unlock()
@@ -428,7 +428,7 @@ func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, g
 	return nil
 }
 
-// GetTiFlashGroupRules to get all placement rule in a certain group.
+// GetGroupRules to get all placement rule in a certain group.
 func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.TiFlashRule, error) {
 	m.Lock()
 	defer m.Unlock()
@@ -438,7 +438,7 @@ func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group s
 	return m.tiflash.HandleGetGroupRules(group)
 }
 
-// PostTiFlashAccelerateSchedule sends `regions/accelerate-schedule` request.
+// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
 func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
 	m.Lock()
 	defer m.Unlock()
@@ -450,7 +450,7 @@ func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context
 	return m.tiflash.HandlePostAccelerateSchedule(hex.EncodeToString(endKey))
 }
 
-// GetTiFlashPDRegionRecordStats is a helper function calling `/stats/region`.
+// GetPDRegionRecordStats is a helper function calling `/stats/region`.
 func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
 	m.Lock()
 	defer m.Unlock()
@@ -461,7 +461,7 @@ func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context
 	return nil
 }
 
-// GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
+// GetStoresStat gets the TiKV store information by accessing PD's api.
 func (m *mockTiFlashPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	m.Lock()
 	defer m.Unlock()

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -1,0 +1,476 @@
+package infosync
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/ddl/placement"
+	"github.com/pingcap/tidb/store/helper"
+	"github.com/pingcap/tidb/tablecodec"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/logutil"
+	"github.com/pingcap/tidb/util/pdapi"
+	"go.uber.org/zap"
+)
+
+// TiFlashPlacementManager manages placement settings for TiFlash
+type TiFlashPlacementManager interface {
+	// SetPlacementRule is a helper function to set placement rule.
+	SetPlacementRule(ctx context.Context, rule placement.Rule) error
+	// DeletePlacementRule is to delete placement rule for certain group.
+	DeletePlacementRule(ctx context.Context, group string, ruleID string) error
+	// GetGroupRules to get all placement rule in a certain group.
+	GetGroupRules(ctx context.Context, group string) ([]placement.Rule, error)
+	// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+	PostAccelerateSchedule(ctx context.Context, tableID int64) error
+	// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+	GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error
+	// GetStoresStat gets the TiKV store information by accessing PD's api.
+	GetStoresStat(ctx context.Context) (*helper.StoresStat, error)
+	// Close is to close TiFlashPlacementManager
+	Close(ctx context.Context)
+}
+
+// TiFlashPDPlacementManager manages placement with pd for TiFlash
+type TiFlashPDPlacementManager struct {
+	addrs []string
+}
+
+// Close is to close TiFlashPDPlacementManager
+func (m *TiFlashPDPlacementManager) Close(ctx context.Context) {
+
+}
+
+// SetPlacementRule is a helper function to set placement rule.
+func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule placement.Rule) error {
+	j, _ := json.Marshal(rule)
+	buf := bytes.NewBuffer(j)
+	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule"), "POST", buf)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if res == nil {
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in SetPlacementRule")
+	}
+	return nil
+}
+
+// DeletePlacementRule is to delete placement rule for certain group.
+func (m *TiFlashPDPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
+	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule", group, ruleID), "DELETE", nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if res == nil {
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in DeletePlacementRule")
+	}
+	return nil
+}
+
+// GetGroupRules to get all placement rule in a certain group.
+func (m *TiFlashPDPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.Rule, error) {
+	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rules", "group", group), "GET", nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if res == nil {
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetGroupRules")
+	}
+
+	var rules []placement.Rule
+	err = json.Unmarshal(res, &rules)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+
+	return rules, nil
+}
+
+// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+func (m *TiFlashPDPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
+	startKey := tablecodec.GenTableRecordPrefix(tableID)
+	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
+	startKey = codec.EncodeBytes([]byte{}, startKey)
+	endKey = codec.EncodeBytes([]byte{}, endKey)
+
+	input := map[string]string{
+		"start_key": hex.EncodeToString(startKey),
+		"end_key":   hex.EncodeToString(endKey),
+	}
+	j, err := json.Marshal(input)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	buf := bytes.NewBuffer(j)
+	res, err := doRequest(ctx, m.addrs, "/pd/api/v1/regions/accelerate-schedule", "POST", buf)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if res == nil {
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in PostAccelerateSchedule")
+	}
+	return nil
+}
+
+// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+func (m *TiFlashPDPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
+	startKey := tablecodec.GenTableRecordPrefix(tableID)
+	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
+	startKey = codec.EncodeBytes([]byte{}, startKey)
+	endKey = codec.EncodeBytes([]byte{}, endKey)
+
+	p := fmt.Sprintf("/pd/api/v1/stats/region?start_key=%s&end_key=%s",
+		url.QueryEscape(string(startKey)),
+		url.QueryEscape(string(endKey)))
+	res, err := doRequest(ctx, m.addrs, p, "GET", nil)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if res == nil {
+		return fmt.Errorf("TiFlashPDPlacementManager returns error in GetPDRegionRecordStats")
+	}
+
+	err = json.Unmarshal(res, stats)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return nil
+}
+
+// GetStoresStat gets the TiKV store information by accessing PD's api.
+func (m *TiFlashPDPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
+	var storesStat helper.StoresStat
+	res, err := doRequest(ctx, m.addrs, pdapi.Stores, "GET", nil)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	if res == nil {
+		return nil, fmt.Errorf("TiFlashPDPlacementManager returns error in GetStoresStat")
+	}
+
+	err = json.Unmarshal(res, &storesStat)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return &storesStat, err
+}
+
+type mockTiFlashPlacementManager struct {
+	sync.Mutex
+	addrs   []string
+	tiflash *MockTiFlash
+}
+
+type mockAddrTiFlashPlacementManager struct {
+	TiFlashPDPlacementManager
+	sync.Mutex
+}
+
+func makeBaseRule() placement.Rule {
+	return placement.Rule{
+		GroupID:  "tiflash",
+		ID:       "",
+		Index:    placement.RuleIndexTiFlash,
+		Override: false,
+		Role:     placement.Learner,
+		Count:    2,
+		Constraints: []placement.Constraint{
+			{
+				Key:    "engine",
+				Op:     placement.In,
+				Values: []string{"tiflash"},
+			},
+		},
+	}
+}
+
+// MakeNewRule creates a pd rule for TiFlash.
+func MakeNewRule(ID int64, Count uint64, LocationLabels []string) *placement.Rule {
+	ruleID := fmt.Sprintf("table-%v-r", ID)
+	startKey := tablecodec.GenTableRecordPrefix(ID)
+	endKey := tablecodec.EncodeTablePrefix(ID + 1)
+	startKey = codec.EncodeBytes([]byte{}, startKey)
+	endKey = codec.EncodeBytes([]byte{}, endKey)
+
+	ruleNew := makeBaseRule()
+	ruleNew.ID = ruleID
+	ruleNew.StartKeyHex = startKey.String()
+	ruleNew.EndKeyHex = endKey.String()
+	ruleNew.Count = int(Count)
+	ruleNew.LocationLabels = LocationLabels
+
+	return &ruleNew
+}
+
+type mockTiFlashTableInfo struct {
+	Regions []int
+	Accel   bool
+}
+
+func (m *mockTiFlashTableInfo) String() string {
+	regionStr := ""
+	for _, s := range m.Regions {
+		regionStr = regionStr + strconv.Itoa(s) + "\n"
+	}
+	if regionStr == "" {
+		regionStr = "\n"
+	}
+	return fmt.Sprintf("%v\n%v", len(m.Regions), regionStr)
+}
+
+// MockTiFlash mocks a TiFlash, with necessary Pd support.
+type MockTiFlash struct {
+	StatusAddr                  string
+	StatusServer                *httptest.Server
+	SyncStatus                  map[int]mockTiFlashTableInfo
+	GlobalTiFlashPlacementRules map[string]placement.Rule
+	PdEnabled                   bool
+	TiflashDelay                time.Duration
+	StartTime                   time.Time
+}
+
+func (tiflash *MockTiFlash) setUpMockTiFlashHTTPServer() (*httptest.Server, string) {
+	// mock TiFlash http server
+	router := mux.NewRouter()
+	server := httptest.NewServer(router)
+	// mock store stats stat
+	statusAddr := strings.TrimPrefix(server.URL, "http://")
+	statusAddrVec := strings.Split(statusAddr, ":")
+	statusPort, _ := strconv.Atoi(statusAddrVec[1])
+	router.HandleFunc("/tiflash/sync-status/{tableid:\\d+}", func(w http.ResponseWriter, req *http.Request) {
+		params := mux.Vars(req)
+		tableID, err := strconv.Atoi(params["tableid"])
+		if err != nil {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		table, ok := tiflash.SyncStatus[tableID]
+		logutil.BgLogger().Info("Mock TiFlash returns", zap.Bool("ok", ok), zap.Int("tableID", tableID))
+		if !ok {
+			b := []byte("0\n\n")
+			w.WriteHeader(http.StatusOK)
+			w.Write(b)
+			return
+		}
+		sync := table.String()
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(sync))
+	})
+	router.HandleFunc("/config", func(w http.ResponseWriter, req *http.Request) {
+		s := fmt.Sprintf("{\n    \"engine-store\": {\n        \"http_port\": %v\n    }\n}", statusPort)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(s))
+	})
+	return server, statusAddr
+}
+
+// NewMockTiFlash creates a MockTiFlash with a mocked TiFlash server.
+func NewMockTiFlash() *MockTiFlash {
+	tiflash := &MockTiFlash{
+		StatusAddr:                  "",
+		StatusServer:                nil,
+		SyncStatus:                  make(map[int]mockTiFlashTableInfo),
+		GlobalTiFlashPlacementRules: make(map[string]placement.Rule),
+		PdEnabled:                   true,
+		TiflashDelay:                0,
+		StartTime:                   time.Now(),
+	}
+	server, addr := tiflash.setUpMockTiFlashHTTPServer()
+	tiflash.StatusAddr = addr
+	tiflash.StatusServer = server
+	return tiflash
+}
+
+// HandleSetPlacementRule is mock function for SetPlacementRule
+func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.Rule) error {
+	if !tiflash.PdEnabled {
+		fmt.Printf("pd server is manually disabled, just quit\n")
+		return errors.New("pd server is manually disabled, just quit")
+	}
+
+	tiflash.GlobalTiFlashPlacementRules[rule.ID] = rule
+	// Pd shall schedule TiFlash, we can mock here
+	tid := 0
+	_, err := fmt.Sscanf(rule.ID, "table-%d-r", &tid)
+	if err != nil {
+		return errors.New("Can't parse rule")
+	}
+	// Set up mock tiflash replica
+	// TODO Shall mock "/pd/api/v1/stats/region", and set correct region here, according to actual pd rule
+	f := func() {
+		if z, ok := tiflash.SyncStatus[tid]; ok {
+			z.Regions = []int{1}
+			tiflash.SyncStatus[tid] = z
+		} else {
+			tiflash.SyncStatus[tid] = mockTiFlashTableInfo{
+				Regions: []int{1},
+				Accel:   false,
+			}
+		}
+	}
+	if tiflash.TiflashDelay > 0 {
+		go func() {
+			time.Sleep(tiflash.TiflashDelay)
+			logutil.BgLogger().Warn("TiFlash replica is available after delay", zap.Duration("duration", tiflash.TiflashDelay))
+			f()
+		}()
+	} else {
+		f()
+	}
+	return nil
+}
+
+// HandleDeletePlacementRule is mock function for DeletePlacementRule
+func (tiflash *MockTiFlash) HandleDeletePlacementRule(group string, ruleID string) {
+	delete(tiflash.GlobalTiFlashPlacementRules, ruleID)
+}
+
+// HandleGetGroupRules is mock function for GetGroupRules
+func (tiflash *MockTiFlash) HandleGetGroupRules(group string) ([]placement.Rule, error) {
+	var result = make([]placement.Rule, 0)
+	for _, item := range tiflash.GlobalTiFlashPlacementRules {
+		result = append(result, item)
+	}
+	return result, nil
+}
+
+// HandlePostAccelerateSchedule is mock function for PostAccelerateSchedule
+func (tiflash *MockTiFlash) HandlePostAccelerateSchedule(endKey string) error {
+	tableID := helper.GetTiFlashTableIDFromEndKey(endKey)
+
+	table, ok := tiflash.SyncStatus[int(tableID)]
+	if ok {
+		table.Accel = true
+		tiflash.SyncStatus[int(tableID)] = table
+	} else {
+		tiflash.SyncStatus[int(tableID)] = mockTiFlashTableInfo{
+			Regions: []int{},
+			Accel:   true,
+		}
+	}
+	return nil
+}
+
+// HandleGetPDRegionRecordStats is mock function for GetPDRegionRecordStats
+func (tiflash *MockTiFlash) HandleGetPDRegionRecordStats(_ int64) *helper.PDRegionStats {
+	return &helper.PDRegionStats{
+		Count:            1,
+		EmptyCount:       1,
+		StorageSize:      1,
+		StorageKeys:      1,
+		StoreLeaderCount: map[uint64]int{1: 1},
+		StorePeerCount:   map[uint64]int{1: 1},
+	}
+}
+
+// HandleGetStoresStat is mock function for GetStoresStat
+func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
+	return &helper.StoresStat{
+		Count: 1,
+		Stores: []helper.StoreStat{
+			{
+				Store: helper.StoreBaseStat{
+					ID:             1,
+					Address:        "127.0.0.1:3930",
+					State:          0,
+					StateName:      "Up",
+					Version:        "4.0.0-alpha",
+					StatusAddress:  tiflash.StatusAddr,
+					GitHash:        "mock-tikv-githash",
+					StartTimestamp: tiflash.StartTime.Unix(),
+					Labels: []helper.StoreLabel{{
+						Key:   "engine",
+						Value: "tiflash",
+					}},
+				},
+			},
+		},
+	}
+}
+
+// SetPlacementRule is a helper function to set placement rule.
+func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule placement.Rule) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return errors.New("MockTiFlash not inited")
+	}
+	return m.tiflash.HandleSetPlacementRule(rule)
+}
+
+// DeletePlacementRule is to delete placement rule for certain group.
+func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, group string, ruleID string) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return errors.New("MockTiFlash not inited")
+	}
+	m.tiflash.HandleDeletePlacementRule(group, ruleID)
+	return nil
+}
+
+// GetGroupRules to get all placement rule in a certain group.
+func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group string) ([]placement.Rule, error) {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return nil, errors.New("MockTiFlash not inited")
+	}
+	return m.tiflash.HandleGetGroupRules(group)
+}
+
+// PostAccelerateSchedule sends `regions/accelerate-schedule` request.
+func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context, tableID int64) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return errors.New("MockTiFlash not inited")
+	}
+	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
+	endKey = codec.EncodeBytes([]byte{}, endKey)
+	return m.tiflash.HandlePostAccelerateSchedule(hex.EncodeToString(endKey))
+}
+
+// GetPDRegionRecordStats is a helper function calling `/stats/region`.
+func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context, tableID int64, stats *helper.PDRegionStats) error {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return errors.New("MockTiFlash not inited")
+	}
+	*stats = *m.tiflash.HandleGetPDRegionRecordStats(tableID)
+	return nil
+}
+
+// GetStoresStat gets the TiKV store information by accessing PD's api.
+func (m *mockTiFlashPlacementManager) GetStoresStat(ctx context.Context) (*helper.StoresStat, error) {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash == nil {
+		return nil, errors.New("MockTiFlash not inited")
+	}
+	return m.tiflash.HandleGetStoresStat(), nil
+}
+
+// Close is to close mockTiFlashPlacementManager
+func (m *mockTiFlashPlacementManager) Close(ctx context.Context) {
+	m.Lock()
+	defer m.Unlock()
+	if m.tiflash.StatusServer != nil {
+		m.tiflash.StatusServer.Close()
+	}
+}

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -1123,8 +1123,8 @@ func (h *Helper) GetPDRegionRecordStats(tableID int64, stats *PDRegionStats) err
 
 // GetTiFlashTableIDFromEndKey computes tableID from pd rule's endKey.
 func GetTiFlashTableIDFromEndKey(endKey string) int64 {
-	endKey, _ = url.QueryUnescape(endKey)
-	_, decodedEndKey, _ := codec.DecodeBytes([]byte(endKey), []byte{})
+	e, _ := hex.DecodeString(endKey)
+	_, decodedEndKey, _ := codec.DecodeBytes(e, []byte{})
 	tableID := tablecodec.DecodeTableID(decodedEndKey)
 	tableID -= 1
 	return tableID


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #29924

Problem Summary:
This PR is the second PR to fix problems described in #29924.
This PR wraps TiFlash and it pd rule related operations into a new `TiFlashPlacementManager` in InfoSyncer.
This PR does not implements basic function of TiFlash replica management, which will be introduced in later PRs.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Wrap TiFlash and its pd rule management into InfoSyncer
```
