### PR TITLE
lightning: fix the problem that status address isn't accurate

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1847,6 +1847,9 @@ func (local *local) EngineFileSizes() (res []backend.EngineFileSize) {
 	return
 }
 
+var getSplitConfFromStoreFunc = getSplitConfFromStore
+
+// return region split size, region split keys, error
 func getSplitConfFromStore(ctx context.Context, host string, tls *common.TLS) (int64, int64, error) {
 	var (
 		nested struct {
@@ -1867,6 +1870,7 @@ func getSplitConfFromStore(ctx context.Context, host string, tls *common.TLS) (i
 	return splitSize, nested.Coprocessor.RegionSplitKeys, nil
 }
 
+// return region split size, region split keys, error
 func getRegionSplitSizeKeys(ctx context.Context, cli pd.Client, tls *common.TLS) (int64, int64, error) {
 	stores, err := cli.GetAllStores(ctx, pd.WithExcludeTombstone())
 	if err != nil {
@@ -1881,7 +1885,7 @@ func getRegionSplitSizeKeys(ctx context.Context, cli pd.Client, tls *common.TLS)
 			StatusAddr: store.StatusAddress,
 		}
 		serverInfo.ResolveLoopBackAddr()
-		regionSplitSize, regionSplitKeys, err := getSplitConfFromStore(ctx, serverInfo.StatusAddr, tls)
+		regionSplitSize, regionSplitKeys, err := getSplitConfFromStoreFunc(ctx, serverInfo.StatusAddr, tls)
 		if err == nil {
 			return regionSplitSize, regionSplitKeys, nil
 		}

--- a/br/pkg/lightning/backend/local/local_test.go
+++ b/br/pkg/lightning/backend/local/local_test.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -45,6 +46,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/mock"
 	"github.com/pingcap/tidb/br/pkg/pdutil"
 	"github.com/pingcap/tidb/br/pkg/restore"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/br/pkg/version"
 	tidbkv "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
@@ -1199,4 +1201,37 @@ func TestLocalWriteAndIngestPairsFailFast(t *testing.T) {
 	err := bak.writeAndIngestPairs(context.Background(), nil, nil, nil, nil, 0, 0)
 	require.Error(t, err)
 	require.Regexp(t, "The available disk of TiKV.*", err.Error())
+}
+
+func TestGetRegionSplitSizeKeys(t *testing.T) {
+	allStores := []*metapb.Store{
+		{
+			Address:       "172.16.102.1:20160",
+			StatusAddress: "0.0.0.0:20180",
+		},
+		{
+			Address:       "172.16.102.2:20160",
+			StatusAddress: "0.0.0.0:20180",
+		},
+		{
+			Address:       "172.16.102.3:20160",
+			StatusAddress: "0.0.0.0:20180",
+		},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cli := utils.FakePDClient{Stores: allStores}
+	defer func() {
+		getSplitConfFromStoreFunc = getSplitConfFromStore
+	}()
+	getSplitConfFromStoreFunc = func(ctx context.Context, host string, tls *common.TLS) (int64, int64, error) {
+		if strings.Contains(host, "172.16.102.3:20180") {
+			return int64(1), int64(2), nil
+		}
+		return 0, 0, errors.New("invalid connection")
+	}
+	splitSize, splitKeys, err := getRegionSplitSizeKeys(ctx, cli, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), splitSize)
+	require.Equal(t, int64(2), splitKeys)
 }

--- a/tools/check/ut.go
+++ b/tools/check/ut.go
@@ -85,7 +85,6 @@ const modulePath = "github.com/pingcap/tidb"
 type task struct {
 	pkg  string
 	test string
-	old  bool
 }
 
 func (t *task) String() string {
@@ -626,17 +625,9 @@ func listTestCases(pkg string, tasks []task) ([]task, error) {
 		return nil, withTrace(err)
 	}
 	for _, c := range newCases {
-		tasks = append(tasks, task{pkg, c, false})
+		tasks = append(tasks, task{pkg, c})
 	}
 
-	oldCases, err := listOldTestCases(pkg)
-	if err != nil {
-		fmt.Println("list old test case error", pkg, err)
-		return nil, withTrace(err)
-	}
-	for _, c := range oldCases {
-		tasks = append(tasks, task{pkg, c, true})
-	}
 	return tasks, nil
 }
 
@@ -692,7 +683,7 @@ type numa struct {
 func (n *numa) worker(wg *sync.WaitGroup, ch chan task) {
 	defer wg.Done()
 	for t := range ch {
-		res := n.runTestCase(t.pkg, t.test, t.old)
+		res := n.runTestCase(t.pkg, t.test)
 		if res.Failure != nil {
 			fmt.Println("[FAIL] ", t.pkg, t.test)
 			fmt.Fprintf(os.Stderr, "err=%s\n%s", res.err.Error(), res.Failure.Contents)
@@ -708,7 +699,7 @@ type testResult struct {
 	err error
 }
 
-func (n *numa) runTestCase(pkg string, fn string, old bool) testResult {
+func (n *numa) runTestCase(pkg string, fn string) testResult {
 	res := testResult{
 		JUnitTestCase: JUnitTestCase{
 			Classname: path.Join(modulePath, pkg),
@@ -720,7 +711,7 @@ func (n *numa) runTestCase(pkg string, fn string, old bool) testResult {
 	var err error
 	var start time.Time
 	for i := 0; i < 3; i++ {
-		cmd := n.testCommand(pkg, fn, old)
+		cmd := n.testCommand(pkg, fn)
 		cmd.Dir = path.Join(workDir, pkg)
 		// Combine the test case output, so the run result for failed cases can be displayed.
 		cmd.Stdout = &buf
@@ -805,7 +796,7 @@ func failureCases(input []JUnitTestCase) int {
 	return sum
 }
 
-func (n *numa) testCommand(pkg string, fn string, old bool) *exec.Cmd {
+func (n *numa) testCommand(pkg string, fn string) *exec.Cmd {
 	args := make([]string, 0, 10)
 	exe := "./" + testFileName(pkg)
 	if coverprofile != "" {
@@ -818,13 +809,8 @@ func (n *numa) testCommand(pkg string, fn string, old bool) *exec.Cmd {
 		// Don't set timeout for race because it takes a longer when race is enabled.
 		args = append(args, []string{"-test.timeout", "2m"}...)
 	}
-	if old {
-		// session.test -test.run '^TestT$' -check.f testTxnStateSerialSuite.TestTxnInfoWithPSProtoco
-		args = append(args, "-test.run", "^TestT$", "-check.f", fn)
-	} else {
-		// session.test -test.run TestClusteredPrefixColum
-		args = append(args, "-test.run", fn)
-	}
+	// session.test -test.run TestClusteredPrefixColum
+	args = append(args, "-test.run", fn)
 
 	return exec.Command(exe, args...)
 }
@@ -916,30 +902,6 @@ func listNewTestCases(pkg string) ([]string, error) {
 	return filter(res, func(s string) bool {
 		return strings.HasPrefix(s, "Test") && s != "TestT" && s != "TestBenchDaily"
 	}), nil
-}
-
-func listOldTestCases(pkg string) (res []string, err error) {
-	exe := "./" + testFileName(pkg)
-
-	// Maybe the restructure is finish on this package.
-	cmd := exec.Command(exe, "-h")
-	cmd.Dir = path.Join(workDir, pkg)
-	buf, err := cmd.CombinedOutput()
-	if err != nil {
-		err = withTrace(err)
-		return
-	}
-	if !bytes.Contains(buf, []byte("check.list")) {
-		// there is no old test case in pkg
-		return
-	}
-
-	// session.test -test.run TestT -check.list Test
-	cmd = exec.Command(exe, "-test.run", "^TestT$", "-check.list", "Test")
-	cmd.Dir = path.Join(workDir, pkg)
-	res, err = cmdToLines(cmd)
-	res = filter(res, func(s string) bool { return strings.Contains(s, "Test") })
-	return res, withTrace(err)
 }
 
 func cmdToLines(cmd *exec.Cmd) ([]string, error) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/34536

Problem Summary:

### What is changed and how it works?
fix the problem that status address isn't accurate. The status address from store might starts with "0.0.0.0".

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Manual test (add detailed scripts or steps below)
Print a special log to check whether the result is correct.

Side effects

- None

Documentation

- None

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
