### PR TITLE
statistics: remove the deltaMap when dump to stats_histograms fail

### DIFF
--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -468,6 +468,7 @@ func (h *Handle) DumpStatsDeltaToKV(mode dumpMode) error {
 			deltaMap.update(id, -item.Delta, -item.Count, nil)
 		}
 		if err = h.dumpTableStatColSizeToKV(id, item); err != nil {
+			delete(deltaMap, id)
 			return errors.Trace(err)
 		}
 		if updated {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32299

Problem Summary:

When the `dumpTableStatColSizeToKV` operation fail, it will not clean the map data.
And then in the next loop, it will retry the operation of `dumpTableStatColSizeToKV`, the fail again and again.

The retry of the failed operation cause transaction conflict and lead to the 10s+ "update mysql.stats_meta" slow query.

### What is changed and how it works?

Clean the data if `dumpTableStatColSizeToKV` fail, so not retry and transaction conflict avalanche.

### Check List

Tests <!-- At least one of them must be included. -->

It's really hard to test, because it's only observed in one customer's env and can't reproduce.
Under common situation, this bug should never happen.

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
