### PR TITLE
restore: Auto set region split size/keys from tikv

### DIFF
--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -5,11 +5,15 @@ package conn
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"fmt"
+	"net/http"
 	"os"
+	"strings"
 	"sync"
 	"time"
 
+	"github.com/docker/go-units"
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
@@ -38,6 +42,13 @@ import (
 )
 
 const (
+	// DefaultMergeRegionSizeBytes is the default region split size, 96MB.
+	// See https://github.com/tikv/tikv/blob/v4.0.8/components/raftstore/src/coprocessor/config.rs#L35-L38
+	DefaultMergeRegionSizeBytes uint64 = 96 * units.MiB
+
+	// DefaultMergeRegionKeyCount is the default region key count, 960000.
+	DefaultMergeRegionKeyCount uint64 = 960000
+
 	dialTimeout = 30 * time.Second
 
 	resetRetryTimes = 3
@@ -456,4 +467,79 @@ func (mgr *Mgr) GetTS(ctx context.Context) (uint64, error) {
 	}
 
 	return oracle.ComposeTS(p, l), nil
+}
+
+// GetMergeRegionSizeAndCount returns the tikv config `coprocessor.region-split-size` and `coprocessor.region-split-key`.
+func (mgr *Mgr) GetMergeRegionSizeAndCount(ctx context.Context) (uint64, uint64, error) {
+	regionSplitSize := DefaultMergeRegionSizeBytes
+	regionSplitKeys := DefaultMergeRegionKeyCount
+	type coprocessor struct {
+		RegionSplitKeys uint64 `json:"region-split-keys"`
+		RegionSplitSize string `json:"region-split-size"`
+	}
+
+	type config struct {
+		Cop coprocessor `json:"coprocessor"`
+	}
+	err := mgr.GetConfigFromTiKV(ctx, http.DefaultClient, func(resp *http.Response) error {
+		c := &config{}
+		e := json.NewDecoder(resp.Body).Decode(c)
+		if e != nil {
+			return e
+		}
+		rs, e := units.RAMInBytes(c.Cop.RegionSplitSize)
+		if e != nil {
+			return e
+		}
+		urs := uint64(rs)
+		if urs < regionSplitSize || c.Cop.RegionSplitKeys < regionSplitKeys {
+			regionSplitSize = urs
+			regionSplitKeys = c.Cop.RegionSplitKeys
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, 0, errors.Trace(err)
+	}
+	return regionSplitSize, regionSplitKeys, nil
+}
+
+func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func(*http.Response) error) error {
+	allStores, err := GetAllTiKVStoresWithRetry(ctx, mgr.GetPDClient(), SkipTiFlash)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	httpPrefix := "http://"
+	if mgr.GetTLSConfig() != nil {
+		httpPrefix = "https://"
+	}
+	for _, store := range allStores {
+		if store.State != metapb.StoreState_Up {
+			continue
+		}
+		// we need make sure every available store support backup-stream otherwise we might lose data.
+		// so check every store's config
+		addr := fmt.Sprintf("%s/config", store.GetStatusAddress())
+		if !strings.HasPrefix(addr, "http") {
+			addr = httpPrefix + addr
+		}
+		err = utils.WithRetry(ctx, func() error {
+			resp, e := cli.Get(addr)
+			if e != nil {
+				return e
+			}
+			err = fn(resp)
+			if err != nil {
+				return err
+			}
+			_ = resp.Body.Close()
+			return nil
+		}, utils.NewPDReqBackoffer())
+		if err != nil {
+			// if one store failed, break and return error
+			return err
+		}
+	}
+	return nil
 }

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -4,8 +4,13 @@ package conn
 
 import (
 	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 
+	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/kvproto/pkg/metapb"
@@ -259,4 +264,132 @@ func TestGetConnOnCanceledContext(t *testing.T) {
 	_, err = mgr.ResetBackupClient(ctx, 42)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "context canceled")
+}
+
+func TestGetMergeRegionSizeAndCount(t *testing.T) {
+	cases := []struct {
+		stores          []*metapb.Store
+		content         []string
+		regionSplitSize uint64
+		regionSplitKeys uint64
+	}{
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tiflash",
+						},
+					},
+				},
+			},
+			content: []string{""},
+			// no tikv detected in this case
+			regionSplitSize: DefaultMergeRegionSizeBytes,
+			regionSplitKeys: DefaultMergeRegionKeyCount,
+		},
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+			},
+			content: []string{
+				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 1, \"region-split-size\": \"1MiB\"}}",
+			},
+			// one tikv detected in this case we are not update default size and keys because they are too small.
+			regionSplitSize: 1 * units.MiB,
+			regionSplitKeys: 1,
+		},
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+			},
+			content: []string{
+				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 10000000, \"region-split-size\": \"1GiB\"}}",
+			},
+			// one tikv detected in this case and we update with new size and keys.
+			regionSplitSize: 1 * units.GiB,
+			regionSplitKeys: 10000000,
+		},
+		{
+			stores: []*metapb.Store{
+				{
+					Id:    1,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+				{
+					Id:    2,
+					State: metapb.StoreState_Up,
+					Labels: []*metapb.StoreLabel{
+						{
+							Key:   "engine",
+							Value: "tikv",
+						},
+					},
+				},
+			},
+			content: []string{
+				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 10000000, \"region-split-size\": \"1GiB\"}}",
+				"{\"log-level\": \"debug\", \"coprocessor\": {\"region-split-keys\": 12000000, \"region-split-size\": \"900MiB\"}}",
+			},
+			// two tikv detected in this case and we choose the small one.
+			regionSplitSize: 900 * units.MiB,
+			regionSplitKeys: 12000000,
+		},
+	}
+
+	ctx := context.Background()
+	for _, ca := range cases {
+		pdCli := utils.FakePDClient{Stores: ca.stores}
+		require.Equal(t, len(ca.content), len(ca.stores))
+		count := 0
+		mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch strings.TrimSpace(r.URL.Path) {
+			case "/config":
+				_, _ = fmt.Fprint(w, ca.content[count])
+			default:
+				http.NotFoundHandler().ServeHTTP(w, r)
+			}
+			count++
+		}))
+
+		for _, s := range ca.stores {
+			s.StatusAddress = mockServer.URL
+		}
+
+		httpCli := mockServer.Client()
+		mgr := &Mgr{PdController: &pdutil.PdController{}}
+		mgr.PdController.SetPDClient(pdCli)
+		rs, rk, err := mgr.GetMergeRegionSizeAndCount(ctx, httpCli)
+		require.NoError(t, err)
+		require.Equal(t, ca.regionSplitSize, rs)
+		require.Equal(t, ca.regionSplitKeys, rk)
+		mockServer.Close()
+	}
 }

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -316,7 +316,6 @@ func (p *PdController) getClusterVersionWith(ctx context.Context, get pdHTTPRequ
 	return "", errors.Trace(err)
 }
 
