### PR TITLE
ddl: support index regions and updating the existed table rule when changing partition 

### DIFF
--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -74,7 +74,6 @@ func TestAlterTableAttributes(t *testing.T) {
 	// without equal
 	tk.MustExec(`alter table alter_t attributes " merge_option=allow ";`)
 	tk.MustExec(`alter table alter_t attributes " merge_option=allow , key=value ";`)
-
 }
 
 func TestAlterTablePartitionAttributes(t *testing.T) {
@@ -101,6 +100,42 @@ PARTITION BY RANGE (c) (
 	// without equal
 	tk.MustExec(`alter table alter_p partition p1 attributes " merge_option=allow ";`)
 	tk.MustExec(`alter table alter_p partition p1 attributes " merge_option=allow , key=value ";`)
+
+	// reset all
+	tk.MustExec(`alter table alter_p partition p0 attributes default;`)
+	tk.MustExec(`alter table alter_p partition p1 attributes default;`)
+	tk.MustExec(`alter table alter_p partition p2 attributes default;`)
+	tk.MustExec(`alter table alter_p partition p3 attributes default;`)
+
+	// add table level attribute
+	tk.MustExec(`alter table alter_p attributes="merge_option=deny";`)
+	rows := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
+	require.Len(t, rows, 1)
+
+	// add a new partition p4
+	tk.MustExec(`alter table alter_p add partition (PARTITION p4 VALUES LESS THAN (60));`)
+	rows1 := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
+	require.Len(t, rows1, 1)
+	require.NotEqual(t, rows[0][3], rows1[0][3])
+
+	// drop the new partition p4
+	tk.MustExec(`alter table alter_p drop partition p4;`)
+	rows2 := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
+	require.Len(t, rows2, 1)
+	require.Equal(t, rows[0][3], rows2[0][3])
+
+	// add a new partition p5
+	tk.MustExec(`alter table alter_p add partition (PARTITION p5 VALUES LESS THAN (80));`)
+	rows3 := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
+	require.Len(t, rows3, 1)
+	require.NotEqual(t, rows[0][3], rows3[0][3])
+
+	// truncate the new partition p5
+	tk.MustExec(`alter table alter_p truncate partition p5;`)
+	rows4 := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
+	require.Len(t, rows2, 1)
+	require.NotEqual(t, rows3[0][3], rows4[0][3])
+	require.NotEqual(t, rows[0][3], rows4[0][3])
 }
 
 func TestTruncateTable(t *testing.T) {

--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -133,7 +133,7 @@ PARTITION BY RANGE (c) (
 	// truncate the new partition p5
 	tk.MustExec(`alter table alter_p truncate partition p5;`)
 	rows4 := tk.MustQuery(`select * from information_schema.attributes;`).Sort().Rows()
-	require.Len(t, rows2, 1)
+	require.Len(t, rows4, 1)
 	require.NotEqual(t, rows3[0][3], rows4[0][3])
 	require.NotEqual(t, rows[0][3], rows4[0][3])
 }

--- a/ddl/attributes_sql_test.go
+++ b/ddl/attributes_sql_test.go
@@ -478,7 +478,8 @@ PARTITION BY RANGE (c) (
 	require.Len(t, rows1, 2)
 	require.Equal(t, "schema/test/part", rows1[0][0])
 	require.Equal(t, `"key=value"`, rows1[0][2])
-	require.Equal(t, rows[0][3], rows1[0][3])
+	// table attribute only contains three ranges now
+	require.NotEqual(t, rows[0][3], rows1[0][3])
 	require.Equal(t, "schema/test/part/p1", rows1[1][0])
 	require.Equal(t, `"key2=value2"`, rows1[1][2])
 	require.Equal(t, rows[2][3], rows1[1][3])

--- a/ddl/label/rule.go
+++ b/ddl/label/rule.go
@@ -144,8 +144,8 @@ func (r *Rule) Reset(dbName, tableName, partName string, ids ...int64) *Rule {
 	sort.Slice(ids, func(i, j int) bool { return ids[i] < ids[j] })
 	for i := 0; i < len(ids); i++ {
 		data := map[string]string{
-			"start_key": hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(ids[i]))),
-			"end_key":   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(ids[i]+1))),
+			"start_key": hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(ids[i]))),
+			"end_key":   hex.EncodeToString(codec.EncodeBytes(nil, tablecodec.GenTablePrefix(ids[i]+1))),
 		}
 		r.Data = append(r.Data, data)
 	}

