### PR TITLE
planner: Fix the issue that TiDB may dispatch duplicated tasks to TiFlash

### DIFF
--- a/planner/core/fragment.go
+++ b/planner/core/fragment.go
@@ -127,7 +127,7 @@ func (f *Fragment) init(p PhysicalPlan) error {
 		f.TableScan = x
 	case *PhysicalExchangeReceiver:
 		// TODO: after we support partial merge, we should check whether all the target exchangeReceiver is same.
-		f.singleton = x.children[0].(*PhysicalExchangeSender).ExchangeType == tipb.ExchangeType_PassThrough
+		f.singleton = f.singleton || x.children[0].(*PhysicalExchangeSender).ExchangeType == tipb.ExchangeType_PassThrough
 		f.ExchangeReceivers = append(f.ExchangeReceivers, x)
 	case *PhysicalUnionAll:
 		return errors.New("unexpected union all detected")

--- a/planner/core/fragment_test.go
+++ b/planner/core/fragment_test.go
@@ -1,3 +1,17 @@
+// Copyright 2020 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package core
 
 import (

--- a/planner/core/fragment_test.go
+++ b/planner/core/fragment_test.go
@@ -1,0 +1,39 @@
+package core
+
+import (
+	"github.com/pingcap/tipb/go-tipb"
+	"github.com/stretchr/testify/require"
+
+	"testing"
+)
+
+func TestFragmentInitSingleton(t *testing.T) {
+	r1, r2 := &PhysicalExchangeReceiver{}, &PhysicalExchangeReceiver{}
+	r1.SetChildren(&PhysicalExchangeSender{ExchangeType: tipb.ExchangeType_PassThrough})
+	r2.SetChildren(&PhysicalExchangeSender{ExchangeType: tipb.ExchangeType_Broadcast})
+	p := &PhysicalHashJoin{}
+
+	f := &Fragment{}
+	p.SetChildren(r1, r1)
+	err := f.init(p)
+	require.NoError(t, err)
+	require.Equal(t, f.singleton, true)
+
+	f = &Fragment{}
+	p.SetChildren(r1, r2)
+	err = f.init(p)
+	require.NoError(t, err)
+	require.Equal(t, f.singleton, true)
+
+	f = &Fragment{}
+	p.SetChildren(r2, r1)
+	err = f.init(p)
+	require.NoError(t, err)
+	require.Equal(t, f.singleton, true)
+
+	f = &Fragment{}
+	p.SetChildren(r2, r2)
+	err = f.init(p)
+	require.NoError(t, err)
+	require.Equal(t, f.singleton, false)
+}


### PR DESCRIPTION
### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

so stupid.
-->

Issue Number: close https://github.com/pingcap/tidb/issues/32814, https://github.com/pingcap/tics/issues/4163

Problem Summary:

1. if a fragment has two children, one's ExchangeSender is Broadcast Type, another's is Type PassThrough.
2. This fragment should be singleton, but because of the wrong implementation, it isn't.
3. So this fragment will generate two tasks, and the data will be double.

### What is changed and how it works?

if there is one child with passthrough exchangeType, the fragment will be singleton.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
planner: Fix the issue that TiDB may dispatch duplicated tasks to TiFlash
```
