### PR TITLE
ddl: fix error that pd rules are not deleted when alter TiFlash replica count to 0

### DIFF
--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -187,6 +187,7 @@ func updateTiFlashStores(pollTiFlashContext *TiFlashManagementContext) error {
 	// We need the up-to-date information about TiFlash stores.
 	// Since TiFlash Replica synchronize may happen immediately after new TiFlash stores are added.
 	tikvStats, err := infosync.GetTiFlashStoresStat(context.Background())
+	// If MockTiFlash is not set, will issue a MockTiFlashError here.
 	if err != nil {
 		return err
 	}

--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -360,6 +360,7 @@ func (s *tiflashDDLTestSuite) TestTiFlashReplicaAvailable(c *C) {
 
 	s.CheckFlashback(tk, c)
 	tb, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("ddltiflash"))
+	c.Assert(err, IsNil)
 	r, ok := s.tiflash.GetPlacementRule(fmt.Sprintf("table-%v-r", tb.Meta().ID))
 	c.Assert(r, NotNil)
 	c.Assert(ok, Equals, true)

--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -359,12 +359,19 @@ func (s *tiflashDDLTestSuite) TestTiFlashReplicaAvailable(c *C) {
 	CheckTableAvailableWithTableName(s.dom, c, 1, []string{}, "test", "ddltiflash2")
 
 	s.CheckFlashback(tk, c)
+	tb, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("ddltiflash"))
+	r, ok := s.tiflash.GetPlacementRule(fmt.Sprintf("table-%v-r", tb.Meta().ID))
+	c.Assert(r, NotNil)
+	c.Assert(ok, Equals, true)
 	tk.MustExec("alter table ddltiflash set tiflash replica 0")
 	time.Sleep(ddl.PollTiFlashInterval * RoundToBeAvailable)
-	tb, err := s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("ddltiflash"))
+	tb, err = s.dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("ddltiflash"))
 	c.Assert(err, IsNil)
 	replica := tb.Meta().TiFlashReplica
 	c.Assert(replica, IsNil)
+	r, ok = s.tiflash.GetPlacementRule(fmt.Sprintf("table-%v-r", tb.Meta().ID))
+	c.Assert(r, IsNil)
+	c.Assert(ok, Equals, false)
 }
 
 // Truncate partition shall not block.

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -89,18 +89,18 @@ func createTable(d *ddlCtx, t *meta.Meta, job *model.Job) (*model.TableInfo, err
 				logutil.BgLogger().Info("Set TiFlash replica pd rule for partitioned table when creating", zap.Int64("tableID", tbInfo.ID))
 				if e := infosync.ConfigureTiFlashPDForPartitions(false, &pi.Definitions, replicaInfo.Count, &replicaInfo.LocationLabels); e != nil {
 					job.State = model.JobStateCancelled
-					return tbInfo, errors.Trace(err)
+					return tbInfo, errors.Trace(e)
 				}
 				// Partitions that in adding mid-state. They have high priorities, so we should set accordingly pd rules.
 				if e := infosync.ConfigureTiFlashPDForPartitions(true, &pi.AddingDefinitions, replicaInfo.Count, &replicaInfo.LocationLabels); e != nil {
 					job.State = model.JobStateCancelled
-					return tbInfo, errors.Trace(err)
+					return tbInfo, errors.Trace(e)
 				}
 			} else {
 				logutil.BgLogger().Info("Set TiFlash replica pd rule when creating", zap.Int64("tableID", tbInfo.ID))
 				if e := infosync.ConfigureTiFlashPDForTable(tbInfo.ID, replicaInfo.Count, &replicaInfo.LocationLabels); e != nil {
 					job.State = model.JobStateCancelled
-					return tbInfo, errors.Trace(err)
+					return tbInfo, errors.Trace(e)
 				}
 			}
 		}