-
 // GetRegionCount returns the region count in the specified range.
 func (p *PdController) GetRegionCount(ctx context.Context, startKey, endKey []byte) (int, error) {
 	return p.getRegionCountWith(ctx, pdRequest, startKey, endKey)

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -316,6 +316,7 @@ func (p *PdController) getClusterVersionWith(ctx context.Context, get pdHTTPRequ
 	return "", errors.Trace(err)
 }
 
+
 // GetRegionCount returns the region count in the specified range.
 func (p *PdController) GetRegionCount(ctx context.Context, startKey, endKey []byte) (int, error) {
 	return p.getRegionCountWith(ctx, pdRequest, startKey, endKey)

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1586,7 +1586,7 @@ func (rc *Client) FixIndex(ctx context.Context, schema, table, index string) err
 	return nil
 }
 
-// FixIndicdesOfTables tries to fix the indices of the tables via `ADMIN RECOVERY INDEX`.
+// FixIndicesOfTables tries to fix the indices of the tables via `ADMIN RECOVERY INDEX`.
 func (rc *Client) FixIndicesOfTables(
 	ctx context.Context,
 	fullBackupTables map[int64]*metautil.Table,
@@ -1819,7 +1819,7 @@ func (rc *Client) RestoreMetaKVFiles(
 	return nil
 }
 
-// RestoreMetaKVFiles tries to restore a file about meta kv-event from stream-backup.
+// RestoreMetaKVFile tries to restore a file about meta kv-event from stream-backup.
 func (rc *Client) RestoreMetaKVFile(
 	ctx context.Context,
 	file *backuppb.DataFileInfo,
@@ -1890,7 +1890,7 @@ func transferBoolToValue(enable bool) string {
 	return "OFF"
 }
 
-// GenGlobalIDs generates a global id by transaction way.
+// GenGlobalID generates a global id by transaction way.
 func (rc *Client) GenGlobalID(ctx context.Context) (int64, error) {
 	var id int64
 	storage := rc.GetDomain().Store()

--- a/br/pkg/restore/merge.go
+++ b/br/pkg/restore/merge.go
@@ -16,7 +16,6 @@ import (
 )
 
 const (
-
 	writeCFName   = "write"
 	defaultCFName = "default"
 )

--- a/br/pkg/restore/merge.go
+++ b/br/pkg/restore/merge.go
@@ -5,7 +5,6 @@ package restore
 import (
 	"strings"
 
-	"github.com/docker/go-units"
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
@@ -17,12 +16,6 @@ import (
 )
 
 const (
-	// DefaultMergeRegionSizeBytes is the default region split size, 96MB.
-	// See https://github.com/tikv/tikv/blob/v4.0.8/components/raftstore/src/coprocessor/config.rs#L35-L38
-	DefaultMergeRegionSizeBytes uint64 = 96 * units.MiB
-
-	// DefaultMergeRegionKeyCount is the default region key count, 960000.
-	DefaultMergeRegionKeyCount uint64 = 960000
 
 	writeCFName   = "write"
 	defaultCFName = "default"

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -83,10 +83,10 @@ type RestoreCommonConfig struct {
 // useful when not starting BR from CLI (e.g. from BRIE in SQL).
 func (cfg *RestoreCommonConfig) adjust() {
 	if cfg.MergeSmallRegionKeyCount == 0 {
-		cfg.MergeSmallRegionKeyCount = restore.DefaultMergeRegionKeyCount
+		cfg.MergeSmallRegionKeyCount = conn.DefaultMergeRegionKeyCount
 	}
 	if cfg.MergeSmallRegionSizeBytes == 0 {
-		cfg.MergeSmallRegionSizeBytes = restore.DefaultMergeRegionSizeBytes
+		cfg.MergeSmallRegionSizeBytes = conn.DefaultMergeRegionSizeBytes
 	}
 }
 
@@ -95,9 +95,9 @@ func DefineRestoreCommonFlags(flags *pflag.FlagSet) {
 	// TODO remove experimental tag if it's stable
 	flags.Bool(flagOnline, false, "(experimental) Whether online when restore")
 
-	flags.Uint64(FlagMergeRegionSizeBytes, restore.DefaultMergeRegionSizeBytes,
+	flags.Uint64(FlagMergeRegionSizeBytes, conn.DefaultMergeRegionSizeBytes,
 		"the threshold of merging small regions (Default 96MB, region split size)")
-	flags.Uint64(FlagMergeRegionKeyCount, restore.DefaultMergeRegionKeyCount,
+	flags.Uint64(FlagMergeRegionKeyCount, conn.DefaultMergeRegionKeyCount,
 		"the threshold of merging small regions (Default 960_000, region split key count)")
 	flags.Uint(FlagPDConcurrency, defaultPDConcurrency,
 		"concurrency pd-relative operations like split & scatter.")
@@ -399,6 +399,18 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	}
 	defer mgr.Close()
 
+	mergeRegionSize := cfg.MergeSmallRegionSizeBytes
+	mergeRegionCount := cfg.MergeSmallRegionKeyCount
+	if mergeRegionSize == conn.DefaultMergeRegionSizeBytes &&
+		mergeRegionCount == conn.DefaultMergeRegionKeyCount {
+		// according to https://github.com/pingcap/tidb/issues/34167.
+		// we should get the real config from tikv to adapt the dynamic region.
+		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx)
+		if err != nil {
+			return errors.Trace(err)
+		}
+	}
+
 	keepaliveCfg.PermitWithoutStream = true
 	client := restore.NewRestoreClient(mgr.GetPDClient(), mgr.GetTLSConfig(), keepaliveCfg, false)
 	err = configureRestoreClient(ctx, client, cfg)
@@ -537,7 +549,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 	log.Debug("mapped table to files", zap.Any("result map", tableFileMap))
 
 	rangeStream := restore.GoValidateFileRanges(
-		ctx, tableStream, tableFileMap, cfg.MergeSmallRegionSizeBytes, cfg.MergeSmallRegionKeyCount, errCh)
+		ctx, tableStream, tableFileMap, mergeRegionSize, mergeRegionCount, errCh)
 
 	rangeSize := restore.EstimateRangeSize(files)
 	summary.CollectInt("restore ranges", rangeSize)

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -4,6 +4,7 @@ package task
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 
@@ -405,7 +406,7 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		mergeRegionCount == conn.DefaultMergeRegionKeyCount {
 		// according to https://github.com/pingcap/tidb/issues/34167.
 		// we should get the real config from tikv to adapt the dynamic region.
-		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx)
+		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, http.DefaultClient)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -5,6 +5,7 @@ package task
 import (
 	"context"
 	"github.com/pingcap/tidb/br/pkg/conn"
+	"net/http"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
@@ -78,7 +79,7 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 		mergeRegionCount == conn.DefaultMergeRegionKeyCount {
 		// according to https://github.com/pingcap/tidb/issues/34167.
 		// we should get the real config from tikv to adapt the dynamic region.
-		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx)
+		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, http.DefaultClient)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -418,7 +418,7 @@ func (s *streamMgr) checkRequirements(ctx context.Context) (bool, error) {
 
 	supportBackupStream := true
 	hasTiKV := false
-	err := s.mgr.GetConfigFromTiKV(ctx, s.httpCli, func(resp*http.Response) error {
+	err := s.mgr.GetConfigFromTiKV(ctx, s.httpCli, func(resp *http.Response) error {
 		hasTiKV = true
 		c := &config{}
 		e := json.NewDecoder(resp.Body).Decode(c)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -18,7 +18,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"math"
 	"net/http"
 	"sort"
@@ -29,7 +28,6 @@ import (
 	"github.com/opentracing/opentracing-go"
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
-	"github.com/pingcap/kvproto/pkg/metapb"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/backup"
 	"github.com/pingcap/tidb/br/pkg/conn"
@@ -411,11 +409,6 @@ func (s *streamMgr) buildObserveRanges(ctx context.Context) ([]kv.KeyRange, erro
 
 // checkRequirements will check some requirements before stream starts.
 func (s *streamMgr) checkRequirements(ctx context.Context) (bool, error) {
-	allStores, err := conn.GetAllTiKVStoresWithRetry(ctx, s.mgr.GetPDClient(), conn.SkipTiFlash)
-	if err != nil {
-		return false, errors.Trace(err)
-	}
-
 	type backupStream struct {
 		EnableStreaming bool `json:"enable"`
 	}
@@ -423,41 +416,20 @@ func (s *streamMgr) checkRequirements(ctx context.Context) (bool, error) {
 		BackupStream backupStream `json:"log-backup"`
 	}
 
-	httpPrefix := "http://"
-	if s.mgr.GetTLSConfig() != nil {
-		httpPrefix = "https://"
-	}
 	supportBackupStream := true
 	hasTiKV := false
-	for _, store := range allStores {
-		if store.State != metapb.StoreState_Up {
-			continue
-		}
+	err := s.mgr.GetConfigFromTiKV(ctx, s.httpCli, func(resp*http.Response) error {
 		hasTiKV = true
-		// we need make sure every available store support backup-stream otherwise we might lose data.
-		// so check every store's config
-		addr := fmt.Sprintf("%s/config", store.GetStatusAddress())
-		if !strings.HasPrefix(addr, "http") {
-			addr = httpPrefix + addr
+		c := &config{}
+		e := json.NewDecoder(resp.Body).Decode(c)
+		if e != nil {
+			return e
 		}
-		err = utils.WithRetry(ctx, func() error {
-			resp, e := s.httpCli.Get(addr)
-			if e != nil {
-				return e
-			}
-			c := &config{}
-			e = json.NewDecoder(resp.Body).Decode(c)
-			if e != nil {
-				return e
-			}
-			supportBackupStream = supportBackupStream && c.BackupStream.EnableStreaming
-			_ = resp.Body.Close()
-			return nil
-		}, utils.NewPDReqBackoffer())
-		if err != nil {
-			// if one store failed, break and return error
-			break
-		}
+		supportBackupStream = supportBackupStream && c.BackupStream.EnableStreaming
+		return nil
+	})
+	if err != nil {
+		return false, errors.Trace(err)
 	}
 	return hasTiKV && supportBackupStream, err
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34370
Problem Summary:
1. get region-split-size/region-split-keys from tikv status_address
2. auto set the smallest region-split-size/region-split-keys config to merge size/keys.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
