### PR TITLE
parser: make the prepared statement parameter marker support escape

### DIFF
--- a/parser/ast/expressions_test.go
+++ b/parser/ast/expressions_test.go
@@ -287,6 +287,8 @@ func TestPatternLikeExprRestore(t *testing.T) {
 		{"a not like 't1%'", "`a` NOT LIKE _UTF8MB4't1%'"},
 		{"a not like '%D%v%'", "`a` NOT LIKE _UTF8MB4'%D%v%'"},
 		{"a not like '%t1_|'", "`a` NOT LIKE _UTF8MB4'%t1_|'"},
+		{"a like 't1' escape '#'", "`a` LIKE _UTF8MB4't1' ESCAPE '#'"},
+		{"a not like 't1' escape '#'", "`a` NOT LIKE _UTF8MB4't1' ESCAPE '#'"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1377,6 +1377,8 @@ import (
 	StatsOptionsOpt                        "Stats options"
 	DryRunOptions                          "Dry run options"
 	OptionalShardColumn                    "Optional shard column"
+	LikeEscapeOpt                          "like escape option clause"
+	EscapeExpr                             "escape value or param marker cases"
 
 %type	<ident>
 	AsOpt             "AS or EmptyString"
@@ -1445,7 +1447,6 @@ import (
 	FieldTerminator                 "Field terminator"
 	FlashbackToNewName              "Flashback to new name"
 	HashString                      "Hashed string"
-	LikeEscapeOpt                   "like escape option"
 	LinesTerminated                 "Lines terminated by"
 	OptCharset                      "Optional Character setting"
 	OptCollate                      "Optional Collate setting"
@@ -5819,18 +5820,20 @@ PredicateExpr:
 	}
 |	BitExpr LikeOrNotOp SimpleExpr LikeEscapeOpt
 	{
-		escape := $4
-		if len(escape) > 1 {
-			yylex.AppendError(ErrWrongArguments.GenWithStackByArgs("ESCAPE"))
-			return 1
-		} else if len(escape) == 0 {
-			escape = "\\"
+		escapeexpr := $4
+		if _, ok := escapeexpr.(ast.ParamMarkerExpr); !ok {
+			// it can not convert to `ParamMarkerExpr`, so it must be `ValueExpr`
+			escape := escapeexpr.(ast.ValueExpr).GetString()
+			if len(escape) > 1 {
+				yylex.AppendError(ErrWrongArguments.GenWithStackByArgs("ESCAPE"))
+				return 1
+			}
 		}
 		$$ = &ast.PatternLikeExpr{
 			Expr:    $1,
 			Pattern: $3,
 			Not:     !$2.(bool),
-			Escape:  escape[0],
+			Escape:  $4.(ast.ValueExpr),
 		}
 	}
 |	BitExpr RegexpOrNotOp SimpleExpr
@@ -5850,11 +5853,26 @@ RegexpSym:
 LikeEscapeOpt:
 	%prec empty
 	{
-		$$ = "\\"
+		expr := ast.NewValueExpr("\\", parser.charset, parser.collation)
+		$$ = expr
 	}
-|	"ESCAPE" stringLit
+|	"ESCAPE" EscapeExpr
 	{
 		$$ = $2
+	}
+
+EscapeExpr:
+	stringLit
+	{
+		if len($1) == 0 {
+			$1 = "\\"
+		}
+		expr := ast.NewValueExpr($1, parser.charset, parser.collation)
+		$$ = expr
+	}
+|	paramMarker
+	{
+		$$ = ast.NewParamMarkerExpr(yyS[yypt].offset)
 	}
 
 Field:
@@ -11248,9 +11266,10 @@ ShowLikeOrWhereOpt:
 	}
 |	"LIKE" SimpleExpr
 	{
+		expr := ast.NewValueExpr("\\", parser.charset, parser.collation)
 		$$ = &ast.PatternLikeExpr{
 			Pattern: $2,
-			Escape:  '\\',
+			Escape:  expr,
 		}
 	}
 |	"WHERE" Expression

--- a/planner/core/show_predicate_extractor.go
+++ b/planner/core/show_predicate_extractor.go
@@ -74,8 +74,9 @@ func (e *ShowBaseExtractor) Extract() bool {
 		switch pattern.Pattern.(type) {
 		case *driver.ValueExpr:
 			// It is used in `SHOW XXXX in t LIKE `abc``.
+			escape := pattern.Escape.(*driver.ValueExpr).GetString()
 			ptn := pattern.Pattern.(*driver.ValueExpr).GetString()
-			patValue, patTypes := stringutil.CompilePattern(ptn, pattern.Escape)
+			patValue, patTypes := stringutil.CompilePattern(ptn, escape[0])
 			if stringutil.IsExactMatch(patTypes) {
 				e.field = strings.ToLower(string(patValue))
 				return true

--- a/types/parser_driver/value_expr.go
+++ b/types/parser_driver/value_expr.go
@@ -255,8 +255,8 @@ func newParamMarkerExpr(offset int) ast.ParamMarkerExpr {
 }
 
 // Format the ExprNode into a Writer.
-func (*ParamMarkerExpr) Format(_ io.Writer) {
-	panic("Not implemented")
+func (*ParamMarkerExpr) Format(w io.Writer) {
+	fmt.Fprint(w, "?")
 }
 
 // Accept implements Node Accept interface.


### PR DESCRIPTION
Signed-off-by: fanrenhoo <fanrenhoo@sina.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32246

Problem Summary: the prepared statement did not support escape to have a paramenter marker ?, parser will treat it as wrong syntax as normal sql

### What is changed and how it works?
I added the paramMarker in parser.y to support "ESCAPE paramMarker", so if in the prepared statement, now we can write "escape ?", that mean the escape character can also be parameterized in prepared statement. 
Add also add a test case for this
I did not commit the parser.go, because I think it's should be auto generated from parser.y

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
I tested, now it works:

>drop table if exists t1;
>create table t1 (a varchar(10), key(a));
>prepare stmt1 from 'select * from t1 where a like \'a\\%\' escape ?';
Query OK, 0 rows affected (0.00 sec)

- [ ] No code

Side effects
No
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
No
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Make the prepared statement support escape character be parameterized(issue 32246). the prepared statement "escape ?", , parser will treat it as wrong syntax as normal sql, now the escape character can also be parameterized in prepared statement.
```
/cc @xiongjiwei