### PR TITLE
executor: fix unstable unit test TestIssue16696

### DIFF
--- a/executor/main_test.go
+++ b/executor/main_test.go
@@ -16,7 +16,6 @@ package executor_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	"github.com/pingcap/tidb/config"
@@ -51,9 +50,6 @@ func TestMain(m *testing.M) {
 		conf.Experimental.AllowsExpressionIndex = true
 	})
 	tikv.EnableFailpoints()
-	tmpDir := config.GetGlobalConfig().TempStoragePath
-	_ = os.RemoveAll(tmpDir) // clean the uncleared temp file during the last run.
-	_ = os.MkdirAll(tmpDir, 0755)
 
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/pkg/logutil.(*MergeLogger).outputLoop"),

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -37,12 +37,10 @@ func TestSortInDisk(t *testing.T) {
 func testSortInDisk(t *testing.T, removeDir bool) {
 	restore := config.RestoreFunc()
 	defer restore()
-	tempPath, err := os.MkdirTemp(os.TempDir(), "*-tidb")
-	require.NoError(t, err)
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
 		conf.OOMAction = config.OOMActionLog
-		conf.TempStoragePath = tempPath
+		conf.TempStoragePath = t.TempDir()
 	})
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testSortedRowContainerSpill", "return(true)"))
 	defer func() {
@@ -98,12 +96,10 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 
 func TestIssue16696(t *testing.T) {
 	defer config.RestoreFunc()()
-	tempPath, err := os.MkdirTemp(os.TempDir(), "*-tidb")
-	require.NoError(t, err)
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
 		conf.OOMAction = config.OOMActionLog
-		conf.TempStoragePath = tempPath
+		conf.TempStoragePath = t.TempDir()
 	})
 	alarmRatio := variable.MemoryUsageAlarmRatio.Load()
 	variable.MemoryUsageAlarmRatio.Store(0.0)

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -37,9 +37,12 @@ func TestSortInDisk(t *testing.T) {
 func testSortInDisk(t *testing.T, removeDir bool) {
 	restore := config.RestoreFunc()
 	defer restore()
+	tempPath, err := os.MkdirTemp(os.TempDir(), "*-tidb")
+	require.NoError(t, err)
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
 		conf.OOMAction = config.OOMActionLog
+		conf.TempStoragePath = tempPath
 	})
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testSortedRowContainerSpill", "return(true)"))
 	defer func() {
@@ -95,9 +98,12 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 
 func TestIssue16696(t *testing.T) {
 	defer config.RestoreFunc()()
+	tempPath, err := os.MkdirTemp(os.TempDir(), "*-tidb")
+	require.NoError(t, err)
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
 		conf.OOMAction = config.OOMActionLog
+		conf.TempStoragePath = tempPath
 	})
 	alarmRatio := variable.MemoryUsageAlarmRatio.Load()
 	variable.MemoryUsageAlarmRatio.Store(0.0)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32040

Problem Summary:

Some test case depends on the temporary file, while some other test case remove the temporary path directory.
When those tests run parallely, they are unstable.

### What is changed and how it works?

Use another temporary directory instead of the default one for some test cases.

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
