### PR TITLE
util/printer: add store to tidb_version() info

### DIFF
--- a/util/printer/printer.go
+++ b/util/printer/printer.go
@@ -58,7 +58,8 @@ func GetTiDBInfo() string {
 		"GoVersion: %s\n"+
 		"Race Enabled: %v\n"+
 		"TiKV Min Version: %s\n"+
-		"Check Table Before Drop: %v",
+		"Check Table Before Drop: %v\n"+
+		"Store: %s",
 		mysql.TiDBReleaseVersion,
 		versioninfo.TiDBEdition,
 		versioninfo.TiDBGitHash,
@@ -67,7 +68,9 @@ func GetTiDBInfo() string {
 		buildVersion,
 		israce.RaceEnabled,
 		versioninfo.TiKVMinVersion,
-		config.CheckTableBeforeDrop)
+		config.CheckTableBeforeDrop,
+		config.GetGlobalConfig().Store,
+	)
 }
 
 // checkValidity checks whether cols and every data have the same length.


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/14487

Problem Summary:

Typically, bug reports include the output of `tidb_version()`. However, this is not always enough to reproduce because many bugs are also store dependent. Previously it was proposed that the store version also be listed - but there's a long discussion to that, and it didn't end. Really just listing the store is sufficient for most cases, since most people run a pretty similarly versioned store to tidb-server.

See https://github.com/pingcap/tidb/issues/35054 for a recent example.

### What is changed and how it works?

The output of the function tidb_server() now includes the store being used (i.e. tikv or unistore).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
tidb> select tidb_version()\G
*************************** 1. row ***************************
tidb_version(): Release Version: v6.2.0-alpha-28-gf51460cd4-dirty
Edition: Community
Git Commit Hash: f51460cd441cb882164ea5c0ff2f2925d7b3e824
Git Branch: add-store-to-tidb-version
UTC Build Time: 2022-05-31 01:28:49
GoVersion: go1.18.2
Race Enabled: false
TiKV Min Version: v3.0.0-60965b006877ca7234adaced7890d7b029ed1306
Check Table Before Drop: false
Store: tikv
1 row in set (0.00 sec)

```
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
The output of the function tidb_server() now includes the store being used (i.e. tikv or unistore).
```
