### PR TITLE
expr: fix instr function get stuck 

### DIFF
--- a/expression/expr_to_pb_test.go
+++ b/expression/expr_to_pb_test.go
@@ -1387,11 +1387,6 @@ func TestExprPushDownToTiKV(t *testing.T) {
 			args:         []Expression{stringColumn, stringColumn, intColumn},
 		},
 		{
-			functionName: ast.Instr,
-			retType:      types.NewFieldType(mysql.TypeInt24),
-			args:         []Expression{stringColumn, stringColumn},
-		},
-		{
 			functionName: ast.Quote,
 			retType:      types.NewFieldType(mysql.TypeString),
 			args:         []Expression{stringColumn},

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -970,7 +970,7 @@ func scalarExprSupportedByTiKV(sf *ScalarFunction) bool {
 		// string functions.
 		ast.Bin, ast.Unhex, ast.Locate, ast.Ord, ast.Lpad, ast.Rpad,
 		ast.Trim, ast.FromBase64, ast.ToBase64, ast.Upper, ast.Lower, ast.InsertFunc,
-		ast.MakeSet, ast.SubstringIndex, ast.Instr, ast.Quote, ast.Oct,
+		ast.MakeSet, ast.SubstringIndex /* ast.Instr */, ast.Quote, ast.Oct,
 		ast.FindInSet, ast.Repeat,
 		ast.Length, ast.BitLength, ast.Concat, ast.ConcatWS, ast.Replace, ast.ASCII, ast.Hex,
 		ast.Reverse, ast.LTrim, ast.RTrim, ast.Strcmp, ast.Space, ast.Elt, ast.Field,

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2912,10 +2912,6 @@ func TestScalarFunctionPushDown(t *testing.T) {
 	tk.MustQuery("explain analyze select /*+read_from_storage(tikv[t])*/ * from t where substring_index(c,c,1)").
 		CheckAt([]int{0, 3, 6}, rows)
 
-	rows[1][2] = "instr(test.t.c, test.t.c)"
-	tk.MustQuery("explain analyze select /*+read_from_storage(tikv[t])*/ * from t where instr(c,c)").
-		CheckAt([]int{0, 3, 6}, rows)
-
 	rows[1][2] = "quote(test.t.c)"
 	tk.MustQuery("explain analyze select /*+read_from_storage(tikv[t])*/ * from t where quote(c)").
 		CheckAt([]int{0, 3, 6}, rows)


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33367

Problem Summary:

### What is changed and how it works?
switch off instr pushing down in tikv in order not to block release 6.0 until we find out reason later

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] manual test
```sql
use test;
source [test.txt](https://github.com/pingcap/tidb/files/8338139/test.txt);

select col1, instr(col1, substr(col1, 3)) from PK_RCP9283 where instr(col1, substr(col1, 3)) >= instr("轜廞豑悒笡ç梎尠理襟", substr("轜廞豑悒笡ç梎尠理襟", 3));
``` 

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
