### PR TITLE
br: add search key debug command

### DIFF
--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -402,8 +402,8 @@ func setPDConfigCommand() *cobra.Command {
 
 func searchStreamBackupCommand() *cobra.Command {
 	searchBackupCMD := &cobra.Command{
-		Use:   "search-stream",
-		Short: "search stream backup by key",
+		Use:   "search-log-backup",
+		Short: "search log backup by key",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithCancel(GetDefaultContext())

--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -434,8 +434,10 @@ func searchStreamBackupCommand() *cobra.Command {
 			if err = cfg.ParseFromFlags(cmd.Flags()); err != nil {
 				return errors.Trace(err)
 			}
-
 			_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
+			if err != nil {
+				return errors.Trace(err)
+			}
 			comparator := restore.NewStartWithComparator()
 			bs := restore.NewStreamBackupSearch(s, comparator, keyBytes)
 			bs.SetStartTS(startTs)

--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -461,7 +461,7 @@ func searchStreamBackupCommand() *cobra.Command {
 	flags := searchBackupCMD.Flags()
 	flags.String("search-key", "", "hex encoded key")
 	flags.Uint64("start-ts", 0, "search from start TSO, default is no start TSO limit")
-	flags.Uint64("end-ts", 0, "search from end TSO, default is no end TSO limit")
+	flags.Uint64("end-ts", 0, "search to end TSO, default is no end TSO limit")
 
 	return searchBackupCMD
 }

--- a/br/cmd/br/debug.go
+++ b/br/cmd/br/debug.go
@@ -53,6 +53,7 @@ func NewDebugCommand() *cobra.Command {
 	meta.AddCommand(decodeBackupMetaCommand())
 	meta.AddCommand(encodeBackupMetaCommand())
 	meta.AddCommand(setPDConfigCommand())
+	meta.AddCommand(searchStreamBackupCommand())
 	meta.Hidden = true
 
 	return meta
@@ -397,4 +398,70 @@ func setPDConfigCommand() *cobra.Command {
 		},
 	}
 	return pdConfigCmd
+}
+
+func searchStreamBackupCommand() *cobra.Command {
+	searchBackupCMD := &cobra.Command{
+		Use:   "search-stream",
+		Short: "search stream backup by key",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx, cancel := context.WithCancel(GetDefaultContext())
+			defer cancel()
+
+			searchKey, err := cmd.Flags().GetString("search-key")
+			if err != nil {
+				return errors.Trace(err)
+			}
+			if searchKey == "" {
+				return errors.New("key param can't be empty")
+			}
+			keyBytes, err := hex.DecodeString(searchKey)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			startTs, err := cmd.Flags().GetUint64("start-ts")
+			if err != nil {
+				return errors.Trace(err)
+			}
+			endTs, err := cmd.Flags().GetUint64("end-ts")
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			var cfg task.Config
+			if err = cfg.ParseFromFlags(cmd.Flags()); err != nil {
+				return errors.Trace(err)
+			}
+
+			_, s, err := task.GetStorage(ctx, cfg.Storage, &cfg)
+			comparator := restore.NewStartWithComparator()
+			bs := restore.NewStreamBackupSearch(s, comparator, keyBytes)
+			bs.SetStartTS(startTs)
+			bs.SetEndTs(endTs)
+
+			kvs, err := bs.Search(ctx)
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			kvsBytes, err := json.MarshalIndent(kvs, "", "  ")
+			if err != nil {
+				return errors.Trace(err)
+			}
+
+			cmd.Println("search result")
+			cmd.Println(string(kvsBytes))
+
+			return nil
+		},
+	}
+
+	flags := searchBackupCMD.Flags()
+	flags.String("search-key", "", "hex encoded key")
+	flags.Uint64("start-ts", 0, "search from start TSO, default is no start TSO limit")
+	flags.Uint64("end-ts", 0, "search from end TSO, default is no end TSO limit")
+
+	return searchBackupCMD
 }

--- a/br/pkg/restore/search.go
+++ b/br/pkg/restore/search.go
@@ -1,0 +1,284 @@
+package restore
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"strings"
+	"sync"
+
+	"github.com/pingcap/tidb/util/codec"
+
+	"github.com/pingcap/tidb/br/pkg/utils"
+
+	"github.com/pingcap/errors"
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
+	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"go.uber.org/zap"
+)
+
+const (
+	encodeMarker   = byte(0xFF)
+	encodePadding  = byte(0x0)
+	encodeGroupLen = 8
+)
+
+type Comparator interface {
+	Compare(src, dst []byte) bool
+}
+
+type startWithComparator struct{}
+
+func NewStartWithComparator() Comparator {
+	return new(startWithComparator)
+}
+
+func (ec *startWithComparator) Compare(src, dst []byte) bool {
+	return bytes.HasPrefix(src, dst)
+}
+
+type StreamKVInfo struct {
+	Key       string `json:"key"`
+	WriteType byte   `json:"write_type"`
+	StartTs   uint64 `json:"start_ts"`
+	CommitTs  uint64 `json:"commit_ts"`
+	CFName    string `json:"cf_name"`
+	Value     string `json:"value"`
+}
+
+type StreamBackupSearch struct {
+	storage    storage.ExternalStorage
+	comparator Comparator
+	searchKey  []byte
+	startTs    uint64
+	endTs      uint64
+}
+
+func NewStreamBackupSearch(storage storage.ExternalStorage, comparator Comparator, searchKey []byte) *StreamBackupSearch {
+	bs := &StreamBackupSearch{
+		storage:    storage,
+		comparator: comparator,
+	}
+
+	bs.searchKey = codec.EncodeBytes([]byte{}, searchKey)
+	return bs
+}
+
+func (s *StreamBackupSearch) SetStartTS(startTs uint64) {
+	s.startTs = startTs
+}
+
+func (s *StreamBackupSearch) SetEndTs(endTs uint64) {
+	s.endTs = endTs
+}
+
+func (s *StreamBackupSearch) decodeToRawKey(key []byte) ([]byte, error) {
+	decodedKey := make([]byte, 0, len(key))
+	for len(key) > encodeGroupLen {
+		group := key[:encodeGroupLen+1]
+		key = key[encodeGroupLen+1:]
+		paddingNum := int(encodeMarker - group[encodeGroupLen])
+		if paddingNum < 0 || paddingNum >= encodeGroupLen {
+			return nil, errors.New("invalid padding number")
+		}
+
+		decodedKey = append(decodedKey, group[:encodeGroupLen-paddingNum]...)
+		if paddingNum > 0 {
+			break
+		}
+	}
+
+	decodedKey = append(decodedKey, key...)
+	return decodedKey, nil
+}
+
+func (s *StreamBackupSearch) encodeRawKey(key []byte) []byte {
+	encodedKey := make([]byte, 0, (len(key)/8+1)*9)
+	for len(key) > encodeGroupLen {
+		group := key[:encodeGroupLen]
+		key = key[encodeGroupLen:]
+		encodedKey = append(encodedKey, group...)
+		encodedKey = append(encodedKey, encodeMarker)
+	}
+
+	paddingNum := encodeGroupLen - len(key)
+	encodedKey = append(encodedKey, key...)
+	for i := 0; i < paddingNum; i++ {
+		encodedKey = append(encodedKey, encodePadding)
+	}
+	encodedKey = append(encodedKey, encodeMarker-byte(paddingNum))
+	return encodedKey
+}
+
+func (s *StreamBackupSearch) readDataFiles(ctx context.Context, ch chan<- *backuppb.DataFileInfo) error {
+	opt := &storage.WalkOption{SubDir: GetStreamBackupMetaPrefix()}
+	return s.storage.WalkDir(ctx, opt, func(path string, size int64) error {
+		if strings.Contains(path, streamBackupMetaPrefix) {
+			m := &backuppb.Metadata{}
+			b, err := s.storage.ReadFile(ctx, path)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			err = m.Unmarshal(b)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			// TODO find a way to filter some unnecessary meta files.
+			log.Debug("backup stream collect meta file", zap.String("file", path))
+
+			s.resolveMetaData(ctx, m, ch)
+		}
+		return nil
+	})
+}
+
+func (s *StreamBackupSearch) resolveMetaData(ctx context.Context, metaData *backuppb.Metadata, ch chan<- *backuppb.DataFileInfo) {
+	for _, file := range metaData.Files {
+		if file.IsMeta {
+			continue
+		}
+
+		// TODO dynamically configure filter policy
+		if bytes.Compare(s.searchKey, file.StartKey) < 0 {
+			continue
+		}
+
+		if bytes.Compare(s.searchKey, file.EndKey) > 0 {
+			continue
+		}
+
+		if s.startTs > 0 {
+			if file.MaxTs < s.startTs {
+				continue
+			}
+		}
+
+		if s.endTs > 0 {
+			if file.MinTs > s.endTs {
+				continue
+			}
+		}
+
+		ch <- file
+	}
+}
+
+func (s *StreamBackupSearch) Search(ctx context.Context) ([]*StreamKVInfo, error) {
+	dataFilesCh := make(chan *backuppb.DataFileInfo, 32)
+	go func() {
+		defer close(dataFilesCh)
+		s.readDataFiles(ctx, dataFilesCh) // TODO deal with error
+	}()
+
+	pool := utils.NewWorkerPool(16, "search key")
+	var wg, errWg sync.WaitGroup
+	entriesCh, errCh := make(chan *StreamKVInfo, 64), make(chan error, 8)
+
+	errWg.Add(1)
+	go func() {
+		defer errWg.Done()
+		for err := range errCh {
+			log.Warn("error happened when search data file", zap.Error(err))
+		}
+	}()
+
+	for dataFile := range dataFilesCh {
+		wg.Add(1)
+		file := dataFile
+		pool.Apply(func() {
+			defer wg.Done()
+			if err := s.searchFromDataFile(ctx, file, entriesCh); err != nil {
+				errCh <- err
+			}
+		})
+	}
+
+	go func() {
+		wg.Wait()
+		close(entriesCh)
+		close(errCh)
+	}()
+
+	entries := make([]*StreamKVInfo, 0, 128)
+	for entry := range entriesCh {
+		entries = append(entries, entry)
+	}
+
+	errWg.Wait()
+
+	return entries, nil
+}
+
+func (s *StreamBackupSearch) searchFromDataFile(ctx context.Context, dataFile *backuppb.DataFileInfo, ch chan<- *StreamKVInfo) error {
+	buff, err := s.storage.ReadFile(ctx, dataFile.Path)
+	if err != nil {
+		return errors.Annotatef(err, "read data file error, file: %s", dataFile.Path)
+	}
+
+	if checksum := sha256.Sum256(buff); !bytes.Equal(checksum[:], dataFile.GetSha256()) {
+		return errors.Annotatef(err, "validate checksum failed, file: %s", dataFile.Path)
+	}
+
+	iter := stream.NewEventIterator(buff)
+	for iter.Valid() {
+		iter.Next()
+		if err := iter.GetError(); err != nil {
+			return errors.Trace(err)
+		}
+
+		k, v := iter.Key(), iter.Value()
+
+		if !s.comparator.Compare(k, s.searchKey) {
+			continue
+		}
+
+		_, ts, err := codec.DecodeUintDesc(k[len(k)-8:])
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		k = k[:len(k)-8]
+		_, rawKey, err := codec.DecodeBytes(k, nil)
+		if err != nil {
+			return errors.Trace(err)
+		}
+
+		if dataFile.Cf == writeCFName {
+			rawWriteCFValue := new(stream.RawWriteCFValue)
+			rawWriteCFValue.HasShortValue()
+			if err := rawWriteCFValue.ParseFrom(v); err != nil {
+				return errors.Trace(err)
+			}
+
+			valueStr := ""
+			if rawWriteCFValue.HasShortValue() {
+				valueStr = base64.StdEncoding.EncodeToString(rawWriteCFValue.GetShortValue())
+			}
+
+			kvInfo := &StreamKVInfo{
+				WriteType: rawWriteCFValue.GetWriteType(),
+				CFName:    dataFile.Cf,
+				CommitTs:  ts,
+				StartTs:   rawWriteCFValue.GetStartTs(),
+				Key:       strings.ToUpper(hex.EncodeToString(rawKey)),
+				Value:     valueStr,
+			}
+			ch <- kvInfo
+		} else if dataFile.Cf == defaultCFName {
+			kvInfo := &StreamKVInfo{
+				CFName:  dataFile.Cf,
+				StartTs: ts,
+				Key:     strings.ToUpper(hex.EncodeToString(rawKey)),
+				Value:   base64.StdEncoding.EncodeToString(v),
+			}
+			ch <- kvInfo
+		}
+	}
+
+	log.Info("finish search data file", zap.String("file", dataFile.Path))
+	return nil
+}

--- a/br/pkg/restore/search_test.go
+++ b/br/pkg/restore/search_test.go
@@ -1,4 +1,4 @@
-// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+// Copyright 2022 PingCAP, Inc. Licensed under Apache-2.0.
 
 package restore
 

--- a/br/pkg/restore/search_test.go
+++ b/br/pkg/restore/search_test.go
@@ -1,0 +1,67 @@
+package restore
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/pingcap/tidb/tablecodec"
+
+	"github.com/pingcap/tidb/kv"
+
+	"github.com/pingcap/tidb/util/codec"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pingcap/tidb/br/pkg/storage"
+)
+
+func TestSearchKey(t *testing.T) {
+	key, err := hex.DecodeString("7480000000000000BC5F72800000000000003A")
+	require.NoError(t, err)
+	backend, err := storage.ParseBackend("s3://stream/2022-05-20/1?access-key=XG0Z3WGDWX7J1PM3ORCM&secret-access-key=7OFdwBCBonZ8+WHF6QTBerEeq7diFXScAyS3rBlI&endpoint=http://172.16.102.96:9000&force-path-style=true", nil)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	s, err := storage.New(ctx, backend, &storage.ExternalStorageOptions{SendCredentials: false})
+	require.NoError(t, err)
+
+	comparator := NewStartWithComparator()
+	streamBackupSearch := NewStreamBackupSearch(s, comparator, key)
+	kvs, err := streamBackupSearch.Search(ctx)
+	require.NoError(t, err)
+
+	for _, row := range kvs {
+		t.Log(row)
+		t.Log("key:", row.Key)
+		t.Log("value:", row.Value)
+	}
+}
+
+func TestEncodedKey(t *testing.T) {
+	key, err := hex.DecodeString("74800000000000003B5F69800000000000000203800000000000000105BFF199999999999A013131310000000000FA")
+	require.NoError(t, err)
+
+	tableID, indexID, indexValues, err := tablecodec.DecodeIndexKey(key)
+	require.NoError(t, err)
+	t.Log("table id", tableID, "index id", indexID, "index values", indexValues)
+
+	t.Log(string(key[:1]))
+	key = key[1:]
+	key, tableID, err = codec.DecodeInt(key)
+	require.NoError(t, err)
+	t.Log("table id", tableID)
+
+	t.Log("split", string(key[:2]))
+	key = key[2:]
+
+	t.Log(key)
+
+	key, intHandle, err := codec.DecodeInt(key)
+	handle := kv.IntHandle(intHandle)
+
+	t.Log(handle.Encoded())
+	t.Log(handle.IntValue())
+
+	t.Log(key)
+}

