### PR TITLE
planner: update the default values of `PreparedPlanCache.Enabled` and `PreparedPlanCache.Capacity` in `defaultConf`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -859,8 +859,8 @@ var defaultConf = Config{
 		HeaderTimeout: 5,
 	},
 	PreparedPlanCache: PreparedPlanCache{
-		Enabled:          false,
-		Capacity:         1000,
+		Enabled:          true,
+		Capacity:         100,
 		MemoryGuardRatio: 0.1,
 	},
 	OpenTracing: OpenTracing{


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34942

Problem Summary: planner: update the default values of `PreparedPlanCache.Enabled` and `PreparedPlanCache.Capacity` in `defaultConf`

### What is changed and how it works?

In v6.1, we moved `PreparedPlanCache.Enabled` and `PreparedPlanCache.Capacity` from the config file to `sysvars` and updated their default values to `(ON, 100)`, but the default values of them in `defaultConf` were not updated as well, which may let an upgraded TiDB cluster still use the old default values `(OFF, 1000)` if the user doesn't specify a config file when upgrading.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
