### PR TITLE
planner: do not cache tableDual plan

### DIFF
--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -599,10 +599,11 @@ func containTableDual(p Plan) bool {
 	if !ok {
 		return false
 	}
+	childContainTableDual := false
 	for _, child := range physicalPlan.Children() {
-		return containTableDual(child)
+		childContainTableDual = childContainTableDual || containTableDual(child)
 	}
-	return false
+	return childContainTableDual
 }
 
 // tryCachePointPlan will try to cache point execution plan, there may be some


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/31375

Problem Summary:
The check for `containTableDual` has some bugs.

### What is changed and how it works?
Do not cache the tableDual plan.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
