### PR TITLE
lightning: fix data race in lightning serial test suite

### DIFF
--- a/br/pkg/lightning/lightning_server_serial_test.go
+++ b/br/pkg/lightning/lightning_server_serial_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -33,6 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// initProgressOnce is used to ensure init progress once to avoid data race.
+var initProgressOnce sync.Once
+
 type lightningServerSuite struct {
 	lightning *Lightning
 	taskCfgCh chan *config.Config
@@ -40,6 +44,8 @@ type lightningServerSuite struct {
 }
 
 func createSuite(t *testing.T) (s *lightningServerSuite, clean func()) {
+	initProgressOnce.Do(web.EnableCurrentProgress)
+	
 	cfg := config.NewGlobalConfig()
 	cfg.TiDB.Host = "test.invalid"
 	cfg.TiDB.Port = 4000
@@ -63,8 +69,6 @@ func createSuite(t *testing.T) (s *lightningServerSuite, clean func()) {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/br/pkg/lightning/SkipRunTask"))
 		s.lightning.Stop()
 	}
-
-	web.EnableCurrentProgress()
 
 	return
 }

--- a/br/pkg/lightning/lightning_server_serial_test.go
+++ b/br/pkg/lightning/lightning_server_serial_test.go
@@ -45,7 +45,7 @@ type lightningServerSuite struct {
 
 func createSuite(t *testing.T) (s *lightningServerSuite, clean func()) {
 	initProgressOnce.Do(web.EnableCurrentProgress)
-	
+
 	cfg := config.NewGlobalConfig()
 	cfg.TiDB.Host = "test.invalid"
 	cfg.TiDB.Port = 4000


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32236

Problem Summary:

### What is changed and how it works?
Avoid data race in test by use `sync.Once` to init the global variable only once.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
