### PR TITLE
br/stream: Retry apply when meet store errors

### DIFF
--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -313,6 +313,35 @@ func (importer *FileImporter) getKeyRangeForFiles(
 }
 
 // Import tries to import a file.
+func (importer *FileImporter) ImportKVFileForRegion(
+	ctx context.Context,
+	file *backuppb.DataFileInfo,
+	rule *RewriteRules,
+	restoreTs uint64,
+	info *RegionInfo,
+) RPCResult {
+	// Try to download file.
+	result := importer.downloadAndApplyKVFile(ctx, file, rule, info, restoreTs)
+	if !result.OK() {
+		errDownload := result.Err
+		for _, e := range multierr.Errors(errDownload) {
+			switch errors.Cause(e) { // nolint:errorlint
+			case berrors.ErrKVRewriteRuleNotFound, berrors.ErrKVRangeIsEmpty:
+				// Skip this region
+				logutil.CL(ctx).Warn("download file skipped",
+					logutil.Region(info.Region),
+					logutil.ShortError(e))
+				return RPCResultOK()
+			}
+		}
+		logutil.CL(ctx).Warn("download and apply file failed",
+			logutil.ShortError(&result))
+		return result
+	}
+	summary.CollectInt("RegionInvolved", 1)
+	return RPCResultOK()
+}
+
 func (importer *FileImporter) ImportKVFiles(
 	ctx context.Context,
 	file *backuppb.DataFileInfo,
@@ -321,16 +350,9 @@ func (importer *FileImporter) ImportKVFiles(
 ) error {
 	startTime := time.Now()
 	log.Debug("import kv files", zap.String("file", file.Path))
-	var startKey, endKey []byte
-	start, end, err := RewriteFileKeys(file, rule)
+	startKey, endKey, err := RewriteFileKeys(file, rule)
 	if err != nil {
 		return errors.Trace(err)
-	}
-	if len(startKey) == 0 || bytes.Compare(startKey, start) > 0 {
-		startKey = start
-	}
-	if bytes.Compare(endKey, end) < 0 {
-		endKey = end
 	}
 
 	log.Debug("rewrite file keys",
@@ -338,60 +360,18 @@ func (importer *FileImporter) ImportKVFiles(
 		logutil.Key("startKey", startKey),
 		logutil.Key("endKey", endKey))
 
-	err = utils.WithRetry(ctx, func() error {
-		tctx, cancel := context.WithTimeout(ctx, importScanRegionTime)
-		defer cancel()
-		// Scan regions covered by the file range
-		regionInfos, errScanRegion := PaginateScanRegion(
-			tctx, importer.metaClient, startKey, endKey, ScanRegionPaginationLimit)
-		if errScanRegion != nil {
-			return errors.Trace(errScanRegion)
-		}
+	rs := utils.InitialRetryState(16, 100*time.Millisecond, 4*time.Second)
+	ctl := OverRegionsInRange(startKey, endKey, importer.metaClient, rs)
+	err = ctl.Run(ctx, func(ctx context.Context, r *RegionInfo) RPCResult {
+		return importer.ImportKVFileForRegion(ctx, file, rule, restoreTs, r)
+	})
 
-		log.Debug("scan regions", zap.String("name", file.Path), zap.Int("count", len(regionInfos)))
-		// Try to download and ingest the file in every region
-	regionLoop:
-		for _, regionInfo := range regionInfos {
-			info := regionInfo
-			// Try to download file.
-			errDownload := utils.WithRetry(ctx, func() error {
-				return importer.downloadAndApplyKVFile(ctx, file, rule, info, restoreTs)
-			}, utils.NewDownloadSSTBackoffer())
-			if errDownload != nil {
-				for _, e := range multierr.Errors(errDownload) {
-					switch errors.Cause(e) { // nolint:errorlint
-					case berrors.ErrKVRewriteRuleNotFound, berrors.ErrKVRangeIsEmpty:
-						// Skip this region
-						log.Warn("download file skipped",
-							logutil.Region(info.Region),
-							logutil.Key("startKey", startKey),
-							logutil.Key("endKey", endKey),
-							logutil.Key("fileStart", file.StartKey),
-							logutil.Key("fileEnd", file.EndKey),
-							logutil.ShortError(e))
-						continue regionLoop
-					}
-				}
-				log.Error("download and apply file failed",
-					logutil.Region(info.Region),
-					logutil.Key("startKey", startKey),
-					logutil.Key("endKey", endKey),
-					logutil.Key("fileStart", file.StartKey),
-					logutil.Key("fileEnd", file.EndKey),
-					logutil.ShortError(errDownload))
-				return errors.Trace(errDownload)
-			}
-			log.Debug("download and apply file done",
-				zap.String("file", file.Path),
-				zap.Stringer("take", time.Since(startTime)),
-				logutil.Key("fileStart", file.StartKey),
-				logutil.Key("fileEnd", file.EndKey),
-				logutil.Region(info.Region),
-			)
-			summary.CollectInt("RegionInvolved", 1)
-		}
-		return nil
-	}, utils.NewImportSSTBackoffer())
+	log.Debug("download and apply file done",
+		zap.String("file", file.Path),
+		zap.Stringer("take", time.Since(startTime)),
+		logutil.Key("fileStart", file.StartKey),
+		logutil.Key("fileEnd", file.EndKey),
+	)
 	return errors.Trace(err)
 }
 
@@ -784,16 +764,17 @@ func (importer *FileImporter) downloadAndApplyKVFile(
 	rules *RewriteRules,
 	regionInfo *RegionInfo,
 	restoreTs uint64,
-) error {
+) RPCResult {
 	leader := regionInfo.Leader
 	if leader == nil {
-		return errors.Annotatef(berrors.ErrPDLeaderNotFound,
-			"region id %d has no leader", regionInfo.Region.Id)
+		return RPCResultFromError(errors.Annotatef(berrors.ErrPDLeaderNotFound,
+			"region id %d has no leader", regionInfo.Region.Id))
 	}
 	// Get the rewrite rule for the file.
 	fileRule := findMatchedRewriteRule(file, rules)
 	if fileRule == nil {
-		return errors.Trace(berrors.ErrKVRewriteRuleNotFound)
+		return RPCResultFromError(errors.Annotatef(berrors.ErrKVRewriteRuleNotFound,
+			"rewrite rule for file %+v not find (in %+v)", file, rules))
 	}
 	rule := import_sstpb.RewriteRule{
 		OldKeyPrefix: encodeKeyPrefix(fileRule.GetOldKeyPrefix()),
@@ -824,8 +805,15 @@ func (importer *FileImporter) downloadAndApplyKVFile(
 		Context:        reqCtx,
 	}
 	log.Debug("apply kv file", logutil.Leader(leader))
-	_, err := importer.importClient.ApplyKVFile(ctx, leader.GetStoreId(), req)
-	return errors.Trace(err)
+	resp, err := importer.importClient.ApplyKVFile(ctx, leader.GetStoreId(), req)
+	if err != nil {
+		return RPCResultFromError(errors.Trace(err))
+	}
+	if resp.GetError() != nil {
+		logutil.CL(ctx).Warn("backup meet error", zap.Stringer("error", resp.GetError()))
+		return RPCResultFromPBError(resp.GetError())
+	}
+	return RPCResultOK()
 }
 
 func isDecryptSstErr(err error) bool {

--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -1,0 +1,248 @@
+// Copyright 2020 PingCAP, Inc. Licensed under Apache-2.0.
+
+package restore
+
+import (
+	"context"
+	"time"
+
+	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/errorpb"
+	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	berrors "github.com/pingcap/tidb/br/pkg/errors"
+	"github.com/pingcap/tidb/br/pkg/logutil"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"go.uber.org/multierr"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+type RegionFunc func(ctx context.Context, r *RegionInfo) RPCResult
+
+type OverRegionsInRangeController struct {
+	start      []byte
+	end        []byte
+	metaClient SplitClient
+
+	errors error
+	rs     utils.RetryState
+}
+
+// OverRegionsInRange creates a controller that cloud be used to scan regions in a range and
+// apply a function over these regions.
+// You can then call the `Run` method for applying some functions.
+func OverRegionsInRange(start, end []byte, metaClient SplitClient, retryStatus utils.RetryState) OverRegionsInRangeController {
+	return OverRegionsInRangeController{
+		start:      start,
+		end:        end,
+		metaClient: metaClient,
+		rs:         retryStatus,
+	}
+}
+
+func (o *OverRegionsInRangeController) onError(ctx context.Context, result RPCResult, region *RegionInfo) {
+	o.errors = multierr.Append(o.errors, errors.Annotatef(&result, "execute over region %v failed", region.Region))
+	// TODO: Maybe handle some of region errors like `epoch not match`?
+}
+
+func (o *OverRegionsInRangeController) tryFindLeader(ctx context.Context, region *RegionInfo) (*metapb.Peer, error) {
+	var leader *metapb.Peer
+	failed := false
+	leaderRs := utils.InitialRetryState(4, 5*time.Second, 10*time.Second)
+	err := utils.WithRetry(ctx, func() error {
+		r, err := o.metaClient.GetRegionByID(ctx, region.Region.Id)
+		if err != nil {
+			return err
+		}
+		if !checkRegionEpoch(r, region) {
+			failed = true
+			return nil
+		}
+		if r.Leader != nil {
+			leader = r.Leader
+			return nil
+		}
+		return errors.Annotatef(berrors.ErrPDLeaderNotFound, "there is no leader for region %d", region.Region.Id)
+	}, &leaderRs)
+	if failed {
+		return nil, errors.Annotatef(berrors.ErrKVEpochNotMatch, "the current epoch of %s is changed", region)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return leader, nil
+}
+
+// handleInRegionError handles the error happens internal in the region. Update the region info, and perform a suitable backoff.
+func (o *OverRegionsInRangeController) handleInRegionError(ctx context.Context, result RPCResult, region *RegionInfo) (cont bool) {
+
+	if nl := result.StoreError.GetNotLeader(); nl != nil {
+		if nl.Leader != nil {
+			region.Leader = nl.Leader
+			// try the new leader immediately.
+			return true
+		}
+		// we retry manually, simply record the retry event.
+		o.rs.RecordRetry()
+		// There may not be leader, waiting...
+		leader, err := o.tryFindLeader(ctx, region)
+		if err != nil {
+			// Leave the region info unchanged, let it retry then.
+			logutil.CL(ctx).Warn("failed to find leader", logutil.Region(region.Region), logutil.ShortError(err))
+			return false
+		}
+		region.Leader = leader
+		return true
+	}
+	// For other errors, like `ServerIsBusy`, `RegionIsNotInitialized`, just trivially backoff.
+	time.Sleep(o.rs.ExponentialBackoff())
+	return true
+}
+
+// Run executes the `regionFunc` over the regions in `o.start` and `o.end`.
+// It would retry the errors according to the `rpcResponse`.
+func (o *OverRegionsInRangeController) Run(ctx context.Context, f RegionFunc) error {
+	if !o.rs.ShouldRetry() {
+		return o.errors
+	}
+	tctx, cancel := context.WithTimeout(ctx, importScanRegionTime)
+	defer cancel()
+	// Scan regions covered by the file range
+	regionInfos, errScanRegion := PaginateScanRegion(
+		tctx, o.metaClient, o.start, o.end, ScanRegionPaginationLimit)
+	if errScanRegion != nil {
+		return errors.Trace(errScanRegion)
+	}
+
+	// Try to download and ingest the file in every region
+	lctx := logutil.ContextWithField(
+		ctx,
+		logutil.Key("startKey", o.start),
+		logutil.Key("endKey", o.end),
+	)
+
+	for _, region := range regionInfos {
+		cont, err := o.runInRegion(lctx, f, region)
+		if err != nil {
+			return err
+		}
+		if !cont {
+			return nil
+		}
+	}
+	return nil
+}
+
+// runInRegion executes the function in the region, and returns `cont = false` if no need for trying for next region.
+func (o *OverRegionsInRangeController) runInRegion(ctx context.Context, f RegionFunc, region *RegionInfo) (cont bool, err error) {
+	if !o.rs.ShouldRetry() {
+		return false, o.errors
+	}
+	result := f(ctx, region)
+
+	if !result.OK() {
+		o.onError(ctx, result, region)
+		switch result.StrategyForRetry() {
+		case giveUp:
+			logutil.CL(ctx).Warn("unexpected error, should stop to retry", logutil.ShortError(&result), logutil.Region(region.Region))
+			return false, o.errors
+		case fromThisRegion:
+			logutil.CL(ctx).Warn("retry for region", logutil.Region(region.Region), logutil.ShortError(&result))
+			if !o.handleInRegionError(ctx, result, region) {
+				return false, o.Run(ctx, f)
+			}
+			return o.runInRegion(ctx, f, region)
+		case fromStart:
+			logutil.CL(ctx).Warn("retry for execution over regions", logutil.ShortError(&result))
+			// TODO: make a backoffer considering more about the error info,
+			//       instead of ingore the result and retry.
+			time.Sleep(o.rs.ExponentialBackoff())
+			return false, o.Run(ctx, f)
+		}
+	}
+	return true, nil
+}
+
+// RPCResult is the result after executing some RPCs to TiKV.
+type RPCResult struct {
+	Err error
+
+	ImportError string
+	StoreError  *errorpb.Error
+}
+
+func RPCResultFromPBError(err *import_sstpb.Error) RPCResult {
+	return RPCResult{
+		ImportError: err.GetMessage(),
+		StoreError:  err.GetStoreError(),
+	}
+}
+
+func RPCResultFromError(err error) RPCResult {
+	return RPCResult{
+		Err: err,
+	}
+}
+
+func RPCResultOK() RPCResult {
+	return RPCResult{}
+}
+
+type retryStrategy int
+
+const (
+	giveUp retryStrategy = iota
+	fromThisRegion
+	fromStart
+)
+
+func (r *RPCResult) StrategyForRetry() retryStrategy {
+	if r.Err != nil {
+		return r.StrategyForRetryGoError()
+	}
+	return r.StrategyForRetryStoreError()
+}
+
+func (r *RPCResult) StrategyForRetryStoreError() retryStrategy {
+	if r.StoreError == nil {
+		return giveUp
+	}
+
+	if r.StoreError.GetServerIsBusy() != nil ||
+		r.StoreError.GetRegionNotInitialized() != nil ||
+		r.StoreError.GetNotLeader() != nil {
+		return fromThisRegion
+	}
+
+	return fromStart
+}
+
+func (r *RPCResult) StrategyForRetryGoError() retryStrategy {
+	if r.Err == nil {
+		return giveUp
+	}
+
+	if gRPCErr, ok := status.FromError(r.Err); ok {
+		switch gRPCErr.Code() {
+		case codes.Unavailable, codes.Aborted, codes.ResourceExhausted:
+			return fromThisRegion
+		}
+	}
+
+	return giveUp
+}
+
+func (r *RPCResult) Error() string {
+	if r.Err != nil {
+		return r.Err.Error()
+	}
+	if r.StoreError != nil {
+		return r.StoreError.GetMessage()
+	}
+	return "<no error>"
+}
+
+func (r *RPCResult) OK() bool {
+	return r.Err == nil && r.ImportError == "" && r.StoreError == nil
+}

--- a/br/pkg/restore/import_retry_test.go
+++ b/br/pkg/restore/import_retry_test.go
@@ -1,0 +1,262 @@
+// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+
+package restore_test
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	"github.com/pingcap/kvproto/pkg/errorpb"
+	"github.com/pingcap/kvproto/pkg/import_sstpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/br/pkg/restore"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/pingcap/tidb/store/pdtypes"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/stretchr/testify/require"
+)
+
+func assertDecode(t *testing.T, key []byte) []byte {
+	if len(key) == 0 {
+		return []byte{}
+	}
+	_, decoded, err := codec.DecodeBytes(key, nil)
+	require.NoError(t, err)
+	return decoded
+}
+
+func assertRegions(t *testing.T, regions []*restore.RegionInfo, keys ...string) {
+	require.Equal(t, len(regions)+1, len(keys))
+	last := keys[0]
+	for i, r := range regions {
+		start := assertDecode(t, r.Region.StartKey)
+		end := assertDecode(t, r.Region.EndKey)
+
+		require.Equal(t, start, []byte(last), "not match for region: %+v", *r)
+		last = keys[i+1]
+		require.Equal(t, end, []byte(last), "not match for region: %+v", *r)
+	}
+}
+
+func TestScanSuccess(t *testing.T) {
+	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
+	cli := initTestClient()
+	rs := utils.InitialRetryState(1, 0, 0)
+	ctl := restore.OverRegionsInRange([]byte("aaz"), []byte("bb"), cli, rs)
+	ctx := context.Background()
+	colletedRegions := []*restore.RegionInfo{}
+	ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		colletedRegions = append(colletedRegions, r)
+		return restore.RPCResultOK()
+	})
+	assertRegions(t, colletedRegions, "aay", "bba")
+
+	ctl = restore.OverRegionsInRange([]byte("aa"), []byte("cc"), cli, rs)
+	colletedRegions = []*restore.RegionInfo{}
+	ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		colletedRegions = append(colletedRegions, r)
+		return restore.RPCResultOK()
+	})
+	assertRegions(t, colletedRegions, "", "aay", "bba", "bbh", "cca")
+
+	ctl = restore.OverRegionsInRange([]byte("aa"), []byte(""), cli, rs)
+	colletedRegions = []*restore.RegionInfo{}
+	ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		colletedRegions = append(colletedRegions, r)
+		return restore.RPCResultOK()
+	})
+	assertRegions(t, colletedRegions, "", "aay", "bba", "bbh", "cca", "")
+}
+
+func TestNotLeader(t *testing.T) {
+	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
+	cli := initTestClient()
+	rs := utils.InitialRetryState(1, 0, 0)
+	ctl := restore.OverRegionsInRange([]byte(""), []byte(""), cli, rs)
+	ctx := context.Background()
+
+	notLeader := errorpb.Error{
+		NotLeader: &errorpb.NotLeader{
+			Leader: &metapb.Peer{
+				Id: 42,
+			},
+		},
+	}
+	// record the regions we didn't touch.
+	meetRegions := []*restore.RegionInfo{}
+	// record all regions we meet with id == 2.
+	idEqualsTo2Regions := []*restore.RegionInfo{}
+	err := ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		if r.Region.Id == 2 {
+			idEqualsTo2Regions = append(idEqualsTo2Regions, r)
+		}
+		if r.Region.Id == 2 && (r.Leader == nil || r.Leader.Id != 42) {
+			return restore.RPCResult{
+				StoreError: &notLeader,
+			}
+		}
+		meetRegions = append(meetRegions, r)
+		return restore.RPCResultOK()
+	})
+
+	require.NoError(t, err)
+	require.Len(t, idEqualsTo2Regions, 2)
+	if idEqualsTo2Regions[1].Leader != nil {
+		require.NotEqual(t, 42, idEqualsTo2Regions[0].Leader.Id)
+	}
+	require.EqualValues(t, 42, idEqualsTo2Regions[1].Leader.Id)
+	assertRegions(t, meetRegions, "", "aay", "bba", "bbh", "cca", "")
+}
+
+func printRegion(name string, infos []*restore.RegionInfo) {
+	fmt.Printf(">>>>> %s <<<<<\n", name)
+	for _, info := range infos {
+		fmt.Printf("[%d] %s ~ %s\n", info.Region.Id, hex.EncodeToString(info.Region.StartKey), hex.EncodeToString(info.Region.EndKey))
+	}
+	fmt.Printf("<<<<< %s >>>>>\n", name)
+}
+
+func printPDRegion(name string, infos []*pdtypes.Region) {
+	fmt.Printf(">>>>> %s <<<<<\n", name)
+	for _, info := range infos {
+		fmt.Printf("[%d] %s ~ %s\n", info.Meta.Id, hex.EncodeToString(info.Meta.StartKey), hex.EncodeToString(info.Meta.EndKey))
+	}
+	fmt.Printf("<<<<< %s >>>>>\n", name)
+}
+
+func TestEpochNotMatch(t *testing.T) {
+	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
+	cli := initTestClient()
+	rs := utils.InitialRetryState(2, 0, 0)
+	ctl := restore.OverRegionsInRange([]byte(""), []byte(""), cli, rs)
+	ctx := context.Background()
+
+	printPDRegion("cli", cli.regionsInfo.Regions)
+	regions, err := restore.PaginateScanRegion(ctx, cli, []byte("aaz"), []byte("bbb"), 2)
+	require.NoError(t, err)
+	require.Len(t, regions, 2)
+	left, right := regions[0], regions[1]
+	info := restore.RegionInfo{
+		Region: &metapb.Region{
+			StartKey: left.Region.StartKey,
+			EndKey:   right.Region.EndKey,
+			Id:       42,
+			Peers: []*metapb.Peer{
+				{Id: 43},
+			},
+		},
+		Leader: &metapb.Peer{Id: 43},
+	}
+	newRegion := pdtypes.NewRegionInfo(info.Region, info.Leader)
+	mergeRegion := func() {
+		cli.regionsInfo.SetRegion(newRegion)
+		cli.regions[42] = &info
+	}
+	epochNotMatch := &import_sstpb.Error{
+		Message: "Epoch not match",
+		StoreError: &errorpb.Error{
+			EpochNotMatch: &errorpb.EpochNotMatch{
+				CurrentRegions: []*metapb.Region{info.Region},
+			},
+		}}
+	firstRunRegions := []*restore.RegionInfo{}
+	secondRunRegions := []*restore.RegionInfo{}
+	isSecondRun := false
+	err = ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		if !isSecondRun && r.Region.Id == left.Region.Id {
+			mergeRegion()
+			isSecondRun = true
+			return restore.RPCResultFromPBError(epochNotMatch)
+		}
+		if isSecondRun {
+			secondRunRegions = append(secondRunRegions, r)
+		} else {
+			firstRunRegions = append(firstRunRegions, r)
+		}
+		return restore.RPCResultOK()
+	})
+	printRegion("first", firstRunRegions)
+	printRegion("second", secondRunRegions)
+	printPDRegion("cli", cli.regionsInfo.Regions)
+	assertRegions(t, firstRunRegions, "", "aay")
+	assertRegions(t, secondRunRegions, "", "aay", "bbh", "cca", "")
+	require.NoError(t, err)
+}
+
+func TestRegionSplit(t *testing.T) {
+	// region: [, aay), [aay, bba), [bba, bbh), [bbh, cca), [cca, )
+	cli := initTestClient()
+	rs := utils.InitialRetryState(2, 0, 0)
+	ctl := restore.OverRegionsInRange([]byte(""), []byte(""), cli, rs)
+	ctx := context.Background()
+
+	printPDRegion("cli", cli.regionsInfo.Regions)
+	regions, err := restore.PaginateScanRegion(ctx, cli, []byte("aaz"), []byte("aazz"), 1)
+	require.NoError(t, err)
+	require.Len(t, regions, 1)
+	target := regions[0]
+
+	newRegions := []*restore.RegionInfo{
+		{
+			Region: &metapb.Region{
+				Id:       42,
+				StartKey: target.Region.StartKey,
+				EndKey:   codec.EncodeBytes(nil, []byte("aayy")),
+			},
+			Leader: &metapb.Peer{
+				Id: 43,
+			},
+		},
+		{
+			Region: &metapb.Region{
+				Id:       44,
+				StartKey: codec.EncodeBytes(nil, []byte("aayy")),
+				EndKey:   target.Region.EndKey,
+			},
+			Leader: &metapb.Peer{
+				Id: 45,
+			},
+		},
+	}
+	splitRegion := func() {
+		for _, r := range newRegions {
+			newRegion := pdtypes.NewRegionInfo(r.Region, r.Leader)
+			cli.regionsInfo.SetRegion(newRegion)
+			cli.regions[r.Region.Id] = r
+		}
+	}
+	epochNotMatch := &import_sstpb.Error{
+		Message: "Epoch not match",
+		StoreError: &errorpb.Error{
+			EpochNotMatch: &errorpb.EpochNotMatch{
+				CurrentRegions: []*metapb.Region{
+					newRegions[0].Region,
+					newRegions[1].Region,
+				},
+			},
+		}}
+	firstRunRegions := []*restore.RegionInfo{}
+	secondRunRegions := []*restore.RegionInfo{}
+	isSecondRun := false
+	err = ctl.Run(ctx, func(ctx context.Context, r *restore.RegionInfo) restore.RPCResult {
+		if !isSecondRun && r.Region.Id == target.Region.Id {
+			splitRegion()
+			isSecondRun = true
+			return restore.RPCResultFromPBError(epochNotMatch)
+		}
+		if isSecondRun {
+			secondRunRegions = append(secondRunRegions, r)
+		} else {
+			firstRunRegions = append(firstRunRegions, r)
+		}
+		return restore.RPCResultOK()
+	})
+	printRegion("first", firstRunRegions)
+	printRegion("second", secondRunRegions)
+	printPDRegion("cli", cli.regionsInfo.Regions)
+	assertRegions(t, firstRunRegions, "", "aay")
+	assertRegions(t, secondRunRegions, "", "aay", "aayy", "bba", "bbh", "cca", "")
+	require.NoError(t, err)
+}

