### PR TITLE
br/stream: refactor the status command && print "no task" when no task here

### DIFF
--- a/br/pkg/glue/console_glue.go
+++ b/br/pkg/glue/console_glue.go
@@ -95,8 +95,8 @@ type ConsoleGlue interface {
 
 type NoOPConsoleGlue struct{}
 
-func (NoOPConsoleGlue) Write([]byte) (int, error) {
-	return 0, nil
+func (NoOPConsoleGlue) Write(bs []byte) (int, error) {
+	return len(bs), nil
 }
 
 func (NoOPConsoleGlue) IsInteractive() bool {

--- a/br/pkg/gluetidb/glue.go
+++ b/br/pkg/gluetidb/glue.go
@@ -5,7 +5,6 @@ package gluetidb
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"strings"
 
 	"github.com/pingcap/errors"
@@ -51,6 +50,8 @@ func New() Glue {
 
 // Glue is an implementation of glue.Glue using a new TiDB session.
 type Glue struct {
+	glue.StdIOGlue
+
 	tikvGlue gluetikv.Glue
 }
 
@@ -111,19 +112,6 @@ func (g Glue) Record(name string, value uint64) {
 // GetVersion implements glue.Glue.
 func (g Glue) GetVersion() string {
 	return g.tikvGlue.GetVersion()
-}
-
-func (g Glue) Print(args ...interface{}) {
-	fmt.Print(args...)
-}
-
-// IsInteractive checks whether the shell supports input.
-func (g Glue) IsInteractive() bool {
-	return true
-}
-
-func (g Glue) Scanln(args ...interface{}) (int, error) {
-	return fmt.Scanln(args...)
 }
 
 // Execute implements glue.Session.

--- a/br/pkg/gluetikv/glue.go
+++ b/br/pkg/gluetikv/glue.go
@@ -4,7 +4,6 @@ package gluetikv
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/pingcap/tidb/br/pkg/glue"
 	"github.com/pingcap/tidb/br/pkg/summary"
@@ -24,7 +23,9 @@ var (
 )
 
 // Glue is an implementation of glue.Glue that accesses only TiKV without TiDB.
-type Glue struct{}
+type Glue struct {
+	glue.StdIOGlue
+}
 
 // GetDomain implements glue.Glue.
 func (Glue) GetDomain(store kv.Storage) (*domain.Domain, error) {
@@ -66,17 +67,4 @@ func (Glue) Record(name string, val uint64) {
 // GetVersion implements glue.Glue.
 func (Glue) GetVersion() string {
 	return "BR\n" + build.Info()
-}
-
-func (Glue) Print(args ...interface{}) {
-	fmt.Print(args...)
-}
-
-// IsInteractive checks whether the shell supports input.
-func (Glue) IsInteractive() bool {
-	return true
-}
-
-func (Glue) Scanln(args ...interface{}) (int, error) {
-	return fmt.Scanln(args...)
 }

--- a/br/pkg/stream/stream_misc_test.go
+++ b/br/pkg/stream/stream_misc_test.go
@@ -1,0 +1,32 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package stream_test
+
+import (
+	"testing"
+
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCheckpointOfTask(t *testing.T) {
+	task := stream.TaskStatus{
+		Info: backuppb.StreamBackupTaskInfo{
+			StartTs: 8,
+		},
+		Progress: map[uint64]uint64{
+			1: 10,
+			2: 8,
+			6: 12,
+		},
+	}
+
+	require.Equal(t, task.GetCheckpoint(), uint64(8), "progress = %v", task.Progress)
+	task.Progress[2] = 18
+
+	require.Equal(t, task.GetCheckpoint(), uint64(10))
+	task.Progress[1] = 14
+
+	require.Equal(t, task.GetCheckpoint(), uint64(12), "progress = %v", task.Progress)
+}

--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -338,7 +338,7 @@ func (ctl *StatusController) getTask(ctx context.Context, name string) ([]TaskSt
 	return []TaskStatus{status}, nil
 }
 
-func (ctl *StatusController) PrintToView(tasks []TaskStatus) {
+func (ctl *StatusController) printToView(tasks []TaskStatus) {
 	for _, task := range tasks {
 		ctl.view.AddTask(task)
 	}
@@ -351,6 +351,6 @@ func (ctl *StatusController) PrintStatusOfTask(ctx context.Context, name string)
 	if err != nil {
 		return err
 	}
-	ctl.PrintToView(tasks)
+	ctl.printToView(tasks)
 	return nil
 }

--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -27,6 +27,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const WildCard = "*"
+
 type TaskStatus struct {
 	Info backuppb.StreamBackupTaskInfo
 	// Progress maps the StoreID to NextBackupTs.
@@ -42,8 +44,8 @@ type TaskPrinter interface {
 
 // PrintTaskByTable make a TaskPrinter,
 // which prints the task by the `Table` implement of the console.
-func PrintTaskByTable(t *glue.Table) TaskPrinter {
-	return printByTable{inner: t}
+func PrintTaskByTable(c glue.ConsoleOperations) TaskPrinter {
+	return &printByTable{console: c}
 }
 
 // PrintTaskWithJSON make a TaskPrinter,
@@ -55,21 +57,22 @@ func PrintTaskWithJSON(c glue.ConsoleOperations) TaskPrinter {
 }
 
 type printByTable struct {
-	inner *glue.Table
+	console       glue.ConsoleOperations
+	pendingTables []*glue.Table
 }
 
 func (t TaskStatus) getCheckpoint() uint64 {
 	checkpoint := t.Info.StartTs
 	for _, ts := range t.Progress {
-		if checkpoint == 0 || ts < checkpoint {
+		if checkpoint == t.Info.StartTs || ts < checkpoint {
 			checkpoint = ts
 		}
 	}
 	return checkpoint
 }
 
-func (p printByTable) AddTask(task TaskStatus) {
-	table := p.inner
+func (p *printByTable) AddTask(task TaskStatus) {
+	table := p.console.CreateTable()
 	table.Add("name", task.Info.Name)
 	table.Add("start", fmt.Sprint(oracle.GetTimeFromTS(task.Info.StartTs)))
 	if task.Info.EndTs > 0 {
@@ -94,10 +97,20 @@ func (p printByTable) AddTask(task TaskStatus) {
 	for store, p := range task.Progress {
 		table.Add(fmt.Sprintf("checkpoint[store=%d]", store), formatTS(p))
 	}
+	p.pendingTables = append(p.pendingTables, table)
 }
 
-func (p printByTable) PrintTasks() {
-	p.inner.Print()
+func (p *printByTable) PrintTasks() {
+	em := color.New(color.Bold).SprintfFunc()
+	if len(p.pendingTables) == 0 {
+		p.console.Println(color.HiRedString("○"), em("No Task Yet."))
+		return
+	}
+	p.console.Println(color.HiGreenString("●"), "Total", em("%d", len(p.pendingTables)), "Items.")
+	for i, t := range p.pendingTables {
+		p.console.Println("> #", em("%d ", i+1), "<")
+		t.Print()
+	}
 }
 
 type printByJSON struct {
@@ -231,4 +244,94 @@ func MaybeQPS(ctx context.Context, mgr *conn.Mgr) (float64, error) {
 		return true
 	})
 	return qps, nil
+}
+
+// StatusController is the controller type (or context type) for the command `stream status`.
+type StatusController struct {
+	meta *MetaDataClient
+	mgr  *conn.Mgr
+	view TaskPrinter
+}
+
+// NewStatusContorller make a status controller via some resource accessors.
+func NewStatusController(meta *MetaDataClient, mgr *conn.Mgr, view TaskPrinter) *StatusController {
+	return &StatusController{
+		meta: meta,
+		mgr:  mgr,
+		view: view,
+	}
+}
+
+// fillTask queries and fills the extra infromation for a raw task.
+func (ctl *StatusController) fillTask(ctx context.Context, task Task) (TaskStatus, error) {
+	var err error
+	s := TaskStatus{
+		Info: task.Info,
+	}
+	s.Progress, err = task.NextBackupTSList(ctx)
+	if err != nil {
+		return s, errors.Annotatef(err, "failed to get progress of task %s", s.Info.Name)
+	}
+	stores, err := ctl.mgr.GetPDClient().GetAllStores(ctx)
+	if err != nil {
+		return s, errors.Annotate(err, "failed to get stores from PD")
+	}
+	for _, store := range stores {
+		if _, ok := s.Progress[store.GetId()]; !ok {
+			s.Progress[store.GetId()] = s.Info.StartTs
+		}
+	}
+	s.QPS, err = MaybeQPS(ctx, ctl.mgr)
+	if err != nil {
+		return s, errors.Annotatef(err, "failed to get QPS of task %s", s.Info.Name)
+	}
+	return s, nil
+}
+
+// getTask fetches the task by the name, if the name is the wildcard ("*"), fetch all tasks.
+func (ctl *StatusController) getTask(ctx context.Context, name string) ([]TaskStatus, error) {
+	if name == WildCard {
+		// get status about all of tasks
+		tasks, err := ctl.meta.GetAllTasks(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		result := make([]TaskStatus, 0, len(tasks))
+		for _, task := range tasks {
+			status, err := ctl.fillTask(ctx, task)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, status)
+		}
+		return result, nil
+	}
+	// get status about TaskName
+	task, err := ctl.meta.GetTask(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	status, err := ctl.fillTask(ctx, *task)
+	if err != nil {
+		return nil, err
+	}
+	return []TaskStatus{status}, nil
+}
+
+func (ctl *StatusController) PrintToView(tasks []TaskStatus) {
+	for _, task := range tasks {
+		ctl.view.AddTask(task)
+	}
+	ctl.view.PrintTasks()
+}
+
+// PrintStatusOfTask prints the status of tasks with the name. When the name is *, print all tasks.
+func (ctl *StatusController) PrintStatusOfTask(ctx context.Context, name string) error {
+	tasks, err := ctl.getTask(ctx, name)
+	if err != nil {
+		return err
+	}
+	ctl.PrintToView(tasks)
+	return nil
 }

--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -281,7 +281,7 @@ func NewStatusController(meta *MetaDataClient, mgr *conn.Mgr, view TaskPrinter) 
 	}
 }
 
-// fillTask queries and fills the extra infromation for a raw task.
+// fillTask queries and fills the extra information for a raw task.
 func (ctl *StatusController) fillTask(ctx context.Context, task Task) (TaskStatus, error) {
 	var err error
 	s := TaskStatus{

--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -61,6 +61,22 @@ type printByTable struct {
 	pendingTables []*glue.Table
 }
 
+// statusOK make a string like <green>●</green> <bold>{message}</bold>
+func statusOK(message string) string {
+	return color.GreenString("●") + color.New(color.Bold).Sprintf(" %s", message)
+}
+
+// statusErr make a string like <red>○</red> <bold>{message}</bold>
+func statusErr(message string) string {
+	return color.RedString("○") + color.New(color.Bold).Sprintf(" %s", message)
+}
+
+func colorfulStatusString() string {
+	// TODO: after pause implemented, adapt it.
+	// This function always return `Normal` for now.
+	return statusOK("NORMAL")
+}
+
 // GetCheckpoint calculates the checkpoint of the task.
 func (t TaskStatus) GetCheckpoint() uint64 {
 	initialized := false
@@ -77,6 +93,7 @@ func (t TaskStatus) GetCheckpoint() uint64 {
 func (p *printByTable) AddTask(task TaskStatus) {
 	table := p.console.CreateTable()
 	table.Add("name", task.Info.Name)
+	table.Add("status", colorfulStatusString())
 	table.Add("start", fmt.Sprint(oracle.GetTimeFromTS(task.Info.StartTs)))
 	if task.Info.EndTs > 0 {
 		table.Add("end", fmt.Sprint(oracle.GetTimeFromTS(task.Info.EndTs)))
@@ -104,14 +121,13 @@ func (p *printByTable) AddTask(task TaskStatus) {
 }
 
 func (p *printByTable) PrintTasks() {
-	em := color.New(color.Bold).SprintfFunc()
 	if len(p.pendingTables) == 0 {
-		p.console.Println(color.HiRedString("○"), em("No Task Yet."))
+		p.console.Println(statusErr("No Task Yet."))
 		return
 	}
-	p.console.Println(color.HiGreenString("●"), "Total", em("%d", len(p.pendingTables)), "Items.")
+	p.console.Println(statusOK(fmt.Sprintf("Total %d Tasks.", len(p.pendingTables))))
 	for i, t := range p.pendingTables {
-		p.console.Println("> #", em("%d ", i+1), "<")
+		p.console.Printf("> #%d <\n", i+1)
 		t.Print()
 	}
 }

--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -61,10 +61,13 @@ type printByTable struct {
 	pendingTables []*glue.Table
 }
 
-func (t TaskStatus) getCheckpoint() uint64 {
+// GetCheckpoint calculates the checkpoint of the task.
+func (t TaskStatus) GetCheckpoint() uint64 {
+	initialized := false
 	checkpoint := t.Info.StartTs
 	for _, ts := range t.Progress {
-		if checkpoint == t.Info.StartTs || ts < checkpoint {
+		if !initialized || ts < checkpoint {
+			initialized = true
 			checkpoint = ts
 		}
 	}
@@ -93,7 +96,7 @@ func (p *printByTable) AddTask(task TaskStatus) {
 		info := fmt.Sprintf("%s; gap=%s", pTime, gapColor.Sprint(gap))
 		return info
 	}
-	table.Add("checkpoint[global]", formatTS(task.getCheckpoint()))
+	table.Add("checkpoint[global]", formatTS(task.GetCheckpoint()))
 	for store, p := range task.Progress {
 		table.Add(fmt.Sprintf("checkpoint[store=%d]", store), formatTS(p))
 	}
@@ -153,7 +156,7 @@ func (p *printByJSON) PrintTasks() {
 			TableFilter: t.Info.GetTableFilter(),
 			Progress:    sp,
 			Storage:     s.String(),
-			Checkpoint:  t.getCheckpoint(),
+			Checkpoint:  t.GetCheckpoint(),
 			EstQPS:      t.QPS,
 		}
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -775,6 +775,9 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	formatTs := func(ts uint64) string {
 		return oracle.GetTimeFromTS(ts).Format("2006-01-02 15:04:05.0000")
 	}
+	if cfg.Until == 0 {
+		return errors.Annotatef(berrors.ErrInvalidArgument, "please provide the `--until` ts")
+	}
 
 	cfg.adjustRestoreConfig()
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -58,7 +58,6 @@ const (
 	flagUntil                   = "until"
 	flagStreamJSONOutput        = "json"
 	flagStreamTaskName          = "task-name"
-	flagStreamTaskNameDefault   = "all" // used for get status for all of tasks.
 	flagStreamStartTS           = "start-ts"
 	flagStreamEndTS             = "end-ts"
 	flagGCSafePointTTS          = "gc-ttl"
@@ -165,7 +164,7 @@ func DefineStreamCommonFlags(flags *pflag.FlagSet) {
 }
 
 func DefineStreamStatusCommonFlags(flags *pflag.FlagSet) {
-	flags.String(flagStreamTaskName, flagStreamTaskNameDefault,
+	flags.String(flagStreamTaskName, stream.WildCard,
 		"The task name for backup stream log. If default, get status of all of tasks",
 	)
 	flags.Bool(flagStreamJSONOutput, false,
@@ -707,6 +706,38 @@ func RunStreamResume(
 	return nil
 }
 
+func checkConfigForStatus(cfg *StreamConfig) error {
+	if len(cfg.PD) == 0 {
+		return errors.Annotatef(berrors.ErrInvalidArgument,
+			"the command needs access to PD, please specify `-u` or `--pd`")
+	}
+
+	return nil
+}
+
+// makeStatusController makes the status controller via some config.
+// this should better be in the `stream` package but it is impossible because of cyclic requirements.
+func makeStatusController(ctx context.Context, cfg *StreamConfig, g glue.Glue) (*stream.StatusController, error) {
+	console := glue.GetConsole(g)
+	etcdCLI, err := dialEtcdWithCfg(ctx, cfg.Config)
+	if err != nil {
+		return nil, err
+	}
+	cli := stream.NewMetaDataClient(etcdCLI)
+	var printer stream.TaskPrinter
+	if !cfg.JSONOutput {
+		printer = stream.PrintTaskByTable(console)
+	} else {
+		printer = stream.PrintTaskWithJSON(console)
+	}
+	mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
+		cfg.CheckRequirements, false)
+	if err != nil {
+		return nil, err
+	}
+	return stream.NewStatusController(cli, mgr, printer), nil
+}
+
 // RunStreamStatus get status for a specific stream task
 func RunStreamStatus(
 	c context.Context,
@@ -714,7 +745,6 @@ func RunStreamStatus(
 	cmdName string,
 	cfg *StreamConfig,
 ) error {
-	console := glue.GetConsole(g)
 	ctx, cancelFn := context.WithCancel(c)
 	defer cancelFn()
 
@@ -727,74 +757,19 @@ func RunStreamStatus(
 		ctx = opentracing.ContextWithSpan(ctx, span1)
 	}
 
-	etcdCLI, err := dialEtcdWithCfg(ctx, cfg.Config)
+	if err := checkConfigForStatus(cfg); err != nil {
+		return err
+	}
+	ctl, err := makeStatusController(ctx, cfg, g)
 	if err != nil {
 		return err
 	}
-	cli := stream.NewMetaDataClient(etcdCLI)
-
-	var printer stream.TaskPrinter
-	if !cfg.JSONOutput {
-		printer = stream.PrintTaskByTable(console.CreateTable())
-	} else {
-		printer = stream.PrintTaskWithJSON(console)
-	}
-
-	fillTaskExtraInfo := func(task stream.Task) (stream.TaskStatus, error) {
-		var err error
-		s := stream.TaskStatus{
-			Info: task.Info,
-		}
-		s.Progress, err = task.NextBackupTSList(ctx)
-		if err != nil {
-			return s, err
-		}
-		mgr, err := NewMgr(ctx, g, cfg.PD, cfg.TLS, GetKeepalive(&cfg.Config),
-			cfg.CheckRequirements, false)
-		if err != nil {
-			return s, err
-		}
-		s.QPS, err = stream.MaybeQPS(ctx, mgr)
-		if err != nil {
-			return s, err
-		}
-		return s, nil
-	}
-
-	// to add backoff
-	if flagStreamTaskNameDefault == cfg.TaskName {
-		// get status about all of tasks
-		tasks, err := cli.GetAllTasks(ctx)
-		if err != nil {
-			return errors.Trace(err)
-		}
-
-		for _, task := range tasks {
-			status, err := fillTaskExtraInfo(task)
-			if err != nil {
-				return err
-			}
-			printer.AddTask(status)
-		}
-	} else {
-		// get status about TaskName
-		task, err := cli.GetTask(ctx, cfg.TaskName)
-		if err != nil {
-			return errors.Trace(err)
-		}
-		status, err := fillTaskExtraInfo(*task)
-		if err != nil {
-			return err
-		}
-		printer.AddTask(status)
-	}
-	printer.PrintTasks()
-	return nil
+	return ctl.PrintStatusOfTask(ctx, cfg.TaskName)
 }
 
 func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *StreamConfig) error {
 	console := glue.GetConsole(g)
-	em := color.New(color.Bold, color.FgHiWhite).SprintFunc()
+	em := color.New(color.Bold).SprintFunc()
 	done := color.New(color.FgGreen).SprintFunc()
 	warn := color.New(color.Bold, color.FgHiRed).SprintFunc()
 	formatTs := func(ts uint64) string {
@@ -849,10 +824,9 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 		fileCount++
 		return
 	})
-	console.Println("We are going to remove ",
+	console.Printf("We are going to remove %s files, until %s.\n",
 		em(fileCount),
-		" files, until ",
-		em(formatTs(minTs))+".",
+		em(formatTs(minTs)),
 	)
 	if !cfg.SkipPrompt && !console.PromptBool(warn("Sure? ")) {
 		return nil


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33410

Problem Summary:
There are some bugs after #33411:
- Nothing printed when there are no tasks.
- The global checkpoint ts doesn't be advanced.

### What is changed and how it works?
Those bugs are fixed, and some refactors are applied to the `status` command and the `ConsoleGlue` type.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (TBD)
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
