### PR TITLE
*: using EscapeSQL to enhance SQL formatting in dumping & lightning

### DIFF
--- a/br/pkg/lightning/checkpoints/checkpoints_sql_test.go
+++ b/br/pkg/lightning/checkpoints/checkpoints_sql_test.go
@@ -362,11 +362,11 @@ func TestIgnoreAllErrorCheckpoints_SQL(t *testing.T) {
 
 	s.mock.ExpectBegin()
 	s.mock.
-		ExpectExec("UPDATE `mock-schema`\\.engine_v\\d+ SET status = 30 WHERE 'all' = \\? AND status <= 25").
+		ExpectExec("UPDATE `mock-schema`\\.`engine_v\\d+` SET status = 30 WHERE 'all' = \\? AND status <= 25").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(5, 3))
 	s.mock.
-		ExpectExec("UPDATE `mock-schema`\\.table_v\\d+ SET status = 30 WHERE 'all' = \\? AND status <= 25").
+		ExpectExec("UPDATE `mock-schema`\\.`table_v\\d+` SET status = 30 WHERE 'all' = \\? AND status <= 25").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(6, 2))
 	s.mock.ExpectCommit()
@@ -381,11 +381,11 @@ func TestIgnoreOneErrorCheckpoint(t *testing.T) {
 
 	s.mock.ExpectBegin()
 	s.mock.
-		ExpectExec("UPDATE `mock-schema`\\.engine_v\\d+ SET status = 30 WHERE table_name = \\? AND status <= 25").
+		ExpectExec("UPDATE `mock-schema`\\.`engine_v\\d+` SET status = 30 WHERE table_name = \\? AND status <= 25").
 		WithArgs("`db1`.`t2`").
 		WillReturnResult(sqlmock.NewResult(5, 2))
 	s.mock.
-		ExpectExec("UPDATE `mock-schema`\\.table_v\\d+ SET status = 30 WHERE table_name = \\? AND status <= 25").
+		ExpectExec("UPDATE `mock-schema`\\.`table_v\\d+` SET status = 30 WHERE table_name = \\? AND status <= 25").
 		WithArgs("`db1`.`t2`").
 		WillReturnResult(sqlmock.NewResult(6, 1))
 	s.mock.ExpectCommit()
@@ -407,15 +407,15 @@ func TestDestroyAllErrorCheckpoints_SQL(t *testing.T) {
 				AddRow("`db1`.`t2`", -1, 0),
 		)
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.chunk_v\\d+ WHERE table_name IN .+ 'all' = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`chunk_v\\d+` WHERE table_name IN .+ 'all' = \\?").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 5))
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.engine_v\\d+ WHERE table_name IN .+ 'all' = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`engine_v\\d+` WHERE table_name IN .+ 'all' = \\?").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 3))
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.table_v\\d+ WHERE 'all' = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`table_v\\d+` WHERE 'all' = \\?").
 		WithArgs(sqlmock.AnyArg()).
 		WillReturnResult(sqlmock.NewResult(0, 2))
 	s.mock.ExpectCommit()
@@ -442,15 +442,15 @@ func TestDestroyOneErrorCheckpoints(t *testing.T) {
 				AddRow("`db1`.`t2`", -1, 0),
 		)
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.chunk_v\\d+ WHERE .+table_name = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`chunk_v\\d+` WHERE .+table_name = \\?").
 		WithArgs("`db1`.`t2`").
 		WillReturnResult(sqlmock.NewResult(0, 4))
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.engine_v\\d+ WHERE .+table_name = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`engine_v\\d+` WHERE .+table_name = \\?").
 		WithArgs("`db1`.`t2`").
 		WillReturnResult(sqlmock.NewResult(0, 2))
 	s.mock.
-		ExpectExec("DELETE FROM `mock-schema`\\.table_v\\d+ WHERE table_name = \\?").
+		ExpectExec("DELETE FROM `mock-schema`\\.`table_v\\d+` WHERE table_name = \\?").
 		WithArgs("`db1`.`t2`").
 		WillReturnResult(sqlmock.NewResult(0, 1))
 	s.mock.ExpectCommit()

--- a/br/pkg/lightning/restore/meta_manager.go
+++ b/br/pkg/lightning/restore/meta_manager.go
@@ -286,9 +286,7 @@ func (m *dbTableMetaMgr) AllocTableRowIDs(ctx context.Context, rawRowIDMax int64
 				newStatus = metaStatusRestoreStarted
 			}
 
-			// nolint:gosec
-			query := fmt.Sprintf("update %s set row_id_base = ?, row_id_max = ?, status = ? where table_id = ? and task_id = ?", m.tableName)
-			_, err := tx.ExecContext(ctx, query, newRowIDBase, newRowIDMax, newStatus.String(), m.tr.tableInfo.ID, m.taskID)
+			_, err := tx.ExecContext(ctx, fmt.Sprintf("update %s set row_id_base = ?, row_id_max = ?, status = ? where table_id = ? and task_id = ?", m.tableName), newRowIDBase, newRowIDMax, newStatus.String(), m.tr.tableInfo.ID, m.taskID)
 			if err != nil {
 				return errors.Trace(err)
 			}
@@ -456,9 +454,7 @@ func (m *dbTableMetaMgr) CheckAndUpdateLocalChecksum(ctx context.Context, checks
 			return errors.Trace(rows.Err())
 		}
 
-		// nolint:gosec
-		query := fmt.Sprintf("update %s set total_kvs = ?, total_bytes = ?, checksum = ?, status = ?, has_duplicates = ? where table_id = ? and task_id = ?", m.tableName)
-		_, err = tx.ExecContext(ctx, query, checksum.SumKVS(), checksum.SumSize(), checksum.Sum(), newStatus.String(), hasLocalDupes, m.tr.tableInfo.ID, m.taskID)
+		_, err = tx.ExecContext(ctx, fmt.Sprintf("update %s set total_kvs = ?, total_bytes = ?, checksum = ?, status = ?, has_duplicates = ? where table_id = ? and task_id = ?", m.tableName), checksum.SumKVS(), checksum.SumSize(), checksum.Sum(), newStatus.String(), hasLocalDupes, m.tr.tableInfo.ID, m.taskID)
 		return errors.Annotate(err, "update local checksum failed")
 	})
 	if err != nil {
@@ -677,9 +673,7 @@ func (m *dbTaskMetaMgr) CheckTasksExclusively(ctx context.Context, action func(t
 			return errors.Trace(err)
 		}
 		for _, task := range newTasks {
-			// nolint:gosec
-			query := fmt.Sprintf("REPLACE INTO %s (task_id, pd_cfgs, status, state, source_bytes, cluster_avail) VALUES(?, ?, ?, ?, ?, ?)", m.tableName)
-			if _, err = tx.ExecContext(ctx, query, task.taskID, task.pdCfgs, task.status.String(), task.state, task.sourceBytes, task.clusterAvail); err != nil {
+			if _, err = tx.ExecContext(ctx, fmt.Sprintf("REPLACE INTO %s (task_id, pd_cfgs, status, state, source_bytes, cluster_avail) VALUES(?, ?, ?, ?, ?, ?)", m.tableName), task.taskID, task.pdCfgs, task.status.String(), task.state, task.sourceBytes, task.clusterAvail); err != nil {
 				return errors.Trace(err)
 			}
 		}
@@ -785,9 +779,7 @@ func (m *dbTaskMetaMgr) CheckAndPausePdSchedulers(ctx context.Context) (pdutil.U
 			return errors.Trace(err)
 		}
 
-		// nolint:gosec
-		query := fmt.Sprintf("update %s set pd_cfgs = ?, status = ? where task_id = ?", m.tableName)
-		_, err = tx.ExecContext(ctx, query, string(jsonByts), taskMetaStatusScheduleSet.String(), m.taskID)
+		_, err = tx.ExecContext(ctx, fmt.Sprintf("update %s set pd_cfgs = ?, status = ? where task_id = ?", m.tableName), string(jsonByts), taskMetaStatusScheduleSet.String(), m.taskID)
 
 		return errors.Annotate(err, "update task pd configs failed")
 	})
@@ -898,9 +890,7 @@ func (m *dbTaskMetaMgr) CheckAndFinishRestore(ctx context.Context, finished bool
 				newStatus = taskMetaStatusSwitchSkipped
 			}
 
-			// nolint:gosec
-			query := fmt.Sprintf("update %s set status = ?, state = ? where task_id = ?", m.tableName)
-			if _, err = tx.ExecContext(ctx, query, newStatus.String(), newState, m.taskID); err != nil {
+			if _, err = tx.ExecContext(ctx, fmt.Sprintf("update %s set status = ?, state = ? where task_id = ?", m.tableName), newStatus.String(), newState, m.taskID); err != nil {
 				return errors.Trace(err)
 			}
 		}

--- a/br/pkg/mock/mock_cluster.go
+++ b/br/pkg/mock/mock_cluster.go
@@ -164,6 +164,7 @@ func waitUntilServerOnline(addr string, statusPort uint) string {
 	// connect http status
 	statusURL := fmt.Sprintf("http://127.0.0.1:%d/status", statusPort)
 	for retry = 0; retry < retryTime; retry++ {
+		// #nosec G107
 		resp, err := http.Get(statusURL) // nolint:noctx,gosec
 		if err == nil {
 			// Ignore errors.

--- a/cmd/pluginpkg/pluginpkg.go
+++ b/cmd/pluginpkg/pluginpkg.go
@@ -126,7 +126,7 @@ func main() {
 	}
 
 	genFileName := filepath.Join(pkgDir, filepath.Base(pkgDir)+".gen.go")
-	genFile, err := os.OpenFile(genFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700) // # nosec G302
+	genFile, err := os.OpenFile(genFileName, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0700) // #nosec G302
 	if err != nil {
 		log.Printf("generate code failure during prepare output file, %+v\n", err)
 		os.Exit(1)

--- a/dumpling/tests/s3/import.go
+++ b/dumpling/tests/s3/import.go
@@ -10,6 +10,7 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/util/sqlexec"
 	"github.com/spf13/cobra"
 	"golang.org/x/sync/errgroup"
 )
@@ -62,7 +63,12 @@ func main() {
 			return errors.Trace(err)
 		}
 
-		query := fmt.Sprintf("insert into %s values('aaaaaaaaaa')", table) // nolint:gosec
+		query, escapeErr := sqlexec.EscapeSQL("insert into %n values('aaaaaaaaaa')", table)
+		if escapeErr != nil {
+			fmt.Printf("fail to import data, err: %v", escapeErr)
+			os.Exit(2)
+		}
+
 		for i := 1; i < 10000; i++ {
 			query += ",('aaaaaaaaaa')"
 		}

--- a/executor/select_into.go
+++ b/executor/select_into.go
@@ -53,7 +53,7 @@ func (s *SelectIntoExec) Open(ctx context.Context) error {
 	}
 
 	// MySQL-compatible behavior: allow files to be group-readable
-	f, err := os.OpenFile(s.intoOpt.FileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0640) // # nosec G302
+	f, err := os.OpenFile(s.intoOpt.FileName, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0640) // #nosec G302
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/util/security.go
+++ b/util/security.go
@@ -95,7 +95,7 @@ func ToTLSConfigWithVerify(caPath, certPath, keyPath string, verifyCN []string) 
 	}
 	//nolint:gosec
 	tlsCfg := &tls.Config{
-		MinVersion:   tls.VersionTLS10,
+		MinVersion:   tls.VersionTLS12,
 		Certificates: certificates,
 		RootCAs:      certPool,
 		ClientCAs:    certPool,
@@ -125,7 +125,7 @@ func ToTLSConfigWithVerifyByRawbytes(caData, certData, keyData []byte, verifyCN 
 	}
 	//nolint:gosec
 	tlsCfg := &tls.Config{
-		MinVersion:   tls.VersionTLS10,
+		MinVersion:   tls.VersionTLS12,
 		Certificates: certificates,
 		RootCAs:      certPool,
 		ClientCAs:    certPool,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33950

Problem Summary:

Due to the lack of support for escape functions in the golang standard library ([database/sql: missing escape functions #18478](https://github.com/golang/go/issues/18478)), formatting functions have to be used in dumplings and lightning to splicing fields such as schema, table name, column name, etc., which will bring security risks.

### What is changed and how it works?

The TiDB kernel implements some utility functions to handle internal SQL calls in secure. We can use the tool function EscapeSQL implemented by the TiDB kernel to escape fields such as schema, table name or column name, to eliminate the hidden dangers of current SQL formatting.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
