### PR TITLE
planner: fix wrong range calculation for Nulleq function on Enum values

### DIFF
--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -2110,8 +2110,7 @@ func TestIssue30100(t *testing.T) {
 	tk.MustExec("set @a=0;")
 	tk.MustQuery("execute stmt using @a").Check(testkit.Rows())
 	tk.MustQuery("execute stmt using @a").Check(testkit.Rows())
-	// If the plan contains the tableDual, it can not be cached.
-	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
+	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("1"))
 }
 
 func TestPartitionTable(t *testing.T) {

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -458,6 +458,10 @@ func handleEnumFromBinOp(sc *stmtctx.StatementContext, ft *types.FieldType, val 
 		res = append(res, &point{value: d, excl: false, start: false})
 	}
 
+	if op == ast.NullEQ && val.IsNull() {
+		res = append(res, &point{start: true}, &point{}) // null point
+	}
+
 	tmpEnum := types.Enum{}
 	for i := 0; i <= len(ft.Elems); i++ {
 		if i == 0 {
@@ -486,7 +490,7 @@ func handleEnumFromBinOp(sc *stmtctx.StatementContext, ft *types.FieldType, val 
 				if v >= 0 {
 					appendPointFunc(d)
 				}
-			case ast.EQ:
+			case ast.EQ, ast.NullEQ:
 				if v == 0 {
 					appendPointFunc(d)
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32428

Problem Summary: planner: fix wrong range calculation for Nulleq function on Enum values

### What is changed and how it works?

planner: fix wrong range calculation for Nulleq function on Enum values

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: fix wrong range calculation for Nulleq function on Enum values
```
