### PR TITLE
executor: print slow logs by default logger

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1258,6 +1258,7 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 		trace.Log(a.GoCtx, "details", slowLog)
 	}
 	logutil.SlowQueryLogger.Warn(slowLog)
+	logutil.BgLogger().Warn("SLOW_QUERY", zap.String("details", slowLog))
 	if costTime >= threshold {
 		if sessVars.InRestrictedSQL {
 			totalQueryProcHistogramInternal.Observe(costTime.Seconds())

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1258,7 +1258,9 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 		trace.Log(a.GoCtx, "details", slowLog)
 	}
 	logutil.SlowQueryLogger.Warn(slowLog)
-	logutil.BgLogger().Warn("SLOW_QUERY", zap.String("details", slowLog))
+	if variable.EnableUnifiedSlowLog.Load() {
+		logutil.BgLogger().Info("SLOW_QUERY", zap.String("details", slowLog))
+	}
 	if costTime >= threshold {
 		if sessVars.InRestrictedSQL {
 			totalQueryProcHistogramInternal.Observe(costTime.Seconds())

--- a/executor/set_test.go
+++ b/executor/set_test.go
@@ -424,6 +424,12 @@ func TestSetVar(t *testing.T) {
 	tk.MustExec("set global tidb_txn_commit_batch_size = 100")
 	tk.MustQuery("select @@global.tidb_txn_commit_batch_size;").Check(testkit.Rows("100"))
 
+	tk.MustQuery("select @@global.tidb_enable_unified_slow_log;").Check(testkit.Rows("0"))
+	tk.MustExec("set @@global.tidb_enable_unified_slow_log = on")
+	tk.MustQuery("select @@global.tidb_enable_unified_slow_log;").Check(testkit.Rows("1"))
+	tk.MustExec("set global tidb_enable_unified_slow_log = off")
+	tk.MustQuery("select @@global.tidb_enable_unified_slow_log;").Check(testkit.Rows("0"))
+
 	tk.MustQuery("select @@session.tidb_metric_query_step;").Check(testkit.Rows("60"))
 	tk.MustExec("set @@session.tidb_metric_query_step = 120")
 	tk.MustExec("set @@session.tidb_metric_query_step = 9")

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -563,6 +563,14 @@ var defaultSysVars = []*SysVar{
 			tikvstore.TxnCommitBatchSize.Store(uint64(TidbOptInt64(val, int64(tikvstore.DefTxnCommitBatchSize))))
 			return nil
 		}},
+	{Scope: ScopeGlobal, Name: TiDBEnableUnifiedSlowLog, Value: BoolToOnOff(DefEnableUnifiedSlowLog), Type: TypeBool, skipInit: true,
+		GetGlobal: func(sv *SessionVars) (string, error) {
+			return BoolToOnOff(EnableUnifiedSlowLog.Load()), nil
+		},
+		SetGlobal: func(s *SessionVars, val string) error {
+			EnableUnifiedSlowLog.Store(TiDBOptOn(val))
+			return nil
+		}},
 	{Scope: ScopeGlobal, Name: TiDBRestrictedReadOnly, Value: BoolToOnOff(DefTiDBRestrictedReadOnly), Type: TypeBool, SetGlobal: func(s *SessionVars, val string) error {
 		on := TiDBOptOn(val)
 		// For user initiated SET GLOBAL, also change the value of TiDBSuperReadOnly

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -563,10 +563,9 @@ var defaultSysVars = []*SysVar{
 			tikvstore.TxnCommitBatchSize.Store(uint64(TidbOptInt64(val, int64(tikvstore.DefTxnCommitBatchSize))))
 			return nil
 		}},
-	{Scope: ScopeGlobal, Name: TiDBEnableUnifiedSlowLog, Value: BoolToOnOff(DefEnableUnifiedSlowLog), Type: TypeBool, skipInit: true,
-		GetGlobal: func(sv *SessionVars) (string, error) {
-			return BoolToOnOff(EnableUnifiedSlowLog.Load()), nil
-		},
+	{Scope: ScopeGlobal, Name: TiDBEnableUnifiedSlowLog, Value: BoolToOnOff(DefEnableUnifiedSlowLog), Type: TypeBool, GetGlobal: func(sv *SessionVars) (string, error) {
+		return BoolToOnOff(EnableUnifiedSlowLog.Load()), nil
+	},
 		SetGlobal: func(s *SessionVars, val string) error {
 			EnableUnifiedSlowLog.Store(TiDBOptOn(val))
 			return nil

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -136,6 +136,9 @@ const (
 	// TiDBEnableChunkRPC enables TiDB to use Chunk format for coprocessor requests.
 	TiDBEnableChunkRPC = "tidb_enable_chunk_rpc"
 
+	// TiDBEnableUnifiedSlowLog enables TiDB to use Chunk format for coprocessor requests.
+	TiDBEnableUnifiedSlowLog = "tidb_enable_unified_slow_log"
+
 	// TiDBOptimizerSelectivityLevel is used to control the selectivity estimation level.
 	TiDBOptimizerSelectivityLevel = "tidb_optimizer_selectivity_level"
 
@@ -820,6 +823,7 @@ const (
 	DefChecksumTableConcurrency                    = 4
 	DefSkipUTF8Check                               = false
 	DefSkipASCIICheck                              = false
+	DefEnableUnifiedSlowLog                        = false
 	DefOptAggPushDown                              = false
 	DefOptCartesianBCJ                             = 1
 	DefOptMPPOuterJoinFixedBuildSide               = false
@@ -1054,10 +1058,7 @@ var (
 	EnableConcurrentDDL               = atomic.NewBool(DefTiDBEnableConcurrentDDL)
 	DDLForce2Queue                    = atomic.NewBool(false)
 	EnableNoopVariables               = atomic.NewBool(DefTiDBEnableNoopVariables)
-	// EnableFastReorg indicates whether to use lightning to enhance DDL reorg performance.
-	EnableFastReorg = atomic.NewBool(DefTiDBEnableFastReorg)
-	// DDLDiskQuota is the temporary variable for set disk quota for lightning
-	DDLDiskQuota = atomic.NewInt64(DefTiDBDDLDiskQuota)
+	EnableUnifiedSlowLog              = atomic.NewBool(DefEnableUnifiedSlowLog)
 )
 
 var (

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1060,6 +1060,10 @@ var (
 	DDLForce2Queue                    = atomic.NewBool(false)
 	EnableNoopVariables               = atomic.NewBool(DefTiDBEnableNoopVariables)
 	EnableUnifiedSlowLog              = atomic.NewBool(DefEnableUnifiedSlowLog)
+	// EnableFastReorg indicates whether to use lightning to enhance DDL reorg performance.
+	EnableFastReorg = atomic.NewBool(DefTiDBEnableFastReorg)
+	// DDLDiskQuota is the temporary variable for set disk quota for lightning
+	DDLDiskQuota = atomic.NewInt64(DefTiDBDDLDiskQuota)
 )
 
 var (

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -136,7 +136,8 @@ const (
 	// TiDBEnableChunkRPC enables TiDB to use Chunk format for coprocessor requests.
 	TiDBEnableChunkRPC = "tidb_enable_chunk_rpc"
 
-	// TiDBEnableUnifiedSlowLog enables TiDB to use Chunk format for coprocessor requests.
+	// TiDBEnableUnifiedSlowLog enables TiDB's default system log to output slow logs.
+	// Note that the original slow logger is still in effect, and it will still print the logs.
 	TiDBEnableUnifiedSlowLog = "tidb_enable_unified_slow_log"
 
 	// TiDBOptimizerSelectivityLevel is used to control the selectivity estimation level.


### PR DESCRIPTION
Signed-off-by: Jack Yu <jackysp@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34798

Problem Summary:
It's very hard to search slow logs in Kibana, because it prints in several lines.

### What is changed and how it works?
Print another slow log by default logger.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

1. start a cluster
1. `set global tidb_enable_unified_slow_log = on;`
2. `select sleep(1);`
3. find the key word `SLOW_QUERY` in tidb log files.

```text
[2022/05/19 10:17:36.537 +08:00] [WARN] [adapter.go:1096] [SLOW_QUERY] [details="# Txn_start_ts: 433304805451235328\n# Query_time: 0.000265375\n# Parse_time: 0\n# Compile_time: 0.000070042\n# Rewrite_time: 0.000055542\n# Optimize_time: 0.001257167\n# Wait_TS: 0.000014834\n# Is_internal: true\n# Digest: b95a604794f9eff17a1a6a37d754324be11ede348a0d1e53da2bc3c32d6a4142\n# Num_cop_tasks: 0\n# Prepared: false\n# Plan_from_cache: false\n# Plan_from_binding: false\n# Has_more_results: false\n# KV_total: 0\n# PD_total: 0.0000015\n# Backoff_total: 0\n# Write_sql_response_total: 0\n# Result_rows: 3\n# Succ: true\n# IsExplicitTxn: false\n# Plan: tidb_decode_plan('qQHAMAkzOF8xCTAJMwl0YWJsZTpHTE9CQUxfVkFSSUFCTEVTLCBpbmRleDpQUklNQVJZKBEZdF9OQU1FKSwga2VlcCBvcmRlcjpmYWxzZSwgZGVzYwkM2AkzCXRpbWU6MTExLjLCtXMsIGxvb3BzOjIsIEJhdGNoR2V0OntudW1fcnBjOjIsIHRvdGFsX3QBM0AzNy4ywrVzfQlOL0EJTi9BCg==')\n# Plan_digest: 9449388a4efbc35c8eca1639aec164392df687869239f9ad16ea37887d98c42a\nselect sleep(1);"]
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
