### PR TITLE
server: change the log to debug level when handshake error

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -519,7 +519,7 @@ func (s *Server) onConn(conn *clientConn) {
 		} else {
 			metrics.HandShakeErrorCounter.Inc()
 			logutil.BgLogger().With(zap.Uint64("conn", conn.connectionID)).
-				Warn("Server.onConn handshake", zap.Error(err),
+				Debug("Server.onConn handshake", zap.Error(err),
 					zap.String("remote addr", conn.bufReadConn.RemoteAddr().String()))
 		}
 		terror.Log(conn.Close())


### PR DESCRIPTION
Signed-off-by: Jack Yu <jackysp@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33977 

Problem Summary:
The log is noisy, and it's hard to distinguish which is not need to highlight.

### What is changed and how it works?
Change it to debug level, though it has a metrics for the users to know there're some handshake errors.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
