### PR TITLE
expr: fix unstable comparing push down fucntion result testcase 

### DIFF
--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -2792,10 +2792,6 @@ func TestTimeScalarFunctionPushDownResult(t *testing.T) {
 		function string
 	}{
 		{
-			sql:      "select now(), now() from t where sysdate()-now()<2;",
-			function: "sysdate",
-		},
-		{
 			sql:      "select col1, to_days(col1) from t where to_days(col1)=to_days('2022-03-24 01:02:03.040506');",
 			function: "to_days",
 		},


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/31872

Problem Summary:

### What is changed and how it works?

The `now` / `sysdate` function result shouldn't be compared between push down or not, thus we removed it from testcase

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
