### PR TITLE
sessionctx/variable: add audit redact switch

### DIFF
--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -746,6 +746,7 @@ var defaultSysVars = []*SysVar{
 	{ScopeGlobal | ScopeSession, TiDBEnableAmendPessimisticTxn, boolToOnOff(DefTiDBEnableAmendPessimisticTxn)},
 	{ScopeGlobal | ScopeSession, TiDBMultiStatementMode, Off},
 	{ScopeGlobal | ScopeSession, TiDBEnableOrderedResultMode, boolToOnOff(DefTiDBEnableOrderedResultMode)},
+	{ScopeGlobal, TiDBAuditRedactLog, boolToOnOff(DefTiDBAuditRedactLog)},
 }
 
 // SynonymsSysVariables is synonyms of system variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -438,6 +438,11 @@ const (
 
 	// TiDBEnableOrderedResultMode indicates if stabilize query results.
 	TiDBEnableOrderedResultMode = "tidb_enable_ordered_result_mode"
+
+	// TiDBAuditRedactLog indicates whether audit to redact the log. In TiDB 5.2+ this sysvar
+	// is registered with the sysvar API by the plugin directly, but in 4.0 we need
+	// to register it with the server like this.
+	TiDBAuditRedactLog = "tidb_audit_redact_log"
 )
 
 // Default TiDB system variable values.
@@ -542,6 +547,7 @@ const (
 	DefTiDBEnableAmendPessimisticTxn   = false
 	DefTiDBEnableRateLimitAction       = true
 	DefTiDBEnableOrderedResultMode     = false
+	DefTiDBAuditRedactLog              = true
 )
 
 // Process global variables.


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: fixes https://github.com/pingcap/tidb/issues/32677

Problem Summary:

This adds a new system variable `tidb_audit_redact_log`, which is used by plugins.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Covered by existing tests. I ran a manual test to verify that the plugin works with/without this system variable, and when set to off, the behavior in the audit log is correct (full sql statements).

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
The system variable `tidb_audit_redact_log` was added. This is used by the TiDB audit plugin only.
```
