### PR TITLE
planner: add logic transformation rule groupby_str2int

### DIFF
--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -601,6 +601,14 @@ func TestSetVar(t *testing.T) {
 	tk.MustQuery("select @@global.tidb_remove_orderby_in_subquery").Check(testkit.Rows("0")) // default value is 0
 	tk.MustExec("set global tidb_remove_orderby_in_subquery=1")
 	tk.MustQuery("select @@global.tidb_remove_orderby_in_subquery").Check(testkit.Rows("1"))
+
+	// test for tidb_enable_groupby_str2int
+	tk.MustQuery("select @@session.tidb_enable_groupby_str2int").Check(testkit.Rows("0")) // default value is 0
+	tk.MustExec("set session tidb_enable_groupby_str2int=1")
+	tk.MustQuery("select @@session.tidb_enable_groupby_str2int").Check(testkit.Rows("1"))
+	tk.MustQuery("select @@global.tidb_enable_groupby_str2int").Check(testkit.Rows("0")) // default value is 0
+	tk.MustExec("set global tidb_enable_groupby_str2int=1")
+	tk.MustQuery("select @@global.tidb_enable_groupby_str2int").Check(testkit.Rows("1"))
 }
 
 func TestTruncateIncorrectIntSessionVar(t *testing.T) {

--- a/expression/constant.go
+++ b/expression/constant.go
@@ -63,6 +63,18 @@ func NewNull() *Constant {
 	}
 }
 
