### PR TITLE
tools/check: revise the error message for failed test case

### DIFF
--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -580,8 +580,8 @@ func (n *numa) worker(wg *sync.WaitGroup, ch chan task) {
 	for t := range ch {
 		res := n.runTestCase(t.pkg, t.test, t.old)
 		if res.Failure != nil {
-			fmt.Println("[FAIL] ", t.pkg, t.test, t.old)
-			fmt.Fprintf(os.Stderr, "%s", res.Failure.Contents)
+			fmt.Println("[FAIL] ", t.pkg, t.test)
+			fmt.Fprintf(os.Stderr, "err=%s\n%s", res.err, res.Failure.Contents)
 			n.Fail = true
 		}
 		n.results = append(n.results, res)
@@ -590,7 +590,8 @@ func (n *numa) worker(wg *sync.WaitGroup, ch chan task) {
 
 type testResult struct {
 	JUnitTestCase
-	d time.Duration
+	d   time.Duration
+	err error
 }
 
 func (n *numa) runTestCase(pkg string, fn string, old bool) testResult {
@@ -612,6 +613,7 @@ func (n *numa) runTestCase(pkg string, fn string, old bool) testResult {
 			Message:  "Failed",
 			Contents: buf.String(),
 		}
+		res.err = err
 	}
 	res.d = time.Since(start)
 	res.Time = formatDurationAsSeconds(res.d)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32532

Problem Summary:

### What is changed and how it works?

Before this change, only the Stdin, Stderr is collected as the error message.
But in some cases, there is nothing in Stdin, Stderr

So it's better to also print the error from `cmd.Run()` result to get more information.
For example, the test case output nothing but exit with -1...

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [X] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
