### PR TITLE
encoding: refactor `transform` to avoid the misuse buffer

### DIFF
--- a/cmd/explaintest/r/new_character_set.result
+++ b/cmd/explaintest/r/new_character_set.result
@@ -87,3 +87,13 @@ utf8_unicode_ci	utf8	192		Yes	1
 utf8mb4_bin	utf8mb4	46	Yes	Yes	1
 utf8mb4_general_ci	utf8mb4	45		Yes	1
 utf8mb4_unicode_ci	utf8mb4	224		Yes	1
+set names utf8mb4;
+drop table if exists t;
+create table t(a blob, b char(10));
+insert into t values (0x61, 'å•Š');
+insert into t values (0x61, 'ä¸€');
+set names gbk;
+select * from t;
+a	b
+a	°¡
+a	Ò»

--- a/cmd/explaintest/t/new_character_set.test
+++ b/cmd/explaintest/t/new_character_set.test
@@ -48,3 +48,11 @@ select b, d from t;
 select hex(b), hex(d) from t;
 show charset;
 show collation;
+
+set names utf8mb4;
+drop table if exists t;
+create table t(a blob, b char(10));
+insert into t values (0x61, '啊');
+insert into t values (0x61, '一');
+set names gbk;
+select * from t;

--- a/parser/charset/encoding.go
+++ b/parser/charset/encoding.go
@@ -13,6 +13,8 @@
 
 package charset
 
