### PR TITLE
executor: fix panic when granting privilege to a non-exists user

### DIFF
--- a/executor/grant.go
+++ b/executor/grant.go
@@ -163,7 +163,7 @@ func (e *GrantExec) Next(ctx context.Context, req *chunk.Chunk) error {
 				return errors.Trace(ErrPasswordFormat)
 			}
 			authPlugin := mysql.AuthNativePassword
-			if user.AuthOpt.AuthPlugin != "" {
+			if user.AuthOpt != nil && user.AuthOpt.AuthPlugin != "" {
 				authPlugin = user.AuthOpt.AuthPlugin
 			}
 			_, err := internalSession.(sqlexec.SQLExecutor).ExecuteInternal(ctx,

--- a/executor/grant_test.go
+++ b/executor/grant_test.go
@@ -260,6 +260,13 @@ func TestCreateUserWhenGrant(t *testing.T) {
 		testkit.Rows("test"),
 	)
 	tk.MustExec(`DROP USER IF EXISTS 'test'@'%'`)
+	// Grant without a password.
+	tk.MustExec(`GRANT ALL PRIVILEGES ON *.* to 'test'@'%'`)
+	// Make sure user is created automatically when grant to a non-exists one.
+	tk.MustQuery(`SELECT user, plugin FROM mysql.user WHERE user='test' and host='%'`).Check(
+		testkit.Rows("test mysql_native_password"),
+	)
+	tk.MustExec(`DROP USER IF EXISTS 'test'@'%'`)
 }
 
 func TestCreateUserWithTooLongName(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35310

Problem Summary:

When `sql_mode` doesn't contain `NO_AUTO_CREATE_USER` and the grant statement doesn't contain a password, TiDB will panic because of a previous PR that supports auth-plugin.

### What is changed and how it works?

Check nil.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