--- a/br/pkg/utils/backoff.go
+++ b/br/pkg/utils/backoff.go
@@ -31,6 +31,59 @@ const (
 	resetTSMaxWaitInterval = 500 * time.Millisecond
 )
 
+// RetryState is the mutable state needed for retrying.
+// It likes the `utils.Backoffer`, but more fundamental:
+// this only control the backoff time and knows nothing about what error happens.
+// NOTE: Maybe also implement the backoffer via this.
+type RetryState struct {
+	maxRetry   int
+	retryTimes int
+
+	maxBackoff  time.Duration
+	nextBackoff time.Duration
+}
+
+// Whether in the current state we can retry.
+func (rs *RetryState) ShouldRetry() bool {
+	return rs.retryTimes < rs.maxRetry
+}
+
+// Get the exponential backoff durion and transform the state.
+func (rs *RetryState) ExponentialBackoff() time.Duration {
+	rs.retryTimes++
+	backoff := rs.nextBackoff
+	rs.nextBackoff *= 2
+	if rs.nextBackoff > rs.maxBackoff {
+		rs.nextBackoff = rs.maxBackoff
+	}
+	return backoff
+}
+
+// InitialRetryState make the initial state for retrying.
+func InitialRetryState(maxRetryTimes int, initialBackoff, maxBackoff time.Duration) RetryState {
+	return RetryState{
+		maxRetry:    maxRetryTimes,
+		maxBackoff:  maxBackoff,
+		nextBackoff: initialBackoff,
+	}
+}
+
+// RecordRetry simply record retry times, and no backoff
+func (rs *RetryState) RecordRetry() {
+	rs.retryTimes++
+}
+
+// Attempt implements the `Backoffer`.
+// TODO: Maybe use this to replace the `exponentialBackoffer` (which is nearly homomorphic to this)?
+func (rs *RetryState) Attempt() int {
+	return rs.maxRetry - rs.retryTimes
+}
+
+// NextBackoff implements the `Backoffer`.
+func (rs *RetryState) NextBackoff(error) time.Duration {
+	return rs.ExponentialBackoff()
+}
+
 type importerBackoffer struct {
 	attempt      int
 	delayTime    time.Duration


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32974 

Problem Summary:

See the issue.

### What is changed and how it works?

1. Made a new "Backoffer" named `overRegionsInRange`, which would retry a function over all regions in some range, it would handle common errors like `EpochNotMatch` or something likewise.
2. Adapt it to the Log Restore.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
It can retry properly.
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/36239017/157434982-9b79206e-7014-4802-b1a8-17946352e793.png">
(The reason of many retry logs burst is probably region split and made many requests sent to stale epoch.)
- [ ] No code


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