+// NewInt creates an INT constant with value v.
+func NewInt(v int) *Constant {
+	retT := types.NewFieldType(mysql.TypeLong)
+	retT.Flag |= mysql.NotNullFlag
+	retT.Flen = mysql.MaxIntWidth
+	retT.Decimal = 0
+	return &Constant{
+		Value:   types.NewDatum(v),
+		RetType: retT,
+	}
+}
+
 // Constant stands for a constant value.
 type Constant struct {
 	Value   types.Datum

--- a/expression/expression.go
+++ b/expression/expression.go
@@ -732,6 +732,9 @@ func extractBinaryOpItems(conditions *ScalarFunction, funcName string) []Express
 // FlattenDNFConditions extracts DNF expression's leaf item.
 // e.g. or(or(a=1, a=2), or(a=3, a=4)), we'll get [a=1, a=2, a=3, a=4].
 func FlattenDNFConditions(DNFCondition *ScalarFunction) []Expression {
+	if DNFCondition.FuncName.L != ast.LogicOr {
+		return []Expression{DNFCondition}
+	}
 	return extractBinaryOpItems(DNFCondition, ast.LogicOr)
 }
 

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -179,6 +179,10 @@ func (b *PlanBuilder) buildAggregation(ctx context.Context, p LogicalPlan, aggFu
 	b.optFlag |= flagEliminateAgg
 	b.optFlag |= flagEliminateProjection
 
+	if b.ctx.GetSessionVars().EnableGroupByString2Int {
+		b.optFlag |= flagGroupbyStr2Int
+	}
+
 	plan4Agg := LogicalAggregation{AggFuncs: make([]*aggregation.AggFuncDesc, 0, len(aggFuncList))}.Init(b.ctx, b.getSelectOffset())
 	if hint := b.TableHints(); hint != nil {
 		plan4Agg.aggHints = hint.aggHints

--- a/planner/core/optimizer.go
+++ b/planner/core/optimizer.go
@@ -58,6 +58,7 @@ const (
 	flagBuildKeyInfo
 	flagDecorrelate
 	flagEliminateAgg
+	flagGroupbyStr2Int
 	flagEliminateProjection
 	flagMaxMinEliminate
 	flagPredicatePushDown
@@ -78,6 +79,7 @@ var optRuleList = []logicalOptRule{
 	&buildKeySolver{},
 	&decorrelateSolver{},
 	&aggregationEliminator{},
+	&groupbyStr2IntConverter{},
 	&projectionEliminator{},
 	&maxMinEliminator{},
 	&ppdSolver{},

--- a/planner/core/physical_plan_trace_test.go
+++ b/planner/core/physical_plan_trace_test.go
@@ -84,7 +84,7 @@ func TestPhysicalOptimizeWithTraceEnabled(t *testing.T) {
 		plan, err := builder.Build(context.TODO(), stmt)
 		require.NoError(t, err)
 		flag := uint64(0)
-		flag = flag | 1<<3 | 1<<8
+		flag = flag | 1<<3 | 1<<9
 		_, _, err = core.DoOptimize(context.TODO(), sctx, flag, plan.(core.LogicalPlan))
 		require.NoError(t, err)
 		otrace := sctx.GetSessionVars().StmtCtx.OptimizeTracer.Physical

--- a/planner/core/rule_groupby_str2int.go
+++ b/planner/core/rule_groupby_str2int.go
@@ -1,0 +1,389 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core
+
+import (
+	"context"
+
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/expression/aggregation"
+	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/parser/mysql"
+	"github.com/pingcap/tidb/sessionctx"
+	"github.com/pingcap/tidb/types"
+)
+
+// This rule trys to convert an Aggregation on string column to Aggregation on int column.
+// There are several requirements that have to be met so that this rule can be applied:
+// 1. There is a Selection under Aggregation
+// 2. The Selection has equality filter on one of the group keys
+// 3. The filtered group key must be string type
+// 4. The filter condition must be disjoint of IN or EQ scalar function
+//
+// e.g.
+//  SELECT a, b, max(c) FROM foo WHERE a in ('x', 'y', 'z') GROUP BY a,b;
+//
+// will be transformed into
+//  SELECT CASE WHEN a=0 THEN 'x' WHEN a=1 THEN 'y' WHEN a=2 THEN 'z' END as a, b, max
+//  FROM (
+//		SELECT a, b, max(c)
+//		FROM (
+//			 SELECT CASE WHEN a='x' THEN 0 WHEN a='y' THEN 1 WHEN a='z' THEN 2 END as a, b, c
+//			 FROM foo
+//			 WHERE a in ('x', 'y', 'z')
+//		) t GROUP BY a,b
+//  ) t;
+//
+// NB: This rule doesn't guarantee to yield better alternative, especially when
+//  1. The IN list constant values are too many, hence the comparison may take a lot more time.
+//  2. There is an index on the string group key that can be utilized by top Aggregation, whereas
+//     the alternative will break the order property of the index.
+//
+// For the moment, we don't consider other special cases, such as the filter condition is below
+// the child of Aggregation, unless we can pull up the filter from child operators.
+//
+// Ideally, the optimization should be done in query executor automatically, without intervention
+// of optimizer, which requires that there is dictionary encoding in the storage engine and the
+// execution engine can do the transformation on the fly.
+//
+// This rule is turned off by default. Use with caution.
+type groupbyStr2IntConverter struct {
+}
+
+func (a *groupbyStr2IntConverter) tryToConvertGroubyStr2Int(
+	agg *LogicalAggregation, sel *LogicalSelection,
+	mapping map[string]*expression.Column, opt *logicalOptimizeOp) *LogicalProjection {
+	if len(sel.Conditions) != 1 {
+		return nil
+	}
+	cond := sel.Conditions[0]
+	filter, ok := cond.(*expression.ScalarFunction)
+	if !ok {
+		return nil
+	}
+	dnfExprs := expression.FlattenDNFConditions(filter)
+	ok, colExpr, consts := extractStrConstsFromExpr(dnfExprs)
+	if !ok {
+		return nil
+	}
+
+	filterOnGroupKey := false
+	var groupKey expression.Expression
+	// now check the filter column or expression is in the group keys
+	for _, groupKey = range agg.GroupByItems {
+		if groupKey.Equal(nil, colExpr) {
+			filterOnGroupKey = true
+			break
+		}
+	}
+
+	// the filter column is not on group key
+	if !filterOnGroupKey {
+		return nil
+	}
+
+	// CASE WHEN expression that translates string to int
+	lowerCaseExpr, err := makeCaseWhenFunc(agg.ctx, types.NewFieldType(mysql.TypeLong), colExpr, consts...)
+	if err != nil {
+		return nil
+	}
+
+	// create project on top of filter that transforms string to int
+	lowerProj, newCol := createProjectOnFilter(sel, groupKey, lowerCaseExpr)
+
+	// aggregate on int column
+	newAgg := createAggOnProject(agg, lowerProj, groupKey, newCol)
+
+	// CASE WHEN expression that translates int back to string
+	upperCaseExpr, err := makeCaseWhenFunc(agg.ctx, groupKey.GetType(), newCol, consts...)
+	if newAgg == nil || err != nil {
+		return nil
+	}
+
+	// final Project that translate int group key to string
+	topProj, caseCol := createProjectOnAgg(newAgg, newCol, upperCaseExpr)
+
+	mapping[string(groupKey.HashCode(nil))] = caseCol
+
+	return topProj
+}
+
+// extractStrConstsFromExpr extracts column expression and string constants from a list of disjoint expressions, e.g.
+// a = '1' or a = '2' or a in ('3', '4') or a in ('5', '6', '7')
+// will return a and ['1', '2', '3', '4', '5', '6', '7']
+//
+// CONCAT(a, b) = 'xxx' or CONCAT(a, b) = 'yyy' or CONCAT(a,b) in ('zzz', 'xyz')
+// will return CONCAT(a, b) and ['xxx', 'yyy', 'zzz', 'xyz']
+func extractStrConstsFromExpr(exprs []expression.Expression) (bool, expression.Expression, []expression.Constant) {
+	var leftExpr expression.Expression
+	var consts []expression.Constant
+
+	for _, expr := range exprs {
+		scfun, ok := expr.(*expression.ScalarFunction)
+		if !ok {
+			return false, nil, nil
+		}
+		var col expression.Expression
+		if scfun.FuncName.L == ast.EQ {
+			// for case: foo.col1 = 'xxx'
+			col = scfun.GetArgs()[0]
+			v, ok := scfun.GetArgs()[1].(*expression.Constant)
+			if !ok {
+				// for case: 'xxx' = foo.col1
+				col = scfun.GetArgs()[1]
+				v, ok = scfun.GetArgs()[0].(*expression.Constant)
+				if !ok {
+					return false, nil, nil
+				}
+			}
+			// we only care about string constants
+			if types.IsString(v.RetType.Tp) {
+				consts = append(consts, *v)
+			} else {
+				return false, nil, nil
+			}
+		} else if scfun.FuncName.L == ast.In {
+			col = scfun.GetArgs()[0]
+			for i := 1; i < len(scfun.GetArgs()); i++ {
+				v, ok := scfun.GetArgs()[i].(*expression.Constant)
+				if !ok {
+					return false, nil, nil
+				}
+				// we only care about string constants
+				if types.IsString(v.RetType.Tp) {
+					consts = append(consts, *v)
+				} else {
+					return false, nil, nil
+				}
+			}
+		} else {
+			return false, nil, nil
+		}
+
+		// make sure the conditions are using the same column or expression
+		if leftExpr == nil {
+			leftExpr = col
+		} else if !leftExpr.Equal(nil, col) {
+			return false, nil, nil
+		}
+	}
+
+	return true, leftExpr, consts
+}
+
+// makeCaseWhenFunc creates a CASE WHEN... expression.
+//
+// If the retType is TypeLong, col is foo.a, strConsts is ['aaa', 'bbb', 'ccc'],
+// it will generate the following expression:
+// CASE WHEN foo.a='aaa' THEN 0 WHEN foo.a='bbb' THEN 1 WHEN foo.a='ccc' THEN 2 END
+//
+// If the retType is NOT TypeLong, col is foo.a, strConsts is ['aaa', 'bbb', 'ccc'],
+// it will generate the following expression:
+// CASE WHEN foo.a=0 THEN 'aaa' WHEN foo.a=1 THEN 'bbb' WHEN foo.a=2 THEN 'ccc' END
+func makeCaseWhenFunc(ctx sessionctx.Context, retType *types.FieldType, col expression.Expression,
+	strConsts ...expression.Constant) (expression.Expression, error) {
+	size := len(strConsts)
+	args := make([]expression.Expression, size*2)
+	intConsts := make([]expression.Constant, size)
+
+	for i := 0; i < size; i++ {
+		intConsts[i] = *expression.NewInt(i)
+	}
+
+	// constants that we originally had
+	srcConsts := strConsts
+	// constants that we will have
+	dstConsts := intConsts
+
+	// this means we need to translate int constants to string constants
+	if retType.Tp != mysql.TypeLong {
+		srcConsts = intConsts
+		dstConsts = strConsts
+	}
+
+	// create WHEN...THEN... pairs
+	for i := 0; i < size; i++ {
+		exp, err := expression.NewFunction(ctx, ast.EQ, types.NewFieldType(mysql.TypeTiny), col, &srcConsts[i])
+		if err != nil {
+			return exp, err
+		}
+		args[i*2] = exp
+		args[i*2+1] = &dstConsts[i]
+	}
+
+	return expression.NewFunction(ctx, ast.Case, retType, args...)
+}
+
+// createProjectOnFilter creates a lower Project on top of Selection. The new Project
+// will translate string constants into int constants starting from 0.
+func createProjectOnFilter(sel *LogicalSelection, groupKey expression.Expression,
+	projExpr expression.Expression) (*LogicalProjection, *expression.Column) {
+	found := false
+	proj := LogicalProjection{
+		Exprs: make([]expression.Expression, 0, sel.Schema().Len()),
+	}.Init(sel.ctx, sel.blockOffset)
+
+	newCol := &expression.Column{
+		UniqueID: sel.SCtx().GetSessionVars().AllocPlanColumnID(),
+		RetType:  projExpr.GetType(),
+	}
+
+	projSchema := make([]*expression.Column, 0, sel.Schema().Len())
+
+	for _, column := range sel.Schema().Columns {
+		// if the agg key is a column
+		if column.Equal(sel.ctx, groupKey) {
+			proj.Exprs = append(proj.Exprs, projExpr)
+			projSchema = append(projSchema, newCol)
+			found = true
+		} else {
+			proj.Exprs = append(proj.Exprs, column)
+			projSchema = append(projSchema, column)
+		}
+	}
+	// if agg key is a scalar function
+	if !found {
+		proj.Exprs = append(proj.Exprs, projExpr)
+		projSchema = append(projSchema, newCol)
+	}
+
+	proj.SetSchema(expression.NewSchema(projSchema...))
+	proj.SetChildren(sel)
+	return proj, newCol
+}
+
+// createAggOnProject creates an Agg on top of generated Projection, the new Agg replace
+// string agg key with int agg key.
+func createAggOnProject(agg *LogicalAggregation, proj *LogicalProjection,
+	groupKey expression.Expression, newCol *expression.Column) *LogicalAggregation {
+	newAgg := LogicalAggregation{
+		AggFuncs:     make([]*aggregation.AggFuncDesc, 0, len(agg.AggFuncs)),
+		GroupByItems: make([]expression.Expression, 0, len(agg.GroupByItems)),
+		aggHints:     agg.aggHints,
+	}.Init(agg.ctx, agg.blockOffset)
+
+	for _, aggfunc := range agg.AggFuncs {
+		newAf := aggfunc.Clone()
+		for i, arg := range newAf.Args {
+			if arg.Equal(agg.ctx, groupKey) {
+				if i != 0 || newAf.Name != "firstrow" {
+					return nil
+				}
+				newAf.Args[i] = newCol
+				newAf.RetTp = types.NewFieldType(mysql.TypeLong)
+			}
+		}
+		newAgg.AggFuncs = append(newAgg.AggFuncs, newAf)
+	}
+
+	for _, item := range agg.GroupByItems {
+		if item.Equal(agg.ctx, groupKey) {
+			newAgg.GroupByItems = append(newAgg.GroupByItems, newCol)
+		} else {
+			newAgg.GroupByItems = append(newAgg.GroupByItems, item)
+		}
+	}
+
+	aggSchema := make([]*expression.Column, 0, agg.Schema().Len())
+	for _, column := range agg.Schema().Columns {
+		if groupKey.Equal(agg.ctx, column) {
+			aggSchema = append(aggSchema, newCol)
+		} else {
+			aggSchema = append(aggSchema, column)
+		}
+	}
+	newAgg.SetSchema(expression.NewSchema(aggSchema...))
+	newAgg.SetChildren(proj)
+	return newAgg
+}
+
+// createProjectOnAgg creates a Project on top of Aggregate.
+// That Project will translate int back to string.
+func createProjectOnAgg(newAgg *LogicalAggregation,
+	groupKey expression.Expression, caseExpr expression.Expression) (*LogicalProjection, *expression.Column) {
+	found := false
+	proj := LogicalProjection{
+		Exprs: make([]expression.Expression, 0, newAgg.Schema().Len()),
+	}.Init(newAgg.ctx, newAgg.blockOffset)
+
+	newCol := &expression.Column{
+		UniqueID: newAgg.SCtx().GetSessionVars().AllocPlanColumnID(),
+		RetType:  caseExpr.GetType(),
+	}
+
+	projSchema := make([]*expression.Column, 0, newAgg.Schema().Len())
+
+	for _, column := range newAgg.Schema().Columns {
+		// if the agg key is a column
+		if column.Equal(newAgg.ctx, groupKey) {
+			proj.Exprs = append(proj.Exprs, caseExpr)
+			projSchema = append(projSchema, newCol)
+			found = true
+		} else {
+			proj.Exprs = append(proj.Exprs, column)
+			projSchema = append(projSchema, column)
+		}
+	}
+
+	if !found {
+		return nil, nil
+	}
+
+	proj.SetSchema(expression.NewSchema(projSchema...))
+	proj.SetChildren(newAgg)
+	return proj, newCol
+}
+
+func (a *groupbyStr2IntConverter) recursiveOptimize(ctx context.Context, p LogicalPlan,
+	mapping map[string]*expression.Column, opt *logicalOptimizeOp) (LogicalPlan, error) {
+	newChildren := make([]LogicalPlan, 0, len(p.Children()))
+	for _, child := range p.Children() {
+		newChild, err := a.recursiveOptimize(ctx, child, mapping, opt)
+		if err != nil {
+			return nil, err
+		}
+		newChildren = append(newChildren, newChild)
+	}
+	p.SetChildren(newChildren...)
+
+	// we have to update the parent's reference to the child columns
+	p.replaceExprColumns(mapping)
+	for _, dst := range p.Schema().Columns {
+		resolveColumnAndReplace(dst, mapping)
+	}
+
+	agg, ok := p.(*LogicalAggregation)
+	if !ok {
+		return p, nil
+	}
+	sel, ok := agg.children[0].(*LogicalSelection)
+	if !ok {
+		return p, nil
+	}
+	if proj := a.tryToConvertGroubyStr2Int(agg, sel, mapping, opt); proj != nil {
+		return proj, nil
+	}
+	return p, nil
+}
+
+func (a *groupbyStr2IntConverter) optimize(ctx context.Context, p LogicalPlan, opt *logicalOptimizeOp) (LogicalPlan, error) {
+	mapping := make(map[string]*expression.Column)
+	plan, err := a.recursiveOptimize(ctx, p, mapping, opt)
+	return plan, err
+}
+
+func (*groupbyStr2IntConverter) name() string {
+	return "groupby_str2int"
+}

--- a/planner/core/rule_groupby_str2int_test.go
+++ b/planner/core/rule_groupby_str2int_test.go
@@ -1,0 +1,128 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	"testing"
+
+	"github.com/pingcap/tidb/testkit"
+)
+
+func TestGByStr2Int1(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("set session tidb_enable_groupby_str2int=1")
+	tk.MustExec("CREATE TABLE t (a varchar(10), b int, c int, d text, e char(20))")
+	tk.MustQuery("explain format=brief SELECT d, b, max(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b").Check(testkit.Rows(
+		"Projection 24.00 root  case(eq(Column#8, 0), x, eq(Column#8, 1), y, eq(Column#8, 2), z)->Column#9, test.t.b, Column#7",
+		"└─HashAgg 24.00 root  group by:Column#10, test.t.b, funcs:max(Column#11)->Column#7, funcs:firstrow(test.t.b)->test.t.b, funcs:firstrow(Column#10)->Column#8",
+		"  └─TableReader 24.00 root  data:HashAgg",
+		"    └─HashAgg 24.00 cop[tikv]  group by:case(eq(test.t.d, \"x\"), 0, eq(test.t.d, \"y\"), 1, eq(test.t.d, \"z\"), 2), test.t.b, funcs:max(test.t.c)->Column#11",
+		"      └─Selection 30.00 cop[tikv]  in(test.t.d, \"x\", \"y\", \"z\")",
+		"        └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain format=brief SELECT a, b, max(c) FROM t WHERE a in ('x', 'y', 'z') GROUP BY a,b").Check(testkit.Rows(
+		"Projection 24.00 root  case(eq(Column#8, 0), x, eq(Column#8, 1), y, eq(Column#8, 2), z)->Column#9, test.t.b, Column#7",
+		"└─HashAgg 24.00 root  group by:Column#10, test.t.b, funcs:max(Column#11)->Column#7, funcs:firstrow(Column#10)->Column#8, funcs:firstrow(test.t.b)->test.t.b",
+		"  └─TableReader 24.00 root  data:HashAgg",
+		"    └─HashAgg 24.00 cop[tikv]  group by:case(eq(test.t.a, \"x\"), 0, eq(test.t.a, \"y\"), 1, eq(test.t.a, \"z\"), 2), test.t.b, funcs:max(test.t.c)->Column#11",
+		"      └─Selection 30.00 cop[tikv]  in(test.t.a, \"x\", \"y\", \"z\")",
+		"        └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain format=brief SELECT b,e, max(c) FROM t WHERE e in ('x', 'y', 'z') GROUP BY b,e").Check(testkit.Rows(
+		"Projection 24.00 root  test.t.b, case(eq(Column#8, 0), x, eq(Column#8, 1), y, eq(Column#8, 2), z)->Column#9, Column#7",
+		"└─HashAgg 24.00 root  group by:Column#10, test.t.b, funcs:max(Column#11)->Column#7, funcs:firstrow(test.t.b)->test.t.b, funcs:firstrow(Column#10)->Column#8",
+		"  └─TableReader 24.00 root  data:HashAgg",
+		"    └─HashAgg 24.00 cop[tikv]  group by:case(eq(test.t.e, \"x\"), 0, eq(test.t.e, \"y\"), 1, eq(test.t.e, \"z\"), 2), test.t.b, funcs:max(test.t.c)->Column#11",
+		"      └─Selection 30.00 cop[tikv]  in(test.t.e, \"x\", \"y\", \"z\")",
+		"        └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	tk.MustQuery("explain format=brief SELECT b,e, max(c) FROM t WHERE e in ('x', 'y') or e='z' GROUP BY b,e").Check(testkit.Rows(
+		"Projection 24.00 root  test.t.b, case(eq(Column#8, 0), x, eq(Column#8, 1), y, eq(Column#8, 2), z)->Column#9, Column#7",
+		"└─HashAgg 24.00 root  group by:Column#10, test.t.b, funcs:max(Column#11)->Column#7, funcs:firstrow(test.t.b)->test.t.b, funcs:firstrow(Column#10)->Column#8",
+		"  └─TableReader 24.00 root  data:HashAgg",
+		"    └─HashAgg 24.00 cop[tikv]  group by:case(eq(test.t.e, \"x\"), 0, eq(test.t.e, \"y\"), 1, eq(test.t.e, \"z\"), 2), test.t.b, funcs:max(test.t.c)->Column#11",
+		"      └─Selection 30.00 cop[tikv]  or(in(test.t.e, \"x\", \"y\"), eq(test.t.e, \"z\"))",
+		"        └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+
+	// group key with scalar function is not supported yet
+	tk.MustQuery("explain format=brief SELECT concat(d,'pp'), b, max(c) FROM t WHERE concat(d,'pp') in ('x', 'y', 'z') GROUP BY concat(d,'pp'),b").Check(testkit.Rows(
+		"Projection 6400.00 root  concat(test.t.d, pp)->Column#8, test.t.b, Column#7",
+		"└─HashAgg 6400.00 root  group by:Column#19, Column#20, funcs:max(Column#16)->Column#7, funcs:firstrow(Column#17)->test.t.b, funcs:firstrow(Column#18)->test.t.d",
+		"  └─Projection 8000.00 root  test.t.c, test.t.b, test.t.d, concat(test.t.d, pp)->Column#19, test.t.b",
+		"    └─TableReader 8000.00 root  data:Selection",
+		"      └─Selection 8000.00 cop[tikv]  in(concat(test.t.d, \"pp\"), \"x\", \"y\", \"z\")",
+		"        └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+}
+
+func TestGByStr2Int2(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("set session tidb_enable_groupby_str2int=1")
+	tk.MustExec("CREATE TABLE t (a int,b int,c int, d text)")
+	tk.MustExec("insert into t values(1,1,1,'x')")
+	tk.MustQuery(" SELECT d, b, max(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b").Check(testkit.Rows(
+		"x 1 1"))
+	tk.MustExec("insert into t values(1,1,2,'x')")
+	tk.MustQuery(" SELECT d, b, max(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b").Check(testkit.Rows(
+		"x 1 2"))
+	tk.MustExec("insert into t values(1,8,9,'y')")
+	tk.MustExec("insert into t values(1,5,6,'y')")
+	tk.MustExec("insert into t values(1,1,2,'p')")
+	tk.MustQuery(" SELECT d, b, max(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b ORDER BY d,b").Check(testkit.Rows(
+		"x 1 2", "y 5 6", "y 8 9"))
+}
+
+func TestGByStr2Int3(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("set session tidb_enable_groupby_str2int=1")
+	tk.MustExec("CREATE TABLE t (a varchar(10), b int, c int, d text, e char(20))")
+	tk.MustExec("insert into t values('xx',1,1,'x','y')")
+	tk.MustQuery(" SELECT d, b, max(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b").Check(testkit.Rows(
+		"x 1 1"))
+	tk.MustQuery(" SELECT a, b, max(c) FROM t WHERE a in ('x', 'xx', 'z') GROUP BY a,b").Check(testkit.Rows(
+		"xx 1 1"))
+	tk.MustQuery(" SELECT e, b, max(c) FROM t WHERE e in ('x', 'y', 'z') GROUP BY e,b").Check(testkit.Rows(
+		"y 1 1"))
+	tk.MustExec("insert into t values('xx',1,3,'x','y')")
+	tk.MustExec("insert into t values('xx',1,2,'x1','y')")
+	tk.MustExec("insert into t values('xx',2,4,'x1','y')")
+	tk.MustExec("insert into t values('xx',2,5,'x','y1')")
+	tk.MustExec("insert into t values('xx',2,6,'z','y1')")
+	tk.MustExec("insert into t values('yy',1,3,'x','y3')")
+	tk.MustExec("insert into t values('yy',1,2,'y','y1')")
+	tk.MustExec("insert into t values('xx',2,4,'y','y2')")
+	tk.MustExec("insert into t values('zz',2,5,'z','y3')")
+	tk.MustExec("insert into t values('zz',2,6,'z','y3')")
+	tk.MustQuery(" SELECT d, b, sum(c) FROM t WHERE d in ('x', 'y', 'z') GROUP BY d,b ORDER BY d,b").Check(testkit.Rows(
+		"x 1 7]\n[x 2 5]\n[y 1 2]\n[y 2 4]\n[z 2 17"))
+	tk.MustQuery(" SELECT a, b, sum(c) FROM t WHERE a in ('x', 'xx', 'z') GROUP BY a,b ORDER BY a,b").Check(testkit.Rows(
+		"xx 1 6]\n[xx 2 19"))
+	tk.MustQuery(" SELECT e, b, sum(c) FROM t WHERE e in ('y1', 'y', 'y3') GROUP BY e,b ORDER BY e,b").Check(testkit.Rows(
+		"y 1 6]\n[y 2 4]\n[y1 1 2]\n[y1 2 11]\n[y3 1 3]\n[y3 2 11"))
+}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1026,6 +1026,8 @@ type SessionVars struct {
 	RcReadCheckTS bool
 	// RemoveOrderbyInSubquery indicates whether to remove ORDER BY in subquery.
 	RemoveOrderbyInSubquery bool
+	// EnableGroupByString2Int indicates whether to enable rule groupby_str2int.
+	EnableGroupByString2Int bool
 }
 
 // InitStatementContext initializes a StatementContext, the object is reused to reduce allocation.
@@ -1262,6 +1264,7 @@ func NewSessionVars() *SessionVars {
 		StatsLoadSyncWait:           StatsLoadSyncWait.Load(),
 		EnableLegacyInstanceScope:   DefEnableLegacyInstanceScope,
 		RemoveOrderbyInSubquery:     DefTiDBRemoveOrderbyInSubquery,
+		EnableGroupByString2Int:     DefTiDBEnableGroupbyString2Int,
 	}
 	vars.KVVars = tikvstore.NewVariables(&vars.Killed)
 	vars.Concurrency = Concurrency{

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1397,6 +1397,10 @@ var defaultSysVars = []*SysVar{
 		s.RcReadCheckTS = TiDBOptOn(val)
 		return nil
 	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBEnableGroupbyString2Int, Value: BoolToOnOff(DefTiDBEnableGroupbyString2Int), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.EnableGroupByString2Int = TiDBOptOn(val)
+		return nil
+	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBRemoveOrderbyInSubquery, Value: BoolToOnOff(DefTiDBRemoveOrderbyInSubquery), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
 		s.RemoveOrderbyInSubquery = TiDBOptOn(val)
 		return nil

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -597,6 +597,9 @@ const (
 	// TiDBRemoveOrderbyInSubquery indicates whether to remove ORDER BY in subquery.
 	TiDBRemoveOrderbyInSubquery = "tidb_remove_orderby_in_subquery"
 
+	// TiDBRemoveOrderbyInSubquery indicates whether to enable rule groupby_str2int.
+	TiDBEnableGroupbyString2Int = "tidb_enable_groupby_str2int"
+
 	// TiDBEnablePseudoForOutdatedStats indicates whether use pseudo for outdated stats
 	TiDBEnablePseudoForOutdatedStats = "tidb_enable_pseudo_for_outdated_stats"
 
@@ -829,6 +832,7 @@ const (
 	DefTiDBBatchPendingTiFlashCount       = 4000
 	DefRCReadCheckTS                      = false
 	DefTiDBRemoveOrderbyInSubquery        = false
+	DefTiDBEnableGroupbyString2Int        = false
 	DefTiDBReadStaleness                  = 0
 	DefTiDBGCMaxWaitTime                  = 24 * 60 * 60
 )


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/33949

This rule tries to convert an Aggregation on a string column to Aggregation on int column.
There are several requirements that have to be met so that this rule can be applied:
1. There is a Selection under Aggregation
2. The Selection has equality filter on one of the group keys
3. The filtered group key must be string type
4. The filter condition must be disjoint of IN or EQ scalar function

e.g.
```sql
 SELECT a, b, max(c) FROM foo WHERE a in ('x', 'y', 'z') GROUP BY a,b;
```
will be transformed into
```sql
 SELECT CASE WHEN a=0 THEN 'x' WHEN a=1 THEN 'y' WHEN a=2 THEN 'z' END as a, b, max
 FROM (
	SELECT a, b, max(c)
	FROM (
	   SELECT CASE WHEN a='x' THEN 0 WHEN a='y' THEN 1 WHEN a='z' THEN 2 END as a, b, c
	   FROM foo
	   WHERE a in ('x', 'y', 'z')
	) t GROUP BY a,b
 ) t;
```

NB: This rule doesn't guarantee to yield better alternative, especially when
 1. The IN list constant values are too many, hence the comparison may take a lot more time.
 2. There is an index on the string group key that can be utilized by top Aggregation, whereas
    the alternative will break the order property of the index.

For the moment, we don't consider other special cases, such as the filter condition is below
the child of Aggregation, unless we can pull up the filter from child operators.

Ideally, the optimization should be done in query executor automatically, without intervention
of optimizer, which requires that there is dictionary encoding in the storage engine and the
execution engine can do the transformation on the fly.

This rule is turned off by default. Use with caution.


### Check List

Tests 

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

```release-note
None
```
