### PR TITLE
planner: fix incorrect estCost displayed in explain results

### DIFF
--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -2064,7 +2064,6 @@ func (p *PhysicalStreamAgg) attach2Task(tasks ...task) task {
 			t = cop.convertToRootTask(p.ctx)
 			inputRows = t.count()
 			attachPlan2Task(finalAgg, t)
-			finalAgg.SetCost(cop.cost())
 		}
 	} else if mpp, ok := t.(*mppTask); ok {
 		t = mpp.convertToRootTask(p.ctx)
@@ -2073,7 +2072,7 @@ func (p *PhysicalStreamAgg) attach2Task(tasks ...task) task {
 		attachPlan2Task(p, t)
 	}
 	t.addCost(p.GetCost(inputRows, true))
-	p.SetCost(t.cost())
+	t.plan().SetCost(t.cost())
 	return t
 }
 
@@ -2290,7 +2289,7 @@ func (p *PhysicalHashAgg) attach2Task(tasks ...task) task {
 	// To make it simple, we also treat 2-phase parallel hash aggregation in TiDB layer as
 	// 1-phase when computing cost.
 	t.addCost(p.GetCost(inputRows, true, false))
-	p.cost = t.cost()
+	t.plan().SetCost(t.cost())
 	return t
 }
 

--- a/planner/core/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/testdata/enforce_mpp_suite_out.json
@@ -31,9 +31,9 @@
       {
         "SQL": "explain format='verbose' select count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_24 1.00 485.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_24 1.00 35.88 root  funcs:count(Column#6)->Column#4",
           "└─IndexReader_25 1.00 32.88 root  index:StreamAgg_9",
-          "  └─StreamAgg_9 1.00 35.88 cop[tikv]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_9 1.00 485.00 cop[tikv]  funcs:count(1)->Column#6",
           "    └─IndexRangeScan_23 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -41,9 +41,9 @@
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_17 1.00 485.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_17 1.00 35.88 root  funcs:count(Column#6)->Column#4",
           "└─IndexReader_18 1.00 32.88 root  index:StreamAgg_9",
-          "  └─StreamAgg_9 1.00 35.88 cop[tikv]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_9 1.00 485.00 cop[tikv]  funcs:count(1)->Column#6",
           "    └─IndexRangeScan_16 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -51,9 +51,9 @@
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tiflash[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_20 1.00 285050.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_20 1.00 19006.88 root  funcs:count(Column#6)->Column#4",
           "└─TableReader_21 1.00 19003.88 root  data:StreamAgg_9",
-          "  └─StreamAgg_9 1.00 19006.88 batchCop[tiflash]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_9 1.00 285050.00 batchCop[tiflash]  funcs:count(1)->Column#6",
           "    └─Selection_19 10.00 285020.00 batchCop[tiflash]  eq(test.t.a, 1)",
           "      └─TableFullScan_18 10000.00 255020.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
         ],
@@ -72,9 +72,9 @@
       {
         "SQL": "explain format='verbose' select count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_30 1.00 485.00 root  funcs:count(Column#7)->Column#4",
+          "StreamAgg_30 1.00 35.88 root  funcs:count(Column#7)->Column#4",
           "└─IndexReader_31 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 35.88 cop[tikv]  funcs:count(1)->Column#7",
+          "  └─StreamAgg_10 1.00 485.00 cop[tikv]  funcs:count(1)->Column#7",
           "    └─IndexRangeScan_29 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -82,9 +82,9 @@
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_18 1.00 485.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_18 1.00 35.88 root  funcs:count(Column#6)->Column#4",
           "└─IndexReader_19 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 35.88 cop[tikv]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_10 1.00 485.00 cop[tikv]  funcs:count(1)->Column#6",
           "    └─IndexRangeScan_17 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -121,9 +121,9 @@
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_18 1.00 485.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_18 1.00 35.88 root  funcs:count(Column#6)->Column#4",
           "└─IndexReader_19 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 35.88 cop[tikv]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_10 1.00 485.00 cop[tikv]  funcs:count(1)->Column#6",
           "    └─IndexRangeScan_17 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
@@ -160,9 +160,9 @@
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_19 1.00 485.00 root  funcs:count(Column#6)->Column#4",
+          "StreamAgg_19 1.00 35.88 root  funcs:count(Column#6)->Column#4",
           "└─IndexReader_20 1.00 32.88 root  index:StreamAgg_11",
-          "  └─StreamAgg_11 1.00 35.88 cop[tikv]  funcs:count(1)->Column#6",
+          "  └─StreamAgg_11 1.00 485.00 cop[tikv]  funcs:count(1)->Column#6",
           "    └─IndexRangeScan_18 10.00 455.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": [

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -2338,18 +2338,18 @@
       {
         "SQL": "explain format = 'verbose' select count(*) from t3",
         "Plan": [
-          "StreamAgg_20 1.00 137.00 root  funcs:count(Column#9)->Column#4",
+          "StreamAgg_20 1.00 12.68 root  funcs:count(Column#9)->Column#4",
           "└─TableReader_21 1.00 9.68 root  data:StreamAgg_8",
-          "  └─StreamAgg_8 1.00 12.68 cop[tikv]  funcs:count(1)->Column#9",
+          "  └─StreamAgg_8 1.00 137.00 cop[tikv]  funcs:count(1)->Column#9",
           "    └─TableFullScan_18 3.00 128.00 cop[tikv] table:t3 keep order:false"
         ]
       },
       {
         "SQL": "explain format = 'verbose' select count(*) from t2",
         "Plan": [
-          "StreamAgg_25 1.00 69.50 root  funcs:count(Column#7)->Column#4",
+          "StreamAgg_25 1.00 8.18 root  funcs:count(Column#7)->Column#4",
           "└─TableReader_26 1.00 5.17 root  data:StreamAgg_9",
-          "  └─StreamAgg_9 1.00 8.18 batchCop[tiflash]  funcs:count(1)->Column#7",
+          "  └─StreamAgg_9 1.00 69.50 batchCop[tiflash]  funcs:count(1)->Column#7",
           "    └─TableFullScan_24 3.00 60.50 batchCop[tiflash] table:t2 keep order:false"
         ]
       },
@@ -2475,9 +2475,9 @@
         "Plan": [
           "HashJoin_19 3.00 127.40 root  CARTESIAN left outer semi join",
           "├─Selection_39(Build) 0.80 11.18 root  eq(2, Column#18)",
-          "│ └─StreamAgg_60 1.00 69.50 root  funcs:count(Column#32)->Column#18",
+          "│ └─StreamAgg_60 1.00 8.18 root  funcs:count(Column#32)->Column#18",
           "│   └─TableReader_61 1.00 5.17 root  data:StreamAgg_44",
-          "│     └─StreamAgg_44 1.00 8.18 batchCop[tiflash]  funcs:count(1)->Column#32",
+          "│     └─StreamAgg_44 1.00 69.50 batchCop[tiflash]  funcs:count(1)->Column#32",
           "│       └─TableFullScan_59 3.00 60.50 batchCop[tiflash] table:t1 keep order:false",
           "└─Projection_20(Probe) 3.00 95.82 root  1->Column#28",
           "  └─Apply_22 3.00 76.02 root  CARTESIAN left outer join",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32672

Problem Summary: planner: fix incorrect estCost displayed in explain results

### What is changed and how it works?

planner: fix incorrect estCost displayed in explain results

This only fixes `estCost` displayed in explain results and won't affect costs used for plan selection.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
