### PR TITLE
metrics: replace histogram with counter for packet IO

### DIFF
--- a/metrics/grafana/tidb.json
+++ b/metrics/grafana/tidb.json
@@ -3180,14 +3180,14 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "sum(rate(tidb_server_packet_io_bytes_sum{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type)",
+              "expr": "sum(rate(tidb_server_packet_io_bytes{tidb_cluster=\"$tidb_cluster\"}[1m])) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}-rate",
               "refId": "A"
             },
             {
-              "expr": "sum(tidb_server_packet_io_bytes_sum{tidb_cluster=\"$tidb_cluster\"}) by (type)",
+              "expr": "sum(tidb_server_packet_io_bytes{tidb_cluster=\"$tidb_cluster\"}) by (type)",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "{{type}}-total",

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -112,7 +112,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(PanicCounter)
 	prometheus.MustRegister(PlanCacheCounter)
 	prometheus.MustRegister(PseudoEstimation)
-	prometheus.MustRegister(PacketIOHistogram)
+	prometheus.MustRegister(PacketIOCounter)
 	prometheus.MustRegister(QueryDurationHistogram)
 	prometheus.MustRegister(QueryTotalCounter)
 	prometheus.MustRegister(SchemaLeaseErrorCounter)

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -27,13 +27,12 @@ var (
 
 // Metrics
 var (
-	PacketIOHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
+	PacketIOCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
 			Namespace: "tidb",
 			Subsystem: "server",
 			Name:      "packet_io_bytes",
-			Help:      "Bucketed histogram of packet IO bytes.",
-			Buckets:   prometheus.ExponentialBuckets(4, 4, 21), // 4Bytes ~ 4TB
+			Help:      "Counters of packet IO bytes.",
 		}, []string{LblType})
 
 	QueryDurationHistogram = prometheus.NewHistogramVec(

--- a/server/packetio.go
+++ b/server/packetio.go
@@ -49,8 +49,8 @@ import (
 const defaultWriterSize = 16 * 1024
 
 var (
-	readPacketBytes  = metrics.PacketIOHistogram.WithLabelValues("read")
-	writePacketBytes = metrics.PacketIOHistogram.WithLabelValues("write")
+	readPacketBytes  = metrics.PacketIOCounter.WithLabelValues("read")
+	writePacketBytes = metrics.PacketIOCounter.WithLabelValues("write")
 )
 
 // packetIO is a helper to read and write data in packet format.
@@ -120,7 +120,7 @@ func (p *packetIO) readPacket() ([]byte, error) {
 	}
 
 	if len(data) < mysql.MaxPayloadLen {
-		readPacketBytes.Observe(float64(len(data)))
+		readPacketBytes.Add(float64(len(data)))
 		return data, nil
 	}
 
@@ -138,14 +138,14 @@ func (p *packetIO) readPacket() ([]byte, error) {
 		}
 	}
 
-	readPacketBytes.Observe(float64(len(data)))
+	readPacketBytes.Add(float64(len(data)))
 	return data, nil
 }
 
 // writePacket writes data that already have header
 func (p *packetIO) writePacket(data []byte) error {
 	length := len(data) - 4
-	writePacketBytes.Observe(float64(len(data)))
+	writePacketBytes.Add(float64(len(data)))
 
 	for length >= mysql.MaxPayloadLen {
 		data[0] = 0xff


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: ref #32075 

Problem Summary:

### What is changed and how it works?
As stated in the title and the related issue.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
The metrics shown in Grafana are the same as the previous one: verified by a local env with `tiup playground`:

![image](https://user-images.githubusercontent.com/1174042/152693091-cd16336d-8c1b-4b2f-8671-63c95c3cbcf0.png)

Side effects

- [x] Performance improvement: Consumes less CPU

Documentation

- NA

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
