### PR TITLE
backup-log: remove duplicated meta key in a batch.

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1871,7 +1871,7 @@ func (rc *Client) RestoreMetaKVFile(
 		log.Debug("rewrite txn entry", zap.Int("newKey-len", len(newEntry.Key)),
 			zap.Int("newValue-len", len(txnEntry.Value)), zap.ByteString("newkey", newEntry.Key))
 
-		if err := rc.rawKVClient.Put(ctx, newEntry.Key, newEntry.Value); err != nil {
+		if err := rc.rawKVClient.Put(ctx, newEntry.Key, newEntry.Value, ts); err != nil {
 			return errors.Trace(err)
 		}
 	}

--- a/br/pkg/restore/rawkv_client.go
+++ b/br/pkg/restore/rawkv_client.go
@@ -4,7 +4,9 @@ package restore
 
 import (
 	"context"
+	"reflect"
 	"time"
+	"unsafe"
 
 	"github.com/pingcap/errors"
 	"github.com/tikv/client-go/v2/config"
@@ -31,14 +33,35 @@ func NewRawkvClient(ctx context.Context, pdAddrs []string, security config.Secur
 		pd.WithMaxErrorRetry(5))
 }
 
+func string2Bytes(s string) []byte {
+	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	bh := reflect.SliceHeader{
+		Data: sh.Data,
+		Len:  sh.Len,
+		Cap:  sh.Len,
+	}
+	return *(*[]byte)(unsafe.Pointer(&bh))
+}
+
+func bytes2String(b []byte) string {
+	return *(*string)(unsafe.Pointer(&b))
+}
+
+type KVPair struct {
+	ts    uint64
+	key   []byte
+	value []byte
+}
+
 // RawKVBatchClient is used to put raw kv-entry into tikv.
 // Note: it is not thread safe.
 type RawKVBatchClient struct {
-	cf          string
-	cap         int
-	size        int
-	keys        [][]byte
-	values      [][]byte
+	cf   string
+	cap  int
+	size int
+	// use map to remove duplicate entry, cause duplicate entry will make tikv panic when resolved_ts enabled.
+	// see https://github.com/tikv/tikv/blob/a401f78bc86f7e6ea6a55ad9f453ae31be835b55/components/resolved_ts/src/cmd.rs#L204
+	kvs         map[string]KVPair
 	rawkvClient RawkvClient
 }
 
@@ -49,8 +72,7 @@ func NewRawKVBatchClient(
 ) *RawKVBatchClient {
 	return &RawKVBatchClient{
 		cap:         batchCount,
-		keys:        make([][]byte, 0, batchCount),
-		values:      make([][]byte, 0, batchCount),
+		kvs:         make(map[string]KVPair),
 		rawkvClient: rawkvClient,
 	}
 }
@@ -67,12 +89,31 @@ func (c *RawKVBatchClient) SetColumnFamily(columnFamily string) {
 
 // Put puts (key, value) into buffer justly, wait for batch write if the buffer is full.
 func (c *RawKVBatchClient) Put(ctx context.Context, key, value []byte) error {
-	c.keys = append(c.keys, key)
-	c.values = append(c.values, value)
+	k, ts, err := SplitKeyTS(key)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	sk := bytes2String(k)
+	if v, ok := c.kvs[sk]; ok {
+		if v.ts < ts {
+			c.kvs[sk] = KVPair{ts, key, value}
+			c.size++
+		}
+	} else {
+		c.kvs[sk] = KVPair{ts, key, value}
+		c.size++
+	}
 	c.size++
 
 	if c.size >= c.cap {
-		err := c.rawkvClient.BatchPut(ctx, c.keys, c.values, rawkv.SetColumnFamily(c.cf))
+		keys := make([][]byte, 0, len(c.kvs))
+		values := make([][]byte, 0, len(c.kvs))
+		for _, kv := range c.kvs {
+			keys = append(keys, kv.key)
+			values = append(values, kv.value)
+		}
+		err := c.rawkvClient.BatchPut(ctx, keys, values, rawkv.SetColumnFamily(c.cf))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -85,7 +126,13 @@ func (c *RawKVBatchClient) Put(ctx context.Context, key, value []byte) error {
 // PutRest writes the rest pairs (key, values) into tikv.
 func (c *RawKVBatchClient) PutRest(ctx context.Context) error {
 	if c.size > 0 {
-		err := c.rawkvClient.BatchPut(ctx, c.keys, c.values, rawkv.SetColumnFamily(c.cf))
+		keys := make([][]byte, 0, len(c.kvs))
+		values := make([][]byte, 0, len(c.kvs))
+		for _, kv := range c.kvs {
+			keys = append(keys, kv.key)
+			values = append(values, kv.value)
+		}
+		err := c.rawkvClient.BatchPut(ctx, keys, values, rawkv.SetColumnFamily(c.cf))
 		if err != nil {
 			return errors.Trace(err)
 		}
@@ -96,7 +143,6 @@ func (c *RawKVBatchClient) PutRest(ctx context.Context) error {
 }
 
 func (c *RawKVBatchClient) reset() {
-	c.keys = make([][]byte, 0, c.cap)
-	c.values = make([][]byte, 0, c.cap)
+	c.kvs = make(map[string]KVPair)
 	c.size = 0
 }

--- a/br/pkg/restore/rawkv_client.go
+++ b/br/pkg/restore/rawkv_client.go
@@ -4,12 +4,13 @@ package restore
 
 import (
 	"context"
+	"time"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/tikv/client-go/v2/config"
 	"github.com/tikv/client-go/v2/rawkv"
 	pd "github.com/tikv/pd/client"
-	"time"
 )
 
 // RawkvClient is the interface for rawkv.client

--- a/br/pkg/restore/rawkv_client.go
+++ b/br/pkg/restore/rawkv_client.go
@@ -4,7 +4,6 @@ package restore
 
 import (
 	"context"
-	"reflect"
 	"time"
 	"unsafe"
 
@@ -31,16 +30,6 @@ func NewRawkvClient(ctx context.Context, pdAddrs []string, security config.Secur
 		security,
 		pd.WithCustomTimeoutOption(10*time.Second),
 		pd.WithMaxErrorRetry(5))
-}
-
-func string2Bytes(s string) []byte {
-	sh := (*reflect.StringHeader)(unsafe.Pointer(&s))
-	bh := reflect.SliceHeader{
-		Data: sh.Data,
-		Len:  sh.Len,
-		Cap:  sh.Len,
-	}
-	return *(*[]byte)(unsafe.Pointer(&bh))
 }
 
 func bytes2String(b []byte) string {
@@ -98,13 +87,11 @@ func (c *RawKVBatchClient) Put(ctx context.Context, key, value []byte) error {
 	if v, ok := c.kvs[sk]; ok {
 		if v.ts < ts {
 			c.kvs[sk] = KVPair{ts, key, value}
-			c.size++
 		}
 	} else {
 		c.kvs[sk] = KVPair{ts, key, value}
 		c.size++
 	}
-	c.size++
 
 	if c.size >= c.cap {
 		keys := make([][]byte, 0, len(c.kvs))

--- a/br/pkg/restore/rawkv_client.go
+++ b/br/pkg/restore/rawkv_client.go
@@ -73,19 +73,15 @@ func (c *RawKVBatchClient) SetColumnFamily(columnFamily string) {
 }
 
 // Put puts (key, value) into buffer justly, wait for batch write if the buffer is full.
-func (c *RawKVBatchClient) Put(ctx context.Context, key, value []byte) error {
-	k, ts, err := SplitKeyTS(key)
-	if err != nil {
-		return errors.Trace(err)
-	}
-
+func (c *RawKVBatchClient) Put(ctx context.Context, key, value []byte, originTs uint64) error {
+	k := TruncateTS(key)
 	sk := hack.String(k)
 	if v, ok := c.kvs[sk]; ok {
-		if v.ts < ts {
-			c.kvs[sk] = KVPair{ts, key, value}
+		if v.ts < originTs {
+			c.kvs[sk] = KVPair{originTs, key, value}
 		}
 	} else {
-		c.kvs[sk] = KVPair{ts, key, value}
+		c.kvs[sk] = KVPair{originTs, key, value}
 		c.size++
 	}
 

--- a/br/pkg/restore/rawkv_client_test.go
+++ b/br/pkg/restore/rawkv_client_test.go
@@ -73,13 +73,13 @@ func TestRawKVBatchClient(t *testing.T) {
 
 	for i := 0; i < batchCount; i++ {
 		require.Equal(t, 0, len(fakeRawkvClient.kvs))
-		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value)
+		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value, uint64(i+1))
 		require.Nil(t, err)
 	}
 	require.Equal(t, batchCount, len(fakeRawkvClient.kvs))
 
 	for i := batchCount; i < len(kvs); i++ {
-		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value)
+		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value, uint64(i+1))
 		require.Nil(t, err)
 	}
 	require.Equal(t, batchCount, len(fakeRawkvClient.kvs))
@@ -118,14 +118,14 @@ func TestRawKVBatchClientDuplicated(t *testing.T) {
 
 	for i := 0; i < batchCount; i++ {
 		require.Equal(t, 0, len(fakeRawkvClient.kvs))
-		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value)
+		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value, uint64(i+1))
 		require.Nil(t, err)
 	}
 	// There only two different keys which doesn't send to kv.
 	require.Equal(t, 0, len(fakeRawkvClient.kvs))
 
 	for i := batchCount; i < 5; i++ {
-		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value)
+		err := rawkvBatchClient.Put(context.TODO(), kvs[i].Key, kvs[i].Value, uint64(i+1))
 		require.Nil(t, err)
 		require.Equal(t, batchCount, len(fakeRawkvClient.kvs))
 	}

--- a/br/pkg/restore/rawkv_client_test.go
+++ b/br/pkg/restore/rawkv_client_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/tikv/client-go/v2/rawkv"
 
 	"github.com/pingcap/tidb/util/codec"
-
 )
 
 // fakeRawkvClient is a mock for rawkv.client
@@ -101,7 +100,7 @@ func TestRawKVBatchClientDuplicated(t *testing.T) {
 	rawkvBatchClient.SetColumnFamily("default")
 
 	kvs := []kv.Entry{
-		{Key: codec.EncodeUintDesc([]byte("key1"), 1) ,Value: []byte("v1")},
+		{Key: codec.EncodeUintDesc([]byte("key1"), 1), Value: []byte("v1")},
 		{Key: codec.EncodeUintDesc([]byte("key1"), 2), Value: []byte("v2")},
 		{Key: codec.EncodeUintDesc([]byte("key3"), 3), Value: []byte("v3")},
 		{Key: codec.EncodeUintDesc([]byte("key4"), 4), Value: []byte("v4")},
@@ -138,4 +137,3 @@ func TestRawKVBatchClientDuplicated(t *testing.T) {
 	})
 	require.Equal(t, expectedKvs, fakeRawkvClient.kvs)
 }
-

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -186,7 +186,7 @@ func GetRewriteRuleOfTable(
 	return &RewriteRules{Data: dataRules}
 }
 
-// GetSSTMetaFromFile compares the kvs in file, region and rewrite rules, then returns a sst conn.
+// GetSSTMetaFromFile compares the keys in file, region and rewrite rules, then returns a sst conn.
 // The range of the returned sst meta is [regionRule.NewKeyPrefix, append(regionRule.NewKeyPrefix, 0xff)].
 func GetSSTMetaFromFile(
 	id []byte,
@@ -202,7 +202,7 @@ func GetSSTMetaFromFile(
 		cfName = writeCFName
 	}
 	// Find the overlapped part between the file and the region.
-	// Here we rewrites the kvs to compare with the kvs of the region.
+	// Here we rewrites the keys to compare with the keys of the region.
 	rangeStart := regionRule.GetNewKeyPrefix()
 	//  rangeStart = max(rangeStart, region.StartKey)
 	if bytes.Compare(rangeStart, region.GetStartKey()) < 0 {
@@ -349,10 +349,10 @@ func GoValidateFileRanges(
 					zap.Int("File(write)", stat.TotalWriteCFFile),
 					zap.Int("File(default)", stat.TotalDefaultCFFile),
 					zap.Int("Region(total)", stat.TotalRegions),
-					zap.Int("Regoin(kvs avg)", stat.RegionKeysAvg),
+					zap.Int("Regoin(keys avg)", stat.RegionKeysAvg),
 					zap.Int("Region(bytes avg)", stat.RegionBytesAvg),
 					zap.Int("Merged(regions)", stat.MergedRegions),
-					zap.Int("Merged(kvs avg)", stat.MergedRegionKeysAvg),
+					zap.Int("Merged(keys avg)", stat.MergedRegionKeysAvg),
 					zap.Int("Merged(bytes avg)", stat.MergedRegionBytesAvg))
 
 				tableWithRange := TableWithRange{
@@ -455,7 +455,8 @@ func SplitKeyTS(key []byte) ([]byte, uint64, error) {
 		return nil, 0, errors.Annotatef(berrors.ErrInvalidArgument,
 			"the length of key is smaller than 8, key:%s", redact.Key(key))
 	}
-	return codec.DecodeUintDesc(key[len(key)-8:])
+	_, ts, err := codec.DecodeUintDesc(key[len(key)-8:])
+	return key[:len(key)-8], ts, err
 }
 
 func GetKeyTS(key []byte) (uint64, error) {

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -450,15 +450,6 @@ func matchOldPrefix(key []byte, rewriteRules *RewriteRules) *import_sstpb.Rewrit
 	return nil
 }
 
-func SplitKeyTS(key []byte) ([]byte, uint64, error) {
-	if len(key) < 8 {
-		return nil, 0, errors.Annotatef(berrors.ErrInvalidArgument,
-			"the length of key is smaller than 8, key:%s", redact.Key(key))
-	}
-	_, ts, err := codec.DecodeUintDesc(key[len(key)-8:])
-	return key[:len(key)-8], ts, err
-}
-
 func GetKeyTS(key []byte) (uint64, error) {
 	if len(key) < 8 {
 		return 0, errors.Annotatef(berrors.ErrInvalidArgument,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/29501

Problem Summary:
when raw put a duplicated keys in a batch and resolved_ts enabled. tikv will panic.

### What is changed and how it works?
This PR remove the duplicated in a batch.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
