### PR TITLE
br-stream: implement cleanup files.

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1687,6 +1687,14 @@ func (rc *Client) RestoreKVFiles(
 	return nil
 }
 
+func (rc *Client) CleanUpKVFiles(
+	ctx context.Context,
+) error {
+	// Current we only have v1 prefix.
+	// In the future, we can add more operation for this interface.
+	return rc.fileImporter.ClearFiles(ctx, rc.pdClient, "v1")
+}
+
 // InitSchemasReplaceForDDL gets schemas information Mapping from old schemas to new schemas.
 // It is used to rewrite meta kv-event.
 func (rc *Client) InitSchemasReplaceForDDL(

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1656,7 +1656,6 @@ func (rc *Client) RestoreKVFiles(
 			})
 		}
 	}
-
 	for _, file := range files {
 		if file.Type == backuppb.FileType_Delete {
 			// collect delete type file and apply it later.
@@ -1666,7 +1665,9 @@ func (rc *Client) RestoreKVFiles(
 		fileReplica := file
 		applyFunc(fileReplica)
 	}
-
+	if len(deleteFiles) > 0 {
+		log.Info("restore delete files", zap.Int("count", len(deleteFiles)))
+	}
 	for _, file := range deleteFiles {
 		fileReplica := file
 		applyFunc(fileReplica)

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -43,6 +43,12 @@ const (
 
 // ImporterClient is used to import a file to TiKV.
 type ImporterClient interface {
+	ClearFiles(
+		ctx context.Context,
+		storeID uint64,
+		req *import_sstpb.ClearRequest,
+	) (*import_sstpb.ClearResponse, error)
+
 	ApplyKVFile(
 		ctx context.Context,
 		storeID uint64,
@@ -340,6 +346,26 @@ func (importer *FileImporter) ImportKVFileForRegion(
 	}
 	summary.CollectInt("RegionInvolved", 1)
 	return RPCResultOK()
+}
+
+func (importer *FileImporter) ClearFiles(ctx context.Context, pdClient pd.Client, prefix string) error {
+	allStores, err := conn.GetAllTiKVStoresWithRetry(ctx, pdClient, conn.SkipTiFlash)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	for _, s := range allStores {
+		if s.State != metapb.StoreState_Up {
+			continue
+		}
+		req := &import_sstpb.ClearRequest{
+			Prefix: prefix,
+		}
+		_, err = importer.importClient.ClearFiles(ctx, s.GetId(), req)
+		if err != nil {
+			log.Warn("cleanup kv files failed", zap.Uint64("store", s.GetId()), zap.Error(err))
+		}
+	}
+	return nil
 }
 
 func (importer *FileImporter) ImportKVFiles(

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -105,6 +105,18 @@ func NewImportClient(metaClient SplitClient, tlsConf *tls.Config, keepaliveConf 
 	}
 }
 
+func (ic *importClient) ClearFiles(
+	ctx context.Context,
+	storeID uint64,
+	req *import_sstpb.ClearRequest,
+) (*import_sstpb.ClearResponse, error) {
+	client, err := ic.GetImportClient(ctx, storeID)
+	if err != nil {
+		return nil, errors.Trace(err)
+	}
+	return client.ClearFiles(ctx, req)
+}
+
 func (ic *importClient) ApplyKVFile(
 	ctx context.Context,
 	storeID uint64,

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -461,6 +461,9 @@ func TruncateTS(key []byte) []byte {
 	if len(key) == 0 {
 		return nil
 	}
+	if len(key) < 8 {
+		return key
+	}
 	return key[:len(key)-8]
 }
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1056,6 +1056,12 @@ func restoreStream(
 	if err != nil {
 		return errors.Annotate(err, "failed to fix index for some table")
 	}
+
+	err = client.CleanUpKVFiles(ctx)
+	if err != nil {
+		return errors.Annotate(err, "failed to clean up")
+	}
+
 	return nil
 }
 

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1024,11 +1024,11 @@ func restoreStream(
 	}
 	defer rawkvClient.Close()
 
-	pm := g.StartProgress(ctx, "Restore DDL files", int64(len(ddlFiles)), !cfg.LogProgress)
+	pm := g.StartProgress(ctx, "Restore Meta Files", int64(len(ddlFiles)), !cfg.LogProgress)
 	if err = withProgress(pm, func(p glue.Progress) error {
 		return client.RestoreMetaKVFiles(ctx, rawkvClient, ddlFiles, schemasReplace, p.Inc)
 	}); err != nil {
-		return errors.Annotate(err, "failed to restore DDL files")
+		return errors.Annotate(err, "failed to restore meta files")
 	}
 
 	// perform restore kv files
@@ -1038,12 +1038,12 @@ func restoreStream(
 	}
 	updateRewriteRules(rewriteRules, schemasReplace)
 
-	pd := g.StartProgress(ctx, "Restore DML Files", int64(len(dmlFiles)), !cfg.LogProgress)
+	pd := g.StartProgress(ctx, "Restore KV Files", int64(len(dmlFiles)), !cfg.LogProgress)
 	err = withProgress(pd, func(p glue.Progress) error {
 		return client.RestoreKVFiles(ctx, rewriteRules, dmlFiles, p.Inc)
 	})
 	if err != nil {
-		return errors.Annotate(err, "failed to restore DML files")
+		return errors.Annotate(err, "failed to restore kv files")
 	}
 
 	// fix indices.

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1056,8 +1056,6 @@ func restoreStream(
 	if err != nil {
 		return errors.Annotate(err, "failed to fix index for some table")
 	}
-
-	// TODO split put and delete files
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/pingcap/errors v0.11.5-0.20211224045212-9687c2b0f87c
 	github.com/pingcap/failpoint v0.0.0-20220303073211-00fea37feb66
 	github.com/pingcap/fn v0.0.0-20200306044125-d5540d389059
-	github.com/pingcap/kvproto v0.0.0-20220412031131-2f16e3348000
+	github.com/pingcap/kvproto v0.0.0-20220419085416-762b02ddcc44
 	github.com/pingcap/log v0.0.0-20211215031037-e024ba4eb0ee
 	github.com/pingcap/sysutil v0.0.0-20220114020952-ea68d2dbf5b4
 	github.com/pingcap/tidb-tools v6.0.0-alpha.0.20220309081549-563c2a342f9c+incompatible

--- a/go.sum
+++ b/go.sum
@@ -598,8 +598,8 @@ github.com/pingcap/goleveldb v0.0.0-20191226122134-f82aafb29989/go.mod h1:O17Xtb
 github.com/pingcap/kvproto v0.0.0-20191211054548-3c6b38ea5107/go.mod h1:WWLmULLO7l8IOcQG+t+ItJ3fEcrL5FxF0Wu+HrMy26w=
 github.com/pingcap/kvproto v0.0.0-20220302110454-c696585a961b/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/kvproto v0.0.0-20220304032058-ccd676426a27/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
-github.com/pingcap/kvproto v0.0.0-20220412031131-2f16e3348000 h1:eh4QMFRYfkghl5VwV7qIdlk1BjBwcHaJH6VcYB40uJs=
-github.com/pingcap/kvproto v0.0.0-20220412031131-2f16e3348000/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
+github.com/pingcap/kvproto v0.0.0-20220419085416-762b02ddcc44 h1:CJ9dDjE/qEZhNaKc0EweC+q7fKSY0yEyzLGSUcYp/Xg=
+github.com/pingcap/kvproto v0.0.0-20220419085416-762b02ddcc44/go.mod h1:IOdRDPLyda8GX2hE/jO7gqaCV/PNFh8BZQCQZXfIOqI=
 github.com/pingcap/log v0.0.0-20191012051959-b742a5d432e9/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20200511115504-543df19646ad/go.mod h1:4rbK1p9ILyIfb6hU7OG2CiWSqMXnp3JMbiaVJ6mvoY8=
 github.com/pingcap/log v0.0.0-20210625125904-98ed8e2eb1c7/go.mod h1:8AanEdAHATuRurdGxZXBz0At+9avep+ub7U1AGYLIMM=


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34098

Problem Summary:
This PR try to remove the temporary kv file download in TiKV and fix the issue that pd scan fewer region which caused data lost.

### What is changed and how it works?
1. Implement clearFiles rpc.
2. make endKey from exclusive to inclusive by `TruncateTS(end)` then `PrefixNext(end)`.
3. Split delete files and put files, make sure delete files apply after put files.

### Check List

Tests <!-- At least one of them must be included. -->
- [x] Unit Test
- [x] Manual test (add detailed scripts or steps below)

<img width="446" alt="截屏2022-04-20 下午5 01 55" src="https://user-images.githubusercontent.com/5906259/164192927-95918d54-f43c-46ca-bedb-f74a25e4c734.png">

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
