### PR TITLE
store/client: fix data race in connArray

### DIFF
--- a/store/tikv/client.go
+++ b/store/tikv/client.go
@@ -214,11 +214,10 @@ func (a *connArray) Close() {
 		a.batchConn.Close()
 	}
 
-	for i, c := range a.v {
+	for _, c := range a.v {
 		if c != nil {
 			err := c.Close()
 			terror.Log(errors.Trace(err))
-			a.v[i] = nil
 		}
 	}
 

--- a/store/tikv/client_test.go
+++ b/store/tikv/client_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/pingcap/kvproto/pkg/tikvpb"
 	"github.com/pingcap/tidb/store/tikv/config"
 	"github.com/pingcap/tidb/store/tikv/tikvrpc"
+	"google.golang.org/grpc/connectivity"
 	"google.golang.org/grpc/metadata"
 )
 
@@ -68,6 +69,18 @@ func (s *testClientSerialSuite) TestConn(c *C) {
 	conn3, err := client.getConnArray(addr, true)
 	c.Assert(err, NotNil)
 	c.Assert(conn3, IsNil)
+}
+
+func (s *testClientSerialSuite) TestGetConnAfterClose(c *C) {
+	client := NewRPCClient(config.Security{})
+
+	addr := "127.0.0.1:6379"
+	connArray, err := client.getConnArray(addr, true)
+	c.Assert(err, IsNil)
+	connArray.Close()
+	conn := connArray.Get()
+	state := conn.GetState()
+	c.Assert(state, Equals, connectivity.Shutdown)
 }
 
 func (s *testClientSuite) TestCancelTimeoutRetErr(c *C) {


### PR DESCRIPTION
Signed-off-by: youjiali1995 <zlwgx1023@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33773

Problem Summary:
Cherry pick https://github.com/tikv/client-go/pull/465, https://github.com/pingcap/tidb/pull/33775 manually.


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

Documentation


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that TiDB server may panic due to data race in client-go.
```
