### PR TITLE
executor: Fix a panic when using on duplicate update (#31287)

### DIFF
--- a/executor/insert.go
+++ b/executor/insert.go
@@ -345,7 +345,7 @@ func (e *InsertExec) initEvalBuffer4Dup() {
 		evalBufferTypes = append(evalBufferTypes, &col.FieldType)
 	}
 	if extraLen > 0 {
-		evalBufferTypes = append(evalBufferTypes, e.SelectExec.base().retFieldTypes[numWritableCols:]...)
+		evalBufferTypes = append(evalBufferTypes, e.SelectExec.base().retFieldTypes[e.rowLen:]...)
 	}
 	for _, col := range e.Table.Cols() {
 		evalBufferTypes = append(evalBufferTypes, &col.FieldType)
@@ -354,7 +354,7 @@ func (e *InsertExec) initEvalBuffer4Dup() {
 		evalBufferTypes = append(evalBufferTypes, types.NewFieldType(mysql.TypeLonglong))
 	}
 	e.evalBuffer4Dup = chunk.MutRowFromTypes(evalBufferTypes)
-	e.curInsertVals = chunk.MutRowFromTypes(evalBufferTypes[numWritableCols:])
+	e.curInsertVals = chunk.MutRowFromTypes(evalBufferTypes[numWritableCols+extraLen:])
 	e.row4Update = make([]types.Datum, 0, len(evalBufferTypes))
 }
 

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -208,6 +208,36 @@ func (s *testSuite8) TestInsertOnDuplicateKey(c *C) {
 	c.Assert(tk.Se.AffectedRows(), Equals, uint64(2))
 	tk.MustQuery("select * from a").Check(testkit.Rows("2"))
 
+	// Test issue 28078.
+	// Use different types of columns so that there's likely to be error if the types mismatches.
+	tk.MustExec("drop table if exists a, b")
+	tk.MustExec("create table a(id int, a1 timestamp, a2 varchar(10), a3 float, unique(id))")
+	tk.MustExec("create table b(id int, b1 time, b2 varchar(10), b3 int)")
+	tk.MustExec("insert into a values (1, '2022-01-04 07:02:04', 'a', 1.1), (2, '2022-01-04 07:02:05', 'b', 2.2)")
+	tk.MustExec("insert into b values (2, '12:34:56', 'c', 10), (3, '01:23:45', 'd', 20)")
+	tk.MustExec("insert into a (id) select id from b on duplicate key update a.a2 = b.b2, a.a3 = 3.3")
+	c.Assert(tk.Se.AffectedRows(), Equals, uint64(3))
+	tk.MustQuery("select * from a").Check(testutil.RowsWithSep("/",
+		"1/2022-01-04 07:02:04/a/1.1",
+		"2/2022-01-04 07:02:05/c/3.3",
+		"3/<nil>/<nil>/<nil>"))
+	tk.MustExec("insert into a (id) select 4 from b where b3 = 20 on duplicate key update a.a3 = b.b3")
+	c.Assert(tk.Se.AffectedRows(), Equals, uint64(1))
+	tk.MustQuery("select * from a").Check(testutil.RowsWithSep("/",
+		"1/2022-01-04 07:02:04/a/1.1",
+		"2/2022-01-04 07:02:05/c/3.3",
+		"3/<nil>/<nil>/<nil>",
+		"4/<nil>/<nil>/<nil>"))
+	tk.MustExec("insert into a (a2, a3) select 'x', 1.2 from b on duplicate key update a.a2 = b.b3")
+	c.Assert(tk.Se.AffectedRows(), Equals, uint64(2))
+	tk.MustQuery("select * from a").Check(testutil.RowsWithSep("/",
+		"1/2022-01-04 07:02:04/a/1.1",
+		"2/2022-01-04 07:02:05/c/3.3",
+		"3/<nil>/<nil>/<nil>",
+		"4/<nil>/<nil>/<nil>",
+		"<nil>/<nil>/x/1.2",
+		"<nil>/<nil>/x/1.2"))
+
 	// reproduce insert on duplicate key update bug under new row format.
 	tk.MustExec(`drop table if exists t1`)
 	tk.MustExec(`create table t1(c1 decimal(6,4), primary key(c1))`)


### PR DESCRIPTION
cherry-pick #31287 to release-5.0-20220107 (hotfix to 5.0.6)

---

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #28078

Problem Summary: When using statements like `insert into a select ... from b on duplicate key update a.y = b.y`, where b.y is not selected in `select ... from b` part, sometimes it may panic and reports "slice bounds out of range".

`initEvalBuffer4Dup` constructs a list of column types (the `evalBufferTypes` variable), which is expected to match the [`Schema4OnDuplicate` built in function `Schema4OnDuplicate`](https://github.com/pingcap/tidb/blob/b43c9ffa85c7c5eaa4e01ffe3d39e7eb9ae36af1/planner/core/planbuilder.go#L3817-L3819). It contains several parts sequentially:
* columns of already-existed rows
* extra columns to select (the implicitly required columns in the `on duplicate key update` clause)
* columns of new rows to insert

The problem is:
1. When constructing `evalBufferTypes`, wrong index is used to find the second part (extra columns to select) . The inner select plan contains both explicitly written columns in `select` clause (which are columns `[:actualColLen]`), and the implicitly required columns in the `on duplicate key update` clause (which are columns `[actualColLen:]`). In function `initEvalBuffer4Dup`, the `actualColLen` is exactly `e.rowLen`.
2. Then it creates a buffer for storing values to be inserted. It's expected to match the third part of `evalBufferTypes` mentioned above. However wrong index is used again and it didn't count the number of extra columns to the offset.

### What is changed and how it works?

Fixed the above two mistakes.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix a panic that may happen when using `on duplicate key update`.
```
