### PR TITLE
table/tables: remove int handle id from row to fix binlog issue (#30489)

### DIFF
--- a/table/tables/partition.go
+++ b/table/tables/partition.go
@@ -1285,9 +1285,8 @@ func partitionedTableUpdateRecord(gctx context.Context, ctx sessionctx.Context, 
 		// 'Key Already Exists' will generally happen during step1, errors are
 		// unlikely to happen in step2.
 		deleteData := currData
-		if !t.Meta().IsCommonHandle && !t.Meta().PKIsHandle {
+		if !t.Meta().IsCommonHandle && !t.Meta().PKIsHandle && len(deleteData) > len(t.Cols()) {
 			// The row already has the handle column added, remove it since it is not expected in RemoveRecord!
-			// TODO: Should we also verify that the handle actually is int and is equal to the last column in the row?
 			deleteData = deleteData[:len(deleteData)-1]
 		}
 		err = t.GetPartition(from).RemoveRecord(ctx, h, deleteData)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
The int handle id is still in the row when writing to binlog, which causes an error. We follow a similar path as for non-partitioned tables and removing the handle id from the row if it exists.
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #30489

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [X] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
When updating a row which would move it from one partition to another and binlog is enabled, there was a column count check that failed, which is now corrected.```
