### PR TITLE
br-stream: add precheck before create task

### DIFF
--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -10,20 +10,11 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/br/pkg/pdutil"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/stretchr/testify/require"
-	pd "github.com/tikv/pd/client"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-type fakePDClient struct {
-	pd.Client
-	stores []*metapb.Store
-}
-
-func (c fakePDClient) GetAllStores(context.Context, ...pd.GetStoreOption) ([]*metapb.Store, error) {
-	return append([]*metapb.Store{}, c.stores...), nil
-}
 
 func TestGetAllTiKVStoresWithRetryCancel(t *testing.T) {
 	_ = failpoint.Enable("github.com/pingcap/tidb/br/pkg/conn/hint-GetAllTiKVStores-cancel", "return(true)")
@@ -56,8 +47,8 @@ func TestGetAllTiKVStoresWithRetryCancel(t *testing.T) {
 		},
 	}
 
-	fpdc := fakePDClient{
-		stores: stores,
+	fpdc := utils.FakePDClient{
+		Stores: stores,
 	}
 
 	_, err := GetAllTiKVStoresWithRetry(ctx, fpdc, SkipTiFlash)
@@ -96,8 +87,8 @@ func TestGetAllTiKVStoresWithUnknown(t *testing.T) {
 		},
 	}
 
-	fpdc := fakePDClient{
-		stores: stores,
+	fpdc := utils.FakePDClient{
+		Stores: stores,
 	}
 
 	_, err := GetAllTiKVStoresWithRetry(ctx, fpdc, SkipTiFlash)
@@ -151,8 +142,8 @@ func TestCheckStoresAlive(t *testing.T) {
 		},
 	}
 
-	fpdc := fakePDClient{
-		stores: stores,
+	fpdc := utils.FakePDClient{
+		Stores: stores,
 	}
 
 	kvStores, err := GetAllTiKVStoresWithRetry(ctx, fpdc, SkipTiFlash)
@@ -240,7 +231,7 @@ func TestGetAllTiKVStores(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		pdClient := fakePDClient{stores: testCase.stores}
+		pdClient := utils.FakePDClient{Stores: testCase.stores}
 		stores, err := GetAllTiKVStores(context.Background(), pdClient, testCase.storeBehavior)
 		if len(testCase.expectedError) != 0 {
 			require.Error(t, err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -19,8 +19,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pingcap/kvproto/pkg/metapb"
-	"github.com/pingcap/tidb/br/pkg/httputil"
 	"net/http"
 	"sort"
 	"strings"
@@ -28,11 +26,13 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/backup"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/httputil"
 	"github.com/pingcap/tidb/br/pkg/logutil"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/restore"
@@ -366,6 +366,7 @@ func (s *streamMgr) checkRequirements(ctx context.Context) (bool, error) {
 				return e
 			}
 			supportBackupStream = supportBackupStream && c.BackupStream.EnableStreaming
+			_ = resp.Body.Close()
 			return nil
 		}, utils.NewPDReqBackoffer())
 		if err != nil {

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -17,16 +17,17 @@ package task
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
 	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	"github.com/pingcap/tidb/br/pkg/pdutil"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/stretchr/testify/require"
 	pd "github.com/tikv/pd/client"
-	"net/http"
-	"net/http/httptest"
-	"strings"
-	"testing"
 )
 
 func newMockStreamMgr(pdCli pd.Client, httpCli *http.Client) *streamMgr {

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -1,0 +1,139 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package task
+
+import (
+	"context"
+	"fmt"
+	"github.com/pingcap/kvproto/pkg/metapb"
+	"github.com/pingcap/tidb/br/pkg/conn"
+	"github.com/pingcap/tidb/br/pkg/pdutil"
+	"github.com/pingcap/tidb/br/pkg/utils"
+	"github.com/stretchr/testify/require"
+	pd "github.com/tikv/pd/client"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newMockStreamMgr(pdCli pd.Client, httpCli *http.Client) *streamMgr {
+	pdController := &pdutil.PdController{}
+	pdController.SetPDClient(pdCli)
+	mgr := &conn.Mgr{PdController: pdController}
+	return &streamMgr{mgr: mgr, httpCli: httpCli}
+}
+
+func TestStreamStartChecks(t *testing.T) {
+	cases := []struct {
+		stores        []*metapb.Store
+		content       []string
+		supportStream bool
+	}{
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tiflash",
+						},
+					},
+				},
+			},
+			content: []string{""},
+			// no tikv detected in this case, so support is false.
+			supportStream: false,
+		},
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+			},
+			content: []string{
+				"{\"log-level\": \"debug\", \"backup-stream\": {\"enable-streaming\": true}}",
+			},
+			// one tikv detected in this case and `enable-streaming` is true.
+			supportStream: true,
+		},
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+				{
+					Id:    2,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+			},
+			content: []string{
+				"{\"log-level\": \"debug\", \"backup-stream\": {\"enable-streaming\": true}}",
+				"{\"log-level\": \"debug\", \"backup-stream\": {\"enable-streaming\": false}}",
+			},
+			// two tikv detected in this case and one of them's `enable-streaming` is false.
+			supportStream: false,
+		},
+	}
+
+	ctx := context.Background()
+	for _, ca := range cases {
+		pdCli := utils.FakePDClient{Stores: ca.stores}
+		require.Equal(t, len(ca.content), len(ca.stores))
+		count := 0
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch strings.TrimSpace(r.URL.Path) {
+			case "/config":
+				_, _ = fmt.Fprint(w, ca.content[count])
+			default:
+				http.NotFoundHandler().ServeHTTP(w, r)
+			}
+			count++
+		}))
+
+		for _, s := range ca.stores {
+			s.StatusAddress = mockServer.URL
+		}
+
+		httpCli := mockServer.Client()
+		sMgr := newMockStreamMgr(pdCli, httpCli)
+		support, err := sMgr.checkRequirements(ctx)
+		require.NoError(t, err)
+		require.Equal(t, ca.supportStream, support)
+		mockServer.Close()
+	}
+}

--- a/br/pkg/utils/safe_point.go
+++ b/br/pkg/utils/safe_point.go
@@ -144,6 +144,7 @@ type FakePDClient struct {
 	Stores []*metapb.Store
 }
 
+// GetAllStores return fake stores.
 func (c FakePDClient) GetAllStores(context.Context, ...pd.GetStoreOption) ([]*metapb.Store, error) {
 	return append([]*metapb.Store{}, c.Stores...), nil
 }

--- a/br/pkg/utils/safe_point.go
+++ b/br/pkg/utils/safe_point.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/tikv/client-go/v2/oracle"
@@ -136,4 +137,13 @@ func StartServiceSafePointKeeper(
 		}
 	}()
 	return nil
+}
+
+type FakePDClient struct {
+	pd.Client
+	Stores []*metapb.Store
+}
+
+func (c FakePDClient) GetAllStores(context.Context, ...pd.GetStoreOption) ([]*metapb.Store, error) {
+	return append([]*metapb.Store{}, c.Stores...), nil
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33087

Problem Summary:
make sure that all stores support log backup then create log backup tasks.

### What is changed and how it works?
1. add a check before task starts.
2. use tikv status_address to get config and check when log backup is enabled.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code



### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
