### PR TITLE
*: fix data race on `enableTiFlashPoll`

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -49,6 +49,7 @@ import (
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/pingcap/tidb/util/logutil"
 	"go.etcd.io/etcd/clientv3"
+	atomicutil "go.uber.org/atomic"
 	"go.uber.org/zap"
 )
 
@@ -191,7 +192,7 @@ type ddl struct {
 	workers           map[workerType]*worker
 	sessPool          *sessionPool
 	delRangeMgr       delRangeManager
-	enableTiFlashPoll bool
+	enableTiFlashPoll atomicutil.Bool
 }
 
 // ddlCtx is the context when we use worker to handle DDL jobs.
@@ -229,20 +230,20 @@ func (dc *ddlCtx) isOwner() bool {
 // EnableTiFlashPoll enables TiFlash poll loop aka PollTiFlashReplicaStatus.
 func EnableTiFlashPoll(d interface{}) {
 	if dd, ok := d.(*ddl); ok {
-		dd.enableTiFlashPoll = true
+		dd.enableTiFlashPoll.Store(true)
 	}
 }
 
 // DisableTiFlashPoll disables TiFlash poll loop aka PollTiFlashReplicaStatus.
 func DisableTiFlashPoll(d interface{}) {
 	if dd, ok := d.(*ddl); ok {
-		dd.enableTiFlashPoll = false
+		dd.enableTiFlashPoll.Store(false)
 	}
 }
 
 // IsTiFlashPollEnabled reveals enableTiFlashPoll
 func (d *ddl) IsTiFlashPollEnabled() bool {
-	return d.enableTiFlashPoll
+	return d.enableTiFlashPoll.Load()
 }
 
 // RegisterStatsHandle registers statistics handle and its corresponding even channel for ddl.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -192,7 +192,7 @@ type ddl struct {
 	workers           map[workerType]*worker
 	sessPool          *sessionPool
 	delRangeMgr       delRangeManager
-	enableTiFlashPoll atomicutil.Bool
+	enableTiFlashPoll *atomicutil.Bool
 }
 
 // ddlCtx is the context when we use worker to handle DDL jobs.
@@ -331,7 +331,7 @@ func newDDL(ctx context.Context, options ...Option) *ddl {
 		ctx:               ctx,
 		ddlCtx:            ddlCtx,
 		limitJobCh:        make(chan *limitJobTask, batchAddingJobs),
-		enableTiFlashPoll: true,
+		enableTiFlashPoll: atomicutil.NewBool(true),
 	}
 
 	return d


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31818

Problem Summary:
Make `enableTiFlashPoll` as atomic bool.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix data race on enableTiFlashPoll 
```
