### PR TITLE
ddl: skip shard_row_id_bits check if it is zero

### DIFF
--- a/ddl/table.go
+++ b/ddl/table.go
@@ -857,12 +857,14 @@ func (w *worker) onShardRowID(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int6
 }
 
 func verifyNoOverflowShardBits(s *sessionPool, tbl table.Table, shardRowIDBits uint64) error {
+	if shardRowIDBits == 0 {
+		return nil
+	}
 	ctx, err := s.get()
 	if err != nil {
 		return errors.Trace(err)
 	}
 	defer s.put(ctx)
-
 	// Check next global max auto ID first.
 	autoIncID, err := tbl.Allocators(ctx).Get(autoid.RowIDAllocType).NextGlobalAutoID()
 	if err != nil {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35406

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)

Since it is not possible to have both `shard_row_id_bits` and clustered pk in master, I remove the check:

```diff
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2833,9 +2833,9 @@ func handleTableOptions(options []*ast.TableOption, tbInfo *model.TableInfo) err
                case ast.TableOptionCompression:
                        tbInfo.Compression = op.StrValue
                case ast.TableOptionShardRowID:
-                       if op.UintValue > 0 && tbInfo.HasClusteredIndex() {
-                               return dbterror.ErrUnsupportedShardRowIDBits
-                       }
+                       //if op.UintValue > 0 && tbInfo.HasClusteredIndex() {
+                       //      return dbterror.ErrUnsupportedShardRowIDBits
+                       //}
                        tbInfo.ShardRowIDBits = op.UintValue
```

And I create the table:

```sql
mysql> create table t (a int primary key) shard_row_id_bits = 4;
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t;
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                                              |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) NOT NULL,
  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin /*T! SHARD_ROW_ID_BITS=4 */ |
+-------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```

After this PR:

```sql
mysql> alter table t shard_row_id_bits = 0;
Query OK, 0 rows affected (0.03 sec)

mysql> show create table t;
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Table | Create Table                                                                                                                                                  |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
| t     | CREATE TABLE `t` (
  `a` int(11) NOT NULL,
  PRIMARY KEY (`a`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin |
+-------+---------------------------------------------------------------------------------------------------------------------------------------------------------------+
1 row in set (0.00 sec)
```

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
