### PR TITLE
*: (DRAFT) Refactor stale read code

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -672,6 +672,7 @@ func VerifyTxnScope(txnScope string, physicalTableID int64, is infoschema.InfoSc
 		return false
 	}
 	return true
+
 }
 
 func indexRangesToKVWithoutSplit(sc *stmtctx.StatementContext, tids []int64, idxID int64, ranges []*ranger.Range, memTracker *memory.Tracker, interruptSignal *atomic.Value) ([]kv.KeyRange, error) {

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -672,7 +672,6 @@ func VerifyTxnScope(txnScope string, physicalTableID int64, is infoschema.InfoSc
 		return false
 	}
 	return true
-
 }
 
 func indexRangesToKVWithoutSplit(sc *stmtctx.StatementContext, tids []int64, idxID int64, ranges []*ranger.Range, memTracker *memory.Tracker, interruptSignal *atomic.Value) ([]kv.KeyRange, error) {

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -296,7 +296,7 @@ func (a *ExecStmt) IsReadOnly(vars *variable.SessionVars) bool {
 func (a *ExecStmt) RebuildPlan(ctx context.Context) (int64, error) {
 	ret := &plannercore.PreprocessorReturn{}
 	if err := plannercore.
-		Preprocess(a.Ctx, a.StmtNode, plannercore.InTxnRetry, plannercore.InitTxnContextProvider, plannercore.WithPreprocessorReturn(ret)); err != nil {
+		Preprocess(a.Ctx, a.StmtNode, plannercore.InTxnRetry, plannercore.WithPreprocessorReturn(ret)); err != nil {
 		return 0, err
 	}
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -296,7 +296,7 @@ func (a *ExecStmt) IsReadOnly(vars *variable.SessionVars) bool {
 func (a *ExecStmt) RebuildPlan(ctx context.Context) (int64, error) {
 	ret := &plannercore.PreprocessorReturn{}
 	if err := plannercore.
-		Preprocess(a.Ctx, a.StmtNode, plannercore.InTxnRetry, plannercore.WithPreprocessorReturn(ret)); err != nil {
+		Preprocess(a.Ctx, a.StmtNode, plannercore.InTxnRetry, plannercore.InitTxnContextProvider, plannercore.WithPreprocessorReturn(ret)); err != nil {
 		return 0, err
 	}
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -358,7 +358,7 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 
 	failpoint.Inject("assertStaleTSO", func(val failpoint.Value) {
 		if n, ok := val.(int); ok && staleread.IsTxnStaleness(a.Ctx) {
-			ts, err := sessiontxn.GetTxnManager(a.Ctx).GetStmtReadTS()
+			ts, err := sessiontxn.GetTxnManager(a.Ctx).GetReadTS()
 			if err != nil {
 				panic(err)
 			}

--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -27,6 +27,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pingcap/tidb/kv"
+
+	"github.com/pingcap/tidb/sessiontxn"
+
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/executor/aggfuncs"
 	"github.com/pingcap/tidb/expression"
@@ -281,6 +285,14 @@ func defaultAggTestCase(exec string) *aggTestCase {
 	ctx := mock.NewContext()
 	ctx.GetSessionVars().InitChunkSize = variable.DefInitChunkSize
 	ctx.GetSessionVars().MaxChunkSize = variable.DefMaxChunkSize
+	err := sessiontxn.GetTxnManager(ctx).SetContextProvider(&sessiontxn.SimpleTxnContextProvider{
+		Sctx:             ctx,
+		InfoSchema:       nil,
+		ReadReplicaScope: kv.GlobalReplicaScope,
+	})
+	if err != nil {
+		panic(err)
+	}
 	return &aggTestCase{exec, ast.AggFuncSum, 1000, false, 10000000, 4, true, ctx}
 }
 

--- a/executor/benchmark_test.go
+++ b/executor/benchmark_test.go
@@ -46,7 +46,6 @@ import (
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/stringutil"
-	"github.com/tikv/client-go/v2/oracle"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -293,7 +292,7 @@ func buildHashAggExecutor(ctx sessionctx.Context, src Executor, schema *expressi
 	plan.SetSchema(schema)
 	plan.Init(ctx, nil, 0)
 	plan.SetChildren(nil)
-	b := newExecutorBuilder(ctx, nil, nil, 0, false, oracle.GlobalTxnScope)
+	b := newExecutorBuilder(ctx, nil)
 	exec := b.build(plan)
 	hashAgg := exec.(*HashAggExec)
 	hashAgg.children[0] = src
@@ -345,7 +344,7 @@ func buildStreamAggExecutor(ctx sessionctx.Context, srcExec Executor, schema *ex
 		plan = sg
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil, 0, false, oracle.GlobalTxnScope)
+	b := newExecutorBuilder(ctx, nil)
 	return b.build(plan)
 }
 
@@ -578,7 +577,7 @@ func buildWindowExecutor(ctx sessionctx.Context, windowFunc string, funcs int, f
 		plan = win
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil, 0, false, oracle.GlobalTxnScope)
+	b := newExecutorBuilder(ctx, nil)
 	exec := b.build(plan)
 	return exec
 }
@@ -1318,7 +1317,7 @@ func prepare4IndexInnerHashJoin(tc *indexJoinTestCase, outerDS *mockDataSource, 
 		keyOff2IdxOff[i] = i
 	}
 
-	readerBuilder, err := newExecutorBuilder(tc.ctx, nil, nil, 0, false, oracle.GlobalTxnScope).
+	readerBuilder, err := newExecutorBuilder(tc.ctx, nil).
 		newDataReaderBuilder(&mockPhysicalIndexReader{e: innerDS})
 	if err != nil {
 		return nil, err
@@ -1392,7 +1391,7 @@ func prepare4IndexMergeJoin(tc *indexJoinTestCase, outerDS *mockDataSource, inne
 		outerCompareFuncs = append(outerCompareFuncs, expression.GetCmpFunction(nil, outerJoinKeys[i], outerJoinKeys[i]))
 	}
 
-	readerBuilder, err := newExecutorBuilder(tc.ctx, nil, nil, 0, false, oracle.GlobalTxnScope).
+	readerBuilder, err := newExecutorBuilder(tc.ctx, nil).
 		newDataReaderBuilder(&mockPhysicalIndexReader{e: innerDS})
 	if err != nil {
 		return nil, err

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -129,7 +129,7 @@ func newExecutorBuilder(ctx sessionctx.Context, ti *TelemetryInfo) *executorBuil
 	}
 
 	if provider, ok := txnManager.GetContextProvider().(*sessiontxn.SimpleTxnContextProvider); ok {
-		provider.GetStmtReadTSFunc = b.getReadTS
+		provider.GetReadTSFunc = b.getReadTS
 	}
 
 	return b
@@ -758,7 +758,7 @@ func (b *executorBuilder) buildExecute(v *plannercore.Execute) Executor {
 			panic("is not staleness")
 		}
 
-		staleReadTS, err := sessiontxn.GetTxnManager(b.ctx).GetStmtReadTS()
+		staleReadTS, err := sessiontxn.GetTxnManager(b.ctx).GetReadTS()
 		if err != nil {
 			panic(err)
 		}
@@ -1511,7 +1511,7 @@ func (b *executorBuilder) getSnapshotTS() (uint64, error) {
 		return b.forUpdateTS, nil
 	}
 
-	return sessiontxn.GetTxnManager(b.ctx).GetStmtReadTS()
+	return sessiontxn.GetTxnManager(b.ctx).GetReadTS()
 }
 
 // getReadTS returns the ts used by select (without for-update clause). The return value is affected by the isolation level

--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -64,7 +64,7 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (*ExecStm
 		stmtNode,
 		plannercore.WithPreprocessorReturn(ret),
 		plannercore.WithExecuteInfoSchemaUpdate(pe),
-		plannercore.InitTxnContextProvider,
+		plannercore.InitTxnContext,
 	)
 	if err != nil {
 		return nil, err

--- a/executor/coprocessor.go
+++ b/executor/coprocessor.go
@@ -32,7 +32,6 @@ import (
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/pingcap/tipb/go-tipb"
-	"github.com/tikv/client-go/v2/oracle"
 )
 
 // CoprocessorDAGHandler uses to handle cop dag request.
@@ -170,7 +169,7 @@ func (h *CoprocessorDAGHandler) buildDAGExecutor(req *coprocessor.Request) (Exec
 	}
 	plan = core.InjectExtraProjection(plan)
 	// Build executor.
-	b := newExecutorBuilder(h.sctx, is, nil, 0, false, oracle.GlobalTxnScope)
+	b := newExecutorBuilder(h.sctx, nil)
 	return b.build(plan), nil
 }
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/temptable"
 	"github.com/pingcap/tidb/util/admin"
@@ -367,7 +368,7 @@ func (e *DDLExec) executeCreateView(s *ast.CreateViewStmt) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if ret.IsStaleness {
+	if staleread.IsTxnStaleness(e.ctx) {
 		return ErrViewInvalid.GenWithStackByArgs(s.ViewName.Schema.L, s.ViewName.Name.L)
 	}
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -362,14 +362,9 @@ func (e *DDLExec) createSessionTemporaryTable(s *ast.CreateTableStmt) error {
 }
 
 func (e *DDLExec) executeCreateView(s *ast.CreateViewStmt) error {
-	ret := &core.PreprocessorReturn{}
-	err := core.Preprocess(e.ctx, s.Select, core.WithPreprocessorReturn(ret))
+	err := core.Preprocess(e.ctx, s.Select, core.ValidateCreateView)
 	if err != nil {
 		return errors.Trace(err)
-	}
-
-	if ret.IsStaleness {
-		return ErrViewInvalid.GenWithStackByArgs(s.ViewName.Schema.L, s.ViewName.Name.L)
 	}
 
 	return domain.GetDomain(e.ctx).DDL().CreateView(e.ctx, s)

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -362,7 +362,10 @@ func (e *DDLExec) createSessionTemporaryTable(s *ast.CreateTableStmt) error {
 }
 
 func (e *DDLExec) executeCreateView(s *ast.CreateViewStmt) error {
-	err := core.Preprocess(e.ctx, s.Select, core.ValidateCreateView)
+	err := core.Preprocess(e.ctx, s.Select, core.ValidateCreateView(func() error {
+		return ErrViewInvalid.GenWithStackByArgs(s.ViewName.Schema, s.ViewName.Name)
+	}))
+
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -31,7 +31,6 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/temptable"
 	"github.com/pingcap/tidb/util/admin"
@@ -368,7 +367,8 @@ func (e *DDLExec) executeCreateView(s *ast.CreateViewStmt) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if staleread.IsTxnStaleness(e.ctx) {
+
+	if ret.IsStaleness {
 		return ErrViewInvalid.GenWithStackByArgs(s.ViewName.Schema.L, s.ViewName.Name.L)
 	}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1702,7 +1702,6 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	sc.TimeZone = vars.Location()
 	sc.TaskID = stmtctx.AllocateTaskID()
 	sc.CTEStorageMap = map[int]*CTEStorages{}
-	sc.IsStaleness = false
 	sc.LockTableIDs = make(map[int64]struct{})
 	sc.EnableOptimizeTrace = false
 	sc.OptimizeTracer = nil

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1195,7 +1195,7 @@ func init() {
 	// While doing optimization in the plan package, we need to execute uncorrelated subquery,
 	// but the plan package cannot import the executor package because of the dependency cycle.
 	// So we assign a function implemented in the executor package to the plan package to avoid the dependency cycle.
-	plannercore.EvalSubqueryFirstRow = func(ctx context.Context, p plannercore.PhysicalPlan, is infoschema.InfoSchema, sctx sessionctx.Context) ([]types.Datum, error) {
+	plannercore.EvalSubqueryFirstRow = func(ctx context.Context, p plannercore.PhysicalPlan, sctx sessionctx.Context) ([]types.Datum, error) {
 		defer func(begin time.Time) {
 			s := sctx.GetSessionVars()
 			s.RewritePhaseInfo.PreprocessSubQueries++
@@ -1208,7 +1208,7 @@ func init() {
 			ctx = opentracing.ContextWithSpan(ctx, span1)
 		}
 
-		e := &executorBuilder{is: is, ctx: sctx}
+		e := newExecutorBuilder(sctx, nil)
 		exec := e.build(p)
 		if e.err != nil {
 			return nil, e.err

--- a/executor/executor_required_rows_test.go
+++ b/executor/executor_required_rows_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/pingcap/tidb/util/disk"
 	"github.com/pingcap/tidb/util/memory"
 	"github.com/pingcap/tidb/util/mock"
-	"github.com/tikv/client-go/v2/oracle"
 )
 
 var _ = SerialSuites(&testExecSuite{})
@@ -854,7 +853,7 @@ func buildMergeJoinExec(ctx sessionctx.Context, joinType plannercore.JoinType, i
 		j.CompareFuncs = append(j.CompareFuncs, expression.GetCmpFunction(nil, j.LeftJoinKeys[i], j.RightJoinKeys[i]))
 	}
 
-	b := newExecutorBuilder(ctx, nil, nil, 0, false, oracle.GlobalTxnScope)
+	b := newExecutorBuilder(ctx, nil)
 	return b.build(j)
 }
 

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -9683,6 +9683,7 @@ func (s *testSerialSuite) TestUnreasonablyClose(c *C) {
 		&plannercore.PhysicalUnionAll{},
 	}
 	err = sessiontxn.GetTxnManager(se).SetContextProvider(&sessiontxn.SimpleTxnContextProvider{
+		Sctx:       se,
 		InfoSchema: is,
 	})
 	c.Assert(err, IsNil)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -9681,7 +9681,7 @@ func (s *testSerialSuite) TestUnreasonablyClose(c *C) {
 		&plannercore.PhysicalShuffle{},
 		&plannercore.PhysicalUnionAll{},
 	}
-	executorBuilder := executor.NewMockExecutorBuilderForTest(se, is, nil, math.MaxUint64, false, "global")
+	executorBuilder := executor.NewMockExecutorBuilderForTest(se, nil)
 
 	var opsNeedsCoveredMask uint64 = 1<<len(opsNeedsCovered) - 1
 	opsAlreadyCoveredMask := uint64(0)

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -61,6 +61,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/store/copr"
 	error2 "github.com/pingcap/tidb/store/driver/error"
@@ -9681,6 +9682,10 @@ func (s *testSerialSuite) TestUnreasonablyClose(c *C) {
 		&plannercore.PhysicalShuffle{},
 		&plannercore.PhysicalUnionAll{},
 	}
+	err = sessiontxn.GetTxnManager(se).SetContextProvider(&sessiontxn.SimpleTxnContextProvider{
+		InfoSchema: is,
+	})
+	c.Assert(err, IsNil)
 	executorBuilder := executor.NewMockExecutorBuilderForTest(se, nil)
 
 	var opsNeedsCoveredMask uint64 = 1<<len(opsNeedsCovered) - 1

--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -23,7 +23,6 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/executor"
-	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/metrics"
 	"github.com/pingcap/tidb/parser/mysql"
 	plannercore "github.com/pingcap/tidb/planner/core"
@@ -157,8 +156,7 @@ func TestPrepared(t *testing.T) {
 		tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows())
 
 		// Check that ast.Statement created by executor.CompileExecutePreparedStmt has query text.
-		stmt, _, _, err := executor.CompileExecutePreparedStmt(context.TODO(), tk.Session(), stmtID,
-			tk.Session().GetInfoSchema().(infoschema.InfoSchema), 0, []types.Datum{types.NewDatum(1)})
+		stmt, _, _, err := executor.CompileExecutePreparedStmt(context.TODO(), tk.Session(), stmtID, []types.Datum{types.NewDatum(1)})
 		require.NoError(t, err)
 		require.Equal(t, query, stmt.OriginText())
 

--- a/executor/set.go
+++ b/executor/set.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/pingcap/tidb/sessiontxn/staleread"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"
@@ -177,7 +179,7 @@ func (e *SetExecutor) setSysVariable(ctx context.Context, name string, v *expres
 	newSnapshotIsSet := newSnapshotTS > 0 && newSnapshotTS != oldSnapshotTS
 	if newSnapshotIsSet {
 		if name == variable.TiDBTxnReadTS {
-			err = sessionctx.ValidateStaleReadTS(ctx, e.ctx, newSnapshotTS)
+			err = staleread.ValidateStaleReadTS(ctx, e.ctx, newSnapshotTS)
 		} else {
 			err = sessionctx.ValidateSnapshotReadTS(ctx, e.ctx, newSnapshotTS)
 			// Also check gc safe point for snapshot read.

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl/placement"
+	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/tikv/client-go/v2/oracle"
@@ -1113,7 +1114,7 @@ func (s *testStaleTxnSerialSuite) TestStmtCtxStaleFlag(c *C) {
 		tk.MustExec(testcase.sql)
 		failpoint.Disable("github.com/pingcap/tidb/exector/assertStmtCtxIsStaleness")
 		// assert stale read flag should be false after each statement execution
-		c.Assert(tk.Se.GetSessionVars().StmtCtx.IsStaleness, IsFalse)
+		c.Assert(staleread.IsTxnStaleness(tk.Se), IsFalse)
 	}
 }
 

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl/placement"
-	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/testkit"
 	"github.com/tikv/client-go/v2/oracle"
@@ -1113,8 +1112,6 @@ func (s *testStaleTxnSerialSuite) TestStmtCtxStaleFlag(c *C) {
 			fmt.Sprintf("return(%v)", testcase.hasStaleFlag))
 		tk.MustExec(testcase.sql)
 		failpoint.Disable("github.com/pingcap/tidb/exector/assertStmtCtxIsStaleness")
-		// assert stale read flag should be false after each statement execution
-		c.Assert(staleread.IsTxnStaleness(tk.Se), IsFalse)
 	}
 }
 

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -996,6 +996,7 @@ func (s *testStaleTxnSerialSuite) TestStaleReadPrepare(c *C) {
 		placement.DCLabelKey: "sh",
 	}
 	config.StoreGlobalConfig(&conf)
+	tk.MustExec("set @@tidb_replica_read='closest-replicas'")
 	time1 := time.Now()
 	tso := oracle.ComposeTS(time1.Unix()*1000, 0)
 	time.Sleep(200 * time.Millisecond)

--- a/planner/core/errors.go
+++ b/planner/core/errors.go
@@ -100,7 +100,6 @@ var (
 	ErrAccessDenied              = dbterror.ClassOptimizer.NewStdErr(mysql.ErrAccessDenied, mysql.MySQLErrName[mysql.ErrAccessDeniedNoPassword])
 	ErrBadNull                   = dbterror.ClassOptimizer.NewStd(mysql.ErrBadNull)
 	ErrNotSupportedWithSem       = dbterror.ClassOptimizer.NewStd(mysql.ErrNotSupportedWithSem)
-	ErrAsOf                      = dbterror.ClassOptimizer.NewStd(mysql.ErrAsOf)
 	ErrOptOnTemporaryTable       = dbterror.ClassOptimizer.NewStd(mysql.ErrOptOnTemporaryTable)
 	ErrOptOnCacheTable           = dbterror.ClassOptimizer.NewStd(mysql.ErrOptOnCacheTable)
 	ErrDropTableOnTemporaryTable = dbterror.ClassOptimizer.NewStd(mysql.ErrDropTableOnTemporaryTable)

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -49,7 +49,7 @@ import (
 )
 
 // EvalSubqueryFirstRow evaluates incorrelated subqueries once, and get first row.
-var EvalSubqueryFirstRow func(ctx context.Context, p PhysicalPlan, is infoschema.InfoSchema, sctx sessionctx.Context) (row []types.Datum, err error)
+var EvalSubqueryFirstRow func(ctx context.Context, p PhysicalPlan, sctx sessionctx.Context) (row []types.Datum, err error)
 
 // evalAstExpr evaluates ast expression directly.
 func evalAstExpr(sctx sessionctx.Context, expr ast.ExprNode) (types.Datum, error) {
@@ -822,7 +822,7 @@ func (er *expressionRewriter) handleExistSubquery(ctx context.Context, v *ast.Ex
 			er.err = err
 			return v, true
 		}
-		row, err := EvalSubqueryFirstRow(ctx, physicalPlan, er.b.is, er.b.ctx)
+		row, err := EvalSubqueryFirstRow(ctx, physicalPlan, er.b.ctx)
 		if err != nil {
 			er.err = err
 			return v, true
@@ -1008,7 +1008,7 @@ func (er *expressionRewriter) handleScalarSubquery(ctx context.Context, v *ast.S
 		er.err = err
 		return v, true
 	}
-	row, err := EvalSubqueryFirstRow(ctx, physicalPlan, er.b.is, er.b.ctx)
+	row, err := EvalSubqueryFirstRow(ctx, physicalPlan, er.b.ctx)
 	if err != nil {
 		er.err = err
 		return v, true

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -25,6 +25,8 @@ import (
 	"time"
 	"unicode"
 
+	"github.com/pingcap/tidb/sessiontxn/staleread"
+
 	"github.com/cznic/mathutil"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl"
@@ -4184,7 +4186,7 @@ func (b *PlanBuilder) buildDataSource(ctx context.Context, tn *ast.TableName, as
 		result = us
 	}
 	// If a table is a cache table, it is judged whether it satisfies the conditions of read cache.
-	if tableInfo.TableCacheStatusType == model.TableCacheStatusEnable && b.ctx.GetSessionVars().SnapshotTS == 0 && !b.ctx.GetSessionVars().StmtCtx.IsStaleness {
+	if tableInfo.TableCacheStatusType == model.TableCacheStatusEnable && b.ctx.GetSessionVars().SnapshotTS == 0 && !staleread.IsTxnStaleness(b.ctx) {
 		cachedTable := tbl.(table.CachedTable)
 		txn, err := b.ctx.Txn(true)
 		if err != nil {

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -45,6 +45,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/statistics"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/temptable"
@@ -60,7 +61,6 @@ import (
 	"github.com/pingcap/tidb/util/sem"
 	"github.com/pingcap/tidb/util/set"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/tikv/client-go/v2/oracle"
 	"github.com/tikv/client-go/v2/tikv"
 
 	"github.com/cznic/mathutil"
@@ -1151,7 +1151,7 @@ func getPossibleAccessPaths(ctx sessionctx.Context, tableHints *tableHintInfo, i
 	}
 
 	available = removeIgnoredPaths(available, ignored, tblInfo)
-	if ctx.GetSessionVars().StmtCtx.IsStaleness {
+	if staleread.IsTxnStaleness(ctx) {
 		// skip tiflash if the statement is for stale read until tiflash support stale read
 		available = removeTiflashDuringStaleRead(available)
 	}
@@ -3076,54 +3076,8 @@ func (b *PlanBuilder) buildSimple(ctx context.Context, node ast.StmtNode) (Plan,
 		}
 	case *ast.ShutdownStmt:
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.ShutdownPriv, "", "", "", nil)
-	case *ast.BeginStmt:
-		readTS := b.ctx.GetSessionVars().TxnReadTS.PeakTxnReadTS()
-		if raw.AsOf != nil {
-			startTS, err := calculateTsExpr(b.ctx, raw.AsOf)
-			if err != nil {
-				return nil, err
-			}
-			if err := sessionctx.ValidateStaleReadTS(ctx, b.ctx, startTS); err != nil {
-				return nil, err
-			}
-			p.StaleTxnStartTS = startTS
-		} else if readTS > 0 {
-			p.StaleTxnStartTS = readTS
-			// consume read ts here
-			b.ctx.GetSessionVars().TxnReadTS.UseTxnReadTS()
-		}
 	}
 	return p, nil
-}
-
-// calculateTsExpr calculates the TsExpr of AsOfClause to get a StartTS.
-func calculateTsExpr(sctx sessionctx.Context, asOfClause *ast.AsOfClause) (uint64, error) {
-	tsVal, err := evalAstExpr(sctx, asOfClause.TsExpr)
-	if err != nil {
-		return 0, err
-	}
-	toTypeTimestamp := types.NewFieldType(mysql.TypeTimestamp)
-	// We need at least the millionsecond here, so set fsp to 3.
-	toTypeTimestamp.Decimal = 3
-	tsTimestamp, err := tsVal.ConvertTo(sctx.GetSessionVars().StmtCtx, toTypeTimestamp)
-	if err != nil {
-		return 0, err
-	}
-	tsTime, err := tsTimestamp.GetMysqlTime().GoTime(sctx.GetSessionVars().Location())
-	if err != nil {
-		return 0, err
-	}
-	return oracle.GoTimeToTS(tsTime), nil
-}
-
-func calculateTsWithReadStaleness(sctx sessionctx.Context, readStaleness time.Duration) (uint64, error) {
-	nowVal, err := expression.GetStmtTimestamp(sctx)
-	if err != nil {
-		return 0, err
-	}
-	tsVal := nowVal.Add(readStaleness)
-	minTsVal := expression.GetMinSafeTime(sctx)
-	return oracle.GoTimeToTS(expression.CalAppropriateTime(tsVal, nowVal, minTsVal)), nil
 }
 
 func collectVisitInfoFromRevokeStmt(sctx sessionctx.Context, vi []visitInfo, stmt *ast.RevokeStmt) ([]visitInfo, error) {

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -132,6 +132,7 @@ func Preprocess(ctx sessionctx.Context, node ast.Node, preprocessOpt ...Preproce
 	v.ensureInfoSchema()
 
 	v.TSEvaluatorForPreparedStmt = v.staleReadProcessor.GetTSEvaluatorForPreparedStmt()
+	v.IsStaleness = v.staleReadProcessor.IsStaleness()
 	v.initTxnContextProviderIfNecessary()
 
 	return errors.Trace(v.err)
@@ -160,6 +161,7 @@ const (
 // PreprocessorReturn is used to retain information obtained in the preprocessor.
 type PreprocessorReturn struct {
 	InfoSchema                 infoschema.InfoSchema
+	IsStaleness                bool
 	TSEvaluatorForPreparedStmt func(sctx sessionctx.Context) (uint64, error)
 }
 

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -20,11 +20,9 @@ import (
 	"strings"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta/autoid"
 	"github.com/pingcap/tidb/parser"
 	"github.com/pingcap/tidb/parser/ast"
@@ -1604,15 +1602,7 @@ func (p *preprocessor) initTxnContextProviderIfNecessary() {
 	txnManager := sessiontxn.GetTxnManager(p.ctx)
 	if provider, ok := txnManager.GetContextProvider().(*sessiontxn.SimpleTxnContextProvider); ok {
 		provider.InfoSchema = p.ensureInfoSchema()
-		provider.ReadReplicaScope = p.getReadReplicaScope()
+		provider.ReadReplicaScope = p.ctx.GetSessionVars().CheckAndGetTxnScope()
 	}
 	return
-}
-
-func (p *preprocessor) getReadReplicaScope() string {
-	instanceScope := config.GetTxnScopeFromConfig()
-	if p.ctx.GetSessionVars().GetReplicaRead().IsClosestRead() && instanceScope != kv.GlobalReplicaScope {
-		return instanceScope
-	}
-	return p.ctx.GetSessionVars().TxnCtx.TxnScope
 }

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -15,7 +15,6 @@
 package core
 
 import (
-	"context"
 	"fmt"
 	"math"
 	"strings"
@@ -23,7 +22,6 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/ddl"
-	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
@@ -38,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/sessiontxn"
+	"github.com/pingcap/tidb/sessiontxn/staleread"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/temptable"
 	"github.com/pingcap/tidb/types"
@@ -112,7 +111,12 @@ func TryAddExtraLimit(ctx sessionctx.Context, node ast.StmtNode) ast.StmtNode {
 // Preprocess resolves table names of the node, and checks some statements' validation.
 // preprocessReturn used to extract the infoschema for the tableName and the timestamp from the asof clause.
 func Preprocess(ctx sessionctx.Context, node ast.Node, preprocessOpt ...PreprocessOpt) error {
-	v := preprocessor{ctx: ctx, tableAliasInJoin: make([]map[string]interface{}, 0), withName: make(map[string]interface{})}
+	v := preprocessor{
+		ctx:              ctx,
+		tableAliasInJoin: make([]map[string]interface{}, 0),
+		withName:         make(map[string]interface{}),
+	}
+
 	for _, optFn := range preprocessOpt {
 		optFn(&v)
 	}
@@ -120,11 +124,15 @@ func Preprocess(ctx sessionctx.Context, node ast.Node, preprocessOpt ...Preproce
 	if v.PreprocessorReturn == nil {
 		v.PreprocessorReturn = &PreprocessorReturn{}
 	}
+
+	v.staleReadProcessor = staleread.NewStmtPreprocessor(ctx, v.flag&initTxnContextProvider != 0)
+
 	node.Accept(&v)
 	// InfoSchema must be non-nil after preprocessing
 	v.ensureInfoSchema()
 
-	v.initTxnContextProviderIfNecessary(node)
+	v.TSEvaluatorForPreparedStmt = v.staleReadProcessor.GetTSEvaluatorForPreparedStmt()
+	v.initTxnContextProviderIfNecessary()
 
 	return errors.Trace(v.err)
 }
@@ -149,19 +157,10 @@ const (
 	initTxnContextProvider
 )
 
-// Make linter happy.
-var _ = PreprocessorReturn{}.initedLastSnapshotTS
-
 // PreprocessorReturn is used to retain information obtained in the preprocessor.
 type PreprocessorReturn struct {
-	initedLastSnapshotTS bool
-	IsStaleness          bool
-	SnapshotTSEvaluator  func(sessionctx.Context) (uint64, error)
-	// LastSnapshotTS is the last evaluated snapshotTS if any
-	// otherwise it defaults to zero
-	LastSnapshotTS   uint64
-	InfoSchema       infoschema.InfoSchema
-	ReadReplicaScope string
+	InfoSchema                 infoschema.InfoSchema
+	TSEvaluatorForPreparedStmt func(sctx sessionctx.Context) (uint64, error)
 }
 
 // PreprocessExecuteISUpdate is used to update information schema for special Execute statement in the preprocessor.
@@ -182,6 +181,8 @@ type preprocessor struct {
 	// len(tableAliasInJoin) may bigger than 1 because the left/right child of join may be subquery that contains `JOIN`
 	tableAliasInJoin []map[string]interface{}
 	withName         map[string]interface{}
+
+	staleReadProcessor *staleread.StmtPreprocessor
 
 	// values that may be returned
 	*PreprocessorReturn
@@ -314,20 +315,8 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 			p.withName[cte.Name.L] = struct{}{}
 		}
 	case *ast.BeginStmt:
-		// If the begin statement was like following:
-		// start transaction read only as of timestamp ....
-		// then we need set StmtCtx.IsStaleness as true in order to avoid take tso in PrepareTSFuture.
-		if node.AsOf != nil {
-			p.ctx.GetSessionVars().StmtCtx.IsStaleness = true
-			p.IsStaleness = true
-		} else if p.ctx.GetSessionVars().TxnReadTS.PeakTxnReadTS() > 0 {
-			// If the begin statement was like following:
-			// set transaction read only as of timestamp ...
-			// begin
-			// then we need set StmtCtx.IsStaleness as true in order to avoid take tso in PrepareTSFuture.
-			p.ctx.GetSessionVars().StmtCtx.IsStaleness = true
-			p.IsStaleness = true
-		}
+		p.ctx.GetSessionVars().StmtCtx.ContextProviderForBeginStmt = nil
+		p.err = p.staleReadProcessor.OnStartTransaction(node)
 	default:
 		p.flag &= ^parentIsJoin
 	}
@@ -1418,9 +1407,11 @@ func (p *preprocessor) handleTableName(tn *ast.TableName) {
 		return
 	}
 
-	p.handleAsOfAndReadTS(tn.AsOf)
-	if p.err != nil {
-		return
+	if p.stmtTp == TypeSelect {
+		p.err = p.staleReadProcessor.OnSelectTable(tn)
+		if p.err != nil {
+			return
+		}
 	}
 
 	table, err := p.tableByName(tn)
@@ -1501,23 +1492,7 @@ func (p *preprocessor) resolveExecuteStmt(node *ast.ExecuteStmt) {
 		return
 	}
 
-	if prepared.SnapshotTSEvaluator != nil {
-		snapshotTS, err := prepared.SnapshotTSEvaluator(p.ctx)
-		if err != nil {
-			p.err = err
-			return
-		}
-
-		is, err := domain.GetDomain(p.ctx).GetSnapshotInfoSchema(snapshotTS)
-		if err != nil {
-			p.err = err
-			return
-		}
-
-		p.LastSnapshotTS = snapshotTS
-		p.initedLastSnapshotTS = true
-		p.InfoSchema = temptable.AttachLocalTemporaryTableInfoSchema(p.ctx, is)
-	}
+	p.err = p.staleReadProcessor.OnTSEvaluatorInExecute(prepared.SnapshotTSEvaluator)
 }
 
 func (p *preprocessor) resolveCreateTableStmt(node *ast.CreateTableStmt) {
@@ -1579,133 +1554,6 @@ func (p *preprocessor) checkFuncCastExpr(node *ast.FuncCastExpr) {
 	}
 }
 
-// handleAsOfAndReadTS tries to handle as of closure, or possibly read_ts.
-func (p *preprocessor) handleAsOfAndReadTS(node *ast.AsOfClause) {
-	if p.stmtTp != TypeSelect {
-		return
-	}
-	defer func() {
-		// If the select statement was like 'select * from t as of timestamp ...' or in a stale read transaction
-		// or is affected by the tidb_read_staleness session variable, then the statement will be makred as isStaleness
-		// in stmtCtx
-		if p.flag&inPrepare == 0 && p.IsStaleness {
-			p.ctx.GetSessionVars().StmtCtx.IsStaleness = true
-		}
-	}()
-	// When statement is during the Txn, we check whether there exists AsOfClause. If exists, we will return error,
-	// otherwise we should directly set the return param from TxnCtx.
-	p.ReadReplicaScope = kv.GlobalReplicaScope
-	if p.ctx.GetSessionVars().InTxn() {
-		if node != nil {
-			p.err = ErrAsOf.FastGenWithCause("as of timestamp can't be set in transaction.")
-			return
-		}
-		txnCtx := p.ctx.GetSessionVars().TxnCtx
-		p.ReadReplicaScope = txnCtx.TxnScope
-		// It means we meet following case:
-		// 1. start transaction read only as of timestamp ts
-		// 2. select statement
-		if txnCtx.IsStaleness {
-			p.LastSnapshotTS = txnCtx.StartTS
-			p.IsStaleness = txnCtx.IsStaleness
-			p.initedLastSnapshotTS = true
-			return
-		}
-	}
-	scope := config.GetTxnScopeFromConfig()
-	if p.ctx.GetSessionVars().GetReplicaRead().IsClosestRead() && scope != kv.GlobalReplicaScope {
-		p.ReadReplicaScope = scope
-	}
-
-	// If the statement is in auto-commit mode, we will check whether there exists read_ts, if exists,
-	// we will directly use it. The txnScope will be defined by the zone label, if it is not set, we will use
-	// global txnScope directly.
-	readTS := p.ctx.GetSessionVars().TxnReadTS.UseTxnReadTS()
-	readStaleness := p.ctx.GetSessionVars().ReadStaleness
-	var ts uint64
-	switch {
-	case readTS > 0:
-		ts = readTS
-		if node != nil {
-			p.err = ErrAsOf.FastGenWithCause("can't use select as of while already set transaction as of")
-			return
-		}
-		if !p.initedLastSnapshotTS {
-			p.SnapshotTSEvaluator = func(sessionctx.Context) (uint64, error) {
-				return ts, nil
-			}
-			p.LastSnapshotTS = ts
-			p.IsStaleness = true
-		}
-	case readTS == 0 && node != nil:
-		// If we didn't use read_ts, and node isn't nil, it means we use 'select table as of timestamp ... '
-		// for stale read
-		// It means we meet following case:
-		// select statement with as of timestamp
-		ts, p.err = calculateTsExpr(p.ctx, node)
-		if p.err != nil {
-			return
-		}
-		if err := sessionctx.ValidateStaleReadTS(context.Background(), p.ctx, ts); err != nil {
-			p.err = errors.Trace(err)
-			return
-		}
-		if !p.initedLastSnapshotTS {
-			p.SnapshotTSEvaluator = func(ctx sessionctx.Context) (uint64, error) {
-				return calculateTsExpr(ctx, node)
-			}
-			p.LastSnapshotTS = ts
-			p.IsStaleness = true
-		}
-	case readTS == 0 && node == nil && readStaleness != 0:
-		// If both readTS and node is empty while the readStaleness isn't, it means we meet following situation:
-		// set @@tidb_read_staleness='-5';
-		// select * from t;
-		// Then the following select statement should be affected by the tidb_read_staleness in session.
-		ts, p.err = calculateTsWithReadStaleness(p.ctx, readStaleness)
-		if p.err != nil {
-			return
-		}
-		if err := sessionctx.ValidateStaleReadTS(context.Background(), p.ctx, ts); err != nil {
-			p.err = errors.Trace(err)
-			return
-		}
-		if !p.initedLastSnapshotTS {
-			p.SnapshotTSEvaluator = func(ctx sessionctx.Context) (uint64, error) {
-				return calculateTsWithReadStaleness(p.ctx, readStaleness)
-			}
-			p.LastSnapshotTS = ts
-			p.IsStaleness = true
-		}
-	case readTS == 0 && node == nil && readStaleness == 0:
-		// If both readTS and node is empty while the readStaleness is empty,
-		// setting p.ReadReplicaScope is necessary to verify the txn scope later
-		// because we may be in a local txn without using the Stale Read.
-		p.ReadReplicaScope = scope
-	}
-
-	// If the select statement is related to multi tables, we should grantee that all tables use the same timestamp
-	if p.LastSnapshotTS != ts {
-		p.err = ErrAsOf.GenWithStack("can not set different time in the as of")
-		return
-	}
-	if p.LastSnapshotTS != 0 {
-		dom := domain.GetDomain(p.ctx)
-		is, err := dom.GetSnapshotInfoSchema(p.LastSnapshotTS)
-		// if infoschema is empty, LastSnapshotTS init failed
-		if err != nil {
-			p.err = err
-			return
-		}
-		if is == nil {
-			p.err = fmt.Errorf("can not get any information schema based on snapshotTS: %d", p.LastSnapshotTS)
-			return
-		}
-		p.InfoSchema = temptable.AttachLocalTemporaryTableInfoSchema(p.ctx, is)
-	}
-	p.initedLastSnapshotTS = true
-}
-
 // ensureInfoSchema get the infoschema from the preprocessor.
 // there some situations:
 //    - the stmt specifies the schema version.
@@ -1715,6 +1563,12 @@ func (p *preprocessor) ensureInfoSchema() infoschema.InfoSchema {
 	if p.InfoSchema != nil {
 		return p.InfoSchema
 	}
+
+	if p.staleReadProcessor.IsStaleness() {
+		p.InfoSchema = p.staleReadProcessor.GetStaleReadInfoSchema()
+		return p.InfoSchema
+	}
+
 	// `Execute` under some conditions need to see the latest information schema.
 	if p.PreprocessExecuteISUpdate != nil {
 		if newInfoSchema := p.ExecuteInfoSchemaUpdate(p.Node, p.ctx); newInfoSchema != nil {
@@ -1726,12 +1580,23 @@ func (p *preprocessor) ensureInfoSchema() infoschema.InfoSchema {
 	return p.InfoSchema
 }
 
-func (p *preprocessor) initTxnContextProviderIfNecessary(node ast.Node) {
+func (p *preprocessor) initTxnContextProviderIfNecessary() {
 	if p.err != nil || p.flag&initTxnContextProvider == 0 {
 		return
 	}
 
-	p.err = sessiontxn.GetTxnManager(p.ctx).SetContextProvider(&sessiontxn.SimpleTxnContextProvider{
-		InfoSchema: p.ensureInfoSchema(),
-	})
+	txnManager := sessiontxn.GetTxnManager(p.ctx)
+	if provider, ok := txnManager.GetContextProvider().(*sessiontxn.SimpleTxnContextProvider); ok {
+		provider.InfoSchema = p.ensureInfoSchema()
+		provider.ReadReplicaScope = p.getReadReplicaScope()
+	}
+	return
+}
+
+func (p *preprocessor) getReadReplicaScope() string {
+	instanceScope := config.GetTxnScopeFromConfig()
+	if p.ctx.GetSessionVars().GetReplicaRead().IsClosestRead() && instanceScope != kv.GlobalReplicaScope {
+		return instanceScope
+	}
+	return p.ctx.GetSessionVars().TxnCtx.TxnScope
 }

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -63,8 +63,10 @@ func InTxnRetry(p *preprocessor) {
 	p.staleReadProcessor = staleread.NewInitContextProcessor(p.ctx)
 }
 
-func ValidateCreateView(p *preprocessor) {
-	p.staleReadProcessor = staleread.NewCreateViewProcessor(p.ctx)
+func ValidateCreateView(getError func() error) PreprocessOpt {
+	return func(p *preprocessor) {
+		p.staleReadProcessor = staleread.NewCreateViewProcessor(p.ctx, getError)
+	}
 }
 
 // InitTxnContext is a PreprocessOpt that indicates preprocess should init transaction's context

--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/executor"
-	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/store/mockstore"
 	"github.com/pingcap/tidb/types"
@@ -1808,11 +1807,10 @@ func BenchmarkCompileExecutePreparedStmt(b *testing.B) {
 	}
 
 	args := []types.Datum{types.NewDatum(3401544)}
-	is := se.GetInfoSchema()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, _, _, err := executor.CompileExecutePreparedStmt(context.Background(), se, stmtID, is.(infoschema.InfoSchema), 0, args)
+		_, _, _, err := executor.CompileExecutePreparedStmt(context.Background(), se, stmtID, args)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -2160,8 +2160,7 @@ func (s *session) ExecutePreparedStmt(ctx context.Context, stmtID uint32, args [
 		return nil, errors.Errorf("invalid CachedPrepareStmt type")
 	}
 
-	staleReadProcessor := staleread.NewStmtPreprocessor(s, true)
-	if err = staleReadProcessor.OnTSEvaluatorInExecute(preparedStmt.SnapshotTSEvaluator); err != nil {
+	if err = staleread.NewInitContextProcessor(s).OnExecuteStmtWithPreparedTS(preparedStmt.SnapshotTSEvaluator); err != nil {
 		return nil, err
 	}
 

--- a/session/session.go
+++ b/session/session.go
@@ -2958,6 +2958,7 @@ func (s *session) PrepareTxnCtx(ctx context.Context) error {
 	}
 
 	return sessiontxn.GetTxnManager(s).SetContextProvider(&sessiontxn.SimpleTxnContextProvider{
+		Sctx:       s,
 		InfoSchema: is.(infoschema.InfoSchema),
 	})
 }

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -15,6 +15,7 @@
 package session
 
 import (
+	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessiontxn"
 )
@@ -45,6 +46,20 @@ func newTxnManager(sctx sessionctx.Context) *txnManager {
 
 func (m *txnManager) InExplicitTxn() bool {
 	return m.sctx.GetSessionVars().TxnCtx.IsExplicit
+}
+
+func (m *txnManager) GetTxnInfoSchema() infoschema.InfoSchema {
+	if m.TxnContextProvider == nil {
+		return nil
+	}
+	return m.TxnContextProvider.GetTxnInfoSchema()
+}
+
+func (m *txnManager) GetReadReplicaScope() string {
+	if m.TxnContextProvider == nil {
+		return ""
+	}
+	return m.TxnContextProvider.GetReadReplicaScope()
 }
 
 func (m *txnManager) GetContextProvider() sessiontxn.TxnContextProvider {

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -15,7 +15,6 @@
 package session
 
 import (
-	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessiontxn"
 )
@@ -36,43 +35,23 @@ func getTxnManager(sctx sessionctx.Context) sessiontxn.TxnManager {
 
 // txnManager implements sessiontxn.TxnManager
 type txnManager struct {
+	sessiontxn.TxnContextProvider
 	sctx sessionctx.Context
-
-	ctxProvider sessiontxn.TxnContextProvider
 }
 
 func newTxnManager(sctx sessionctx.Context) *txnManager {
 	return &txnManager{sctx: sctx}
 }
 
-func (m *txnManager) GetTxnInfoSchema() infoschema.InfoSchema {
-	if m.ctxProvider == nil {
-		return nil
-	}
-	return m.ctxProvider.GetTxnInfoSchema()
-}
-
-// GetReadReplicaScope returns the read replica scope for the txn
-func (m *txnManager) GetReadReplicaScope() string {
-	if m.ctxProvider == nil {
-		return ""
-	}
-	return m.ctxProvider.GetReadReplicaScope()
-}
-
 func (m *txnManager) InExplicitTxn() bool {
 	return m.sctx.GetSessionVars().TxnCtx.IsExplicit
 }
 
-func (m *txnManager) GetReadTS() (uint64, error) {
-	return m.ctxProvider.GetReadTS()
-}
-
 func (m *txnManager) GetContextProvider() sessiontxn.TxnContextProvider {
-	return m.ctxProvider
+	return m.TxnContextProvider
 }
 
 func (m *txnManager) SetContextProvider(provider sessiontxn.TxnContextProvider) error {
-	m.ctxProvider = provider
+	m.TxnContextProvider = provider
 	return nil
 }

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -64,8 +64,8 @@ func (m *txnManager) InExplicitTxn() bool {
 	return m.sctx.GetSessionVars().TxnCtx.IsExplicit
 }
 
-func (m *txnManager) GetStmtReadTS() (uint64, error) {
-	return m.ctxProvider.GetStmtReadTS()
+func (m *txnManager) GetReadTS() (uint64, error) {
+	return m.ctxProvider.GetReadTS()
 }
 
 func (m *txnManager) GetContextProvider() sessiontxn.TxnContextProvider {

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -38,7 +38,8 @@ func getTxnManager(sctx sessionctx.Context) sessiontxn.TxnManager {
 type txnManager struct {
 	sctx sessionctx.Context
 
-	ctxProvider sessiontxn.TxnContextProvider
+	ctxProvider      sessiontxn.TxnContextProvider
+	preparedProvider sessiontxn.TxnContextProvider
 }
 
 func newTxnManager(sctx sessionctx.Context) *txnManager {
@@ -50,6 +51,22 @@ func (m *txnManager) GetTxnInfoSchema() infoschema.InfoSchema {
 		return nil
 	}
 	return m.ctxProvider.GetTxnInfoSchema()
+}
+
+// GetReadReplicaScope returns the read replica scope for the txn
+func (m *txnManager) GetReadReplicaScope() string {
+	if m.ctxProvider == nil {
+		return ""
+	}
+	return m.ctxProvider.GetReadReplicaScope()
+}
+
+func (m *txnManager) InExplicitTxn() bool {
+	return m.sctx.GetSessionVars().TxnCtx.IsExplicit
+}
+
+func (m *txnManager) GetStmtReadTS() (uint64, error) {
+	return m.ctxProvider.GetStmtReadTS()
 }
 
 func (m *txnManager) GetContextProvider() sessiontxn.TxnContextProvider {

--- a/session/txnmanager.go
+++ b/session/txnmanager.go
@@ -38,8 +38,7 @@ func getTxnManager(sctx sessionctx.Context) sessiontxn.TxnManager {
 type txnManager struct {
 	sctx sessionctx.Context
 
-	ctxProvider      sessiontxn.TxnContextProvider
-	preparedProvider sessiontxn.TxnContextProvider
+	ctxProvider sessiontxn.TxnContextProvider
 }
 
 func newTxnManager(sctx sessionctx.Context) *txnManager {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -94,10 +94,6 @@ type StatementContext struct {
 	SkipUTF8Check          bool
 	SkipASCIICheck         bool
 	SkipUTF8MB4Check       bool
-	// If the select statement was like 'select * from t as of timestamp ...' or in a stale read transaction
-	// or is affected by the tidb_read_staleness session variable, then the statement will be makred as isStaleness
-	// in stmtCtx
-	IsStaleness bool
 	// mu struct holds variables that change during execution.
 	mu struct {
 		sync.Mutex
@@ -235,6 +231,7 @@ type StatementContext struct {
 		// LoadStartTime is to record the load start time to calculate latency
 		LoadStartTime time.Time
 	}
+	ContextProviderForBeginStmt interface{}
 }
 
 // StmtHints are SessionVars related sql hints.

--- a/sessiontxn/interface.go
+++ b/sessiontxn/interface.go
@@ -34,6 +34,7 @@ type TxnContextProvider interface {
 // It is only used in refactor stage
 // TODO: remove it after refactor finished
 type SimpleTxnContextProvider struct {
+	Sctx             sessionctx.Context
 	InfoSchema       infoschema.InfoSchema
 	GetReadTSFunc    func() (uint64, error)
 	ReadReplicaScope string
@@ -56,16 +57,11 @@ func (p *SimpleTxnContextProvider) GetReadTS() (uint64, error) {
 
 // TxnManager is an interface providing txn context management in session
 type TxnManager interface {
+	TxnContextProvider
 	// InExplicitTxn returns whether in an explicit txn or not
 	InExplicitTxn() bool
-	// GetTxnInfoSchema returns the information schema used by txn
-	GetTxnInfoSchema() infoschema.InfoSchema
-	// GetReadTS returns statement's read timestamp in current isolation level.
-	// It is used by ready only statements, so insert/update/delete/select-for-update should NOT use it
-	GetReadTS() (uint64, error)
 	// GetReadReplicaScope returns the read replica scope for the txn
 	GetReadReplicaScope() string
-
 	// GetContextProvider returns the current TxnContextProvider
 	GetContextProvider() TxnContextProvider
 	// SetContextProvider sets the context provider

--- a/sessiontxn/staleread/errors.go
+++ b/sessiontxn/staleread/errors.go
@@ -1,0 +1,24 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staleread
+
+import (
+	mysql "github.com/pingcap/tidb/errno"
+	"github.com/pingcap/tidb/util/dbterror"
+)
+
+var (
+	errAsOf = dbterror.ClassOptimizer.NewStd(mysql.ErrAsOf)
+)

--- a/sessiontxn/staleread/helper.go
+++ b/sessiontxn/staleread/helper.go
@@ -1,0 +1,96 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staleread
+
+import (
+	"context"
+	"time"
+
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/kv"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/types"
+
+	"github.com/pingcap/tidb/parser/ast"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/tikv/client-go/v2/oracle"
+)
+
+const maxAllowedStaleReadIntervalAfterNow = 100 * time.Millisecond
+
+// ValidateStaleReadTS validates that readTS does not exceed the current time not strictly.
+func ValidateStaleReadTS(ctx context.Context, sctx sessionctx.Context, readTS uint64) error {
+	// readTS == 0 means no stale read
+	if readTS == 0 {
+		return nil
+	}
+
+	currentTS, err := sctx.GetStore().GetOracle().GetStaleTimestamp(ctx, oracle.GlobalTxnScope, 0)
+	// If we fail to calculate currentTS from local time, fallback to get a timestamp from PD
+	if err != nil {
+		metrics.ValidateReadTSFromPDCount.Inc()
+		currentVer, err := sctx.GetStore().CurrentVersion(oracle.GlobalTxnScope)
+		if err != nil {
+			return errors.Errorf("fail to validate read timestamp: %v", err)
+		}
+		currentTS = currentVer.Ver
+	}
+	if oracle.GetTimeFromTS(readTS).After(oracle.GetTimeFromTS(currentTS).Add(maxAllowedStaleReadIntervalAfterNow)) {
+		return errors.Errorf("cannot set read timestamp to a future time")
+	}
+	return nil
+}
+
+func calculateAsOfTsExpr(sctx sessionctx.Context, asOfClause *ast.AsOfClause) (uint64, error) {
+	tsVal, err := expression.EvalAstExpr(sctx, asOfClause.TsExpr)
+	if err != nil {
+		return 0, err
+	}
+	toTypeTimestamp := types.NewFieldType(mysql.TypeTimestamp)
+	// We need at least the millionsecond here, so set fsp to 3.
+	toTypeTimestamp.Decimal = 3
+	tsTimestamp, err := tsVal.ConvertTo(sctx.GetSessionVars().StmtCtx, toTypeTimestamp)
+	if err != nil {
+		return 0, err
+	}
+	tsTime, err := tsTimestamp.GetMysqlTime().GoTime(sctx.GetSessionVars().Location())
+	if err != nil {
+		return 0, err
+	}
+	return oracle.GoTimeToTS(tsTime), nil
+}
+
+func calculateTsWithReadStaleness(sctx sessionctx.Context, readStaleness time.Duration) (uint64, error) {
+	nowVal, err := expression.GetStmtTimestamp(sctx)
+	if err != nil {
+		return 0, err
+	}
+	tsVal := nowVal.Add(readStaleness)
+	minTsVal := expression.GetMinSafeTime(sctx)
+	return oracle.GoTimeToTS(expression.CalAppropriateTime(tsVal, nowVal, minTsVal)), nil
+}
+
+func getStaleReadReplicaScope(sctx sessionctx.Context) string {
+	instanceScope := config.GetTxnScopeFromConfig()
+	if sctx.GetSessionVars().GetReplicaRead().IsClosestRead() && instanceScope != kv.GlobalReplicaScope {
+		return instanceScope
+	}
+	return kv.GlobalReplicaScope
+}

--- a/sessiontxn/staleread/helper.go
+++ b/sessiontxn/staleread/helper.go
@@ -18,18 +18,13 @@ import (
 	"context"
 	"time"
 
-	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/kv"
-
-	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/types"
-
-	"github.com/pingcap/tidb/parser/ast"
-
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/metrics"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
 	"github.com/tikv/client-go/v2/oracle"
 )
 
@@ -113,12 +108,4 @@ func getTsEvaluatorFromReadStaleness(sctx sessionctx.Context) PreparedTSEvaluato
 	return func(sctx sessionctx.Context) (uint64, error) {
 		return calculateTsWithReadStaleness(sctx, readStaleness)
 	}
-}
-
-func getStaleReadReplicaScope(sctx sessionctx.Context) string {
-	instanceScope := config.GetTxnScopeFromConfig()
-	if sctx.GetSessionVars().GetReplicaRead().IsClosestRead() && instanceScope != kv.GlobalReplicaScope {
-		return instanceScope
-	}
-	return kv.GlobalReplicaScope
 }

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -312,7 +312,7 @@ type CreateViewProcessor struct {
 
 func NewCreateViewProcessor(sctx sessionctx.Context, getError func() error) *CreateViewProcessor {
 	p := &CreateViewProcessor{}
-	p.init(sctx, ProcessTypeParsePrepare)
+	p.init(sctx, ProcessTypeValidateCreateView)
 	p.getError = getError
 	return p
 }

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -307,17 +307,19 @@ func (p *PrepareParseProcessor) OnSelectTable(tn *ast.TableName) (err error) {
 
 type CreateViewProcessor struct {
 	baseProcessor
+	getError func() error
 }
 
-func NewCreateViewProcessor(sctx sessionctx.Context) *CreateViewProcessor {
+func NewCreateViewProcessor(sctx sessionctx.Context, getError func() error) *CreateViewProcessor {
 	p := &CreateViewProcessor{}
 	p.init(sctx, ProcessTypeParsePrepare)
+	p.getError = getError
 	return p
 }
 
 func (p *CreateViewProcessor) OnSelectTable(tn *ast.TableName) (err error) {
 	if tn.AsOf != nil {
-		return errAsOf.FastGenWithCause("can't use select as of while create view")
+		return p.getError()
 	}
 	return nil
 }

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -1,0 +1,279 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staleread
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/sessionctx/variable"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessiontxn"
+	"github.com/pingcap/tidb/table/temptable"
+)
+
+type baseProcessor struct {
+	sctx               sessionctx.Context
+	txnManager         sessiontxn.TxnManager
+	isUpdateTxnContext bool
+
+	evaluated                  bool
+	ts                         uint64
+	is                         infoschema.InfoSchema
+	readReplicaScope           string
+	tsEvaluatorForPreparedStmt func(sctx sessionctx.Context) (uint64, error)
+}
+
+func (p *baseProcessor) init(sctx sessionctx.Context, isUpdateTxnContext bool) {
+	p.sctx = sctx
+	p.txnManager = sessiontxn.GetTxnManager(sctx)
+	p.isUpdateTxnContext = isUpdateTxnContext
+}
+
+func (p *baseProcessor) IsStaleness() bool {
+	return p.ts != 0
+}
+
+func (p *baseProcessor) GetStaleReadTS() uint64 {
+	return p.ts
+}
+
+func (p *baseProcessor) GetStaleReadInfoSchema() infoschema.InfoSchema {
+	return p.is
+}
+
+func (p *StmtPreprocessor) GetTSEvaluatorForPreparedStmt() func(sctx sessionctx.Context) (uint64, error) {
+	return p.tsEvaluatorForPreparedStmt
+}
+
+func (p *baseProcessor) setEvaluatedTS(ts uint64) error {
+	if p.evaluated {
+		return errors.New("already evaluated")
+	}
+
+	if ts != 0 {
+		is, err := domain.GetDomain(p.sctx).GetSnapshotInfoSchema(ts)
+		if err != nil {
+			return err
+		}
+		p.is = temptable.AttachLocalTemporaryTableInfoSchema(p.sctx, is)
+		p.readReplicaScope = getStaleReadReplicaScope(p.sctx)
+	}
+
+	p.ts = ts
+	p.evaluated = true
+	return nil
+}
+
+func (p *baseProcessor) buildContextProvider() sessiontxn.TxnContextProvider {
+	if p.ts == 0 {
+		return nil
+	}
+
+	return &staleReadTxnContextProvider{
+		is:               p.is,
+		ts:               p.ts,
+		readReplicaScope: p.readReplicaScope,
+	}
+}
+
+func (p *baseProcessor) getAsOfTS(asOf *ast.AsOfClause) (uint64, error) {
+	if asOf == nil {
+		return 0, nil
+	}
+
+	staleReadTS, err := calculateAsOfTsExpr(p.sctx, asOf)
+	if err != nil {
+		return 0, err
+	}
+
+	if err = ValidateStaleReadTS(context.TODO(), p.sctx, staleReadTS); err != nil {
+		return 0, err
+	}
+
+	return staleReadTS, nil
+}
+
+func (p *baseProcessor) useStmtOrTxnReadTS(stmtTS uint64) (ts uint64, err error) {
+	if p.sctx.GetSessionVars().TxnReadTS.PeakTxnReadTS() != 0 && stmtTS != 0 {
+		return 0, errAsOf.FastGenWithCause("can't use select as of while already set transaction as of")
+	}
+
+	staleReadTS := p.sctx.GetSessionVars().TxnReadTS.UseTxnReadTS()
+	if staleReadTS == 0 {
+		staleReadTS = stmtTS
+	}
+
+	return staleReadTS, nil
+}
+
+func (p *baseProcessor) getReadStalenessTS() (uint64, func(sctx sessionctx.Context) (uint64, error), error) {
+	readStaleness := p.sctx.GetSessionVars().ReadStaleness
+	if readStaleness == 0 {
+		return 0, nil, nil
+	}
+
+	staleReadTS, err := calculateTsWithReadStaleness(p.sctx, readStaleness)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return staleReadTS, func(sctx sessionctx.Context) (uint64, error) {
+		return calculateTsWithReadStaleness(sctx, readStaleness)
+	}, nil
+}
+
+func (p *baseProcessor) onStmtTS(ts uint64) error {
+	if p.txnManager.InExplicitTxn() {
+		if ts != 0 {
+			return errAsOf.FastGenWithCause("as of timestamp can't be set in transaction.")
+		}
+		return nil
+	}
+
+	staleReadTS, err := p.useStmtOrTxnReadTS(ts)
+	if err != nil {
+		return err
+	}
+
+	var tsEvaluatorForPreparedStmt func(sctx sessionctx.Context) (uint64, error)
+	if staleReadTS == 0 {
+		staleReadTS, tsEvaluatorForPreparedStmt, err = p.getReadStalenessTS()
+		if err != nil {
+			return err
+		}
+	} else {
+		tsEvaluatorForPreparedStmt = func(sctx sessionctx.Context) (uint64, error) {
+			return staleReadTS, nil
+		}
+	}
+
+	if !p.evaluated {
+		err = p.setEvaluatedTS(staleReadTS)
+		if err != nil {
+			return err
+		}
+		p.tsEvaluatorForPreparedStmt = tsEvaluatorForPreparedStmt
+
+		if p.isUpdateTxnContext {
+			provider := p.buildContextProvider()
+			if provider != nil {
+				if err = p.txnManager.SetContextProvider(provider); err != nil {
+					return err
+				}
+			}
+		}
+	} else if staleReadTS != p.ts {
+		return errAsOf.GenWithStack("can not set different time in the as of")
+	}
+
+	return nil
+}
+
+type StmtPreprocessor struct {
+	baseProcessor
+}
+
+func NewStmtPreprocessor(sctx sessionctx.Context, isUpdateTxnContext bool) *StmtPreprocessor {
+	p := &StmtPreprocessor{}
+	p.init(sctx, isUpdateTxnContext)
+	return p
+}
+
+func (p *StmtPreprocessor) OnTSEvaluatorInExecute(evaluator func(sctx sessionctx.Context) (uint64, error)) (err error) {
+	ts := uint64(0)
+	if evaluator != nil {
+		ts, err = evaluator(p.sctx)
+		if err != nil {
+			return err
+		}
+	}
+
+	return p.onStmtTS(ts)
+}
+
+func (p *StmtPreprocessor) OnSelectTable(tn *ast.TableName) error {
+	ts, err := p.getAsOfTS(tn.AsOf)
+	if err != nil {
+		return err
+	}
+	return p.onStmtTS(ts)
+}
+
+func (p *StmtPreprocessor) OnStartTransaction(begin *ast.BeginStmt) error {
+	if !p.isUpdateTxnContext {
+		return errors.New("Must update txn context when start tarnsaction")
+	}
+
+	ts, err := p.getAsOfTS(begin.AsOf)
+	if err != nil {
+		return err
+	}
+
+	if !p.txnManager.InExplicitTxn() {
+		ts, err = p.useStmtOrTxnReadTS(ts)
+		if err != nil {
+			return err
+		}
+	}
+
+	if err = p.setEvaluatedTS(ts); err != nil {
+		return err
+	}
+
+	if provider := p.buildContextProvider(); provider != nil {
+		p.sctx.GetSessionVars().StmtCtx.ContextProviderForBeginStmt = provider
+		if !p.txnManager.InExplicitTxn() {
+			if err = p.txnManager.SetContextProvider(provider); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func ShouldStartStaleReadTxn(sctx sessionctx.Context) bool {
+	provider := sctx.GetSessionVars().StmtCtx.ContextProviderForBeginStmt
+	if provider == nil {
+		return false
+	}
+
+	_, ok := provider.(*staleReadTxnContextProvider)
+	return ok
+}
+
+func ExplicitStartStaleReadTxn(ctx context.Context, sctx sessionctx.Context) error {
+	provider := sctx.GetSessionVars().StmtCtx.ContextProviderForBeginStmt.(*staleReadTxnContextProvider)
+	if err := sctx.NewStaleTxnWithStartTS(ctx, provider.ts); err != nil {
+		return err
+	}
+	if err := sessiontxn.GetTxnManager(sctx).SetContextProvider(provider); err != nil {
+		return err
+	}
+	// With START TRANSACTION, autocommit remains disabled until you end
+	// the transaction with COMMIT or ROLLBACK. The autocommit mode then
+	// reverts to its previous state.
+	vars := sctx.GetSessionVars()
+	if err := vars.SetSystemVar(variable.TiDBSnapshot, ""); err != nil {
+		return errors.Trace(err)
+	}
+	vars.SetInTxn(true)
+	return nil
+}

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -45,6 +45,15 @@ func (p *baseProcessor) init(sctx sessionctx.Context, isUpdateTxnContext bool) {
 	p.sctx = sctx
 	p.txnManager = sessiontxn.GetTxnManager(sctx)
 	p.isUpdateTxnContext = isUpdateTxnContext
+
+	if p.txnManager.InExplicitTxn() {
+		if provider, ok := p.txnManager.GetContextProvider().(*staleReadTxnContextProvider); ok {
+			p.evaluated = true
+			p.ts = provider.ts
+			p.is = provider.is
+			p.readReplicaScope = provider.readReplicaScope
+		}
+	}
 }
 
 func (p *baseProcessor) IsStaleness() bool {

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -246,7 +246,7 @@ func (p *InitTxnContextProcessor) onSelectOrExecuteTS(ts uint64) (err error) {
 	}
 
 	if ts != 0 {
-		err = p.txnManager.SetContextProvider(p.buildContextProvider(getStaleReadReplicaScope(p.sctx)))
+		err = p.txnManager.SetContextProvider(p.buildContextProvider(config.GetTxnScopeFromConfig()))
 	}
 
 	return err

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -236,7 +236,7 @@ func (p *StmtPreprocessor) OnSelectTable(tn *ast.TableName) error {
 
 func (p *StmtPreprocessor) OnStartTransaction(begin *ast.BeginStmt) error {
 	if !p.isUpdateTxnContext {
-		return errors.New("Must update txn context when start tarnsaction")
+		return errors.New("Must update txn context when start transaction")
 	}
 
 	ts, err := p.getAsOfTS(begin.AsOf)

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -132,6 +132,7 @@ func (p *baseProcessor) buildContextProvider(readReplicaScope string) sessiontxn
 	}
 
 	return &staleReadTxnContextProvider{
+		sctx:             p.sctx,
 		is:               p.is,
 		ts:               p.ts,
 		readReplicaScope: readReplicaScope,

--- a/sessiontxn/staleread/processor.go
+++ b/sessiontxn/staleread/processor.go
@@ -45,15 +45,6 @@ func (p *baseProcessor) init(sctx sessionctx.Context, isUpdateTxnContext bool) {
 	p.sctx = sctx
 	p.txnManager = sessiontxn.GetTxnManager(sctx)
 	p.isUpdateTxnContext = isUpdateTxnContext
-
-	if p.txnManager.InExplicitTxn() {
-		if provider, ok := p.txnManager.GetContextProvider().(*staleReadTxnContextProvider); ok {
-			p.evaluated = true
-			p.ts = provider.ts
-			p.is = provider.is
-			p.readReplicaScope = provider.readReplicaScope
-		}
-	}
 }
 
 func (p *baseProcessor) IsStaleness() bool {

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -34,7 +34,7 @@ func (p *staleReadTxnContextProvider) GetReadReplicaScope() string {
 	return p.readReplicaScope
 }
 
-func (p *staleReadTxnContextProvider) GetStmtReadTS() (uint64, error) {
+func (p *staleReadTxnContextProvider) GetReadTS() (uint64, error) {
 	return p.ts, nil
 }
 

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -1,0 +1,49 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package staleread
+
+import (
+	"github.com/pingcap/tidb/infoschema"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/sessiontxn"
+)
+
+type staleReadTxnContextProvider struct {
+	is               infoschema.InfoSchema
+	ts               uint64
+	readReplicaScope string
+}
+
+func (p *staleReadTxnContextProvider) GetTxnInfoSchema() infoschema.InfoSchema {
+	return p.is
+}
+
+func (p *staleReadTxnContextProvider) GetReadReplicaScope() string {
+	return p.readReplicaScope
+}
+
+func (p *staleReadTxnContextProvider) GetStmtReadTS() (uint64, error) {
+	return p.ts, nil
+}
+
+func IsTxnStaleness(sctx sessionctx.Context) bool {
+	provider := sessiontxn.GetTxnManager(sctx).GetContextProvider()
+	if provider == nil {
+		return false
+	}
+
+	_, ok := provider.(*staleReadTxnContextProvider)
+	return ok
+}

--- a/sessiontxn/staleread/provider.go
+++ b/sessiontxn/staleread/provider.go
@@ -21,6 +21,7 @@ import (
 )
 
 type staleReadTxnContextProvider struct {
+	sctx             sessionctx.Context
 	is               infoschema.InfoSchema
 	ts               uint64
 	readReplicaScope string


### PR DESCRIPTION
This is a draft to refactor stale read according to new txn context management design: #30535 . In this PR, the stale read implements are moved to a standalone package to make the code more cohesive. This PR also provides some interfaces and decouple the stale read processing to some inherent classes according the different scenes.

### staleReadTxnContextProvider

In this PR we introduce a new struct `staleReadTxnContextProvider`. `staleReadTxnContextProvider` implements `TxnContextProvider` , and it provides the txn context when the current scene is stale read. `staleReadTxnContextProvider` implements the below methods:

- `GetTxnInfoSchema` returns the information schema for stale read.
- `GetReadTS` returns the ts for read
- `GetReadReplicaScope` returns the read replica prefer for the stale read

Notice that `staleReadTxnContextProvider` is only one of subclasses for `TxnContextProvider` , we'll implement other providers like `RRTxnContextProvider` or `RCTxnContextProvider` . So the concept of these methods should not limited only to stale read.

After moving the stale read context to `TxnManager` we can the fetch these context from session instead of passing them as method arguments, it makes the code more simple and clear.


### `staleread.StmtProcessor`

In this PR, we moved the stale read processing code to `staleread.StmtProcessor` . Comparing the old code, it decoupled stale read processing from preprocessor and make the code easier to do uint test. 

We should process stale read for below scenes:

- Initialize stale read context before execute the sql.
- Prepare a sql and extracting the stale read timestamp which should be saved in prepared statement
- Validating a sql in create view (Create view should fail when the select statement contains stale read)

The process rules for the above scenes are not the same. The old implement write all the processing code together that makes it hard to understand and easier to get a bug. In the PR, we separate them  into different logicals. The below processors are introduced:

- `InitTxnContextProcessor` It is used to initialize stale read txn context. This processor will parse the stale read context from sql and sys variables and set the TxnManager's provider to `staleReadTxnContextProvider`
- `PrepareParseProcessor` It is used to parse the stale read ts for a sql to prepare. It will not affect the current txn context. 
- `CreateViewProcessor` It is used to forbid stale read sql when creating a view.

All the above processors will parse the stale read ts, but the paring ways may be a little different. For example `CreateViewProcessor` will ignore sys variables and only check stale read settings in sql.

All the above processors will implement a interface below and the `preprocessor` need not to care about the differences for the above scenes:

```
type StmtProcessor interface {
	// GetType returns the process type
	GetType() ProcessType
	// IsStmtStaleness indicates that whether the stmt has the staleness declaration
	IsStmtStaleness() bool
	// GetStalenessInfoSchema returns the information schema if it is stale read, otherwise returns nil
	GetStalenessInfoSchema() infoschema.InfoSchema
	// GetStalenessReadTS returns the ts if it is stale read, otherwise returns 0
	GetStalenessReadTS() uint64

	// OnSelectTable will be called when process table in select statement.
	// Support type: ProcessTypeInitTxnContext, ProcessTypeParsePrepare, ProcessTypeValidateCreateView
	OnSelectTable(tn *ast.TableName) error
	// OnExecuteStmtWithPreparedTS will be called when process execute statement
	// Support type: ProcessTypeInitTxnContext
	OnExecuteStmtWithPreparedTS(evaluator PreparedTSEvaluator) error
	// OnBeginStmt will be called when process begin statement
	// Support type: ProcessTypeInitTxnContext
	OnBeginStmt(begin *ast.BeginStmt) error
}
```

### Other

In this PR, the `staleread` package also provides some methods to encapsulate some stale read operations. For example: `staleread.IsStaleness` returns wether the current statement is staleness according to the current txn provider and `ExplicitStartStaleReadTxn` starts new stale read txn. To move most of the complexity to the `staleread` package, the code is easier to maintain.

