### PR TITLE
planner: when transform the parameter in order by positionExpr considering origin projection length

### DIFF
--- a/expression/schema.go
+++ b/expression/schema.go
@@ -46,6 +46,7 @@ type Schema struct {
 	// UniqueKeys stores those unique indexes that allow null values, but Keys does not allow null values.
 	// since equivalence conditions can filter out null values, in this case a unique index with null values can be a Key.
 	UniqueKeys []KeyInfo
+	OldLen     int
 }
 
 // String implements fmt.Stringer interface.
@@ -73,6 +74,7 @@ func (s *Schema) Clone() *Schema {
 	}
 	schema := NewSchema(cols...)
 	schema.SetUniqueKeys(keys)
+	schema.OldLen = s.OldLen
 	return schema
 }
 

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -219,7 +219,6 @@ type expressionRewriter struct {
 	p          LogicalPlan
 	schema     *expression.Schema
 	names      []*types.FieldName
-	oldLen     int
 	err        error
 	aggrMap    map[*ast.AggregateFuncExpr]int
 	windowMap  map[*ast.WindowFuncExpr]int

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -219,6 +219,7 @@ type expressionRewriter struct {
 	p          LogicalPlan
 	schema     *expression.Schema
 	names      []*types.FieldName
+	oldLen     int
 	err        error
 	aggrMap    map[*ast.AggregateFuncExpr]int
 	windowMap  map[*ast.WindowFuncExpr]int
@@ -1417,7 +1418,11 @@ func (er *expressionRewriter) positionToScalarFunc(v *ast.PositionExpr) {
 		}
 		er.err = err
 	}
-	if er.err == nil && pos > 0 && pos <= er.schema.Len() && !er.schema.Columns[pos-1].IsHidden {
+	oldSchemaLen := er.schema.Len()
+	if er.schema.OldLen != 0 {
+		oldSchemaLen = er.schema.OldLen
+	}
+	if er.err == nil && pos > 0 && pos <= oldSchemaLen && !er.schema.Columns[pos-1].IsHidden {
 		er.ctxStackAppend(er.schema.Columns[pos-1], er.names[pos-1])
 	} else {
 		er.err = ErrUnknownColumn.GenWithStackByArgs(str, clauseMsg[er.b.curClause])

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -6649,3 +6649,19 @@ func TestIssue31609(t *testing.T) {
 		"      └─MemTableScan_9 10000.00 root table:TABLES ",
 	))
 }
+
+func TestIssue24667(t *testing.T) {
+	store, _, clean := testkit.CreateMockStoreAndDomain(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("create table t(a int, b int, c int);")
+	tk.MustQuery("select a from t group by a having sum(b) > 0 order by 1;").Check(testkit.Rows())
+	err := tk.ExecToErr("select a from t group by a having sum(b) > 0 order by 2;")
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "[planner:1054]Unknown column '2' in 'order clause'")
+	err = tk.ExecToErr("select a from t group by a having sum(b) > 0 order by 3;")
+	require.NotNil(t, err)
+	require.Equal(t, err.Error(), "[planner:1054]Unknown column '3' in 'order clause'")
+}

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -1310,6 +1310,7 @@ func (b *PlanBuilder) buildProjection(ctx context.Context, p LogicalPlan, fields
 		schema.Append(col)
 		newNames = append(newNames, name)
 	}
+	schema.OldLen = oldLen
 	proj.SetSchema(schema)
 	proj.names = newNames
 	if expandGenerateColumn {


### PR DESCRIPTION
Signed-off-by: AilinKid <314806019@qq.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/24667
Problem Summary:

### What is changed and how it works?
when using the projection's schema to rewrite positionExpr in order by clause, we should consider the origin projection length in which range the positionExpr is valid.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
planner: when transform the parameter in order by clause considering origin projection length
```