--- a/ddl/label/rule_test.go
+++ b/ddl/label/rule_test.go
@@ -75,14 +75,14 @@ func TestReset(t *testing.T) {
 	require.Equal(t, rule.Index, 2)
 
 	r := rule.Data[0].(map[string]string)
-	require.Equal(t, "7480000000000000ff015f720000000000fa", r["start_key"])
-	require.Equal(t, "7480000000000000ff025f720000000000fa", r["end_key"])
+	require.Equal(t, "7480000000000000ff0100000000000000f8", r["start_key"])
+	require.Equal(t, "7480000000000000ff0200000000000000f8", r["end_key"])
 	r = rule.Data[1].(map[string]string)
-	require.Equal(t, "7480000000000000ff025f720000000000fa", r["start_key"])
-	require.Equal(t, "7480000000000000ff035f720000000000fa", r["end_key"])
+	require.Equal(t, "7480000000000000ff0200000000000000f8", r["start_key"])
+	require.Equal(t, "7480000000000000ff0300000000000000f8", r["end_key"])
 	r = rule.Data[2].(map[string]string)
-	require.Equal(t, "7480000000000000ff035f720000000000fa", r["start_key"])
-	require.Equal(t, "7480000000000000ff045f720000000000fa", r["end_key"])
+	require.Equal(t, "7480000000000000ff0300000000000000f8", r["start_key"])
+	require.Equal(t, "7480000000000000ff0400000000000000f8", r["end_key"])
 
 	r1 := rule.Clone()
 	require.Equal(t, r1, rule)
@@ -97,8 +97,8 @@ func TestReset(t *testing.T) {
 	require.Equal(t, rule.Index, 3)
 
 	r = r2.Data[0].(map[string]string)
-	require.Equal(t, "7480000000000000ff025f720000000000fa", r["start_key"])
-	require.Equal(t, "7480000000000000ff035f720000000000fa", r["end_key"])
+	require.Equal(t, "7480000000000000ff0200000000000000f8", r["start_key"])
+	require.Equal(t, "7480000000000000ff0300000000000000f8", r["end_key"])
 
 	// default case
 	spec = &ast.AttributesSpec{Default: true}

--- a/ddl/partition.go
+++ b/ddl/partition.go
@@ -152,6 +152,15 @@ func (w *worker) onAddTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (v
 			return ver, errors.Wrapf(err, "failed to notify PD the placement rules")
 		}
 
+		ids := getIDs([]*model.TableInfo{tblInfo})
+		for _, p := range tblInfo.Partition.AddingDefinitions {
+			ids = append(ids, p.ID)
+		}
+		if err := alterTableLabelRule(job.SchemaName, tblInfo, ids); err != nil {
+			job.State = model.JobStateCancelled
+			return ver, err
+		}
+
 		// none -> replica only
 		job.SchemaState = model.StateReplicaOnly
 	case model.StateReplicaOnly:
@@ -197,6 +206,27 @@ func (w *worker) onAddTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (v
 	}
 
 	return ver, errors.Trace(err)
+}
+
+func alterTableLabelRule(schemaName string, meta *model.TableInfo, ids []int64) error {
+	tableRuleID := fmt.Sprintf(label.TableIDFormat, label.IDPrefix, schemaName, meta.Name.L)
+	oldRule, err := infosync.GetLabelRules(context.TODO(), []string{tableRuleID})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if len(oldRule) == 0 {
+		return nil
+	}
+
+	r, ok := oldRule[tableRuleID]
+	if ok {
+		rule := r.Reset(schemaName, meta.Name.L, "", ids...)
+		err = infosync.PutLabelRule(context.TODO(), rule)
+		if err != nil {
+			return errors.Wrapf(err, "failed to notify PD label rule")
+		}
+	}
+	return nil
 }
 
 func alterTablePartitionBundles(t *meta.Meta, tblInfo *model.TableInfo, addingDefinitions []model.PartitionDefinition) ([]*placement.Bundle, error) {
@@ -1069,6 +1099,12 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 			job.State = model.JobStateCancelled
 			return ver, errors.Wrapf(err, "failed to notify PD the label rules")
 		}
+
+		if err := alterTableLabelRule(job.SchemaName, tblInfo, getIDs([]*model.TableInfo{tblInfo})); err != nil {
+			job.State = model.JobStateCancelled
+			return ver, err
+		}
+
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, true)
 		if err != nil {
 			return ver, errors.Trace(err)
@@ -1100,6 +1136,12 @@ func (w *worker) onDropTablePartition(d *ddlCtx, t *meta.Meta, job *model.Job) (
 			job.State = model.JobStateCancelled
 			return ver, errors.Wrapf(err, "failed to notify PD the label rules")
 		}
+
+		if err := alterTableLabelRule(job.SchemaName, tblInfo, getIDs([]*model.TableInfo{tblInfo})); err != nil {
+			job.State = model.JobStateCancelled
+			return ver, err
+		}
+
 		job.SchemaState = model.StateDeleteOnly
 		ver, err = updateVersionAndTableInfo(t, job, tblInfo, originalState != job.SchemaState)
 	case model.StateDeleteOnly:


### PR DESCRIPTION
Signed-off-by: Ryan Leung <rleungx@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33929

Problem Summary: The table rule won't be updated when adding/dropping a partition.

### What is changed and how it works?
This PR supports updating the existed table rules when adding or dropping a partition.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test (https://github.com/pingcap/endless/pull/582)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that the table attributes don't support index and won't be updated when the partition changes
```