### PR TITLE
planner: introduce new cost formula for IndexLookup

### DIFF
--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -241,11 +241,11 @@ func (p *PhysicalIndexLookUpReader) GetPlanCost(taskType property.TaskType, cost
 func (p *PhysicalIndexLookUpReader) estNumDoubleReadTasks(costFlag uint64) float64 {
 	doubleReadRows := p.indexPlan.StatsCount()
 	batchSize := float64(p.ctx.GetSessionVars().IndexLookupSize)
-	magicRatio := 40.0 // indicate how many requests corresponding to a batch
-	// TODO: consider correlation between index and PK to make it more accurate.
-	numDoubleReadTasks := (doubleReadRows / batchSize) * magicRatio
-	// use Float64 instead of Int like `Ceil(numDoubleReadTasks)` to make the cost continuous.
-	return numDoubleReadTasks
+	// distRatio indicates how many requests corresponding to a batch, current value is from experiments.
+	// TODO: estimate it by using index correlation or make it configurable.
+	distRatio := 40.0
+	numDoubleReadTasks := (doubleReadRows / batchSize) * distRatio
+	return numDoubleReadTasks // use Float64 instead of Int like `Ceil(...)` to make the cost continuous
 }
 
 // GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35240

Problem Summary: introduce new cost formula for IndexLookup

### What is changed and how it works?

Introduce new cost formula for IndexLookup: accumulate the real double-read cost:
1. `doubleReadCost = numDoubleReadTasks * SeekFactor`;
2. `numDoubleReadTasks` is based on a magic number `distRatio=40`, `doubleReadRows / IndexBatchSize * distRatio`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
