### PR TITLE
executor: fix data race in the AnalyzeColumnsExec

### DIFF
--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -566,6 +566,24 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 			d.mu.hook.OnJobRunBefore(job)
 			d.mu.RUnlock()
 
+			switch job.Type {
+			case model.ActionDropSchema,
+				model.ActionDropTable,
+				model.ActionDropColumn,
+				model.ActionDropIndex,
+				model.ActionDropForeignKey,
+				model.ActionTruncateTable,
+				model.ActionDropView,
+				model.ActionDropPrimaryKey,
+				model.ActionDropSequence,
+				model.ActionDropColumns,
+				model.ActionDropCheckConstraint,
+				model.ActionDropIndexes,
+				model.ActionDropPlacementPolicy:
+				txn.SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlreadyFull)
+			default:
+				txn.SetDiskFullOpt(kvrpcpb.DiskFullOpt_NotAllowedOnFull)
+			}
 			// If running job meets error, we will save this error in job Error
 			// and retry later if the job is not cancelled.
 			schemaVer, runJobErr = w.runDDLJob(d, t, job)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -566,24 +566,6 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 			d.mu.hook.OnJobRunBefore(job)
 			d.mu.RUnlock()
 
-			switch job.Type {
-			case model.ActionDropSchema,
-				model.ActionDropTable,
-				model.ActionDropColumn,
-				model.ActionDropIndex,
-				model.ActionDropForeignKey,
-				model.ActionTruncateTable,
-				model.ActionDropView,
-				model.ActionDropPrimaryKey,
-				model.ActionDropSequence,
-				model.ActionDropColumns,
-				model.ActionDropCheckConstraint,
-				model.ActionDropIndexes,
-				model.ActionDropPlacementPolicy:
-				txn.SetDiskFullOpt(kvrpcpb.DiskFullOpt_AllowedOnAlreadyFull)
-			default:
-				txn.SetDiskFullOpt(kvrpcpb.DiskFullOpt_NotAllowedOnFull)
-			}
 			// If running job meets error, we will save this error in job Error
 			// and retry later if the job is not cancelled.
 			schemaVer, runJobErr = w.runDDLJob(d, t, job)

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -1370,7 +1370,7 @@ workLoop:
 		select {
 		case task, ok := <-taskCh:
 			if !ok {
-				break
+				break workLoop
 			}
 			var collector *statistics.SampleCollector
 			if task.isColumn {

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -820,7 +820,6 @@ type AnalyzeColumnsExec struct {
 	indexes       []*model.IndexInfo
 	core.AnalyzeInfo
 
-	subIndexWorkerWg  *analyzeResultsNotifyWaitGroupWrapper
 	samplingBuilderWg *util.NotifyErrorWaitGroupWrapper
 	samplingMergeWg   *util.WaitGroupWrapper
 
@@ -1142,9 +1141,9 @@ func (e *AnalyzeColumnsExec) handleNDVForSpecialIndexes(indexInfos []*model.Inde
 	if len(tasks) < statsConcurrncy {
 		statsConcurrncy = len(tasks)
 	}
-	e.subIndexWorkerWg = NewAnalyzeResultsNotifyWaitGroupWrapper(resultsCh)
+	var subIndexWorkerWg = NewAnalyzeResultsNotifyWaitGroupWrapper(resultsCh)
 	for i := 0; i < statsConcurrncy; i++ {
-		e.subIndexWorkerWg.Run(func() { e.subIndexWorkerForNDV(taskCh, resultsCh) })
+		subIndexWorkerWg.Run(func() { e.subIndexWorkerForNDV(taskCh, resultsCh) })
 	}
 	for _, task := range tasks {
 		taskCh <- task

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -1185,7 +1185,7 @@ func (e *AnalyzeColumnsExec) subIndexWorkerForNDV(taskCh chan *analyzeTask, resu
 			buf := make([]byte, 4096)
 			stackSize := runtime.Stack(buf, false)
 			buf = buf[:stackSize]
-			logutil.BgLogger().Error("analyze worker panicked", zap.String("stack", string(buf)))
+			logutil.BgLogger().Error("analyze worker panicked", zap.Any("recover", r), zap.String("stack", string(buf)))
 			metrics.PanicCounter.WithLabelValues(metrics.LabelAnalyze).Inc()
 			resultsCh <- &statistics.AnalyzeResults{
 				Err: errAnalyzeWorkerPanic,

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -2326,7 +2326,7 @@ type analyzeResultsNotifyWaitGroupWrapper struct {
 	cnt    atomicutil.Uint64
 }
 
-// analyzeResultsNotifyWaitGroupWrapper is to create analyzeResultsNotifyWaitGroupWrapper
+// NewAnalyzeResultsNotifyWaitGroupWrapper is to create analyzeResultsNotifyWaitGroupWrapper
 func NewAnalyzeResultsNotifyWaitGroupWrapper(notify chan *statistics.AnalyzeResults) *analyzeResultsNotifyWaitGroupWrapper {
 	return &analyzeResultsNotifyWaitGroupWrapper{
 		notify: notify,

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -93,6 +93,9 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	}
 	taskCh := make(chan *analyzeTask, len(e.tasks))
 	resultsCh := make(chan *statistics.AnalyzeResults, len(e.tasks))
+	if len(e.tasks) < concurrency {
+		concurrency = len(e.tasks)
+	}
 	for i := 0; i < concurrency; i++ {
 		e.wg.Run(func() { e.analyzeWorker(taskCh, resultsCh) })
 	}

--- a/executor/analyze.go
+++ b/executor/analyze.go
@@ -109,10 +109,8 @@ func (e *AnalyzeExec) Next(ctx context.Context, req *chunk.Chunk) error {
 		taskCh <- task
 	}
 	close(taskCh)
-	go func() {
-		e.wg.Wait()
-		close(resultsCh)
-	}()
+	e.wg.Wait()
+	close(resultsCh)
 
 	statsHandle := domain.GetDomain(e.ctx).StatsHandle()
 	panicCnt := 0

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -2690,7 +2690,6 @@ func (b *executorBuilder) buildAnalyze(v *plannercore.Analyze) Executor {
 	e := &AnalyzeExec{
 		baseExecutor: newBaseExecutor(b.ctx, v.Schema(), v.ID()),
 		tasks:        make([]*analyzeTask, 0, len(v.ColTasks)+len(v.IdxTasks)),
-		wg:           &sync.WaitGroup{},
 		opts:         v.Opts,
 		OptionsMap:   v.OptionsMap,
 	}

--- a/util/wait_group_wrapper.go
+++ b/util/wait_group_wrapper.go
@@ -16,6 +16,8 @@ package util
 
 import (
 	"sync"
+
+	"go.uber.org/atomic"
 )
 
 // WaitGroupWrapper is a wrapper for sync.WaitGroup
@@ -50,4 +52,37 @@ func (w *WaitGroupWrapper) RunWithRecover(exec func(), recoverFn func(r interfac
 		}()
 		exec()
 	}()
+}
+
+// NotifyErrorWaitGroupWrapper is a wrapper for sync.WaitGroup
+type NotifyErrorWaitGroupWrapper struct {
+	sync.WaitGroup
+	notify chan error
+	cnt    atomic.Uint64
+}
+
+// NewNotifyErrorWaitGroupWrapper is to create NotifyErrorWaitGroupWrapper
+func NewNotifyErrorWaitGroupWrapper(notify chan error) *NotifyErrorWaitGroupWrapper {
+	return &NotifyErrorWaitGroupWrapper{
+		notify: notify,
+		cnt:    *atomic.NewUint64(0),
+	}
+}
+
+// Run runs a function in a goroutine, adds 1 to WaitGroup
+// and calls done when function returns. Please DO NOT use panic
+// in the cb function.
+func (w *NotifyErrorWaitGroupWrapper) Run(exec func()) {
+	w.Add(1)
+	old := w.cnt.Inc() - 1
+	go func(cnt uint64) {
+		defer func() {
+			w.Done()
+			if cnt == 0 {
+				w.Wait()
+				close(w.notify)
+			}
+		}()
+		exec()
+	}(old)
 }

--- a/util/wait_group_wrapper_test.go
+++ b/util/wait_group_wrapper_test.go
@@ -48,3 +48,17 @@ func TestWaitGroupWrapperRunWithRecover(t *testing.T) {
 	wg.Wait()
 	require.Equal(t, expect, val.Load())
 }
+
+func TestNotifyErrorWaitGroupWrapper(t *testing.T) {
+	var expect int32 = 4
+	var errCh = make(chan error, 1)
+	var val atomic.Int32
+	var wg = NewNotifyErrorWaitGroupWrapper(errCh)
+	for i := int32(0); i < expect; i++ {
+		wg.Run(func() {
+			val.Inc()
+		})
+	}
+	<-errCh
+	require.Equal(t, expect, val.Load())
+}


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32978

Problem Summary:

### What is changed and how it works?

- executor/analyze.go:707 it create a goroutine but it has not ```wg.Wait```. so it is a goroutine leak. then it will cause a data race.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
