### PR TITLE
*: make txnCommitBatchSize adjustable by SQL

### DIFF
--- a/domain/sysvar_cache.go
+++ b/domain/sysvar_cache.go
@@ -243,6 +243,8 @@ func (do *Domain) checkEnableServerGlobalVar(name, sVal string) {
 		variable.StatsLoadSyncWait.Store(val)
 	case variable.TiDBStatsLoadPseudoTimeout:
 		variable.StatsLoadPseudoTimeout.Store(variable.TiDBOptOn(sVal))
+	case variable.TiDBTxnCommitBatchSize:
+		storekv.TxnCommitBatchSize.Store(uint64(variable.TidbOptInt64(sVal, int64(storekv.DefTxnCommitBatchSize))))
 	}
 	if err != nil {
 		logutil.BgLogger().Error(fmt.Sprintf("load global variable %s error", name), zap.Error(err))

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -336,6 +336,14 @@ func TestSetVar(t *testing.T) {
 	tk.MustExec("set global tidb_store_limit = 100")
 	tk.MustQuery("select @@global.tidb_store_limit;").Check(testkit.Rows("100"))
 
+	tk.MustQuery("select @@global.tidb_txn_commit_batch_size;").Check(testkit.Rows("16384"))
+	tk.MustExec("set @@global.tidb_txn_commit_batch_size = 100")
+	tk.MustQuery("select @@global.tidb_txn_commit_batch_size;").Check(testkit.Rows("100"))
+	tk.MustExec("set @@global.tidb_txn_commit_batch_size = 0")
+	tk.MustQuery("select @@global.tidb_txn_commit_batch_size;").Check(testkit.Rows("1"))
+	tk.MustExec("set global tidb_txn_commit_batch_size = 100")
+	tk.MustQuery("select @@global.tidb_txn_commit_batch_size;").Check(testkit.Rows("100"))
+
 	tk.MustQuery("select @@session.tidb_metric_query_step;").Check(testkit.Rows("60"))
 	tk.MustExec("set @@session.tidb_metric_query_step = 120")
 	tk.MustExec("set @@session.tidb_metric_query_step = 9")

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2
-	github.com/tikv/client-go/v2 v2.0.1-0.20220328083738-8489c3e8c3d9
+	github.com/tikv/client-go/v2 v2.0.1-0.20220329092050-6bf6951325ad
 	github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710
 	github.com/twmb/murmur3 v1.1.3
 	github.com/uber/jaeger-client-go v2.22.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -749,8 +749,8 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2 h1:mbAskLJ0oJfDRtkanvQPiooDH8HvJ2FBh+iKT/OmiQQ=
 github.com/tiancaiamao/appdash v0.0.0-20181126055449-889f96f722a2/go.mod h1:2PfKggNGDuadAa0LElHrByyrz4JPZ9fFx6Gs7nx7ZZU=
-github.com/tikv/client-go/v2 v2.0.1-0.20220328083738-8489c3e8c3d9 h1:TgSywPECh84B5S6Z97jhMdQVrezPwUbOKbCZFie2kPI=
-github.com/tikv/client-go/v2 v2.0.1-0.20220328083738-8489c3e8c3d9/go.mod h1:0scaG+seu7L56apm+Gjz9vckyO7ABIzM6T7n00mrIXs=
+github.com/tikv/client-go/v2 v2.0.1-0.20220329092050-6bf6951325ad h1:Imm87gW7/Pra/NdUc7D3wkdtlZgo/iw0lSLIWZPiMS0=
+github.com/tikv/client-go/v2 v2.0.1-0.20220329092050-6bf6951325ad/go.mod h1:0scaG+seu7L56apm+Gjz9vckyO7ABIzM6T7n00mrIXs=
 github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710 h1:jxgmKOscXSjaFEKQGRyY5qOpK8hLqxs2irb/uDJMtwk=
 github.com/tikv/pd/client v0.0.0-20220307081149-841fa61e9710/go.mod h1:AtvppPwkiyUgQlR1W9qSqfTB+OsOIu19jDCOxOsPkmU=
 github.com/tklauser/go-sysconf v0.3.9 h1:JeUVdAOWhhxVcU6Eqr/ATFHgXk/mmiItdKeJPev3vTo=

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -529,7 +529,7 @@ var defaultSysVars = []*SysVar{
 		tikvstore.StoreLimit.Store(TidbOptInt64(val, DefTiDBStoreLimit))
 		return nil
 	}},
-	{Scope: ScopeGlobal, Name: TiDBTxnCommitBatchSize, Value: strconv.FormatUint(tikvstore.DefTxnCommitBatchSize, 10), Type: TypeUnsigned, MinValue: 1, MaxValue: math.MaxInt64,
+	{Scope: ScopeGlobal, Name: TiDBTxnCommitBatchSize, Value: strconv.FormatUint(tikvstore.DefTxnCommitBatchSize, 10), Type: TypeUnsigned, MinValue: 1, MaxValue: 1 << 30,
 		GetGlobal: func(sv *SessionVars) (string, error) {
 			return strconv.FormatUint(tikvstore.TxnCommitBatchSize.Load(), 10), nil
 		},

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -529,6 +529,14 @@ var defaultSysVars = []*SysVar{
 		tikvstore.StoreLimit.Store(TidbOptInt64(val, DefTiDBStoreLimit))
 		return nil
 	}},
+	{Scope: ScopeGlobal, Name: TiDBTxnCommitBatchSize, Value: strconv.FormatUint(tikvstore.DefTxnCommitBatchSize, 10), Type: TypeUnsigned, MinValue: 1, MaxValue: math.MaxInt64,
+		GetGlobal: func(sv *SessionVars) (string, error) {
+			return strconv.FormatUint(tikvstore.TxnCommitBatchSize.Load(), 10), nil
+		},
+		SetGlobal: func(s *SessionVars, val string) error {
+			tikvstore.TxnCommitBatchSize.Store(uint64(TidbOptInt64(val, int64(tikvstore.DefTxnCommitBatchSize))))
+			return nil
+		}},
 	{Scope: ScopeGlobal, Name: TiDBRestrictedReadOnly, Value: BoolToOnOff(DefTiDBRestrictedReadOnly), Type: TypeBool, SetGlobal: func(s *SessionVars, val string) error {
 		on := TiDBOptOn(val)
 		if on {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -579,8 +579,15 @@ const (
 
 	// TiDBEnableLocalTxn indicates whether to enable Local Txn.
 	TiDBEnableLocalTxn = "tidb_enable_local_txn"
+
 	// TiDBTSOClientBatchMaxWaitTime indicates the max value of the TSO Batch Wait interval time of PD client.
 	TiDBTSOClientBatchMaxWaitTime = "tidb_tso_client_batch_max_wait_time"
+
+	// TiDBTxnCommitBatchSize is used to control the batch size of transaction commit related requests sent by TiDB to TiKV.
+	// If a single transaction has a large amount of writes, you can increase the batch size to improve the batch effect,
+	// setting too large will exceed TiKV's raft-entry-max-size limit and cause commit failure.
+	TiDBTxnCommitBatchSize = "tidb_txn_commit_batch_size"
+
 	// TiDBEnableTSOFollowerProxy indicates whether to enable the TSO Follower Proxy feature of PD client.
 	TiDBEnableTSOFollowerProxy = "tidb_enable_tso_follower_proxy"
 


### PR DESCRIPTION
Signed-off-by: Jack Yu <jackysp@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33508

Problem Summary:
Expose `txnCommitBatchSize` to make it adjustable and use it to facilitate some performance optimization to find the best performance configuration.

### What is changed and how it works?
Set `tidb_txn_commit_batch_size` to 1M and run sysbench to prepare 64 tables of 10 million, the data import time is significantly reduced (the add indexing part is not included here.). The benefit here should come from a higher 1pc ratio.

master: 40min
<img width="901" alt="截屏2022-03-28 17 42 59" src="https://user-images.githubusercontent.com/4352397/160371651-99822418-34bb-4d12-8249-befff8c05f45.png">

this PR: 27min
<img width="914" alt="截屏2022-03-26 11 14 44" src="https://user-images.githubusercontent.com/4352397/160371703-59b72999-58f3-4616-86d0-b66fd564a960.png">



### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Add a variable `tidb_txn_commit_batch_size` to control the transaction commit batch size to make it easier to find the most reasonable value.
```
