### PR TITLE
parser: make the prepared statement like expression support escape issue#32246

### DIFF
--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -72,6 +72,36 @@ func TestUnsupportedStmtForPrepare(t *testing.T) {
 	tk.MustGetErrCode(`prepare stmt4 from "prepare stmt3 from 'create table t1(a int, b int)'"`, mysql.ErrUnsupportedPs)
 }
 
+func TestEscapeSupportForPrepareStmt(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`drop table if exists t1;`)
+	tk.MustExec(`create table t1 (a varchar(10), key(a));`)
+	tk.MustExec(`insert into t1 values ('a'), ('a\\b');`)
+	tk.MustExec("prepare stmt1 from 'select * from t1 where a like \\'a\\\\%\\' escape ?';")
+	tk.MustExec("set @e='#';")
+	result := tk.MustQuery("execute stmt1 using @e;")
+	result.Check(testkit.Rows("a\\b"))
+	tk.MustExec("deallocate prepare stmt1;")
+	tk.MustExec("prepare stmt1 from 'select * from t1 where a like \\'a\\\\%\\' escape ?';")
+	tk.MustExec("set @e='\\\\';")
+	result = tk.MustQuery("execute stmt1 using @e;")
+	result.Check(testkit.Rows())
+	tk.MustExec("deallocate prepare stmt1;")
+	tk.MustExec("prepare stmt1 from 'select * from t1 where a not like \\'a\\\\%\\' escape ?';")
+	tk.MustExec("set @e='#';")
+	result = tk.MustQuery("execute stmt1 using @e;")
+	result.Check(testkit.Rows("a"))
+	tk.MustExec("deallocate prepare stmt1;")
+	tk.MustExec("prepare stmt1 from 'select * from t1 where a not like \\'a\\\\%\\' escape ?';")
+	tk.MustExec("set @e='\\\\';")
+	result = tk.MustQuery("execute stmt1 using @e;")
+	result.Check(testkit.Rows("a", "a\\b"))
+	tk.MustExec("deallocate prepare stmt1;")
+}
+
 func TestIgnorePlanCache(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/parser/ast/expressions.go
+++ b/parser/ast/expressions.go
@@ -883,7 +883,7 @@ type PatternLikeExpr struct {
 	// Not is true, the expression is "not like".
 	Not bool
 
-	Escape byte
+	Escape ExprNode
 
 	PatChars []byte
 	PatTypes []byte
@@ -905,12 +905,16 @@ func (n *PatternLikeExpr) Restore(ctx *format.RestoreCtx) error {
 		return errors.Annotate(err, "An error occurred while restore PatternLikeExpr.Pattern")
 	}
 
-	escape := string(n.Escape)
-	if escape != "\\" {
-		ctx.WriteKeyWord(" ESCAPE ")
-		ctx.WriteString(escape)
-
+	escape := "?"
+	if _, ok := n.Escape.(ParamMarkerExpr); !ok {
+		// it can not convert to `ParamMarkerExpr`, so it must be `ValueExpr`
+		if n.Escape.(ValueExpr).GetString() == "\\" {
+			return nil
+		}
+		escape = n.Escape.(ValueExpr).GetString()
 	}
+	ctx.WriteKeyWord(" ESCAPE ")
+	ctx.WriteString(escape)
 	return nil
 }
 
@@ -923,10 +927,16 @@ func (n *PatternLikeExpr) Format(w io.Writer) {
 		fmt.Fprint(w, " LIKE ")
 	}
 	n.Pattern.Format(w)
-	if n.Escape != '\\' {
-		fmt.Fprint(w, " ESCAPE ")
-		fmt.Fprintf(w, "'%c'", n.Escape)
+	escape := "?"
+	if _, ok := n.Escape.(ParamMarkerExpr); !ok {
+		// it can not convert to `ParamMarkerExpr`, so it must be `ValueExpr`
+		if n.Escape.(ValueExpr).GetString() == "\\" {
+			return
+		}
+		escape = n.Escape.(ValueExpr).GetString()
 	}
+	fmt.Fprint(w, " ESCAPE ")
+	fmt.Fprintf(w, "'%c'", escape[0])
 }
 
 // Accept implements Node Accept interface.
@@ -949,6 +959,13 @@ func (n *PatternLikeExpr) Accept(v Visitor) (Node, bool) {
 			return n, false
 		}
 		n.Pattern = node.(ExprNode)
+	}
+	if n.Escape != nil {
+		node, ok := n.Escape.Accept(v)
+		if !ok {
+			return n, false
+		}
+		n.Escape = node.(ExprNode)
 	}
 	return v.Leave(n)
 }

