### PR TITLE
executor: fix unstable TestCheckActRowsWithUnistore

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/parser/auth"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"
@@ -296,6 +297,10 @@ func checkActRows(t *testing.T, tk *testkit.TestKit, sql string, expected []stri
 }
 
 func TestCheckActRowsWithUnistore(t *testing.T) {
+	defer config.RestoreFunc()()
+	config.UpdateGlobal(func(conf *config.Config) {
+		conf.EnableCollectExecutionInfo = true
+	})
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	// testSuite1 use default mockstore which is unistore


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33768

Problem Summary:

### What is changed and how it works?

`TestCheckActRowsWithUnistore` would fail only if `EnableCollectExecutionInfo` is false.

This request fixed it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- bugfix or new feature needs a release note -->

```release-note
None
```
