### PR TITLE
*: move config file option oom-action to sysvar

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -162,7 +162,6 @@ type Config struct {
 	TokenLimit       uint   `toml:"token-limit" json:"token-limit"`
 	OOMUseTmpStorage bool   `toml:"oom-use-tmp-storage" json:"oom-use-tmp-storage"`
 	TempStoragePath  string `toml:"tmp-storage-path" json:"tmp-storage-path"`
-	OOMAction        string `toml:"oom-action" json:"oom-action"`
 	// TempStorageQuota describe the temporary storage Quota during query exector when OOMUseTmpStorage is enabled
 	// If the quota exceed the capacity of the TempStoragePath, the tidb-server would exit with fatal error
 	TempStorageQuota           int64                   `toml:"tmp-storage-quota" json:"tmp-storage-quota"` // Bytes
@@ -753,7 +752,6 @@ var defaultConf = Config{
 	OOMUseTmpStorage:             true,
 	TempStorageQuota:             -1,
 	TempStoragePath:              tempStorageDirName,
-	OOMAction:                    OOMActionCancel,
 	EnableBatchDML:               false,
 	CheckMb4ValueInUTF8:          *NewAtomicBool(true),
 	MaxIndexLength:               3072,
@@ -961,10 +959,6 @@ func isAllDeprecatedConfigItems(items []string) bool {
 	return true
 }
 
-// IsOOMActionSetByUser indicates whether the config item mem-action is set by
-// the user.
-var IsOOMActionSetByUser bool
-
 // InitializeConfig initialize the global config handler.
 // The function enforceCmdArgs is used to merge the config file with command arguments:
 // For example, if you start TiDB by the command "./tidb-server --port=3000", the port number should be
@@ -1022,9 +1016,6 @@ func (c *Config) Load(confFile string) error {
 	metaData, err := toml.DecodeFile(confFile, c)
 	if c.TokenLimit == 0 {
 		c.TokenLimit = 1000
-	}
-	if metaData.IsDefined("oom-action") {
-		IsOOMActionSetByUser = true
 	}
 	// If any items in confFile file are not mapped into the Config struct, issue
 	// an error and stop the server from starting.
@@ -1100,10 +1091,6 @@ func (c *Config) Valid() error {
 	}
 	if c.Log.File.MaxSize > MaxLogFileSize {
 		return fmt.Errorf("invalid max log file size=%v which is larger than max=%v", c.Log.File.MaxSize, MaxLogFileSize)
-	}
-	c.OOMAction = strings.ToLower(c.OOMAction)
-	if c.OOMAction != OOMActionLog && c.OOMAction != OOMActionCancel {
-		return fmt.Errorf("unsupported OOMAction %v, TiDB only supports [%v, %v]", c.OOMAction, OOMActionLog, OOMActionCancel)
 	}
 	if c.TableColumnCountLimit < DefTableColumnCountLimit || c.TableColumnCountLimit > DefMaxOfTableColumnCountLimit {
 		return fmt.Errorf("table-column-limit should be [%d, %d]", DefIndexLimit, DefMaxOfTableColumnCountLimit)
@@ -1234,15 +1221,6 @@ func initByLDFlags(edition, checkBeforeDropLDFlag string) {
 		CheckTableBeforeDrop = true
 	}
 }
-
-// The following constants represents the valid action configurations for OOMAction.
-// NOTE: Although the values is case-insensitive, we should use lower-case
-// strings because the configuration value will be transformed to lower-case
-// string and compared with these constants in the further usage.
-const (
-	OOMActionCancel = "cancel"
-	OOMActionLog    = "log"
-)
 
 // hideConfig is used to filter a single line of config for hiding.
 var hideConfig = []string{

--- a/config/config.toml.example
+++ b/config/config.toml.example
@@ -44,10 +44,6 @@ oom-use-tmp-storage = true
 # The default value of tmp-storage-quota is under 0 which means tidb-server wouldn't check the capacity.
 tmp-storage-quota = -1
 
-# Specifies what operation TiDB performs when a single SQL statement exceeds the memory quota specified by the memory quota and cannot be spilled over to disk.
-# Valid options: ["log", "cancel"]
-oom-action = "cancel"
-
 # Make "kill query" behavior compatible with MySQL. It's not recommend to
 # turn on this option when TiDB server is behind a proxy.
 compatible-kill-query = false

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -473,24 +473,6 @@ xkNuJ2BlEGkwWLiRbKy1lNBBFUXKuhh3L/EIY10WTnr3TQzeL6H1
 	}
 }
 
-func TestOOMActionValid(t *testing.T) {
-	c1 := NewConfig()
-	tests := []struct {
-		oomAction string
-		valid     bool
-	}{
-		{"log", true},
-		{"Log", true},
-		{"Cancel", true},
-		{"cANceL", true},
-		{"quit", false},
-	}
-	for _, tt := range tests {
-		c1.OOMAction = tt.oomAction
-		require.Equal(t, tt.valid, c1.Valid() == nil)
-	}
-}
-
 func TestTxnTotalSizeLimitValid(t *testing.T) {
 	conf := NewConfig()
 	tests := []struct {

--- a/config/config_util.go
+++ b/config/config_util.go
@@ -45,7 +45,6 @@ var (
 		"Performance.PseudoEstimateRatio": {},
 		"Performance.StmtCountLimit":      {},
 		"Performance.TCPKeepAlive":        {},
-		"OOMAction":                       {},
 		"TiKVClient.StoreLimit":           {},
 		"Log.Level":                       {},
 		"Log.ExpensiveThreshold":          {},

--- a/config/config_util_test.go
+++ b/config/config_util_test.go
@@ -53,7 +53,6 @@ func TestMergeConfigItems(t *testing.T) {
 	newConf.Performance.FeedbackProbability = 123
 	newConf.Performance.QueryFeedbackLimit = 123
 	newConf.Performance.PseudoEstimateRatio = 123
-	newConf.OOMAction = "panic"
 	newConf.TiKVClient.StoreLimit = 123
 
 	// rejected
@@ -63,7 +62,7 @@ func TestMergeConfigItems(t *testing.T) {
 	newConf.Instance.SlowThreshold = 2345
 
 	as, rs := MergeConfigItems(oldConf, newConf)
-	require.Equal(t, 9, len(as))
+	require.Equal(t, 8, len(as))
 	require.Equal(t, 3, len(rs))
 	for _, a := range as {
 		_, ok := dynamicConfigItems[a]
@@ -80,7 +79,6 @@ func TestMergeConfigItems(t *testing.T) {
 	require.Equal(t, newConf.Performance.FeedbackProbability, oldConf.Performance.FeedbackProbability)
 	require.Equal(t, newConf.Performance.QueryFeedbackLimit, oldConf.Performance.QueryFeedbackLimit)
 	require.Equal(t, newConf.Performance.PseudoEstimateRatio, oldConf.Performance.PseudoEstimateRatio)
-	require.Equal(t, newConf.OOMAction, oldConf.OOMAction)
 	require.Equal(t, newConf.TiKVClient.StoreLimit, oldConf.TiKVClient.StoreLimit)
 	require.Equal(t, newConf.Instance.SlowThreshold, oldConf.Instance.SlowThreshold)
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1792,12 +1792,12 @@ func ResetContextOfStmt(ctx sessionctx.Context, s ast.StmtNode) (err error) {
 	if globalConfig.OOMUseTmpStorage && GlobalDiskUsageTracker != nil {
 		sc.DiskTracker.AttachToGlobalTracker(GlobalDiskUsageTracker)
 	}
-	switch globalConfig.OOMAction {
-	case config.OOMActionCancel:
+	switch variable.OOMAction.Load() {
+	case variable.OOMActionCancel:
 		action := &memory.PanicOnExceed{ConnID: ctx.GetSessionVars().ConnectionID}
 		action.SetLogHook(domain.GetDomain(ctx).ExpensiveQueryHandle().LogOnQueryExceedMemQuota)
 		sc.MemTracker.SetActionOnExceed(action)
-	case config.OOMActionLog:
+	case variable.OOMActionLog:
 		fallthrough
 	default:
 		action := &memory.LogOnExceed{ConnID: ctx.GetSessionVars().ConnectionID}

--- a/executor/executor_failpoint_test.go
+++ b/executor/executor_failpoint_test.go
@@ -299,10 +299,8 @@ func TestCoprocessorOOMTiCase(t *testing.T) {
 		tk.MustExec(fmt.Sprintf("insert into t5 (id) values (%v)", i))
 		tk.MustExec(fmt.Sprintf("insert into t6 (id) values (%v)", i))
 	}
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionLog
-	})
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='LOG'")
 	testcases := []struct {
 		name string
 		sql  string

--- a/executor/executor_issue_test.go
+++ b/executor/executor_issue_test.go
@@ -304,14 +304,8 @@ func TestIssue28650(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		tk.MustExec("insert into t1 select rand()*400 from t1;")
 	}
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionCancel
-	})
-	defer func() {
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.OOMAction = config.OOMActionLog
-		})
-	}()
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action = 'CANCEL'")
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action='LOG'")
 	wg.Wait()
 	for _, sql := range sqls {
 		tk.MustExec("set @@tidb_mem_quota_query = 1073741824") // 1GB
@@ -439,10 +433,8 @@ func TestIndexJoin31494(t *testing.T) {
 	}
 	tk.Session().SetSessionManager(sm)
 	dom.ExpensiveQueryHandle().SetSessionManager(sm)
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionCancel
-	})
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
 	require.True(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil))
 	tk.MustExec("set @@tidb_mem_quota_query=2097152;")
 	// This bug will be reproduced in 10 times.

--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -3626,10 +3626,8 @@ func TestOOMPanicAction(t *testing.T) {
 	}
 	tk.Session().SetSessionManager(sm)
 	dom.ExpensiveQueryHandle().SetSessionManager(sm)
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionCancel
-	})
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
 	tk.MustExec("set @@tidb_mem_quota_query=1;")
 	err := tk.QueryToErr("select sum(b) from t group by a;")
 	require.Error(t, err)
@@ -6060,10 +6058,8 @@ func TestSummaryFailedUpdate(t *testing.T) {
 	}
 	tk.Session().SetSessionManager(sm)
 	dom.ExpensiveQueryHandle().SetSessionManager(sm)
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionCancel
-	})
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
 	require.True(t, tk.Session().Auth(&auth.UserIdentity{Username: "root", Hostname: "%"}, nil, nil))
 	tk.MustExec("set @@tidb_mem_quota_query=1")
 	tk.MustMatchErrMsg("update t set t.a = t.a - 1 where t.a in (select a from t where a < 4)", "Out Of Memory Quota!.*")

--- a/executor/main_test.go
+++ b/executor/main_test.go
@@ -51,7 +51,6 @@ func TestMain(m *testing.M) {
 		conf.TiKVClient.AsyncCommit.SafeWindow = 0
 		conf.TiKVClient.AsyncCommit.AllowedClockDrift = 0
 		conf.Experimental.AllowsExpressionIndex = true
-		conf.OOMAction = config.OOMActionLog
 	})
 	tikv.EnableFailpoints()
 

