### PR TITLE
parser: fix the Incompatible parser behavior for HAVING clause #34642

### DIFF
--- a/executor/executor_test.go
+++ b/executor/executor_test.go
@@ -225,6 +225,9 @@ func TestSelectWithoutFrom(t *testing.T) {
 	tk.MustQuery("select 1 + 2*3;").Check(testkit.Rows("7"))
 	tk.MustQuery(`select _utf8"string";`).Check(testkit.Rows("string"))
 	tk.MustQuery("select 1 order by 1;").Check(testkit.Rows("1"))
+	tk.MustQuery("SELECT  'a' as f1 having f1 = 'a';").Check(testkit.Rows("a"))
+	tk.MustQuery("SELECT (SELECT * FROM (SELECT 'a') t) AS f1 HAVING (f1 = 'a' OR TRUE);").Check(testkit.Rows("a"))
+	tk.MustQuery("SELECT (SELECT * FROM (SELECT 'a') t) + 1 AS f1 HAVING (f1 = 'a' OR TRUE)").Check(testkit.Rows("1"))
 }
 
 // TestSelectBackslashN Issue 3685.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -8172,7 +8172,7 @@ HelpStmt:
 	}
 
 SelectStmtBasic:
-	"SELECT" SelectStmtOpts SelectStmtFieldList
+	"SELECT" SelectStmtOpts SelectStmtFieldList HavingClause
 	{
 		st := &ast.SelectStmt{
 			SelectStmtOpts: $2.(*ast.SelectStmtOpts),
@@ -8182,6 +8182,9 @@ SelectStmtBasic:
 		}
 		if st.SelectStmtOpts.TableHints != nil {
 			st.TableHints = st.SelectStmtOpts.TableHints
+		}
+		if $4 != nil {
+			st.Having = $4.(*ast.HavingClause)
 		}
 		$$ = st
 	}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -236,6 +236,11 @@ func TestSimple(t *testing.T) {
 	_, err = p.ParseOneStmt(src, "", "")
 	require.NoError(t, err)
 
+	// for issue #34642
+	src = `SELECT a as c having c = a;`
+	_, err = p.ParseOneStmt(src, "", "")
+	require.NoError(t, err)
+
 	// for issue #9823
 	src = "SELECT 9223372036854775807;"
 	st, err = p.ParseOneStmt(src, "", "")


### PR DESCRIPTION
Signed-off-by: fanrenhoo <fanrenhoo@sina.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34642

Problem Summary: make the basic select statement compatible for having clause

### What is changed and how it works?
before the basic select statement incompatible for having claues, but MySQL does. So make parser to compatible for this case.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
After fix, now it works as：
MySQL [(none)]> SELECT (SELECT * FROM (SELECT 'a') t) AS f1 HAVING (f1 = 'a' OR TRUE);
+------+
| f1   |
+------+
| a    |
+------+
1 row in set (0.00 sec)

MySQL [(none)]> SELECT (SELECT * FROM (SELECT 'a') t) + 1 AS f1 HAVING (f1 = 'a' OR TRUE);
+----+
| f1 |
+----+
|  1 |
+----+
1 row in set, 2 warnings (0.00 sec)

MySQL [(none)]> SELECT 1 + (SELECT * FROM (SELECT 'a') t) AS f1 HAVING (f1 = 'a' OR TRUE);
+----+
| f1 |
+----+
|  1 |
+----+
1 row in set, 2 warnings (0.00 sec)

- [ ] No code

Side effects
No
- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation
No
- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Make the basic select statement compatible for having clause like mysql does.
```
