### PR TITLE
insert: fix insert into select statement should ignore the error and insert default value

### DIFF
--- a/executor/insert_common.go
+++ b/executor/insert_common.go
@@ -441,13 +441,6 @@ func insertRowsFromSelect(ctx context.Context, base insertCommon) error {
 	// In order to ensure the correctness of the `transaction write throughput` SLI statistics,
 	// just ignore the transaction which contain `insert|replace into ... select ... from ...` statement.
 	e.ctx.GetTxnWriteThroughputSLI().SetInvalid()
-	// it's a tricky way to mute the error message from `insert into select statement` and insert the default value just like mysql did.
-	// eg: insert into select sleep(null), the insert result should be 0 with warnings even with the strict sql mode.
-	originSQLMode := e.ctx.GetSessionVars().StrictSQLMode
-	e.ctx.GetSessionVars().StrictSQLMode = false
-	defer func() {
-		e.ctx.GetSessionVars().StrictSQLMode = originSQLMode
-	}()
 	for {
 		err := Next(ctx, selectExec, chk)
 		if err != nil {

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -16,7 +16,6 @@ package executor_test
 
 import (
 	"fmt"
-	testkit2 "github.com/pingcap/tidb/testkit"
 	"math"
 	"strconv"
 	"strings"

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1926,10 +1926,10 @@ func TestReplaceAllocatingAutoID(t *testing.T) {
 }
 
 func TestInsertIntoSelectError(t *testing.T) {
-	store, clean := testkit2.CreateMockStore(t)
+	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 
-	tk := testkit2.NewTestKit(t, store)
+	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("DROP TABLE IF EXISTS t1;")
 	tk.MustExec("CREATE TABLE t1(a INT) ENGINE = InnoDB;")

--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1935,6 +1935,9 @@ func TestInsertIntoSelectError(t *testing.T) {
 	tk.MustExec("CREATE TABLE t1(a INT) ENGINE = InnoDB;")
 	tk.MustExec("INSERT IGNORE into t1(SELECT SLEEP(NULL));")
 	tk.MustQuery("SHOW WARNINGS;").Check(testkit.Rows("Warning 1210 Incorrect arguments to sleep"))
-	tk.MustQuery("SELECT * FROM t1;").Check(testkit.Rows("0"))
+	tk.MustExec("INSERT IGNORE into t1(SELECT SLEEP(-1));")
+	tk.MustQuery("SHOW WARNINGS;").Check(testkit.Rows("Warning 1210 Incorrect arguments to sleep"))
+	tk.MustExec("INSERT IGNORE into t1(SELECT SLEEP(1));")
+	tk.MustQuery("SELECT * FROM t1;").Check(testkit.Rows("0", "0", "0"))
 	tk.MustExec("DROP TABLE t1;")
 }

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -137,7 +137,8 @@ func (b *builtinSleepSig) evalInt(row chunk.Row) (int64, bool, error) {
 
 	sessVars := b.ctx.GetSessionVars()
 	if isNull || val < 0 {
-		if sessVars.StrictSQLMode {
+		// for insert ignore stmt, the StrictSQLMode and ignoreErr should both be considered.
+		if !sessVars.StmtCtx.BadNullAsWarning {
 			return 0, false, errIncorrectArgs.GenWithStackByArgs("sleep")
 		}
 		err := errIncorrectArgs.GenWithStackByArgs("sleep")

--- a/expression/builtin_miscellaneous_vec.go
+++ b/expression/builtin_miscellaneous_vec.go
@@ -341,7 +341,8 @@ func (b *builtinSleepSig) vecEvalInt(input *chunk.Chunk, result *chunk.Column) e
 
 		sessVars := b.ctx.GetSessionVars()
 		if isNull || val < 0 {
-			if sessVars.StrictSQLMode {
+			// for insert ignore stmt, the StrictSQLMode and ignoreErr should both be considered.
+			if !sessVars.StmtCtx.BadNullAsWarning {
 				return errIncorrectArgs.GenWithStackByArgs("sleep")
 			}
 			err := errIncorrectArgs.GenWithStackByArgs("sleep")

--- a/expression/builtin_miscellaneous_vec_test.go
+++ b/expression/builtin_miscellaneous_vec_test.go
@@ -152,7 +152,7 @@ func TestSleepVectorized(t *testing.T) {
 	warnCnt := counter{}
 
 	// non-strict model
-	sessVars.StrictSQLMode = false
+	sessVars.StmtCtx.BadNullAsWarning = true
 	input.AppendFloat64(0, 1)
 	err = f.vecEvalInt(input, result)
 	require.NoError(t, err)
@@ -185,7 +185,7 @@ func TestSleepVectorized(t *testing.T) {
 	require.Equal(t, uint16(warnCnt.add(2)), sessVars.StmtCtx.WarningCount())
 
 	// for error case under the strict model
-	sessVars.StrictSQLMode = true
+	sessVars.StmtCtx.BadNullAsWarning = false
 	input.Reset()
 	input.AppendNull(0)
 	err = f.vecEvalInt(input, result)

--- a/expression/evaluator_test.go
+++ b/expression/evaluator_test.go
@@ -103,7 +103,7 @@ func TestSleep(t *testing.T) {
 
 	fc := funcs[ast.Sleep]
 	// non-strict model
-	sessVars.StrictSQLMode = false
+	sessVars.StmtCtx.BadNullAsWarning = true
 	d := make([]types.Datum, 1)
 	f, err := fc.getFunction(ctx, datumsToConstants(d))
 	require.NoError(t, err)
@@ -120,7 +120,7 @@ func TestSleep(t *testing.T) {
 	require.Equal(t, int64(0), ret)
 
 	// for error case under the strict model
-	sessVars.StrictSQLMode = true
+	sessVars.StmtCtx.BadNullAsWarning = false
 	d[0].SetNull()
 	_, err = fc.getFunction(ctx, datumsToConstants(d))
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: ailinkid <314806019@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/31432

### What is changed and how it works?

select sleep(null/neg) should consider Insert ignore flag as well (now only consider the strictMode). 
For other functions: seems it won't convert it to default 0 as sleep function does.
```
mysql> insert ignore into t (select period_add(0, 20));
ERROR 1210 (HY000): Incorrect arguments to period_add
mysql> insert ignore into t (select name_const("hello", 1+1));
ERROR 1210 (HY000): Incorrect arguments to NAME_CONST
mysql> insert ignore into t (select name_const(concat('a', 'b'), 555));
ERROR 1210 (HY000): Incorrect arguments to NAME_CONST
mysql> insert ignore into t (select sleep(null));
Query OK, 1 row affected, 1 warning (0.00 sec)
Records: 1  Duplicates: 0  Warnings: 1

mysql> show warnings;
+---------+------+-------------------------------+
| Level   | Code | Message                       |
+---------+------+-------------------------------+
| Warning | 1210 | Incorrect arguments to sleep. |
+---------+------+-------------------------------+
1 row in set (0.00 sec)
```


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
