### PR TITLE
executor: fix unstable test TestPlanCacheWithStaleReadByBinaryProto

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1303,15 +1303,22 @@ func TestPlanCacheWithStaleReadByBinaryProto(t *testing.T) {
 	tk.MustExec("create table t1 (id int primary key, v int)")
 	tk.MustExec("insert into t1 values(1, 10)")
 	se := tk.Session()
-	time.Sleep(time.Second * 3)
+	tk.MustExec("set @a=now(6)")
+	time.Sleep(time.Millisecond * 5)
 	tk.MustExec("update t1 set v=100 where id=1")
 
-	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp NOW() - INTERVAL 2 SECOND where id=1")
+	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp @a where id=1")
 	require.NoError(t, err)
 
-	for i := 0; i < 3; i++ {
-		rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-		require.NoError(t, err)
-		tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
-	}
+	rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
+	require.NoError(t, err)
+	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+
+	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
+	require.NoError(t, err)
+	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+
+	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
+	require.NoError(t, err)
+	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
 }

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1302,12 +1302,12 @@ func TestPlanCacheWithStaleReadByBinaryProto(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (id int primary key, v int)")
 	tk.MustExec("insert into t1 values(1, 10)")
-	time.Sleep(time.Second)
 	se := tk.Session()
-	now := time.Now()
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Millisecond * 100)
+	tk.MustExec("set @a=now(6)")
+	time.Sleep(time.Second)
 	tk.MustExec("update t1 set v=100 where id=1")
-	stmtID1, _, _, err := se.PrepareStmt(fmt.Sprintf("select * from t1 as of timestamp '%v' where id=1", now.Format("2006-1-2 15:04:05")))
+	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp @a where id=1")
 	require.NoError(t, err)
 
 	for i := 0; i < 3; i++ {

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1303,22 +1303,15 @@ func TestPlanCacheWithStaleReadByBinaryProto(t *testing.T) {
 	tk.MustExec("create table t1 (id int primary key, v int)")
 	tk.MustExec("insert into t1 values(1, 10)")
 	se := tk.Session()
-	tk.MustExec("set @a=now(6)")
-	time.Sleep(time.Millisecond * 5)
+	time.Sleep(time.Second * 3)
 	tk.MustExec("update t1 set v=100 where id=1")
 
-	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp @a where id=1")
+	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp NOW() - INTERVAL 2 SECOND where id=1")
 	require.NoError(t, err)
 
-	rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
-
-	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
-
-	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+	for i := 0; i < 3; i++ {
+		rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
+		require.NoError(t, err)
+		tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+	}
 }

--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1302,23 +1302,17 @@ func TestPlanCacheWithStaleReadByBinaryProto(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("create table t1 (id int primary key, v int)")
 	tk.MustExec("insert into t1 values(1, 10)")
+	time.Sleep(time.Second)
 	se := tk.Session()
-	tk.MustExec("set @a=now(6)")
-	time.Sleep(time.Millisecond * 5)
+	now := time.Now()
+	time.Sleep(time.Second * 2)
 	tk.MustExec("update t1 set v=100 where id=1")
-
-	stmtID1, _, _, err := se.PrepareStmt("select * from t1 as of timestamp @a where id=1")
+	stmtID1, _, _, err := se.PrepareStmt(fmt.Sprintf("select * from t1 as of timestamp '%v' where id=1", now.Format("2006-1-2 15:04:05")))
 	require.NoError(t, err)
 
-	rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
-
-	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
-
-	rs, err = se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
-	require.NoError(t, err)
-	tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+	for i := 0; i < 3; i++ {
+		rs, err := se.ExecutePreparedStmt(context.TODO(), stmtID1, nil)
+		require.NoError(t, err)
+		tk.ResultSetToResult(rs, fmt.Sprintf("%v", rs)).Check(testkit.Rows("1 10"))
+	}
 }


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33349

Problem Summary:

### What is changed and how it works?

TestPlanCacheWithStaleReadByBinaryProto is unstable due to local time skew error, this request fixed it.

I run `go test -run TestPlanCacheWithStaleReadByBinaryProto -count 10` locally, the result is pass as expected.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
