### PR TITLE
config: remove performance.force-priority

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -611,7 +611,6 @@ type Performance struct {
 	FeedbackProbability   float64 `toml:"feedback-probability" json:"feedback-probability"`
 	QueryFeedbackLimit    uint    `toml:"query-feedback-limit" json:"query-feedback-limit"`
 	PseudoEstimateRatio   float64 `toml:"pseudo-estimate-ratio" json:"pseudo-estimate-ratio"`
-	ForcePriority         string  `toml:"force-priority" json:"force-priority"`
 	BindInfoLease         string  `toml:"bind-info-lease" json:"bind-info-lease"`
 	TxnEntrySizeLimit     uint64  `toml:"txn-entry-size-limit" json:"txn-entry-size-limit"`
 	TxnTotalSizeLimit     uint64  `toml:"txn-total-size-limit" json:"txn-total-size-limit"`
@@ -637,6 +636,9 @@ type Performance struct {
 	// CommitterConcurrency, RunAutoAnalyze unused since bootstrap v90
 	CommitterConcurrency int  `toml:"committer-concurrency" json:"committer-concurrency"`
 	RunAutoAnalyze       bool `toml:"run-auto-analyze" json:"run-auto-analyze"`
+
+	// ForcePriority unused since bootstrap v92
+	ForcePriority string `toml:"force-priority" json:"force-priority"`
 }
 
 // PlanCache is the PlanCache section of the config.
@@ -974,6 +976,8 @@ var removedConfig = map[string]struct{}{
 	"prepared-plan-cache.capacity":           {},
 	"prepared-plan-cache.memory-guard-ratio": {},
 	"oom-action":                             {},
+	// use tidb_force_priority
+	"performance.force-priority": {},
 }
 
 // isAllRemovedConfigItems returns true if all the items that couldn't validate

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -264,7 +264,7 @@ delay-clean-table-lock = 0
 # Maximum number of the splitting region, which is used by the split region statement.
 split-region-max-num = 1000
 
-# alter-primary-key is used to control whether the primary keys are clustered. 
+# alter-primary-key is used to control whether the primary keys are clustered.
 # Note that this config is deprecated. Only valid when @@global.tidb_enable_clustered_index = 'int_only'.
 # Default is false, only the integer primary keys are clustered.
 # If it is true, all types of primary keys are nonclustered.
@@ -649,7 +649,7 @@ allow-expression-index = false
 [isolation-read]
 # engines means allow the tidb server read data from which types of engines. options: "tikv", "tiflash", "tidb".
 engines = ["tikv", "tiflash", "tidb"]
-		`, errors.New("The following configuration options are no longer supported in this version of TiDB. Check the release notes for more information: enable-batch-dml, log.query-log-max-len, lower-case-table-names, mem-quota-query, oom-action, performance.committer-concurrency, performance.run-auto-analyze, prepared-plan-cache.capacity, prepared-plan-cache.enabled, prepared-plan-cache.memory-guard-ratio")},
+		`, errors.New("The following configuration options are no longer supported in this version of TiDB. Check the release notes for more information: enable-batch-dml, log.query-log-max-len, lower-case-table-names, mem-quota-query, oom-action, performance.committer-concurrency, performance.force-priority, performance.run-auto-analyze, prepared-plan-cache.capacity, prepared-plan-cache.enabled, prepared-plan-cache.memory-guard-ratio")},
 	}
 
 	for _, test := range configTest {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -1882,8 +1882,7 @@ func upgradeToVer92(s Session, ver int64) {
 	if ver >= version92 {
 		return
 	}
-	valStr := config.GetGlobalConfig().Performance.ForcePriority
-	importConfigOption(s, "performance.force-priority", variable.TiDBForcePriority, valStr)
+	importConfigOption(s, "performance.force-priority", variable.TiDBForcePriority, config.GetGlobalConfig().Performance.ForcePriority)
 }
 
 func writeOOMAction(s Session) {

--- a/session/bootstrap.go
+++ b/session/bootstrap.go
@@ -619,11 +619,13 @@ const (
 	version90 = 90
 	// version91 converts prepared-plan-cache to sysvars
 	version91 = 91
+	// version92 converts performance.force-priority to sysvars
+	version92 = 92
 )
 
 // currentBootstrapVersion is defined as a variable, so we can modify its value for testing.
 // please make sure this is the largest version
-var currentBootstrapVersion int64 = version91
+var currentBootstrapVersion int64 = version92
 
 var (
 	bootstrapVersion = []func(Session, int64){
@@ -718,6 +720,7 @@ var (
 		upgradeToVer89,
 		upgradeToVer90,
 		upgradeToVer91,
+		upgradeToVer92,
 	}
 )
 
@@ -1873,6 +1876,14 @@ func upgradeToVer91(s Session, ver int64) {
 
 	valStr = strconv.FormatFloat(config.GetGlobalConfig().PreparedPlanCache.MemoryGuardRatio, 'f', -1, 64)
 	importConfigOption(s, "prepared-plan-cache.memory-guard-ratio", variable.TiDBPrepPlanCacheMemoryGuardRatio, valStr)
+}
+
+func upgradeToVer92(s Session, ver int64) {
+	if ver >= version92 {
+		return
+	}
+	valStr := config.GetGlobalConfig().Performance.ForcePriority
+	importConfigOption(s, "performance.force-priority", variable.TiDBForcePriority, valStr)
 }
 
 func writeOOMAction(s Session) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #34961 

Problem Summary:

After https://github.com/pingcap/tidb/pull/34927 merges, we should use the same technique to remove the duplicated non-[instance] names from server meta data.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test (Use previous UT)
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```sql
tidb> pager grep priority
PAGER set to 'grep priority'
tidb> select @@tidb_config\G
		"tidb_force_priority": "NO_PRIORITY",
1 row in set (0.00 sec)
```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
