### PR TITLE
br/stream: added basic utilities for error handing

### DIFF
--- a/br/pkg/glue/console_glue.go
+++ b/br/pkg/glue/console_glue.go
@@ -5,15 +5,29 @@ package glue
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
+	"regexp"
 	"strings"
 
 	"github.com/fatih/color"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/logutil"
+	"go.uber.org/zap"
+	"golang.org/x/term"
 )
 
 // ConsoleOperations are some operations based on ConsoleGlue.
 type ConsoleOperations struct {
 	ConsoleGlue
+}
+
+func (ops ConsoleOperations) RootFrame() Frame {
+	return Frame{
+		width:   ops.GetWidth(),
+		offset:  0,
+		console: ops,
+	}
 }
 
 // PromptBool prompts a boolean from the user.
@@ -75,11 +89,33 @@ func (t *Table) maxKeyLen() int {
 	return maxLen
 }
 
+// Print prints the table.
+// The format would be like:
+//    Key1: <Value>
+//   Other: <Value>
+// LongKey: <Value>
+// The format may change if the terminal size is small.
 func (t *Table) Print() {
 	value := color.New(color.Bold)
 	maxLen := t.maxKeyLen()
+	f, ok := t.console.RootFrame().OffsetLeftWithMinWidth( /* maxLen + len(": ") */ maxLen+2, 40)
+	// If the terminal is too narrow, we should use a compacted format for printing, like:
+	// Key:
+	// <Value>
+	if !ok {
+		// No padding keys if we use the two-line style for printing.
+		maxLen = 0
+	}
 	for _, item := range t.items {
-		t.console.Println(fmt.Sprintf("%*s: %s", maxLen, item[0], value.Sprint(item[1])))
+		t.console.Printf("%*s: ", maxLen, item[0])
+		vs := NewPrettyString(value.Sprint(item[1]))
+		if !ok {
+			// If the terminal is too narrow to hold the line,
+			// print the information to next line directly.
+			t.console.Println()
+		}
+		f.Print(vs)
+		t.console.Println()
 	}
 }
 
@@ -91,6 +127,7 @@ type ConsoleGlue interface {
 	// IsInteractive checks whether the shell supports input.
 	IsInteractive() bool
 	Scanln(args ...interface{}) (int, error)
+	GetWidth() int
 }
 
 type NoOPConsoleGlue struct{}
