### PR TITLE
session: release lock correctly for tidb to exit

### DIFF
--- a/session/tidb.go
+++ b/session/tidb.go
@@ -53,6 +53,7 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	// If this is the only domain instance, and the caller doesn't provide store.
 	if len(dm.domains) == 1 && store == nil {
 		for _, r := range dm.domains {
+			dm.mu.RUnlock()
 			return r, nil
 		}
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34123

Problem Summary:

### What is changed and how it works?

When `store == nil`, `domainMap.Get()` function would exit without release the read lock.
In the tidb exit code path, tidb can't obtain the lock and hang forever.
Ctrl+C can't make tidb exit.

```
goroutine 647 [semacquire, 17 minutes]:
sync.runtime_SemacquireMutex(0xc0003dfd20?, 0x6?, 0x5b595a0?)
	/home/genius/project/go/src/runtime/sema.go:71 +0x25
sync.(*RWMutex).Lock(0xc0003dfd78?)
	/home/genius/project/go/src/sync/rwmutex.go:144 +0x71
github.com/pingcap/tidb/session.(*domainMap).Delete(0x5b24580, {0x3ded190, 0xc000dff3b0})
	/home/genius/project/src/github.com/pingcap/tidb/session/tidb.go:102 +0x36
github.com/pingcap/tidb/session.(*domainMap).Get.func1.1()
	/home/genius/project/src/github.com/pingcap/tidb/session/tidb.go:81 +0x25
github.com/pingcap/tidb/domain.(*Domain).Close(0xc0004ac640)
	/home/genius/project/src/github.com/pingcap/tidb/domain/domain.go:709 +0x178
main.closeDomainAndStorage({0x3ded190, 0xc000dff3b0}, 0xc00197e820?)
	/home/genius/project/src/github.com/pingcap/tidb/tidb-server/main.go:733 +0x35
main.cleanup(0xc00197e7e0?, {0x3ded190, 0xc000dff3b0}, 0x0?, 0x0?)
	/home/genius/project/src/github.com/pingcap/tidb/tidb-server/main.go:746 +0x8c
main.main.func1(0x0?)
	/home/genius/project/src/github.com/pingcap/tidb/tidb-server/main.go:215 +0x6f
github.com/pingcap/tidb/util/signal.SetupSignalHandler.func2()
	/home/genius/project/src/github.com/pingcap/tidb/util/signal/signal_posix.go:56 +0x1e2
created by github.com/pingcap/tidb/util/signal.SetupSignalHandler
	/home/genius/project/src/github.com/pingcap/tidb/util/signal/signal_posix.go:53 +0x19f
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

After this fix, Ctrl+C can make tidb exit successfully.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix a bug that Ctrl+C can't make the tidb-server exit, the bug is more likely to trigger when the enterprise plugin is used.
```
