### PR TITLE
(WIP) server: deprecate `EOF` packets by introducing `CLIENT_DEPRECATE_EOF` flag

### DIFF
--- a/parser/mysql/const.go
+++ b/parser/mysql/const.go
@@ -155,6 +155,9 @@ const (
 	ClientPluginAuth
 	ClientConnectAtts
 	ClientPluginAuthLenencClientData
+	ClientCanHandleExpiredPasswords
+	ClientSessionTrack
+	ClientDeprecateEof
 )
 
 // Cache type information.

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -96,7 +96,7 @@ func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
 			}
 		}
 
-		if err := cc.writeEOF(0); err != nil {
+		if err := cc.writeEOF(ctx, mysql.ServerMoreResultsExists); err != nil {
 			return err
 		}
 	}
@@ -110,11 +110,13 @@ func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
 				return err
 			}
 		}
+		//if err := cc.flush(ctx); err != nil {
+		//	return err
+		//}
 
-		if err := cc.writeEOF(0); err != nil {
+		if err := cc.writeEOF(ctx, 0); err != nil {
 			return err
 		}
-
 	}
 	return cc.flush(ctx)
 }
@@ -239,7 +241,7 @@ func (cc *clientConn) executePreparedStmtAndWriteResult(ctx context.Context, stm
 		cc.initResultEncoder(ctx)
 		defer cc.rsEncoder.clean()
 		stmt.StoreResultSet(rs)
-		err = cc.writeColumnInfo(rs.Columns(), mysql.ServerStatusCursorExists)
+		err = cc.writeColumnInfo(ctx, rs.Columns(), mysql.ServerStatusCursorExists)
 		if err != nil {
 			return false, err
 		}
@@ -678,7 +680,7 @@ func (cc *clientConn) handleSetOption(ctx context.Context, data []byte) (err err
 	default:
 		return mysql.ErrMalformPacket
 	}
-	if err = cc.writeEOF(0); err != nil {
+	if err = cc.writeEOF(ctx, 0); err != nil {
 		return err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -111,7 +111,8 @@ const defaultCapability = mysql.ClientLongPassword | mysql.ClientLongFlag |
 	mysql.ClientConnectWithDB | mysql.ClientProtocol41 |
 	mysql.ClientTransactions | mysql.ClientSecureConnection | mysql.ClientFoundRows |
 	mysql.ClientMultiStatements | mysql.ClientMultiResults | mysql.ClientLocalFiles |
-	mysql.ClientConnectAtts | mysql.ClientPluginAuth | mysql.ClientInteractive
+	mysql.ClientConnectAtts | mysql.ClientPluginAuth | mysql.ClientInteractive |
+	mysql.ClientDeprecateEof
 
 // Server is the MySQL protocol server
 type Server struct {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #32118 

Problem Summary:

### What is changed and how it works?

Improving the server protocol handling codes, basically following the updates of MySQL server described in [WL#7766](https://dev.mysql.com/worklog/task/?id=7766)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test

Side effects

Theoretically, this change does not introduce any compatibility breaks, however, careful tests should be made for varieties of MySQL clients/connectors.

Documentation

- NA

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
