### PR TITLE
types: GetBinaryLiteral4Cmp returns 0 instead of empty for an empty binary

### DIFF
--- a/table/tables/tables_test.go
+++ b/table/tables/tables_test.go
@@ -956,3 +956,13 @@ func TestTxnAssertion(t *testing.T) {
 	testUntouchedIndexImpl("OFF", false)
 	testUntouchedIndexImpl("OFF", true)
 }
+
+func TestInsertIgnoreBitWithIndex(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("set @@tidb_enable_mutation_checker=1")
+	tk.MustExec("create table t1(a bit not null, key i1(a));")
+	tk.MustExec("insert ignore into t1 values (), (), ();")
+}

--- a/types/datum.go
+++ b/types/datum.go
@@ -301,7 +301,8 @@ func (d *Datum) SetMinNotNull() {
 func (d *Datum) GetBinaryLiteral4Cmp() BinaryLiteral {
 	bitLen := len(d.b)
 	if bitLen == 0 {
-		return d.b
+		// For a binary type, []byte{0} should be equal to []byte{}. So return []byte{0} for an empty binary.
+		return []byte{0}
 	}
 	for i := 0; i < bitLen; i++ {
 		// Remove the prefix 0 in the bit array.


### PR DESCRIPTION
Signed-off-by: ekexium <ekexium@fastmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35140 

Problem Summary:

### What is changed and how it works?

For a binary type, `[]byte{0}` should be equivalent to `[]byte{}`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
