### PR TITLE
metrics: add more metrics for golang gc

### DIFF
--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -162,7 +162,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(TopSQLReportDataHistogram)
 	prometheus.MustRegister(PDApiExecutionHistogram)
 	prometheus.MustRegister(CPUProfileCounter)
-
+	prometheus.MustRegister(GCPausePercent)
+	prometheus.MustRegister(GCIntervals)
 	tikvmetrics.InitMetrics(TiDB, TiKVClient)
 	tikvmetrics.RegisterMetrics()
 	tikvmetrics.TiKVPanicCounter = PanicCounter // reset tidb metrics for tikv metrics

--- a/metrics/system.go
+++ b/metrics/system.go
@@ -1,0 +1,49 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import "github.com/prometheus/client_golang/prometheus"
+
+var (
+	GCCount = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "system",
+			Name:      "golang_gc_count",
+			Help:      "Total number of Golang GC runs",
+		})
+	GCPauseNS = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "system",
+			Name:      "golang_gc_pause_ns",
+			Help:      "Total GC pause",
+		})
+
+	GCPausePercent = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "system",
+			Name:      "golang_gc_pause_ns",
+			Help:      "Current GC pause percentage",
+		})
+	GCIntervals = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: "tidb",
+			Subsystem: "system",
+			Name:      "golang_gc_intervals_ns",
+			Help:      "intervals between GC",
+		})
+)

--- a/metrics/system.go
+++ b/metrics/system.go
@@ -17,14 +17,7 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	GCPauseNS = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "tidb",
-			Subsystem: "system",
-			Name:      "golang_gc_pause_ns",
-			Help:      "Total GC pause",
-		})
-
+	// GCPausePercent means Current GC pause percentage
 	GCPausePercent = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "tidb",
@@ -32,6 +25,7 @@ var (
 			Name:      "golang_gc_pause_ns",
 			Help:      "Current GC pause percentage",
 		})
+	// GCIntervals means intervals between GC
 	GCIntervals = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "tidb",

