### PR TITLE
* : Fix mistakes in comments about assertion; remove unnecessary deep copy to key when setting assertion

### DIFF
--- a/store/driver/txn/txn_driver.go
+++ b/store/driver/txn/txn_driver.go
@@ -292,18 +292,16 @@ func (txn *tikvTxn) extractKeyExistsErr(key kv.Key) error {
 	return extractKeyExistsErrFromIndex(key, value, tblInfo, indexID)
 }
 
-// SetAssertion sets a assertion for the key operation.
+// SetAssertion sets an assertion for the key operation.
 func (txn *tikvTxn) SetAssertion(key []byte, assertion ...kv.FlagsOp) error {
-	// Deep copy the key since it's memory is referenced from union store and overwrite change later.
-	key1 := append([]byte{}, key...)
-	f, err := txn.GetUnionStore().GetMemBuffer().GetFlags(key1)
+	f, err := txn.GetUnionStore().GetMemBuffer().GetFlags(key)
 	if err != nil && !tikverr.IsErrNotFound(err) {
 		return err
 	}
 	if err == nil && f.HasAssertionFlags() {
 		return nil
 	}
-	txn.GetUnionStore().GetMemBuffer().UpdateFlags(key1, getTiKVFlagsOps(assertion)...)
+	txn.GetUnionStore().GetMemBuffer().UpdateFlags(key, getTiKVFlagsOps(assertion)...)
 	return nil
 }
 

--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -768,8 +768,6 @@ func TestConstraintCheckForOptimisticUntouched(t *testing.T) {
 func TestTxnAssertion(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
-	// TODO: Locks produced by this test may be left without cleaning up, causing the test runs longer than expected.
-	// This is caused by that client-go didn't clean up the transaction when `initKeysAndMutations` returns error.
 
 	se, err := session.CreateSession4Test(store)
 	se.SetConnectionID(1)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #26833 

Problem Summary:

This is a fix to the dev branch `ft-data-inconsistency`, to address comments in #31547 .

* Fix a typo in comment;
* Remove an unnecessary comment;
* Remove unnecessary deep copy to key when setting assertion.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
