### PR TITLE
executor: Fix unstable test TestCheckFailReport

### DIFF
--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -1181,8 +1181,8 @@ func (w *tableWorker) compareData(ctx context.Context, task *lookupTableTask, ta
 			return errors.Trace(err)
 		}
 
-		// If ctx is cancelled, `Next` may re turn empty result when the actual data is not empty. To avoid producing
-		// false-positive error logs that causes confusion, exit in this case.
+		// If ctx is cancelled, `Next` may return empty result when the actual data is not empty. To avoid producing
+		// false-positive error logs that cause confusion, exit in this case.
 		select {
 		case <-ctx.Done():
 			return nil

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -1180,6 +1180,15 @@ func (w *tableWorker) compareData(ctx context.Context, task *lookupTableTask, ta
 		if err != nil {
 			return errors.Trace(err)
 		}
+
+		// If ctx is cancelled, `Next` may re turn empty result when the actual data is not empty. To avoid producing
+		// false-positive error logs that causes confusion, exit in this case.
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		if chk.NumRows() == 0 {
 			task.indexOrder.Range(func(h kv.Handle, val interface{}) bool {
 				idxRow := task.idxRows.GetRow(val.(int))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #26833

Problem Summary: TestCheckFailReport is unstable. There's such a problem: when executing admin check, it didn't handle context cancellation correctly, therefore if admin check fails, and another working goroutine inner the TableReaderExecutor returns empty result due to being cancelled, there's some chance that the admin check procedure produced one more false-positive error log, which may cause confusion and misleading.

### What is changed and how it works?

After reading from table, exit before reporting error if context is cancelled.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test



### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
