### PR TITLE
*: Add `tidb_audit_log_version` to control audit log's behavior

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -898,7 +898,12 @@ func (a *ExecStmt) logAudit() {
 		if audit.OnGeneralEvent != nil {
 			cmd := mysql.Command2Str[byte(atomic.LoadUint32(&a.Ctx.GetSessionVars().CommandValue))]
 			ctx := context.WithValue(context.Background(), plugin.ExecStartTimeCtxKey, a.Ctx.GetSessionVars().StartTime)
-			audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
+			switch variable.AuditLogVersion.Load() {
+			case 1:
+				audit.OnGeneralEvent(ctx, sessVars, plugin.Log, cmd)
+			default:
+				audit.OnGeneralEvent(ctx, sessVars, plugin.Completed, cmd)
+			}
 		}
 		return nil
 	})

--- a/plugin/audit.go
+++ b/plugin/audit.go
@@ -24,9 +24,11 @@ import (
 type GeneralEvent byte
 
 const (
-	// Starting represents a GeneralEvent that is about to start
+	// Log presents log event. Only valid when tidb_audit_log_ver=1
+	Log GeneralEvent = iota
+	// Starting represents a GeneralEvent that is about to start. Only valid when tidb_audit_log_ver=1
 	Starting GeneralEvent = iota
-	// Completed represents a GeneralEvent that has completed
+	// Completed represents a GeneralEvent that has completed. Only valid when tidb_audit_log_ver=1
 	Completed
 	// Error represents a GeneralEvent that has error (and typically couldn't start)
 	Error

--- a/plugin/conn_ip_example/conn_ip_example.go
+++ b/plugin/conn_ip_example/conn_ip_example.go
@@ -103,6 +103,8 @@ func OnGeneralEvent(ctx context.Context, sctx *variable.SessionVars, event plugi
 		fmt.Printf("---- executed by user: %#v\n", sctx.User)
 	}
 	switch event {
+	case plugin.Log:
+		fmt.Println("---- event: Log")
 	case plugin.Starting:
 		fmt.Println("---- event: Statement Starting")
 	case plugin.Completed:

--- a/plugin/conn_ip_example/conn_ip_example_test.go
+++ b/plugin/conn_ip_example/conn_ip_example_test.go
@@ -56,6 +56,7 @@ func TestLoadPlugin(t *testing.T) {
 		}, nil
 	}
 	plugin.SetTestHook(loadOne)
+	defer plugin.ClearTestHook()
 
 	// trigger load.
 	err := plugin.Load(ctx, cfg)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -321,6 +321,10 @@ func SetTestHook(fn func(plugin *Plugin, dir string, pluginID ID) (manifest func
 	testHook = &struct{ loadOne loadFn }{loadOne: fn}
 }
 
+func ClearTestHook() {
+	testHook = nil
+}
+
 func loadManifestByGoPlugin(plugin *Plugin, dir string, pluginID ID) (manifest func() *Manifest, err error) {
 	plugin.Path = filepath.Join(dir, string(pluginID)+LibrarySuffix)
 	plugin.library, err = gplugin.Open(plugin.Path)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -321,6 +321,7 @@ func SetTestHook(fn func(plugin *Plugin, dir string, pluginID ID) (manifest func
 	testHook = &struct{ loadOne loadFn }{loadOne: fn}
 }
 
+// ClearTestHook for uint test in custom plugin to clear the test hook.
 func ClearTestHook() {
 	testHook = nil
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -61,9 +61,7 @@ func TestLoadPluginSuccess(t *testing.T) {
 			return ExportManifest(m)
 		}, nil
 	})
-	defer func() {
-		testHook = nil
-	}()
+	defer ClearTestHook()
 
 	// trigger load.
 	err := Load(ctx, cfg)
@@ -136,9 +134,7 @@ func TestLoadPluginSkipError(t *testing.T) {
 			return ExportManifest(m)
 		}, nil
 	})
-	defer func() {
-		testHook = nil
-	}()
+	defer ClearTestHook()
 
 	// trigger load.
 	err := Load(ctx, cfg)
@@ -212,9 +208,7 @@ func TestLoadFail(t *testing.T) {
 			return ExportManifest(m)
 		}, nil
 	})
-	defer func() {
-		testHook = nil
-	}()
+	defer ClearTestHook()
 
 	err := Load(ctx, cfg)
 	require.Error(t, err)

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1570,6 +1570,20 @@ var defaultSysVars = []*SysVar{
 			return nil
 		},
 	},
+	{Scope: ScopeGlobal, Name: TiDBAuditLogVersion, Hidden: true, Value: strconv.Itoa(2), Type: TypeUnsigned, MinValue: 1, MaxValue: 2,
+		GetGlobal: func(s *SessionVars) (string, error) {
+			return strconv.FormatInt(AuditLogVersion.Load(), 10), nil
+		},
+		SetGlobal: func(s *SessionVars, sVal string) error {
+			val, err := strconv.ParseInt(sVal, 10, 64)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			AuditLogVersion.Store(val)
+			return nil
+		},
+	},
 }
 
 // FeedbackProbability points to the FeedbackProbability in statistics package.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -701,6 +701,8 @@ const (
 	TiDBPrepPlanCacheSize = "tidb_prepared_plan_cache_size"
 	// TiDBPrepPlanCacheMemoryGuardRatio is used to prevent [performance.max-memory] from being exceeded
 	TiDBPrepPlanCacheMemoryGuardRatio = "tidb_prepared_plan_cache_memory_guard_ratio"
+	// TiDBAuditLogVersion indicates the version for tidb audit log
+	TiDBAuditLogVersion = "tidb_audit_log_version"
 )
 
 // TiDB intentional limits
@@ -888,6 +890,7 @@ const (
 	DefTiDBEnablePrepPlanCache                   = true
 	DefTiDBPrepPlanCacheSize                     = 100
 	DefTiDBPrepPlanCacheMemoryGuardRatio         = 0.1
+	DefTiDBAuditLogVersion                       = 2
 )
 
 // Process global variables.
@@ -928,6 +931,7 @@ var (
 	GCMaxWaitTime                         = atomic.NewInt64(DefTiDBGCMaxWaitTime)
 	StatsCacheMemQuota                    = atomic.NewInt64(DefTiDBStatsCacheMemQuota)
 	OOMAction                             = atomic.NewString(DefTiDBMemOOMAction)
+	AuditLogVersion                       = atomic.NewInt64(DefTiDBAuditLogVersion)
 	// variables for plan cache
 	EnablePreparedPlanCache           = atomic.NewBool(DefTiDBEnablePrepPlanCache)
 	PreparedPlanCacheSize             = atomic.NewUint64(DefTiDBPrepPlanCacheSize)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34963

### What is changed and how it works?

Added a new hidden variable `tidb_audit_log_version` to control audit log's behavior. It is an unsigned int and has a range [1, 2] , the default value is 2.

When the version is 1, it only logs the sql after it is finished.
When the version is 2,  it will log the sql twice when the sql is starting and finsihed.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