--- a/parser/ast/expressions_test.go
+++ b/parser/ast/expressions_test.go
@@ -287,6 +287,8 @@ func TestPatternLikeExprRestore(t *testing.T) {
 		{"a not like 't1%'", "`a` NOT LIKE _UTF8MB4't1%'"},
 		{"a not like '%D%v%'", "`a` NOT LIKE _UTF8MB4'%D%v%'"},
 		{"a not like '%t1_|'", "`a` NOT LIKE _UTF8MB4'%t1_|'"},
+		{"a like 't1' escape '#'", "`a` LIKE _UTF8MB4't1' ESCAPE '#'"},
+		{"a not like 't1' escape '#'", "`a` NOT LIKE _UTF8MB4't1' ESCAPE '#'"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node.(*SelectStmt).Fields.Fields[0].Expr

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1621,7 +1621,7 @@ func (er *expressionRewriter) caseToExpression(v *ast.CaseExpr) {
 
 func (er *expressionRewriter) patternLikeToExpression(v *ast.PatternLikeExpr) {
 	l := len(er.ctxStack)
-	er.err = expression.CheckArgsNotMultiColumnRow(er.ctxStack[l-2:]...)
+	er.err = expression.CheckArgsNotMultiColumnRow(er.ctxStack[l-3:]...)
 	if er.err != nil {
 		return
 	}
@@ -1630,22 +1630,38 @@ func (er *expressionRewriter) patternLikeToExpression(v *ast.PatternLikeExpr) {
 	var function expression.Expression
 	fieldType := &types.FieldType{}
 	isPatternExactMatch := false
+	escape := "\\"
+	if escapeExpression, ok := er.ctxStack[l-1].(*expression.Constant); ok {
+		str, isNull, err := escapeExpression.EvalString(nil, chunk.Row{})
+		if err != nil {
+			er.err = err
+			return
+		}
+		if !isNull {
+			escape = str
+		}
+	}
 	// Treat predicate 'like' the same way as predicate '=' when it is an exact match and new collation is not enabled.
-	if patExpression, ok := er.ctxStack[l-1].(*expression.Constant); ok && !collate.NewCollationEnabled() {
+	isParamMarker := false
+	switch v.Escape.(type) {
+	case *driver.ParamMarkerExpr:
+		isParamMarker = true
+	}
+	if patExpression, ok := er.ctxStack[l-2].(*expression.Constant); ok && !collate.NewCollationEnabled() && !isParamMarker {
 		patString, isNull, err := patExpression.EvalString(nil, chunk.Row{})
 		if err != nil {
 			er.err = err
 			return
 		}
 		if !isNull {
-			patValue, patTypes := stringutil.CompilePattern(patString, v.Escape)
-			if stringutil.IsExactMatch(patTypes) && er.ctxStack[l-2].GetType().EvalType() == types.ETString {
+			patValue, patTypes := stringutil.CompilePattern(patString, escape[0])
+			if stringutil.IsExactMatch(patTypes) && er.ctxStack[l-3].GetType().EvalType() == types.ETString {
 				op := ast.EQ
 				if v.Not {
 					op = ast.NE
 				}
 				types.DefaultTypeForValue(string(patValue), fieldType, char, col)
-				function, er.err = er.constructBinaryOpFunction(er.ctxStack[l-2],
+				function, er.err = er.constructBinaryOpFunction(er.ctxStack[l-3],
 					&expression.Constant{Value: types.NewStringDatum(string(patValue)), RetType: fieldType},
 					op)
 				isPatternExactMatch = true
@@ -1653,12 +1669,12 @@ func (er *expressionRewriter) patternLikeToExpression(v *ast.PatternLikeExpr) {
 		}
 	}
 	if !isPatternExactMatch {
-		types.DefaultTypeForValue(int(v.Escape), fieldType, char, col)
+		types.DefaultTypeForValue(int(escape[0]), fieldType, char, col)
 		function = er.notToExpression(v.Not, ast.Like, &v.Type,
-			er.ctxStack[l-2], er.ctxStack[l-1], &expression.Constant{Value: types.NewIntDatum(int64(v.Escape)), RetType: fieldType})
+			er.ctxStack[l-3], er.ctxStack[l-2], &expression.Constant{Value: types.NewIntDatum(int64(escape[0])), RetType: fieldType})
 	}
 
-	er.ctxStackPop(2)
+	er.ctxStackPop(3)
 	er.ctxStackAppend(function, types.EmptyName)
 }
 

--- a/planner/core/show_predicate_extractor.go
+++ b/planner/core/show_predicate_extractor.go
@@ -58,8 +58,9 @@ func (e *ShowBaseExtractor) Extract(show *ast.ShowStmt) bool {
 		switch pattern.Pattern.(type) {
 		case *driver.ValueExpr:
 			// It is used in `SHOW XXXX in t LIKE `abc``.
+			escape := pattern.Escape.(*driver.ValueExpr).GetString()
 			ptn := pattern.Pattern.(*driver.ValueExpr).GetString()
-			patValue, patTypes := stringutil.CompilePattern(ptn, pattern.Escape)
+			patValue, patTypes := stringutil.CompilePattern(ptn, escape[0])
 			if stringutil.IsExactMatch(patTypes) {
 				e.Field = strings.ToLower(string(patValue))
 				return true
@@ -83,8 +84,9 @@ func (e *ShowColumnsTableExtractor) Extract(show *ast.ShowStmt) bool {
 		switch pattern.Pattern.(type) {
 		case *driver.ValueExpr:
 			// It is used in `SHOW COLUMNS FROM t LIKE `abc``.
+			escape := pattern.Escape.(*driver.ValueExpr).GetString()
 			ptn := pattern.Pattern.(*driver.ValueExpr).GetString()
-			patValue, patTypes := stringutil.CompilePattern(ptn, pattern.Escape)
+			patValue, patTypes := stringutil.CompilePattern(ptn, escape[0])
 			if stringutil.IsExactMatch(patTypes) {
 				e.Field = strings.ToLower(string(patValue))
 				return true

--- a/types/parser_driver/value_expr.go
+++ b/types/parser_driver/value_expr.go
@@ -236,7 +236,7 @@ func newParamMarkerExpr(offset int) ast.ParamMarkerExpr {
 
 // Format the ExprNode into a Writer.
 func (n *ParamMarkerExpr) Format(w io.Writer) {
-	panic("Not implemented")
+	fmt.Fprint(w, "?")
 }
 
 // Accept implements Node Accept interface.


### PR DESCRIPTION
Signed-off-by: fanrenhoo <fanrenhoo@sina.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #32246

Problem Summary: the prepared statement did not support escape to have a paramenter marker ?, parser will treat it as wrong syntax as normal sql

### What is changed and how it works?
I added the paramMarker for "select...PatternLike" in parser.y to support "ESCAPE paramMarker", so if in the prepared statement, now we can write "escape ?", that mean the escape character can also be parameterized in "select...PatternLike" 
prepared statement.
Add also add a test case for this

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)
drop table if exists t1;
create table t1 (a varchar(10), key(a));
prepare stmt1 from 'select * from t1 where a like 'a\%' escape ?';
Query OK, 0 rows affected (0.00 sec)

also add test cases

- [ ] No code

Side effects
no
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
no
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Make the prepared statement support escape character be parameterized for "select patternlikeexpr"(issue 32246). previously the prepared statement "escape ?", , parser will treat it as wrong syntax as normal sql, now the escape character can also be parameterized in prepared statement for "select patternlikeexpr".
```
