### PR TITLE
test: stabilize `testDDLSuite.TestParallelDDL`

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -237,17 +237,6 @@ func buildCreateIdxJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo, unique bo
 	}
 }
 
-func buildModifyColJob(dbInfo *model.DBInfo, tblInfo *model.TableInfo) *model.Job {
-	newCol := table.ToColumn(tblInfo.Columns[0])
-	return &model.Job{
-		SchemaID:   dbInfo.ID,
-		TableID:    tblInfo.ID,
-		Type:       model.ActionModifyColumn,
-		BinlogInfo: &model.HistoryInfo{},
-		Args:       []interface{}{&newCol, newCol.Name, ast.ColumnPosition{Tp: ast.ColumnPositionNone}, 0},
-	}
-}
-
 func testCreatePrimaryKey(c *C, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo, tblInfo *model.TableInfo, colName string) *model.Job {
 	job := buildCreateIdxJob(dbInfo, tblInfo, true, "primary", colName)
 	job.Type = model.ActionAddPrimaryKey

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -1605,7 +1605,7 @@ func (s *testDDLSuite) TestParallelDDL(c *C) {
 	c.Assert(err, IsNil)
 
 	// set hook to execute jobs after all jobs are in queue.
-	jobCnt := int64(12)
+	jobCnt := int64(11)
 	tc := &TestDDLCallback{}
 	once := sync.Once{}
 	var checkErr error
@@ -1655,8 +1655,7 @@ func (s *testDDLSuite) TestParallelDDL(c *C) {
 		/     8		/	 	2			/		3		/	rebase autoID/
 		/     9		/	 	1			/		1		/	add index	 /
 		/     10	/	 	2			/		null   	/	drop schema  /
-		/     11    /       1           /       1       /   modify column/
-		/     12	/	 	2			/		2		/	add index	 /
+		/     11	/	 	2			/		2		/	add index	 /
 	*/
 	job1 := buildCreateIdxJob(dbInfo1, tblInfo1, false, "db1_idx1", "c1")
 	addDDLJob(c, d, job1)
@@ -1678,10 +1677,8 @@ func (s *testDDLSuite) TestParallelDDL(c *C) {
 	addDDLJob(c, d, job9)
 	job10 := buildDropSchemaJob(dbInfo2)
 	addDDLJob(c, d, job10)
-	job11 := buildModifyColJob(dbInfo1, tblInfo1)
+	job11 := buildCreateIdxJob(dbInfo2, tblInfo3, false, "db3_idx1", "c2")
 	addDDLJob(c, d, job11)
-	job12 := buildCreateIdxJob(dbInfo2, tblInfo3, false, "db3_idx1", "c2")
-	addDDLJob(c, d, job12)
 	// TODO: add rename table job
 
 	// check results.
@@ -1689,20 +1686,20 @@ func (s *testDDLSuite) TestParallelDDL(c *C) {
 	for !isChecked {
 		err := kv.RunInNewTxn(context.Background(), store, false, func(ctx context.Context, txn kv.Transaction) error {
 			m := meta.NewMeta(txn)
-			lastJob, err := m.GetHistoryDDLJob(job12.ID)
+			lastJob, err := m.GetHistoryDDLJob(job11.ID)
 			c.Assert(err, IsNil)
 			// all jobs are finished.
 			if lastJob != nil {
 				finishedJobs, err := m.GetAllHistoryDDLJobs()
 				c.Assert(err, IsNil)
 				// get the last 12 jobs completed.
-				finishedJobs = finishedJobs[len(finishedJobs)-12:]
+				finishedJobs = finishedJobs[len(finishedJobs)-11:]
 				// check some jobs are ordered because of the dependence.
 				c.Assert(finishedJobs[0].ID, Equals, job1.ID, Commentf("%v", finishedJobs))
 				c.Assert(finishedJobs[1].ID, Equals, job2.ID, Commentf("%v", finishedJobs))
 				c.Assert(finishedJobs[2].ID, Equals, job3.ID, Commentf("%v", finishedJobs))
 				c.Assert(finishedJobs[4].ID, Equals, job5.ID, Commentf("%v", finishedJobs))
-				c.Assert(finishedJobs[11].ID, Equals, job12.ID, Commentf("%v", finishedJobs))
+				c.Assert(finishedJobs[10].ID, Equals, job11.ID, Commentf("%v", finishedJobs))
 				// check the jobs are ordered in the backfill-job queue or general-job queue.
 				backfillJobID := int64(0)
 				generalJobID := int64(0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31590

Problem Summary:

After moving non-reorg job to general queue, the execution order of add-index job and modify-column job becomes undetermined.

### What is changed and how it works?

This PR remove the modify-column job in `TestParallelDDL` to make it stable.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
