### PR TITLE
planner: move all functions about cost calculation to plan_cost.go

### DIFF
--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -15,15 +15,15 @@
 package core
 
 import (
-	"github.com/pingcap/tidb/config"
-	"github.com/pingcap/tidb/expression"
-	"github.com/pingcap/tidb/util/paging"
 	"math"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/planner/property"
 	"github.com/pingcap/tidb/statistics"
+	"github.com/pingcap/tidb/util/paging"
 )
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.

--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -15,6 +15,9 @@
 package core
 
 import (
+	"github.com/pingcap/tidb/config"
+	"github.com/pingcap/tidb/expression"
+	"github.com/pingcap/tidb/util/paging"
 	"math"
 
 	"github.com/pingcap/errors"
@@ -65,6 +68,19 @@ func (p *PhysicalSelection) GetPlanCost(taskType property.TaskType) (float64, er
 	return p.planCost, nil
 }
 
+// GetCost computes the cost of projection operator itself.
+func (p *PhysicalProjection) GetCost(count float64) float64 {
+	sessVars := p.ctx.GetSessionVars()
+	cpuCost := count * sessVars.CPUFactor
+	concurrency := float64(sessVars.ProjectionConcurrency())
+	if concurrency <= 0 {
+		return cpuCost
+	}
+	cpuCost /= concurrency
+	concurrencyCost := (1 + concurrency) * sessVars.ConcurrencyFactor
+	return cpuCost + concurrencyCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalProjection) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -78,6 +94,52 @@ func (p *PhysicalProjection) GetPlanCost(taskType property.TaskType) (float64, e
 	p.planCost += p.GetCost(p.StatsCount()) // projection cost
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes cost of index lookup operator itself.
+func (p *PhysicalIndexLookUpReader) GetCost() (cost float64) {
+	indexPlan, tablePlan := p.indexPlan, p.tablePlan
+	ctx := p.ctx
+	sessVars := ctx.GetSessionVars()
+	// Add cost of building table reader executors. Handles are extracted in batch style,
+	// each handle is a range, the CPU cost of building copTasks should be:
+	// (indexRows / batchSize) * batchSize * CPUFactor
+	// Since we don't know the number of copTasks built, ignore these network cost now.
+	indexRows := indexPlan.statsInfo().RowCount
+	idxCst := indexRows * sessVars.CPUFactor
+	// if the expectCnt is below the paging threshold, using paging API, recalculate idxCst.
+	// paging API reduces the count of index and table rows, however introduces more seek cost.
+	if ctx.GetSessionVars().EnablePaging && p.expectedCnt > 0 && p.expectedCnt <= paging.Threshold {
+		p.Paging = true
+		pagingCst := calcPagingCost(ctx, p.indexPlan, p.expectedCnt)
+		// prevent enlarging the cost because we take paging as a better plan,
+		// if the cost is enlarged, it'll be easier to go another plan.
+		idxCst = math.Min(idxCst, pagingCst)
+	}
+	cost += idxCst
+	// Add cost of worker goroutines in index lookup.
+	numTblWorkers := float64(sessVars.IndexLookupConcurrency())
+	cost += (numTblWorkers + 1) * sessVars.ConcurrencyFactor
+	// When building table reader executor for each batch, we would sort the handles. CPU
+	// cost of sort is:
+	// CPUFactor * batchSize * Log2(batchSize) * (indexRows / batchSize)
+	indexLookupSize := float64(sessVars.IndexLookupSize)
+	batchSize := math.Min(indexLookupSize, indexRows)
+	if batchSize > 2 {
+		sortCPUCost := (indexRows * math.Log2(batchSize) * sessVars.CPUFactor) / numTblWorkers
+		cost += sortCPUCost
+	}
+	// Also, we need to sort the retrieved rows if index lookup reader is expected to return
+	// ordered results. Note that row count of these two sorts can be different, if there are
+	// operators above table scan.
+	tableRows := tablePlan.statsInfo().RowCount
+	selectivity := tableRows / indexRows
+	batchSize = math.Min(indexLookupSize*selectivity, tableRows)
+	if p.keepOrder && batchSize > 2 {
+		sortCPUCost := (tableRows * math.Log2(batchSize) * sessVars.CPUFactor) / numTblWorkers
+		cost += sortCPUCost
+	}
+	return
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -261,6 +323,55 @@ func (p *PhysicalIndexScan) GetPlanCost(taskType property.TaskType) (float64, er
 	return p.planCost, nil
 }
 
+// GetCost computes the cost of index join operator and its children.
+func (p *PhysicalIndexJoin) GetCost(outerCnt, innerCnt float64, outerCost, innerCost float64) float64 {
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	// Add the cost of evaluating outer filter, since inner filter of index join
+	// is always empty, we can simply tell whether outer filter is empty using the
+	// summed length of left/right conditions.
+	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
+		cpuCost += sessVars.CPUFactor * outerCnt
+		outerCnt *= SelectionFactor
+	}
+	// Cost of extracting lookup keys.
+	innerCPUCost := sessVars.CPUFactor * outerCnt
+	// Cost of sorting and removing duplicate lookup keys:
+	// (outerCnt / batchSize) * (batchSize * Log2(batchSize) + batchSize) * CPUFactor
+	batchSize := math.Min(float64(p.ctx.GetSessionVars().IndexJoinBatchSize), outerCnt)
+	if batchSize > 2 {
+		innerCPUCost += outerCnt * (math.Log2(batchSize) + 1) * sessVars.CPUFactor
+	}
+	// Add cost of building inner executors. CPU cost of building copTasks:
+	// (outerCnt / batchSize) * (batchSize * distinctFactor) * CPUFactor
+	// Since we don't know the number of copTasks built, ignore these network cost now.
+	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
+	// CPU cost of building hash table for inner results:
+	// (outerCnt / batchSize) * (batchSize * distinctFactor) * innerCnt * CPUFactor
+	innerCPUCost += outerCnt * distinctFactor * innerCnt * sessVars.CPUFactor
+	innerConcurrency := float64(p.ctx.GetSessionVars().IndexLookupJoinConcurrency())
+	cpuCost += innerCPUCost / innerConcurrency
+	// Cost of probing hash table in main thread.
+	numPairs := outerCnt * innerCnt
+	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		if len(p.OtherConditions) > 0 {
+			numPairs *= 0.5
+		} else {
+			numPairs = 0
+		}
+	}
+	probeCost := numPairs * sessVars.CPUFactor
+	// Cost of additional concurrent goroutines.
+	cpuCost += probeCost + (innerConcurrency+1.0)*sessVars.ConcurrencyFactor
+	// Memory cost of hash tables for inner rows. The computed result is the upper bound,
+	// since the executor is pipelined and not all workers are always in full load.
+	memoryCost := innerConcurrency * (batchSize * distinctFactor) * innerCnt * sessVars.MemoryFactor
+	// Cost of inner child plan, i.e, mainly I/O and network cost.
+	innerPlanCost := outerCnt * innerCost
+	return outerCost + innerPlanCost + cpuCost + memoryCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalIndexJoin) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -278,6 +389,66 @@ func (p *PhysicalIndexJoin) GetPlanCost(taskType property.TaskType) (float64, er
 	p.planCost = p.GetCost(outerChild.StatsCount(), innerChild.StatsCount(), outerCost, innerCost)
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes the cost of index merge join operator and its children.
+func (p *PhysicalIndexHashJoin) GetCost(outerCnt, innerCnt, outerCost, innerCost float64) float64 {
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	// Add the cost of evaluating outer filter, since inner filter of index join
+	// is always empty, we can simply tell whether outer filter is empty using the
+	// summed length of left/right conditions.
+	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
+		cpuCost += sessVars.CPUFactor * outerCnt
+		outerCnt *= SelectionFactor
+	}
+	// Cost of extracting lookup keys.
+	innerCPUCost := sessVars.CPUFactor * outerCnt
+	// Cost of sorting and removing duplicate lookup keys:
+	// (outerCnt / batchSize) * (batchSize * Log2(batchSize) + batchSize) * CPUFactor
+	batchSize := math.Min(float64(sessVars.IndexJoinBatchSize), outerCnt)
+	if batchSize > 2 {
+		innerCPUCost += outerCnt * (math.Log2(batchSize) + 1) * sessVars.CPUFactor
+	}
+	// Add cost of building inner executors. CPU cost of building copTasks:
+	// (outerCnt / batchSize) * (batchSize * distinctFactor) * CPUFactor
+	// Since we don't know the number of copTasks built, ignore these network cost now.
+	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
+	concurrency := float64(sessVars.IndexLookupJoinConcurrency())
+	cpuCost += innerCPUCost / concurrency
+	// CPU cost of building hash table for outer results concurrently.
+	// (outerCnt / batchSize) * (batchSize * CPUFactor)
+	outerCPUCost := outerCnt * sessVars.CPUFactor
+	cpuCost += outerCPUCost / concurrency
+	// Cost of probing hash table concurrently.
+	numPairs := outerCnt * innerCnt
+	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		if len(p.OtherConditions) > 0 {
+			numPairs *= 0.5
+		} else {
+			numPairs = 0
+		}
+	}
+	// Inner workers do hash join in parallel, but they can only save ONE outer
+	// batch results. So as the number of outer batch exceeds inner concurrency,
+	// it would fall back to linear execution. In a word, the hash join only runs
+	// in parallel for the first `innerConcurrency` number of inner tasks.
+	var probeCost float64
+	if outerCnt/batchSize >= concurrency {
+		probeCost = (numPairs - batchSize*innerCnt*(concurrency-1)) * sessVars.CPUFactor
+	} else {
+		probeCost = batchSize * innerCnt * sessVars.CPUFactor
+	}
+	cpuCost += probeCost
+	// Cost of additional concurrent goroutines.
+	cpuCost += (concurrency + 1.0) * sessVars.ConcurrencyFactor
+	// Memory cost of hash tables for outer rows. The computed result is the upper bound,
+	// since the executor is pipelined and not all workers are always in full load.
+	memoryCost := concurrency * (batchSize * distinctFactor) * innerCnt * sessVars.MemoryFactor
+	// Cost of inner child plan, i.e, mainly I/O and network cost.
+	innerPlanCost := outerCnt * innerCost
+	return outerCost + innerPlanCost + cpuCost + memoryCost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -299,6 +470,68 @@ func (p *PhysicalIndexHashJoin) GetPlanCost(taskType property.TaskType) (float64
 	return p.planCost, nil
 }
 
+// GetCost computes the cost of index merge join operator and its children.
+func (p *PhysicalIndexMergeJoin) GetCost(outerCnt, innerCnt, outerCost, innerCost float64) float64 {
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	// Add the cost of evaluating outer filter, since inner filter of index join
+	// is always empty, we can simply tell whether outer filter is empty using the
+	// summed length of left/right conditions.
+	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
+		cpuCost += sessVars.CPUFactor * outerCnt
+		outerCnt *= SelectionFactor
+	}
+	// Cost of extracting lookup keys.
+	innerCPUCost := sessVars.CPUFactor * outerCnt
+	// Cost of sorting and removing duplicate lookup keys:
+	// (outerCnt / batchSize) * (sortFactor + 1.0) * batchSize * cpuFactor
+	// If `p.NeedOuterSort` is true, the sortFactor is batchSize * Log2(batchSize).
+	// Otherwise, it's 0.
+	batchSize := math.Min(float64(p.ctx.GetSessionVars().IndexJoinBatchSize), outerCnt)
+	sortFactor := 0.0
+	if p.NeedOuterSort {
+		sortFactor = math.Log2(batchSize)
+	}
+	if batchSize > 2 {
+		innerCPUCost += outerCnt * (sortFactor + 1.0) * sessVars.CPUFactor
+	}
+	// Add cost of building inner executors. CPU cost of building copTasks:
+	// (outerCnt / batchSize) * (batchSize * distinctFactor) * cpuFactor
+	// Since we don't know the number of copTasks built, ignore these network cost now.
+	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
+	innerConcurrency := float64(p.ctx.GetSessionVars().IndexLookupJoinConcurrency())
+	cpuCost += innerCPUCost / innerConcurrency
+	// Cost of merge join in inner worker.
+	numPairs := outerCnt * innerCnt
+	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		if len(p.OtherConditions) > 0 {
+			numPairs *= 0.5
+		} else {
+			numPairs = 0
+		}
+	}
+	avgProbeCnt := numPairs / outerCnt
+	var probeCost float64
+	// Inner workers do merge join in parallel, but they can only save ONE outer batch
+	// results. So as the number of outer batch exceeds inner concurrency, it would fall back to
+	// linear execution. In a word, the merge join only run in parallel for the first
+	// `innerConcurrency` number of inner tasks.
+	if outerCnt/batchSize >= innerConcurrency {
+		probeCost = (numPairs - batchSize*avgProbeCnt*(innerConcurrency-1)) * sessVars.CPUFactor
+	} else {
+		probeCost = batchSize * avgProbeCnt * sessVars.CPUFactor
+	}
+	cpuCost += probeCost + (innerConcurrency+1.0)*sessVars.ConcurrencyFactor
+
+	// Index merge join save the join results in inner worker.
+	// So the memory cost consider the results size for each batch.
+	memoryCost := innerConcurrency * (batchSize * avgProbeCnt) * sessVars.MemoryFactor
+
+	innerPlanCost := outerCnt * innerCost
+	return outerCost + innerPlanCost + cpuCost + memoryCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalIndexMergeJoin) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -316,6 +549,33 @@ func (p *PhysicalIndexMergeJoin) GetPlanCost(taskType property.TaskType) (float6
 	p.planCost = p.GetCost(outerChild.StatsCount(), innerChild.StatsCount(), outerCost, innerCost)
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes the cost of apply operator.
+func (p *PhysicalApply) GetCost(lCount, rCount, lCost, rCost float64) float64 {
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	if len(p.LeftConditions) > 0 {
+		cpuCost += lCount * sessVars.CPUFactor
+		lCount *= SelectionFactor
+	}
+	if len(p.RightConditions) > 0 {
+		cpuCost += lCount * rCount * sessVars.CPUFactor
+		rCount *= SelectionFactor
+	}
+	if len(p.EqualConditions)+len(p.OtherConditions) > 0 {
+		if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+			p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+			cpuCost += lCount * rCount * sessVars.CPUFactor * 0.5
+		} else {
+			cpuCost += lCount * rCount * sessVars.CPUFactor
+		}
+	}
+	// Apply uses a NestedLoop method for execution.
+	// For every row from the left(outer) side, it executes
+	// the whole right(inner) plan tree. So the cost of apply
+	// should be : apply cost + left cost + left count * right cost
+	return cpuCost + lCost + lCount*rCost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -337,6 +597,52 @@ func (p *PhysicalApply) GetPlanCost(taskType property.TaskType) (float64, error)
 	return p.planCost, nil
 }
 
