### PR TITLE
executor: fix unstable test of `TestTimestampDefaultValueTimeZone`

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -2503,11 +2503,11 @@ func TestTimestampDefaultValueTimeZone(t *testing.T) {
 	// change timezone
 	tk.MustExec(`set time_zone = 'Asia/Shanghai'`)
 	tk.MustExec(`create table t(a timestamp default current_timestamp)`)
-	tk.MustExec(`insert into t set a=now()`)
+	tk.MustExec(`insert into t set a="20220413154712"`)
 	tk.MustExec(`alter table t add column b timestamp as (a+1) virtual;`)
 	// change timezone
 	tk.MustExec(`set time_zone = '+05:00'`)
-	tk.MustExec(`insert into t set a=now()`)
+	tk.MustExec(`insert into t set a="20220413154840"`)
 	tk.MustExec(`alter table t add index(b);`)
 	tk.MustExec("admin check table t")
 	tk.MustExec(`set time_zone = '-03:00'`)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33923

Problem Summary:

When "b timestamp as (a+1) virtual" is met and the value "now ()" is inserted into column a, it may return the error of `[types:1292]Incorrect timestamp value: '20220412172760'`.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
