### PR TITLE
lightning: fix build error and failed test

### DIFF
--- a/br/pkg/lightning/restore/restore_test.go
+++ b/br/pkg/lightning/restore/restore_test.go
@@ -16,7 +16,6 @@ package restore
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/table/tables"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -59,6 +58,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/br/pkg/version/build"
 	"github.com/pingcap/tidb/ddl"
+	"github.com/pingcap/tidb/table/tables"
 	tmock "github.com/pingcap/tidb/util/mock"
 )
 

--- a/br/pkg/lightning/restore/restore_test.go
+++ b/br/pkg/lightning/restore/restore_test.go
@@ -16,6 +16,7 @@ package restore
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/table/tables"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -558,8 +559,7 @@ func (s *tableRestoreSuite) TestRestoreEngineFailed(c *C) {
 	}
 	defer close(rc.saveCpCh)
 	go func() {
-		for cp := range rc.saveCpCh {
-			cp.waitCh <- nil
+		for range rc.saveCpCh {
 		}
 	}()
 
@@ -573,7 +573,7 @@ func (s *tableRestoreSuite) TestRestoreEngineFailed(c *C) {
 	c.Assert(err, IsNil)
 	_, indexUUID := backend.MakeUUID("`db`.`table`", -1)
 	_, dataUUID := backend.MakeUUID("`db`.`table`", 0)
-	realBackend := tidb.NewTiDBBackend(nil, "replace", nil)
+	realBackend := tidb.NewTiDBBackend(nil, "replace")
 	mockBackend.EXPECT().OpenEngine(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockBackend.EXPECT().OpenEngine(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockBackend.EXPECT().CloseEngine(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()

--- a/br/pkg/lightning/restore/tidb.go
+++ b/br/pkg/lightning/restore/tidb.go
@@ -182,7 +182,7 @@ loopCreate:
 }
 
 func createIfNotExistsStmt(p *parser.Parser, createTable, dbName, tblName string) ([]string, error) {
-	stmts, _, err := p.ParseSQL(createTable)
+	stmts, _, err := p.Parse(createTable, "", "")
 	if err != nil {
 		return []string{}, err
 	}

--- a/br/tests/lightning_new_collation/data/nc.t-schema.sql
+++ b/br/tests/lightning_new_collation/data/nc.t-schema.sql
@@ -1,0 +1,1 @@
+CREATE TABLE t(i INT PRIMARY KEY, s varchar(32), j TINYINT, KEY s_j (s, i)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;

--- a/br/tests/lightning_new_collation/data/nc.t.0.sql
+++ b/br/tests/lightning_new_collation/data/nc.t.0.sql
@@ -1,0 +1,6 @@
+INSERT INTO t (s, i, j) VALUES
+  ("this_is_test1", 1, 1),
+  ("this_is_test2", 2, 2),
+  ("this_is_test3", 3, 3),
+  ("this_is_test4", 4, 4),
+  ("this_is_test5", 5, 5);

--- a/br/tests/lightning_new_collation/data/nc.t.1.sql
+++ b/br/tests/lightning_new_collation/data/nc.t.1.sql
@@ -1,0 +1,1 @@
+INSERT INTO t(s, i, j) VALUES ("another test case", 6, 6);

--- a/br/tests/lightning_new_collation/run.sh
+++ b/br/tests/lightning_new_collation/run.sh
@@ -23,27 +23,11 @@ cur=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # restart cluster with new collation enabled
 start_services --tidb-cfg $cur/tidb-new-collation.toml
 
-# Populate the mydumper source
-DBPATH="$TEST_DIR/nc.mydump"
-mkdir -p $DBPATH
-echo 'CREATE DATABASE nc;' > "$DBPATH/nc-schema-create.sql"
-# create table with collate `utf8_general_ci`, the index key will be different between old/new collation
-echo "CREATE TABLE t(i INT PRIMARY KEY, s varchar(32), j TINYINT, KEY s_j (s, i)) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;" > "$DBPATH/nc.t-schema.sql"
-cat > "$DBPATH/nc.t.0.sql" << _EOF_
-INSERT INTO t (s, i, j) VALUES
-  ("this_is_test1", 1, 1),
-  ("this_is_test2", 2, 2),
-  ("this_is_test3", 3, 3),
-  ("this_is_test4", 4, 4),
-  ("this_is_test5", 5, 5);
-_EOF_
-echo 'INSERT INTO t(s, i, j) VALUES ("another test case", 6, 6);' > "$DBPATH/nc.t.1.sql"
-
 for BACKEND in local importer tidb; do
   # Start importing the tables.
   run_sql 'DROP DATABASE IF EXISTS nc'
 
-  run_lightning -d "$DBPATH" --backend $BACKEND 2> /dev/null
+  run_lightning --backend $BACKEND 2> /dev/null
 
   run_sql 'SELECT count(*), sum(i) FROM `nc`.t'
   check_contains "count(*): 6"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/31913

Problem Summary:

cherry-pick https://github.com/pingcap/tidb/pull/32256 caused lightning build error.

Recently, CI skipped `br_unit_test`. Some cherry-pick break build and tests but were not detected.

### What is changed and how it works?

Fix build error and failed test.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
