### PR TITLE
executor: add some memory tracker in HashJoin

### DIFF
--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -385,7 +385,12 @@ func (ht *concurrentMapHashTable) Get(hashKey uint64) (rowPtrs []chunk.RowPtr) {
 
 // GetMemoryDelta gets the memDelta of the concurrentMapHashTable. Memory delta will be cleared after each fetch.
 func (ht *concurrentMapHashTable) GetMemoryDelta() int64 {
-	memDelta := atomic.LoadInt64(&ht.memDelta)
-	atomic.AddInt64(&ht.memDelta, -memDelta)
+	var memDelta int64
+	for {
+		memDelta = atomic.LoadInt64(&ht.memDelta)
+		if atomic.CompareAndSwapInt64(&ht.memDelta, memDelta, 0) {
+			break
+		}
+	}
 	return memDelta
 }

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -352,6 +352,7 @@ func newConcurrentMapHashTable() *concurrentMapHashTable {
 	ht.hashMap = newConcurrentMap()
 	ht.entryStore = newEntryStore()
 	ht.length = 0
+	ht.memDelta = hack.DefBucketMemoryUsageForMapIntToPtr + int64(unsafe.Sizeof(entry{}))*initialEntrySliceLen
 	return ht
 }
 

--- a/util/hack/hack.go
+++ b/util/hack/hack.go
@@ -56,3 +56,12 @@ const (
 	// LoadFactorDen is the denominator of load factor
 	LoadFactorDen = 2
 )
+
+const (
+	// DefBucketMemoryUsageForMapStrToSlice = bucketSize*(1+unsafe.Sizeof(string) + unsafe.Sizeof(slice))+2*ptrSize
+	// ref https://github.com/golang/go/blob/go1.15.6/src/reflect/type.go#L2162.
+	// The bucket size may be changed by golang implement in the future.
+	DefBucketMemoryUsageForMapStrToSlice = 8*(1+16+24) + 16
+	// DefBucketMemoryUsageForMapIntToPtr = bucketSize*(1+unsafe.Sizeof(uint64) + unsafe.Sizeof(pointer))+2*ptrSize
+	DefBucketMemoryUsageForMapIntToPtr = 8*(1+8+8) + 16
+)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/33877

Problem Summary:

### What is changed and how it works?
Track the memory usage of Golang map and entryStore in HashJoin.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
