### PR TITLE
parser: Add not null flag for ExtraPhysTblIDColInfo and ExtraPartitionIDColInfo

### DIFF
--- a/pkg/meta/model/column.go
+++ b/pkg/meta/model/column.go
@@ -303,6 +303,7 @@ func NewExtraPhysTblIDColInfo() *ColumnInfo {
 		Name: ExtraPhysTblIDName,
 	}
 	colInfo.SetType(mysql.TypeLonglong)
+	colInfo.SetFlag(mysql.NotNullFlag)
 	flen, decimal := mysql.GetDefaultFieldLengthAndDecimal(mysql.TypeLonglong)
 	colInfo.SetFlen(flen)
 	colInfo.SetDecimal(decimal)

--- a/pkg/meta/model/column_test.go
+++ b/pkg/meta/model/column_test.go
@@ -100,4 +100,7 @@ func TestDefaultValue(t *testing.T) {
 			require.NotEqual(t, col.GetOriginDefaultValue(), newCol.GetOriginDefaultValue(), comment)
 		}
 	}
+	extraPhysTblIDCol := NewExtraPhysTblIDColInfo()
+	require.Equal(t, mysql.NotNullFlag, extraPhysTblIDCol.GetFlag())
+	require.Equal(t, mysql.TypeLonglong, extraPhysTblIDCol.GetType())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32881

Problem Summary:
Add not null flag for ExtraPhysTblIDColInfo and ExtraPartitionIDColInfo

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
