### PR TITLE
br: use the correct status address

### DIFF
--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -552,10 +552,10 @@ func handleTiKVAddress(store *metapb.Store, httpPrefix string) (*url.URL, error)
 	statusAddr := store.GetStatusAddress()
 	nodeAddr := store.GetAddress()
 	if !strings.HasPrefix(statusAddr, "http") {
-		statusAddr = httpPrefix + "://" + statusAddr
+		statusAddr = httpPrefix + statusAddr
 	}
 	if !strings.HasPrefix(nodeAddr, "http") {
-		nodeAddr = httpPrefix + "://" + nodeAddr
+		nodeAddr = httpPrefix + nodeAddr
 	}
 
 	statusUrl, err := url.Parse(statusAddr)
@@ -563,6 +563,9 @@ func handleTiKVAddress(store *metapb.Store, httpPrefix string) (*url.URL, error)
 		return nil, err
 	}
 	nodeUrl, err := url.Parse(nodeAddr)
+	if err != nil {
+		return nil, err
+	}
 
 	// we try status address as default
 	addr := statusUrl

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -522,12 +523,13 @@ func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func
 		}
 		// we need make sure every available store support backup-stream otherwise we might lose data.
 		// so check every store's config
-		addr := fmt.Sprintf("%s/config", store.GetStatusAddress())
-		if !strings.HasPrefix(addr, "http") {
-			addr = httpPrefix + addr
+		addr, err := handleTiKVAddress(store, httpPrefix)
+		if err != nil {
+			return err
 		}
+
 		err = utils.WithRetry(ctx, func() error {
-			resp, e := cli.Get(addr)
+			resp, e := cli.Get(addr.String())
 			if e != nil {
 				return e
 			}
@@ -544,4 +546,36 @@ func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func
 		}
 	}
 	return nil
+}
+
+func handleTiKVAddress(store *metapb.Store, httpPrefix string) (*url.URL, error) {
+	statusAddr := store.GetStatusAddress()
+	nodeAddr := store.GetAddress()
+	if !strings.HasPrefix(statusAddr, "http") {
+		statusAddr = httpPrefix + "://" + statusAddr
+	}
+	if !strings.HasPrefix(nodeAddr, "http") {
+		nodeAddr = httpPrefix + "://" + nodeAddr
+	}
+
+	statusUrl, err := url.Parse(statusAddr)
+	if err != nil {
+		return nil, err
+	}
+	nodeUrl, err := url.Parse(nodeAddr)
+
+	// we try status address as default
+	addr := statusUrl
+	// but in sometimes we may not get the correct status address from PD.
+	if statusUrl.Hostname() != nodeUrl.Hostname() {
+		// if not matched, we use the address as default, but change the port
+		addr.Host = nodeUrl.Hostname() + ":" + statusUrl.Port()
+		log.Warn("store address and status address mismatch the host, we will use the store address as hostname",
+			zap.Uint64("store", store.Id),
+			zap.String("status address", statusAddr),
+			zap.String("node address", nodeAddr),
+			zap.Any("request address", statusUrl),
+		)
+	}
+	return addr, nil
 }

