### PR TITLE
br: restore full and stream by one command

### DIFF
--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -43,12 +43,13 @@ func NewStreamCommand() *cobra.Command {
 	command.AddCommand(
 		newStreamStartCommand(),
 		newStreamStopCommand(),
-		newStreamPauseCommand(),
-		newStreamResumeCommand(),
+		//newStreamPauseCommand(),
+		//newStreamResumeCommand(),
 		newStreamStatusCommand(),
 		newStreamRestoreCommand(),
 		newStreamTruncateCommand(),
 	)
+
 	return command
 }
 
@@ -135,7 +136,8 @@ func newStreamRestoreCommand() *cobra.Command {
 			return streamCommand(command, task.StreamRestore)
 		},
 	}
-	task.DefineFilterFlags(command, acceptAllTables, false)
+	task.DefineRestoreFlags(command.PersistentFlags())
+	task.DefineFilterFlags(command, filterOutSysAndMemTables, false)
 	task.DefineStreamRestoreFlags(command.Flags())
 	return command
 }
@@ -161,12 +163,17 @@ func streamCommand(command *cobra.Command, cmdName string) error {
 			command.SilenceUsage = false
 		}
 	}()
+
+	cfg.Config = task.Config{LogProgress: HasLogFile()}
 	if err = cfg.Config.ParseFromFlags(command.Flags()); err != nil {
 		return errors.Trace(err)
 	}
 
 	switch cmdName {
 	case task.StreamRestore:
+		if err = cfg.RestoreConfig.ParseFromFlags(command.Flags()); err != nil {
+			return errors.Trace(err)
+		}
 		if err = cfg.ParseStreamRestoreFromFlags(command.Flags()); err != nil {
 			return errors.Trace(err)
 		}

--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -83,6 +83,7 @@ func newStreamStopCommand() *cobra.Command {
 	return command
 }
 
+//nolint:unused,deadcode
 func newStreamPauseCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "pause",
@@ -97,6 +98,7 @@ func newStreamPauseCommand() *cobra.Command {
 	return command
 }
 
+//nolint:unused,deadcode
 func newStreamResumeCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "resume",


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33452

Problem Summary: As title.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![image](https://user-images.githubusercontent.com/57036248/160121347-62070a5c-e1a9-45b8-a1f4-f6cf59f5c9c0.png)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Use one command to restore full and stream log.
```