@@ -105,6 +142,10 @@ func (NoOPConsoleGlue) IsInteractive() bool {
 
 func (NoOPConsoleGlue) Scanln(args ...interface{}) (int, error) {
 	return 0, nil
+}
+
+func (NoOPConsoleGlue) GetWidth() int {
+	return math.MaxUint32
 }
 
 func GetConsole(g Glue) ConsoleOperations {
@@ -123,9 +164,158 @@ func (s StdIOGlue) Write(p []byte) (n int, err error) {
 // IsInteractive checks whether the shell supports input.
 func (s StdIOGlue) IsInteractive() bool {
 	// should we detach whether we are in a interactive tty here?
-	return true
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func (s StdIOGlue) Scanln(args ...interface{}) (int, error) {
 	return fmt.Scanln(args...)
+}
+
+func (s StdIOGlue) GetWidth() int {
+	width, _, err := term.GetSize(int(os.Stdin.Fd()))
+	if err != nil {
+		log.Warn("failed to get terminal size, using infinity", logutil.ShortError(err), zap.Int("fd", int(os.Stdin.Fd())))
+		return math.MaxUint32
+	}
+	log.Debug("terminal width got.", zap.Int("width", width))
+	return width
+}
+
+// PrettyString is a string with ANSI escape sequence which would change its color.
+// this wrapper can help to do some operations over those string.
+type PrettyString struct {
+	pretty              string
+	raw                 string
+	escapeSequencePlace [][]int
+}
+
+var ansiEscapeCodeRe = regexp.MustCompile("\x1b" + `\[(?:(?:\d+;)*\d+)?m`)
+
+// NewPrettyString wraps a string with ANSI escape seuqnces with PrettyString.
+func NewPrettyString(s string) PrettyString {
+	return PrettyString{
+		pretty:              s,
+		raw:                 ansiEscapeCodeRe.ReplaceAllLiteralString(s, ""),
+		escapeSequencePlace: ansiEscapeCodeRe.FindAllStringIndex(s, -1),
+	}
+}
+
+// Len returns the length of the string with removal of all ANSI sequences.
+// ("The raw length") .
+// Example: "\e[38;5;226mhello, world\e[0m".Len() => 12
+// Note: The length of golden string "hello, world" is 12.
+func (ps PrettyString) Len() int {
+	return len(ps.raw)
+}
+
+// Pretty returns the pretty form of the string:
+// with keeping all ANSI escape sequences.
+// Example: "\e[38;5;226mhello, world\e[0m".Pretty() => "\e[38;5;226mhello, world\e[0m"
+func (ps PrettyString) Pretty() string {
+	return ps.pretty
+}
+
+// Raw returns the raw form of the pretty string:
+// with removal of all ANSI escape sequences.
+// Example: "\e[38;5;226mhello, world\e[0m".Raw() => "hello, world"
+func (ps PrettyString) Raw() string {
+	return ps.raw
+}
+
+// SplitAt splits a pretty string at the place and ignoring all formats.
+// Example: "\e[38;5;226mhello, world\e[0m".SplitAt(5) => ["\e[38;5;226mhello", ", world\e[0m"]
+func (ps PrettyString) SplitAt(n int) (left, right PrettyString) {
+	if n < 0 {
+		panic(fmt.Sprintf("PrettyString::SplitAt: index out of bound (%d vs %d)", n, len(ps.raw)))
+	}
+	if n >= len(ps.raw) {
+		left = ps
+		return
+	}
+	realSlicePoint, endAt := ps.slicePointOf(n)
+	left.pretty = ps.pretty[:realSlicePoint]
+	left.raw = ps.raw[:n]
+	left.escapeSequencePlace = ps.escapeSequencePlace[:endAt]
+	right.pretty = ps.pretty[realSlicePoint:]
+	right.raw = ps.raw[n:]
+	for _, rp := range ps.escapeSequencePlace[endAt:] {
+		right.escapeSequencePlace = append(right.escapeSequencePlace, []int{
+			rp[0] - realSlicePoint,
+			rp[1] - realSlicePoint,
+		})
+	}
+	return
+}
+
+func (ps PrettyString) slicePointOf(s int) (realSlicePoint, endAt int) {
+	endAt = 0
+	realSlicePoint = s
+	for i, m := range ps.escapeSequencePlace {
+		start, end := m[0], m[1]
+		length := end - start
+		if realSlicePoint > start {
+			realSlicePoint += length
+		} else {
+			endAt = i
+			return
+		}
+	}
+	return
+}
+
+// Frame is an fix-width place for printing.
+// It is the abstraction of some subarea of the terminal,
+// you might imagine it as a panel in the tmux, but with infinity height.
+// For example, printing a frame with the width of 10 chars, and 4 chars offset left, would be like:
+//    v~~~~~~~~~~v Here is the "width of a frame".
+// +--+----------+--+
+// |   Hello, wor   |
+// |   ld.          |
+// +--+----------+--+
+// ^~~^
+// Here is the "offset of a frame".
+type Frame struct {
+	offset  int
+	width   int
+	console ConsoleOperations
+}
+
+func (f Frame) newLine() {
+	f.console.Printf("\n%s", strings.Repeat(" ", f.offset))
+}
+
+func (f Frame) Print(s PrettyString) {
+	if f.width <= 0 {
+		f.console.Print(s.Pretty())
+		return
+	}
+	for left, right := s.SplitAt(f.width); left.Len() > 0; left, right = right.SplitAt(f.width) {
+		f.console.Print(left.Pretty())
+		if right.Len() > 0 {
+			f.newLine()
+		}
+	}
+}
+
+func (f Frame) WithWidth(width int) Frame {
+	return Frame{
+		offset:  f.offset,
+		width:   width,
+		console: f.console,
+	}
+}
+
+func (f Frame) OffsetLeftWithMinWidth(offset, minWidth int) (Frame, bool) {
+	if f.width-offset < minWidth {
+		return f, false
+	}
+	return Frame{
+		offset:  offset,
+		width:   f.width - offset,
+		console: f.console,
+	}, true
+}
+
+func (f Frame) OffsetLeft(offset int) (Frame, bool) {
+	return f.OffsetLeftWithMinWidth(offset, 1)
 }

--- a/br/pkg/glue/console_glue_test.go
+++ b/br/pkg/glue/console_glue_test.go
@@ -1,0 +1,140 @@
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
+
+package glue_test
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/stretchr/testify/require"
+)
+
+func TestColorfulTUIFunctions(t *testing.T) {
+	// when testing, the teriminal would be redirected to the dummy terminal.
+	color.NoColor = false
+
+	t.Run("TestPrettyString", testPrettyString)
+	t.Run("TestPrettyStringSlicing", testPrettyStringSlicing)
+	t.Run("TestPrintFrame", testPrintFrame)
+}
+
+func testPrettyString(t *testing.T) {
+	fgAttrs := []color.Attribute{
+		// -1 means skip this type of attr.
+		color.Attribute(-1),
+		color.FgHiBlack,
+		color.FgHiRed,
+		color.FgHiGreen,
+		color.FgHiYellow,
+		color.FgHiBlue,
+		color.FgHiMagenta,
+		color.FgHiCyan,
+		color.FgHiWhite,
+	}
+	bgAttrs := []color.Attribute{
+		color.Attribute(-1),
+		color.BgBlack,
+		color.BgRed,
+		color.BgGreen,
+		color.BgYellow,
+		color.BgBlue,
+		color.BgMagenta,
+		color.BgCyan,
+		color.BgWhite,
+	}
+	fontAttrs := []color.Attribute{
+		color.Attribute(-1),
+		color.Bold,
+		color.Faint,
+		color.Italic,
+		color.Underline,
+		color.BlinkSlow,
+		color.BlinkRapid,
+		color.ReverseVideo,
+		color.Concealed,
+		color.CrossedOut,
+	}
+	runTest := func(c *color.Color) {
+		ps := glue.NewPrettyString(c.Sprint("hello, world"))
+		require.Equal(t, ps.Len(), 12, "%v vs %v", ps.Pretty(), ps.Raw())
+	}
+
+	for _, fg := range fgAttrs {
+		for _, bg := range bgAttrs {
+			for _, ft := range fontAttrs {
+				as := make([]color.Attribute, 0, 3)
+				for _, attr := range []color.Attribute{fg, bg, ft} {
+					if attr != -1 {
+						as = append(as, attr)
+					}
+				}
+
+				runTest(color.New(as...))
+			}
+		}
+	}
+
+}
+
+func testPrettyStringSlicing(t *testing.T) {
+	bs := glue.NewPrettyString(color.HiBlackString("hello, world") + color.CyanString(", and my friend"))
+	checkInternalConsistency := func(ss ...glue.PrettyString) {
+		for _, s := range ss {
+			sp := glue.NewPrettyString(s.Pretty())
+			require.Equal(t, sp.Raw(), s.Raw(), "%#v", ss)
+		}
+	}
+	testSplit := func(s glue.PrettyString, n int) (glue.PrettyString, glue.PrettyString) {
+		raw := s.Raw()
+		left, right := s.SplitAt(n)
+		require.Equal(t, left.Raw(), raw[:n], "%#v(@%d) -> (\n%#v \n%#v)", s, n, left, right)
+		require.Equal(t, right.Raw(), raw[n:], "%#v(@%d) -> (\n%#v \n%#v)", s, n, left, right)
+		checkInternalConsistency(left, right)
+		return left, right
+	}
+
+	testSplit(bs, 5)
+	l, r := testSplit(bs, 15)
+	testSplit(l, 5)
+	testSplit(r, 3)
+	testSplit(bs, 12)
+}
+
+type writerGlue struct {
+	glue.NoOPConsoleGlue
+	w io.Writer
+}
+
+func (w writerGlue) Write(b []byte) (int, error) {
+	return w.w.Write(b)
+}
+
+func testPrintFrame(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	ops := glue.ConsoleOperations{writerGlue{w: buf}}
+	f, ok := ops.RootFrame().OffsetLeft(10)
+	require.True(t, ok)
+	f = f.WithWidth(10)
+	bs := glue.NewPrettyString(color.HiGreenString("hello, world") +
+		color.CyanString(", and my friend") +
+		color.RedString(", and all good people."))
+	indent := strings.Repeat(" ", 10)
+	/*
+		hello, wor
+		ld, and my
+		 friend, a
+		nd all goo
+		d people.
+	*/
+	expected := color.HiGreenString("hello, wor\n"+
+		indent+"ld") + color.CyanString(", and my\n"+
+		indent+" friend") + color.RedString(", a\n"+
+		indent+"nd all goo\n"+
+		indent+"d people.")
+	f.Print(bs)
+	require.Equal(t, expected, buf.String())
+}

--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -240,7 +240,10 @@ func (r *RPCResult) Error() string {
 	if r.StoreError != nil {
 		return r.StoreError.GetMessage()
 	}
-	return "<no error>"
+	if r.ImportError != "" {
+		return r.ImportError
+	}
+	return "BUG(There is no error but reported as error)"
 }
 
 func (r *RPCResult) OK() bool {

--- a/go.mod
+++ b/go.mod
@@ -180,6 +180,7 @@ require (
 	go.opentelemetry.io/proto/otlp v0.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210915214749-c084706c2272 // indirect
 	golang.org/x/exp v0.0.0-20200513190911-00229845015e // indirect
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20220216160803-4663080d8bc8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1061,6 +1061,7 @@ golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5 h1:y/woIyUBFbpQGKS0u1aHF/40WUDnek3fPOyD08H5Vng=
 golang.org/x/sys v0.0.0-20220310020820-b874c991c1a5/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #30544

Problem Summary:

When we want to handing errors from TiKV, the error message may be long and the text may be soft-wrapped by the terminal:

```console
  error message[store=1]: Some Long Long Long Long Long Long
Error Message.
     error code[store=1]: *Some:Error:Code*
```

The soft wrap may make the error message hard for reading. 

### What is changed and how it works?

This PR enhanced the TUI library and we are now able to wrap lines manually via the `Frame` interface.

Now the table would be like:

```console
  error message[store=1]: Some Long Long Long Long Long Long
                          Error Message.
     error code[store=1]: *Some:Error:Code*
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
