### PR TITLE
log backup: hidden the log backup and restore point

### DIFF
--- a/br/cmd/br/restore.go
+++ b/br/cmd/br/restore.go
@@ -160,5 +160,6 @@ func newStreamRestoreCommand() *cobra.Command {
 	}
 	task.DefineFilterFlags(command, filterOutSysAndMemTables, true)
 	task.DefineStreamRestoreFlags(command)
+	command.Hidden = true
 	return command
 }

--- a/br/cmd/br/stream.go
+++ b/br/cmd/br/stream.go
@@ -55,6 +55,7 @@ func NewStreamCommand() *cobra.Command {
 		command.Root().HelpFunc()(command, strings)
 	})
 
+	command.Hidden = true
 	return command
 }
 


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/29501

Problem Summary:

### What is changed and how it works?
PiTR future is support in version 6.1.0, in which we hidden the `br log` and `br restore point`.  

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test 
- before hidden
![image](https://user-images.githubusercontent.com/57036248/170535428-e5495f84-5a34-4ebc-9924-8b8e671b9e5b.png)
![image](https://user-images.githubusercontent.com/57036248/170535558-9b694e84-9cfa-4b39-a6c0-c58c52b3a67b.png)

- after hidden
![image](https://user-images.githubusercontent.com/57036248/170535686-c85f86b0-5893-431e-95a1-2e7dc32396ad.png)
![image](https://user-images.githubusercontent.com/57036248/170535784-0ee2c021-b79a-4c7a-893c-54445281bfc6.png)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
