### PR TITLE
statistics: fix data race in the Handle.mu.ctx

### DIFF
--- a/statistics/handle/ddl.go
+++ b/statistics/handle/ddl.go
@@ -19,13 +19,13 @@ import (
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/ddl/util"
-	"github.com/pingcap/tidb/infoschema"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/sqlexec"
 )
@@ -81,7 +81,7 @@ func (h *Handle) updateGlobalStats(tblInfo *model.TableInfo) error {
 		return err
 	}
 	sctx := se.(sessionctx.Context)
-	is := sctx.GetInfoSchema().(infoschema.InfoSchema)
+	is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
 	h.pool.Put(se)
 	globalStats, err := h.TableStatsFromStorage(tblInfo, tableID, true, 0)
 	if err != nil {

--- a/statistics/handle/ddl.go
+++ b/statistics/handle/ddl.go
@@ -81,8 +81,8 @@ func (h *Handle) updateGlobalStats(tblInfo *model.TableInfo) error {
 		return err
 	}
 	sctx := se.(sessionctx.Context)
-	defer h.pool.Put(se)
 	is := sctx.GetInfoSchema().(infoschema.InfoSchema)
+	h.pool.Put(se)
 	globalStats, err := h.TableStatsFromStorage(tblInfo, tableID, true, 0)
 	if err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34715

Problem Summary:

We call (*Handle).updateGlobalStats, which uses Handle.mu.ctx to fetch another session from session pool to execute internal SQL. it will happen to a data race. 

### What is changed and how it works?

We can get sessionctx from sessionpool to avoid it.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
