### PR TITLE
*: Refactor session#domainMap use RWMutex to replace Mutex

### DIFF
--- a/session/tidb.go
+++ b/session/tidb.go
@@ -103,13 +103,11 @@ func (dm *domainMap) Delete(store kv.Storage) {
 	dm.mu.Unlock()
 }
 
-
 func (dm *domainMap) Set(store kv.Storage, domain *domain.Domain) {
 	dm.mu.Lock()
 	dm.domains[store.UUID()] = domain
 	dm.mu.Unlock()
 }
-
 
 var (
 	domap = &domainMap{

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -44,12 +44,11 @@ import (
 
 type domainMap struct {
 	domains map[string]*domain.Domain
-	mu      sync.Mutex
+	mu      sync.RWMutex
 }
 
 func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
-	dm.mu.Lock()
-	defer dm.mu.Unlock()
+	dm.mu.RLock()
 
 	// If this is the only domain instance, and the caller doesn't provide store.
 	if len(dm.domains) == 1 && store == nil {
@@ -60,6 +59,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 
 	key := store.UUID()
 	d = dm.domains[key]
+	dm.mu.RUnlock()
 	if d != nil {
 		return
 	}
@@ -92,7 +92,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	if err != nil {
 		return nil, err
 	}
-	dm.domains[key] = d
+	dm.Set(store, d)
 
 	return
 }
@@ -102,6 +102,14 @@ func (dm *domainMap) Delete(store kv.Storage) {
 	delete(dm.domains, store.UUID())
 	dm.mu.Unlock()
 }
+
+
+func (dm *domainMap) Set(store kv.Storage, domain *domain.Domain) {
+	dm.mu.Lock()
+	dm.domains[store.UUID()] = domain
+	dm.mu.Unlock()
+}
+
 
 var (
 	domap = &domainMap{


### PR DESCRIPTION

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close  #33737 

Problem Summary: Improve the performance of session#domainMap func of Get()

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
