### PR TITLE
executor: fix label of rollback stmt counter

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -380,7 +380,7 @@ func GetStmtLabel(stmtNode ast.StmtNode) string {
 	case *ast.LoadDataStmt:
 		return "LoadData"
 	case *ast.RollbackStmt:
-		return "RollBack"
+		return "Rollback"
 	case *ast.SelectStmt:
 		return "Select"
 	case *ast.SetStmt, *ast.SetPwdStmt:

--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -360,7 +360,7 @@ func TestAuditLogNormal(t *testing.T) {
 		},
 		{
 			sql:      "ROLLBACK",
-			stmtType: "RollBack",
+			stmtType: "Rollback",
 		},
 		{
 			sql:      "START TRANSACTION",


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34161 

Problem Summary:

### What is changed and how it works?

`GetStmtLabel` returns "RollBack" for a rollback stmt, however, `CountStmtNode` checks "Rollback" [here](https://github.com/pingcap/tidb/blob/a798e78328d9c26eb47c006b787b1539783a28a8/executor/compiler.go#L169-L170), thus, `stmtNodeCounterRollback` never hits. Just fix the typo.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
