### PR TITLE
topsql: fix unstable test in reporter

### DIFF
--- a/util/topsql/reporter/single_target_test.go
+++ b/util/topsql/reporter/single_target_test.go
@@ -43,6 +43,9 @@ func TestSingleTargetDataSink(t *testing.T) {
 	ds.Start()
 	defer ds.Close()
 
+	recordsCnt := server.RecordsCnt()
+	sqlMetaCnt := server.SQLMetaCnt()
+
 	err = ds.TrySend(&ReportData{
 		DataRecords: []tipb.TopSQLRecord{{
 			SqlDigest:  []byte("S1"),
@@ -66,7 +69,8 @@ func TestSingleTargetDataSink(t *testing.T) {
 	}, time.Now().Add(10*time.Second))
 	assert.NoError(t, err)
 
-	server.WaitCollectCnt(1, 5*time.Second)
+	server.WaitCollectCnt(recordsCnt, 1, 5*time.Second)
+	server.WaitCollectCntOfSQLMeta(sqlMetaCnt, 1, 5*time.Second)
 
 	assert.Len(t, server.GetLatestRecords(), 1)
 	assert.Len(t, server.GetTotalSQLMetas(), 1)

--- a/util/topsql/topsql_test.go
+++ b/util/topsql/topsql_test.go
@@ -127,6 +127,7 @@ func TestTopSQLReporter(t *testing.T) {
 
 	sqlMap := make(map[string]string)
 	sql2plan := make(map[string]string)
+	recordsCnt := server.RecordsCnt()
 	for _, req := range reqs {
 		sql2plan[req.sql] = req.plan
 		sqlDigest := mock.GenSQLDigest(req.sql)
@@ -143,7 +144,7 @@ func TestTopSQLReporter(t *testing.T) {
 			}
 		})
 	}
-	server.WaitCollectCnt(1, time.Second*5)
+	server.WaitCollectCnt(recordsCnt, 1, time.Second*5)
 	records := server.GetLatestRecords()
 	checkSQLPlanMap := map[string]struct{}{}
 	for _, req := range records {


### PR DESCRIPTION
Signed-off-by: mornyx <mornyx.z@gmail.com>

Issue Number: close #32002

### What's changed

Make sure to get the exact old value **before** the mock client sends the data, and check the incremented value after sending the data.

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
