### PR TITLE
privileges: show grants return incorrect results when granted with 2 or more privileges

### DIFF
--- a/privilege/privileges/cache.go
+++ b/privilege/privileges/cache.go
@@ -1231,19 +1231,11 @@ func (p *MySQLPrivilege) showGrants(user, host string, roles []*auth.RoleIdentit
 	dbPrivTable := make(map[string]mysql.PrivilegeType)
 	for _, record := range p.DB {
 		if record.fullyMatch(user, host) {
-			if _, ok := dbPrivTable[record.DB]; ok {
-				dbPrivTable[record.DB] |= record.Privileges
-			} else {
-				dbPrivTable[record.DB] = record.Privileges
-			}
+			dbPrivTable[record.DB] |= record.Privileges
 		} else {
 			for _, r := range allRoles {
 				if record.baseRecord.match(r.Username, r.Hostname) {
-					if _, ok := dbPrivTable[record.DB]; ok {
-						dbPrivTable[record.DB] |= record.Privileges
-					} else {
-						dbPrivTable[record.DB] = record.Privileges
-					}
+					dbPrivTable[record.DB] |= record.Privileges
 				}
 			}
 		}
@@ -1273,19 +1265,11 @@ func (p *MySQLPrivilege) showGrants(user, host string, roles []*auth.RoleIdentit
 	for _, record := range p.TablesPriv {
 		recordKey := record.DB + "." + record.TableName
 		if user == record.User && host == record.Host {
-			if _, ok := dbPrivTable[record.DB]; ok {
-				tablePrivTable[recordKey] |= record.TablePriv
-			} else {
-				tablePrivTable[recordKey] = record.TablePriv
-			}
+			tablePrivTable[recordKey] |= record.TablePriv
 		} else {
 			for _, r := range allRoles {
 				if record.baseRecord.match(r.Username, r.Hostname) {
-					if _, ok := dbPrivTable[record.DB]; ok {
-						tablePrivTable[recordKey] |= record.TablePriv
-					} else {
-						tablePrivTable[recordKey] = record.TablePriv
-					}
+					tablePrivTable[recordKey] |= record.TablePriv
 				}
 			}
 		}

--- a/privilege/privileges/privileges_test.go
+++ b/privilege/privileges/privileges_test.go
@@ -271,7 +271,7 @@ func TestShowGrants(t *testing.T) {
 	require.Len(t, gs, 2)
 	expected := []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
 		`GRANT SELECT ON test.* TO 'show'@'localhost'`}
-	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected))
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
 
 	mustExec(t, se, `GRANT Index ON test1.* TO  'show'@'localhost';`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
@@ -280,7 +280,17 @@ func TestShowGrants(t *testing.T) {
 	expected = []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
 		`GRANT SELECT ON test.* TO 'show'@'localhost'`,
 		`GRANT INDEX ON test1.* TO 'show'@'localhost'`}
-	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected))
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
+
+	// Add another db privilege to the same db and test again.
+	mustExec(t, se, `GRANT Delete ON test1.* TO  'show'@'localhost';`)
+	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
+	require.NoError(t, err)
+	require.Len(t, gs, 3)
+	expected = []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
+		`GRANT SELECT ON test.* TO 'show'@'localhost'`,
+		`GRANT DELETE,INDEX ON test1.* TO 'show'@'localhost'`}
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
 
 	mustExec(t, se, `GRANT ALL ON test1.* TO  'show'@'localhost';`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
@@ -289,7 +299,7 @@ func TestShowGrants(t *testing.T) {
 	expected = []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
 		`GRANT SELECT ON test.* TO 'show'@'localhost'`,
 		`GRANT ALL PRIVILEGES ON test1.* TO 'show'@'localhost'`}
-	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected))
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
 
 	// Add table scope privileges
 	mustExec(t, se, `GRANT Update ON test.test TO  'show'@'localhost';`)
