### PR TITLE
server: optimize bce on the packetio.writePacket

### DIFF
--- a/server/packetio.go
+++ b/server/packetio.go
@@ -166,11 +166,10 @@ func (p *packetIO) writePacket(data []byte) error {
 	writePacketBytes.Add(float64(len(data)))
 
 	for length >= mysql.MaxPayloadLen {
+		data[3] = p.sequence
 		data[0] = 0xff
 		data[1] = 0xff
 		data[2] = 0xff
-
-		data[3] = p.sequence
 
 		if n, err := p.bufWriter.Write(data[:4+mysql.MaxPayloadLen]); err != nil {
 			return errors.Trace(mysql.ErrBadConn)
@@ -182,11 +181,10 @@ func (p *packetIO) writePacket(data []byte) error {
 			data = data[mysql.MaxPayloadLen:]
 		}
 	}
-
+	data[3] = p.sequence
 	data[0] = byte(length)
 	data[1] = byte(length >> 8)
 	data[2] = byte(length >> 16)
-	data[3] = p.sequence
 
 	if n, err := p.bufWriter.Write(data); err != nil {
 		terror.Log(errors.Trace(err))

--- a/server/packetio_test.go
+++ b/server/packetio_test.go
@@ -25,6 +25,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func BenchmarkPacketIOWrite(b *testing.B) {
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		var outBuffer bytes.Buffer
+		pkt := &packetIO{bufWriter: bufio.NewWriter(&outBuffer)}
+		_ = pkt.writePacket([]byte{0x6d, 0x44, 0x42, 0x3a, 0x35, 0x36, 0x0, 0x0, 0x0, 0xfc, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x68, 0x54, 0x49, 0x44, 0x3a, 0x31, 0x30, 0x38, 0x0, 0xfe})
+	}
+}
+
 func TestPacketIOWrite(t *testing.T) {
 	// Test write one packet
 	var outBuffer bytes.Buffer


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Go is a memory safe language. In array/slice element indexing and subslice operations, Go runtime will check whether or not the involved indexes are out of range. If an index is out of range, a panic will be produced to prevent the invalid index from doing harm. This is called bounds check. Bounds checks make our code run safely, on the other hand, they also make our code run a little slower.

Issue Number: ref #34669

Problem Summary:

### What is changed and how it works?

before 

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/server
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkPacketIOWrite-16    	10000000	       871.3 ns/op
PASS
ok  	github.com/pingcap/tidb/server	9.875s
```

after

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/server
cpu: Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz
BenchmarkPacketIOWrite-16    	10000000	       830.0 ns/op
PASS
ok  	github.com/pingcap/tidb/server	9.102s
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
