### PR TITLE
lightning: fix test lightning_checkpoint_chunks

### DIFF
--- a/br/pkg/lightning/lightning.go
+++ b/br/pkg/lightning/lightning.go
@@ -267,6 +267,9 @@ func (l *Lightning) RunOnceWithOptions(taskCtx context.Context, taskCfg *config.
 	}
 
 	taskCfg.TaskID = time.Now().UnixNano()
+	failpoint.Inject("SetTaskID", func(val failpoint.Value) {
+		taskCfg.TaskID = int64(val.(int))
+	})
 
 	return l.run(taskCtx, taskCfg, o)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33502

Problem Summary:
https://github.com/pingcap/tidb/pull/33303 introduced a new method `RunOnceWithOptions` and Lightning calls this method to run task instead. However, `RunOnceWithOptions` missed the failpoint function. So test failed.

### What is changed and how it works?

Add taskID failpoint.

### Check List

Tests <!-- At least one of them must be included. -->


- [x] Integration test



### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