--- a/br/pkg/conn/conn.go
+++ b/br/pkg/conn/conn.go
@@ -527,9 +527,10 @@ func (mgr *Mgr) GetConfigFromTiKV(ctx context.Context, cli *http.Client, fn func
 		if err != nil {
 			return err
 		}
+		configAddr := fmt.Sprintf("%s/config", addr.String())
 
 		err = utils.WithRetry(ctx, func() error {
-			resp, e := cli.Get(addr.String())
+			resp, e := cli.Get(configAddr)
 			if e != nil {
 				return e
 			}

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -393,3 +393,38 @@ func TestGetMergeRegionSizeAndCount(t *testing.T) {
 		mockServer.Close()
 	}
 }
+
+func TestHandleTiKVAddress(t *testing.T) {
+	cases := []struct {
+		store      *metapb.Store
+		httpPrefix string
+		result     string
+	}{
+		{
+			store: &metapb.Store{
+				Id:            1,
+				State:         metapb.StoreState_Up,
+				Address:       "127.0.0.1:20160",
+				StatusAddress: "127.0.0.1:20180",
+			},
+			httpPrefix: "http",
+			result:     "http://127.0.0.1:20180",
+		},
+		{
+			store: &metapb.Store{
+				Id:            1,
+				State:         metapb.StoreState_Up,
+				Address:       "192.168.1.5:20160",
+				StatusAddress: "0.0.0.0:20180",
+			},
+			httpPrefix: "https",
+			// if status address and node address not match, we use node address as default host name.
+			result: "https://192.168.1.5:20180",
+		},
+	}
+	for _, ca := range cases {
+		addr, err := handleTiKVAddress(ca.store, ca.httpPrefix)
+		require.Nil(t, err)
+		require.Equal(t, ca.result, addr.String())
+	}
+}

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -407,7 +407,7 @@ func TestHandleTiKVAddress(t *testing.T) {
 				Address:       "127.0.0.1:20160",
 				StatusAddress: "127.0.0.1:20180",
 			},
-			httpPrefix: "http",
+			httpPrefix: "http://",
 			result:     "http://127.0.0.1:20180",
 		},
 		{
@@ -417,7 +417,7 @@ func TestHandleTiKVAddress(t *testing.T) {
 				Address:       "192.168.1.5:20160",
 				StatusAddress: "0.0.0.0:20180",
 			},
-			httpPrefix: "https",
+			httpPrefix: "https://",
 			// if status address and node address not match, we use node address as default host name.
 			result: "https://192.168.1.5:20180",
 		},

--- a/br/pkg/conn/conn_test.go
+++ b/br/pkg/conn/conn_test.go
@@ -380,6 +380,7 @@ func TestGetMergeRegionSizeAndCount(t *testing.T) {
 		}))
 
 		for _, s := range ca.stores {
+			s.Address = mockServer.URL
 			s.StatusAddress = mockServer.URL
 		}
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -4,7 +4,6 @@ package task
 
 import (
 	"context"
-	"net/http"
 	"strings"
 	"time"
 

--- a/br/pkg/task/restore.go
+++ b/br/pkg/task/restore.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/conn"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/httputil"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/pdutil"
 	"github.com/pingcap/tidb/br/pkg/restore"
@@ -407,7 +408,8 @@ func RunRestore(c context.Context, g glue.Glue, cmdName string, cfg *RestoreConf
 		mergeRegionCount == conn.DefaultMergeRegionKeyCount {
 		// according to https://github.com/pingcap/tidb/issues/34167.
 		// we should get the real config from tikv to adapt the dynamic region.
-		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, http.DefaultClient)
+		httpCli := httputil.NewClient(mgr.GetTLSConfig())
+		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, httpCli)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -4,13 +4,12 @@ package task
 
 import (
 	"context"
-	"net/http"
-
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/conn"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
 	"github.com/pingcap/tidb/br/pkg/glue"
+	"github.com/pingcap/tidb/br/pkg/httputil"
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/restore"
 	"github.com/pingcap/tidb/br/pkg/summary"
@@ -79,7 +78,8 @@ func RunRestoreRaw(c context.Context, g glue.Glue, cmdName string, cfg *RestoreR
 		mergeRegionCount == conn.DefaultMergeRegionKeyCount {
 		// according to https://github.com/pingcap/tidb/issues/34167.
 		// we should get the real config from tikv to adapt the dynamic region.
-		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, http.DefaultClient)
+		httpCli := httputil.NewClient(mgr.GetTLSConfig())
+		mergeRegionSize, mergeRegionCount, err = mgr.GetMergeRegionSizeAndCount(ctx, httpCli)
 		if err != nil {
 			return errors.Trace(err)
 		}

--- a/br/pkg/task/restore_raw.go
+++ b/br/pkg/task/restore_raw.go
@@ -4,6 +4,7 @@ package task
 
 import (
 	"context"
+
 	"github.com/pingcap/errors"
 	"github.com/pingcap/log"
 	"github.com/pingcap/tidb/br/pkg/conn"


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34651

Problem Summary:
- After we implement get config from tikv status address. we found sometimes the hostname of tikv node address and tikv status address are not same. and at this situation we should use node address' hostName and status address Port to spell the real status address.
- this pr also tried to fix the broken ci by use the correct tls http client: https://ci.pingcap.net/blue/organizations/jenkins/br_ghpr_unit_and_integration_test/detail/br_ghpr_unit_and_integration_test/11623/pipeline/

### What is changed and how it works?
This pr tried use node address' hostName and status address Port to spell the real status address when they are not matched.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
