### PR TITLE
restore: handle delete meta key

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1811,7 +1811,7 @@ func (rc *Client) RestoreMetaKVFiles(
 		}
 
 		if f.Type == backuppb.FileType_Delete {
-			// this should happen normally.
+			// this should happen abnormally.
 			// only do some preventive checks here.
 			log.Warn("detected delete file of meta key, skip it", zap.Any("file", f))
 			continue

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1810,6 +1810,13 @@ func (rc *Client) RestoreMetaKVFiles(
 			continue
 		}
 
+		if f.Type == backuppb.FileType_Delete {
+			// this should happen normally.
+			// only do some preventive checks here.
+			log.Warn("detected delete file of meta key, skip it", zap.Any("file", f))
+			continue
+		}
+
 		err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
 		if err != nil {
 			return errors.Trace(err)

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1801,7 +1801,7 @@ func (rc *Client) RestoreMetaKVFiles(
 ) error {
 	filesInWriteCF := make([]*backuppb.DataFileInfo, 0, len(files))
 
-	// The k-v envets in default CF should be restored firstly. The reason is that:
+	// The k-v events in default CF should be restored firstly. The reason is that:
 	// The error of transactions of meta will happen,
 	// if restore default CF events successfully, but failed to restore write CF events.
 	for _, f := range files {
@@ -1875,7 +1875,14 @@ func (rc *Client) RestoreMetaKVFile(
 		} else if file.Cf == stream.DefaultCF && ts < rc.shiftStartTS {
 			continue
 		}
-
+		if len(txnEntry.Value) == 0 {
+			// we might record duplicated prewrite keys in some conor cases.
+			// the first prewrite key has the value but the second don't.
+			// so we can ignore the empty value key.
+			// see details at https://github.com/pingcap/tiflow/issues/5468.
+			log.Warn("txn entry is null", zap.Uint64("key-ts", ts), zap.ByteString("tnxKey", txnEntry.Key))
+			continue
+		}
 		log.Debug("txn entry", zap.Uint64("key-ts", ts), zap.Int("txnKey-len", len(txnEntry.Key)),
 			zap.Int("txnValue-len", len(txnEntry.Value)), zap.ByteString("txnKey", txnEntry.Key))
 		newEntry, err := sr.RewriteKvEntry(&txnEntry, file.Cf)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/34821

Problem Summary:
we may record the duplicated prewrite key, but only the first key has the value.  similar with https://github.com/pingcap/tiflow/issues/5468.
and raw put kv client will check the value must not be nil.

### What is changed and how it works?

This PR will filter empty value, and the delete file key as possiable.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
