### PR TITLE
executor: make handles be ordered when build table reader for IndexMerge

### DIFF
--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -616,7 +616,9 @@ func (e *IndexMergeReaderExecutor) buildFinalTableReader(ctx context.Context, tb
 		}
 	}
 	tableReaderExec.buildVirtualColumnInfo()
-	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles, false)
+	// Reorder handles because SplitKeyRangesByLocations() requires startKey of kvRanges is ordered.
+	// Also it's good for performance.
+	tableReader, err := e.dataReaderBuilder.buildTableReaderFromHandles(ctx, tableReaderExec, handles, true)
 	if err != nil {
 		logutil.Logger(ctx).Error("build table reader from handles failed", zap.Error(err))
 		return nil, err

--- a/executor/index_merge_reader_test.go
+++ b/executor/index_merge_reader_test.go
@@ -454,3 +454,23 @@ func (test *testSerialSuite2) TestIndexMergeReaderMemTracker(c *C) {
 	c.Assert(err, IsNil)
 	c.Assert(bytes, Greater, 0.0)
 }
+
+func (test *testSerialSuite2) TestIndexMergeSplitTable(c *C) {
+	tk := testkit.NewTestKit(c, test.store)
+	tk.MustExec("use test;")
+	tk.MustExec("DROP TABLE IF EXISTS tab2;")
+	tk.MustExec("CREATE TABLE tab2(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT);")
+	tk.MustExec("CREATE INDEX idx_tab2_0 ON tab2 (col0 DESC,col3 DESC);")
+	tk.MustExec("CREATE UNIQUE INDEX idx_tab2_3 ON tab2 (col4,col0 DESC);")
+	tk.MustExec("CREATE INDEX idx_tab2_4 ON tab2 (col3,col1 DESC);")
+	tk.MustExec("INSERT INTO tab2 VALUES(0,146,632.63,'shwwd',703,412.47,'xsppr');")
+	tk.MustExec("INSERT INTO tab2 VALUES(1,81,536.29,'trhdh',49,726.3,'chuxv');")
+	tk.MustExec("INSERT INTO tab2 VALUES(2,311,541.72,'txrvb',493,581.92,'xtrra');")
+	tk.MustExec("INSERT INTO tab2 VALUES(3,669,293.27,'vcyum',862,415.14,'nbutk');")
+	tk.MustExec("INSERT INTO tab2 VALUES(4,681,49.46,'odzhp',106,324.65,'deudp');")
+	tk.MustExec("INSERT INTO tab2 VALUES(5,319,769.65,'aeqln',855,197.9,'apipa');")
+	tk.MustExec("INSERT INTO tab2 VALUES(6,610,302.62,'bixap',184,840.31,'vggit');")
+	tk.MustExec("INSERT INTO tab2 VALUES(7,253,453.21,'gjccm',107,104.5,'lvunv');")
+	tk.MustExec("SPLIT TABLE tab2 BY (5);")
+	tk.MustQuery("SELECT /*+ use_index_merge(tab2) */ pk FROM tab2 WHERE (col4 > 565.89 OR col0 > 68 ) and col0 > 10 order by 1;").Check(testkit.Rows("0", "1", "2", "3", "4", "5", "6", "7"))
+}


### PR DESCRIPTION
Signed-off-by: guo-shaoge <shaoge1994@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31295

Problem Summary: 


    DROP TABLE IF EXISTS tab2;
    CREATE TABLE tab2(pk INTEGER PRIMARY KEY, col0 INTEGER, col1 FLOAT, col2 TEXT, col3 INTEGER, col4 FLOAT, col5 TEXT);
    CREATE INDEX idx_tab2_0 ON tab2 (col0 DESC,col3 DESC);
    CREATE UNIQUE INDEX idx_tab2_3 ON tab2 (col4,col0 DESC);
    CREATE INDEX idx_tab2_4 ON tab2 (col3,col1 DESC);
    INSERT INTO tab2 VALUES(0,146,632.63,'shwwd',703,412.47,'xsppr');
    INSERT INTO tab2 VALUES(1,81,536.29,'trhdh',49,726.3,'chuxv');
    INSERT INTO tab2 VALUES(2,311,541.72,'txrvb',493,581.92,'xtrra');
    INSERT INTO tab2 VALUES(3,669,293.27,'vcyum',862,415.14,'nbutk');
    INSERT INTO tab2 VALUES(4,681,49.46,'odzhp',106,324.65,'deudp');
    INSERT INTO tab2 VALUES(5,319,769.65,'aeqln',855,197.9,'apipa');
    INSERT INTO tab2 VALUES(6,610,302.62,'bixap',184,840.31,'vggit');
    INSERT INTO tab2 VALUES(7,253,453.21,'gjccm',107,104.5,'lvunv');
    SPLIT TABLE tab2 BY (5);
    SELECT /*+ use_index_merge(tab2) */ pk FROM tab2 WHERE (col4 > 565.89 OR col0 > 68 ) and col0 > 10;

Because we split `tab2` by 5, so we now have two region.
1. region1: `range: (-inf, 5)`
2. region2: `range: [5, +inf)`

The last `SELECT` give errors because we only got `region2` when sending cop request. Actually we need `region1` and `region2` both.

Why got the wrong region: `(*RegionCache) SplitKeyRangesByLocations` is responsible for region division using kvRange. If kvRanges are:

    kvRanges[0]:        [6, 8)
    kvRanges[1]: [4,    6)

This [if branch](https://github.com/pingcap/tidb/blob/9cc1b169f9080b34eda8468d7a974d2a387673dd/store/copr/region_cache.go#L84) will make `region1` not be returned.
(Looks like `(*RegionCache) SplitKeyRangesByLocations` requires the kvRanges should be ordered by startKey, otherwise we may got wrong region.)

### What is changed and how it works?
Order `handles` when build table reader for IndexMerge, which will fix this problem. Also it's good for performance because less cop rps is needed.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
executor: make handles be ordered when build table reader for IndexMerge
```
