### PR TITLE
server: change haproxy TCPConn alive detectors with error:connection reset by peer to debug

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -37,6 +37,7 @@ import (
 	"math/rand"
 	"net"
 	"net/http"
+	"strings"
 
 	// For pprof
 	_ "net/http/pprof" // #nosec G108
@@ -518,9 +519,15 @@ func (s *Server) onConn(conn *clientConn) {
 				Debug("EOF", zap.String("remote addr", conn.bufReadConn.RemoteAddr().String()))
 		} else {
 			metrics.HandShakeErrorCounter.Inc()
-			logutil.BgLogger().With(zap.Uint64("conn", conn.connectionID)).
-				Warn("Server.onConn handshake", zap.Error(err),
-					zap.String("remote addr", conn.bufReadConn.RemoteAddr().String()))
+			if strings.Contains(err.Error(), "connection reset by peer") {
+				logutil.BgLogger().With(zap.Uint64("conn", conn.connectionID)).
+					Debug("Server.onConn handshake", zap.Error(err),
+						zap.String("remote addr", conn.bufReadConn.RemoteAddr().String()))
+			} else {
+				logutil.BgLogger().With(zap.Uint64("conn", conn.connectionID)).
+					Warn("Server.onConn handshake", zap.Error(err),
+						zap.String("remote addr", conn.bufReadConn.RemoteAddr().String()))
+			}
 		}
 		terror.Log(conn.Close())
 		return


### PR DESCRIPTION
change haproxy TCPConn alive detectors with error:connection reset by peer to debug

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33601 

Problem Summary:

branch main:
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/20178265/162670935-f36d2fbb-6c82-4c57-9c79-7cbec5b4e5a9.png">

release 5.3.0:
<img width="1749" alt="image" src="https://user-images.githubusercontent.com/20178265/162670991-47857c97-b82c-4dfd-bc0c-a7fa2e0364ea.png">

When using haproxy as a load balancer, because the health check mechanism will regularly detect the availability of services, resulting in a large number of such errors or warnings in the log, adjust this type of errors to output only in debug mode

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
5.3.0
5.3.1
5.4.0
```
