### PR TITLE
br: support restore snapshot and log(PiTR) only by one-command

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1816,12 +1816,12 @@ func (rc *Client) RestoreMetaKVFile(
 			return errors.Trace(err)
 		}
 
-		//The commitTs in write CF need be limited on [startTs, restoreTs].
-		//We can restore more key-value in default CF.
-		if file.Cf == "write" {
-			if ts > rc.restoreTs || ts < rc.startTS {
-				continue
-			}
+		// The commitTs in write CF need be limited on [startTs, restoreTs].
+		// We can restore more key-value in default CF.
+		if ts > rc.restoreTs {
+			continue
+		} else if file.Cf == "write" && ts < rc.startTS {
+			continue
 		}
 
 		log.Debug("txn entry", zap.Uint64("key-ts", ts), zap.Int("txnKey-len", len(txnEntry.Key)),

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -45,7 +45,8 @@ const (
 	// current only support STRICT or IGNORE, the default is STRICT according to tidb.
 	FlagWithPlacementPolicy = "with-tidb-placement-mode"
 
-	// FlagStreamRestoreTS is used for log restore.
+	// FlagStreamStartTS and FlagStreamRestoreTS is used for log restore timestamp range.
+	FlagStreamStartTS   = "start-ts"
 	FlagStreamRestoreTS = "restore-ts"
 	// FlagStreamFullBackupStorage is used for log restore, represents the full backup storage.
 	FlagStreamFullBackupStorage = "full-backup-storage"
@@ -144,6 +145,8 @@ type RestoreConfig struct {
 	// if it is empty, directly take restoring log justly.
 	FullBackupStorage string `json:"full-backup-storage" toml:"full-backup-storage"`
 
+	// [startTs, RestoreTS] is used to `restore log` from StartTs to RestoreTS.
+	StartTs   uint64 `json:"start-ts" toml:"start-ts"`
 	RestoreTS uint64 `json:"restore-ts" toml:"restore-ts"`
 }
 
@@ -159,6 +162,9 @@ func DefineRestoreFlags(flags *pflag.FlagSet) {
 
 // DefineStreamRestoreFlags defines for the restore log command.
 func DefineStreamRestoreFlags(command *cobra.Command) {
+	command.Flags().String(FlagStreamStartTS, "", "the start timestamp which log restore from.\n"+
+		"support TSO or datetime, e.g. '400036290571534337' or '2018-05-11 01:42:23'")
+	_ = command.Flags().MarkHidden(flagStreamStartTS)
 	command.Flags().String(FlagStreamRestoreTS, "", "the point of restore, used for log restore.\n"+
 		"support TSO or datetime, e.g. '400036290571534337' or '2018-05-11 01:42:23'")
 	command.Flags().String(FlagStreamFullBackupStorage, "", "specify the backup full storage. "+
@@ -167,13 +173,21 @@ func DefineStreamRestoreFlags(command *cobra.Command) {
 
 // ParseStreamRestoreFlags parses the `restore stream` flags from the flag set.
 func (cfg *RestoreConfig) ParseStreamRestoreFlags(flags *pflag.FlagSet) error {
-	tsString, err := flags.GetString(FlagStreamRestoreTS)
+	tsString, err := flags.GetString(FlagStreamStartTS)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	if cfg.StartTs, err = ParseTSString(tsString); err != nil {
+		return errors.Trace(err)
+	}
+	tsString, err = flags.GetString(FlagStreamRestoreTS)
 	if err != nil {
 		return errors.Trace(err)
 	}
 	if cfg.RestoreTS, err = ParseTSString(tsString); err != nil {
 		return errors.Trace(err)
 	}
+
 	if cfg.FullBackupStorage, err = flags.GetString(FlagStreamFullBackupStorage); err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -145,8 +145,8 @@ type RestoreConfig struct {
 	// if it is empty, directly take restoring log justly.
 	FullBackupStorage string `json:"full-backup-storage" toml:"full-backup-storage"`
 
-	// [startTs, RestoreTS] is used to `restore log` from StartTs to RestoreTS.
-	StartTs   uint64 `json:"start-ts" toml:"start-ts"`
+	// [startTs, RestoreTS] is used to `restore log` from StartTS to RestoreTS.
+	StartTS   uint64 `json:"start-ts" toml:"start-ts"`
 	RestoreTS uint64 `json:"restore-ts" toml:"restore-ts"`
 }
 
@@ -177,7 +177,7 @@ func (cfg *RestoreConfig) ParseStreamRestoreFlags(flags *pflag.FlagSet) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if cfg.StartTs, err = ParseTSString(tsString); err != nil {
+	if cfg.StartTS, err = ParseTSString(tsString); err != nil {
 		return errors.Trace(err)
 	}
 	tsString, err = flags.GetString(FlagStreamRestoreTS)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -909,7 +909,7 @@ func RunStreamRestore(
 		}
 		if cfg.StartTS < logStartTS {
 			return errors.Annotatef(berrors.ErrInvalidArgument,
-				"it has gap bewteen full backup ts:%d(%s) and log backup ts:%d(%s)"+
+				"it has gap between full backup ts:%d(%s) and log backup ts:%d(%s)"+
 					"you can \"restore full\" and \"restore point\" separately",
 				cfg.StartTS, oracle.GetTimeFromTS(cfg.StartTS),
 				logStartTS, oracle.GetTimeFromTS(logStartTS))
@@ -1171,6 +1171,7 @@ func getFullBakcupTS(
 	return backupmeta.GetEndVersion(), nil
 }
 
+// nolint: unused, deadcode
 func getGlobalCheckpointTS(ms []*backuppb.Metadata) uint64 {
 	storeMap := make(map[int64]uint64)
 	for _, m := range ms {


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx


### What is changed and how it works?
- Support restore snapshot and log(PiTR) only by one-command, 
   It will restore snapshot firstly, restore log at the time range [snapshot-ts, restored-ts].

`
    restore point --full-backup-storage "snapshot-storage" 
    --storage "log-storage" --restored-ts=400036290571534337
`
- If it has a gap between snapshot-timestamp of `backup full` and start-timestamp of `backup log`, report an error and a selective plan:

 `br restore full -s "snapshot-storage"`
`br restore point --start-ts  --restored-ts  -s "log-storage" `

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
