### PR TITLE
executor: fix processlist's Mem is not zero when HashJoin finished

### DIFF
--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -221,6 +221,7 @@ func (c *hashRowContainer) Len() uint64 {
 }
 
 func (c *hashRowContainer) Close() error {
+	defer func() { c.memTracker.Consume(-c.memTracker.BytesConsumed()) }()
 	return c.rowContainer.Close()
 }
 

--- a/executor/hash_table.go
+++ b/executor/hash_table.go
@@ -221,7 +221,7 @@ func (c *hashRowContainer) Len() uint64 {
 }
 
 func (c *hashRowContainer) Close() error {
-	defer func() { c.memTracker.Consume(-c.memTracker.BytesConsumed()) }()
+	defer c.memTracker.Detach()
 	return c.rowContainer.Close()
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34571

Problem Summary:
This pr https://github.com/pingcap/tidb/pull/33918 have tracked more memory usage, but forgot to clear the memory usage when sql is finished.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
conn-1:
        drop table if exists t;
        create table t (a int);
        drop table if exists ta;
        create table ta (b int);
        insert into t values (1);
        insert into ta values (11);
        drop table if exists session_info;
        create table session_info(id int, connection_id int);
        insert into session_info values (1, 1);
        select * from t, ta;

conn-2:
        select * from information_schema.processlist where command='Sleep';
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
