### PR TITLE
config, sysvar: fix the missing config of plugins.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -115,8 +115,6 @@ var (
 			map[string]string{
 				"check-mb4-value-in-utf8":       "tidb_check_mb4_value_in_utf8",
 				"enable-collect-execution-info": "tidb_enable_collect_execution_info",
-				"plugin.load":                   "plugin_load",
-				"plugin.dir":                    "plugin_dir",
 			},
 		},
 		{
@@ -132,6 +130,13 @@ var (
 			map[string]string{
 				"force-priority":           "tidb_force_priority",
 				"memory-usage-alarm-ratio": "tidb_memory_usage_alarm_ratio",
+			},
+		},
+		{
+			"plugin",
+			map[string]string{
+				"load": "plugin_load",
+				"dir":  "plugin_dir",
 			},
 		},
 	}

--- a/tidb-server/main.go
+++ b/tidb-server/main.go
@@ -554,10 +554,6 @@ func setGlobalVars() {
 					cfg.Instance.CheckMb4ValueInUTF8.Store(cfg.CheckMb4ValueInUTF8.Load())
 				case "enable-collect-execution-info":
 					cfg.Instance.EnableCollectExecutionInfo = cfg.EnableCollectExecutionInfo
-				case "plugin.load":
-					cfg.Instance.PluginLoad = cfg.Plugin.Load
-				case "plugin.dir":
-					cfg.Instance.PluginDir = cfg.Plugin.Dir
 				}
 			case "log":
 				switch oldName {
@@ -574,6 +570,13 @@ func setGlobalVars() {
 					cfg.Instance.ForcePriority = cfg.Performance.ForcePriority
 				case "memory-usage-alarm-ratio":
 					cfg.Instance.MemoryUsageAlarmRatio = cfg.Performance.MemoryUsageAlarmRatio
+				}
+			case "plugin":
+				switch oldName {
+				case "load":
+					cfg.Instance.PluginLoad = cfg.Plugin.Load
+				case "dir":
+					cfg.Instance.PluginDir = cfg.Plugin.Dir
 				}
 			default:
 			}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34917 

Problem Summary:

When the TiDB cluster upgrades to v6.1.0, the config about plugin is missed.

### What is changed and how it works?

The bug is caused by the wrong convertion of `[plugin]` section in config.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
