### PR TITLE
sessionctx,executor: Revert "sessionctx,executor: disallowed set `null` to sysvar"

### DIFF
--- a/cmd/explaintest/r/new_character_set.result
+++ b/cmd/explaintest/r/new_character_set.result
@@ -1,4 +1,3 @@
-set @@sql_mode='';
 drop table if exists t;
 set names utf8mb4;
 create table t (a varchar(255) charset utf8mb4);
@@ -24,6 +23,10 @@ drop table if exists t;
 set names utf8mb4;
 create table t (a varchar(255) charset gbk, b varchar(255) charset utf8mb4, c varchar(255) charset binary);
 insert into t values ('一', '一', '一');
+set @@character_set_results = null;
+select * from t;
+a	b	c
+һ	一	一
 set @@character_set_results = BINARY;
 select * from t;
 a	b	c
@@ -37,8 +40,6 @@ select * from t;
 a	b	c
 一	一	一
 set @@character_set_results = 'utf8mb4';
-set @@character_set_results = null;
-Error 1231: Variable 'character_set_results' can't be set to the value of 'NULL'
 drop table if exists t;
 create table t (a varchar(255) charset utf8mb4);
 set @@character_set_client = 'gbk';

--- a/cmd/explaintest/t/new_character_set.test
+++ b/cmd/explaintest/t/new_character_set.test
@@ -1,4 +1,3 @@
-set @@sql_mode='';
 -- @@character_set_results = 'gbk', TiDB transforms row value into GBK charset.
 drop table if exists t;
 set names utf8mb4;
@@ -13,11 +12,13 @@ drop table if exists 一;
 create table 一 (二 char(20));
 show create table 一;
 
--- @@character_set_results = binary.
+-- @@character_set_results = null or binary.
 drop table if exists t;
 set names utf8mb4;
 create table t (a varchar(255) charset gbk, b varchar(255) charset utf8mb4, c varchar(255) charset binary);
 insert into t values ('一', '一', '一');
+set @@character_set_results = null;
+select * from t;
 set @@character_set_results = BINARY;
 select * from t;
 set @@character_set_results = "BINARY";
@@ -25,9 +26,6 @@ select * from t;
 set names utf8mb4;
 select * from t;
 set @@character_set_results = 'utf8mb4';
