### PR TITLE
util/testutil: cleanup testutils depend on pingcap/check

### DIFF
--- a/ddl/column_change_test.go
+++ b/ddl/column_change_test.go
@@ -56,7 +56,7 @@ func TestColumnChangeSuite(t *testing.T) {
 
 func (s *testColumnChangeSuiteToVerify) SetupSuite() {
 	SetWaitTimeWhenErrorOccurred(1 * time.Microsecond)
-	s.store = testCreateStore(s.T(), "test_column_change")
+	s.store = createMockStore(s.T())
 	d, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(s.store),

--- a/ddl/column_test.go
+++ b/ddl/column_test.go
@@ -55,7 +55,7 @@ func TestColumnSuite(t *testing.T) {
 }
 
 func (s *testColumnSuiteToVerify) SetupSuite() {
-	s.store = testCreateStore(s.T(), "test_column")
+	s.store = createMockStore(s.T())
 	d, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(s.store),

--- a/ddl/ddl_test.go
+++ b/ddl/ddl_test.go
@@ -105,13 +105,7 @@ func testNewDDLAndStart(ctx context.Context, options ...Option) (*ddl, error) {
 	return d, err
 }
 
-func testCreateStore(t *testing.T, name string) kv.Storage {
-	store, err := mockstore.NewMockStore()
-	require.NoError(t, err)
-	return store
-}
-
-func testCreateStoreT(t *testing.T, name string) kv.Storage {
+func createMockStore(t *testing.T) kv.Storage {
 	store, err := mockstore.NewMockStore()
 	require.NoError(t, err)
 	return store

--- a/ddl/ddl_worker_test.go
+++ b/ddl/ddl_worker_test.go
@@ -36,14 +36,12 @@ import (
 	"github.com/pingcap/tidb/util/admin"
 	"github.com/pingcap/tidb/util/mock"
 	"github.com/pingcap/tidb/util/sqlexec"
-	"github.com/pingcap/tidb/util/testutil"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
 
 type testDDLSuiteToVerify struct {
 	suite.Suite
-	testutil.CommonHandleSuite
 }
 
 func TestDDLSuite(t *testing.T) {
@@ -74,7 +72,7 @@ func (s *testDDLSerialSuiteToVerify) SetupSuite() {
 }
 
 func (s *testDDLSuiteToVerify) TestCheckOwner() {
-	store := testCreateStore(s.T(), "test_owner")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -97,8 +95,10 @@ func (s *testDDLSuiteToVerify) TestCheckOwner() {
 }
 
 func (s *testDDLSuiteToVerify) TestNotifyDDLJob() {
-	store := testCreateStore(s.T(), "test_notify_job")
-	defer store.Close()
+	store := createMockStore(s.T())
+	defer func() {
+		require.NoError(s.T(), store.Close())
+	}()
 
 	getFirstNotificationAfterStartDDL := func(d *ddl) {
 		select {
@@ -189,7 +189,7 @@ func (s *testDDLSuiteToVerify) TestNotifyDDLJob() {
 
 // testRunWorker tests no job is handled when the value of RunWorker is false.
 func (s *testDDLSerialSuiteToVerify) testRunWorker() {
-	store := testCreateStore(s.T(), "test_run_worker")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -229,7 +229,7 @@ func (s *testDDLSerialSuiteToVerify) testRunWorker() {
 }
 
 func (s *testDDLSuiteToVerify) TestSchemaError() {
-	store := testCreateStore(s.T(), "test_schema_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -251,7 +251,7 @@ func (s *testDDLSuiteToVerify) TestSchemaError() {
 }
 
 func (s *testDDLSuiteToVerify) TestTableError() {
-	store := testCreateStore(s.T(), "test_table_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -305,7 +305,7 @@ func (s *testDDLSuiteToVerify) TestTableError() {
 }
 
 func (s *testDDLSuiteToVerify) TestViewError() {
-	store := testCreateStore(s.T(), "test_view_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -341,7 +341,7 @@ func (s *testDDLSuiteToVerify) TestViewError() {
 }
 
 func (s *testDDLSuiteToVerify) TestInvalidDDLJob() {
-	store := testCreateStore(s.T(), "test_invalid_ddl_job_type_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -370,7 +370,7 @@ func (s *testDDLSuiteToVerify) TestInvalidDDLJob() {
 }
 
 func (s *testDDLSuiteToVerify) TestForeignKeyError() {
-	store := testCreateStore(s.T(), "test_foreign_key_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -401,7 +401,7 @@ func (s *testDDLSuiteToVerify) TestForeignKeyError() {
 }
 
 func (s *testDDLSuiteToVerify) TestIndexError() {
-	store := testCreateStore(s.T(), "test_index_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -450,7 +450,7 @@ func (s *testDDLSuiteToVerify) TestIndexError() {
 }
 
 func (s *testDDLSuiteToVerify) TestColumnError() {
-	store := testCreateStore(s.T(), "test_column_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -511,7 +511,7 @@ func (s *testDDLSuiteToVerify) TestColumnError() {
 }
 
 func (s *testDDLSerialSuiteToVerify) TestAddBatchJobError() {
-	store := testCreateStore(s.T(), "test_add_batch_job_error")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -830,7 +830,7 @@ func checkIdxVisibility(changedTable table.Table, idxName string, expected bool)
 }
 
 func (s *testDDLSerialSuiteToVerify) TestCancelJob() {
-	store := testCreateStore(s.T(), "test_cancel_job")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -1457,7 +1457,7 @@ func (s *testDDLSuiteToVerify) TestIgnorableSpec() {
 }
 
 func (s *testDDLSuiteToVerify) TestBuildJobDependence() {
-	store := testCreateStore(s.T(), "test_set_job_relation")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -1544,7 +1544,7 @@ func addDDLJob(t *testing.T, d *ddl, job *model.Job) {
 }
 
 func (s *testDDLSuiteToVerify) TestParallelDDL() {
-	store := testCreateStore(s.T(), "test_parallel_ddl")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -1750,7 +1750,7 @@ func (s *testDDLSuiteToVerify) TestParallelDDL() {
 }
 
 func (s *testDDLSuiteToVerify) TestDDLPackageExecuteSQL() {
-	store := testCreateStore(s.T(), "test_run_sql")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)

--- a/ddl/foreign_key_test.go
+++ b/ddl/foreign_key_test.go
@@ -100,7 +100,7 @@ func TestForeignKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	store := testCreateStoreT(t, "test_foreign")
+	store := createMockStore(t)
 	defer func() {
 		err := store.Close()
 		require.NoError(t, err)

--- a/ddl/index_change_test.go
+++ b/ddl/index_change_test.go
@@ -46,7 +46,7 @@ func TestIndexChangeSuite(t *testing.T) {
 }
 
 func (s *testIndexChangeSuiteToVerify) SetupSuite() {
-	s.store = testCreateStore(s.T(), "test_index_change")
+	s.store = createMockStore(s.T())
 	d, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(s.store),

--- a/ddl/partition_test.go
+++ b/ddl/partition_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func ExportTestDropAndTruncatePartition(t *testing.T) {
-	store := testCreateStoreT(t, "test_store")
+	store := createMockStore(t)
 	defer func() {
 		err := store.Close()
 		require.NoError(t, err)

--- a/ddl/placement_policy_ddl_test.go
+++ b/ddl/placement_policy_ddl_test.go
@@ -54,7 +54,7 @@ func testCreatePlacementPolicy(t *testing.T, ctx sessionctx.Context, d *ddl, pol
 }
 
 func (s *testDDLSuiteToVerify) TestPlacementPolicyInUse() {
-	store := testCreateStore(s.T(), "test_placement_policy_in_use")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)

--- a/ddl/restart_test.go
+++ b/ddl/restart_test.go
@@ -107,7 +107,7 @@ func testRunInterruptedJob(t *testing.T, d *ddl, job *model.Job) {
 }
 
 func TestSchemaResume(t *testing.T) {
-	store := testCreateStore(t, "test_schema_resume")
+	store := createMockStore(t)
 	defer func() {
 		err := store.Close()
 		require.NoError(t, err)
@@ -147,7 +147,7 @@ func TestSchemaResume(t *testing.T) {
 }
 
 func (s *testStatSuiteToVerify) TestStat() {
-	store := testCreateStore(s.T(), "test_stat")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)
@@ -220,7 +220,7 @@ func TestTableSuite(t *testing.T) {
 }
 
 func (s *testTableSuiteToVerify) SetupSuite() {
-	s.store = testCreateStore(s.T(), "test_table")
+	s.store = createMockStore(s.T())
 	ddl, err := testNewDDLAndStart(
 		context.Background(),
 		WithStore(s.store),

--- a/ddl/schema_test.go
+++ b/ddl/schema_test.go
@@ -92,14 +92,6 @@ func testDropSchema(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.
 	return job, ver
 }
 
-func testDropSchemaT(t *testing.T, ctx sessionctx.Context, d *ddl, dbInfo *model.DBInfo) (*model.Job, int64) {
-	job := buildDropSchemaJob(dbInfo)
-	err := d.doDDLJob(ctx, job)
-	require.NoError(t, err)
-	ver := getSchemaVerT(t, ctx)
-	return job, ver
-}
-
 func isDDLJobDone(test *testing.T, t *meta.Meta) bool {
 	job, err := t.GetDDLJobByIdx(0)
 	require.NoError(test, err)
@@ -142,7 +134,7 @@ func testCheckSchemaState(test *testing.T, d *ddl, dbInfo *model.DBInfo, state m
 }
 
 func ExportTestSchema(t *testing.T) {
-	store := testCreateStore(t, "test_schema")
+	store := createMockStore(t)
 	defer func() {
 		err := store.Close()
 		require.NoError(t, err)
@@ -217,7 +209,7 @@ func ExportTestSchema(t *testing.T) {
 }
 
 func TestSchemaWaitJob(t *testing.T) {
-	store := testCreateStore(t, "test_schema_wait")
+	store := createMockStore(t)
 	defer func() {
 		err := store.Close()
 		require.NoError(t, err)

--- a/ddl/serial_test.go
+++ b/ddl/serial_test.go
@@ -150,7 +150,6 @@ func checkGetMaxTableRowID(ctx *testMaxTableRowIDContext, store kv.Storage, expe
 }
 
 type testSerialSuite struct {
-	CommonHandleSuite
 	store   kv.Storage
 	cluster testutils.Cluster
 	dom     *domain.Domain

--- a/ddl/stat_test.go
+++ b/ddl/stat_test.go
@@ -54,7 +54,7 @@ func (s *testStatSuiteToVerify) getDDLSchemaVer(d *ddl) int64 {
 }
 
 func (s *testSerialStatSuiteToVerify) TestDDLStatsInfo() {
-	store := testCreateStore(s.T(), "test_stat")
+	store := createMockStore(s.T())
 	defer func() {
 		err := store.Close()
 		require.NoError(s.T(), err)

--- a/ddl/table_test.go
+++ b/ddl/table_test.go
@@ -281,7 +281,7 @@ func ExportTestTable(t *testing.T) {
 	testCheckJobDoneT(t, ddl, job, true)
 	checkTableNoCacheTest(t, ddl, dbInfo1, tblInfo)
 
-	testDropSchemaT(t, testNewContext(ddl), ddl, dbInfo)
+	testDropSchema(t, testNewContext(ddl), ddl, dbInfo)
 	err = ddl.Stop()
 	require.NoError(t, err)
 	err = store.Close()

--- a/executor/admin_test.go
+++ b/executor/admin_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/logutil"
@@ -335,7 +336,7 @@ func TestClusteredIndexAdminRecoverIndex(t *testing.T) {
 	// Some index entries are missed.
 	txn, err := store.Begin()
 	require.NoError(t, err)
-	cHandle := testkit.MustNewCommonHandle(t, "1", "3")
+	cHandle := testutil.MustNewCommonHandle(t, "1", "3")
 	err = indexOpr.Delete(sc, txn, types.MakeDatums(2), cHandle)
 	require.NoError(t, err)
 	err = txn.Commit(context.Background())
@@ -794,17 +795,17 @@ func TestClusteredAdminCleanupIndex(t *testing.T) {
 		handle kv.Handle
 		idxVal []types.Datum
 	}{
-		{testkit.MustNewCommonHandle(t, "c1_10", "c3_10"), types.MakeDatums(10)},
-		{testkit.MustNewCommonHandle(t, "c1_10", "c3_11"), types.MakeDatums(11)},
-		{testkit.MustNewCommonHandle(t, "c1_12", "c3_12"), types.MakeDatums(12)},
+		{testutil.MustNewCommonHandle(t, "c1_10", "c3_10"), types.MakeDatums(10)},
+		{testutil.MustNewCommonHandle(t, "c1_10", "c3_11"), types.MakeDatums(11)},
+		{testutil.MustNewCommonHandle(t, "c1_12", "c3_12"), types.MakeDatums(12)},
 	}
 	c3DanglingIdx := []struct {
 		handle kv.Handle
 		idxVal []types.Datum
 	}{
-		{testkit.MustNewCommonHandle(t, "c1_13", "c3_13"), types.MakeDatums("c3_13")},
-		{testkit.MustNewCommonHandle(t, "c1_14", "c3_14"), types.MakeDatums("c3_14")},
-		{testkit.MustNewCommonHandle(t, "c1_15", "c3_15"), types.MakeDatums("c3_15")},
+		{testutil.MustNewCommonHandle(t, "c1_13", "c3_13"), types.MakeDatums("c3_13")},
+		{testutil.MustNewCommonHandle(t, "c1_14", "c3_14"), types.MakeDatums("c3_14")},
+		{testutil.MustNewCommonHandle(t, "c1_15", "c3_15"), types.MakeDatums("c3_15")},
 	}
 	txn, err := store.Begin()
 	require.NoError(t, err)

--- a/expression/builtin_arithmetic_test.go
+++ b/expression/builtin_arithmetic_test.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
@@ -315,7 +315,7 @@ func TestArithmeticMultiply(t *testing.T) {
 		val, err := evalBuiltinFunc(sig, chunk.Row{})
 		if tc.expect[1] == nil {
 			require.NoError(t, err)
-			trequire.DatumEqual(t, types.NewDatum(tc.expect[0]), val)
+			testutil.DatumEqual(t, types.NewDatum(tc.expect[0]), val)
 		} else {
 			require.Error(t, err)
 			require.Regexp(t, tc.expect[1], err.Error())
@@ -388,7 +388,7 @@ func TestArithmeticDivide(t *testing.T) {
 		}
 		val, err := evalBuiltinFunc(sig, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tc.expect), val)
+		testutil.DatumEqual(t, types.NewDatum(tc.expect), val)
 	}
 }
 
@@ -499,7 +499,7 @@ func TestArithmeticIntDivide(t *testing.T) {
 		val, err := evalBuiltinFunc(sig, chunk.Row{})
 		if tc.expect[1] == nil {
 			require.NoError(t, err)
-			trequire.DatumEqual(t, types.NewDatum(tc.expect[0]), val)
+			testutil.DatumEqual(t, types.NewDatum(tc.expect[0]), val)
 		} else {
 			require.Error(t, err)
 			require.Regexp(t, tc.expect[1], err.Error())
@@ -655,7 +655,7 @@ func TestArithmeticMod(t *testing.T) {
 			require.Equal(t, tipb.ScalarFuncSig_ModDecimal, sig.PbCode())
 		}
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tc.expect), val)
+		testutil.DatumEqual(t, types.NewDatum(tc.expect), val)
 	}
 }
 

--- a/expression/builtin_control_test.go
+++ b/expression/builtin_control_test.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/pingcap/tidb/parser/ast"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -50,7 +50,7 @@ func TestCaseWhen(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.Ret), d)
+		testutil.DatumEqual(t, types.NewDatum(tt.Ret), d)
 	}
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(errors.New("can't convert string to bool"), 1, true)))
 	require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestIf(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.Ret), d)
+		testutil.DatumEqual(t, types.NewDatum(tt.Ret), d)
 	}
 	f, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(errors.New("must error"), 1, 2)))
 	require.NoError(t, err)

--- a/expression/builtin_info_test.go
+++ b/expression/builtin_info_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/parser/auth"
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
@@ -323,7 +323,7 @@ func TestFormatBytes(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 }
 
@@ -352,6 +352,6 @@ func TestFormatNanoTime(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 }

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/types/json"
 	"github.com/pingcap/tidb/util/chunk"
@@ -49,7 +49,7 @@ func TestJSONType(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Expected"][0], d)
+		testutil.DatumEqual(t, tt["Expected"][0], d)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestJSONQuote(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Expected"][0], d)
+		testutil.DatumEqual(t, tt["Expected"][0], d)
 	}
 }
 
@@ -982,7 +982,7 @@ func TestJSONValid(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Expected"][0], d)
+		testutil.DatumEqual(t, tt["Expected"][0], d)
 	}
 }
 

--- a/expression/builtin_like_test.go
+++ b/expression/builtin_like_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/terror"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/collate"
@@ -57,7 +57,7 @@ func TestLike(t *testing.T) {
 		require.NoError(t, err, comment)
 		r, err := evalBuiltinFuncConcurrent(f, chunk.Row{})
 		require.NoError(t, err, comment)
-		trequire.DatumEqual(t, types.NewDatum(tt.match), r, comment)
+		testutil.DatumEqual(t, types.NewDatum(tt.match), r, comment)
 	}
 }
 
@@ -90,7 +90,7 @@ func TestRegexp(t *testing.T) {
 		match, err := evalBuiltinFunc(f, chunk.Row{})
 		if tt.err == nil {
 			require.NoError(t, err)
-			trequire.DatumEqual(t, types.NewDatum(tt.match), match, fmt.Sprintf("%v", tt))
+			testutil.DatumEqual(t, types.NewDatum(tt.match), match, fmt.Sprintf("%v", tt))
 		} else {
 			require.True(t, terror.ErrorEqual(err, tt.err))
 		}
@@ -141,7 +141,7 @@ func TestCILike(t *testing.T) {
 		f.setCollator(collate.GetCollator("utf8mb4_general_ci"))
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err, comment)
-		trequire.DatumEqual(t, types.NewDatum(tt.generalMatch), r, comment)
+		testutil.DatumEqual(t, types.NewDatum(tt.generalMatch), r, comment)
 	}
 
 	for _, tt := range tests {
@@ -153,6 +153,6 @@ func TestCILike(t *testing.T) {
 		f.setCollator(collate.GetCollator("utf8mb4_unicode_ci"))
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err, comment)
-		trequire.DatumEqual(t, types.NewDatum(tt.unicodeMatch), r, comment)
+		testutil.DatumEqual(t, types.NewDatum(tt.unicodeMatch), r, comment)
 	}
 }

--- a/expression/builtin_math_test.go
+++ b/expression/builtin_math_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	utilMath "github.com/pingcap/tidb/util/math"
@@ -54,7 +54,7 @@ func TestAbs(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 }
 
@@ -108,7 +108,7 @@ func TestCeil(t *testing.T) {
 				if test.isNil {
 					require.Equal(t, types.KindNull, result.Kind())
 				} else {
-					trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+					testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 				}
 			}
 		}
@@ -224,7 +224,7 @@ func TestFloor(t *testing.T) {
 			if test.isNil {
 				require.Equal(t, types.KindNull, result.Kind())
 			} else {
-				trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+				testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 			}
 		}
 	}
@@ -404,7 +404,7 @@ func TestPow(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 
 	errTbl := []struct {
@@ -481,7 +481,7 @@ func TestRound(t *testing.T) {
 		}
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 }
 
@@ -525,7 +525,7 @@ func TestTruncate(t *testing.T) {
 		require.NotNil(t, f)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 }
 
@@ -659,7 +659,7 @@ func TestSign(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.ret), v)
+		testutil.DatumEqual(t, types.NewDatum(tt.ret), v)
 	}
 }
 
@@ -726,7 +726,7 @@ func TestSqrt(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.Ret), v)
+		testutil.DatumEqual(t, types.NewDatum(tt.Ret), v)
 	}
 }
 
@@ -737,7 +737,7 @@ func TestPi(t *testing.T) {
 
 	pi, err := evalBuiltinFunc(f, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(math.Pi), pi)
+	testutil.DatumEqual(t, types.NewDatum(math.Pi), pi)
 }
 
 func TestRadians(t *testing.T) {
@@ -761,7 +761,7 @@ func TestRadians(t *testing.T) {
 		require.NotNil(t, f)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Ret"][0], v)
+		testutil.DatumEqual(t, tt["Ret"][0], v)
 	}
 
 	invalidArg := "notNum"

--- a/expression/builtin_miscellaneous_test.go
+++ b/expression/builtin_miscellaneous_test.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -56,7 +56,7 @@ func TestInetAton(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, tt["Expected"][0], d)
+		testutil.DatumEqual(t, tt["Expected"][0], d)
 	}
 }
 
@@ -85,14 +85,14 @@ func TestIsIPv4(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 	// test NULL input for is_ipv4
 	var argNull types.Datum
 	f, _ := fc.getFunction(ctx, datumsToConstants([]types.Datum{argNull}))
 	r, err := evalBuiltinFunc(f, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(0), r)
+	testutil.DatumEqual(t, types.NewDatum(0), r)
 }
 
 func TestIsUUID(t *testing.T) {
@@ -120,7 +120,7 @@ func TestIsUUID(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
@@ -174,7 +174,7 @@ func TestAnyValue(t *testing.T) {
 		require.NoError(t, err)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(tt.ret), r)
 	}
 }
 
@@ -197,14 +197,14 @@ func TestIsIPv6(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 	// test NULL input for is_ipv6
 	var argNull types.Datum
 	f, _ := fc.getFunction(ctx, datumsToConstants([]types.Datum{argNull}))
 	r, err := evalBuiltinFunc(f, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(0), r)
+	testutil.DatumEqual(t, types.NewDatum(0), r)
 }
 
 func TestInetNtoa(t *testing.T) {
@@ -227,7 +227,7 @@ func TestInetNtoa(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
@@ -265,7 +265,7 @@ func TestInet6NtoA(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
@@ -296,7 +296,7 @@ func TestInet6AtoN(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
@@ -325,14 +325,14 @@ func TestIsIPv4Mapped(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
 	f, _ := fc.getFunction(ctx, datumsToConstants([]types.Datum{argNull}))
 	r, err := evalBuiltinFunc(f, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(int64(0)), r)
+	testutil.DatumEqual(t, types.NewDatum(int64(0)), r)
 }
 
 func TestIsIPv4Compat(t *testing.T) {
@@ -355,14 +355,14 @@ func TestIsIPv4Compat(t *testing.T) {
 		require.NoError(t, err)
 		result, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+		testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 	}
 
 	var argNull types.Datum
 	f, _ := fc.getFunction(ctx, datumsToConstants([]types.Datum{argNull}))
 	r, err := evalBuiltinFunc(f, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(0), r)
+	testutil.DatumEqual(t, types.NewDatum(0), r)
 }
 
 func TestNameConst(t *testing.T) {
@@ -498,7 +498,7 @@ func TestUUIDToBin(t *testing.T) {
 			if test.isNil {
 				require.Equal(t, types.KindNull, result.Kind())
 			} else {
-				trequire.DatumEqual(t, types.NewDatum(test.expect), result)
+				testutil.DatumEqual(t, types.NewDatum(test.expect), result)
 			}
 		}
 	}
@@ -591,7 +591,7 @@ func TestTidbShard(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, res[i], d)
+		testutil.DatumEqual(t, res[i], d)
 	}
 
 	// tidb_shard("string") always return 167
@@ -602,7 +602,7 @@ func TestTidbShard(t *testing.T) {
 		require.NoError(t, err)
 		d, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, res2[0], d)
+		testutil.DatumEqual(t, res2[0], d)
 	}
 
 	args3 := makeDatums([]int{-1, 0, 1, 9999999999999999})

--- a/expression/builtin_op_test.go
+++ b/expression/builtin_op_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/stretchr/testify/require"
@@ -583,7 +583,7 @@ func TestIsTrueOrFalse(t *testing.T) {
 
 		isTrue, err := evalBuiltinFunc(isTrueSig, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tc.isTrue), isTrue)
+		testutil.DatumEqual(t, types.NewDatum(tc.isTrue), isTrue)
 	}
 
 	for _, tc := range testCases {
@@ -593,7 +593,7 @@ func TestIsTrueOrFalse(t *testing.T) {
 
 		isFalse, err := evalBuiltinFunc(isFalseSig, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tc.isFalse), isFalse)
+		testutil.DatumEqual(t, types.NewDatum(tc.isFalse), isFalse)
 	}
 }
 

--- a/expression/builtin_string_test.go
+++ b/expression/builtin_string_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
@@ -728,7 +728,7 @@ func TestReverse(t *testing.T) {
 		require.NotNil(t, f)
 		d, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Expect"][0], d)
+		testutil.DatumEqual(t, c["Expect"][0], d)
 	}
 }
 
@@ -1428,7 +1428,7 @@ func TestChar(t *testing.T) {
 		require.NotNil(t, f, i)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err, i)
-		trequire.DatumEqual(t, types.NewDatum(result), r, i)
+		testutil.DatumEqual(t, types.NewDatum(result), r, i)
 		if warnCnt != 0 {
 			warnings := ctx.GetSessionVars().StmtCtx.TruncateWarnings(0)
 			require.Equal(t, warnCnt, len(warnings), fmt.Sprintf("%d: %v", i, warnings))
@@ -1462,7 +1462,7 @@ func TestCharLength(t *testing.T) {
 		require.NoError(t, err)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(v.result), r)
+		testutil.DatumEqual(t, types.NewDatum(v.result), r)
 	}
 
 	// Test binary string
@@ -1489,7 +1489,7 @@ func TestCharLength(t *testing.T) {
 		require.NoError(t, err)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(v.result), r)
+		testutil.DatumEqual(t, types.NewDatum(v.result), r)
 	}
 }
 
@@ -1517,7 +1517,7 @@ func TestFindInSet(t *testing.T) {
 		require.NoError(t, err)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c.ret), r, fmt.Sprintf("FindInSet(%s, %s)", c.str, c.strlst))
+		testutil.DatumEqual(t, types.NewDatum(c.ret), r, fmt.Sprintf("FindInSet(%s, %s)", c.str, c.strlst))
 	}
 }
 
@@ -1552,7 +1552,7 @@ func TestField(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(c.ret), r)
 	}
 }
 
@@ -1860,7 +1860,7 @@ func TestMakeSet(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(c.ret), r)
 	}
 }
 
@@ -1991,7 +1991,7 @@ func TestFormat(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(tt.ret), r)
 	}
 
 	origConfig := ctx.GetSessionVars().StmtCtx.TruncateAsWarning
@@ -2002,7 +2002,7 @@ func TestFormat(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(tt.ret), r, fmt.Sprintf("test %v", tt))
+		testutil.DatumEqual(t, types.NewDatum(tt.ret), r, fmt.Sprintf("test %v", tt))
 		if tt.warnings > 0 {
 			warnings := ctx.GetSessionVars().StmtCtx.GetWarnings()
 			require.Lenf(t, warnings, tt.warnings, "test %v", tt)
@@ -2018,22 +2018,22 @@ func TestFormat(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, f2)
 	r2, err := evalBuiltinFunc(f2, chunk.Row{})
-	trequire.DatumEqual(t, types.NewDatum(errors.New("not implemented")), types.NewDatum(err))
-	trequire.DatumEqual(t, types.NewDatum(formatTests2.ret), r2)
+	testutil.DatumEqual(t, types.NewDatum(errors.New("not implemented")), types.NewDatum(err))
+	testutil.DatumEqual(t, types.NewDatum(formatTests2.ret), r2)
 
 	f3, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(formatTests3.number, formatTests3.precision, formatTests3.locale)))
 	require.NoError(t, err)
 	require.NotNil(t, f3)
 	r3, err := evalBuiltinFunc(f3, chunk.Row{})
-	trequire.DatumEqual(t, types.NewDatum(errors.New("not support for the specific locale")), types.NewDatum(err))
-	trequire.DatumEqual(t, types.NewDatum(formatTests3.ret), r3)
+	testutil.DatumEqual(t, types.NewDatum(errors.New("not support for the specific locale")), types.NewDatum(err))
+	testutil.DatumEqual(t, types.NewDatum(formatTests3.ret), r3)
 
 	f4, err := fc.getFunction(ctx, datumsToConstants(types.MakeDatums(formatTests4.number, formatTests4.precision, formatTests4.locale)))
 	require.NoError(t, err)
 	require.NotNil(t, f4)
 	r4, err := evalBuiltinFunc(f4, chunk.Row{})
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum(formatTests4.ret), r4)
+	testutil.DatumEqual(t, types.NewDatum(formatTests4.ret), r4)
 	warnings := ctx.GetSessionVars().StmtCtx.GetWarnings()
 	require.Equal(t, 3, len(warnings))
 	for i := 0; i < 3; i++ {
@@ -2253,7 +2253,7 @@ func TestElt(t *testing.T) {
 		require.NoError(t, err)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(c.ret), r)
 	}
 }
 
@@ -2314,7 +2314,7 @@ func TestBin(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c["Expected"][0]), r)
+		testutil.DatumEqual(t, types.NewDatum(c["Expected"][0]), r)
 	}
 }
 
@@ -2343,7 +2343,7 @@ func TestQuote(t *testing.T) {
 		require.NotNil(t, f)
 		r, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, types.NewDatum(c.ret), r)
+		testutil.DatumEqual(t, types.NewDatum(c.ret), r)
 	}
 }
 

--- a/expression/builtin_time_test.go
+++ b/expression/builtin_time_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/mock"
@@ -107,7 +107,7 @@ func TestDate(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Expect"][0], v)
+		testutil.DatumEqual(t, c["Expect"][0], v)
 	}
 
 	// test year, month and day
@@ -137,42 +137,42 @@ func TestDate(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Year"][0], v)
+		testutil.DatumEqual(t, c["Year"][0], v)
 
 		fc = funcs[ast.Month]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Month"][0], v)
+		testutil.DatumEqual(t, c["Month"][0], v)
 
 		fc = funcs[ast.MonthName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["MonthName"][0], v)
+		testutil.DatumEqual(t, c["MonthName"][0], v)
 
 		fc = funcs[ast.DayOfMonth]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfMonth"][0], v)
+		testutil.DatumEqual(t, c["DayOfMonth"][0], v)
 
 		fc = funcs[ast.DayOfWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfWeek"][0], v)
+		testutil.DatumEqual(t, c["DayOfWeek"][0], v)
 
 		fc = funcs[ast.DayOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfYear"][0], v)
+		testutil.DatumEqual(t, c["DayOfYear"][0], v)
 
 		fc = funcs[ast.Weekday]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
@@ -180,35 +180,35 @@ func TestDate(t *testing.T) {
 		require.NotNil(t, f)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekDay"][0], v)
+		testutil.DatumEqual(t, c["WeekDay"][0], v)
 
 		fc = funcs[ast.DayName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayName"][0], v)
+		testutil.DatumEqual(t, c["DayName"][0], v)
 
 		fc = funcs[ast.Week]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Week"][0], v, fmt.Sprintf("no.%d", ith))
+		testutil.DatumEqual(t, c["Week"][0], v, fmt.Sprintf("no.%d", ith))
 
 		fc = funcs[ast.WeekOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekOfYear"][0], v)
+		testutil.DatumEqual(t, c["WeekOfYear"][0], v)
 
 		fc = funcs[ast.YearWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["YearWeek"][0], v, fmt.Sprintf("no.%d", ith))
+		testutil.DatumEqual(t, c["YearWeek"][0], v, fmt.Sprintf("no.%d", ith))
 	}
 
 	// test nil
@@ -238,42 +238,42 @@ func TestDate(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Year"][0], v)
+		testutil.DatumEqual(t, c["Year"][0], v)
 
 		fc = funcs[ast.Month]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Month"][0], v)
+		testutil.DatumEqual(t, c["Month"][0], v)
 
 		fc = funcs[ast.MonthName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["MonthName"][0], v)
+		testutil.DatumEqual(t, c["MonthName"][0], v)
 
 		fc = funcs[ast.DayOfMonth]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfMonth"][0], v)
+		testutil.DatumEqual(t, c["DayOfMonth"][0], v)
 
 		fc = funcs[ast.DayOfWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfWeek"][0], v)
+		testutil.DatumEqual(t, c["DayOfWeek"][0], v)
 
 		fc = funcs[ast.DayOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfYear"][0], v)
+		testutil.DatumEqual(t, c["DayOfYear"][0], v)
 
 		fc = funcs[ast.Weekday]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
@@ -281,35 +281,35 @@ func TestDate(t *testing.T) {
 		require.NotNil(t, f)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekDay"][0], v)
+		testutil.DatumEqual(t, c["WeekDay"][0], v)
 
 		fc = funcs[ast.DayName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayName"][0], v)
+		testutil.DatumEqual(t, c["DayName"][0], v)
 
 		fc = funcs[ast.Week]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Week"][0], v)
+		testutil.DatumEqual(t, c["Week"][0], v)
 
 		fc = funcs[ast.WeekOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekOfYear"][0], v)
+		testutil.DatumEqual(t, c["WeekOfYear"][0], v)
 
 		fc = funcs[ast.YearWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["YearWeek"][0], v)
+		testutil.DatumEqual(t, c["YearWeek"][0], v)
 	}
 
 	// test nil with 'NO_ZERO_DATE' set in sql_mode
@@ -341,42 +341,42 @@ func TestDate(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Year"][0], v)
+		testutil.DatumEqual(t, c["Year"][0], v)
 
 		fc = funcs[ast.Month]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Month"][0], v)
+		testutil.DatumEqual(t, c["Month"][0], v)
 
 		fc = funcs[ast.MonthName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["MonthName"][0], v)
+		testutil.DatumEqual(t, c["MonthName"][0], v)
 
 		fc = funcs[ast.DayOfMonth]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfMonth"][0], v)
+		testutil.DatumEqual(t, c["DayOfMonth"][0], v)
 
 		fc = funcs[ast.DayOfWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfWeek"][0], v)
+		testutil.DatumEqual(t, c["DayOfWeek"][0], v)
 
 		fc = funcs[ast.DayOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayOfYear"][0], v)
+		testutil.DatumEqual(t, c["DayOfYear"][0], v)
 
 		fc = funcs[ast.Weekday]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
@@ -384,35 +384,35 @@ func TestDate(t *testing.T) {
 		require.NotNil(t, f)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekDay"][0], v)
+		testutil.DatumEqual(t, c["WeekDay"][0], v)
 
 		fc = funcs[ast.DayName]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["DayName"][0], v)
+		testutil.DatumEqual(t, c["DayName"][0], v)
 
 		fc = funcs[ast.Week]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Week"][0], v)
+		testutil.DatumEqual(t, c["Week"][0], v)
 
 		fc = funcs[ast.WeekOfYear]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["WeekOfYear"][0], v)
+		testutil.DatumEqual(t, c["WeekOfYear"][0], v)
 
 		fc = funcs[ast.YearWeek]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["YearWeek"][0], v)
+		testutil.DatumEqual(t, c["YearWeek"][0], v)
 	}
 }
 
@@ -640,7 +640,7 @@ func TestDateFormat(t *testing.T) {
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
 		comment := fmt.Sprintf("no.%d\nobtain:%v\nexpect:%v\n", i, v.GetValue(), c["Expect"][0].GetValue())
-		trequire.DatumEqual(t, c["Expect"][0], v, comment)
+		testutil.DatumEqual(t, c["Expect"][0], v, comment)
 	}
 }
 
@@ -668,35 +668,35 @@ func TestClock(t *testing.T) {
 		require.NoError(t, err)
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Hour"][0], v)
+		testutil.DatumEqual(t, c["Hour"][0], v)
 
 		fc = funcs[ast.Minute]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Minute"][0], v)
+		testutil.DatumEqual(t, c["Minute"][0], v)
 
 		fc = funcs[ast.Second]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Second"][0], v)
+		testutil.DatumEqual(t, c["Second"][0], v)
 
 		fc = funcs[ast.MicroSecond]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["MicroSecond"][0], v)
+		testutil.DatumEqual(t, c["MicroSecond"][0], v)
 
 		fc = funcs[ast.Time]
 		f, err = fc.getFunction(ctx, datumsToConstants(c["Input"]))
 		require.NoError(t, err)
 		v, err = evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
-		trequire.DatumEqual(t, c["Time"][0], v)
+		testutil.DatumEqual(t, c["Time"][0], v)
 	}
 
 	// nil
@@ -2577,7 +2577,7 @@ func TestTimeFormat(t *testing.T) {
 		v, err := evalBuiltinFunc(f, chunk.Row{})
 		require.NoError(t, err)
 		comment := fmt.Sprintf("no.%d\nobtain:%v\nexpect:%v\n", i, v.GetValue(), c["Expect"][0].GetValue())
-		trequire.DatumEqual(t, c["Expect"][0], v, comment)
+		testutil.DatumEqual(t, c["Expect"][0], v, comment)
 	}
 }
 

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -22,7 +22,7 @@ import (
 
 	. "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
-	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/stretchr/testify/assert"
@@ -125,7 +125,7 @@ func TestHandle(t *testing.T) {
 	assert.Equal(t, -1, ih.Compare(ih2))
 	assert.Equal(t, "100", ih.String())
 
-	ch := testkit.MustNewCommonHandle(t, 100, "abc")
+	ch := testutil.MustNewCommonHandle(t, 100, "abc")
 	assert.False(t, ch.IsInt())
 
 	ch2 := ch.Next()
@@ -174,7 +174,7 @@ func TestHandleMap(t *testing.T) {
 	assert.False(t, ok)
 	assert.Nil(t, v)
 
-	ch := testkit.MustNewCommonHandle(t, 100, "abc")
+	ch := testutil.MustNewCommonHandle(t, 100, "abc")
 	m.Set(ch, "a")
 	v, ok = m.Get(ch)
 	assert.True(t, ok)
@@ -186,9 +186,9 @@ func TestHandleMap(t *testing.T) {
 	assert.Nil(t, v)
 
 	m.Set(ch, "a")
-	ch2 := testkit.MustNewCommonHandle(t, 101, "abc")
+	ch2 := testutil.MustNewCommonHandle(t, 101, "abc")
 	m.Set(ch2, "b")
-	ch3 := testkit.MustNewCommonHandle(t, 99, "def")
+	ch3 := testutil.MustNewCommonHandle(t, 99, "def")
 	m.Set(ch3, "c")
 	assert.Equal(t, 3, m.Len())
 

--- a/meta/meta_test.go
+++ b/meta/meta_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/store/mockstore"
-	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/util"
 	"github.com/stretchr/testify/require"
 )
@@ -453,8 +453,8 @@ func TestDDL(t *testing.T) {
 		},
 		{
 			"kv.CommonHandle",
-			testkit.MustNewCommonHandle(t, "abc", 1222, "string"),
-			testkit.MustNewCommonHandle(t, "dddd", 1222, "string"),
+			testutil.MustNewCommonHandle(t, "abc", 1222, "string"),
+			testutil.MustNewCommonHandle(t, "dddd", 1222, "string"),
 		},
 	}
 

--- a/planner/core/expression_test.go
+++ b/planner/core/expression_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/charset"
 	"github.com/pingcap/tidb/parser/mysql"
-	"github.com/pingcap/tidb/testkit/trequire"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/stretchr/testify/require"
 )
@@ -124,13 +124,13 @@ func TestCast(t *testing.T) {
 	f.Charset = charset.CharsetBin
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum([]byte("1")), v)
+	testutil.DatumEqual(t, types.NewDatum([]byte("1")), v)
 
 	f.Tp = mysql.TypeString
 	f.Charset = charset.CharsetUTF8
 	v, err = evalAstExpr(ctx, expr)
 	require.NoError(t, err)
-	trequire.DatumEqual(t, types.NewDatum([]byte("1")), v)
+	testutil.DatumEqual(t, types.NewDatum([]byte("1")), v)
 
 	expr.Expr = ast.NewValueExpr(nil, "", "")
 	v, err = evalAstExpr(ctx, expr)

--- a/testkit/testutil/handle.go
+++ b/testkit/testutil/handle.go
@@ -15,21 +15,23 @@
 //go:build !codes
 // +build !codes
 
-package trequire
+package testutil
 
 import (
 	"testing"
 
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/collate"
+	"github.com/pingcap/tidb/util/codec"
 	"github.com/stretchr/testify/require"
 )
 
-// DatumEqual verifies that the actual value is equal to the expected value. For string datum, they are compared by the binary collation.
-func DatumEqual(t *testing.T, expected, actual types.Datum, msgAndArgs ...interface{}) {
-	sc := new(stmtctx.StatementContext)
-	res, err := actual.Compare(sc, &expected, collate.GetBinaryCollator())
-	require.NoError(t, err, msgAndArgs)
-	require.Zero(t, res, msgAndArgs)
+// MustNewCommonHandle create a common handle with given values.
+func MustNewCommonHandle(t *testing.T, values ...interface{}) kv.Handle {
+	encoded, err := codec.EncodeKey(new(stmtctx.StatementContext), nil, types.MakeDatums(values...)...)
+	require.NoError(t, err)
+	ch, err := kv.NewCommonHandle(encoded)
+	require.NoError(t, err)
+	return ch
 }

--- a/testkit/testutil/require.go
+++ b/testkit/testutil/require.go
@@ -15,23 +15,21 @@
 //go:build !codes
 // +build !codes
 
-package testkit
+package testutil
 
 import (
 	"testing"
 
-	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/types"
-	"github.com/pingcap/tidb/util/codec"
+	"github.com/pingcap/tidb/util/collate"
 	"github.com/stretchr/testify/require"
 )
 
-// MustNewCommonHandle create a common handle with given values.
-func MustNewCommonHandle(t *testing.T, values ...interface{}) kv.Handle {
-	encoded, err := codec.EncodeKey(new(stmtctx.StatementContext), nil, types.MakeDatums(values...)...)
-	require.NoError(t, err)
-	ch, err := kv.NewCommonHandle(encoded)
-	require.NoError(t, err)
-	return ch
+// DatumEqual verifies that the actual value is equal to the expected value. For string datum, they are compared by the binary collation.
+func DatumEqual(t *testing.T, expected, actual types.Datum, msgAndArgs ...interface{}) {
+	sc := new(stmtctx.StatementContext)
+	res, err := actual.Compare(sc, &expected, collate.GetBinaryCollator())
+	require.NoError(t, err, msgAndArgs)
+	require.Zero(t, res, msgAndArgs)
 }

--- a/util/keydecoder/keydecoder_test.go
+++ b/util/keydecoder/keydecoder_test.go
@@ -12,20 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package keydecoder_test
+package keydecoder
 
 import (
 	"testing"
 
 	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser/model"
+	_ "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
-	. "github.com/pingcap/tidb/util/keydecoder"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/util/keydecoder/keydecoder_test.go
+++ b/util/keydecoder/keydecoder_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
-	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	. "github.com/pingcap/tidb/util/keydecoder"
@@ -86,7 +86,7 @@ func TestDecodeKey(t *testing.T) {
 	assert.Equal(t, "", decodedKey.IndexName)
 	assert.Nil(t, decodedKey.IndexValues)
 
-	ch := testkit.MustNewCommonHandle(t, 100, "abc")
+	ch := testutil.MustNewCommonHandle(t, 100, "abc")
 	encodedCommonKey := ch.Encoded()
 	key := []byte{
 		't',

--- a/util/rowDecoder/decoder_test.go
+++ b/util/rowDecoder/decoder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/table/tables"
 	"github.com/pingcap/tidb/tablecodec"
-	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/testutil"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/mock"
@@ -188,7 +188,7 @@ func TestClusterIndexRowDecoder(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, bs)
 
-		r, err := de.DecodeAndEvalRowWithMap(ctx, testkit.MustNewCommonHandle(t, 100, "abc"), bs, time.UTC, nil)
+		r, err := de.DecodeAndEvalRowWithMap(ctx, testutil.MustNewCommonHandle(t, 100, "abc"), bs, time.UTC, nil)
 		require.Nil(t, err)
 
 		for i, col := range cols {

--- a/util/testutil/testutil_test.go
+++ b/util/testutil/testutil_test.go
@@ -27,7 +27,6 @@ func TestT(t *testing.T) {
 }
 
 var _ = Suite(&testTestUtilSuite{})
-var _ = Suite(&testCommonHandleSuite{})
 
 type testTestUtilSuite struct{}
 
@@ -49,25 +48,4 @@ func (s *testTestUtilSuite) TestCompareUnorderedString(c *C) {
 	for _, t := range tbl {
 		c.Assert(CompareUnorderedStringSlice(t.a, t.b), Equals, t.r)
 	}
-}
-
-type testCommonHandleSuite struct {
-	CommonHandleSuite
-	expectedIsCommonHandle bool
-}
-
-func (s *testCommonHandleSuite) TestCommonHandleSuiteRerun(c *C) {
-	c.Assert(s.IsCommonHandle, Equals, s.expectedIsCommonHandle)
-	hd := s.NewHandle().Int(1).Build()
-	if s.expectedIsCommonHandle {
-		c.Assert(hd.IsInt(), IsFalse)
-	} else {
-		c.Assert(hd.IsInt(), IsTrue)
-	}
-	s.expectedIsCommonHandle = true
-	s.RerunWithCommonHandleEnabled(c, s.TestCommonHandleSuiteRerun)
-}
-
-func (s *testCommonHandleSuite) TestCommonHandleSuiteInitState(c *C) {
-	c.Assert(s.IsCommonHandle, IsFalse)
 }


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

### What problem does this PR solve?

Issue Number: close #32660

```release-note
None
```

This is a follow up to #31313 so that we don't use a `RerunWithCommonHandleEnabledWithoutCheck` hack.