### PR TITLE
br-stream: fix infinite help function loop

### DIFF
--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -50,8 +50,8 @@ func NewStreamCommand() *cobra.Command {
 		newStreamTruncateCommand(),
 	)
 	command.SetHelpFunc(func(command *cobra.Command, strings []string) {
-		task.HiddenFlagsForStream(command.Parent().PersistentFlags())
-		command.Parent().HelpFunc()(command, strings)
+		task.HiddenFlagsForStream(command.Root().PersistentFlags())
+		command.Root().HelpFunc()(command, strings)
 	})
 
 	return command


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/33795

Problem Summary:
use cmd.Parent() will trigger infinite loop.

### What is changed and how it works?
use cmd.Root() instead.

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Manual test (add detailed scripts or steps below)
<img width="722" alt="image" src="https://user-images.githubusercontent.com/5906259/163513012-672cf169-9faf-4604-81dd-e6c27f1773df.png">



Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
