### PR TITLE
parser: revert latin1 as an alias for utf8mb4

### DIFF
--- a/expression/integration_test.go
+++ b/expression/integration_test.go
@@ -648,7 +648,7 @@ func TestStringBuiltin(t *testing.T) {
 	result = tk.MustQuery("select ord('123'), ord(123), ord(''), ord('你好'), ord(NULL), ord('👍')")
 	result.Check(testkit.Rows("49 49 0 14990752 <nil> 4036989325"))
 	result = tk.MustQuery("select ord(X''), ord(X'6161'), ord(X'e4bd'), ord(X'e4bda0'), ord(_ascii'你'), ord(_latin1'你')")
-	result.Check(testkit.Rows("0 97 228 228 228 14990752"))
+	result.Check(testkit.Rows("0 97 228 228 228 228"))
 
 	// for space
 	result = tk.MustQuery(`select space(0), space(2), space(-1), space(1.1), space(1.9)`)

--- a/parser/charset/encoding_latin1.go
+++ b/parser/charset/encoding_latin1.go
@@ -14,11 +14,12 @@
 package charset
 
 import (
+	"bytes"
 	"golang.org/x/text/encoding"
 )
 
 // EncodingLatin1Impl is the instance of encodingLatin1.
-// In TiDB, latin1 is an alias for utf8, so uses utf8 implementation for latin1.
+// TiDB uses utf8 implementation for latin1 charset because of the backward compatibility.
 var EncodingLatin1Impl = &encodingLatin1{encodingUTF8{encodingBase{enc: encoding.Nop}}}
 
 func init() {
@@ -33,4 +34,26 @@ type encodingLatin1 struct {
 // Name implements Encoding interface.
 func (e *encodingLatin1) Name() string {
 	return CharsetLatin1
+}
+
+// Peek implements Encoding interface.
+func (e *encodingLatin1) Peek(src []byte) []byte {
+	if len(src) == 0 {
+		return src
+	}
+	return src[:1]
+}
+
+// IsValid implements Encoding interface.
+func (e *encodingLatin1) IsValid(src []byte) bool {
+	return true
+}
+
+// Tp implements Encoding interface.
+func (e *encodingLatin1) Tp() EncodingTp {
+	return EncodingTpLatin1
+}
+
+func (e *encodingLatin1) Transform(dest *bytes.Buffer, src []byte, op Op) ([]byte, error) {
+	return src, nil
 }

--- a/parser/mysql/charset.go
+++ b/parser/mysql/charset.go
@@ -593,9 +593,9 @@ const (
 	MaxBytesOfCharacter = 4
 )
 
-// IsUTF8Charset checks if charset is utf8, utf8mb4 or latin1.
+// IsUTF8Charset checks if charset is utf8, utf8mb4.
 func IsUTF8Charset(charset string) bool {
-	return charset == UTF8Charset || charset == UTF8MB4Charset || charset == Latin1Charset
+	return charset == UTF8Charset || charset == UTF8MB4Charset
 }
 
 // RangeGraph defines valid unicode characters to use in column names. It strictly follows MySQL's definition.


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/35025
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/34008

Problem Summary: revert incompatible code

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
revert incompatible implement for latin1
```
