### PR TITLE
br: fix br version to match tikv-server version for ci integration

### DIFF
--- a/br/pkg/lightning/backend/importer/importer_test.go
+++ b/br/pkg/lightning/backend/importer/importer_test.go
@@ -282,12 +282,12 @@ func TestCheckTiDBVersion(t *testing.T) {
 	require.Error(t, err)
 	require.Regexp(t, "^TiDB version too new", err.Error())
 
-	version = "5.7.25-TiDB-v6.0.0"
+	version = "5.7.25-TiDB-v7.0.0"
 	err = checkTiDBVersionByTLS(ctx, tls, requiredMinTiDBVersion, requiredMaxTiDBVersion)
 	require.Error(t, err)
 	require.Regexp(t, "^TiDB version too new", err.Error())
 
-	version = "5.7.25-TiDB-v6.0.0-beta"
+	version = "5.7.25-TiDB-v7.0.0-beta"
 	err = checkTiDBVersionByTLS(ctx, tls, requiredMinTiDBVersion, requiredMaxTiDBVersion)
 	require.Error(t, err)
 	require.Regexp(t, "^TiDB version too new", err.Error())

--- a/br/pkg/version/build/info.go
+++ b/br/pkg/version/build/info.go
@@ -27,7 +27,7 @@ func getReleaseVersion() string {
 	if mysql.TiDBReleaseVersion != "None" {
 		return mysql.TiDBReleaseVersion
 	}
-	return "v5.0.0-master"
+	return "v6.0.0-master"
 }
 
 // AppName is a name of a built binary.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/32805

Problem Summary: 
As issue.

### What is changed and how it works?
Increase `br version` for 6.0 to match the `tikv-server` version.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
