### PR TITLE
ddl: fix panic when ddl close if ddl never started

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -364,7 +364,6 @@ func (d *ddl) newDeleteRangeManager(mock bool) delRangeManager {
 // Start implements DDL.Start interface.
 func (d *ddl) Start(ctxPool *pools.ResourcePool) error {
 	logutil.BgLogger().Info("[ddl] start DDL", zap.String("ID", d.uuid), zap.Bool("runWorker", RunWorker))
-	d.ctx, d.cancel = context.WithCancel(d.ctx)
 
 	d.wg.Add(1)
 	go d.limitDDLJobs()

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -329,11 +329,11 @@ func newDDL(ctx context.Context, options ...Option) *ddl {
 	ddlCtx.mu.hook = opt.Hook
 	ddlCtx.mu.interceptor = &BaseInterceptor{}
 	d := &ddl{
-		ctx:               ctx,
 		ddlCtx:            ddlCtx,
 		limitJobCh:        make(chan *limitJobTask, batchAddingJobs),
 		enableTiFlashPoll: atomicutil.NewBool(true),
 	}
+	d.ctx, d.cancel = context.WithCancel(ctx)
 
 	return d
 }


### PR DESCRIPTION
Signed-off-by: crazycs520 <crazycs520@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32309

```log
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x559fe17]

goroutine 6989 [running]:
github.com/pingcap/tidb/ddl.(*ddl).close(0xc00791e700)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:421 +0x77
github.com/pingcap/tidb/ddl.(*ddl).Stop(0xc00791e700, 0x0, 0x0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/ddl/ddl.go:346 +0x8a
github.com/pingcap/tidb/domain.(*Domain).Close(0xc00730e500)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/domain/domain.go:695 +0x377
github.com/pingcap/tidb/session.(*domainMap).Get.func1(0xc0055be2d0, 0x0, 0x72d18e0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/session/tidb.go:86 +0x69e
github.com/pingcap/tidb/util.RunWithRetry(0x1e, 0x1f4, 0xc007c729e0, 0x24, 0x90ea0a0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/util/misc.go:65 +0x7f
github.com/pingcap/tidb/session.(*domainMap).Get(0x90ad250, 0x73647f0, 0xc00080c2c0, 0xc00730e500, 0x0, 0x0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/session/tidb.go:71 +0x1f0
github.com/pingcap/tidb/session.createSessionWithOpt(0x73647f0, 0xc00080c2c0, 0x0, 0xc004fa3cc0, 0x4b, 0x1)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/session/session.go:2923 +0x59
github.com/pingcap/tidb/session.CreateSessionWithOpt(0x73647f0, 0xc00080c2c0, 0x0, 0x687f260, 0xa695088, 0xc007cb1e10, 0xc000a6ecb0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/session/session.go:2656 +0x45
github.com/pingcap/tidb/session.CreateSession(...)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/session/session.go:2650
github.com/pingcap/tidb/server.(*TiDBDriver).OpenCtx(0xc006c0f640, 0x4b, 0x2d000aa28d, 0xc007c0170c, 0x4, 0x0, 0x690fa80, 0x203002, 0x400ec3b)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/driver_tidb.go:184 +0x45
github.com/pingcap/tidb/server.(*clientConn).openSession(0xc008066c80, 0x40889c6, 0x408af60)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:798 +0x92
github.com/pingcap/tidb/server.(*clientConn).checkAuthPlugin(0xc008066c80, 0x7328b90, 0xc008513560, 0xc007c73578, 0x7328b90, 0xc008513560, 0xc007c0b8b0, 0x41, 0x41)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:850 +0xd7b
github.com/pingcap/tidb/server.(*clientConn).handleAuthPlugin(0xc008066c80, 0x7328b90, 0xc008513560, 0xc007c73578, 0x41, 0x41)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:718 +0x7c
github.com/pingcap/tidb/server.(*clientConn).readOptionalSSLRequestAndHandshakeResponse(0xc008066c80, 0x7328b90, 0xc008513560, 0x0, 0x0)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:692 +0x289
github.com/pingcap/tidb/server.(*clientConn).handshake(0xc008066c80, 0x7328b90, 0xc008513560, 0x7328b90, 0xc008513560)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/conn.go:265 +0x41a
github.com/pingcap/tidb/server.(*Server).onConn(0xc006ad1930, 0xc008066c80)
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/server.go:500 +0xa9
created by github.com/pingcap/tidb/server.(*Server).startNetworkListener
        /Users/cs/code/goread/src/github.com/pingcap/tidb/server/server.go:451 +0x91c
```


Tests <!-- At least one of them must be included. -->

- N/A

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
