### PR TITLE
util/ranger: ignore error from negative int range on unsigned columns

### DIFF
--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -131,6 +131,8 @@ func convertPoint(sctx sessionctx.Context, point *point, tp *types.FieldType) (*
 			// For example, newBuildFromPatternLike calculates the end point by adding 1 to bytes.
 			// We need to skip these invalid strings.
 			return point, nil
+		} else if tp.GetType() == mysql.TypeLonglong && mysql.HasUnsignedFlag(tp.GetFlag()) && terror.ErrorEqual(err, types.ErrOverflow) {
+			// Ignore the types.ErrOverflow when a negative number is specified in range.
 		} else {
 			return point, errors.Trace(err)
 		}

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -1072,6 +1072,32 @@ func TestIndexRangeForBit(t *testing.T) {
 	}
 }
 
+func TestTableRangeForNegativeUnsignedInt(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test;")
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int, b mediumint unsigned, primary key (b, a) /* [cluster_index] clustered */);")
+	tk.MustExec("insert into t values(1, 1), (2, 2);")
+	tk.MustExec("analyze table t;")
+
+	var input []string
+	var output []struct {
+		SQL  string
+		Plan []string
+	}
+	rangerSuiteData.GetTestCases(t, &input, &output)
+	for i, tt := range input {
+		testdata.OnRecord(func() {
+			output[i].SQL = tt
+			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery("explain " + tt).Rows())
+		})
+		tk.MustQuery("explain " + tt).Check(testkit.Rows(output[i].Plan...))
+	}
+}
+
 func TestIndexRangeForYear(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/util/ranger/testdata/ranger_suite_in.json
+++ b/util/ranger/testdata/ranger_suite_in.json
@@ -109,5 +109,13 @@
       "select * from IDT_20755 use index (u_m_col) where col1 = \"xxxxxxxxxxxxxxx\" and col2 in (72, 73) and col3 != \"2024-10-19 08:55:32\"",
       "select * from IDT_20755 use index (u_m_col) where col1 = \"xxxxxxxxxxxxxxx\" and col2 in (72, 73, 74) and col3 != \"2024-10-19 08:55:32\""
     ]
+  },
+  {
+    "name": "TestTableRangeForNegativeUnsignedInt",
+    "cases": [
+      "update t set a = 10 where b in (-1, 1);",
+      "update t set a = 11 where b in (0, 1);",
+      "update t set a = 20 where b in (2, -123) or b in (-10);"
+    ]
   }
 ]

--- a/util/ranger/testdata/ranger_suite_out.json
+++ b/util/ranger/testdata/ranger_suite_out.json
@@ -691,5 +691,34 @@
         ]
       }
     ]
+  },
+  {
+    "Name": "TestTableRangeForNegativeUnsignedInt",
+    "Cases": [
+      {
+        "SQL": "update t set a = 10 where b in (-1, 1);",
+        "Plan": [
+          "Update_4 N/A root  N/A",
+          "└─IndexReader_7 1.00 root  index:IndexRangeScan_6",
+          "  └─IndexRangeScan_6 1.00 cop[tikv] table:t, index:PRIMARY(b, a) range:[1,1], keep order:false"
+        ]
+      },
+      {
+        "SQL": "update t set a = 11 where b in (0, 1);",
+        "Plan": [
+          "Update_4 N/A root  N/A",
+          "└─IndexReader_7 1.00 root  index:IndexRangeScan_6",
+          "  └─IndexRangeScan_6 1.00 cop[tikv] table:t, index:PRIMARY(b, a) range:[0,0], [1,1], keep order:false"
+        ]
+      },
+      {
+        "SQL": "update t set a = 20 where b in (2, -123) or b in (-10);",
+        "Plan": [
+          "Update_4 N/A root  N/A",
+          "└─IndexReader_7 1.00 root  index:IndexRangeScan_6",
+          "  └─IndexRangeScan_6 1.00 cop[tikv] table:t, index:PRIMARY(b, a) range:[2,2], keep order:false"
+        ]
+      }
+    ]
   }
 ]


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34747

Problem Summary:

```sql
drop table if exists t;
create table t (a int, b mediumint unsigned, primary key (b, a) /* [cluster_index] clustered */);
update t set a = 10 where b in (-123, 1000);
```

The negative integer `-123` should be ignored when building a range.

### What is changed and how it works?

After this PR:

```sql
mysql> explain update t set a = 10 where b in (-123, 1000);
+--------------------------+---------+-----------+------------------------------+---------------------------------------------------+
| id                       | estRows | task      | access object                | operator info                                     |
+--------------------------+---------+-----------+------------------------------+---------------------------------------------------+
| Update_4                 | N/A     | root      |                              | N/A                                               |
| └─IndexReader_7          | 10.00   | root      |                              | index:IndexRangeScan_6                            |
|   └─IndexRangeScan_6     | 10.00   | cop[tikv] | table:t, index:PRIMARY(b, a) | range:[1000,1000], keep order:false, stats:pseudo |
+--------------------------+---------+-----------+------------------------------+---------------------------------------------------+
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
