### PR TITLE
session: cleanup check_dev_2 scaffolding

### DIFF
--- a/session/main_test.go
+++ b/session/main_test.go
@@ -38,11 +38,6 @@ import (
 
 var testDataMap = make(testdata.BookKeeper, 1)
 
-var WithTiKV = flag.Bool("with-tikv", false, "workaroundGoCheckFlags: with-tikv")
-var _ = flag.String("pd-addrs", "", "workaroundGoCheckFlags: pd-addrs")
-var _ = flag.String("check.exclude", "", "workaroundGoCheckFlags: check.exclude")
-var _ = flag.String("check.f", "", "workaroundGoCheckFlags: check.f")
-
 func TestMain(m *testing.M) {
 	testmain.ShortCircuitForBench(m)
 

--- a/session/schema_test.go
+++ b/session/schema_test.go
@@ -37,12 +37,6 @@ import (
 	"github.com/tikv/client-go/v2/testutils"
 )
 
-func skipIfWithRealTiKV(t *testing.T) {
-	if *session.WithTiKV {
-		t.Skip("Schema tests has nothing to do with real tikv scenario")
-	}
-}
-
 func createMockStoreForSchemaTest(t *testing.T, opts ...mockstore.MockTiKVStoreOption) (kv.Storage, func()) {
 	store, err := mockstore.NewMockStore(opts...)
 	require.NoError(t, err)
@@ -60,8 +54,6 @@ func createMockStoreForSchemaTest(t *testing.T, opts ...mockstore.MockTiKVStoreO
 }
 
 func TestPrepareStmtCommitWhenSchemaChanged(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -90,8 +82,6 @@ func TestPrepareStmtCommitWhenSchemaChanged(t *testing.T) {
 }
 
 func TestCommitWhenSchemaChanged(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -116,8 +106,6 @@ func TestCommitWhenSchemaChanged(t *testing.T) {
 }
 
 func TestRetrySchemaChangeForEmptyChange(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -149,8 +137,6 @@ func TestRetrySchemaChangeForEmptyChange(t *testing.T) {
 }
 
 func TestRetrySchemaChange(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -193,8 +179,6 @@ func TestRetrySchemaChange(t *testing.T) {
 }
 
 func TestRetryMissingUnionScan(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -220,8 +204,6 @@ func TestRetryMissingUnionScan(t *testing.T) {
 }
 
 func TestTableReaderChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	// Since normally a single region mock tikv only returns one partial result we need to manually split the
 	// table to test multiple chunks.
 	var cluster testutils.Cluster
@@ -273,8 +255,6 @@ func TestTableReaderChunk(t *testing.T) {
 }
 
 func TestInsertExecChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -311,8 +291,6 @@ func TestInsertExecChunk(t *testing.T) {
 }
 
 func TestUpdateExecChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -351,8 +329,6 @@ func TestUpdateExecChunk(t *testing.T) {
 }
 
 func TestDeleteExecChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -384,8 +360,6 @@ func TestDeleteExecChunk(t *testing.T) {
 }
 
 func TestDeleteMultiTableExecChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -439,8 +413,6 @@ func TestDeleteMultiTableExecChunk(t *testing.T) {
 }
 
 func TestIndexLookUpReaderChunk(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	// Since normally a single region mock tikv only returns one partial result we need to manually split the
 	// table to test multiple chunks.
 	var cluster testutils.Cluster
@@ -504,8 +476,6 @@ func TestIndexLookUpReaderChunk(t *testing.T) {
 }
 
 func TestDisableTxnAutoRetry(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -601,8 +571,6 @@ func TestDisableTxnAutoRetry(t *testing.T) {
 }
 
 func TestTxnSize(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -620,8 +588,6 @@ func TestTxnSize(t *testing.T) {
 }
 
 func TestLoadSchemaFailed(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	originalRetryTime := domain.SchemaOutOfDateRetryTimes.Load()
 	originalRetryInterval := domain.SchemaOutOfDateRetryInterval.Load()
 	domain.SchemaOutOfDateRetryTimes.Store(3)
@@ -679,8 +645,6 @@ func TestLoadSchemaFailed(t *testing.T) {
 }
 
 func TestValidationRecursion(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	// We have to expect that validation functions will call GlobalVarsAccessor.GetGlobalSysVar().
 	// This tests for a regression where GetGlobalSysVar() can not safely call the validation
 	// function because it might cause infinite recursion.
@@ -702,8 +666,6 @@ func TestValidationRecursion(t *testing.T) {
 }
 
 func TestSchemaCheckerSQL(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -778,8 +740,6 @@ func TestSchemaCheckerSQL(t *testing.T) {
 }
 
 func TestSchemaCheckerTempTable(t *testing.T) {
-	skipIfWithRealTiKV(t)
-
 	store, clean := createMockStoreForSchemaTest(t)
 	defer clean()
 
@@ -882,7 +842,6 @@ func TestSchemaCheckerTempTable(t *testing.T) {
 }
 
 func TestGlobalAndLocalTxn(t *testing.T) {
-	skipIfWithRealTiKV(t)
 	// Because the PD config of check_dev_2 test is not compatible with local/global txn yet,
 	// so we will skip this test for now.
 	store, clean := testkit.CreateMockStore(t)

--- a/tests/realtikvtest/brietest/backup_restore_test.go
+++ b/tests/realtikvtest/brietest/backup_restore_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains tests about backup restore (br) which need running with real TiKV.
-// Only tests under /session will be run with real TiKV, so we put them here instead of /br.
-
 package brietest
 
 import (

--- a/tests/realtikvtest/brietest/binlog_test.go
+++ b/tests/realtikvtest/brietest/binlog_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains tests about binlog which need running with real TiKV.
-// Only tests under /session will be run with real TiKV, so we put them here.
-
 package brietest
 
 import (

--- a/tests/realtikvtest/statisticstest/statistics_test.go
+++ b/tests/realtikvtest/statisticstest/statistics_test.go
@@ -12,9 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// This file contains tests about statistics which need running with real TiKV.
-// Only tests under /session will be run with real TiKV, so we put them here instead of /statistics.
-
 package statisticstest
 
 import (


### PR DESCRIPTION
As https://github.com/PingCAP-QE/ci/pull/975 merged, check_dev_2 doesn't specially handle `session/` any more. `session/` is a now normal package.

Issue Number: ref #26864

```release-note
None
```
