### PR TITLE
br-stream: fix rewrite skip file end key

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -96,7 +96,7 @@ type Client struct {
 
 	// restoreTs is used for kv file restore.
 	// TiKV will filter the key space larger than this ts.
-	restoreTs   uint64
+	restoreTs uint64
 }
 
 // NewRestoreClient returns a new RestoreClient.

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -748,18 +748,17 @@ func (importer *FileImporter) downloadAndApplyKVFile(
 		NewKeyPrefix: encodeKeyPrefix(fileRule.GetNewKeyPrefix()),
 	}
 
-
 	meta := &import_sstpb.KVMeta{
-		Name:           file.Path,
-		Cf:             file.Cf,
+		Name: file.Path,
+		Cf:   file.Cf,
 		// TODO fill the length
-		Length: 0,
-		IsDelete: file.Type == backuppb.FileType_Delete,
+		Length:    0,
+		IsDelete:  file.Type == backuppb.FileType_Delete,
 		RestoreTs: restoreTs,
 	}
 
 	req := &import_sstpb.ApplyRequest{
-		Meta: meta,
+		Meta:           meta,
 		StorageBackend: importer.backend,
 		RewriteRule:    rule,
 	}

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -285,7 +285,7 @@ func (importer *FileImporter) ImportKVFiles(
 	startTime := time.Now()
 	log.Debug("import kv files", zap.String("file", file.Path))
 	var startKey, endKey []byte
-	start, end, err := rewriteFileKeys(file, rule)
+	start, end, err := RewriteFileKeys(file, rule)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -349,6 +349,7 @@ func (importer *FileImporter) ImportKVFiles(
 				zap.Stringer("take", time.Since(startTime)),
 				logutil.Key("fileStart", file.StartKey),
 				logutil.Key("fileEnd", file.EndKey),
+				logutil.Region(info.Region),
 			)
 		}
 		return nil
@@ -373,7 +374,7 @@ func (importer *FileImporter) ImportSSTFiles(
 		endKey = files[0].EndKey
 	} else {
 		for _, f := range files {
-			start, end, err := rewriteFileKeys(f, rewriteRules)
+			start, end, err := RewriteFileKeys(f, rewriteRules)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/go.sum
+++ b/go.sum
@@ -576,8 +576,6 @@ github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059 h1:Pe2LbxRmbTfAoKJ65bZL
 github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059/go.mod h1:fMRU1BA1y+r89AxUoaAar4JjrhUkVDt0o0Np6V8XbDQ=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989 h1:surzm05a8C9dN8dIUmo4Be2+pMRb6f55i+UIYrluu2E=
 github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17XtbryoCJhkKGbT62+L2OlrniwqiGLSqrmdHCMzZw=
-github.com/pingcap/kvproto v0.0.0-20220121033106-11c47a2c2f8e h1:nqImXVDSjM5gXpNK8Goc5yDYzp7djfAx+IohMUOGHnc=
-github.com/pingcap/kvproto v0.0.0-20220121033106-11c47a2c2f8e/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20220211054355-f7a5a196e629 h1:gms3xgt4GZ91RyOQqAdQ7BFqWhZdHYiiusFQNbsiIpw=
 github.com/pingcap/kvproto v0.0.0-20220211054355-f7a5a196e629/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #???

Problem Summary:

There is a bug when we writing the end key of file: if the file key is encoded (log file), we would leave end key be empty. 

### What is changed and how it works?

Fixed it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
Restore time cost reduced to 2mins (from 50mins).
<img width="772" alt="image" src="https://user-images.githubusercontent.com/36239017/153807008-cb540d19-0d4f-41d0-a004-cabbae326def.png">

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
