### PR TITLE
parser: use utf-8 charset to decode enum binary string literal

### DIFF
--- a/ddl/integration_test.go
+++ b/ddl/integration_test.go
@@ -73,10 +73,14 @@ func TestDefaultValueInEnum(t *testing.T) {
 	tk.MustExec("insert into t values (1), (2);")                 // Use 1-base index to locate the value.
 	tk.MustQuery("select a from t;").Check(testkit.Rows("a", "")) // 0x91 is truncate.
 	tk.MustExec("drop table t;")
+	tk.MustExec("create table t (a enum('a', 0x91)) charset gbk;") // Test for table charset.
+	tk.MustExec("insert into t values (1), (2);")
+	tk.MustQuery("select a from t;").Check(testkit.Rows("a", ""))
+	tk.MustExec("drop table t;")
 	tk.MustGetErrMsg("create table t(a set('a', 0x91, '') charset gbk);",
 		"[types:1291]Column 'a' has duplicated value '' in SET")
-	// Test valid gbk string value in enum.
-	tk.MustExec("create table t (a enum('a', 0xC4E3BAC3) charset gbk);")
+	// Test valid utf-8 string value in enum. Note that the binary literal only can be decoded to utf-8.
+	tk.MustExec("create table t (a enum('a', 0xE4BDA0E5A5BD) charset gbk);")
 	tk.MustExec("insert into t values (1), (2);")
 	tk.MustQuery("select a from t;").Check(testkit.Rows("a", "你好"))
 }

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -3439,13 +3439,19 @@ type TextString struct {
 }
 
 // TransformTextStrings converts a slice of TextString to strings.
+// This is only used by enum/set strings.
 func TransformTextStrings(ts []*TextString, _ string) []string {
+	// The UTF-8 encoding rather than other encoding is used
+	// because parser is not possible to determine the "real"
+	// charset that a binary literal string should be converted to.
 	enc := charset.EncodingUTF8Impl
 	ret := make([]string, 0, len(ts))
 	for _, t := range ts {
 		if !t.IsBinaryLiteral {
 			ret = append(ret, t.Value)
 		} else {
+			// Validate the binary literal string.
+			// See https://github.com/pingcap/tidb/issues/30740.
 			r, _ := enc.Transform(nil, charset.HackSlice(t.Value), charset.OpDecodeNoErr)
 			ret = append(ret, charset.HackString(r))
 		}

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -3439,8 +3439,8 @@ type TextString struct {
 }
 
 // TransformTextStrings converts a slice of TextString to strings.
-func TransformTextStrings(ts []*TextString, chs string) []string {
-	enc := charset.FindEncodingTakeUTF8AsNoop(chs)
+func TransformTextStrings(ts []*TextString, _ string) []string {
+	enc := charset.EncodingUTF8Impl
 	ret := make([]string, 0, len(ts))
 	for _, t := range ts {
 		if !t.IsBinaryLiteral {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #30740, a patch for #31231

Problem Summary:

After #31231, specifying GBK charset on table still causes panic:

```sql
mysql> create table t (a enum(0x91)) charset gbk;
ERROR 1105 (HY000): runtime error: index out of range [1] with length 1
```

The problem still exists because the decoding procedure in #31231 only applicable when the column charset is specified. After the investigation, I found that  it is not possible to get the "environment" charset during parsing. So we cannot decode the binary literal strings before storing them into `FieldType`.

On the other hand, it involves a lot of changes if we decode before reading them. The `FieldType.Elem` needs to know which string is a binary literal.

### What is changed and how it works?

Finally I decide to always use utf-8 to validate the binary literal. This is incompatible with MySQL on other charset like GBK, and it will be one of the limitation that we need to document.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
