### PR TITLE
DDL: Wrong Date type colunm's default value

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -1123,7 +1123,7 @@ func getDefaultValue(ctx sessionctx.Context, col *table.Column, c *ast.ColumnOpt
 	case mysql.TypeEnum:
 		val, err := getEnumDefaultValue(v, col)
 		return val, false, err
-	case mysql.TypeDuration:
+	case mysql.TypeDuration, mysql.TypeDate:
 		if v, err = v.ConvertTo(ctx.GetSessionVars().StmtCtx, &col.FieldType); err != nil {
 			return "", false, errors.Trace(err)
 		}


### PR DESCRIPTION
### What problem does this PR solve?
<!--
Issue number: #30358
 
The problem is when user create table with a date type column like 'da' with using a datetime or timestamp
kind string to be a default value ('1962-03-03 23:30:23'), After table is created, it show the input default value with time part value.  The default value of date column above should be like '1962-03-03' with no time part value.  

The detail information please ref issue #30358

-->

Issue Number: close #30358

Problem Summary:

### What is changed and how it works?
The fix formats the deafult value that is inputed for create/alter a date type column.  If the input default value is datetime or timestamp kind string, it will be converted to date format string and stored.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
None
```
