### PR TITLE
statistics: DumpIndexUsageToKV use batch insert to reduce cost

### DIFF
--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -2406,7 +2406,7 @@ func BenchmarkIndexUsageInformationInsert(b *testing.B) {
 		tk.MustQuery("select j from t_idx where j=1")
 		tk.MustQuery("select k from t_idx where k=1")
 		do := dom
-		err := do.StatsHandle().DumpIndexUsageToKVV1()
+		err := do.StatsHandle().DumpIndexUsageToKV()
 		require.NoError(b, err)
 	}
 }

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -343,9 +343,48 @@ func (h *Handle) sweepIdxUsageList() indexUsageMap {
 func (h *Handle) DumpIndexUsageToKV() error {
 	ctx := context.Background()
 	mapper := h.sweepIdxUsageList()
+	type FullIndexUsageInformation struct {
+		id          GlobalIndexID
+		information IndexUsageInformation
+	}
+	indexInformationSlice := make([]FullIndexUsageInformation, 0, len(mapper))
 	for id, value := range mapper {
-		const sql = `insert into mysql.SCHEMA_INDEX_USAGE values (%?, %?, %?, %?, %?) on duplicate key update query_count=query_count+%?, rows_selected=rows_selected+%?, last_used_at=greatest(last_used_at, %?)`
-		_, _, err := h.execRestrictedSQL(ctx, sql, id.TableID, id.IndexID, value.QueryCount, value.RowsSelected, value.LastUsedAt, value.QueryCount, value.RowsSelected, value.LastUsedAt)
+		indexInformationSlice = append(indexInformationSlice, FullIndexUsageInformation{id: id, information: value})
+	}
+	for i := 0; i < len(mapper); i += 10 {
+		end := i + 10
+		if end > len(mapper) {
+			end = len(mapper)
+		}
+		sql := new(strings.Builder)
+		sqlexec.MustFormatSQL(sql, "insert into mysql.SCHEMA_INDEX_USAGE (table_id,index_id,query_count,rows_selected,last_used_at) values")
+		for j := i; j < end; j++ {
+			index := indexInformationSlice[j]
+			sqlexec.MustFormatSQL(sql, "(%?, %?, %?, %?, %?)", index.id.TableID, index.id.IndexID,
+				index.information.QueryCount, index.information.RowsSelected, index.information.LastUsedAt)
+			if j < end-1 {
+				sqlexec.MustFormatSQL(sql, ",")
+			}
+		}
+		sqlexec.MustFormatSQL(sql, "on duplicate key update query_count=query_count+values(query_count),rows_selected=rows_selected+values(rows_selected),last_used_at=greatest(last_used_at, values(last_used_at))")
+		if _, _, err := h.execRestrictedSQL(ctx, sql.String()); err != nil {
+			return errors.Trace(err)
+		}
+	}
+	return nil
+}
+
+// DumpIndexUsageToKVV1 will dump in-memory index usage information to KV.
+func (h *Handle) DumpIndexUsageToKVV1() error {
+	ctx := context.Background()
+	mapper := h.sweepIdxUsageList()
+	for id, value := range mapper {
+		const sql = `insert into mysql.SCHEMA_INDEX_USAGE
+(table_id,index_id,query_count,rows_selected,last_used_at) values (%?, %?, %?, %?, %?)
+	on duplicate key
+update query_count=query_count+values(query_count),rows_selected=rows_selected+values(rows_selected),
+last_used_at=greatest(last_used_at, values(last_used_at))`
+		_, _, err := h.execRestrictedSQL(ctx, sql, id.TableID, id.IndexID, value.QueryCount, value.RowsSelected, value.LastUsedAt)
 		if err != nil {
 			return err
 		}

--- a/statistics/handle/update.go
+++ b/statistics/handle/update.go
@@ -374,24 +374,6 @@ func (h *Handle) DumpIndexUsageToKV() error {
 	return nil
 }
 
-// DumpIndexUsageToKVV1 will dump in-memory index usage information to KV.
-func (h *Handle) DumpIndexUsageToKVV1() error {
-	ctx := context.Background()
-	mapper := h.sweepIdxUsageList()
-	for id, value := range mapper {
-		const sql = `insert into mysql.SCHEMA_INDEX_USAGE
-(table_id,index_id,query_count,rows_selected,last_used_at) values (%?, %?, %?, %?, %?)
-	on duplicate key
-update query_count=query_count+values(query_count),rows_selected=rows_selected+values(rows_selected),
-last_used_at=greatest(last_used_at, values(last_used_at))`
-		_, _, err := h.execRestrictedSQL(ctx, sql, id.TableID, id.IndexID, value.QueryCount, value.RowsSelected, value.LastUsedAt)
-		if err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // GCIndexUsage will delete the usage information of those indexes that do not exist.
 func (h *Handle) GCIndexUsage() error {
 	// For performance and implementation reasons, mysql.schema_index_usage doesn't handle DDL.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #33980

Problem Summary: Before `DumpIndexUsageToKV` use `for loop insert`,if the table has many index and these index are all used, it wil cost a lot.So we can enhance to use `batch insert` to reduce cost.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Reduce `DumpIndexUsageToKV` cost(Net IO) from TIDB to TIKV
```
