### PR TITLE
planner: forbid NULL as of value in stale read

### DIFF
--- a/executor/stale_txn_test.go
+++ b/executor/stale_txn_test.go
@@ -1334,3 +1334,19 @@ func TestIssue30872(t *testing.T) {
 	tk.MustExec("set autocommit=0")
 	tk.MustQuery("select * from t1 as of timestamp @a").Check(testkit.Rows("1 10"))
 }
+
+func TestIssue33728(t *testing.T) {
+	store, _, clean := testkit.CreateMockStoreAndDomain(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t1 (id int primary key, v int)")
+	err := tk.ExecToErr("select * from t1 as of timestamp NULL")
+	require.Error(t, err)
+	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp cannot be NULL", err.Error())
+
+	err = tk.ExecToErr("start transaction read only as of timestamp NULL")
+	require.Error(t, err)
+	require.Equal(t, "[planner:8135]invalid as of timestamp: as of timestamp cannot be NULL", err.Error())
+}

--- a/sessiontxn/staleread/util.go
+++ b/sessiontxn/staleread/util.go
@@ -31,6 +31,11 @@ func CalculateAsOfTsExpr(sctx sessionctx.Context, asOfClause *ast.AsOfClause) (u
 	if err != nil {
 		return 0, err
 	}
+
+	if tsVal.IsNull() {
+		return 0, errAsOf.FastGenWithCause("as of timestamp cannot be NULL")
+	}
+
 	toTypeTimestamp := types.NewFieldType(mysql.TypeTimestamp)
 	// We need at least the millionsecond here, so set fsp to 3.
 	toTypeTimestamp.Decimal = 3


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33728

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
`select ... as of NULL` will not panic again
```