--- a/metrics/system.go
+++ b/metrics/system.go
@@ -17,13 +17,6 @@ package metrics
 import "github.com/prometheus/client_golang/prometheus"
 
 var (
-	GCCount = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Namespace: "tidb",
-			Subsystem: "system",
-			Name:      "golang_gc_count",
-			Help:      "Total number of Golang GC runs",
-		})
 	GCPauseNS = prometheus.NewGauge(
 		prometheus.GaugeOpts{
 			Namespace: "tidb",

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -206,10 +206,12 @@ func main() {
 	// To prevent misuse, set a flag to indicate that register new error will panic immediately.
 	// For regression of issue like https://github.com/pingcap/tidb/issues/28190
 	terror.RegisterFinish()
-
+	rss := util.NewRuntimeStatSampler()
+	go rss.Start()
 	exited := make(chan struct{})
 	signal.SetupSignalHandler(func(graceful bool) {
 		svr.Close()
+		rss.Close()
 		cleanup(svr, storage, dom, graceful)
 		cpuprofile.StopCPUProfiler()
 		close(exited)

--- a/util/gogc.go
+++ b/util/gogc.go
@@ -77,7 +77,6 @@ func (gss *GOGCStatSampler) sample() {
 		metrics.GCIntervals.Set(float64(gcIntervals.Nanoseconds()))
 	}
 	gss.last.gcPauseTime = uint64(gc.PauseTotal)
-	metrics.GCCount.Set(float64(gc.NumGC))
 	metrics.GCPauseNS.Set(float64(gc.PauseTotal))
 	metrics.GCPausePercent.Set(gcPauseRatio)
 }

--- a/util/gogc.go
+++ b/util/gogc.go
@@ -48,6 +48,7 @@ func GetGOGC() int {
 	return int(gogcValue.Load())
 }
 
+// GOGCStatSampler is a sampler for GOGC.
 type GOGCStatSampler struct {
 	last struct {
 		now         int64
@@ -58,6 +59,7 @@ type GOGCStatSampler struct {
 	exitChan   chan struct{}
 }
 
+// NewRuntimeStatSampler returns a sampler for GOGC.
 func NewRuntimeStatSampler() *GOGCStatSampler {
 	return &GOGCStatSampler{}
 }
@@ -80,6 +82,7 @@ func (gss *GOGCStatSampler) sample() {
 	metrics.GCPausePercent.Set(gcPauseRatio)
 }
 
+// Start is used to start the sampler.
 func (gss *GOGCStatSampler) Start() {
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
@@ -93,6 +96,7 @@ func (gss *GOGCStatSampler) Start() {
 	}
 }
 
+// Close is used to close the sampler.
 func (gss *GOGCStatSampler) Close() {
 	close(gss.exitChan)
 }

--- a/util/gogc.go
+++ b/util/gogc.go
@@ -18,20 +18,19 @@ import (
 	"os"
 	"runtime/debug"
 	"strconv"
-	"sync/atomic"
 	"time"
 
 	"github.com/pingcap/tidb/metrics"
+	atomicutil "go.uber.org/atomic"
 )
 
-var gogcValue int64
+var gogcValue atomicutil.Int64 = *atomicutil.NewInt64(100)
 
 func init() {
-	gogcValue = 100
 	if val, err := strconv.Atoi(os.Getenv("GOGC")); err == nil {
-		gogcValue = int64(val)
+		gogcValue.Store(int64(val))
 	}
-	metrics.GOGC.Set(float64(gogcValue))
+	metrics.GOGC.Set(float64(gogcValue.Load()))
 }
 
 // SetGOGC update GOGC and related metrics.
@@ -41,12 +40,12 @@ func SetGOGC(val int) {
 	}
 	debug.SetGCPercent(val)
 	metrics.GOGC.Set(float64(val))
-	atomic.StoreInt64(&gogcValue, int64(val))
+	gogcValue.Store(int64(val))
 }
 
 // GetGOGC returns the current value of GOGC.
 func GetGOGC() int {
-	return int(atomic.LoadInt64(&gogcValue))
+	return int(gogcValue.Load())
 }
 
 type GOGCStatSampler struct {

--- a/util/gogc.go
+++ b/util/gogc.go
@@ -76,8 +76,8 @@ func (gss *GOGCStatSampler) sample() {
 		gss.last.lastGC = gc.LastGC
 		metrics.GCIntervals.Set(float64(gcIntervals.Nanoseconds()))
 	}
+	gss.last.now = now
 	gss.last.gcPauseTime = uint64(gc.PauseTotal)
-	metrics.GCPauseNS.Set(float64(gc.PauseTotal))
 	metrics.GCPausePercent.Set(gcPauseRatio)
 }
 

--- a/util/gogc.go
+++ b/util/gogc.go
@@ -61,7 +61,9 @@ type GOGCStatSampler struct {
 
 // NewRuntimeStatSampler returns a sampler for GOGC.
 func NewRuntimeStatSampler() *GOGCStatSampler {
-	return &GOGCStatSampler{}
+	return &GOGCStatSampler{
+		exitChan: make(chan struct{}),
+	}
 }
 
 var gc debug.GCStats


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #32090

Problem Summary:

### What is changed and how it works?



#### Intervals between garbage collections

useful to know if we can still tune. For instance, Go forces a garbage collection every 2 minutes. If your service is still having high GC impact, but you already see 120s for this graph, it means that you can no longer tune using GOGC. In this case you would need to optimize your allocations.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

```
> $ curl http://127.0.0.1:10080/metrics |grep golang_gc

# HELP tidb_system_golang_gc_intervals_ns intervals between GC
# TYPE tidb_system_golang_gc_intervals_ns gauge
tidb_system_golang_gc_intervals_ns 1.32817e+08
# HELP tidb_system_golang_gc_pause_ns Current GC pause percentage
# TYPE tidb_system_golang_gc_pause_ns gauge
tidb_system_golang_gc_pause_ns 0.0005715342772578194
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