+// GetCost computes cost of merge join operator itself.
+func (p *PhysicalMergeJoin) GetCost(lCnt, rCnt float64) float64 {
+	outerCnt := lCnt
+	innerKeys := p.RightJoinKeys
+	innerSchema := p.children[1].Schema()
+	innerStats := p.children[1].statsInfo()
+	if p.JoinType == RightOuterJoin {
+		outerCnt = rCnt
+		innerKeys = p.LeftJoinKeys
+		innerSchema = p.children[0].Schema()
+		innerStats = p.children[0].statsInfo()
+	}
+	helper := &fullJoinRowCountHelper{
+		cartesian:     false,
+		leftProfile:   p.children[0].statsInfo(),
+		rightProfile:  p.children[1].statsInfo(),
+		leftJoinKeys:  p.LeftJoinKeys,
+		rightJoinKeys: p.RightJoinKeys,
+		leftSchema:    p.children[0].Schema(),
+		rightSchema:   p.children[1].Schema(),
+	}
+	numPairs := helper.estimate()
+	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		if len(p.OtherConditions) > 0 {
+			numPairs *= 0.5
+		} else {
+			numPairs = 0
+		}
+	}
+	sessVars := p.ctx.GetSessionVars()
+	probeCost := numPairs * sessVars.CPUFactor
+	// Cost of evaluating outer filters.
+	var cpuCost float64
+	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
+		probeCost *= SelectionFactor
+		cpuCost += outerCnt * sessVars.CPUFactor
+	}
+	cpuCost += probeCost
+	// For merge join, only one group of rows with same join key(not null) are cached,
+	// we compute average memory cost using estimated group size.
+	NDV := getColsNDV(innerKeys, innerSchema, innerStats)
+	memoryCost := (innerStats.RowCount / NDV) * sessVars.MemoryFactor
+	return cpuCost + memoryCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalMergeJoin) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -353,6 +659,85 @@ func (p *PhysicalMergeJoin) GetPlanCost(taskType property.TaskType) (float64, er
 	p.planCost += p.GetCost(p.children[0].StatsCount(), p.children[1].StatsCount())
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes cost of hash join operator itself.
+func (p *PhysicalHashJoin) GetCost(lCnt, rCnt float64) float64 {
+	buildCnt, probeCnt := lCnt, rCnt
+	build := p.children[0]
+	// Taking the right as the inner for right join or using the outer to build a hash table.
+	if (p.InnerChildIdx == 1 && !p.UseOuterToBuild) || (p.InnerChildIdx == 0 && p.UseOuterToBuild) {
+		buildCnt, probeCnt = rCnt, lCnt
+		build = p.children[1]
+	}
+	sessVars := p.ctx.GetSessionVars()
+	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
+	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
+	rowSize := getAvgRowSize(build.statsInfo(), build.Schema())
+	spill := oomUseTmpStorage && memQuota > 0 && rowSize*buildCnt > float64(memQuota) && p.storeTp != kv.TiFlash
+	// Cost of building hash table.
+	cpuCost := buildCnt * sessVars.CPUFactor
+	memoryCost := buildCnt * sessVars.MemoryFactor
+	diskCost := buildCnt * sessVars.DiskFactor * rowSize
+	// Number of matched row pairs regarding the equal join conditions.
+	helper := &fullJoinRowCountHelper{
+		cartesian:     false,
+		leftProfile:   p.children[0].statsInfo(),
+		rightProfile:  p.children[1].statsInfo(),
+		leftJoinKeys:  p.LeftJoinKeys,
+		rightJoinKeys: p.RightJoinKeys,
+		leftSchema:    p.children[0].Schema(),
+		rightSchema:   p.children[1].Schema(),
+	}
+	numPairs := helper.estimate()
+	// For semi-join class, if `OtherConditions` is empty, we already know
+	// the join results after querying hash table, otherwise, we have to
+	// evaluate those resulted row pairs after querying hash table; if we
+	// find one pair satisfying the `OtherConditions`, we then know the
+	// join result for this given outer row, otherwise we have to iterate
+	// to the end of those pairs; since we have no idea about when we can
+	// terminate the iteration, we assume that we need to iterate half of
+	// those pairs in average.
+	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
+		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
+		if len(p.OtherConditions) > 0 {
+			numPairs *= 0.5
+		} else {
+			numPairs = 0
+		}
+	}
+	// Cost of querying hash table is cheap actually, so we just compute the cost of
+	// evaluating `OtherConditions` and joining row pairs.
+	probeCost := numPairs * sessVars.CPUFactor
+	probeDiskCost := numPairs * sessVars.DiskFactor * rowSize
+	// Cost of evaluating outer filter.
+	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
+		// Input outer count for the above compution should be adjusted by SelectionFactor.
+		probeCost *= SelectionFactor
+		probeDiskCost *= SelectionFactor
+		probeCost += probeCnt * sessVars.CPUFactor
+	}
+	diskCost += probeDiskCost
+	probeCost /= float64(p.Concurrency)
+	// Cost of additional concurrent goroutines.
+	cpuCost += probeCost + float64(p.Concurrency+1)*sessVars.ConcurrencyFactor
+	// Cost of traveling the hash table to resolve missing matched cases when building the hash table from the outer table
+	if p.UseOuterToBuild {
+		if spill {
+			// It runs in sequence when build data is on disk. See handleUnmatchedRowsFromHashTableInDisk
+			cpuCost += buildCnt * sessVars.CPUFactor
+		} else {
+			cpuCost += buildCnt * sessVars.CPUFactor / float64(p.Concurrency)
+		}
+		diskCost += buildCnt * sessVars.DiskFactor * rowSize
+	}
+
+	if spill {
+		memoryCost *= float64(memQuota) / (rowSize * buildCnt)
+	} else {
+		diskCost = 0
+	}
+	return cpuCost + memoryCost + diskCost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -373,6 +758,21 @@ func (p *PhysicalHashJoin) GetPlanCost(taskType property.TaskType) (float64, err
 	return p.planCost, nil
 }
 
