### PR TITLE
planner, feedback: invalid the feedback when we turn off the feedback

### DIFF
--- a/statistics/feedback.go
+++ b/statistics/feedback.go
@@ -73,9 +73,13 @@ func NewQueryFeedback(physicalID int64, hist *Histogram, expected int64, desc bo
 	if hist != nil && hist.IsIndexHist() {
 		tp = IndexType
 	}
+	var valid bool
+	if FeedbackProbability.Load() > 0 {
+		valid = true
+	}
 	return &QueryFeedback{
 		PhysicalID: physicalID,
-		Valid:      true,
+		Valid:      valid,
 		Tp:         tp,
 		Hist:       hist,
 		Expected:   expected,

--- a/statistics/feedback_test.go
+++ b/statistics/feedback_test.go
@@ -187,6 +187,24 @@ func TestSplitBuckets(t *testing.T) {
 	require.Equal(t, int64(5001), totalCount)
 }
 
+func TestFeedbackVaild(t *testing.T) {
+	oriProbability := FeedbackProbability.Load()
+	defer func() {
+		FeedbackProbability.Store(oriProbability)
+	}()
+	FeedbackProbability.Store(1)
+	q := NewQueryFeedback(0, genHistogram(), 0, false)
+	require.Equal(t, q.Valid, true)
+
+	FeedbackProbability.Store(0)
+	q = NewQueryFeedback(0, genHistogram(), 0, false)
+	require.Equal(t, q.Valid, false)
+
+	FeedbackProbability.Store(0.5)
+	q = NewQueryFeedback(0, genHistogram(), 0, false)
+	require.Equal(t, q.Valid, true)
+}
+
 func TestMergeBuckets(t *testing.T) {
 	tests := []struct {
 		points       []int64


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34155

Problem Summary:
invalid the feedback when we turn off the feedback
### What is changed and how it works?
invalid the feedback when we turn off the feedback

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
