### PR TITLE
planner: make queries with the extra column `_tidb_rowid` can use PointGet

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -757,6 +757,10 @@ func (ds *DataSource) getPruningInfo(candidates []*candidatePath, prop *property
 
 func (ds *DataSource) isPointGetConvertableSchema() bool {
 	for _, col := range ds.Columns {
+		if col.Name.L == model.ExtraHandleName.L {
+			continue
+		}
+
 		// Only handle tables that all columns are public.
 		if col.State != model.StatePublic {
 			return false

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1486,6 +1486,11 @@ func buildPointDeletePlan(ctx sessionctx.Context, pointPlan PhysicalPlan, dbName
 
 func findCol(tbl *model.TableInfo, colName *ast.ColumnName) *model.ColumnInfo {
 	for _, col := range tbl.Columns {
+		if colName.Name.L == model.ExtraHandleName.L && !tbl.PKIsHandle {
+			colInfo := model.NewExtraHandleColInfo()
+			colInfo.Offset = len(tbl.Columns) - 1
+			return colInfo
+		}
 		if col.Name.L == colName.Name.L {
 			return col
 		}

--- a/planner/core/point_get_plan.go
+++ b/planner/core/point_get_plan.go
@@ -1485,12 +1485,12 @@ func buildPointDeletePlan(ctx sessionctx.Context, pointPlan PhysicalPlan, dbName
 }
 
 func findCol(tbl *model.TableInfo, colName *ast.ColumnName) *model.ColumnInfo {
+	if colName.Name.L == model.ExtraHandleName.L && !tbl.PKIsHandle {
+		colInfo := model.NewExtraHandleColInfo()
+		colInfo.Offset = len(tbl.Columns) - 1
+		return colInfo
+	}
 	for _, col := range tbl.Columns {
-		if colName.Name.L == model.ExtraHandleName.L && !tbl.PKIsHandle {
-			colInfo := model.NewExtraHandleColInfo()
-			colInfo.Offset = len(tbl.Columns) - 1
-			return colInfo
-		}
 		if col.Name.L == colName.Name.L {
 			return col
 		}

--- a/planner/core/point_get_plan_test.go
+++ b/planner/core/point_get_plan_test.go
@@ -207,6 +207,34 @@ func (s *testPointGetSuite) TestPointGetForUpdate(c *C) {
 	tk.MustExec("rollback")
 }
 
+func (s *testPointGetSuite) TestGetExtraColumn(c *C) {
+	tk := testkit.NewTestKit(c, s.store)
+	tk.MustExec("use test")
+	tk.MustExec(`CREATE TABLE t (
+	  a int(11) DEFAULT NULL,
+	  b int(11) DEFAULT NULL,
+	  UNIQUE KEY idx (a))`)
+	tk.MustQuery(`explain format='brief' select t.*, _tidb_rowid from t where a = 1`).Check(testkit.Rows("Point_Get 1.00 root table:t, index:idx(a) "))
+	tk.MustQuery(`explain format='brief' select t.*, _tidb_rowid, date_format(a, "") from t where a = 1`).Check(testkit.Rows(
+		`Projection 1.00 root  test.t.a, test.t.b, test.t._tidb_rowid, date_format(cast(test.t.a, datetime BINARY), )->Column#4`,
+		`└─Point_Get 1.00 root table:t, index:idx(a) `))
+	tk.MustExec(`begin`) // in transaction
+	tk.MustExec(`insert into t values (1, 1)`)
+	tk.MustQuery(`explain format='brief' select t.*, _tidb_rowid from t where a = 1`).Check(testkit.Rows(`Point_Get 1.00 root table:t, index:idx(a) `))
+	tk.MustExec(`commit`)
+	tk.MustQuery(`explain format='brief' select count(_tidb_rowid) from t where a=1`).Check(testkit.Rows(
+		`StreamAgg 1.00 root  funcs:count(test.t._tidb_rowid)->Column#4`,
+		`└─Point_Get 1.00 root table:t, index:idx(a) `))
+	tk.MustQuery(`explain format='brief' select *, date_format(b, "") from t where a =1 for update`).Check(testkit.Rows(
+		`Projection 1.00 root  test.t.a, test.t.b, date_format(cast(test.t.b, datetime BINARY), )->Column#4`,
+		`└─SelectLock 1.00 root  for update 0`,
+		`  └─Point_Get 1.00 root table:t, index:idx(a) `))
+
+	// if the PK is handled
+	tk.MustExec(`create table t1 (pk int, a int, b int, primary key(pk), unique key(a))`)
+	c.Check(tk.ExecToErr(`explain format='brief' select t1.*, _tidb_rowid from t1 where a = 1`), ErrorMatches, ".*Unknown column \\'_tidb_rowid\\'.*")
+}
+
 func (s *testPointGetSuite) TestPointGetForUpdateWithSubquery(c *C) {
 	tk := testkit.NewTestKit(c, s.store)
 	tk.MustExec("use test")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31543

Problem Summary: planner: make queries with the extra column `_tidb_rowid` can use PointGet

### What is changed and how it works?

planner: make queries with the extra column `_tidb_rowid` can use PointGet

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: make queries with the extra column `_tidb_rowid` can use PointGet
```
