### PR TITLE
table/tables: fix a corner case of renew lease operation on cached table

### DIFF
--- a/ddl/placement_policy_ddl_test.go
+++ b/ddl/placement_policy_ddl_test.go
@@ -124,7 +124,7 @@ func (s *testDDLSuiteToVerify) TestPlacementPolicyInUse() {
 	t4.State = model.StatePublic
 	db1.Tables = append(db1.Tables, t4)
 
-	builder, err := infoschema.NewBuilder(store, nil, nil).InitWithDBInfos(
+	builder, err := infoschema.NewBuilder(store, nil).InitWithDBInfos(
 		[]*model.DBInfo{db1, db2, dbP},
 		nil,
 		[]*model.PolicyInfo{p1, p2, p3, p4, p5},

--- a/domain/domain.go
+++ b/domain/domain.go
@@ -95,7 +95,6 @@ type Domain struct {
 	serverID             uint64
 	serverIDSession      *concurrency.Session
 	isLostConnectionToPD atomicutil.Int32 // !0: true, 0: false.
-	renewLeaseCh         chan func()      // It is used to call the renewLease function of the cache table.
 	onClose              func()
 	sysExecutorFactory   func(*Domain) (pools.Resource, error)
 }
@@ -162,7 +161,7 @@ func (do *Domain) loadInfoSchema(startTS uint64) (infoschema.InfoSchema, bool, i
 		return nil, false, currentSchemaVersion, nil, err
 	}
 
-	newISBuilder, err := infoschema.NewBuilder(do.Store(), do.renewLeaseCh, do.sysFacHack).InitWithDBInfos(schemas, bundles, policies, neededSchemaVersion)
+	newISBuilder, err := infoschema.NewBuilder(do.Store(), do.sysFacHack).InitWithDBInfos(schemas, bundles, policies, neededSchemaVersion)
 	if err != nil {
 		return nil, false, currentSchemaVersion, nil, err
 	}
@@ -284,7 +283,7 @@ func (do *Domain) tryLoadSchemaDiffs(m *meta.Meta, usedVersion, newVersion int64
 		}
 		diffs = append(diffs, diff)
 	}
-	builder := infoschema.NewBuilder(do.Store(), do.renewLeaseCh, do.sysFacHack).InitWithOldInfoSchema(do.infoCache.GetLatest())
+	builder := infoschema.NewBuilder(do.Store(), do.sysFacHack).InitWithOldInfoSchema(do.infoCache.GetLatest())
 	phyTblIDs := make([]int64, 0, len(diffs))
 	actions := make([]uint64, 0, len(diffs))
 	for _, diff := range diffs {
@@ -731,7 +730,6 @@ func NewDomain(store kv.Storage, ddlLease time.Duration, statsLease time.Duratio
 		indexUsageSyncLease: idxUsageSyncLease,
 		planReplayer:        &planReplayer{planReplayerGCLease: planReplayerGCLease},
 		onClose:             onClose,
-		renewLeaseCh:        make(chan func(), 10),
 		expiredTimeStamp4PC: types.NewTime(types.ZeroCoreTime, mysql.TypeTimestamp, types.DefaultFsp),
 	}
 
@@ -858,10 +856,9 @@ func (do *Domain) Init(ddlLease time.Duration, sysExecutorFactory func(*Domain) 
 		// Local store needs to get the change information for every DDL state in each session.
 		go do.loadSchemaInLoop(ctx, ddlLease)
 	}
-	do.wg.Add(4)
+	do.wg.Add(3)
 	go do.topNSlowQueryLoop()
 	go do.infoSyncerKeeper()
-	go do.renewLease()
 	go do.globalConfigSyncerKeeper()
 	if !skipRegisterToDashboard {
 		do.wg.Add(1)
@@ -1780,22 +1777,6 @@ func (do *Domain) serverIDKeeper() {
 func (do *Domain) MockInfoCacheAndLoadInfoSchema(is infoschema.InfoSchema) {
 	do.infoCache = infoschema.NewCache(16)
 	do.infoCache.Insert(is, 0)
-}
-
-func (do *Domain) renewLease() {
-	defer func() {
-		do.wg.Done()
-		logutil.BgLogger().Info("renew lease goroutine exited.")
-	}()
-	for {
-		select {
-		case <-do.exit:
-			close(do.renewLeaseCh)
-			return
-		case op := <-do.renewLeaseCh:
-			op()
-		}
-	}
 }
 
 func init() {

--- a/executor/slow_query_test.go
+++ b/executor/slow_query_test.go
@@ -54,7 +54,7 @@ func parseLog(retriever *slowQueryRetriever, sctx sessionctx.Context, reader *bu
 }
 
 func newSlowQueryRetriever() (*slowQueryRetriever, error) {
-	newISBuilder, err := infoschema.NewBuilder(nil, nil, nil).InitWithDBInfos(nil, nil, nil, 0)
+	newISBuilder, err := infoschema.NewBuilder(nil, nil).InitWithDBInfos(nil, nil, nil, 0)
 	if err != nil {
 		return nil, err
 	}

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -48,9 +48,8 @@ type Builder struct {
 	// TODO: store is only used by autoid allocators
 	// detach allocators from storage, use passed transaction in the feature
 	store kv.Storage
-	// TODO: renewLeaseCh is only used to pass data between table and domain
-	renewLeaseCh chan func()
-	factory      func() (pools.Resource, error)
+
+	factory func() (pools.Resource, error)
 }
 
 // ApplyDiff applies SchemaDiff to the new InfoSchema.
@@ -711,7 +710,7 @@ func (b *Builder) tableFromMeta(alloc autoid.Allocators, tblInfo *model.TableInf
 			return nil, errors.Trace(err)
 		}
 
-		err = t.Init(b.renewLeaseCh, tmp.(sqlexec.SQLExecutor))
+		err = t.Init(tmp.(sqlexec.SQLExecutor))
 		if err != nil {
 			return nil, errors.Trace(err)
 		}
@@ -755,7 +754,7 @@ func RegisterVirtualTable(dbInfo *model.DBInfo, tableFromMeta tableFromMetaFunc)
 }
 
 // NewBuilder creates a new Builder with a Handle.
-func NewBuilder(store kv.Storage, renewCh chan func(), factory func() (pools.Resource, error)) *Builder {
+func NewBuilder(store kv.Storage, factory func() (pools.Resource, error)) *Builder {
 	return &Builder{
 		store: store,
 		is: &infoSchema{
@@ -764,9 +763,8 @@ func NewBuilder(store kv.Storage, renewCh chan func(), factory func() (pools.Res
 			ruleBundleMap:       map[string]*placement.Bundle{},
 			sortedTablesBuckets: make([]sortedTables, bucketCount),
 		},
-		dirtyDB:      make(map[string]bool),
-		renewLeaseCh: renewCh,
-		factory:      factory,
+		dirtyDB: make(map[string]bool),
+		factory: factory,
 	}
 }
 

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -108,7 +108,7 @@ func TestBasic(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	builder, err := infoschema.NewBuilder(dom.Store(), nil, nil).InitWithDBInfos(dbInfos, nil, nil, 1)
+	builder, err := infoschema.NewBuilder(dom.Store(), nil).InitWithDBInfos(dbInfos, nil, nil, 1)
 	require.NoError(t, err)
 
 	txn, err := store.Begin()
@@ -254,7 +254,7 @@ func TestInfoTables(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	builder, err := infoschema.NewBuilder(store, nil, nil).InitWithDBInfos(nil, nil, nil, 0)
+	builder, err := infoschema.NewBuilder(store, nil).InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	is := builder.Build()
 
@@ -319,7 +319,7 @@ func TestGetBundle(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	builder, err := infoschema.NewBuilder(store, nil, nil).InitWithDBInfos(nil, nil, nil, 0)
+	builder, err := infoschema.NewBuilder(store, nil).InitWithDBInfos(nil, nil, nil, 0)
 	require.NoError(t, err)
 	is := builder.Build()
 

--- a/session/session.go
+++ b/session/session.go
@@ -669,7 +669,7 @@ func (c *cachedTableRenewLease) renew(ctx context.Context, handle tables.StateRe
 	physicalTime := oracle.GetTimeFromTS(oldLease)
 	newLease := oracle.GoTimeToTS(physicalTime.Add(cacheTableWriteLease))
 
-	succ, err := handle.RenewLease(ctx, tid, newLease, tables.RenewWriteLease)
+	succ, err := handle.RenewWriteLease(ctx, tid, newLease)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/table/table.go
+++ b/table/table.go
@@ -256,7 +256,7 @@ var MockTableFromMeta func(tableInfo *model.TableInfo) Table
 type CachedTable interface {
 	Table
 
-	Init(renewCh chan func(), exec sqlexec.SQLExecutor) error
+	Init(exec sqlexec.SQLExecutor) error
 
 	// TryReadFromCache checks if the cache table is readable.
 	TryReadFromCache(ts uint64, leaseDuration time.Duration) kv.MemBuffer

--- a/table/tables/cache.go
+++ b/table/tables/cache.go
@@ -120,6 +120,7 @@ func (c *cachedTable) Init(exec sqlexec.SQLExecutor) error {
 	if !ok {
 		return errors.New("Need sqlExec rather than sqlexec.SQLExecutor")
 	}
+	raw.ExecuteInternal(context.Background(), "set @@session.tidb_retry_limit = 0")
 	c.handle = NewStateRemote(raw)
 	return nil
 }

--- a/table/tables/cache.go
+++ b/table/tables/cache.go
@@ -120,7 +120,6 @@ func (c *cachedTable) Init(exec sqlexec.SQLExecutor) error {
 	if !ok {
 		return errors.New("Need sqlExec rather than sqlexec.SQLExecutor")
 	}
-	raw.ExecuteInternal(context.Background(), "set @@session.tidb_retry_limit = 0")
 	c.handle = NewStateRemote(raw)
 	return nil
 }

--- a/table/tables/cache.go
+++ b/table/tables/cache.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/failpoint"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx"
@@ -42,7 +43,6 @@ type cachedTable struct {
 	handle    StateRemote
 	totalSize int64
 
-	lockingForRead tokenLimit
 	renewReadLease tokenLimit
 }
 
@@ -81,7 +81,13 @@ func (c *cachedTable) TryReadFromCache(ts uint64, leaseDuration time.Duration) k
 		leaseTime := oracle.GetTimeFromTS(data.Lease)
 		nowTime := oracle.GetTimeFromTS(ts)
 		distance := leaseTime.Sub(nowTime)
-		if distance >= 0 && distance <= leaseDuration/2 {
+
+		var triggerFailpoint bool
+		failpoint.Inject("mockRenewLeaseABA1", func(_ failpoint.Value) {
+			triggerFailpoint = true
+		})
+
+		if distance >= 0 && distance <= leaseDuration/2 || triggerFailpoint {
 			select {
 			case c.renewReadLease <- struct{}{}:
 				go c.renewLease(ts, data, data.Lease, leaseDuration)
@@ -97,7 +103,6 @@ func (c *cachedTable) TryReadFromCache(ts uint64, leaseDuration time.Duration) k
 func newCachedTable(tbl *TableCommon) (table.Table, error) {
 	ret := &cachedTable{
 		TableCommon:    *tbl,
-		lockingForRead: make(chan struct{}, 1),
 		renewReadLease: make(chan struct{}, 1),
 	}
 	return ret, nil
@@ -161,7 +166,7 @@ func (c *cachedTable) loadDataFromOriginalTable(store kv.Storage, lease uint64) 
 
 func (c *cachedTable) UpdateLockForRead(ctx context.Context, store kv.Storage, ts uint64, leaseDuration time.Duration) {
 	select {
-	case c.lockingForRead <- struct{}{}:
+	case c.renewReadLease <- struct{}{}:
 		go c.updateLockForRead(ctx, store, ts, leaseDuration)
 	default:
 		// There is a inflight calling already.
@@ -175,7 +180,7 @@ func (c *cachedTable) updateLockForRead(ctx context.Context, store kv.Storage, t
 				zap.Reflect("r", r),
 				zap.Stack("stack trace"))
 		}
-		<-c.lockingForRead
+		<-c.renewReadLease
 	}()
 
 	// Load data from original table and the update lock information.
@@ -239,8 +244,15 @@ func (c *cachedTable) RemoveRecord(sctx sessionctx.Context, h kv.Handle, r []typ
 	return c.TableCommon.RemoveRecord(sctx, h, r)
 }
 
+// TestMockRenewLeaseABA2 is used by test function TestRenewLeaseABAFailPoint.
+var TestMockRenewLeaseABA2 chan struct{}
+
 func (c *cachedTable) renewLease(ts uint64, data *cacheData, oldLease uint64, leaseDuration time.Duration) {
 	defer func() { <-c.renewReadLease }()
+
+	failpoint.Inject("mockRenewLeaseABA2", func(_ failpoint.Value) {
+		<-TestMockRenewLeaseABA2
+	})
 
 	tid := c.Meta().ID
 	lease := leaseFromTS(ts, leaseDuration)
@@ -255,4 +267,8 @@ func (c *cachedTable) renewLease(ts uint64, data *cacheData, oldLease uint64, le
 			MemBuffer: data.MemBuffer,
 		})
 	}
+
+	failpoint.Inject("mockRenewLeaseABA2", func(_ failpoint.Value) {
+		TestMockRenewLeaseABA2 <- struct{}{}
+	})
 }

--- a/table/tables/state_remote.go
+++ b/table/tables/state_remote.go
@@ -69,8 +69,11 @@ type StateRemote interface {
 	// LockForWrite try to add a write lock to the table with the specified tableID
 	LockForWrite(ctx context.Context, tid int64, leaseDuration time.Duration) (uint64, error)
 
-	// RenewLease attempt to renew the read / write lock on the table with the specified tableID
-	RenewLease(ctx context.Context, tid int64, newTs uint64, op RenewLeaseType) (bool, error)
+	// RenewReadLease attempt to renew the read lock lease on the table with the specified tableID
+	RenewReadLease(ctx context.Context, tid int64, oldLocalLease, newValue uint64) (uint64, error)
+
+	// RenewWriteLease attempt to renew the write lock lease on the table with the specified tableID
+	RenewWriteLease(ctx context.Context, tid int64, newTs uint64) (bool, error)
 }
 
 type sqlExec interface {
@@ -214,27 +217,17 @@ func waitForLeaseExpire(oldReadLease, now uint64) time.Duration {
 	return 0
 }
 
-func (h *stateRemoteHandle) RenewLease(ctx context.Context, tid int64, newLease uint64, op RenewLeaseType) (bool, error) {
-	h.Lock()
-	defer h.Unlock()
-
-	switch op {
-	case RenewReadLease:
-		return h.renewReadLease(ctx, tid, newLease)
-	case RenewWriteLease:
-		return h.renewWriteLease(ctx, tid, newLease)
-	}
-	return false, errors.New("wrong renew lease type")
-}
-
-func (h *stateRemoteHandle) renewReadLease(ctx context.Context, tid int64, newLease uint64) (bool, error) {
-	var succ bool
+// RenewReadLease renew the read lock lease.
+// Return the current lease value on success, and return 0 on fail.
+func (h *stateRemoteHandle) RenewReadLease(ctx context.Context, tid int64, oldLocalLease, newValue uint64) (uint64, error) {
+	var newLease uint64
 	err := h.runInTxn(ctx, func(ctx context.Context, now uint64) error {
-		lockType, oldLease, _, err := h.loadRow(ctx, tid)
+		lockType, remoteLease, _, err := h.loadRow(ctx, tid)
 		if err != nil {
 			return errors.Trace(err)
 		}
-		if now >= oldLease {
+
+		if now >= remoteLease {
 			// read lock had already expired, fail to renew
 			return nil
 		}
@@ -243,19 +236,36 @@ func (h *stateRemoteHandle) renewReadLease(ctx context.Context, tid int64, newLe
 			return nil
 		}
 
-		if newLease > oldLease { // lease should never decrease!
-			err = h.updateRow(ctx, tid, "READ", newLease)
+		// It means that the lease had already been changed by some other TiDB instances.
+		if oldLocalLease != remoteLease {
+			// 1. Data in [cacheDataTS -------- oldLocalLease) time range is also immutable.
+			// 2. Data in [              now ------------------- remoteLease) time range is immutable.
+			//
+			// If now < oldLocalLease, it means data in all the time range is immutable,
+			// so the old cache data is still available.
+			if now < oldLocalLease {
+				newLease = remoteLease
+			}
+			// Otherwise, there might be write operation during the oldLocalLease and the new remoteLease
+			// Make renew lease operation fail.
+			return nil
+		}
+
+		if newValue > remoteLease { // lease should never decrease!
+			err = h.updateRow(ctx, tid, "READ", newValue)
 			if err != nil {
 				return errors.Trace(err)
 			}
+			newLease = newValue
+		} else {
+			newLease = remoteLease
 		}
-		succ = true
 		return nil
 	})
-	return succ, err
+	return newLease, err
 }
 
-func (h *stateRemoteHandle) renewWriteLease(ctx context.Context, tid int64, newLease uint64) (bool, error) {
+func (h *stateRemoteHandle) RenewWriteLease(ctx context.Context, tid int64, newLease uint64) (bool, error) {
 	var succ bool
 	err := h.runInTxn(ctx, func(ctx context.Context, now uint64) error {
 		lockType, oldLease, _, err := h.loadRow(ctx, tid)
@@ -300,6 +310,11 @@ func (h *stateRemoteHandle) rollbackTxn(ctx context.Context) error {
 
 func (h *stateRemoteHandle) runInTxn(ctx context.Context, fn func(ctx context.Context, txnTS uint64) error) error {
 	err := h.beginTxn(ctx)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	_, err = h.execSQL(ctx, "set @@session.tidb_retry_limit = 0")
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/table/tables/state_remote.go
+++ b/table/tables/state_remote.go
@@ -324,7 +324,7 @@ func (h *stateRemoteHandle) runInTxn(ctx context.Context, fn func(ctx context.Co
 }
 
 func (h *stateRemoteHandle) loadRow(ctx context.Context, tid int64) (CachedTableLockType, uint64, uint64, error) {
-	chunkRows, err := h.execSQL(ctx, "select lock_type, lease, oldReadLease from mysql.table_cache_meta where tid = %? for update", tid)
+	chunkRows, err := h.execSQL(ctx, "select lock_type, lease, oldReadLease from mysql.table_cache_meta where tid = %?", tid)
 	if err != nil {
 		return 0, 0, 0, errors.Trace(err)
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32642

Problem Summary:

The change is based on https://github.com/pingcap/tidb/pull/32387, please review that one first.

### What is changed and how it works?

Handle the bug that after Read Locked -> Write -> Read Locked state changes, the renew lease operation success mistakenly.
Now I check `oldLocalLease != remoteLease` to see whether there is another intermediate state change, and prevent the ABA issue.
This change can also reduce the conflict when there are several tidb instances handling renew lease simultaneously.


### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
