### PR TITLE
ddl: fix inappropriate schema state output by admin show ddl jobs

### DIFF
--- a/ddl/column_modify_test.go
+++ b/ddl/column_modify_test.go
@@ -456,7 +456,7 @@ func TestCancelDropColumn(t *testing.T) {
 		JobSchemaState model.SchemaState
 		cancelSucc     bool
 	}{
-		{true, model.JobStateNone, model.StateNone, true},
+		{true, model.JobStateQueueing, model.StateNone, true},
 		{false, model.JobStateRunning, model.StateWriteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteReorganization, false},
@@ -560,7 +560,7 @@ func TestCancelDropColumns(t *testing.T) {
 		JobSchemaState model.SchemaState
 		cancelSucc     bool
 	}{
-		{true, model.JobStateNone, model.StateNone, true},
+		{true, model.JobStateQueueing, model.StateNone, true},
 		{false, model.JobStateRunning, model.StateWriteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteReorganization, false},

--- a/ddl/column_type_change_test.go
+++ b/ddl/column_type_change_test.go
@@ -199,7 +199,7 @@ func TestRollbackColumnTypeChangeBetweenInteger(t *testing.T) {
 	// Alter sql will modify column c2 to bigint not null.
 	SQL := "alter table t modify column c2 int not null"
 	err := tk.ExecToErr(SQL)
-	require.EqualError(t, err, "[ddl:1]MockRollingBackInCallBack-queueing")
+	require.EqualError(t, err, "[ddl:1]MockRollingBackInCallBack-none")
 	assertRollBackedColUnchanged(t, tk)
 
 	// Mock roll back at model.StateDeleteOnly.

--- a/ddl/db_rename_test.go
+++ b/ddl/db_rename_test.go
@@ -75,7 +75,7 @@ func TestCancelRenameIndex(t *testing.T) {
 	var checkErr error
 	hook := &ddl.TestDDLCallback{Do: dom}
 	hook.OnJobRunBeforeExported = func(job *model.Job) {
-		if job.Type == model.ActionRenameIndex && job.State == model.JobStateNone {
+		if job.Type == model.ActionRenameIndex && job.State == model.JobStateQueueing {
 			jobIDs := []int64{job.ID}
 			hookCtx := mock.NewContext()
 			hookCtx.Store = store

--- a/ddl/db_table_test.go
+++ b/ddl/db_table_test.go
@@ -59,12 +59,12 @@ func TestCancelDropTableAndSchema(t *testing.T) {
 	}{
 		// Check drop table.
 		// model.JobStateNone means the jobs is canceled before the first run.
-		{true, model.ActionDropTable, model.JobStateNone, model.StateNone, true},
+		{true, model.ActionDropTable, model.JobStateQueueing, model.StateNone, true},
 		{false, model.ActionDropTable, model.JobStateRunning, model.StateWriteOnly, false},
 		{true, model.ActionDropTable, model.JobStateRunning, model.StateDeleteOnly, false},
 
 		// Check drop database.
-		{true, model.ActionDropSchema, model.JobStateNone, model.StateNone, true},
+		{true, model.ActionDropSchema, model.JobStateQueueing, model.StateNone, true},
 		{false, model.ActionDropSchema, model.JobStateRunning, model.StateWriteOnly, false},
 		{true, model.ActionDropSchema, model.JobStateRunning, model.StateDeleteOnly, false},
 	}
@@ -437,8 +437,8 @@ func TestCancelAddTableAndDropTablePartition(t *testing.T) {
 		JobSchemaState model.SchemaState
 		cancelSucc     bool
 	}{
-		{model.ActionAddTablePartition, model.JobStateNone, model.StateNone, true},
-		{model.ActionDropTablePartition, model.JobStateNone, model.StateNone, true},
+		{model.ActionAddTablePartition, model.JobStateQueueing, model.StateNone, true},
+		{model.ActionDropTablePartition, model.JobStateQueueing, model.StateNone, true},
 		// Add table partition now can be cancelled in ReplicaOnly state.
 		{model.ActionAddTablePartition, model.JobStateRunning, model.StateReplicaOnly, true},
 	}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -624,10 +624,6 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 				return errors.Trace(err)
 			}
 
-			if job.IsQueueing() {
-				job.State = model.JobStateNone
-			}
-
 			d.mu.RLock()
 			d.mu.hook.OnJobRunBefore(job)
 			d.mu.RUnlock()

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -301,6 +301,7 @@ func (d *ddl) addBatchDDLJobs(tasks []*limitJobTask) {
 			job.Version = currentVersion
 			job.StartTS = txn.StartTS()
 			job.ID = ids[i]
+			job.State = model.JobStateQueueing
 			if err = buildJobDependence(t, job); err != nil {
 				return errors.Trace(err)
 			}
@@ -621,6 +622,10 @@ func (w *worker) handleDDLJobQueue(d *ddlCtx) error {
 				}
 				err = w.finishDDLJob(t, job)
 				return errors.Trace(err)
+			}
+
+			if job.IsQueueing() {
+				job.State = model.JobStateNone
 			}
 
 			d.mu.RLock()

--- a/ddl/index_modify_test.go
+++ b/ddl/index_modify_test.go
@@ -1151,7 +1151,7 @@ func testCancelDropIndexes(t *testing.T, store kv.Storage, d ddl.DDL) {
 	}{
 		// model.JobStateNone means the jobs is canceled before the first run.
 		// if we cancel successfully, we need to set needAddIndex to false in the next test case. Otherwise, set needAddIndex to true.
-		{true, model.JobStateNone, model.StateNone, true},
+		{true, model.JobStateQueueing, model.StateNone, true},
 		{false, model.JobStateRunning, model.StateWriteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteOnly, false},
 		{true, model.JobStateRunning, model.StateDeleteReorganization, false},

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -504,6 +504,14 @@ func (job *Job) IsRunning() bool {
 	return job.State == JobStateRunning
 }
 
+func (job *Job) IsQueueing() bool {
+	return job.State == JobStateQueueing
+}
+
+func (job *Job) NotStarted() bool {
+	return job.State == JobStateNone || job.State == JobStateQueueing
+}
+
 // JobState is for job state.
 type JobState byte
 
@@ -523,6 +531,8 @@ const (
 	JobStateSynced JobState = 6
 	// JobStateCancelling is used to mark the DDL job is cancelled by the client, but the DDL work hasn't handle it.
 	JobStateCancelling JobState = 7
+	// JobStateQueueing means the job has not yet been started.
+	JobStateQueueing JobState = 8
 )
 
 // String implements fmt.Stringer interface.
@@ -542,6 +552,8 @@ func (s JobState) String() string {
 		return "cancelling"
 	case JobStateSynced:
 		return "synced"
+	case JobStateQueueing:
+		return "queueing"
 	default:
 		return "none"
 	}

--- a/parser/model/model.go
+++ b/parser/model/model.go
@@ -71,7 +71,7 @@ func (s SchemaState) String() string {
 	case StateGlobalTxnOnly:
 		return "global txn only"
 	default:
-		return "queueing"
+		return "none"
 	}
 }
 

--- a/parser/model/model_test.go
+++ b/parser/model/model_test.go
@@ -222,7 +222,7 @@ func TestJobStartTime(t *testing.T) {
 		BinlogInfo: &HistoryInfo{},
 	}
 	require.Equal(t, TSConvert2Time(job.StartTS), time.Unix(0, 0))
-	require.Equal(t, fmt.Sprintf("ID:123, Type:none, State:none, SchemaState:queueing, SchemaID:0, TableID:0, RowCount:0, ArgLen:0, start time: %s, Err:<nil>, ErrCount:0, SnapshotVersion:0", time.Unix(0, 0)), job.String())
+	require.Equal(t, fmt.Sprintf("ID:123, Type:none, State:none, SchemaState:none, SchemaID:0, TableID:0, RowCount:0, ArgLen:0, start time: %s, Err:<nil>, ErrCount:0, SnapshotVersion:0", time.Unix(0, 0)), job.String())
 }
 
 func TestJobCodec(t *testing.T) {

--- a/util/admin/admin_test.go
+++ b/util/admin/admin_test.go
@@ -103,7 +103,7 @@ func TestGetDDLJobs(t *testing.T) {
 		currJobs2 = currJobs2[:0]
 		err = IterAllDDLJobs(txn, func(jobs []*model.Job) (b bool, e error) {
 			for _, job := range jobs {
-				if job.State == model.JobStateNone {
+				if job.NotStarted() {
 					currJobs2 = append(currJobs2, job)
 				} else {
 					return true, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #24420, related to #23494

Problem Summary:

The information "queueing" is introduced by https://github.com/pingcap/parser/pull/1210.

> state-none has two meanings:
>
> - one for adding-type DDL, the job hasn't started yet / the job has been rollbacked.
> - one for removed-type DDL, the job hasn't started yet / the job has done.


### What is changed and how it works?

This PR picks up the work from #31544.

Before this PR:
```
+--------+---------+------------+---------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------+
| JOB_ID | DB_NAME | TABLE_NAME | JOB_TYPE      | SCHEMA_STATE         | SCHEMA_ID | TABLE_ID | ROW_COUNT | CREATE_TIME         | START_TIME          | END_TIME            | STATE   |
+--------+---------+------------+---------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+---------+
|    166 | sbtest  | sbtest1    | add index     | write reorganization |       160 |      162 |         0 | 2022-04-11 14:47:10 | 2022-04-11 14:47:10 | NULL                | running |
|    167 | sbtest2 | sbtest1    | add index     | queueing             |       158 |      164 |         0 | 2022-04-11 14:47:10 | NULL                | NULL                | none    |
```

After this PR:
```
mysql> admin show ddl jobs;
+--------+---------+------------+---------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+----------+
| JOB_ID | DB_NAME | TABLE_NAME | JOB_TYPE      | SCHEMA_STATE         | SCHEMA_ID | TABLE_ID | ROW_COUNT | CREATE_TIME         | START_TIME          | END_TIME            | STATE    |
+--------+---------+------------+---------------+----------------------+-----------+----------+-----------+---------------------+---------------------+---------------------+----------+
|    154 | sbtest  | sbtest1    | add index     | write reorganization |       146 |      150 |    230400 | 2022-04-11 14:24:59 | 2022-04-11 14:24:59 | NULL                | running  |
|    155 | sbtest2 | sbtest1    | add index     | none                 |       148 |      152 |         0 | 2022-04-11 14:25:00 | NULL                | NULL                | queueing |
```

Basically, there are 2 changes:
- There is no "queueing" `SCHEMA_STATE` anymore. Even if the job is in the queue, the `SCHEMA_STATE` is "none".
- The state "queueing" has been added to the `STATE` column. It is used to distinguish whether a job is waiting in the DDL queue.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

See the result above.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that the schema state output by 'admin show ddl jobs' is inappropriate.
```