--- a/br/pkg/restore/search_test.go
+++ b/br/pkg/restore/search_test.go
@@ -1,67 +1,203 @@
+// Copyright 2021 PingCAP, Inc. Licensed under Apache-2.0.
+
 package restore
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/hex"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/pingcap/tidb/tablecodec"
-
-	"github.com/pingcap/tidb/kv"
-
-	"github.com/pingcap/tidb/util/codec"
-
-	"github.com/stretchr/testify/require"
-
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/br/pkg/stream"
+	"github.com/pingcap/tidb/util/codec"
+	"github.com/stretchr/testify/require"
 )
 
-func TestSearchKey(t *testing.T) {
-	key, err := hex.DecodeString("7480000000000000BC5F72800000000000003A")
-	require.NoError(t, err)
-	backend, err := storage.ParseBackend("s3://stream/2022-05-20/1?access-key=XG0Z3WGDWX7J1PM3ORCM&secret-access-key=7OFdwBCBonZ8+WHF6QTBerEeq7diFXScAyS3rBlI&endpoint=http://172.16.102.96:9000&force-path-style=true", nil)
-	require.NoError(t, err)
-
-	ctx := context.Background()
-	s, err := storage.New(ctx, backend, &storage.ExternalStorageOptions{SendCredentials: false})
-	require.NoError(t, err)
-
+func TestStartWithComparator(t *testing.T) {
 	comparator := NewStartWithComparator()
-	streamBackupSearch := NewStreamBackupSearch(s, comparator, key)
-	kvs, err := streamBackupSearch.Search(ctx)
-	require.NoError(t, err)
-
-	for _, row := range kvs {
-		t.Log(row)
-		t.Log("key:", row.Key)
-		t.Log("value:", row.Value)
-	}
+	require.True(t, comparator.Compare([]byte("aa_key"), []byte("aa")))
+	require.False(t, comparator.Compare([]byte("aa_key"), []byte("aak")))
+	require.False(t, comparator.Compare([]byte("aa_key"), []byte("bb")))
 }
 
-func TestEncodedKey(t *testing.T) {
-	key, err := hex.DecodeString("74800000000000003B5F69800000000000000203800000000000000105BFF199999999999A013131310000000000FA")
+func fakeStorage(t *testing.T) storage.ExternalStorage {
+	baseDir := t.TempDir()
+	s, err := storage.NewLocalStorage(baseDir)
 	require.NoError(t, err)
+	return s
+}
 
-	tableID, indexID, indexValues, err := tablecodec.DecodeIndexKey(key)
+func encodeKey(key string, ts int64) []byte {
+	encodedKey := codec.EncodeBytes([]byte{}, []byte(key))
+	return codec.EncodeUintDesc(encodedKey, uint64(ts))
+}
+
+func encodeShortValue(val string, ts int64) []byte {
+	flagShortValuePrefix := byte('v')
+	valBytes := []byte(val)
+	buff := make([]byte, 0, 11+len(valBytes))
+	buff = append(buff, byte('P'))
+	buff = codec.EncodeUvarint(buff, uint64(ts))
+	buff = append(buff, flagShortValuePrefix)
+	buff = append(buff, byte(len(valBytes)))
+	buff = append(buff, valBytes...)
+	return buff
+}
+
+type cf struct {
+	key      string
+	startTs  int64
+	commitTS int64
+	val      string
+}
+
+func fakeCFs() (defaultCFs, writeCFs []*cf) {
+	defaultCFs = []*cf{
+		{
+			key:     "aa_big_key_1",
+			startTs: time.Now().UnixNano(),
+			val:     "aa_big_val_1",
+		},
+		{
+			key:     "bb_big_key_1",
+			startTs: time.Now().UnixNano(),
+			val:     "bb_big_val_1",
+		},
+		{
+			key:     "cc_big_key_1",
+			startTs: time.Now().UnixNano(),
+			val:     "cc_big_val_1",
+		},
+	}
+
+	writeCFs = []*cf{
+		{
+			key:      "aa_small_key_1",
+			startTs:  time.Now().UnixNano(),
+			commitTS: time.Now().UnixNano(),
+			val:      "aa_small_val_1",
+		},
+		{
+			key:      "aa_big_key_1",
+			startTs:  defaultCFs[0].startTs,
+			commitTS: time.Now().UnixNano(),
+			val:      "aa_short_val_1",
+		},
+		{
+			key:      "bb_small_key_1",
+			startTs:  time.Now().UnixNano(),
+			commitTS: time.Now().UnixNano(),
+			val:      "bb_small_val_1",
+		},
+		{
+			key:      "bb_big_key_1",
+			startTs:  defaultCFs[1].startTs,
+			commitTS: time.Now().UnixNano(),
+			val:      "bb_short_val_1",
+		},
+	}
+
+	return
+}
+
+func fakeDataFile(t *testing.T, s storage.ExternalStorage) (defaultCFDataFile, writeCFDataFile *backuppb.DataFileInfo) {
+	const (
+		defaultCFFile = "default_cf"
+		writeCFFile   = "write_cf"
+	)
+	defaultCFs, writeCFs := fakeCFs()
+	ctx := context.Background()
+	defaultCFBuf := bytes.NewBuffer([]byte{})
+	for _, defaultCF := range defaultCFs {
+		defaultCFBuf.Write(stream.EncodeKVEntry(encodeKey(defaultCF.key, defaultCF.startTs), []byte(defaultCF.val)))
+	}
+
+	err := s.WriteFile(ctx, defaultCFFile, defaultCFBuf.Bytes())
 	require.NoError(t, err)
-	t.Log("table id", tableID, "index id", indexID, "index values", indexValues)
+	defaultCFCheckSum := sha256.Sum256(defaultCFBuf.Bytes())
+	defaultCFDataFile = &backuppb.DataFileInfo{
+		Path:   defaultCFFile,
+		Cf:     defaultCFName,
+		Sha256: defaultCFCheckSum[:],
+	}
 
-	t.Log(string(key[:1]))
-	key = key[1:]
-	key, tableID, err = codec.DecodeInt(key)
+	writeCFBuf := bytes.NewBuffer([]byte{})
+	for _, writeCF := range writeCFs {
+		writeCFBuf.Write(stream.EncodeKVEntry(encodeKey(writeCF.key, writeCF.commitTS), encodeShortValue(writeCF.val, writeCF.startTs)))
+	}
+
+	err = s.WriteFile(ctx, writeCFFile, writeCFBuf.Bytes())
 	require.NoError(t, err)
-	t.Log("table id", tableID)
+	writeCFCheckSum := sha256.Sum256(writeCFBuf.Bytes())
+	writeCFDataFile = &backuppb.DataFileInfo{
+		Path:   writeCFFile,
+		Cf:     writeCFName,
+		Sha256: writeCFCheckSum[:],
+	}
 
-	t.Log("split", string(key[:2]))
-	key = key[2:]
+	return
+}
 
-	t.Log(key)
+func TestSearchFromDataFile(t *testing.T) {
+	s := fakeStorage(t)
+	defaultCFDataFile, writeCFDataFile := fakeDataFile(t, s)
+	comparator := NewStartWithComparator()
+	searchKey := []byte("aa_big_key_1")
+	bs := NewStreamBackupSearch(s, comparator, searchKey)
+	ch := make(chan *StreamKVInfo, 16)
+	ctx := context.Background()
 
-	key, intHandle, err := codec.DecodeInt(key)
-	handle := kv.IntHandle(intHandle)
+	err := bs.searchFromDataFile(ctx, defaultCFDataFile, ch)
+	require.NoError(t, err)
+	err = bs.searchFromDataFile(ctx, writeCFDataFile, ch)
+	require.NoError(t, err)
+	close(ch)
 
-	t.Log(handle.Encoded())
-	t.Log(handle.IntValue())
+	hexSearchKey := strings.ToUpper(hex.EncodeToString(searchKey))
+	searchKeyCount := 0
+	for kvEntry := range ch {
+		require.True(t, strings.HasPrefix(kvEntry.Key, hexSearchKey))
+		searchKeyCount++
+	}
 
-	t.Log(key)
+	require.Equal(t, 2, searchKeyCount)
+}
+
+func TestMergeCFEntries(t *testing.T) {
+	defaultCFs, writeCFs := fakeCFs()
+	defaultCFEntries := make(map[string]*StreamKVInfo, 8)
+	writeCFEntries := make(map[string]*StreamKVInfo, 8)
+
+	for _, defaultCF := range defaultCFs {
+		encodedKey := hex.EncodeToString(encodeKey(defaultCF.key, defaultCF.startTs))
+		defaultCFEntries[encodedKey] = &StreamKVInfo{
+			Key:        hex.EncodeToString([]byte(defaultCF.key)),
+			EncodedKey: encodedKey,
+			StartTs:    uint64(defaultCF.startTs),
+			CFName:     defaultCFName,
+			Value:      defaultCF.val,
+		}
+	}
+	for _, writeCF := range writeCFs {
+		encodedKey := hex.EncodeToString(encodeKey(writeCF.key, writeCF.commitTS))
+		writeCFEntries[encodedKey] = &StreamKVInfo{
+			Key:        hex.EncodeToString([]byte(writeCF.key)),
+			EncodedKey: encodedKey,
+			StartTs:    uint64(writeCF.startTs),
+			CommitTs:   uint64(writeCF.commitTS),
+			CFName:     writeCFName,
+			Value:      writeCF.val,
+		}
+	}
+
+	s := fakeStorage(t)
+	comparator := NewStartWithComparator()
+	bs := NewStreamBackupSearch(s, comparator, []byte{})
+	kvEntries := bs.mergeCFEntries(defaultCFEntries, writeCFEntries)
+	require.Equal(t, len(writeCFs)+1, len(kvEntries))
 }

--- a/br/pkg/stream/meta_kv.go
+++ b/br/pkg/stream/meta_kv.go
@@ -179,6 +179,14 @@ func (v *RawWriteCFValue) UpdateShortValue(value []byte) {
 	v.shortValue = value
 }
 
+func (v *RawWriteCFValue) GetStartTs() uint64 {
+	return v.startTs
+}
+
+func (v *RawWriteCFValue) GetWriteType() byte {
+	return v.t
+}
+
 // EncodeTo encodes the RawWriteCFValue to get encoded value.
 func (v *RawWriteCFValue) EncodeTo() []byte {
 	data := make([]byte, 0, 9)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35327

Problem Summary:

add debug command of searching key from log data files.

### What is changed and how it works?

1. get log data files related to searching key by walking all backup meta files.
2. read log data files from step 1, decode key and value, then compare key with searching key.
3. get all KV entries matched searching key, and merge KV entries from write CF and default CF.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
