### PR TITLE
ddl: make sequence cache-opt mutually exclusive to each other

### DIFF
--- a/ddl/sequence.go
+++ b/ddl/sequence.go
@@ -105,7 +105,9 @@ func handleSequenceOptions(seqOptions []*ast.SequenceOption, sequenceInfo *model
 			maxSetFlag = true
 		case ast.SequenceCache:
 			sequenceInfo.CacheValue = op.IntValue
+			sequenceInfo.Cache = true
 		case ast.SequenceNoCache:
+			sequenceInfo.CacheValue = 0
 			sequenceInfo.Cache = false
 		case ast.SequenceCycle:
 			sequenceInfo.Cycle = true
@@ -140,13 +142,13 @@ func handleSequenceOptions(seqOptions []*ast.SequenceOption, sequenceInfo *model
 }
 
 func validateSequenceOptions(seqInfo *model.SequenceInfo) bool {
-	// To ensure that cache * increment will never overflows.
+	// To ensure that cache * increment will never overflow.
 	var maxIncrement int64
 	if seqInfo.Increment == 0 {
 		// Increment shouldn't be set as 0.
 		return false
 	}
-	if seqInfo.CacheValue <= 0 {
+	if seqInfo.Cache && seqInfo.CacheValue <= 0 {
 		// Cache value should be bigger than 0.
 		return false
 	}
@@ -205,7 +207,9 @@ func alterSequenceOptions(sequenceOptions []*ast.SequenceOption, ident ast.Ident
 			oldSequence.MaxValue = op.IntValue
 		case ast.SequenceCache:
 			oldSequence.CacheValue = op.IntValue
+			oldSequence.Cache = true
 		case ast.SequenceNoCache:
+			oldSequence.CacheValue = 0
 			oldSequence.Cache = false
 		case ast.SequenceCycle:
 			oldSequence.Cycle = true

--- a/ddl/sequence_test.go
+++ b/ddl/sequence_test.go
@@ -1103,4 +1103,9 @@ func TestDdl_AlterSequenceIssue31265(t *testing.T) {
 	tk.MustExec("create sequence cache_to_nocache_seq;")
 	tk.MustExec("alter sequence cache_to_nocache_seq nocache;")
 	tk.MustQuery("show create sequence cache_to_nocache_seq;").Check(testkit.Rows("cache_to_nocache_seq CREATE SEQUENCE `cache_to_nocache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB"))
+
+	tk.MustExec("create sequence nocache_to_cache_seq nocache;")
+	tk.MustExec("alter sequence cache_to_nocache_seq cache 10;")
+	tk.MustQuery("show create sequence cache_to_nocache_seq;").Check(testkit.Rows("cache_to_nocache_seq CREATE SEQUENCE `cache_to_nocache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 cache 10 nocycle ENGINE=InnoDB"))
+
 }

--- a/ddl/sequence_test.go
+++ b/ddl/sequence_test.go
@@ -1105,7 +1105,6 @@ func TestDdl_AlterSequenceIssue31265(t *testing.T) {
 	tk.MustQuery("show create sequence cache_to_nocache_seq;").Check(testkit.Rows("cache_to_nocache_seq CREATE SEQUENCE `cache_to_nocache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB"))
 
 	tk.MustExec("create sequence nocache_to_cache_seq nocache;")
-	tk.MustExec("alter sequence cache_to_nocache_seq cache 10;")
-	tk.MustQuery("show create sequence cache_to_nocache_seq;").Check(testkit.Rows("cache_to_nocache_seq CREATE SEQUENCE `cache_to_nocache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 cache 10 nocycle ENGINE=InnoDB"))
-
+	tk.MustExec("alter sequence nocache_to_cache_seq cache 10;")
+	tk.MustQuery("show create sequence nocache_to_cache_seq;").Check(testkit.Rows("nocache_to_cache_seq CREATE SEQUENCE `nocache_to_cache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 cache 10 nocycle ENGINE=InnoDB"))
 }

--- a/ddl/sequence_test.go
+++ b/ddl/sequence_test.go
@@ -16,6 +16,7 @@ package ddl_test
 
 import (
 	"strconv"
+	"testing"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/tidb/ddl"
@@ -25,6 +26,7 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/session"
 	"github.com/pingcap/tidb/table/tables"
+	testkit2 "github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/util/testkit"
 )
 
@@ -1087,4 +1089,18 @@ func (s *testSequenceSuite) TestAlterSequencePrivilege(c *C) {
 	c.Assert(err, NotNil)
 	c.Assert(err.Error(), Equals, "[planner:1142]ALTER command denied to user 'myuser'@'localhost' for table 'my_seq'")
 	tk.MustExec("drop sequence if exists my_seq")
+}
+
+func TestDdl_AlterSequenceIssue31265(t *testing.T) {
+	store, clean := testkit2.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit2.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create sequence seq cache=1 nocache")
+	tk.MustQuery("show create sequence seq").Check(testkit.Rows("seq CREATE SEQUENCE `seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB"))
+
+	tk.MustExec("create sequence cache_to_nocache_seq;")
+	tk.MustExec("alter sequence cache_to_nocache_seq nocache;")
+	tk.MustQuery("show create sequence cache_to_nocache_seq;").Check(testkit.Rows("cache_to_nocache_seq CREATE SEQUENCE `cache_to_nocache_seq` start with 1 minvalue 1 maxvalue 9223372036854775806 increment by 1 nocache nocycle ENGINE=InnoDB"))
 }


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/31265


### What is changed and how it works?
1: sequence cachevalue(int) and cache(bool) opt should be mutually exclusive to each other when setting or altering.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
