### PR TITLE
infoschema: fix the link in infoschema/tables.go not accessible issue#32659

### DIFF
--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -390,7 +390,7 @@ var tablesCols = []columnInfo{
 	{name: "TIDB_PLACEMENT_POLICY_NAME", tp: mysql.TypeVarchar, size: 64},
 }
 
-// See: http://dev.mysql.com/doc/refman/5.7/en/columns-table.html
+// See: http://dev.mysql.com/doc/refman/5.7/en/information-schema-columns-table.html
 var columnsCols = []columnInfo{
 	{name: "TABLE_CATALOG", tp: mysql.TypeVarchar, size: 512},
 	{name: "TABLE_SCHEMA", tp: mysql.TypeVarchar, size: 64},
@@ -495,7 +495,7 @@ var keyColumnUsageCols = []columnInfo{
 	{name: "REFERENCED_COLUMN_NAME", tp: mysql.TypeVarchar, size: 64},
 }
 
-// See http://dev.mysql.com/doc/refman/5.7/en/referential-constraints-table.html
+// See http://dev.mysql.com/doc/refman/5.7/en/information-schema-referential-constraints-table.html
 var referConstCols = []columnInfo{
 	{name: "CONSTRAINT_CATALOG", tp: mysql.TypeVarchar, size: 512, flag: mysql.NotNullFlag},
 	{name: "CONSTRAINT_SCHEMA", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
@@ -510,13 +510,13 @@ var referConstCols = []columnInfo{
 	{name: "REFERENCED_TABLE_NAME", tp: mysql.TypeVarchar, size: 64, flag: mysql.NotNullFlag},
 }
 
-// See http://dev.mysql.com/doc/refman/5.7/en/variables-table.html
+// See http://dev.mysql.com/doc/refman/5.7/en/information-schema-variables-table.html
 var sessionVarCols = []columnInfo{
 	{name: "VARIABLE_NAME", tp: mysql.TypeVarchar, size: 64},
 	{name: "VARIABLE_VALUE", tp: mysql.TypeVarchar, size: 1024},
 }
 
-// See https://dev.mysql.com/doc/refman/5.7/en/plugins-table.html
+// See https://dev.mysql.com/doc/refman/5.7/en/information-schema-plugins-table.html
 var pluginsCols = []columnInfo{
 	{name: "PLUGIN_NAME", tp: mysql.TypeVarchar, size: 64},
 	{name: "PLUGIN_VERSION", tp: mysql.TypeVarchar, size: 20},
@@ -531,7 +531,7 @@ var pluginsCols = []columnInfo{
 	{name: "LOAD_OPTION", tp: mysql.TypeVarchar, size: 64},
 }
 
-// See https://dev.mysql.com/doc/refman/5.7/en/partitions-table.html
+// See https://dev.mysql.com/doc/refman/5.7/en/information-schema-partitions-table.html
 var partitionsCols = []columnInfo{
 	{name: "TABLE_CATALOG", tp: mysql.TypeVarchar, size: 512},
 	{name: "TABLE_SCHEMA", tp: mysql.TypeVarchar, size: 64},


### PR DESCRIPTION
Signed-off-by: fanrenhoo <fanrenhoo@sina.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32659

Problem Summary: all links in infoschema/tables.go are not accessible

### What is changed and how it works?
The http/https link address should have "information-schema-" started, like:
https://dev.mysql.com/doc/refman/5.7/en/information-schema-partitions-table.html
there are four of the same problem now all fixed

Now it works ok.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
 tested the four new updated links, all accessible now

- [ ] No code

Side effects
no
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
no
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Make the links in infoschema/tables.go all can be accessbile
```
/cc xhebox 