### PR TITLE
server: reset accumulatedLength in readPacket() function

### DIFF
--- a/server/packetio.go
+++ b/server/packetio.go
@@ -126,6 +126,7 @@ func (p *packetIO) setMaxAllowedPacket(maxAllowedPacket uint64) {
 }
 
 func (p *packetIO) readPacket() ([]byte, error) {
+	p.accumulatedLength = 0
 	if p.readTimeout == 0 {
 		if err := p.bufReadConn.SetReadDeadline(time.Time{}); err != nil {
 			return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34070

Problem Summary:

### What is changed and how it works?

[max_allowed_packet](https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_max_allowed_packet) is for each packet, but the old code never reset the `accumulatedLength` variable, so it would become larger than `max_allowed_packet` eventually.

Reset `accumulatedLength` to calculate the packet size correctly.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test

The issue if found by the regression of a integration test, and that test covers this change.

- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
