### PR TITLE
ddl: fix data race in TestTiFlashBatchRateLimiter

### DIFF
--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -885,12 +886,17 @@ func TestTiFlashBatchRateLimiter(t *testing.T) {
 
 	// Retrigger, but close session before the whole job ends.
 	var wg util.WaitGroupWrapper
+	var mu sync.Mutex
 	wg.Run(func() {
 		time.Sleep(time.Millisecond * 20)
+		mu.Lock()
+		defer mu.Unlock()
 		tk.Session().Close()
 		logutil.BgLogger().Info("session closed")
 	})
+	mu.Lock()
 	timeOut, err = execWithTimeout(t, tk, time.Second*2, "alter database tiflash_ddl_limit set tiflash replica 1")
+	mu.Unlock()
 	require.NoError(t, err)
 	require.False(t, timeOut)
 	check(5, 5)


### PR DESCRIPTION
Signed-off-by: CalvinNeo <calvinneo1995@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33005

Problem Summary:

`session.Close()` is not thread safe and should be protect.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
