### PR TITLE
ddl: make ddl reorg be affected by the transaction variables

### DIFF
--- a/ddl/index.go
+++ b/ddl/index.go
@@ -1297,6 +1297,8 @@ func (w *addIndexWorker) BackfillDataInTxn(handleRange reorgBackfillTask) (taskC
 		taskCtx.addedCount = 0
 		taskCtx.scanCount = 0
 		txn.SetOption(kv.Priority, w.priority)
+		txn.SetOption(kv.EnableAsyncCommit, w.sessCtx.GetSessionVars().EnableAsyncCommit)
+		txn.SetOption(kv.Enable1PC, w.sessCtx.GetSessionVars().Enable1PC)
 		if tagger := w.ddlWorker.getResourceGroupTaggerForTopSQL(); tagger != nil {
 			txn.SetOption(kv.ResourceGroupTagger, tagger)
 		}

--- a/ddl/util/util.go
+++ b/ddl/util/util.go
@@ -26,8 +26,10 @@ import (
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util/chunk"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/sqlexec"
 	atomicutil "go.uber.org/atomic"
+	"go.uber.org/zap"
 )
 
 const (
@@ -185,6 +187,10 @@ func LoadGlobalVars(ctx context.Context, sctx sessionctx.Context, varNames []str
 		for _, row := range rows {
 			varName := row.GetString(0)
 			varValue := row.GetString(1)
+			logutil.Logger(ctx).Debug("loaded global variables",
+				zap.String("varName", varName),
+				zap.String("varValue", varValue),
+			)
 			if err = sctx.GetSessionVars().SetSystemVar(varName, varValue); err != nil {
 				return err
 			}


### PR DESCRIPTION
Signed-off-by: Jack Yu <jackysp@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33678

Problem Summary:
The internal transactions used by ddl use mock Context to pass session variables and cannot be affected by the new features of transactions. It could be changed.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
1. set the log level of tidb-server to debug 
```sql
create table t (i int);
insert into t values (1);
alter table t add index idx (i);
```
2. check the logs, you will get
```
[2022[/04/02]() 15:29:54.989 +08:00] [DEBUG] [util.go:190] ["loaded global variables"] [varName=tidb_enable_async_commit] [varValue=ON]
[2022[/04/02]() 15:29:54.989 +08:00] [DEBUG] [util.go:190] ["loaded global variables"] [varName=tidb_enable_1pc] [varValue=ON]
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