@@ -686,13 +686,13 @@ func onTruncateTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ erro
 			if e := infosync.ConfigureTiFlashPDForPartitions(true, &pi.Definitions, tblInfo.TiFlashReplica.Count, &tblInfo.TiFlashReplica.LocationLabels); e != nil {
 				logutil.BgLogger().Error("ConfigureTiFlashPDForPartitions fails", zap.Error(err))
 				job.State = model.JobStateCancelled
-				return ver, errors.Trace(err)
+				return ver, errors.Trace(e)
 			}
 		} else {
 			if e := infosync.ConfigureTiFlashPDForTable(newTableID, tblInfo.TiFlashReplica.Count, &tblInfo.TiFlashReplica.LocationLabels); e != nil {
 				logutil.BgLogger().Error("ConfigureTiFlashPDForTable fails", zap.Error(err))
 				job.State = model.JobStateCancelled
-				return ver, errors.Trace(err)
+				return ver, errors.Trace(e)
 			}
 		}
 		tblInfo.TiFlashReplica.AvailablePartitionIDs = nil
@@ -1090,18 +1090,18 @@ func (w *worker) onSetTableFlashReplica(t *meta.Meta, job *model.Job) (ver int64
 		logutil.BgLogger().Info("Set TiFlash replica pd rule for partitioned table", zap.Int64("tableID", tblInfo.ID))
 		if e := infosync.ConfigureTiFlashPDForPartitions(false, &pi.Definitions, replicaInfo.Count, &replicaInfo.Labels); e != nil {
 			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+			return ver, errors.Trace(e)
 		}
 		// Partitions that in adding mid-state. They have high priorities, so we should set accordingly pd rules.
 		if e := infosync.ConfigureTiFlashPDForPartitions(true, &pi.AddingDefinitions, replicaInfo.Count, &replicaInfo.Labels); e != nil {
 			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+			return ver, errors.Trace(e)
 		}
 	} else {
 		logutil.BgLogger().Info("Set TiFlash replica pd rule", zap.Int64("tableID", tblInfo.ID))
 		if e := infosync.ConfigureTiFlashPDForTable(tblInfo.ID, replicaInfo.Count, &replicaInfo.Labels); e != nil {
 			job.State = model.JobStateCancelled
-			return ver, errors.Trace(err)
+			return ver, errors.Trace(e)
 		}
 	}
 

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -1011,10 +1011,10 @@ func ConfigureTiFlashPDForTable(id int64, count uint64, locationLabels *[]string
 		return errors.Trace(err)
 	}
 	ctx := context.Background()
-	logutil.BgLogger().Info("ConfigureTiFlashPDForTable", zap.Int64("tableID", id))
+	logutil.BgLogger().Info("ConfigureTiFlashPDForTable", zap.Int64("tableID", id), zap.Uint64("count", count))
 	ruleNew := MakeNewRule(id, count, *locationLabels)
 	if e := is.tiflashPlacementManager.SetPlacementRule(ctx, *ruleNew); e != nil {
-		return errors.Trace(err)
+		return errors.Trace(e)
 	}
 	return nil
 }
