### PR TITLE
planner: fix the explain `verbose` to be NOT case insensitive

### DIFF
--- a/executor/explainfor_test.go
+++ b/executor/explainfor_test.go
@@ -139,6 +139,10 @@ func TestExplainForVerbose(t *testing.T) {
 			require.Equal(t, rs2[i][j], rs[i][j])
 		}
 	}
+	tk.MustQuery("explain format = 'verbose' select * from t1").Rows()
+	tk.MustQuery("explain format = 'VERBOSE' select * from t1").Rows()
+	tk.MustQuery("explain analyze format = 'verbose' select * from t1").Rows()
+	tk.MustQuery("explain analyze format = 'VERBOSE' select * from t1").Rows()
 }
 
 func TestIssue11124(t *testing.T) {

--- a/planner/core/common_plans.go
+++ b/planner/core/common_plans.go
@@ -1504,14 +1504,14 @@ func (e *Explain) prepareOperatorInfo(p Plan, taskType, driverSide, indent strin
 	var row []string
 	if e.Analyze || e.RuntimeStatsColl != nil {
 		row = []string{id, estRows}
-		if e.Format == types.ExplainFormatVerbose {
+		if strings.ToLower(e.Format) == types.ExplainFormatVerbose {
 			row = append(row, estCost)
 		}
 		actRows, analyzeInfo, memoryInfo, diskInfo := getRuntimeInfo(e.ctx, p, e.RuntimeStatsColl)
 		row = append(row, actRows, taskType, accessObject, analyzeInfo, operatorInfo, memoryInfo, diskInfo)
 	} else {
 		row = []string{id, estRows}
-		if e.Format == types.ExplainFormatVerbose {
+		if strings.ToLower(e.Format) == types.ExplainFormatVerbose {
 			row = append(row, estCost)
 		}
 		row = append(row, taskType, accessObject, operatorInfo)


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34469

Problem Summary:

### What is changed and how it works?
when we fill the result to explain executor, make the judgement to be case-insensitive.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
do the same script as the issue said.
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: fix the explain `verbose` to be case insensitive
```
