### PR TITLE
types: fix creating partition tables fail in ANSI_QUOTES mode

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -3615,3 +3615,19 @@ func TestDuplicatePartitionNames(t *testing.T) {
 		"(PARTITION `p2` VALUES IN (2),\n" +
 		" PARTITION `p3` VALUES IN (3))"))
 }
+
+func TestPartitionTableWithAnsiQuotes(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database partitionWithAnsiQuotes")
+	defer tk.MustExec("drop database partitionWithAnsiQuotes")
+	tk.MustExec("use partitionWithAnsiQuotes")
+	tk.MustExec("SET SESSION sql_mode='ANSI_QUOTES'")
+	tk.MustExec(`create table t1(created_at datetime) PARTITION BY RANGE COLUMNS(created_at) (
+		PARTITION p0 VALUES LESS THAN ('2021-12-01 00:00:00'),
+		PARTITION p1 VALUES LESS THAN ('2022-01-01 00:00:00'))`)
+	tk.MustExec(`create table t2(created_at timestamp) PARTITION BY RANGE (unix_timestamp(created_at)) (
+		PARTITION p0 VALUES LESS THAN (unix_timestamp('2021-12-01 00:00:00')),
+		PARTITION p1 VALUES LESS THAN (unix_timestamp('2022-01-01 00:00:00')))`)
+}

--- a/types/parser_driver/value_expr.go
+++ b/types/parser_driver/value_expr.go
@@ -165,7 +165,10 @@ func (n *ValueExpr) Format(w io.Writer) {
 	case types.KindFloat64:
 		s = strconv.FormatFloat(n.GetFloat64(), 'e', -1, 64)
 	case types.KindString, types.KindBytes:
-		s = strconv.Quote(n.GetString())
+		// If sql_mode='ANSI_QUOTES', strings with double-quotes will be taken as an identifier.
+		// See #35281.
+		s = strings.Replace(n.GetString(), `'`, `''`, -1)
+		s = fmt.Sprintf("'%s'", s)
 	case types.KindMysqlDecimal:
 		s = n.GetMysqlDecimal().String()
 	case types.KindBinaryLiteral:

--- a/types/parser_driver/value_expr_test.go
+++ b/types/parser_driver/value_expr_test.go
@@ -55,3 +55,32 @@ func TestValueExprRestore(t *testing.T) {
 		})
 	}
 }
+
+func TestValueExprFormat(t *testing.T) {
+	tests := []struct {
+		datum  types.Datum
+		expect string
+	}{
+		{types.NewDatum(nil), "NULL"},
+		{types.NewIntDatum(1), "1"},
+		{types.NewIntDatum(-1), "-1"},
+		{types.NewUintDatum(1), "1"},
+		{types.NewFloat32Datum(1.1), "1.1e+00"},
+		{types.NewFloat64Datum(1.1), "1.1e+00"},
+		{types.NewStringDatum("test `s't\"r."), "'test `s''t\"r.'"},
+		{types.NewBytesDatum([]byte("test `s't\"r.")), "'test `s''t\"r.'"},
+		{types.NewBinaryLiteralDatum([]byte("test `s't\"r.")), "b'11101000110010101110011011101000010000001100000011100110010011101110100001000100111001000101110'"},
+		{types.NewDecimalDatum(types.NewDecFromInt(321)), "321"},
+		{types.NewStringDatum("\\"), "'\\'"},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.expect, func(t *testing.T) {
+			var sb strings.Builder
+			expr := &ValueExpr{Datum: test.datum}
+			expr.Format(&sb)
+			require.Equalf(t, test.expect, sb.String(), "datum: %#v", test.datum)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35281, #24980

Problem Summary:
- the expression `'2022-01-01 00:00:00'` is formatted as "2022-01-01 00:00:00" in `buildRangePartitionDefinitions`
- `ParseSimpleExprWithTableInfo` creates the statement `select "2022-01-01 00:00:00"` to eval the value
- `"2022-01-01 00:00:00"` is taken as an identifier since `sql_mode = 'ANSI_QUOTES'`.

### What is changed and how it works?

Format the string with single quotes, because single quotes always work.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
