### PR TITLE
planner: enable memtable operator support enforced property

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -464,6 +464,39 @@ END:
 }
 
 func (p *LogicalMemTable) findBestTask(prop *property.PhysicalProperty, planCounter *PlanCounterTp, opt *physicalOptimizeOp) (t task, cntPlan int64, err error) {
+	// If prop.enforced is true, the prop.cols need to be set nil for p.findBestTask.
+	// Before function return, reset it for enforcing task prop.
+	oldProp := prop.CloneEssentialFields()
+	if prop.CanAddEnforcer {
+		// First, get the bestTask without enforced prop
+		prop.CanAddEnforcer = false
+		cnt := int64(0)
+		t, cnt, err = p.findBestTask(prop, planCounter, opt)
+		if err != nil {
+			return nil, 0, err
+		}
+		prop.CanAddEnforcer = true
+		if t != invalidTask {
+			cntPlan = cnt
+			return
+		}
+		// Next, get the bestTask with enforced prop
+		prop.SortItems = []property.SortItem{}
+		prop.MPPPartitionTp = property.AnyType
+	} else if prop.MPPPartitionTp != property.AnyType {
+		return invalidTask, 0, nil
+	}
+	defer func() {
+		if err != nil {
+			return
+		}
+		if prop.CanAddEnforcer {
+			*prop = *oldProp
+			t = enforceProperty(prop, t, p.basePlan.ctx)
+			prop.CanAddEnforcer = true
+		}
+	}()
+
 	if !prop.IsEmpty() || planCounter.Empty() {
 		return invalidTask, 0, nil
 	}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -486,7 +486,6 @@ func (p *LogicalMemTable) findBestTask(prop *property.PhysicalProperty, planCoun
 		}
 		// Next, get the bestTask with enforced prop
 		prop.SortItems = []property.SortItem{}
-		prop.MPPPartitionTp = property.AnyType
 	}
 	defer func() {
 		if err != nil {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -464,7 +464,7 @@ END:
 }
 
 func (p *LogicalMemTable) findBestTask(prop *property.PhysicalProperty, planCounter *PlanCounterTp, opt *physicalOptimizeOp) (t task, cntPlan int64, err error) {
-	// If prop.enforced is true, the prop.cols need to be set nil for p.findBestTask.
+	// If prop.CanAddEnforcer is true, the prop.SortItems need to be set nil for p.findBestTask.
 	// Before function return, reset it for enforcing task prop.
 	oldProp := prop.CloneEssentialFields()
 	if prop.CanAddEnforcer {
@@ -811,7 +811,7 @@ func (ds *DataSource) findBestTask(prop *property.PhysicalProperty, planCounter 
 		return
 	}
 	var cnt int64
-	// If prop.enforced is true, the prop.cols need to be set nil for ds.findBestTask.
+	// If prop.CanAddEnforcer is true, the prop.SortItems need to be set nil for ds.findBestTask.
 	// Before function return, reset it for enforcing task prop and storing map<prop,task>.
 	oldProp := prop.CloneEssentialFields()
 	if prop.CanAddEnforcer {

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -464,6 +464,10 @@ END:
 }
 
 func (p *LogicalMemTable) findBestTask(prop *property.PhysicalProperty, planCounter *PlanCounterTp, opt *physicalOptimizeOp) (t task, cntPlan int64, err error) {
+	if prop.MPPPartitionTp != property.AnyType {
+		return invalidTask, 0, nil
+	}
+
 	// If prop.CanAddEnforcer is true, the prop.SortItems need to be set nil for p.findBestTask.
 	// Before function return, reset it for enforcing task prop.
 	oldProp := prop.CloneEssentialFields()
@@ -483,8 +487,6 @@ func (p *LogicalMemTable) findBestTask(prop *property.PhysicalProperty, planCoun
 		// Next, get the bestTask with enforced prop
 		prop.SortItems = []property.SortItem{}
 		prop.MPPPartitionTp = property.AnyType
-	} else if prop.MPPPartitionTp != property.AnyType {
-		return invalidTask, 0, nil
 	}
 	defer func() {
 		if err != nil {


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #31609

Problem Summary: 

`(*LogicalMemTable).findBestTask()` doesn't try to enforce order property, then it fails to generate a physical plan for some operators requiring order property.

### What is changed and how it works?

I just basically copied the enforce property logic from `(*DataSource).findBestTask()`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