+import "bytes"
+
 // Make sure all of them implement Encoding interface.
 var (
 	_ Encoding = &encodingUTF8{}
@@ -75,7 +77,7 @@ type Encoding interface {
 	// Foreach iterates the characters in in current encoding.
 	Foreach(src []byte, op Op, fn func(from, to []byte, ok bool) bool)
 	// Transform map the bytes in src to dest according to Op.
-	Transform(dest, src []byte, op Op) ([]byte, error)
+	Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error)
 	// ToUpper change a string to uppercase.
 	ToUpper(src string) string
 	// ToLower change a string to lowercase.

--- a/parser/charset/encoding.go
+++ b/parser/charset/encoding.go
@@ -77,6 +77,8 @@ type Encoding interface {
 	// Foreach iterates the characters in in current encoding.
 	Foreach(src []byte, op Op, fn func(from, to []byte, ok bool) bool)
 	// Transform map the bytes in src to dest according to Op.
+	// **the caller should initialize the dest if it wants to avoid memory alloc every time, or else it will always make a new one**
+	// **the returned array may be the alias of `src`, edit the returned array on your own risk**
 	Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error)
 	// ToUpper change a string to uppercase.
 	ToUpper(src string) string

--- a/parser/charset/encoding_ascii.go
+++ b/parser/charset/encoding_ascii.go
@@ -14,6 +14,7 @@
 package charset
 
 import (
+	"bytes"
 	go_unicode "unicode"
 
 	"golang.org/x/text/encoding"
@@ -60,7 +61,7 @@ func (e *encodingASCII) IsValid(src []byte) bool {
 	return true
 }
 
-func (e *encodingASCII) Transform(dest, src []byte, op Op) ([]byte, error) {
+func (e *encodingASCII) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
 	if e.IsValid(src) {
 		return src, nil
 	}

--- a/parser/charset/encoding_base.go
+++ b/parser/charset/encoding_base.go
@@ -56,11 +56,12 @@ func (b encodingBase) IsValid(src []byte) bool {
 	return isValid
 }
 
-func (b encodingBase) Transform(dest, src []byte, op Op) (result []byte, err error) {
+func (b encodingBase) Transform(dest *bytes.Buffer, src []byte, op Op) (result []byte, err error) {
 	if dest == nil {
-		dest = make([]byte, len(src))
+		dest = &bytes.Buffer{}
+		dest.Grow(len(src))
 	}
-	dest = dest[:0]
+	dest.Reset()
 	b.self.Foreach(src, op, func(from, to []byte, ok bool) bool {
 		if !ok {
 			if err == nil && (op&opSkipError == 0) {
@@ -70,18 +71,18 @@ func (b encodingBase) Transform(dest, src []byte, op Op) (result []byte, err err
 				return false
 			}
 			if op&opTruncateReplace != 0 {
-				dest = append(dest, '?')
+				dest.WriteByte('?')
 				return true
 			}
 		}
 		if op&opCollectFrom != 0 {
-			dest = append(dest, from...)
+			dest.Write(from)
 		} else if op&opCollectTo != 0 {
-			dest = append(dest, to...)
+			dest.Write(to)
 		}
 		return true
 	})
-	return dest, err
+	return dest.Bytes(), err
 }
 
 func (b encodingBase) Foreach(src []byte, op Op, fn func(from, to []byte, ok bool) bool) {

--- a/parser/charset/encoding_bin.go
+++ b/parser/charset/encoding_bin.go
@@ -14,6 +14,7 @@
 package charset
 
 import (
+	"bytes"
 	"golang.org/x/text/encoding"
 )
 
@@ -61,6 +62,6 @@ func (e *encodingBin) Foreach(src []byte, op Op, fn func(from, to []byte, ok boo
 	}
 }
 
-func (e *encodingBin) Transform(dest, src []byte, op Op) ([]byte, error) {
+func (e *encodingBin) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
 	return src, nil
 }

--- a/parser/charset/encoding_latin1.go
+++ b/parser/charset/encoding_latin1.go
@@ -15,6 +15,7 @@ package charset
 
 import (
 	"bytes"
+
 	"golang.org/x/text/encoding"
 )
 

--- a/parser/charset/encoding_latin1.go
+++ b/parser/charset/encoding_latin1.go
@@ -13,7 +13,10 @@
 
 package charset
 
-import "golang.org/x/text/encoding"
+import (
+	"bytes"
+	"golang.org/x/text/encoding"
+)
 
 // EncodingLatin1Impl is the instance of encodingLatin1.
 // TiDB uses utf8 implementation for latin1 charset because of the backward compatibility.
@@ -51,6 +54,6 @@ func (e *encodingLatin1) Tp() EncodingTp {
 	return EncodingTpLatin1
 }
 
-func (e *encodingLatin1) Transform(dest, src []byte, op Op) ([]byte, error) {
+func (e *encodingLatin1) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
 	return src, nil
 }

--- a/parser/charset/encoding_utf8.go
+++ b/parser/charset/encoding_utf8.go
@@ -14,6 +14,7 @@
 package charset
 
 import (
+	"bytes"
 	"unicode/utf8"
 
 	"golang.org/x/text/encoding"
@@ -84,7 +85,7 @@ func (e *encodingUTF8) IsValid(src []byte) bool {
 }
 
 // Transform implements Encoding interface.
-func (e *encodingUTF8) Transform(dest, src []byte, op Op) ([]byte, error) {
+func (e *encodingUTF8) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
 	if e.IsValid(src) {
 		return src, nil
 	}
@@ -127,7 +128,7 @@ func (e *encodingUTF8MB3Strict) Foreach(src []byte, op Op, fn func(srcCh, dstCh 
 }
 
 // Transform implements Encoding interface.
-func (e *encodingUTF8MB3Strict) Transform(dest, src []byte, op Op) ([]byte, error) {
+func (e *encodingUTF8MB3Strict) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
 	if e.IsValid(src) {
 		return src, nil
 	}

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -169,7 +169,6 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		paramValues []byte
 	)
 	cc.initInputEncoder(ctx)
-	defer cc.inputDecoder.clean()
 	numParams := stmt.NumParams()
 	args := make([]types.Datum, numParams)
 	if numParams > 0 {

--- a/server/util.go
+++ b/server/util.go
@@ -292,24 +292,16 @@ func dumpBinaryRow(buffer []byte, columns []*ColumnInfo, row chunk.Row, d *resul
 
 type inputDecoder struct {
 	encoding charset.Encoding
-
-	buffer []byte
 }
 
 func newInputDecoder(chs string) *inputDecoder {
 	return &inputDecoder{
 		encoding: charset.FindEncodingTakeUTF8AsNoop(chs),
-		buffer:   nil,
 	}
 }
 
-// clean prevents the inputDecoder from holding too much memory.
-func (i *inputDecoder) clean() {
-	i.buffer = nil
-}
-
 func (i *inputDecoder) decodeInput(src []byte) []byte {
-	result, err := i.encoding.Transform(i.buffer, src, charset.OpDecode)
+	result, err := i.encoding.Transform(nil, src, charset.OpDecode)
 	if err != nil {
 		return src
 	}
@@ -325,7 +317,7 @@ type resultEncoder struct {
 	// dataEncoding can be updated to match the column data charset.
 	dataEncoding charset.Encoding
 
-	buffer []byte
+	buffer *bytes.Buffer
 
 	isBinary     bool
 	isNull       bool
@@ -386,13 +378,12 @@ func (d *resultEncoder) encodeData(src []byte) []byte {
 }
 
 func (d *resultEncoder) encodeWith(src []byte, enc charset.Encoding) []byte {
-	var err error
-	d.buffer, err = enc.Transform(d.buffer, src, charset.OpEncode)
+	data, err := enc.Transform(d.buffer, src, charset.OpEncode)
 	if err != nil {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))
 	}
 	// The buffer will be reused.
-	return d.buffer
+	return data
 }
 
 func dumpTextRow(buffer []byte, columns []*ColumnInfo, row chunk.Row, d *resultEncoder) ([]byte, error) {

--- a/server/util.go
+++ b/server/util.go
@@ -382,7 +382,6 @@ func (d *resultEncoder) encodeWith(src []byte, enc charset.Encoding) []byte {
 	if err != nil {
 		logutil.BgLogger().Debug("encode error", zap.Error(err))
 	}
-	// The buffer will be reused.
 	return data
 }
 

--- a/server/util.go
+++ b/server/util.go
@@ -329,7 +329,7 @@ func newResultEncoder(chs string) *resultEncoder {
 	return &resultEncoder{
 		chsName:  chs,
 		encoding: charset.FindEncodingTakeUTF8AsNoop(chs),
-		buffer:   nil,
+		buffer:   &bytes.Buffer{},
 		isBinary: chs == charset.CharsetBinary,
 		isNull:   len(chs) == 0,
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/31488

Problem Summary:

`transform` have copy and non-copy implemented in the `dest` parameter, sometimes it will return `src` directly, so we can not reuse it.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code
### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
