### PR TITLE
telemetry: sync the concurrent map access of built-in func usage

### DIFF
--- a/br/pkg/lightning/backend/kv/session.go
+++ b/br/pkg/lightning/backend/kv/session.go
@@ -324,12 +324,6 @@ func (se *session) GetInfoSchema() sessionctx.InfoschemaMetaVersion {
 	return nil
 }
 
-// GetBuiltinFunctionUsage returns the BuiltinFunctionUsage of current Context, which is not thread safe.
-// Use primitive map type to prevent circular import. Should convert it to telemetry.BuiltinFunctionUsage before using.
-func (se *session) GetBuiltinFunctionUsage() map[string]uint32 {
-	return make(map[string]uint32)
-}
-
 // GetStmtStats implements the sessionctx.Context interface.
 func (se *session) GetStmtStats() *stmtstats.StatementStats {
 	return nil

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1225,7 +1225,9 @@ func (er *expressionRewriter) newFunction(funcName string, retType *types.FieldT
 		return
 	}
 	if scalarFunc, ok := ret.(*expression.ScalarFunction); ok {
-		telemetry.BuiltinFunctionsUsage(er.b.ctx.GetBuiltinFunctionUsage()).Inc(scalarFunc.Function.PbCode().String())
+		if collector, ok := er.b.ctx.(telemetry.BuiltinFunctionsUsageCollector); ok {
+			collector.CollectBuiltinFunctionsUsage(scalarFunc.Function.PbCode().String())
+		}
 	}
 	return
 }

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -138,9 +138,6 @@ type Context interface {
 	StoreIndexUsage(tblID int64, idxID int64, rowsSelected int64)
 	// GetTxnWriteThroughputSLI returns the TxnWriteThroughputSLI.
 	GetTxnWriteThroughputSLI() *sli.TxnWriteThroughputSLI
-	// GetBuiltinFunctionUsage returns the BuiltinFunctionUsage of current Context, which is not thread safe.
-	// Use primitive map type to prevent circular import. Should convert it to telemetry.BuiltinFunctionUsage before using.
-	GetBuiltinFunctionUsage() map[string]uint32
 	// GetStmtStats returns stmtstats.StatementStats owned by implementation.
 	GetStmtStats() *stmtstats.StatementStats
 }

--- a/telemetry/data_window.go
+++ b/telemetry/data_window.go
@@ -152,6 +152,7 @@ func (b *BuiltinFunctionsUsage) Dump() map[string]uint32 {
 // GlobalBuiltinFunctionsUsage is used to collect builtin functions usage information
 var GlobalBuiltinFunctionsUsage = NewBuiltinFunctionsUsage()
 
+// BuiltinFunctionsUsageCollector is used to collect the usage of scalar function for telemetry.
 type BuiltinFunctionsUsageCollector interface {
 	CollectBuiltinFunctionsUsage(funcName string)
 }

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -173,11 +173,6 @@ func (c *Context) GetInfoSchema() sessionctx.InfoschemaMetaVersion {
 	return nil
 }
 
-// GetBuiltinFunctionUsage implements sessionctx.Context GetBuiltinFunctionUsage interface.
-func (c *Context) GetBuiltinFunctionUsage() map[string]uint32 {
-	return make(map[string]uint32)
-}
-
 // GetGlobalSysVar implements GlobalVarAccessor GetGlobalSysVar interface.
 func (c *Context) GetGlobalSysVar(ctx sessionctx.Context, name string) (string, error) {
 	v := variable.GetSysVar(name)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32459, related to #26234

Problem Summary:

The panic is caused by the concurrent map access(click the *details* below to see):
<details>

```
runtime.throw (panic.go:1188) runtime
runtime.mapassign_faststr (map_faststr.go:294) runtime
telemetry.BuiltinFunctionsUsage.Inc (data_window.go:130) github.com/pingcap/tidb/telemetry
core.(*expressionRewriter).newFunction (expression_rewriter.go:1228) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).constructBinaryOpFunction (expression_rewriter.go:274) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).binaryOpToExpression (expression_rewriter.go:1354) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).Leave (expression_rewriter.go:1103) github.com/pingcap/tidb/planner/core
ast.(*BinaryOperationExpr).Accept (expressions.go:223) github.com/pingcap/tidb/parser/ast
ast.(*BinaryOperationExpr).Accept (expressions.go:211) github.com/pingcap/tidb/parser/ast
ast.(*BinaryOperationExpr).Accept (expressions.go:211) github.com/pingcap/tidb/parser/ast
ast.(*ParenthesesExpr).Accept (expressions.go:995) github.com/pingcap/tidb/parser/ast
core.(*PlanBuilder).rewriteExprNode (expression_rewriter.go:200) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewriteWithPreprocess (expression_rewriter.go:146) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewrite (expression_rewriter.go:114) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildJoin (logical_plan_builder.go:790) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildResultSetNode (logical_plan_builder.go:327) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildTableRefs (logical_plan_builder.go:321) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildSelect (logical_plan_builder.go:3553) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).Build (planbuilder.go:716) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).BuildDataSourceFromView (logical_plan_builder.go:4379) github.com/pingcap/tidb/planner/core
executor.tryFillViewColumnType (show.go:1839) github.com/pingcap/tidb/executor
executor.(*hugeMemTableRetriever).dataForColumnsInTable (infoschema_reader.go:675) github.com/pingcap/tidb/executor
executor.(*hugeMemTableRetriever).setDataForColumns (infoschema_reader.go:664) github.com/pingcap/tidb/executor
executor.(*hugeMemTableRetriever).retrieve (infoschema_reader.go:2520) github.com/pingcap/tidb/executor
executor.(*MemTableReaderExec).Next (memtable_reader.go:118) github.com/pingcap/tidb/executor
executor.Next (executor.go:302) github.com/pingcap/tidb/executor
executor.(*HashJoinExec).fetchProbeSideChunks (join.go:214) github.com/pingcap/tidb/executor
executor.(*HashJoinExec).fetchAndProbeHashTable.func1 (join.go:338) github.com/pingcap/tidb/executor
util.WithRecovery (misc.go:100) github.com/pingcap/tidb/util
runtime.goexit (asm_arm64.s:1133) runtime
 - Async Stack Trace
executor.(*HashJoinExec).fetchAndProbeHashTable (join.go:336) github.com/pingcap/tidb/executor
```

</details>

### What is changed and how it works?

This PR synchronize the map access.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Fix the panic issue caused by joining views of system tables.
```
