### PR TITLE
br: add flag for skip NewCollactionEnable in restore

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,11 @@ linters-settings:
     checks: ["S1002","S1004","S1007","S1009","S1010","S1012","S1019","S1020","S1021","S1024","S1030","SA2*","SA3*","SA4009","SA5*","SA6000","SA6001","SA6005", "-SA2002"]
   stylecheck:
     checks: ["-ST1003"]
+  gosec:
+    severity: "low"
+    confidence: "low"
+    excludes:
+      - G101
 issues:
   exclude-rules:
     - path: _test\.go

--- a/br/pkg/task/common.go
+++ b/br/pkg/task/common.go
@@ -64,7 +64,6 @@ const (
 	flagCaseSensitive       = "case-sensitive"
 	flagRemoveTiFlash       = "remove-tiflash"
 	flagCheckRequirement    = "check-requirements"
-	flagSkipCollactionCheck = "skip-collaction-check"
 	flagSwitchModeInterval  = "switch-mode-interval"
 	// flagGrpcKeepaliveTime is the interval of pinging the server.
 	flagGrpcKeepaliveTime = "grpc-keepalive-time"
@@ -148,9 +147,6 @@ type Config struct {
 
 	CheckRequirements bool `json:"check-requirements" toml:"check-requirements"`
 
-	// Whether to skip checking NewCollactionEnable.
-	SkipCollactionCheck bool `json:"skip-collaction-check" toml:"skip-collaction-check"`
-
 	// EnableOpenTracing is whether to enable opentracing
 	EnableOpenTracing bool `json:"enable-opentracing" toml:"enable-opentracing"`
 	// SkipCheckPath skips verifying the path
@@ -206,8 +202,6 @@ func DefineCommonFlags(flags *pflag.FlagSet) {
 
 	flags.Bool(flagCheckRequirement, true,
 		"Whether start version check before execute command")
-	flags.Bool(flagSkipCollactionCheck, false,
-		"Whether skip to check config parameter 'NewCollactionEnable'")
 	flags.Duration(flagSwitchModeInterval, defaultSwitchInterval, "maintain import mode on TiKV during restore")
 	flags.Duration(flagGrpcKeepaliveTime, defaultGRPCKeepaliveTime,
 		"the interval of pinging gRPC peer, must keep the same value with TiKV and PD")
@@ -453,10 +447,6 @@ func (cfg *Config) ParseFromFlags(flags *pflag.FlagSet) error {
 	}
 
 	cfg.CheckRequirements, err = flags.GetBool(flagCheckRequirement)
-	if err != nil {
-		return errors.Trace(err)
-	}
-	cfg.SkipCollactionCheck, err = flags.GetBool(flagSkipCollactionCheck)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -271,16 +271,16 @@ func CheckNewCollationEnable(
 	backupNewCollationEnable string,
 	g glue.Glue,
 	storage kv.Storage,
-	CheckRequirements bool,
+	SkipCollactionCheck bool,
 ) error {
 	if backupNewCollationEnable == "" {
-		if CheckRequirements {
+		if !SkipCollactionCheck {
 			return errors.Annotatef(berrors.ErrUnknown,
 				"NewCollactionEnable not found in backupmeta. "+
 					"if you ensure the NewCollactionEnable config of backup cluster is as same as restore cluster, "+
-					"use --check-requirements=false to skip")
+					"use --skip-collaction-check=true to skip")
 		} else {
-			log.Warn("no NewCollactionEnable in backup")
+			log.Warn("no NewCollactionEnable in backup, skip check NewCollactionEnable currently.")
 			return nil
 		}
 	}
@@ -353,7 +353,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 			return errors.Trace(versionErr)
 		}
 	}
-	if err = CheckNewCollationEnable(backupMeta.GetNewCollationsEnabled(), g, mgr.GetStorage(), cfg.CheckRequirements); err != nil {
+	if err = CheckNewCollationEnable(backupMeta.GetNewCollationsEnabled(), g, mgr.GetStorage(), cfg.SkipCollactionCheck); err != nil {
 		return errors.Trace(err)
 	}
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -46,6 +46,9 @@ const (
 	// current only support STRICT or IGNORE, the default is STRICT according to tidb.
 	FlagWithPlacementPolicy = "with-tidb-placement-mode"
 
+	// flagSkipCollactionCheck is used for whether skip to check  the config `new-collaction-enable`
+	flagSkipCollactionCheck = "skip-collaction-check"
+
 	defaultRestoreConcurrency = 128
 	maxRestoreBatchSizeLimit  = 10240
 	defaultPDConcurrency      = 1
@@ -63,6 +66,8 @@ const (
 // RestoreCommonConfig is the common configuration for all BR restore tasks.
 type RestoreCommonConfig struct {
 	Online bool `json:"online" toml:"online"`
+	// Whether to skip checking NewCollactionEnable.
+	SkipCollactionCheck bool `json:"skip-collaction-check" toml:"skip-collaction-check"`
 
 	// MergeSmallRegionSizeBytes is the threshold of merging small regions (Default 96MB, region split size).
 	// MergeSmallRegionKeyCount is the threshold of merging smalle regions (Default 960_000, region split key count).
@@ -86,6 +91,8 @@ func (cfg *RestoreCommonConfig) adjust() {
 func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	// TODO remove experimental tag if it's stable
 	flags.Bool(flagOnline, false, "(experimental) Whether online when restore")
+	flags.Bool(flagSkipCollactionCheck, false,
+		"Whether skip to check config parameter 'NewCollactionEnable'")
 
 	flags.Uint64(FlagMergeRegionSizeBytes, restore.DefaultMergeRegionSizeBytes,
 		"the threshold of merging small regions (Default 96MB, region split size)")
@@ -108,6 +115,10 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 func (cfg *RestoreCommonConfig) ParseFromFlags(flags *pflag.FlagSet) error {
 	var err error
 	cfg.Online, err = flags.GetBool(flagOnline)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	cfg.SkipCollactionCheck, err = flags.GetBool(flagSkipCollactionCheck)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/tests/br_check_new_collocation_enable/run.sh
+++ b/br/tests/br_check_new_collocation_enable/run.sh
@@ -55,9 +55,9 @@ echo "Restart cluster with new_collation_enable=false"
 start_services --tidb-cfg $cur/config/new_collation_enable_false.toml
 
 # restore db from v4.0.8 version backup
-echo "restore start ... without --skip-collaction-check=true"
+echo "restore start ... without --check-new-collations-enable=false"
 restore_fail=0
-error_str="NewCollactionEnable not found in backupmeta"
+error_str="NewCollationEnable not found in backupmeta"
 test_log="new_collotion_enable_test.log"
 unset BR_LOG_TO_TERM
 run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log || restore_fail=1
@@ -74,10 +74,10 @@ fi
 
 rm -rf "$test_log"
 
-echo "restore start ... with --skip-collaction-check=true"
-warn_str="skip check NewCollactionEnable currently"
+echo "restore start ... with --check-new-collations-enable=false"
+warn_str="skip check NewCollationEnable currently"
 unset BR_LOG_TO_TERM
-run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log --skip-collaction-check=true
+run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log --check-new-collations-enable=false
 if ! grep -i "$warn_str" $test_log; then
     echo "${warn_str} not found in log"
     echo "TEST: [$TEST_NAME] test restore failed!"

--- a/br/tests/br_check_new_collocation_enable/run.sh
+++ b/br/tests/br_check_new_collocation_enable/run.sh
@@ -76,9 +76,10 @@ rm -rf "$test_log"
 
 echo "restore start ... with --skip-collaction-check=true"
 warn_str="skip check NewCollactionEnable currently"
+unset BR_LOG_TO_TERM
 run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log --skip-collaction-check=true
-if grep -i "$warn_str" $test_log; then
-    echo "${error_str} not found in log"
+if ! grep -i "$warn_str" $test_log; then
+    echo "${warn_str} not found in log"
     echo "TEST: [$TEST_NAME] test restore failed!"
     exit 1
 fi
@@ -90,11 +91,11 @@ rm -rf "$test_log"
 echo "Restart cluster with new_collation_enable=false"
 start_services --tidb-cfg $cur/config/new_collation_enable_false.toml
 
-echo "backup start ... wich NewCollactionEnable=false in TiDB"
-run_br --pd $PD_ADDR backup db --db "$DB" -s "local://$cur/${DB}"
+echo "backup start ... with NewCollactionEnable=false in TiDB"
+run_br --pd $PD_ADDR backup full -s "local://$cur/${DB}"
 
 echo "restore start ... with NewCollactionEnable=false in TiDB"
-run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR
+run_br restore full -s "local://$cur/${DB}" --pd $PD_ADDR
 
 echo "Restart cluster with new_collation_enable=true"
 start_services --tidb-cfg $cur/config/new_collation_enable_true.toml
@@ -103,7 +104,7 @@ echo "restore start ... with NewCollactionEnable=True in TiDB"
 restore_fail=0
 error_str="newCollationEnable not match"
 unset BR_LOG_TO_TERM
-run_br restore db --db $DB -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log || restore_fail=1
+run_br restore full -s "local://$cur/${DB}" --pd $PD_ADDR --log-file $test_log || restore_fail=1
 if [ $restore_fail -ne 1 ]; then
     echo "TEST: [$TEST_NAME] test restore failed!"
     exit 1

--- a/br/tests/br_gcs/run.sh
+++ b/br/tests/br_gcs/run.sh
@@ -98,7 +98,7 @@ done
 
 # new version restore full
 echo "restore start..."
-run_br restore full -s "gcs://$BUCKET/$DB?" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/"
+run_br restore full -s "gcs://$BUCKET/$DB?" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/" --skip-collaction-check=true
 
 for i in $(seq $DB_COUNT); do
     row_count_new[${i}]=$(run_sql "SELECT COUNT(*) FROM $DB${i}.$TABLE;" | awk '/COUNT/{print $2}')
@@ -126,7 +126,7 @@ for i in $(seq $DB_COUNT); do
 done
 
 echo "v4.0.8 version restore start..."
-run_br restore full -s "gcs://$BUCKET/${DB}_old" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/"
+bin/brv4.0.8 restore full -s "gcs://$BUCKET/${DB}_old" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/" --skip-collaction-check=true
 
 for i in $(seq $DB_COUNT); do
     row_count_new[${i}]=$(run_sql "SELECT COUNT(*) FROM $DB${i}.$TABLE;" | awk '/COUNT/{print $2}')

--- a/br/tests/br_gcs/run.sh
+++ b/br/tests/br_gcs/run.sh
@@ -98,7 +98,7 @@ done
 
 # new version restore full
 echo "restore start..."
-run_br restore full -s "gcs://$BUCKET/$DB?" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/" --skip-collaction-check=true
+run_br restore full -s "gcs://$BUCKET/$DB?" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/" --check-new-collations-enable=false
 
 for i in $(seq $DB_COUNT); do
     row_count_new[${i}]=$(run_sql "SELECT COUNT(*) FROM $DB${i}.$TABLE;" | awk '/COUNT/{print $2}')
@@ -126,7 +126,7 @@ for i in $(seq $DB_COUNT); do
 done
 
 echo "v4.0.8 version restore start..."
-bin/brv4.0.8 restore full -s "gcs://$BUCKET/${DB}_old" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/" --skip-collaction-check=true
+bin/brv4.0.8 restore full -s "gcs://$BUCKET/${DB}_old" --pd $PD_ADDR --gcs.endpoint="http://$GCS_HOST:$GCS_PORT/storage/v1/"
 
 for i in $(seq $DB_COUNT); do
     row_count_new[${i}]=$(run_sql "SELECT COUNT(*) FROM $DB${i}.$TABLE;" | awk '/COUNT/{print $2}')


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33422

Problem Summary:

### What is changed and how it works?
- Add a flag into `br restore` command to skip checking NewCollactionEnable.
- This flag default value is `false`, so `br restore` will check `NewCollactionEnable` between backupmeta and restore cluster.
- If set `true` to it, `br restore` will skip to check `NewCollactionEnable`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

![image](https://user-images.githubusercontent.com/57036248/160783533-c83f5b65-6a09-4331-bc12-a050810f59e5.png)


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
