### PR TITLE
tidb-binlog/pump_client: migrate test-infra to testify

### DIFF
--- a/tidb-binlog/pump_client/bench_test.go
+++ b/tidb-binlog/pump_client/bench_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	pb "github.com/pingcap/tipb/go-binlog"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
@@ -57,10 +58,7 @@ func writeFakeBinlog(b *testing.B, pumpClient *PumpsClient, threadCount int, num
 					StartTs: int64(baseTS + j),
 				}
 				err := pumpClient.WriteBinlog(pBinlog)
-				if err != nil {
-					b.Error(err)
-					return
-				}
+				require.NoError(b, err)
 
 				cBinlog := &pb.Binlog{
 					Tp:       pb.BinlogType_Commit,
@@ -68,10 +66,7 @@ func writeFakeBinlog(b *testing.B, pumpClient *PumpsClient, threadCount int, num
 					CommitTs: int64(baseTS + j),
 				}
 				err = pumpClient.WriteBinlog(cBinlog)
-				if err != nil {
-					b.Error(err)
-					return
-				}
+				require.NoError(b, err)
 			}
 			wg.Done()
 		}(10000000 * i)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33463

Problem Summary: migrate test-infra to testify for tidb-binlog/pump_client pkg

### What is changed and how it works?

- replace the pingcap/check of the tidb-binlog/pump_client package test code with the testify.
- basic test code using testify

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```