-
--- error 1231
-set @@character_set_results = null;
 
 -- Test for @@character_set_client.
 drop table if exists t;

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -743,7 +743,7 @@ func TestColumnCharsetAndCollate(t *testing.T) {
 			collates:    "",
 			exptCharset: "",
 			exptCollate: "",
-			errMsg:      "Unknown charset 'utf16'",
+			errMsg:      "Unknown charset utf16",
 		},
 		{
 			colType:     "varchar(10)",

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2248,11 +2248,6 @@ func (s *testSuiteP2) TestSQLMode(c *C) {
 	tk.MustExec("set sql_mode = 'STRICT_TRANS_TABLES'")
 	tk.MustExec("set @@global.sql_mode = ''")
 
-	_, err = tk.Exec("set sql_mode = null")
-	c.Check(err, NotNil)
-	_, err = tk.Exec("set @@global.sql_mode = null")
-	c.Check(err, NotNil)
-
 	tk2 := testkit.NewTestKit(c, s.store)
 	tk2.MustExec("use test")
 	tk2.MustExec("drop table if exists t2")

--- a/executor/set.go
+++ b/executor/set.go
@@ -299,13 +299,8 @@ func (e *SetExecutor) getVarValue(v *expression.VarAssignment, sysVar *variable.
 		return variable.GetGlobalSystemVar(e.ctx.GetSessionVars(), v.Name)
 	}
 	nativeVal, err := v.Expr.Eval(chunk.Row{})
-	if err != nil {
+	if err != nil || nativeVal.IsNull() {
 		return "", err
-	}
-	// Setting NULL for system variables is not allowed,
-	// See https://github.com/pingcap/tidb/issues/32850#issuecomment-1062527091
-	if nativeVal.IsNull() {
-		return "", variable.ErrWrongValueForVar.GenWithStackByArgs(v.Name, "NULL")
 	}
 	return nativeVal.ToString()
 }

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -50,7 +50,9 @@ func TestSetVar(t *testing.T) {
 	tk.MustExec("SET @a = null;")
 	tk.MustExec("SET @@global.autocommit = 1;")
 
-	tk.MustGetErrCode("SET @@global.autocommit = null;", int(variable.ErrWrongValueForVar.Code()))
+	// TODO: this test case should returns error.
+	// err := tk.ExecToErr("SET @@global.autocommit = null;")
+	// c.Assert(err, NotNil)
 
 	tk.MustExec("SET @@autocommit = 1;")
 	require.Error(t, tk.ExecToErr("SET @@autocommit = null;"))
@@ -131,7 +133,8 @@ func TestSetVar(t *testing.T) {
 	expectErrMsg = "[parser:1115]Unknown character set: 'boguscharsetname'"
 	tk.MustGetErrMsg("set names boguscharsetname", expectErrMsg)
 
-	tk.MustGetErrCode("set character_set_results = NULL", int(variable.ErrWrongValueForVar.Code()))
+	tk.MustExec("set character_set_results = NULL")
+	tk.MustQuery("select @@character_set_results").Check(testkit.Rows(""))
 
 	tk.MustExec("set @@session.ddl_slow_threshold=12345")
 	tk.MustQuery("select @@session.ddl_slow_threshold").Check(testkit.Rows("12345"))
@@ -430,16 +433,19 @@ func TestSetVar(t *testing.T) {
 	require.Error(t, tk.ExecToErr("set tidb_general_log = abc"))
 	require.Error(t, tk.ExecToErr("set tidb_general_log = 123"))
 
+	tk.MustExec(`SET @@character_set_results = NULL;`)
+	tk.MustQuery(`select @@character_set_results;`).Check(testkit.Rows(""))
+
 	varList := []string{"character_set_server", "character_set_client", "character_set_filesystem", "character_set_database"}
 	for _, v := range varList {
 		tk.MustGetErrCode(fmt.Sprintf("SET @@global.%s = @global_start_value;", v), mysql.ErrWrongValueForVar)
 		tk.MustGetErrCode(fmt.Sprintf("SET @@%s = @global_start_value;", v), mysql.ErrWrongValueForVar)
 		tk.MustGetErrCode(fmt.Sprintf("SET @@%s = NULL;", v), mysql.ErrWrongValueForVar)
-		tk.MustGetErrMsg(fmt.Sprintf("SET @@%s = \"\";", v), "Unknown charset ''")
-		tk.MustGetErrMsg(fmt.Sprintf("SET @@%s = \"somecharset\";", v), "Unknown charset 'somecharset'")
+		tk.MustGetErrCode(fmt.Sprintf("SET @@%s = \"\";", v), mysql.ErrWrongValueForVar)
+		tk.MustGetErrMsg(fmt.Sprintf("SET @@%s = \"somecharset\";", v), "Unknown charset somecharset")
 		// we do not support set character_set_xxx or collation_xxx to a collation id.
-		tk.MustGetErrMsg(fmt.Sprintf("SET @@global.%s = 46;", v), "Unknown charset '46'")
-		tk.MustGetErrMsg(fmt.Sprintf("SET @@%s = 46;", v), "Unknown charset '46'")
+		tk.MustGetErrMsg(fmt.Sprintf("SET @@global.%s = 46;", v), "Unknown charset 46")
+		tk.MustGetErrMsg(fmt.Sprintf("SET @@%s = 46;", v), "Unknown charset 46")
 	}
 
 	tk.MustExec("SET SESSION tidb_enable_extended_stats = on")

--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -126,7 +126,7 @@ func GetDefaultCollationLegacy(charset string) (string, error) {
 	case CharsetUTF8, CharsetUTF8MB4, CharsetASCII, CharsetLatin1, CharsetBin:
 		return GetDefaultCollation(charset)
 	default:
-		return "", errors.Errorf("Unknown charset '%s'", charset)
+		return "", errors.Errorf("Unknown charset %s", charset)
 	}
 }
 
@@ -150,7 +150,7 @@ func GetCharsetInfo(cs string) (*Charset, error) {
 		return c, nil
 	}
 
-	return nil, errors.Errorf("Unknown charset '%s'", cs)
+	return nil, errors.Errorf("Unknown charset %s", cs)
 }
 
 // GetCharsetInfoByID returns charset and collation for id as cs_number.

--- a/sessionctx/variable/varsutil.go
+++ b/sessionctx/variable/varsutil.go
@@ -111,6 +111,9 @@ func checkCollation(vars *SessionVars, normalizedValue string, originalValue str
 }
 
 func checkCharacterSet(normalizedValue string, argName string) (string, error) {
+	if normalizedValue == "" {
+		return normalizedValue, errors.Trace(ErrWrongValueForVar.GenWithStackByArgs(argName, "NULL"))
+	}
 	cs, err := charset.GetCharsetInfo(normalizedValue)
 	if err != nil {
 		return normalizedValue, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32987

Problem Summary: JDBC will set `character_set_results` to NULL, TiDB should support it.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
revert #32879
```
