### PR TITLE
session: fix upgrade process for bootstrap v90

### DIFF
--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1835,6 +1835,15 @@ func upgradeToVer89(s Session, ver int64) {
 // to the error log. The message is important since the behavior is weird
 // (changes to the config file will no longer take effect past this point).
 func importConfigOption(s Session, configName, svName, valStr string) {
+	if valStr == "" || valStr == "0" {
+		// We can't technically detect from config if there was no value set. i.e.
+		// a boolean is true/false, not true/false/null.
+		// *However* if there was no value, it does guarantee that it was
+		// not set in the config file. We don't want to import NULL values,
+		// because the behavior will be wrong.
+		// See: https://github.com/pingcap/tidb/issues/34847
+		return
+	}
 	message := fmt.Sprintf("%s is now configured by the system variable %s. One-time importing the value specified in tidb.toml file", configName, svName)
 	logutil.BgLogger().Warn(message, zap.String("value", valStr))
 	// We use insert ignore, since if its a duplicate we don't want to overwrite any user-set values.
@@ -1851,7 +1860,7 @@ func upgradeToVer90(s Session, ver int64) {
 	importConfigOption(s, "enable-batch-dml", variable.TiDBEnableBatchDML, valStr)
 	valStr = fmt.Sprint(config.GetGlobalConfig().MemQuotaQuery)
 	importConfigOption(s, "mem-quota-query", variable.TiDBMemQuotaQuery, valStr)
-	valStr = fmt.Sprint((config.GetGlobalConfig().Log.QueryLogMaxLen), 10)
+	valStr = fmt.Sprint(config.GetGlobalConfig().Log.QueryLogMaxLen)
 	importConfigOption(s, "query-log-max-len", variable.TiDBQueryLogMaxLen, valStr)
 	valStr = fmt.Sprint(config.GetGlobalConfig().Performance.CommitterConcurrency)
 	importConfigOption(s, "committer-concurrency", variable.TiDBCommitterConcurrency, valStr)


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/34847

Problem Summary:

The bootstrap upgrade process did not work when there was no config file present. It has been fixed to handle this case correctly.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

My upgrade script:

```bash
#!/bin/bash

killall -9 tidb-server tikv-server pd-server my-tidb-server
rm -rf /tmp/tidb*
rm -rf /tmp/100*_tidb/
/tmp/my-tidb-server -L warn &

cd ~/go/src/github.com/morgo/tidb
make

sleep 5 

killall -9 tidb-server tikv-server pd-server my-tidb-server
./bin/tidb-server -L warn # -config ~/.tidb.toml
```

Previous output (trimmed for readability):
```
["enable-batch-dml is now configured by the system variable tidb_enable_batch_dml. One-time importing the value specified in tidb.toml file"] [value=OFF]
["mem-quota-query is now configured by the system variable tidb_mem_quota_query. One-time importing the value specified in tidb.toml file"] [value=0]
["query-log-max-len is now configured by the system variable tidb_query_log_max_len. One-time importing the value specified in tidb.toml file"] [value="0 10"]
["committer-concurrency is now configured by the system variable tidb_committer_concurrency. One-time importing the value specified in tidb.toml file"] [value=0]
["run-auto-analyze is now configured by the system variable tidb_enable_auto_analyze. One-time importing the value specified in tidb.toml file"] [value=OFF]
["oom-action is now configured by the system variable tidb_mem_oom_action. One-time importing the value specified in tidb.toml file"] [value=]
["prepared-plan-cache.enable is now configured by the system variable tidb_enable_prepared_plan_cache. One-time importing the value specified in tidb.toml file"] [value=OFF]
["prepared-plan-cache.capacity is now configured by the system variable tidb_prepared_plan_cache_size. One-time importing the value specified in tidb.toml file"] [value=1000]
["prepared-plan-cache.memory-guard-ratio is now configured by the system variable tidb_prepared_plan_cache_memory_guard_ratio. One-time importing the value specified in tidb.toml file"] [value=0.1]
```

New output:

```
["enable-batch-dml is now configured by the system variable tidb_enable_batch_dml. One-time importing the value specified in tidb.toml file"] [value=OFF]
["run-auto-analyze is now configured by the system variable tidb_enable_auto_analyze. One-time importing the value specified in tidb.toml file"] [value=OFF]
["prepared-plan-cache.enable is now configured by the system variable tidb_enable_prepared_plan_cache. One-time importing the value specified in tidb.toml file"] [value=OFF]
["prepared-plan-cache.capacity is now configured by the system variable tidb_prepared_plan_cache_size. One-time importing the value specified in tidb.toml file"] [value=1000]
["prepared-plan-cache.memory-guard-ratio is now configured by the system variable tidb_prepared_plan_cache_memory_guard_ratio. One-time importing the value specified in tidb.toml file"] [value=0.1]
```

Confirming that it still works when a config file is present:

```
["enable-batch-dml is now configured by the system variable tidb_enable_batch_dml. One-time importing the value specified in tidb.toml file"] [value=ON]
["mem-quota-query is now configured by the system variable tidb_mem_quota_query. One-time importing the value specified in tidb.toml file"] [value=1073741824]
["query-log-max-len is now configured by the system variable tidb_query_log_max_len. One-time importing the value specified in tidb.toml file"] [value=4096]
["committer-concurrency is now configured by the system variable tidb_committer_concurrency. One-time importing the value specified in tidb.toml file"] [value=128]
["run-auto-analyze is now configured by the system variable tidb_enable_auto_analyze. One-time importing the value specified in tidb.toml file"] [value=ON]
["oom-action is now configured by the system variable tidb_mem_oom_action. One-time importing the value specified in tidb.toml file"] [value=cancel]
["prepared-plan-cache.enable is now configured by the system variable tidb_enable_prepared_plan_cache. One-time importing the value specified in tidb.toml file"] [value=OFF]
["prepared-plan-cache.capacity is now configured by the system variable tidb_prepared_plan_cache_size. One-time importing the value specified in tidb.toml file"] [value=1000]
["prepared-plan-cache.memory-guard-ratio is now configured by the system variable tidb_prepared_plan_cache_memory_guard_ratio. One-time importing the value specified in tidb.toml file"] [value=0.1]

```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
