### PR TITLE
config, session: fix import of old variable values

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -761,6 +761,8 @@ var defaultConf = Config{
 	OOMUseTmpStorage:             true,
 	TempStorageQuota:             -1,
 	TempStoragePath:              tempStorageDirName,
+	MemQuotaQuery:                1 << 30,
+	OOMAction:                    "cancel",
 	EnableBatchDML:               false,
 	CheckMb4ValueInUTF8:          *NewAtomicBool(true),
 	MaxIndexLength:               3072,
@@ -791,6 +793,7 @@ var defaultConf = Config{
 		EnableErrorStack:    nbUnset, // If both options are nbUnset, getDisableErrorStack() returns true
 		EnableTimestamp:     nbUnset,
 		DisableTimestamp:    nbUnset, // If both options are nbUnset, getDisableTimestamp() returns false
+		QueryLogMaxLen:      logutil.DefaultQueryLogMaxLen,
 		RecordPlanInSlowLog: logutil.DefaultRecordPlanInSlowLog,
 		EnableSlowLog:       *NewAtomicBool(logutil.DefaultTiDBEnableSlowLog),
 	},
@@ -839,6 +842,7 @@ var defaultConf = Config{
 		TxnTotalSizeLimit:     DefTxnTotalSizeLimit,
 		DistinctAggPushDown:   false,
 		ProjectionPushDown:    false,
+		CommitterConcurrency:  defTiKVCfg.CommitterConcurrency,
 		MaxTxnTTL:             defTiKVCfg.MaxTxnTTL, // 1hour
 		// TODO: set indexUsageSyncLease to 60s.
 		IndexUsageSyncLease:      "0s",
@@ -848,6 +852,7 @@ var defaultConf = Config{
 		StatsLoadConcurrency:     5,
 		StatsLoadQueueSize:       1000,
 		EnableStatsCacheMemQuota: false,
+		RunAutoAnalyze:           true,
 	},
 	ProxyProtocol: ProxyProtocol{
 		Networks:      "",

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1835,15 +1835,6 @@ func upgradeToVer89(s Session, ver int64) {
 // to the error log. The message is important since the behavior is weird
 // (changes to the config file will no longer take effect past this point).
 func importConfigOption(s Session, configName, svName, valStr string) {
-	if valStr == "" || valStr == "0" {
-		// We can't technically detect from config if there was no value set. i.e.
-		// a boolean is true/false, not true/false/null.
-		// *However* if there was no value, it does guarantee that it was
-		// not set in the config file. We don't want to import NULL values,
-		// because the behavior will be wrong.
-		// See: https://github.com/pingcap/tidb/issues/34847
-		return
-	}
 	message := fmt.Sprintf("%s is now configured by the system variable %s. One-time importing the value specified in tidb.toml file", configName, svName)
 	logutil.BgLogger().Warn(message, zap.String("value", valStr))
 	// We use insert ignore, since if its a duplicate we don't want to overwrite any user-set values.


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/34877

Problem Summary:

The fix in https://github.com/pingcap/tidb/pull/34862 did not handle run-auto-analyze correctly. I have reverted that fix, and added a more effective fix.

### What is changed and how it works?

By re-adding the defaultConf values for variables, we can rely on them consistently importing with/without a config file.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

I ran the upgrae process:
````
## without config file

[2022/05/23 06:48:23.102 -06:00] [WARN] [bootstrap.go:1839] ["enable-batch-dml is now configured by the system variable tidb_enable_batch_dml. One-time importing the value specified in tidb.toml file"] [value=OFF]
[2022/05/23 06:48:23.103 -06:00] [WARN] [bootstrap.go:1839] ["mem-quota-query is now configured by the system variable tidb_mem_quota_query. One-time importing the value specified in tidb.toml file"] [value=1073741824]
[2022/05/23 06:48:23.103 -06:00] [WARN] [bootstrap.go:1839] ["query-log-max-len is now configured by the system variable tidb_query_log_max_len. One-time importing the value specified in tidb.toml file"] [value=4096]
[2022/05/23 06:48:23.103 -06:00] [WARN] [bootstrap.go:1839] ["committer-concurrency is now configured by the system variable tidb_committer_concurrency. One-time importing the value specified in tidb.toml file"] [value=128]
[2022/05/23 06:48:23.103 -06:00] [WARN] [bootstrap.go:1839] ["run-auto-analyze is now configured by the system variable tidb_enable_auto_analyze. One-time importing the value specified in tidb.toml file"] [value=ON]
[2022/05/23 06:48:23.104 -06:00] [WARN] [bootstrap.go:1839] ["oom-action is now configured by the system variable tidb_mem_oom_action. One-time importing the value specified in tidb.toml file"] [value=cancel]
[2022/05/23 06:48:23.104 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.enable is now configured by the system variable tidb_enable_prepared_plan_cache. One-time importing the value specified in tidb.toml file"] [value=OFF]
[2022/05/23 06:48:23.104 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.capacity is now configured by the system variable tidb_prepared_plan_cache_size. One-time importing the value specified in tidb.toml file"] [value=1000]
[2022/05/23 06:48:23.104 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.memory-guard-ratio is now configured by the system variable tidb_prepared_plan_cache_memory_guard_ratio. One-time importing the value specified in tidb.toml file"] [value=0.1]

## with config file

[2022/05/23 06:49:01.117 -06:00] [WARN] [bootstrap.go:1839] ["enable-batch-dml is now configured by the system variable tidb_enable_batch_dml. One-time importing the value specified in tidb.toml file"] [value=ON]
[2022/05/23 06:49:01.117 -06:00] [WARN] [bootstrap.go:1839] ["mem-quota-query is now configured by the system variable tidb_mem_quota_query. One-time importing the value specified in tidb.toml file"] [value=1073741824]
[2022/05/23 06:49:01.117 -06:00] [WARN] [bootstrap.go:1839] ["query-log-max-len is now configured by the system variable tidb_query_log_max_len. One-time importing the value specified in tidb.toml file"] [value=4096]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["committer-concurrency is now configured by the system variable tidb_committer_concurrency. One-time importing the value specified in tidb.toml file"] [value=128]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["run-auto-analyze is now configured by the system variable tidb_enable_auto_analyze. One-time importing the value specified in tidb.toml file"] [value=ON]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["oom-action is now configured by the system variable tidb_mem_oom_action. One-time importing the value specified in tidb.toml file"] [value=cancel]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.enable is now configured by the system variable tidb_enable_prepared_plan_cache. One-time importing the value specified in tidb.toml file"] [value=OFF]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.capacity is now configured by the system variable tidb_prepared_plan_cache_size. One-time importing the value specified in tidb.toml file"] [value=1000]
[2022/05/23 06:49:01.118 -06:00] [WARN] [bootstrap.go:1839] ["prepared-plan-cache.memory-guard-ratio is now configured by the system variable tidb_prepared_plan_cache_memory_guard_ratio. One-time importing the value specified in tidb.toml file"] [value=0.1]
````

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
