### PR TITLE
config, session: add upgrade to bootstrap

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -258,6 +258,10 @@ type Config struct {
 
 	// EnableBatchDML, unused since bootstrap v90
 	EnableBatchDML bool `toml:"enable-batch-dml" json:"enable-batch-dml"`
+	// MemQuotaQuery,QueryLogMaxLen,CommitterConcurrency, unused since bootstrap v91
+	MemQuotaQuery        int64  `toml:"mem-quota-query" json:"mem-quota-query"`
+	QueryLogMaxLen       uint64 `toml:"query-log-max-len" json:"query-log-max-len"`
+	CommitterConcurrency int    `toml:"committer-concurrency" json:"committer-concurrency"`
 }
 
 // UpdateTempStoragePath is to update the `TempStoragePath` if port/statusPort was changed

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -617,11 +617,13 @@ const (
 	version89 = 89
 	// version90 converts enable-batch-dml to a sysvar
 	version90 = 90
+	// version91 converts mem-quota-query, query-log-max-len, committer-concurrency to a sysvar
+	version91 = 91
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version90
+var currentBootstrapVersion int64 = version91
 
 var (
 	bootstrapVersion = []func(Session, int64){
@@ -715,6 +717,7 @@ var (
 		upgradeToVer88,
 		upgradeToVer89,
 		upgradeToVer90,
+		upgradeToVer91,
 	}
 )
 
@@ -1846,6 +1849,18 @@ func upgradeToVer90(s Session, ver int64) {
 	}
 	valStr := variable.BoolToOnOff(config.GetGlobalConfig().EnableBatchDML)
 	importConfigOption(s, "enable-batch-dml", variable.TiDBEnableBatchDML, valStr)
+}
+
+func upgradeToVer91(s Session, ver int64) {
+	if ver >= version91 {
+		return
+	}
+	valStr := fmt.Sprint(config.GetGlobalConfig().MemQuotaQuery)
+	importConfigOption(s, "mem-quota-query", variable.TiDBMemQuotaQuery, valStr)
+	valStr = fmt.Sprint((config.GetGlobalConfig().QueryLogMaxLen), 10)
+	importConfigOption(s, "query-log-max-len", variable.TiDBQueryLogMaxLen, valStr)
+	valStr = fmt.Sprint(config.GetGlobalConfig().CommitterConcurrency)
+	importConfigOption(s, "committer-concurrency", variable.TiDBCommitterConcurrency, valStr)
 }
 
 func writeOOMAction(s Session) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/33769

Problem Summary:

### What is changed and how it works?
This work changes the current bootstrap version to vesion91 and add upgrade function to ver91 which converts mem-quota-query, query-log-max-len, and committer-concurrency to sysvar.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The most current version in bootstrap.go is now version91, which converts mem-quota-query, query-log-max-len, and committer-concurrency to sysvar.
```