@@ -300,13 +310,33 @@ func TestShowGrants(t *testing.T) {
 		`GRANT SELECT ON test.* TO 'show'@'localhost'`,
 		`GRANT ALL PRIVILEGES ON test1.* TO 'show'@'localhost'`,
 		`GRANT UPDATE ON test.test TO 'show'@'localhost'`}
-	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected))
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
+
+	// Revoke the db privilege of `test` and test again. See issue #30855.
+	mustExec(t, se, `REVOKE SELECT ON test.* FROM 'show'@'localhost'`)
+	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
+	require.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, gs, 3)
+	expected = []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
+		`GRANT ALL PRIVILEGES ON test1.* TO 'show'@'localhost'`,
+		`GRANT UPDATE ON test.test TO 'show'@'localhost'`}
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
+
+	// Add another table privilege and test again.
+	mustExec(t, se, `GRANT Select ON test.test TO  'show'@'localhost';`)
+	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
+	require.NoError(t, err)
+	require.Len(t, gs, 3)
+	expected = []string{`GRANT ALL PRIVILEGES ON *.* TO 'show'@'localhost'`,
+		`GRANT ALL PRIVILEGES ON test1.* TO 'show'@'localhost'`,
+		`GRANT SELECT,UPDATE ON test.test TO 'show'@'localhost'`}
+	require.True(t, testutil.CompareUnorderedStringSlice(gs, expected), fmt.Sprintf("gs: %v, expected: %v", gs, expected))
 
 	// Expected behavior: Usage still exists after revoking all privileges
 	mustExec(t, se, `REVOKE ALL PRIVILEGES ON *.* FROM 'show'@'localhost'`)
-	mustExec(t, se, `REVOKE Select on test.* FROM 'show'@'localhost'`)
 	mustExec(t, se, `REVOKE ALL ON test1.* FROM 'show'@'localhost'`)
-	mustExec(t, se, `REVOKE UPDATE on test.test FROM 'show'@'localhost'`)
+	mustExec(t, se, `REVOKE UPDATE, SELECT on test.test FROM 'show'@'localhost'`)
 	gs, err = pc.ShowGrants(se, &auth.UserIdentity{Username: "show", Hostname: "localhost"}, nil)
 	require.NoError(t, err)
 	require.Len(t, gs, 1)
@@ -2506,17 +2536,16 @@ func TestShowGrantsForCurrentUserUsingRole(t *testing.T) {
 		"GRANT USAGE ON *.* TO 'joe'@'%'",
 		"GRANT SELECT ON test.* TO 'joe'@'%'",
 		"GRANT UPDATE ON role.* TO 'joe'@'%'",
-		"GRANT DELETE ON mysql.user TO 'joe'@'%'",
+		"GRANT SELECT,DELETE ON mysql.user TO 'joe'@'%'",
 		"GRANT 'admins'@'%', 'engineering'@'%', 'otherrole'@'%' TO 'joe'@'%'",
 	))
 	tk.MustQuery("SHOW GRANTS FOR joe USING otherrole;").Check(testkit.Rows(
 		"GRANT USAGE ON *.* TO 'joe'@'%'",
 		"GRANT SELECT ON test.* TO 'joe'@'%'",
 		"GRANT UPDATE ON role.* TO 'joe'@'%'",
-		"GRANT DELETE ON mysql.user TO 'joe'@'%'",
+		"GRANT SELECT,DELETE ON mysql.user TO 'joe'@'%'",
 		"GRANT 'admins'@'%', 'engineering'@'%', 'otherrole'@'%' TO 'joe'@'%'",
 	))
-
 }
 
 func TestGrantPlacementAdminDynamicPriv(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #30855

Problem Summary:
When there is no db privilege granted to the user, but more than 1 table privilege granted to him, `show grants` will show only one table privilege due to a bug.

### What is changed and how it works?

Simplify the code in `showGrants` because it's buggy: it checks `dbPrivTable[record.DB]` before updating `tablePrivTable`. I think the author copied the wrong code.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
- Fix the bug that `show grants` returns incorrect results when granted with 2 or more privileges
```
