### PR TITLE
[WIP] executor: skip null rows when deleting multiple tables

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -9810,3 +9810,17 @@ func (s *testSerialSuite) TestIssue30971(c *C) {
 		c.Assert(fields, HasLen, test.fields)
 	}
 }
+
+func TestDeleteOuterJoin(t *testing.T) {
+	store, clean := testkit2.CreateMockStore(t)
+	defer clean()
+	tk := testkit2.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table a (k1 int);")
+	tk.MustExec("create table b (id int primary key, k1 int);")
+	tk.MustExec("insert into a(k1) values(3);")
+	tk.MustExec("insert into b values(2, 2);")
+	tk.MustExec("insert into b values(0, 0);")
+	tk.MustExec("delete a,b from a left join b on a.k1 = b.k1")
+	tk.MustQuery("select * from b order by id").Check(testkit.Rows("0 0", "2 2"))
+}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -761,3 +761,17 @@ func TestConstraintCheckForOptimisticUntouched(t *testing.T) {
 	err = tk.ExecToErr("commit")
 	require.Error(t, err)
 }
+
+func TestAssertion(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table a (k1 int);")
+	tk.MustExec("create table b (id int primary key, k1 int);")
+	tk.MustExec("insert into a(k1) values(3);")
+	tk.MustExec("insert into b values(2, 2);")
+	tk.MustExec("insert into b values(0, 0);")
+	tk.MustExec("delete a,b from a left join b on a.k1 = b.k1")
+	tk.MustQuery("select * from b order by id").Check(testkit.Rows("0 0", "2 2"))
+}

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -761,17 +761,3 @@ func TestConstraintCheckForOptimisticUntouched(t *testing.T) {
 	err = tk.ExecToErr("commit")
 	require.Error(t, err)
 }
-
-func TestAssertion(t *testing.T) {
-	store, clean := testkit.CreateMockStore(t)
-	defer clean()
-	tk := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk.MustExec("create table a (k1 int);")
-	tk.MustExec("create table b (id int primary key, k1 int);")
-	tk.MustExec("insert into a(k1) values(3);")
-	tk.MustExec("insert into b values(2, 2);")
-	tk.MustExec("insert into b values(0, 0);")
-	tk.MustExec("delete a,b from a left join b on a.k1 = b.k1")
-	tk.MustQuery("select * from b order by id").Check(testkit.Rows("0 0", "2 2"))
-}


### PR DESCRIPTION
Signed-off-by: ekexium <ekexium@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31321 

Problem Summary:

Skip null rows when deleting using outer joins.

I'm not sure whether it's an appropriate way to fix this. Please be careful when reviewing.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