--- a/executor/merge_join_test.go
+++ b/executor/merge_join_test.go
@@ -282,7 +282,6 @@ func TestMergeJoinInDisk(t *testing.T) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
-		conf.OOMAction = config.OOMActionLog
 		conf.TempStoragePath = t.TempDir()
 	})
 
@@ -293,6 +292,8 @@ func TestMergeJoinInDisk(t *testing.T) {
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='LOG'")
 	tk.MustExec("use test")
 
 	sm := &testkit.MockSessionManager{

--- a/executor/oomtest/oom_test.go
+++ b/executor/oomtest/oom_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/log"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/testkit"
 	"github.com/pingcap/tidb/testkit/testsetup"
 	"github.com/stretchr/testify/require"
@@ -35,9 +34,6 @@ import (
 func TestMain(m *testing.M) {
 	testsetup.SetupForCommonTest()
 	registerHook()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionLog
-	})
 	opts := []goleak.Option{
 		goleak.IgnoreTopFunction("github.com/golang/glog.(*loggingT).flushDaemon"),
 		goleak.IgnoreTopFunction("go.etcd.io/etcd/client/pkg/v3/logutil.(*MergeLogger).outputLoop"),

--- a/executor/sort_test.go
+++ b/executor/sort_test.go
@@ -39,7 +39,6 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 	defer restore()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
-		conf.OOMAction = config.OOMActionLog
 		conf.TempStoragePath = t.TempDir()
 	})
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/executor/testSortedRowContainerSpill", "return(true)"))
@@ -49,6 +48,8 @@ func testSortInDisk(t *testing.T, removeDir bool) {
 	store, dom, clean := testkit.CreateMockStoreAndDomain(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='LOG'")
 	tk.MustExec("use test")
 
 	sm := &testkit.MockSessionManager{
@@ -98,7 +99,6 @@ func TestIssue16696(t *testing.T) {
 	defer config.RestoreFunc()()
 	config.UpdateGlobal(func(conf *config.Config) {
 		conf.OOMUseTmpStorage = true
-		conf.OOMAction = config.OOMActionLog
 		conf.TempStoragePath = t.TempDir()
 	})
 	alarmRatio := variable.MemoryUsageAlarmRatio.Load()
@@ -112,6 +112,8 @@ func TestIssue16696(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()
 	tk := testkit.NewTestKit(t, store)
+	defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+	tk.MustExec("SET GLOBAL tidb_mem_oom_action='LOG'")
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("CREATE TABLE `t` (`a` int(11) DEFAULT NULL,`b` int(11) DEFAULT NULL)")

--- a/server/rpc_server.go
+++ b/server/rpc_server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pingcap/tidb/privilege"
 	"github.com/pingcap/tidb/privilege/privileges"
 	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/util"
 	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/memory"
@@ -223,9 +224,8 @@ func (s *rpcServer) createSession() (session.Session, error) {
 	vars.SetHashAggFinalConcurrency(1)
 	vars.StmtCtx.InitMemTracker(memory.LabelForSQLText, vars.MemQuotaQuery)
 	vars.StmtCtx.MemTracker.AttachToGlobalTracker(executor.GlobalMemoryUsageTracker)
-	globalConfig := config.GetGlobalConfig()
-	switch globalConfig.OOMAction {
-	case config.OOMActionCancel:
+	switch variable.OOMAction.Load() {
+	case variable.OOMActionCancel:
 		action := &memory.PanicOnExceed{}
 		action.SetLogHook(domain.GetDomain(se).ExpensiveQueryHandle().LogOnQueryExceedMemQuota)
 		vars.StmtCtx.MemTracker.SetActionOnExceed(action)

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1851,7 +1851,7 @@ func upgradeToVer90(s Session, ver int64) {
 func writeOOMAction(s Session) {
 	comment := "oom-action is `log` by default in v3.0.x, `cancel` by default in v4.0.11+"
 	mustExecute(s, `INSERT HIGH_PRIORITY INTO %n.%n VALUES (%?, %?, %?) ON DUPLICATE KEY UPDATE VARIABLE_VALUE= %?`,
-		mysql.SystemDB, mysql.TiDBTable, tidbDefOOMAction, config.OOMActionLog, comment, config.OOMActionLog,
+		mysql.SystemDB, mysql.TiDBTable, tidbDefOOMAction, variable.OOMActionLog, comment, variable.OOMActionLog,
 	)
 }
 
@@ -1981,6 +1981,12 @@ func doDMLWorks(s Session) {
 				if flag.Lookup("test.v") != nil || flag.Lookup("check.v") != nil || config.CheckTableBeforeDrop {
 					// enable Dynamic Prune by default in test case.
 					vVal = string(variable.Dynamic)
+				}
+			}
+			if v.Name == variable.TiDBMemOOMAction {
+				if flag.Lookup("test.v") != nil || flag.Lookup("check.v") != nil {
+					// Change the OOM action to log for the test suite.
+					vVal = variable.OOMActionLog
 				}
 			}
 			if v.Name == variable.TiDBEnableChangeMultiSchema {

--- a/session/bootstrap_test.go
+++ b/session/bootstrap_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 
 	"github.com/pingcap/tidb/bindinfo"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/auth"
@@ -210,13 +209,6 @@ func TestBootstrapWithError(t *testing.T) {
 
 // TestUpgrade tests upgrading
 func TestUpgrade(t *testing.T) {
-	oomAction := config.GetGlobalConfig().OOMAction
-	defer func() {
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.OOMAction = oomAction
-		})
-	}()
-
 	ctx := context.Background()
 
 	store, dom := createStoreAndBootstrap(t)
@@ -297,12 +289,6 @@ func TestUpgrade(t *testing.T) {
 }
 
 func TestIssue17979_1(t *testing.T) {
-	oomAction := config.GetGlobalConfig().OOMAction
-	defer func() {
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.OOMAction = oomAction
-		})
-	}()
 	ctx := context.Background()
 
 	store, dom := createStoreAndBootstrap(t)
@@ -333,18 +319,11 @@ func TestIssue17979_1(t *testing.T) {
 	r := mustExec(t, seV4, "select variable_value from mysql.tidb where variable_name='default_oom_action'")
 	req := r.NewChunk(nil)
 	require.NoError(t, r.Next(ctx, req))
-	require.Equal(t, "log", req.GetRow(0).GetString(0))
-	require.Equal(t, config.OOMActionLog, config.GetGlobalConfig().OOMAction)
+	require.Equal(t, variable.OOMActionLog, req.GetRow(0).GetString(0))
 	domV4.Close()
 }
 
 func TestIssue17979_2(t *testing.T) {
-	oomAction := config.GetGlobalConfig().OOMAction
-	defer func() {
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.OOMAction = oomAction
-		})
-	}()
 	ctx := context.Background()
 
 	store, dom := createStoreAndBootstrap(t)
@@ -378,7 +357,6 @@ func TestIssue17979_2(t *testing.T) {
 	req := r.NewChunk(nil)
 	require.NoError(t, r.Next(ctx, req))
 	require.Equal(t, 0, req.NumRows())
-	require.Equal(t, config.OOMActionCancel, config.GetGlobalConfig().OOMAction)
 }
 
 // TestIssue20900_2 tests that a user can upgrade from TiDB 2.1 to latest,
@@ -388,13 +366,6 @@ func TestIssue17979_2(t *testing.T) {
 // but from 4.0 -> 5.0, the new default is picked up.
 
 func TestIssue20900_2(t *testing.T) {
-	oomAction := config.GetGlobalConfig().OOMAction
-	defer func() {
-		config.UpdateGlobal(func(conf *config.Config) {
-			conf.OOMAction = oomAction
-		})
-	}()
-
 	ctx := context.Background()
 
 	store, dom := createStoreAndBootstrap(t)

--- a/session/nontransactional.go
+++ b/session/nontransactional.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/failpoint"
-	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/domain"
 	"github.com/pingcap/tidb/errno"
 	"github.com/pingcap/tidb/executor"
@@ -114,13 +113,12 @@ func HandleNonTransactionalDelete(ctx context.Context, stmt *ast.NonTransactiona
 
 func setMemTracker(se Session) *memory.Tracker {
 	memTracker := memory.NewTracker(memory.LabelForNonTransactionalDML, se.GetSessionVars().MemQuotaQuery)
-	globalConfig := config.GetGlobalConfig()
-	switch globalConfig.OOMAction {
-	case config.OOMActionCancel:
+	switch variable.OOMAction.Load() {
+	case variable.OOMActionCancel:
 		action := &memory.PanicOnExceed{ConnID: se.GetSessionVars().ConnectionID}
 		action.SetLogHook(domain.GetDomain(se).ExpensiveQueryHandle().LogOnQueryExceedMemQuota)
 		memTracker.SetActionOnExceed(action)
-	case config.OOMActionLog:
+	case variable.OOMActionLog:
 		fallthrough
 	default:
 		action := &memory.LogOnExceed{ConnID: se.GetSessionVars().ConnectionID}

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -754,6 +754,14 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
+	{Scope: ScopeGlobal, Name: TiDBMemOOMAction, Value: DefTiDBMemOOMAction, PossibleValues: []string{"CANCEL", "LOG"}, Type: TypeEnum,
+		GetGlobal: func(s *SessionVars) (string, error) {
+			return OOMAction.Load(), nil
+		},
+		SetGlobal: func(s *SessionVars, val string) error {
+			OOMAction.Store(val)
+			return nil
+		}},
 
 	/* The system variables below have GLOBAL and SESSION scope  */
 	{Scope: ScopeGlobal | ScopeSession, Name: SQLSelectLimit, Value: "18446744073709551615", Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -691,7 +691,7 @@ const (
 	// TiDBEnableAutoAnalyze determines whether TiDB executes automatic analysis.
 	TiDBEnableAutoAnalyze = "tidb_enable_auto_analyze"
 	//TiDBMemOOMAction indicates what operation TiDB perform when a single SQL statement exceeds
-	// the memory quota specifed by tidb_mem_quota_query and cannot be spilled to disk.
+	// the memory quota specified by tidb_mem_quota_query and cannot be spilled to disk.
 	TiDBMemOOMAction = "tidb_mem_oom_action"
 )
 

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -690,6 +690,9 @@ const (
 	TiDBMemQuotaAnalyze = "tidb_mem_quota_analyze"
 	// TiDBEnableAutoAnalyze determines whether TiDB executes automatic analysis.
 	TiDBEnableAutoAnalyze = "tidb_enable_auto_analyze"
+	//TiDBMemOOMAction indicates what operation TiDB perform when a single SQL statement exceeds
+	// the memory quota specifed by tidb_mem_quota_query and cannot be spilled to disk.
+	TiDBMemOOMAction = "tidb_mem_oom_action"
 )
 
 // TiDB intentional limits
@@ -872,6 +875,7 @@ const (
 	DefTiDBBatchDMLIgnoreError                   = false
 	DefTiDBMemQuotaAnalyze                       = -1
 	DefTiDBEnableAutoAnalyze                     = true
+	DefTiDBMemOOMAction                          = "CANCEL"
 )
 
 // Process global variables.
@@ -911,6 +915,7 @@ var (
 	MemQuotaBindingCache                  = atomic.NewInt64(DefTiDBMemQuotaBindingCache)
 	GCMaxWaitTime                         = atomic.NewInt64(DefTiDBGCMaxWaitTime)
 	StatsCacheMemQuota                    = atomic.NewInt64(DefTiDBStatsCacheMemQuota)
+	OOMAction                             = atomic.NewString(DefTiDBMemOOMAction)
 )
 
 var (

--- a/sessionctx/variable/variable.go
+++ b/sessionctx/variable/variable.go
@@ -75,6 +75,10 @@ const (
 	AssertionFastStr = "FAST"
 	// AssertionOffStr is a choice of variable TiDBTxnAssertionLevel that means no assertion should be performed.
 	AssertionOffStr = "OFF"
+	// OOMActionCancel constants represents the valid action configurations for OOMAction "CANCEL".
+	OOMActionCancel = "CANCEL"
+	// OOMActionLog constants represents the valid action configurations for OOMAction "LOG".
+	OOMActionLog = "LOG"
 )
 
 // Global config name list.

--- a/tests/realtikvtest/sessiontest/session_test.go
+++ b/tests/realtikvtest/sessiontest/session_test.go
@@ -1396,10 +1396,6 @@ func TestCoprocessorOOMAction(t *testing.T) {
 			sql:  "select id from t5",
 		},
 	}
-	defer config.RestoreFunc()()
-	config.UpdateGlobal(func(conf *config.Config) {
-		conf.OOMAction = config.OOMActionCancel
-	})
 	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/store/copr/testRateLimitActionMockConsumeAndAssert", `return(true)`))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/store/copr/testRateLimitActionMockConsumeAndAssert"))
@@ -1409,6 +1405,8 @@ func TestCoprocessorOOMAction(t *testing.T) {
 		t.Logf("enable OOM, testcase: %v", name)
 		// larger than 4 copResponse, smaller than 5 copResponse
 		quota := 5*copr.MockResponseSizeForTest - 100
+		defer tk.MustExec("SET GLOBAL tidb_mem_oom_action = DEFAULT")
+		tk.MustExec("SET GLOBAL tidb_mem_oom_action='CANCEL'")
 		tk.MustExec("use test")
 		tk.MustExec("set @@tidb_distsql_scan_concurrency = 10")
 		tk.MustExec(fmt.Sprintf("set @@tidb_mem_quota_query=%v;", quota))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:


-->

### What problem does this PR solve?

Issue Number: ref #33769 

Problem Summary:

The option oom-action has historically been a config option. But based on requirements from cloud & PM it should instead be a sysvar.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [x] Breaking backward compatibility
  This might be a bit confusing during upgrade for users who have previously set oom-action(most users haven't). It needs to be documented in the release notes that it has been replaced with the system variable tidb_mem_oom_action.

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [x] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The TiDB configuration file option `oom-action` has been replaced by the system variable `tidb_mem_oom_action`. This change makes it easier to modify this setting on a cluster wide basis.
```
