### PR TITLE
Executor: compatible with MySQL when fold constant expression .

### DIFF
--- a/executor/insert_test.go
+++ b/executor/insert_test.go
@@ -1878,6 +1878,22 @@ func TestIssue26762(t *testing.T) {
 	require.EqualError(t, err, `[table:1292]Incorrect date value: '2020-02-31' for column 'c1' at row 1`)
 }
 
+// Fix issue:https://github.com/pingcap/tidb/issues/32614
+func TestUpdateConstFold(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	// Where clause const should be folded completely, without raise an error.
+	tk.MustExec(`DROP TABLE IF EXISTS t0;`)
+	tk.MustExec("CREATE TABLE t0(c0 INT);")
+	_, err := tk.Exec("INSERT INTO t0 VALUES(1);")
+	_, err = tk.Exec("UPDATE t0 SET c0 = 2 WHERE (1 | BIN(100000000)) IS NOT NULL;")
+	require.NoError(t, err)
+
+	tk.MustExec("drop table if exists t0")
+}
+
 func TestStringtoDecimal(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/expression/constant_fold.go
+++ b/expression/constant_fold.go
@@ -164,6 +164,10 @@ func foldConstant(expr Expression) (Expression, bool) {
 		hasNullArg := false
 		allConstArg := true
 		isDeferredConst := false
+
+		// We save the OverflowAsWarning when fold constant. When finish function call, we should restore the value.
+		saveOverflowAsWarning := sc.OverflowAsWarning
+
 		for i := 0; i < len(args); i++ {
 			switch x := args[i].(type) {
 			case *Constant:
@@ -190,7 +194,12 @@ func foldConstant(expr Expression) (Expression, bool) {
 			if err != nil {
 				return expr, isDeferredConst
 			}
+
+			// When fold the const function, we ignore the overflow errors to compatiable with MySQL.
+			sc.OverflowAsWarning = true
 			value, err := dummyScalarFunc.Eval(chunk.Row{})
+			sc.OverflowAsWarning = saveOverflowAsWarning
+
 			if err != nil {
 				return expr, isDeferredConst
 			}
@@ -210,7 +219,12 @@ func foldConstant(expr Expression) (Expression, bool) {
 			}
 			return expr, isDeferredConst
 		}
+
+		// When fold the const function, we ignore the overflow errors to compatiable with MySQL.
+		sc.OverflowAsWarning = true
 		value, err := x.Eval(chunk.Row{})
+		sc.OverflowAsWarning = saveOverflowAsWarning
+
 		retType := x.RetType.Clone()
 		if !hasNullArg {
 			// set right not null flag for constant value


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32614

Problem Summary:
DROP TABLE IF EXISTS t0;
CREATE TABLE t0(c0 INT);
INSERT INTO t0 VALUES(1);
UPDATE t0 SET c0 = 2 WHERE (1 | BIN(100000000)) IS NOT NULL;
TiDB raise an error：
mysql> UPDATE t0 SET c0 = 2 WHERE (1 | BIN(100000000)) IS NOT NULL;
ERROR 1690 (22003): BIGINT value is out of range in '101111101011110000100000000'

UPDATE should succeed, because IS NOT NULL in the where clause, thus we only need to check whether the two arguments to the equality are NULL or not, without having to actually evaluate the equality.

### What is changed and how it works?
When the constant is foldable, we disable the overflow check to be compatible with MySQL.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [x] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
Compatible with MySQL when fold constant expression
```
