### PR TITLE
ddl: fix data race and goroutine leak in test

### DIFF
--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/testleak"
 	"github.com/stretchr/testify/require"
-	"github.com/tikv/client-go/v2/tikv"
 )
 
 type DDLForTest interface {
@@ -85,7 +84,6 @@ func TestT(t *testing.T) {
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
 		conf.Experimental.AllowsExpressionIndex = true
 	})
-	tikv.EnableFailpoints()
 
 	_, err = infosync.GlobalInfoSyncerInit(context.Background(), "t", func() uint64 { return 1 }, nil, true)
 	if err != nil {

--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -223,7 +223,13 @@ func (s *tiflashDDLTestSuite) SetPdLoop(tick int) func() {
 
 // Run all kinds of DDLs, and will create no redundant pd rules for TiFlash.
 func (s *tiflashDDLTestSuite) TestTiFlashNoRedundantPDRules(c *C) {
-	_, _, cluster, _ := unistore.New("")
+	rpcClient, pdClient, cluster, err := unistore.New("")
+	c.Assert(err, IsNil)
+	defer func() {
+		rpcClient.Close()
+		pdClient.Close()
+		cluster.Close()
+	}()
 	for _, store := range s.cluster.GetAllStores() {
 		cluster.AddStore(store.Id, store.Address, store.Labels...)
 	}
@@ -535,7 +541,13 @@ func (s *tiflashDDLTestSuite) TestSetPlacementRuleNormal(c *C) {
 
 // When gc worker works, it will automatically remove pd rule for TiFlash.
 func (s *tiflashDDLTestSuite) TestSetPlacementRuleWithGCWorker(c *C) {
-	_, _, cluster, err := unistore.New("")
+	rpcClient, pdClient, cluster, err := unistore.New("")
+	c.Assert(err, IsNil)
+	defer func() {
+		rpcClient.Close()
+		pdClient.Close()
+		cluster.Close()
+	}()
 	for _, store := range s.cluster.GetAllStores() {
 		cluster.AddStore(store.Id, store.Address, store.Labels...)
 	}
@@ -545,7 +557,6 @@ func (s *tiflashDDLTestSuite) TestSetPlacementRuleWithGCWorker(c *C) {
 	}()
 	fCancelPD := s.SetPdLoop(10000)
 	defer fCancelPD()
-	c.Assert(err, IsNil)
 	gcWorker, err := gcworker.NewMockGCWorker(s.store)
 	c.Assert(err, IsNil)
 	// Make SetPdLoop take effects.

--- a/ddl/main_test.go
+++ b/ddl/main_test.go
@@ -1,0 +1,35 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/util/testbridge"
+	"github.com/tikv/client-go/v2/tikv"
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	testbridge.SetupForCommonTest()
+	tikv.EnableFailpoints()
+
+	opts := []goleak.Option{
+		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),
+	}
+
+	goleak.VerifyTestMain(m, opts...)
+}

--- a/ddl/options_test.go
+++ b/ddl/options_test.go
@@ -28,6 +28,10 @@ import (
 func TestOptions(t *testing.T) {
 	client, err := clientv3.NewFromURL("test")
 	require.NoError(t, err)
+	defer func() {
+		err := client.Close()
+		require.NoError(t, err)
+	}()
 	callback := &ddl.BaseCallback{}
 	lease := time.Second * 3
 	store := &mock.Store{}

--- a/ddl/partition_test.go
+++ b/ddl/partition_test.go
@@ -27,6 +27,10 @@ import (
 
 func ExportTestDropAndTruncatePartition(t *testing.T) {
 	store := testCreateStoreT(t, "test_store")
+	defer func() {
+		err := store.Close()
+		require.NoError(t, err)
+	}()
 	d, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(store),

--- a/ddl/placement_policy_ddl_test.go
+++ b/ddl/placement_policy_ddl_test.go
@@ -63,6 +63,10 @@ func (s *testDDLSuiteToVerify) TestPlacementPolicyInUse() {
 	ctx := context.Background()
 	d, err := testNewDDLAndStart(ctx, WithStore(store))
 	require.NoError(s.T(), err)
+	defer func() {
+		err := d.Stop()
+		require.NoError(s.T(), err)
+	}()
 	sctx := testNewContext(d)
 
 	db1, err := testSchemaInfo(d, "db1")

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -348,6 +348,10 @@ func testAlterNoCacheTable(t *testing.T, ctx sessionctx.Context, d *ddl, newSche
 
 func ExportTestRenameTables(t *testing.T) {
 	store, err := mockstore.NewMockStore()
+	defer func() {
+		err := store.Close()
+		require.NoError(t, err)
+	}()
 	require.NoError(t, err)
 	ddl, err := testNewDDLAndStart(
 		context.Background(),
@@ -355,6 +359,10 @@ func ExportTestRenameTables(t *testing.T) {
 		WithLease(testLease),
 	)
 	require.NoError(t, err)
+	defer func() {
+		err := ddl.Stop()
+		require.NoError(t, err)
+	}()
 
 	dbInfo, err := testSchemaInfo(ddl, "test_table")
 	require.NoError(t, err)
@@ -397,12 +405,20 @@ func ExportTestRenameTables(t *testing.T) {
 func TestCreateTables(t *testing.T) {
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
+	defer func() {
+		err := store.Close()
+		require.NoError(t, err)
+	}()
 	ddl, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(store),
 		WithLease(testLease),
 	)
 	require.NoError(t, err)
+	defer func() {
+		err := ddl.Stop()
+		require.NoError(t, err)
+	}()
 
 	dbInfo, err := testSchemaInfo(ddl, "test_table")
 	require.NoError(t, err)


### PR DESCRIPTION
Signed-off-by: disksing <i@disksing.com>

### What problem does this PR solve?

Issue Number: close #31875

Problem Summary: ddl test sometimes failed due to client-go data race

### What is changed and how it works?

- add `TestMain` and move `EnableFailpoint` into it (this step should fix the issue)
- fix goroutine leaks

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Unit test

### Release note
```release-note
None
```
