### PR TITLE
sysvar: bypass validation for noop variables

### DIFF
--- a/expression/integration_serial_test.go
+++ b/expression/integration_serial_test.go
@@ -3854,8 +3854,8 @@ func TestSetVariables(t *testing.T) {
 	require.NoError(t, err)
 	//require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_user_connections").Error())
 	_, err = tk.Exec("set @@global.max_prepared_stmt_count='';")
-	require.NoError(t, err)
-	//require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_prepared_stmt_count").Error())
+	require.Error(t, err)
+	require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_prepared_stmt_count").Error())
 }
 
 func TestPreparePlanCache(t *testing.T) {

--- a/expression/integration_serial_test.go
+++ b/expression/integration_serial_test.go
@@ -3851,11 +3851,11 @@ func TestSetVariables(t *testing.T) {
 	tk.MustExec("set global tidb_enable_noop_functions=1")
 
 	_, err = tk.Exec("set @@global.max_user_connections='';")
-	require.Error(t, err)
-	require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_user_connections").Error())
+	require.NoError(t, err)
+	//require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_user_connections").Error())
 	_, err = tk.Exec("set @@global.max_prepared_stmt_count='';")
-	require.Error(t, err)
-	require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_prepared_stmt_count").Error())
+	require.NoError(t, err)
+	//require.Error(t, err, variable.ErrWrongTypeForVar.GenWithStackByArgs("max_prepared_stmt_count").Error())
 }
 
 func TestPreparePlanCache(t *testing.T) {

--- a/sessionctx/variable/sysvar_test.go
+++ b/sessionctx/variable/sysvar_test.go
@@ -834,3 +834,16 @@ func TestIndexMergeSwitcher(t *testing.T) {
 	require.Equal(t, DefTiDBEnableIndexMerge, true)
 	require.Equal(t, BoolToOnOff(DefTiDBEnableIndexMerge), val)
 }
+
+func TestNoValidateForNoop(t *testing.T) {
+	vars := NewSessionVars()
+
+	// for noop variables, no error
+	val, err := GetSysVar("rpl_semi_sync_slave_enabled").ValidateFromType(vars, "", ScopeGlobal)
+	require.NoError(t, err)
+	require.Equal(t, val, "")
+
+	// for other variables, error
+	_, err = GetSysVar(TiDBAllowBatchCop).ValidateFromType(vars, "", ScopeGlobal)
+	require.Error(t, err)
+}

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -267,6 +267,10 @@ func (sv *SysVar) ValidateFromType(vars *SessionVars, value string, scope ScopeF
 	if value == "" && ((sv.AllowEmpty && scope == ScopeSession) || sv.AllowEmptyAll) {
 		return value, nil
 	}
+	// FIXME: hack to bypass some bugs
+	if sv.IsNoop {
+		return value, nil
+	}
 	// Provide validation using the SysVar struct
 	switch sv.Type {
 	case TypeUnsigned:

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -261,7 +261,7 @@ func (sv *SysVar) Validate(vars *SessionVars, value string, scope ScopeFlag) (st
 
 // ValidateFromType provides automatic validation based on the SysVar's type
 func (sv *SysVar) ValidateFromType(vars *SessionVars, value string, scope ScopeFlag) (string, error) {
-	// FIXME: hack to bypass some bugs
+	// TODO: this is a temporary solution for issue: https://github.com/pingcap/tidb/issues/31538, an elegant solution is needed.
 	if sv.IsNoop {
 		return value, nil
 	}

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -261,14 +261,14 @@ func (sv *SysVar) Validate(vars *SessionVars, value string, scope ScopeFlag) (st
 
 // ValidateFromType provides automatic validation based on the SysVar's type
 func (sv *SysVar) ValidateFromType(vars *SessionVars, value string, scope ScopeFlag) (string, error) {
+	// FIXME: hack to bypass some bugs
+	if sv.IsNoop {
+		return value, nil
+	}
 	// Some sysvars in TiDB have a special behavior where the empty string means
 	// "use the config file value". This needs to be cleaned up once the behavior
 	// for instance variables is determined.
 	if value == "" && ((sv.AllowEmpty && scope == ScopeSession) || sv.AllowEmptyAll) {
-		return value, nil
-	}
-	// FIXME: hack to bypass some bugs
-	if sv.IsNoop {
 		return value, nil
 	}
 	// Provide validation using the SysVar struct

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -262,7 +262,7 @@ func (sv *SysVar) Validate(vars *SessionVars, value string, scope ScopeFlag) (st
 // ValidateFromType provides automatic validation based on the SysVar's type
 func (sv *SysVar) ValidateFromType(vars *SessionVars, value string, scope ScopeFlag) (string, error) {
 	// TODO: this is a temporary solution for issue: https://github.com/pingcap/tidb/issues/31538, an elegant solution is needed.
-	if sv.IsNoop {
+	if value == "" && sv.IsNoop {
 		return value, nil
 	}
 	// Some sysvars in TiDB have a special behavior where the empty string means


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #31538 

Problem Summary: This is a quick dirty workaround for the issue. It should not change much since affected variables are all no-op. We could fix it more smoothly by versioned sysvars or whatever in the future.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Remove validation for noop variables like `rpl_semi_sync_master_wait_point` in case it is an empty string to workaround upgrading
```
