### PR TITLE
ddl: use `tidb_allow_remove_auto_inc` to control drop column with auto_inc

### DIFF
--- a/ddl/column.go
+++ b/ddl/column.go
@@ -631,15 +631,6 @@ func checkDropColumn(t *meta.Meta, job *model.Job) (*model.TableInfo, *model.Col
 		return nil, nil, nil, errors.Trace(err)
 	}
 	idxInfos := listIndicesWithColumn(colName.L, tblInfo.Indices)
-	if len(idxInfos) > 0 {
-		for _, idxInfo := range idxInfos {
-			err = checkDropIndexOnAutoIncrementColumn(tblInfo, idxInfo)
-			if err != nil {
-				job.State = model.JobStateCancelled
-				return nil, nil, nil, err
-			}
-		}
-	}
 	return tblInfo, colInfo, idxInfos, nil
 }
 

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2701,6 +2701,20 @@ func TestDropColumnWithIndex(t *testing.T) {
 	tk.MustQuery(query).Check(testkit.Rows())
 }
 
+func TestDropColumnWithAutoInc(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int, b int auto_increment, c int, key(b))")
+	defer tk.MustExec("drop table if exists t")
+	tk.MustGetErrCode("alter table t drop column b", errno.ErrUnsupportedDDLOperation)
+	tk.MustExec("set @@tidb_allow_remove_auto_inc = true")
+	tk.MustExec("alter table t drop column b")
+	query := queryIndexOnTable("test", "t")
+	tk.MustQuery(query).Check(testkit.Rows())
+}
+
 func TestDropColumnWithMultiIndex(t *testing.T) {
 	store, clean := testkit.CreateMockStore(t)
 	defer clean()

--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -2707,12 +2707,15 @@ func TestDropColumnWithAutoInc(t *testing.T) {
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
 	tk.MustExec("create table t(a int, b int auto_increment, c int, key(b))")
-	defer tk.MustExec("drop table if exists t")
 	tk.MustGetErrCode("alter table t drop column b", errno.ErrUnsupportedDDLOperation)
 	tk.MustExec("set @@tidb_allow_remove_auto_inc = true")
 	tk.MustExec("alter table t drop column b")
 	query := queryIndexOnTable("test", "t")
 	tk.MustQuery(query).Check(testkit.Rows())
+	tk.MustExec("drop table t")
+
+	tk.MustExec("create table t(a int auto_increment, b int, key(a, b))")
+	tk.MustGetErrCode("alter table t drop column b", errno.ErrUnsupportedDDLOperation)
 }
 
 func TestDropColumnWithMultiIndex(t *testing.T) {

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -4147,7 +4147,7 @@ func checkIsDroppableColumn(ctx sessionctx.Context, t table.Table, spec *ast.Alt
 		return false, dbterror.ErrUnsupportedPKHandle
 	}
 	if mysql.HasAutoIncrementFlag(col.GetFlag()) && !ctx.GetSessionVars().AllowRemoveAutoInc {
-		return false, dbterror.ErrCantDropColWithIndex.GenWithStack("can't remove column with auto_increment when @@tidb_allow_remove_auto_inc disabled")
+		return false, dbterror.ErrCantDropColWithAutoInc
 	}
 	return true, nil
 }

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -4146,6 +4146,9 @@ func checkIsDroppableColumn(ctx sessionctx.Context, t table.Table, spec *ast.Alt
 	if col.IsPKHandleColumn(tblInfo) {
 		return false, dbterror.ErrUnsupportedPKHandle
 	}
+	if mysql.HasAutoIncrementFlag(col.GetFlag()) && !ctx.GetSessionVars().AllowRemoveAutoInc {
+		return false, dbterror.ErrCantDropColWithIndex.GenWithStack("can't remove column with auto_increment when @@tidb_allow_remove_auto_inc disabled")
+	}
 	return true, nil
 }
 

--- a/util/dbterror/ddl_terror.go
+++ b/util/dbterror/ddl_terror.go
@@ -43,7 +43,9 @@ var (
 
 	// ErrCantDropColWithIndex means can't drop the column with index. We don't support dropping column with index covered now.
 	ErrCantDropColWithIndex = ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message(fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation].Raw, "drop column with index"), nil))
-	// ErrUnsupportedAddColumn means add columns is unsupoorted
+	// ErrCantDropColWithAutoInc means can't drop column with auto_increment
+	ErrCantDropColWithAutoInc = ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message(fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation].Raw, "can't remove column with auto_increment when @@tidb_allow_remove_auto_inc disabled"), nil))
+	// ErrUnsupportedAddColumn means add columns is unsupported
 	ErrUnsupportedAddColumn = ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message(fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation].Raw, "add column"), nil))
 	// ErrUnsupportedModifyColumn means modify columns is unsupoorted
 	ErrUnsupportedModifyColumn = ClassDDL.NewStdErr(mysql.ErrUnsupportedDDLOperation, parser_mysql.Message(fmt.Sprintf(mysql.MySQLErrName[mysql.ErrUnsupportedDDLOperation].Raw, "modify column: %s"), nil))


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34891

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
fix can't drop column with auto_inc
```
