### PR TITLE
plugin: revert #27269 for test

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -890,7 +890,7 @@ func (a *ExecStmt) logAudit() {
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
 			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
-			audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
+			audit.OnGeneralEvent(ctx, sessVars, plugin.Log, cmd)
 		}
 		return nil
 	})

--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -24,27 +24,29 @@ import (
 type GeneralEvent byte
 
 const (
-	// Starting represents a GeneralEvent that is about to start
-	Starting GeneralEvent = iota
-	// Completed represents a GeneralEvent that has completed
-	Completed
-	// Error represents a GeneralEvent that has error (and typically couldn't start)
+	// Log presents log event.
+	Log GeneralEvent = iota
+	// Error presents error event.
 	Error
+	// Result presents result event.
+	Result
+	// Status presents status event.
+	Status
 )
 
 // ConnectionEvent presents TiDB connection event.
 type ConnectionEvent byte
 
 const (
-	// Connected represents new connection establish event(finish auth).
+	// Connected presents new connection establish event(finish auth).
 	Connected ConnectionEvent = iota
-	// Disconnect represents disconnect event.
+	// Disconnect presents disconnect event.
 	Disconnect
-	// ChangeUser represents change user.
+	// ChangeUser presents change user.
 	ChangeUser
-	// PreAuth represents event before start auth.
+	// PreAuth presents event before start auth.
 	PreAuth
-	// Reject represents event reject connection event.
+	// Reject presents event reject connection event.
 	Reject
 )
 

--- a/plugin/conn_ip_example/conn_ip_example.go
+++ b/plugin/conn_ip_example/conn_ip_example.go
@@ -79,7 +79,7 @@ func OnInit(ctx context.Context, manifest *plugin.Manifest) error {
 
 // OnShutdown implements TiDB plugin's OnShutdown SPI.
 func OnShutdown(ctx context.Context, manifest *plugin.Manifest) error {
-	fmt.Println("## conn_ip_example OnShutdown called ##")
+	fmt.Println("## conn_ip_examples OnShutdown called ##")
 	fmt.Printf("---- context: %s\n", ctx)
 	fmt.Printf("---- read cfg in shutdown [key: conn_ip_example_key, value: %s]\n", variable.GetSysVar("conn_ip_example_key").Value)
 	atomic.SwapInt32(&connection, 0)
@@ -89,22 +89,19 @@ func OnShutdown(ctx context.Context, manifest *plugin.Manifest) error {
 // OnGeneralEvent implements TiDB Audit plugin's OnGeneralEvent SPI.
 func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugin.GeneralEvent, cmd string) {
 	fmt.Println("## conn_ip_example OnGeneralEvent called ##")
+	fmt.Printf("---- new connection by %s\n", ctx.Value("ip"))
 	if sctx != nil {
 		fmt.Printf("---- session status: %d\n", sctx.Status)
-		digest, _ := sctx.StmtCtx.SQLDigest()
-		fmt.Printf("---- statement sql: %s, digest: %s\n", sctx.StmtCtx.OriginalSQL, digest)
-		if len(sctx.StmtCtx.Tables) > 0 {
-			fmt.Printf("---- statement tables: %#v\n", sctx.StmtCtx.Tables)
-		}
-		fmt.Printf("---- executed by user: %#v\n", sctx.User)
 	}
 	switch event {
-	case plugin.Starting:
-		fmt.Println("---- event: Statement Starting")
-	case plugin.Completed:
-		fmt.Println("---- event: Statement Completed")
+	case plugin.Log:
+		fmt.Println("---- event: Log")
 	case plugin.Error:
-		fmt.Println("---- event: ERROR!")
+		fmt.Println("---- event: Error")
+	case plugin.Result:
+		fmt.Println("---- event: Result")
+	case plugin.Status:
+		fmt.Println("---- event: Status")
 	default:
 		fmt.Println("---- event: unrecognized")
 	}
@@ -120,7 +117,6 @@ func OnConnectionEvent(ctx context.Context, event plugin.ConnectionEvent, info *
 	fmt.Println("## conn_ip_example onConnectionEvent called ##")
 	fmt.Printf("---- conenct event: %s, reason: [%s]\n", event, reason)
 	fmt.Printf("---- connection host: %s\n", info.Host)
-	fmt.Printf("---- connection details: %s@%s/%s type: %s\n", info.User, info.Host, info.DB, info.ConnectionType)
 	atomic.AddInt32(&connection, 1)
 	return nil
 }

--- a/plugin/conn_ip_example/conn_ip_example_test.go
+++ b/plugin/conn_ip_example/conn_ip_example_test.go
@@ -65,7 +65,7 @@ func TestLoadPlugin(t *testing.T) {
 	require.NoErrorf(t, err, "init plugin [%s] fail, error [%s]\n", pluginSign, err)
 
 	err = plugin.ForeachPlugin(plugin.Audit, func(auditPlugin *plugin.Plugin) error {
-		plugin.DeclareAuditManifest(auditPlugin.Manifest).OnGeneralEvent(context.Background(), nil, plugin.Completed, "QUERY")
+		plugin.DeclareAuditManifest(auditPlugin.Manifest).OnGeneralEvent(context.Background(), nil, plugin.Log, "QUERY")
 		return nil
 	})
 	require.NoErrorf(t, err, "query event fail, error [%s]\n", err)

--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -696,23 +696,15 @@ func TestAuditLogNormal(t *testing.T) {
 		query := append([]byte{mysql.ComQuery}, []byte(test.sql)...)
 		err := conn.Dispatch(context.Background(), query)
 		require.NoError(t, err, errMsg)
-		require.Equal(t, 2, len(testResults), errMsg)
+		require.Equal(t, 1, len(testResults), errMsg)
 		result := testResults[0]
 		// TODO: currently, result.text is wrong.
 		require.Equal(t, "Query", result.cmd, errMsg)
-		require.Equal(t, plugin.Starting, result.event, errMsg)
-		result = testResults[1]
-		if test.text == "" {
-			require.Equal(t, test.sql, result.text, errMsg)
-		} else {
-			require.Equal(t, test.text, result.text, errMsg)
-		}
 		require.Equal(t, test.rows, result.rows, errMsg)
 		require.Equal(t, test.stmtType, result.stmtType, errMsg)
 		require.Equal(t, test.dbs, result.dbs, errMsg)
 		require.Equal(t, test.tables, result.tables, errMsg)
 		require.Equal(t, "Query", result.cmd, errMsg)
-		require.Equal(t, plugin.Completed, result.event, errMsg)
 	}
 }
 

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -438,7 +438,7 @@ func (p *Plugin) supportsFlush(pluginName string) error {
 		return errors.Errorf("plugin '%s' is not ready", pluginName)
 	}
 	if p.Manifest.flushWatcher == nil {
-		return errors.Errorf("plugin %s does not support flush, or PD is not available", pluginName)
+		return errors.Errorf("plugin %s does not support flush", pluginName)
 	}
 	return nil
 }

--- a/plugin/spi_test.go
+++ b/plugin/spi_test.go
@@ -46,7 +46,7 @@ func TestExportManifest(t *testing.T) {
 	err := exported.OnInit(context.Background(), exported)
 	require.NoError(t, err)
 	audit := plugin.DeclareAuditManifest(exported)
-	audit.OnGeneralEvent(context.Background(), nil, plugin.Completed, "QUERY")
+	audit.OnGeneralEvent(context.Background(), nil, plugin.Log, "QUERY")
 	require.True(t, callRecorder.NotifyEventCalled)
 	require.True(t, callRecorder.OnInitCalled)
 }


### PR DESCRIPTION
This PR reverts #27269 for `release-5.4-20220308`, in which 'logging the SQL twice on success' is not expected. You can treat it as a hot patch.