### PR TITLE
PiTR: support empty schema in PiTR.

### DIFF
--- a/br/pkg/backup/client.go
+++ b/br/pkg/backup/client.go
@@ -330,7 +330,7 @@ func BuildBackupRangeAndSchema(
 
 		if len(tables) == 0 {
 			log.Info("backup empty database", zap.Stringer("db", dbInfo.Name))
-			backupSchemas.addSchema(dbInfo, nil)
+			backupSchemas.AddSchema(dbInfo, nil)
 			continue
 		}
 
@@ -436,6 +436,11 @@ func BuildFullSchema(storage kv.Storage, backupTS uint64) (*Schemas, error) {
 		tables, err := m.ListTables(db.ID)
 		if err != nil {
 			return nil, errors.Trace(err)
+		}
+
+		// backup this empty db if this schema is empty.
+		if len(tables) == 0 {
+			newBackupSchemas.AddSchema(db, nil)
 		}
 
 		for _, table := range tables {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1736,6 +1736,10 @@ func (rc *Client) InitSchemasReplaceForDDL(
 			dbMap[t.DB.ID] = dbReplace
 		}
 
+		if t.Info == nil {
+			// If the db is empty, skip it.
+			continue
+		}
 		newTableInfo, err := rc.GetTableSchema(rc.GetDomain(), dbName, t.Info.Name)
 		if err != nil {
 			log.Info("table not existed", zap.String("tablename", dbName.String()+"."+t.Info.Name.String()))

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -100,20 +100,26 @@ func NewSchemasReplace(
 
 // TidyOldSchemas produces schemas information.
 func (sr *SchemasReplace) TidyOldSchemas() *backup.Schemas {
+	var schemaIsEmpty bool
 	schemas := backup.NewBackupSchemas()
-	// note:
-	// when the PR about backup empty database merged, it can backup empty database schema.
+
 	for _, dr := range sr.DbMap {
 		if dr.OldDBInfo == nil {
 			continue
 		}
 
+		schemaIsEmpty = true
 		for _, tr := range dr.TableMap {
 			if tr.OldTableInfo == nil {
 				continue
 			}
-
 			schemas.AddSchema(dr.OldDBInfo, tr.OldTableInfo)
+			schemaIsEmpty = false
+		}
+
+		// backup this empty schema if it has nothing table.
+		if schemaIsEmpty {
+			schemas.AddSchema(dr.OldDBInfo, nil)
 		}
 	}
 	return schemas

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1253,6 +1253,11 @@ func initFullBackupTables(
 		}
 
 		for _, table := range db.Tables {
+			// check this db is empty.
+			if table.Info == nil {
+				tables[db.Info.ID] = table
+				continue
+			}
 			if !cfg.TableFilter.MatchTable(dbName, table.Info.Name.O) {
 				continue
 			}
@@ -1271,6 +1276,10 @@ func initRewriteRules(client *restore.Client, tables map[int64]*metautil.Table) 
 			// skip system table for now
 			continue
 		}
+		if t.Info == nil {
+			continue
+		}
+
 		newTableInfo, err := client.GetTableSchema(client.GetDomain(), t.DB.Name, t.Info.Name)
 		if err != nil {
 			// If table not existed, skip it directly.

--- a/br/pkg/utils/json.go
+++ b/br/pkg/utils/json.go
@@ -103,8 +103,11 @@ func makeJSONSchema(schema *backuppb.Schema) (*jsonSchema, error) {
 	if err := json.Unmarshal(schema.Db, &result.DB); err != nil {
 		return nil, errors.Trace(err)
 	}
-	if err := json.Unmarshal(schema.Table, &result.Table); err != nil {
-		return nil, errors.Trace(err)
+
+	if schema.Table != nil {
+		if err := json.Unmarshal(schema.Table, &result.Table); err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	return result, nil
 }
@@ -116,9 +119,11 @@ func fromJSONSchema(jSchema *jsonSchema) (*backuppb.Schema, error) {
 	if err != nil {
 		return nil, errors.Trace(err)
 	}
-	schema.Table, err = json.Marshal(jSchema.Table)
-	if err != nil {
-		return nil, errors.Trace(err)
+	if jSchema.Table != nil {
+		schema.Table, err = json.Marshal(jSchema.Table)
+		if err != nil {
+			return nil, errors.Trace(err)
+		}
 	}
 	return schema, nil
 }
@@ -157,6 +162,7 @@ func makeJSONBackupMeta(meta *backuppb.BackupMeta) (*jsonBackupMeta, error) {
 
 func fromJSONBackupMeta(jMeta *jsonBackupMeta) (*backuppb.BackupMeta, error) {
 	meta := jMeta.BackupMeta
+
 	for _, schema := range jMeta.Schemas {
 		s, err := fromJSONSchema(schema)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/33866

Problem Summary:

### What is changed and how it works?
Support empty schema in PiTR.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### test
- backup steps
    - create empty schema `emptydb`
    - `br backup full` in up-stream
    - `br log start ` in up-stream
    - create table `emptydb.t` and insert 1000 record.
   
- restore steps 1
- `br restore point --full-backup-storage --s ` in down-stream.   `emptydb.t` and records has been recovered.

- restore steps 2
- `br restore full` in down-stream
- `br restore point --start-ts --restore-ts ` in down-stream. `emptydb.t` and records has been recovered.



Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
