### PR TITLE
executor: add the missed runtime stats when the index merge partial task returns 0 row

### DIFF
--- a/executor/explain_test.go
+++ b/executor/explain_test.go
@@ -424,3 +424,21 @@ func TestFix29401(t *testing.T) {
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin;`)
 	tk.MustExec(" explain select /*+ inl_hash_join(t1) */ * from tt123 t1 join tt123 t2 on t1.b=t2.e;")
 }
+
+func TestIssue35296(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t(a int, b int , c int, d int, e int,index ia(a), index ib(b), index ic(c), index idd(d), index ie(e));")
+
+	rows := tk.MustQuery("explain analyze select * from t where a = 10 or b = 30 or c = 10 or d = 1 or e = 90;").Rows()
+
+	require.Contains(t, rows[0][0], "IndexMerge")
+	require.NotRegexp(t, "^time:0s", rows[1][5])
+	require.NotRegexp(t, "^time:0s", rows[2][5])
+	require.NotRegexp(t, "^time:0s", rows[3][5])
+	require.NotRegexp(t, "^time:0s", rows[4][5])
+	require.NotRegexp(t, "^time:0s", rows[5][5])
+}

--- a/executor/index_merge_reader.go
+++ b/executor/index_merge_reader.go
@@ -820,6 +820,9 @@ func (w *partialIndexWorker) fetchHandles(
 			return count, err
 		}
 		if len(handles) == 0 {
+			if basicStats != nil {
+				basicStats.Record(time.Since(start), chk.NumRows())
+			}
 			return count, nil
 		}
 		count += int64(len(handles))


### PR DESCRIPTION
### What problem does this PR solve?


Issue Number: close #35296 

Problem Summary:

If the there is no more handle, the time for this cop task execution is not recorded.

### What is changed and how it works?

Record the missed information.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