@@ -1027,10 +1027,10 @@ func ConfigureTiFlashPDForPartitions(accel bool, definitions *[]model.PartitionD
 	}
 	ctx := context.Background()
 	for _, p := range *definitions {
-		logutil.BgLogger().Info("ConfigureTiFlashPDForPartitions", zap.Int64("partID", p.ID), zap.Bool("accel", accel))
+		logutil.BgLogger().Info("ConfigureTiFlashPDForPartitions", zap.Int64("partID", p.ID), zap.Bool("accel", accel), zap.Uint64("count", count))
 		ruleNew := MakeNewRule(p.ID, count, *locationLabels)
 		if e := is.tiflashPlacementManager.SetPlacementRule(ctx, *ruleNew); e != nil {
-			return errors.Trace(err)
+			return errors.Trace(e)
 		}
 		if accel {
 			e := is.tiflashPlacementManager.PostAccelerateSchedule(ctx, p.ID)

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -525,7 +525,7 @@ func (m *mockTiFlashPlacementManager) SetPlacementRule(ctx context.Context, rule
 	m.Lock()
 	defer m.Unlock()
 	if m.tiflash == nil {
-		return &MockTiFlashError{"MockTiFlash is not accessible"}
+		return nil
 	}
 	return m.tiflash.HandleSetPlacementRule(rule)
 }
@@ -535,7 +535,7 @@ func (m *mockTiFlashPlacementManager) DeletePlacementRule(ctx context.Context, g
 	m.Lock()
 	defer m.Unlock()
 	if m.tiflash == nil {
-		return &MockTiFlashError{"MockTiFlash is not accessible"}
+		return nil
 	}
 	logutil.BgLogger().Info("Remove TiFlash rule", zap.String("ID", ruleID))
 	m.tiflash.HandleDeletePlacementRule(group, ruleID)
@@ -547,7 +547,7 @@ func (m *mockTiFlashPlacementManager) GetGroupRules(ctx context.Context, group s
 	m.Lock()
 	defer m.Unlock()
 	if m.tiflash == nil {
-		return nil, &MockTiFlashError{"MockTiFlash is not accessible"}
+		return []placement.TiFlashRule{}, nil
 	}
 	return m.tiflash.HandleGetGroupRules(group)
 }
@@ -557,7 +557,7 @@ func (m *mockTiFlashPlacementManager) PostAccelerateSchedule(ctx context.Context
 	m.Lock()
 	defer m.Unlock()
 	if m.tiflash == nil {
-		return &MockTiFlashError{"MockTiFlash is not accessible"}
+		return nil
 	}
 	endKey := tablecodec.EncodeTablePrefix(tableID + 1)
 	endKey = codec.EncodeBytes([]byte{}, endKey)
@@ -569,7 +569,7 @@ func (m *mockTiFlashPlacementManager) GetPDRegionRecordStats(ctx context.Context
 	m.Lock()
 	defer m.Unlock()
 	if m.tiflash == nil {
-		return &MockTiFlashError{"MockTiFlash is not accessible"}
+		return nil
 	}
 	*stats = m.tiflash.HandleGetPDRegionRecordStats(tableID)
 	return nil

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -70,6 +70,9 @@ func (m *TiFlashPDPlacementManager) Close(ctx context.Context) {
 
 // SetPlacementRule is a helper function to set placement rule.
 func (m *TiFlashPDPlacementManager) SetPlacementRule(ctx context.Context, rule placement.TiFlashRule) error {
+	if rule.Count == 0 {
+		return m.DeletePlacementRule(ctx, rule.GroupID, rule.ID)
+	}
 	j, _ := json.Marshal(rule)
 	buf := bytes.NewBuffer(j)
 	res, err := doRequest(ctx, m.addrs, path.Join(pdapi.Config, "rule"), "POST", buf)

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -320,7 +320,11 @@ func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.TiFlashRule) e
 		return nil
 	}
 
-	tiflash.GlobalTiFlashPlacementRules[rule.ID] = rule
+	if rule.Count == 0 {
+		delete(tiflash.GlobalTiFlashPlacementRules, rule.ID)
+	} else {
+		tiflash.GlobalTiFlashPlacementRules[rule.ID] = rule
+	}
 	// Pd shall schedule TiFlash, we can mock here
 	tid := 0
 	_, err := fmt.Sscanf(rule.ID, "table-%d-r", &tid)

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -316,7 +316,8 @@ func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.TiFlashRule) e
 	tiflash.Lock()
 	defer tiflash.Unlock()
 	if !tiflash.PdEnabled {
-		return errors.New("pd server is manually disabled, just quit")
+		logutil.BgLogger().Info("pd server is manually disabled, just quit")
+		return nil
 	}
 
 	tiflash.GlobalTiFlashPlacementRules[rule.ID] = rule


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32190

Problem Summary:
When remove a TiFlash replica, we need to delete its pd rule. Though we can delete a rule by setting `count=0` through pd-ctl, we can't do that by Pd's HTTP API. It will cause some rules not be gc-ed.

This PR will solve this problem by deleting related rules directly.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
fix error that pd rules are not deleted when alter TiFlash replica count to 0
```
