### PR TITLE
optimizer: calculate digest only once for plan cache

### DIFF
--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -68,7 +68,8 @@ func (h *SessionHandle) CreateBindRecord(sctx sessionctx.Context, record *BindRe
 // DropBindRecord drops a BindRecord in the cache.
 func (h *SessionHandle) DropBindRecord(originalSQL, db string, binding *Binding) error {
 	db = strings.ToLower(db)
-	oldRecord := h.GetBindRecord(originalSQL, db)
+	hash := parser.DigestNormalized(originalSQL).String()
+	oldRecord := h.GetBindRecord(originalSQL, hash, db)
 	var newRecord *BindRecord
 	record := &BindRecord{OriginalSQL: originalSQL, Db: db}
 	if binding != nil {
@@ -79,14 +80,13 @@ func (h *SessionHandle) DropBindRecord(originalSQL, db string, binding *Binding)
 	} else {
 		newRecord = record
 	}
-	h.ch.setBindRecord(parser.DigestNormalized(record.OriginalSQL).String(), newRecord)
+	h.ch.setBindRecord(hash, newRecord)
 	updateMetrics(metrics.ScopeSession, oldRecord, newRecord, false)
 	return nil
 }
 
 // GetBindRecord return the BindMeta of the (normdOrigSQL,db) if BindMeta exist.
-func (h *SessionHandle) GetBindRecord(normdOrigSQL, db string) *BindRecord {
-	hash := parser.DigestNormalized(normdOrigSQL).String()
+func (h *SessionHandle) GetBindRecord(hash, normdOrigSQL, db string) *BindRecord {
 	bindRecords := h.ch[hash]
 	for _, bindRecord := range bindRecords {
 		if bindRecord.OriginalSQL == normdOrigSQL {

--- a/bindinfo/session_handle.go
+++ b/bindinfo/session_handle.go
@@ -69,7 +69,7 @@ func (h *SessionHandle) CreateBindRecord(sctx sessionctx.Context, record *BindRe
 func (h *SessionHandle) DropBindRecord(originalSQL, db string, binding *Binding) error {
 	db = strings.ToLower(db)
 	hash := parser.DigestNormalized(originalSQL).String()
-	oldRecord := h.GetBindRecord(originalSQL, hash, db)
+	oldRecord := h.GetBindRecord(hash, originalSQL, db)
 	var newRecord *BindRecord
 	record := &BindRecord{OriginalSQL: originalSQL, Db: db}
 	if binding != nil {

--- a/bindinfo/session_handle_test.go
+++ b/bindinfo/session_handle_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/tidb/bindinfo"
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/auth"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session/txninfo"
@@ -121,7 +122,8 @@ func TestSessionBinding(t *testing.T) {
 		require.Equal(t, testSQL.memoryUsage, pb.GetGauge().GetValue())
 
 		handle := tk.Session().Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-		bindData := handle.GetBindRecord(testSQL.originSQL, "test")
+		hash := parser.DigestNormalized(testSQL.originSQL).String()
+		bindData := handle.GetBindRecord(hash, testSQL.originSQL, "test")
 		require.NotNil(t, bindData)
 		require.Equal(t, testSQL.originSQL, bindData.OriginalSQL)
 		bind := bindData.Bindings[0]
@@ -158,7 +160,7 @@ func TestSessionBinding(t *testing.T) {
 
 		_, err = tk.Exec("drop session " + testSQL.dropSQL)
 		require.NoError(t, err)
-		bindData = handle.GetBindRecord(testSQL.originSQL, "test")
+		bindData = handle.GetBindRecord(hash, testSQL.originSQL, "test")
 		require.NotNil(t, bindData)
 		require.Equal(t, testSQL.originSQL, bindData.OriginalSQL)
 		require.Len(t, bindData.Bindings, 0)

--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -201,17 +201,17 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 
 	var (
-		normalizedSQL4PC, normalizedSQL4PCHash string
-		selectStmtNode                         ast.StmtNode
+		normalizedSQL4PC, digest4PC string
+		selectStmtNode              ast.StmtNode
 	)
 	if !plannercore.PreparedPlanCacheEnabled() {
 		prepared.UseCache = false
 	} else {
 		prepared.UseCache = plannercore.CacheableWithCtx(e.ctx, stmt, ret.InfoSchema)
-		selectStmtNode, normalizedSQL4PC, normalizedSQL4PCHash, err = planner.ExtractSelectAndNormalizeDigest(stmt, e.ctx.GetSessionVars().CurrentDB)
+		selectStmtNode, normalizedSQL4PC, digest4PC, err = planner.ExtractSelectAndNormalizeDigest(stmt, e.ctx.GetSessionVars().CurrentDB)
 		if err != nil || selectStmtNode == nil {
 			normalizedSQL4PC = ""
-			normalizedSQL4PCHash = ""
+			digest4PC = ""
 		}
 	}
 
@@ -243,14 +243,14 @@ func (e *PrepareExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 
 	preparedObj := &plannercore.CachedPrepareStmt{
-		PreparedAst:          prepared,
-		VisitInfos:           destBuilder.GetVisitInfo(),
-		NormalizedSQL:        normalizedSQL,
-		SQLDigest:            digest,
-		ForUpdateRead:        destBuilder.GetIsForUpdateRead(),
-		SnapshotTSEvaluator:  ret.SnapshotTSEvaluator,
-		NormalizedSQL4PC:     normalizedSQL4PC,
-		NormalizedSQL4PCHash: normalizedSQL4PCHash,
+		PreparedAst:         prepared,
+		VisitInfos:          destBuilder.GetVisitInfo(),
+		NormalizedSQL:       normalizedSQL,
+		SQLDigest:           digest,
+		ForUpdateRead:       destBuilder.GetIsForUpdateRead(),
+		SnapshotTSEvaluator: ret.SnapshotTSEvaluator,
+		NormalizedSQL4PC:    normalizedSQL4PC,
+		SQLDigest4PC:        digest4PC,
 	}
 	return vars.AddPreparedStmt(e.ID, preparedObj)
 }

--- a/planner/core/cache.go
+++ b/planner/core/cache.go
@@ -206,18 +206,18 @@ func NewPlanCacheValue(plan Plan, names []*types.FieldName, srcMap map[*model.Ta
 
 // CachedPrepareStmt store prepared ast from PrepareExec and other related fields
 type CachedPrepareStmt struct {
-	PreparedAst          *ast.Prepared
-	VisitInfos           []visitInfo
-	ColumnInfos          interface{}
-	Executor             interface{}
-	NormalizedSQL        string
-	NormalizedPlan       string
-	SQLDigest            *parser.Digest
-	PlanDigest           *parser.Digest
-	ForUpdateRead        bool
-	SnapshotTSEvaluator  func(sessionctx.Context) (uint64, error)
-	NormalizedSQL4PC     string
-	NormalizedSQL4PCHash string
+	PreparedAst         *ast.Prepared
+	VisitInfos          []visitInfo
+	ColumnInfos         interface{}
+	Executor            interface{}
+	NormalizedSQL       string
+	NormalizedPlan      string
+	SQLDigest           *parser.Digest
+	PlanDigest          *parser.Digest
+	ForUpdateRead       bool
+	SnapshotTSEvaluator func(sessionctx.Context) (uint64, error)
+	NormalizedSQL4PC    string
+	SQLDigest4PC        string
 }
 
 // GetPreparedStmt extract the prepared statement from the execute statement.

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -394,14 +394,14 @@ func (e *Execute) setFoundInPlanCache(sctx sessionctx.Context, opt bool) error {
 // GetBindSQL4PlanCache used to get the bindSQL for plan cache to build the plan cache key.
 func GetBindSQL4PlanCache(sctx sessionctx.Context, preparedStmt *CachedPrepareStmt) string {
 	useBinding := sctx.GetSessionVars().UsePlanBaselines
-	if !useBinding || preparedStmt.PreparedAst.Stmt == nil || preparedStmt.NormalizedSQL4PC == "" || preparedStmt.NormalizedSQL4PCHash == "" {
+	if !useBinding || preparedStmt.PreparedAst.Stmt == nil || preparedStmt.NormalizedSQL4PC == "" || preparedStmt.SQLDigest4PC == "" {
 		return ""
 	}
 	if sctx.Value(bindinfo.SessionBindInfoKeyType) == nil {
 		return ""
 	}
 	sessionHandle := sctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-	bindRecord := sessionHandle.GetBindRecord(preparedStmt.NormalizedSQL4PC, "")
+	bindRecord := sessionHandle.GetBindRecord(preparedStmt.SQLDigest4PC, preparedStmt.NormalizedSQL4PC, "")
 	if bindRecord != nil {
 		usingBinding := bindRecord.FindUsingBinding()
 		if usingBinding != nil {
@@ -412,7 +412,7 @@ func GetBindSQL4PlanCache(sctx sessionctx.Context, preparedStmt *CachedPrepareSt
 	if globalHandle == nil {
 		return ""
 	}
-	bindRecord = globalHandle.GetBindRecord(preparedStmt.NormalizedSQL4PCHash, preparedStmt.NormalizedSQL4PC, "")
+	bindRecord = globalHandle.GetBindRecord(preparedStmt.SQLDigest4PC, preparedStmt.NormalizedSQL4PC, "")
 	if bindRecord != nil {
 		usingBinding := bindRecord.FindUsingBinding()
 		if usingBinding != nil {

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -443,7 +443,7 @@ func getBindRecord(ctx sessionctx.Context, stmt ast.StmtNode) (*bindinfo.BindRec
 		return nil, "", err
 	}
 	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-	bindRecord := sessionHandle.GetBindRecord(normalizedSQL, hash, "")
+	bindRecord := sessionHandle.GetBindRecord(hash, normalizedSQL, "")
 	if bindRecord != nil {
 		if bindRecord.HasUsingBinding() {
 			return bindRecord, metrics.ScopeSession, nil

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -443,7 +443,7 @@ func getBindRecord(ctx sessionctx.Context, stmt ast.StmtNode) (*bindinfo.BindRec
 		return nil, "", err
 	}
 	sessionHandle := ctx.Value(bindinfo.SessionBindInfoKeyType).(*bindinfo.SessionHandle)
-	bindRecord := sessionHandle.GetBindRecord(normalizedSQL, "")
+	bindRecord := sessionHandle.GetBindRecord(normalizedSQL, hash, "")
 	if bindRecord != nil {
 		if bindRecord.HasUsingBinding() {
 			return bindRecord, metrics.ScopeSession, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31269

Problem Summary:
`GetBindSQL4PlanCache` calculates digest again, which is unnecessary and brings 1% performance regression. It is stored as `CachedPrepareStmt.SQLDigest4PC` already and we can use it directly.

![image](https://user-images.githubusercontent.com/29590578/148712184-03a2ce9d-4ffb-44a7-ab08-5bb2862250d3.png)

### What is changed and how it works?

- Reuse `CachedPrepareStmt.SQLDigest4PC` as the hash of bind records.
- Change the parameters of `SessionHandle.GetBindRecord` as the same with `BindHandle.GetBindRecord`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

After this PR, oltp_point_select improves about 3%.
![image](https://user-images.githubusercontent.com/29590578/148712368-6dc08cce-eae5-484c-9a32-439d6e3b09ee.png)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