+// GetCost computes cost of stream aggregation considering CPU/memory.
+func (p *PhysicalStreamAgg) GetCost(inputRows float64, isRoot bool) float64 {
+	aggFuncFactor := p.getAggFuncCostFactor(false)
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	if isRoot {
+		cpuCost = inputRows * sessVars.CPUFactor * aggFuncFactor
+	} else {
+		cpuCost = inputRows * sessVars.CopCPUFactor * aggFuncFactor
+	}
+	rowsPerGroup := inputRows / p.statsInfo().RowCount
+	memoryCost := rowsPerGroup * distinctFactor * sessVars.MemoryFactor * float64(p.numDistinctFunc())
+	return cpuCost + memoryCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalStreamAgg) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -386,6 +786,31 @@ func (p *PhysicalStreamAgg) GetPlanCost(taskType property.TaskType) (float64, er
 	p.planCost += p.GetCost(p.children[0].StatsCount(), taskType == property.RootTaskType)
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes the cost of hash aggregation considering CPU/memory.
+func (p *PhysicalHashAgg) GetCost(inputRows float64, isRoot bool, isMPP bool) float64 {
+	cardinality := p.statsInfo().RowCount
+	numDistinctFunc := p.numDistinctFunc()
+	aggFuncFactor := p.getAggFuncCostFactor(isMPP)
+	var cpuCost float64
+	sessVars := p.ctx.GetSessionVars()
+	if isRoot {
+		cpuCost = inputRows * sessVars.CPUFactor * aggFuncFactor
+		divisor, con := p.cpuCostDivisor(numDistinctFunc > 0)
+		if divisor > 0 {
+			cpuCost /= divisor
+			// Cost of additional goroutines.
+			cpuCost += (con + 1) * sessVars.ConcurrencyFactor
+		}
+	} else {
+		cpuCost = inputRows * sessVars.CopCPUFactor * aggFuncFactor
+	}
+	memoryCost := cardinality * sessVars.MemoryFactor * float64(len(p.AggFuncs))
+	// When aggregation has distinct flag, we would allocate a map for each group to
+	// check duplication.
+	memoryCost += inputRows * distinctFactor * sessVars.MemoryFactor * float64(numDistinctFunc)
+	return cpuCost + memoryCost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -412,6 +837,28 @@ func (p *PhysicalHashAgg) GetPlanCost(taskType property.TaskType) (float64, erro
 	return p.planCost, nil
 }
 
+// GetCost computes the cost of in memory sort.
+func (p *PhysicalSort) GetCost(count float64, schema *expression.Schema) float64 {
+	if count < 2.0 {
+		count = 2.0
+	}
+	sessVars := p.ctx.GetSessionVars()
+	cpuCost := count * math.Log2(count) * sessVars.CPUFactor
+	memoryCost := count * sessVars.MemoryFactor
+
+	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
+	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
+	rowSize := getAvgRowSize(p.statsInfo(), schema)
+	spill := oomUseTmpStorage && memQuota > 0 && rowSize*count > float64(memQuota)
+	diskCost := count * sessVars.DiskFactor * rowSize
+	if !spill {
+		diskCost = 0
+	} else {
+		memoryCost *= float64(memQuota) / (rowSize * count)
+	}
+	return cpuCost + memoryCost + diskCost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *PhysicalSort) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -425,6 +872,29 @@ func (p *PhysicalSort) GetPlanCost(taskType property.TaskType) (float64, error) 
 	p.planCost += p.GetCost(p.children[0].StatsCount(), p.Schema())
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost computes cost of TopN operator itself.
+func (p *PhysicalTopN) GetCost(count float64, isRoot bool) float64 {
+	heapSize := float64(p.Offset + p.Count)
+	if heapSize < 2.0 {
+		heapSize = 2.0
+	}
+	sessVars := p.ctx.GetSessionVars()
+	// Ignore the cost of `doCompaction` in current implementation of `TopNExec`, since it is the
+	// special side-effect of our Chunk format in TiDB layer, which may not exist in coprocessor's
+	// implementation, or may be removed in the future if we change data format.
+	// Note that we are using worst complexity to compute CPU cost, because it is simpler compared with
+	// considering probabilities of average complexity, i.e, we may not need adjust heap for each input
+	// row.
+	var cpuCost float64
+	if isRoot {
+		cpuCost = count * math.Log2(heapSize) * sessVars.CPUFactor
+	} else {
+		cpuCost = count * math.Log2(heapSize) * sessVars.CopCPUFactor
+	}
+	memoryCost := heapSize * sessVars.MemoryFactor
+	return cpuCost + memoryCost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
@@ -442,6 +912,28 @@ func (p *PhysicalTopN) GetPlanCost(taskType property.TaskType) (float64, error) 
 	return p.planCost, nil
 }
 
+// GetCost returns cost of the PointGetPlan.
+func (p *BatchPointGetPlan) GetCost() float64 {
+	cols := p.accessCols
+	if cols == nil {
+		return 0 // the cost of BatchGet generated in fast plan optimization is always 0
+	}
+	sessVars := p.ctx.GetSessionVars()
+	var rowSize, rowCount float64
+	cost := 0.0
+	if p.IndexInfo == nil {
+		rowCount = float64(len(p.Handles))
+		rowSize = p.stats.HistColl.GetTableAvgRowSize(p.ctx, cols, kv.TiKV, true)
+	} else {
+		rowCount = float64(len(p.IndexValues))
+		rowSize = p.stats.HistColl.GetIndexAvgRowSize(p.ctx, cols, p.IndexInfo.Unique)
+	}
+	cost += rowCount * rowSize * sessVars.GetNetworkFactor(p.TblInfo)
+	cost += rowCount * sessVars.GetSeekFactor(p.TblInfo)
+	cost /= float64(sessVars.DistSQLScanConcurrency())
+	return cost
+}
+
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 func (p *BatchPointGetPlan) GetPlanCost(taskType property.TaskType) (float64, error) {
 	if p.planCostInit {
@@ -450,6 +942,26 @@ func (p *BatchPointGetPlan) GetPlanCost(taskType property.TaskType) (float64, er
 	p.planCost = p.GetCost()
 	p.planCostInit = true
 	return p.planCost, nil
+}
+
+// GetCost returns cost of the PointGetPlan.
+func (p *PointGetPlan) GetCost() float64 {
+	cols := p.accessCols
+	if cols == nil {
+		return 0 // the cost of PointGet generated in fast plan optimization is always 0
+	}
+	sessVars := p.ctx.GetSessionVars()
+	var rowSize float64
+	cost := 0.0
+	if p.IndexInfo == nil {
+		rowSize = p.stats.HistColl.GetTableAvgRowSize(p.ctx, cols, kv.TiKV, true)
+	} else {
+		rowSize = p.stats.HistColl.GetIndexAvgRowSize(p.ctx, cols, p.IndexInfo.Unique)
+	}
+	cost += rowSize * sessVars.GetNetworkFactor(p.TblInfo)
+	cost += sessVars.GetSeekFactor(p.TblInfo)
+	cost /= float64(sessVars.DistSQLScanConcurrency())
+	return cost
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -18,7 +18,6 @@ import (
 	"math"
 
 	"github.com/pingcap/errors"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/expression/aggregation"
 	"github.com/pingcap/tidb/kv"
@@ -256,33 +255,6 @@ func (p *PhysicalApply) attach2Task(tasks ...task) task {
 	return t
 }
 
-// GetCost computes the cost of apply operator.
-func (p *PhysicalApply) GetCost(lCount, rCount, lCost, rCost float64) float64 {
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	if len(p.LeftConditions) > 0 {
-		cpuCost += lCount * sessVars.CPUFactor
-		lCount *= SelectionFactor
-	}
-	if len(p.RightConditions) > 0 {
-		cpuCost += lCount * rCount * sessVars.CPUFactor
-		rCount *= SelectionFactor
-	}
-	if len(p.EqualConditions)+len(p.OtherConditions) > 0 {
-		if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-			p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-			cpuCost += lCount * rCount * sessVars.CPUFactor * 0.5
-		} else {
-			cpuCost += lCount * rCount * sessVars.CPUFactor
-		}
-	}
-	// Apply uses a NestedLoop method for execution.
-	// For every row from the left(outer) side, it executes
-	// the whole right(inner) plan tree. So the cost of apply
-	// should be : apply cost + left cost + left count * right cost
-	return cpuCost + lCost + lCount*rCost
-}
-
 func (p *PhysicalIndexMergeJoin) attach2Task(tasks ...task) task {
 	innerTask := p.innerTask
 	outerTask := tasks[1-p.InnerChildIdx].convertToRootTask(p.ctx)
@@ -297,68 +269,6 @@ func (p *PhysicalIndexMergeJoin) attach2Task(tasks ...task) task {
 	}
 	p.cost = t.cost()
 	return t
-}
-
-// GetCost computes the cost of index merge join operator and its children.
-func (p *PhysicalIndexMergeJoin) GetCost(outerCnt, innerCnt, outerCost, innerCost float64) float64 {
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	// Add the cost of evaluating outer filter, since inner filter of index join
-	// is always empty, we can simply tell whether outer filter is empty using the
-	// summed length of left/right conditions.
-	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
-		cpuCost += sessVars.CPUFactor * outerCnt
-		outerCnt *= SelectionFactor
-	}
-	// Cost of extracting lookup keys.
-	innerCPUCost := sessVars.CPUFactor * outerCnt
-	// Cost of sorting and removing duplicate lookup keys:
-	// (outerCnt / batchSize) * (sortFactor + 1.0) * batchSize * cpuFactor
-	// If `p.NeedOuterSort` is true, the sortFactor is batchSize * Log2(batchSize).
-	// Otherwise, it's 0.
-	batchSize := math.Min(float64(p.ctx.GetSessionVars().IndexJoinBatchSize), outerCnt)
-	sortFactor := 0.0
-	if p.NeedOuterSort {
-		sortFactor = math.Log2(batchSize)
-	}
-	if batchSize > 2 {
-		innerCPUCost += outerCnt * (sortFactor + 1.0) * sessVars.CPUFactor
-	}
-	// Add cost of building inner executors. CPU cost of building copTasks:
-	// (outerCnt / batchSize) * (batchSize * distinctFactor) * cpuFactor
-	// Since we don't know the number of copTasks built, ignore these network cost now.
-	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
-	innerConcurrency := float64(p.ctx.GetSessionVars().IndexLookupJoinConcurrency())
-	cpuCost += innerCPUCost / innerConcurrency
-	// Cost of merge join in inner worker.
-	numPairs := outerCnt * innerCnt
-	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-		if len(p.OtherConditions) > 0 {
-			numPairs *= 0.5
-		} else {
-			numPairs = 0
-		}
-	}
-	avgProbeCnt := numPairs / outerCnt
-	var probeCost float64
-	// Inner workers do merge join in parallel, but they can only save ONE outer batch
-	// results. So as the number of outer batch exceeds inner concurrency, it would fall back to
-	// linear execution. In a word, the merge join only run in parallel for the first
-	// `innerConcurrency` number of inner tasks.
-	if outerCnt/batchSize >= innerConcurrency {
-		probeCost = (numPairs - batchSize*avgProbeCnt*(innerConcurrency-1)) * sessVars.CPUFactor
-	} else {
-		probeCost = batchSize * avgProbeCnt * sessVars.CPUFactor
-	}
-	cpuCost += probeCost + (innerConcurrency+1.0)*sessVars.ConcurrencyFactor
-
-	// Index merge join save the join results in inner worker.
-	// So the memory cost consider the results size for each batch.
-	memoryCost := innerConcurrency * (batchSize * avgProbeCnt) * sessVars.MemoryFactor
-
-	innerPlanCost := outerCnt * innerCost
-	return outerCost + innerPlanCost + cpuCost + memoryCost
 }
 
 func (p *PhysicalIndexHashJoin) attach2Task(tasks ...task) task {
@@ -377,66 +287,6 @@ func (p *PhysicalIndexHashJoin) attach2Task(tasks ...task) task {
 	return t
 }
 
-// GetCost computes the cost of index merge join operator and its children.
-func (p *PhysicalIndexHashJoin) GetCost(outerCnt, innerCnt, outerCost, innerCost float64) float64 {
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	// Add the cost of evaluating outer filter, since inner filter of index join
-	// is always empty, we can simply tell whether outer filter is empty using the
-	// summed length of left/right conditions.
-	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
-		cpuCost += sessVars.CPUFactor * outerCnt
-		outerCnt *= SelectionFactor
-	}
-	// Cost of extracting lookup keys.
-	innerCPUCost := sessVars.CPUFactor * outerCnt
-	// Cost of sorting and removing duplicate lookup keys:
-	// (outerCnt / batchSize) * (batchSize * Log2(batchSize) + batchSize) * CPUFactor
-	batchSize := math.Min(float64(sessVars.IndexJoinBatchSize), outerCnt)
-	if batchSize > 2 {
-		innerCPUCost += outerCnt * (math.Log2(batchSize) + 1) * sessVars.CPUFactor
-	}
-	// Add cost of building inner executors. CPU cost of building copTasks:
-	// (outerCnt / batchSize) * (batchSize * distinctFactor) * CPUFactor
-	// Since we don't know the number of copTasks built, ignore these network cost now.
-	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
-	concurrency := float64(sessVars.IndexLookupJoinConcurrency())
-	cpuCost += innerCPUCost / concurrency
-	// CPU cost of building hash table for outer results concurrently.
-	// (outerCnt / batchSize) * (batchSize * CPUFactor)
-	outerCPUCost := outerCnt * sessVars.CPUFactor
-	cpuCost += outerCPUCost / concurrency
-	// Cost of probing hash table concurrently.
-	numPairs := outerCnt * innerCnt
-	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-		if len(p.OtherConditions) > 0 {
-			numPairs *= 0.5
-		} else {
-			numPairs = 0
-		}
-	}
-	// Inner workers do hash join in parallel, but they can only save ONE outer
-	// batch results. So as the number of outer batch exceeds inner concurrency,
-	// it would fall back to linear execution. In a word, the hash join only runs
-	// in parallel for the first `innerConcurrency` number of inner tasks.
-	var probeCost float64
-	if outerCnt/batchSize >= concurrency {
-		probeCost = (numPairs - batchSize*innerCnt*(concurrency-1)) * sessVars.CPUFactor
-	} else {
-		probeCost = batchSize * innerCnt * sessVars.CPUFactor
-	}
-	cpuCost += probeCost
-	// Cost of additional concurrent goroutines.
-	cpuCost += (concurrency + 1.0) * sessVars.ConcurrencyFactor
-	// Memory cost of hash tables for outer rows. The computed result is the upper bound,
-	// since the executor is pipelined and not all workers are always in full load.
-	memoryCost := concurrency * (batchSize * distinctFactor) * innerCnt * sessVars.MemoryFactor
-	// Cost of inner child plan, i.e, mainly I/O and network cost.
-	innerPlanCost := outerCnt * innerCost
-	return outerCost + innerPlanCost + cpuCost + memoryCost
-}
-
 func (p *PhysicalIndexJoin) attach2Task(tasks ...task) task {
 	innerTask := p.innerTask
 	outerTask := tasks[1-p.InnerChildIdx].convertToRootTask(p.ctx)
@@ -453,55 +303,6 @@ func (p *PhysicalIndexJoin) attach2Task(tasks ...task) task {
 	return t
 }
 
-// GetCost computes the cost of index join operator and its children.
-func (p *PhysicalIndexJoin) GetCost(outerCnt, innerCnt float64, outerCost, innerCost float64) float64 {
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	// Add the cost of evaluating outer filter, since inner filter of index join
-	// is always empty, we can simply tell whether outer filter is empty using the
-	// summed length of left/right conditions.
-	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
-		cpuCost += sessVars.CPUFactor * outerCnt
-		outerCnt *= SelectionFactor
-	}
-	// Cost of extracting lookup keys.
-	innerCPUCost := sessVars.CPUFactor * outerCnt
-	// Cost of sorting and removing duplicate lookup keys:
-	// (outerCnt / batchSize) * (batchSize * Log2(batchSize) + batchSize) * CPUFactor
-	batchSize := math.Min(float64(p.ctx.GetSessionVars().IndexJoinBatchSize), outerCnt)
-	if batchSize > 2 {
-		innerCPUCost += outerCnt * (math.Log2(batchSize) + 1) * sessVars.CPUFactor
-	}
-	// Add cost of building inner executors. CPU cost of building copTasks:
-	// (outerCnt / batchSize) * (batchSize * distinctFactor) * CPUFactor
-	// Since we don't know the number of copTasks built, ignore these network cost now.
-	innerCPUCost += outerCnt * distinctFactor * sessVars.CPUFactor
-	// CPU cost of building hash table for inner results:
-	// (outerCnt / batchSize) * (batchSize * distinctFactor) * innerCnt * CPUFactor
-	innerCPUCost += outerCnt * distinctFactor * innerCnt * sessVars.CPUFactor
-	innerConcurrency := float64(p.ctx.GetSessionVars().IndexLookupJoinConcurrency())
-	cpuCost += innerCPUCost / innerConcurrency
-	// Cost of probing hash table in main thread.
-	numPairs := outerCnt * innerCnt
-	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-		if len(p.OtherConditions) > 0 {
-			numPairs *= 0.5
-		} else {
-			numPairs = 0
-		}
-	}
-	probeCost := numPairs * sessVars.CPUFactor
-	// Cost of additional concurrent goroutines.
-	cpuCost += probeCost + (innerConcurrency+1.0)*sessVars.ConcurrencyFactor
-	// Memory cost of hash tables for inner rows. The computed result is the upper bound,
-	// since the executor is pipelined and not all workers are always in full load.
-	memoryCost := innerConcurrency * (batchSize * distinctFactor) * innerCnt * sessVars.MemoryFactor
-	// Cost of inner child plan, i.e, mainly I/O and network cost.
-	innerPlanCost := outerCnt * innerCost
-	return outerCost + innerPlanCost + cpuCost + memoryCost
-}
-
 func getAvgRowSize(stats *property.StatsInfo, schema *expression.Schema) (size float64) {
 	if stats.HistColl != nil {
 		size = stats.HistColl.GetAvgRowSizeListInDisk(schema.Columns)
@@ -513,85 +314,6 @@ func getAvgRowSize(stats *property.StatsInfo, schema *expression.Schema) (size f
 		}
 	}
 	return
-}
-
-// GetCost computes cost of hash join operator itself.
-func (p *PhysicalHashJoin) GetCost(lCnt, rCnt float64) float64 {
-	buildCnt, probeCnt := lCnt, rCnt
-	build := p.children[0]
-	// Taking the right as the inner for right join or using the outer to build a hash table.
-	if (p.InnerChildIdx == 1 && !p.UseOuterToBuild) || (p.InnerChildIdx == 0 && p.UseOuterToBuild) {
-		buildCnt, probeCnt = rCnt, lCnt
-		build = p.children[1]
-	}
-	sessVars := p.ctx.GetSessionVars()
-	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
-	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
-	rowSize := getAvgRowSize(build.statsInfo(), build.Schema())
-	spill := oomUseTmpStorage && memQuota > 0 && rowSize*buildCnt > float64(memQuota) && p.storeTp != kv.TiFlash
-	// Cost of building hash table.
-	cpuCost := buildCnt * sessVars.CPUFactor
-	memoryCost := buildCnt * sessVars.MemoryFactor
-	diskCost := buildCnt * sessVars.DiskFactor * rowSize
-	// Number of matched row pairs regarding the equal join conditions.
-	helper := &fullJoinRowCountHelper{
-		cartesian:     false,
-		leftProfile:   p.children[0].statsInfo(),
-		rightProfile:  p.children[1].statsInfo(),
-		leftJoinKeys:  p.LeftJoinKeys,
-		rightJoinKeys: p.RightJoinKeys,
-		leftSchema:    p.children[0].Schema(),
-		rightSchema:   p.children[1].Schema(),
-	}
-	numPairs := helper.estimate()
-	// For semi-join class, if `OtherConditions` is empty, we already know
-	// the join results after querying hash table, otherwise, we have to
-	// evaluate those resulted row pairs after querying hash table; if we
-	// find one pair satisfying the `OtherConditions`, we then know the
-	// join result for this given outer row, otherwise we have to iterate
-	// to the end of those pairs; since we have no idea about when we can
-	// terminate the iteration, we assume that we need to iterate half of
-	// those pairs in average.
-	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-		if len(p.OtherConditions) > 0 {
-			numPairs *= 0.5
-		} else {
-			numPairs = 0
-		}
-	}
-	// Cost of querying hash table is cheap actually, so we just compute the cost of
-	// evaluating `OtherConditions` and joining row pairs.
-	probeCost := numPairs * sessVars.CPUFactor
-	probeDiskCost := numPairs * sessVars.DiskFactor * rowSize
-	// Cost of evaluating outer filter.
-	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
-		// Input outer count for the above compution should be adjusted by SelectionFactor.
-		probeCost *= SelectionFactor
-		probeDiskCost *= SelectionFactor
-		probeCost += probeCnt * sessVars.CPUFactor
-	}
-	diskCost += probeDiskCost
-	probeCost /= float64(p.Concurrency)
-	// Cost of additional concurrent goroutines.
-	cpuCost += probeCost + float64(p.Concurrency+1)*sessVars.ConcurrencyFactor
-	// Cost of traveling the hash table to resolve missing matched cases when building the hash table from the outer table
-	if p.UseOuterToBuild {
-		if spill {
-			// It runs in sequence when build data is on disk. See handleUnmatchedRowsFromHashTableInDisk
-			cpuCost += buildCnt * sessVars.CPUFactor
-		} else {
-			cpuCost += buildCnt * sessVars.CPUFactor / float64(p.Concurrency)
-		}
-		diskCost += buildCnt * sessVars.DiskFactor * rowSize
-	}
-
-	if spill {
-		memoryCost *= float64(memQuota) / (rowSize * buildCnt)
-	} else {
-		diskCost = 0
-	}
-	return cpuCost + memoryCost + diskCost
 }
 
 func (p *PhysicalHashJoin) attach2Task(tasks ...task) task {
@@ -862,52 +584,6 @@ func (p *PhysicalHashJoin) attach2TaskForTiFlash(tasks ...task) task {
 	return task
 }
 
-// GetCost computes cost of merge join operator itself.
-func (p *PhysicalMergeJoin) GetCost(lCnt, rCnt float64) float64 {
-	outerCnt := lCnt
-	innerKeys := p.RightJoinKeys
-	innerSchema := p.children[1].Schema()
-	innerStats := p.children[1].statsInfo()
-	if p.JoinType == RightOuterJoin {
-		outerCnt = rCnt
-		innerKeys = p.LeftJoinKeys
-		innerSchema = p.children[0].Schema()
-		innerStats = p.children[0].statsInfo()
-	}
-	helper := &fullJoinRowCountHelper{
-		cartesian:     false,
-		leftProfile:   p.children[0].statsInfo(),
-		rightProfile:  p.children[1].statsInfo(),
-		leftJoinKeys:  p.LeftJoinKeys,
-		rightJoinKeys: p.RightJoinKeys,
-		leftSchema:    p.children[0].Schema(),
-		rightSchema:   p.children[1].Schema(),
-	}
-	numPairs := helper.estimate()
-	if p.JoinType == SemiJoin || p.JoinType == AntiSemiJoin ||
-		p.JoinType == LeftOuterSemiJoin || p.JoinType == AntiLeftOuterSemiJoin {
-		if len(p.OtherConditions) > 0 {
-			numPairs *= 0.5
-		} else {
-			numPairs = 0
-		}
-	}
-	sessVars := p.ctx.GetSessionVars()
-	probeCost := numPairs * sessVars.CPUFactor
-	// Cost of evaluating outer filters.
-	var cpuCost float64
-	if len(p.LeftConditions)+len(p.RightConditions) > 0 {
-		probeCost *= SelectionFactor
-		cpuCost += outerCnt * sessVars.CPUFactor
-	}
-	cpuCost += probeCost
-	// For merge join, only one group of rows with same join key(not null) are cached,
-	// we compute average memory cost using estimated group size.
-	NDV := getColsNDV(innerKeys, innerSchema, innerStats)
-	memoryCost := (innerStats.RowCount / NDV) * sessVars.MemoryFactor
-	return cpuCost + memoryCost
-}
-
 func (p *PhysicalMergeJoin) attach2Task(tasks ...task) task {
 	lTask := tasks[0].convertToRootTask(p.ctx)
 	rTask := tasks[1].convertToRootTask(p.ctx)
@@ -918,52 +594,6 @@ func (p *PhysicalMergeJoin) attach2Task(tasks ...task) task {
 	}
 	p.cost = t.cost()
 	return t
-}
-
-// GetCost computes cost of index lookup operator itself.
-func (p *PhysicalIndexLookUpReader) GetCost() (cost float64) {
-	indexPlan, tablePlan := p.indexPlan, p.tablePlan
-	ctx := p.ctx
-	sessVars := ctx.GetSessionVars()
-	// Add cost of building table reader executors. Handles are extracted in batch style,
-	// each handle is a range, the CPU cost of building copTasks should be:
-	// (indexRows / batchSize) * batchSize * CPUFactor
-	// Since we don't know the number of copTasks built, ignore these network cost now.
-	indexRows := indexPlan.statsInfo().RowCount
-	idxCst := indexRows * sessVars.CPUFactor
-	// if the expectCnt is below the paging threshold, using paging API, recalculate idxCst.
-	// paging API reduces the count of index and table rows, however introduces more seek cost.
-	if ctx.GetSessionVars().EnablePaging && p.expectedCnt > 0 && p.expectedCnt <= paging.Threshold {
-		p.Paging = true
-		pagingCst := calcPagingCost(ctx, p.indexPlan, p.expectedCnt)
-		// prevent enlarging the cost because we take paging as a better plan,
-		// if the cost is enlarged, it'll be easier to go another plan.
-		idxCst = math.Min(idxCst, pagingCst)
-	}
-	cost += idxCst
-	// Add cost of worker goroutines in index lookup.
-	numTblWorkers := float64(sessVars.IndexLookupConcurrency())
-	cost += (numTblWorkers + 1) * sessVars.ConcurrencyFactor
-	// When building table reader executor for each batch, we would sort the handles. CPU
-	// cost of sort is:
-	// CPUFactor * batchSize * Log2(batchSize) * (indexRows / batchSize)
-	indexLookupSize := float64(sessVars.IndexLookupSize)
-	batchSize := math.Min(indexLookupSize, indexRows)
-	if batchSize > 2 {
-		sortCPUCost := (indexRows * math.Log2(batchSize) * sessVars.CPUFactor) / numTblWorkers
-		cost += sortCPUCost
-	}
-	// Also, we need to sort the retrieved rows if index lookup reader is expected to return
-	// ordered results. Note that row count of these two sorts can be different, if there are
-	// operators above table scan.
-	tableRows := tablePlan.statsInfo().RowCount
-	selectivity := tableRows / indexRows
-	batchSize = math.Min(indexLookupSize*selectivity, tableRows)
-	if p.keepOrder && batchSize > 2 {
-		sortCPUCost := (tableRows * math.Log2(batchSize) * sessVars.CPUFactor) / numTblWorkers
-		cost += sortCPUCost
-	}
-	return
 }
 
 func buildIndexLookUpTask(ctx sessionctx.Context, t *copTask) *rootTask {
@@ -1307,29 +937,6 @@ func (p *PhysicalLimit) sinkIntoIndexLookUp(t task) bool {
 	return true
 }
 
-// GetCost computes cost of TopN operator itself.
-func (p *PhysicalTopN) GetCost(count float64, isRoot bool) float64 {
-	heapSize := float64(p.Offset + p.Count)
-	if heapSize < 2.0 {
-		heapSize = 2.0
-	}
-	sessVars := p.ctx.GetSessionVars()
-	// Ignore the cost of `doCompaction` in current implementation of `TopNExec`, since it is the
-	// special side-effect of our Chunk format in TiDB layer, which may not exist in coprocessor's
-	// implementation, or may be removed in the future if we change data format.
-	// Note that we are using worst complexity to compute CPU cost, because it is simpler compared with
-	// considering probabilities of average complexity, i.e, we may not need adjust heap for each input
-	// row.
-	var cpuCost float64
-	if isRoot {
-		cpuCost = count * math.Log2(heapSize) * sessVars.CPUFactor
-	} else {
-		cpuCost = count * math.Log2(heapSize) * sessVars.CopCPUFactor
-	}
-	memoryCost := heapSize * sessVars.MemoryFactor
-	return cpuCost + memoryCost
-}
-
 // canPushDown checks if this topN can be pushed down. If each of the expression can be converted to pb, it can be pushed.
 func (p *PhysicalTopN) canPushDown(storeTp kv.StoreType) bool {
 	exprs := make([]expression.Expression, 0, len(p.ByItems))
@@ -1337,28 +944,6 @@ func (p *PhysicalTopN) canPushDown(storeTp kv.StoreType) bool {
 		exprs = append(exprs, item.Expr)
 	}
 	return expression.CanExprsPushDown(p.ctx.GetSessionVars().StmtCtx, exprs, p.ctx.GetClient(), storeTp)
-}
-
-// GetCost computes the cost of in memory sort.
-func (p *PhysicalSort) GetCost(count float64, schema *expression.Schema) float64 {
-	if count < 2.0 {
-		count = 2.0
-	}
-	sessVars := p.ctx.GetSessionVars()
-	cpuCost := count * math.Log2(count) * sessVars.CPUFactor
-	memoryCost := count * sessVars.MemoryFactor
-
-	oomUseTmpStorage := config.GetGlobalConfig().OOMUseTmpStorage
-	memQuota := sessVars.StmtCtx.MemTracker.GetBytesLimit() // sessVars.MemQuotaQuery && hint
-	rowSize := getAvgRowSize(p.statsInfo(), schema)
-	spill := oomUseTmpStorage && memQuota > 0 && rowSize*count > float64(memQuota)
-	diskCost := count * sessVars.DiskFactor * rowSize
-	if !spill {
-		diskCost = 0
-	} else {
-		memoryCost *= float64(memQuota) / (rowSize * count)
-	}
-	return cpuCost + memoryCost + diskCost
 }
 
 func (p *PhysicalSort) attach2Task(tasks ...task) task {
@@ -1442,19 +1027,6 @@ func (p *PhysicalTopN) attach2Task(tasks ...task) task {
 	rootTask.addCost(p.GetCost(rootTask.count(), true))
 	p.cost = rootTask.cost()
 	return attachPlan2Task(p, rootTask)
-}
-
-// GetCost computes the cost of projection operator itself.
-func (p *PhysicalProjection) GetCost(count float64) float64 {
-	sessVars := p.ctx.GetSessionVars()
-	cpuCost := count * sessVars.CPUFactor
-	concurrency := float64(sessVars.ProjectionConcurrency())
-	if concurrency <= 0 {
-		return cpuCost
-	}
-	cpuCost /= concurrency
-	concurrencyCost := (1 + concurrency) * sessVars.ConcurrencyFactor
-	return cpuCost + concurrencyCost
 }
 
 func (p *PhysicalProjection) attach2Task(tasks ...task) task {
@@ -2105,21 +1677,6 @@ func (p *PhysicalStreamAgg) attach2Task(tasks ...task) task {
 	return t
 }
 
-// GetCost computes cost of stream aggregation considering CPU/memory.
-func (p *PhysicalStreamAgg) GetCost(inputRows float64, isRoot bool) float64 {
-	aggFuncFactor := p.getAggFuncCostFactor(false)
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	if isRoot {
-		cpuCost = inputRows * sessVars.CPUFactor * aggFuncFactor
-	} else {
-		cpuCost = inputRows * sessVars.CopCPUFactor * aggFuncFactor
-	}
-	rowsPerGroup := inputRows / p.statsInfo().RowCount
-	memoryCost := rowsPerGroup * distinctFactor * sessVars.MemoryFactor * float64(p.numDistinctFunc())
-	return cpuCost + memoryCost
-}
-
 // cpuCostDivisor computes the concurrency to which we would amortize CPU cost
 // for hash aggregation.
 func (p *PhysicalHashAgg) cpuCostDivisor(hasDistinct bool) (float64, float64) {
@@ -2324,31 +1881,6 @@ func (p *PhysicalHashAgg) attach2Task(tasks ...task) task {
 	t.addCost(final.GetCost(inputRows, true, false))
 	t.plan().SetCost(t.cost())
 	return t
-}
-
-// GetCost computes the cost of hash aggregation considering CPU/memory.
-func (p *PhysicalHashAgg) GetCost(inputRows float64, isRoot bool, isMPP bool) float64 {
-	cardinality := p.statsInfo().RowCount
-	numDistinctFunc := p.numDistinctFunc()
-	aggFuncFactor := p.getAggFuncCostFactor(isMPP)
-	var cpuCost float64
-	sessVars := p.ctx.GetSessionVars()
-	if isRoot {
-		cpuCost = inputRows * sessVars.CPUFactor * aggFuncFactor
-		divisor, con := p.cpuCostDivisor(numDistinctFunc > 0)
-		if divisor > 0 {
-			cpuCost /= divisor
-			// Cost of additional goroutines.
-			cpuCost += (con + 1) * sessVars.ConcurrencyFactor
-		}
-	} else {
-		cpuCost = inputRows * sessVars.CopCPUFactor * aggFuncFactor
-	}
-	memoryCost := cardinality * sessVars.MemoryFactor * float64(len(p.AggFuncs))
-	// When aggregation has distinct flag, we would allocate a map for each group to
-	// check duplication.
-	memoryCost += inputRows * distinctFactor * sessVars.MemoryFactor * float64(numDistinctFunc)
-	return cpuCost + memoryCost
 }
 
 // mppTask can not :


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #33945

Problem Summary: move all functions about cost calculation to plan_cost.go

### What is changed and how it works?

No logical change, just move all functions about cost calculation to `plan_cost.go`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
