### PR TITLE
br: fix bug in PiTR

### DIFF
--- a/br/cmd/br/restore.go
+++ b/br/cmd/br/restore.go
@@ -158,7 +158,7 @@ func newStreamRestoreCommand() *cobra.Command {
 			return runRestoreCommand(command, task.PointRestoreCmd)
 		},
 	}
-	task.DefineFilterFlags(command, filterOutSysAndMemTables, false)
+	task.DefineFilterFlags(command, filterOutSysAndMemTables, true)
 	task.DefineStreamRestoreFlags(command)
 	return command
 }

--- a/br/pkg/backup/schema.go
+++ b/br/pkg/backup/schema.go
@@ -127,7 +127,9 @@ func (ss *Schemas) BackupSchemas(
 			if err := metaWriter.Send(s, op); err != nil {
 				return errors.Trace(err)
 			}
-			updateCh.Inc()
+			if updateCh != nil {
+				updateCh.Inc()
+			}
 			return nil
 		})
 	}

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1790,10 +1790,10 @@ func (rc *Client) RestoreMetaKVFile(
 		if err != nil {
 			return errors.Trace(err)
 		} else if ts > rc.restoreTs {
-			break
+			continue
 		}
 
-		log.Debug("txn entry", zap.Int("txnKey-len", len(txnEntry.Key)),
+		log.Debug("txn entry", zap.Uint64("key-ts", ts), zap.Int("txnKey-len", len(txnEntry.Key)),
 			zap.Int("txnValue-len", len(txnEntry.Value)), zap.ByteString("txnKey", txnEntry.Key))
 
 		newEntry, err := sr.RewriteKvEntry(&txnEntry, file.Cf)

--- a/br/pkg/stream/client.go
+++ b/br/pkg/stream/client.go
@@ -61,6 +61,7 @@ func (c *MetaDataClient) DeleteTask(ctx context.Context, taskName string) error 
 	_, err := c.KV.Txn(ctx).
 		Then(clientv3.OpDelete(TaskOf(taskName)),
 			clientv3.OpDelete(RangesOf(taskName), clientv3.WithPrefix()),
+			clientv3.OpDelete(CheckPointsOf(taskName), clientv3.WithPrefix()),
 			clientv3.OpDelete(Pause(taskName))).
 		Commit()
 	if err != nil {

--- a/br/pkg/stream/client.go
+++ b/br/pkg/stream/client.go
@@ -61,10 +61,13 @@ func (c *MetaDataClient) PutTask(ctx context.Context, task TaskInfo) error {
 // DeleteTask deletes a task, along with its metadata.
 func (c *MetaDataClient) DeleteTask(ctx context.Context, taskName string) error {
 	_, err := c.KV.Txn(ctx).
-		Then(clientv3.OpDelete(TaskOf(taskName)),
+		Then(
+			clientv3.OpDelete(TaskOf(taskName)),
 			clientv3.OpDelete(RangesOf(taskName), clientv3.WithPrefix()),
 			clientv3.OpDelete(CheckPointsOf(taskName), clientv3.WithPrefix()),
-			clientv3.OpDelete(Pause(taskName))).
+			clientv3.OpDelete(Pause(taskName)),
+			clientv3.OpDelete(LastErrorPrefixOf(taskName), clientv3.WithPrefix()),
+		).
 		Commit()
 	if err != nil {
 		return errors.Annotatef(err, "failed to delete task itself %s", taskName)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -988,7 +988,7 @@ func restoreStream(
 	}
 	client.SetRestoreTs(cfg.RestoreTS)
 	client.SetCurrentTS(currentTS)
-	log.Info("start restore on point", zap.Uint64("ts", cfg.RestoreTS))
+	log.Info("start restore on point", zap.Uint64("restore-ts", cfg.RestoreTS))
 
 	// get full backup meta to generate rewrite rules.
 	fullBackupTables, err := initFullBackupTables(ctx, cfg)
@@ -1064,6 +1064,7 @@ func withProgress(p glue.Progress, cc func(p glue.Progress) error) error {
 	return cc(p)
 }
 
+// nolint: unused, deadcode
 func countIndices(ts map[int64]*metautil.Table) int64 {
 	result := int64(0)
 	for _, t := range ts {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -464,10 +464,8 @@ func (s *streamMgr) backupFullSchemas(ctx context.Context, g glue.Glue) error {
 	}
 
 	schemasConcurrency := uint(utils.MinInt(backup.DefaultSchemaConcurrency, schemas.Len()))
-	updateCh := g.StartProgress(ctx, "Checksum", int64(schemas.Len()), !s.cfg.LogProgress)
-
 	err = schemas.BackupSchemas(ctx, metaWriter, s.mgr.GetStorage(), nil,
-		s.cfg.StartTS, schemasConcurrency, 0, true, updateCh)
+		s.cfg.StartTS, schemasConcurrency, 0, true, nil)
 	if err != nil {
 		return errors.Trace(err)
 	}
@@ -550,7 +548,7 @@ func RunStreamStart(
 	if count, err := cli.GetTaskCount(ctx); err != nil {
 		return errors.Trace(err)
 	} else if count > 0 {
-		return errors.Annotate(berrors.ErrStreamLogTaskExist, "It supports single stream log task current")
+		return errors.Annotate(berrors.ErrStreamLogTaskExist, "It supports single stream log task currently")
 	}
 
 	if err = streamMgr.setLock(ctx); err != nil {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1045,15 +1045,14 @@ func restoreStream(
 	}
 
 	// fix indices.
-	// to do:
 	// No need to fix indices if backup stream all of tables, because the index recored has been observed.
-	pi := g.StartProgress(ctx, "Restore Index", countIndices(fullBackupTables), !cfg.LogProgress)
-	err = withProgress(pi, func(p glue.Progress) error {
-		return client.FixIndicesOfTables(ctx, fullBackupTables, p.Inc)
-	})
-	if err != nil {
-		return errors.Annotate(err, "failed to fix index for some table")
-	}
+	// pi := g.StartProgress(ctx, "Restore Index", countIndices(fullBackupTables), !cfg.LogProgress)
+	// err = withProgress(pi, func(p glue.Progress) error {
+	// 	return client.FixIndicesOfTables(ctx, fullBackupTables, p.Inc)
+	// })
+	// if err != nil {
+	// 	return errors.Annotate(err, "failed to fix index for some table")
+	// }
 
 	// TODO split put and delete files
 	return nil


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/34122

Problem Summary:

### What is changed and how it works?
- Remove checkpointTs and error information in pd when `br stop stream task`.
- Don't show checksum when `br start stream task`.
- Don't need to fix index when restore point, because it can backup and restore row KV and index KV.
- Hidden `filter` flag in `br restore point`, because it need support filtering table in current version.


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
