### PR TITLE
init ddl tables

### DIFF
--- a/ddl/constant.go
+++ b/ddl/constant.go
@@ -1,0 +1,24 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ddl
+
+const (
+	// JobTable stores the information of DDL jobs.
+	JobTable = "tidb_ddl_job"
+	// ReorgTable stores the information of DDL reorganization.
+	ReorgTable = "tidb_ddl_reorg"
+	// HistoryTable stores the history DDL jobs.
+	HistoryTable = "tidb_ddl_history"
+)

--- a/meta/meta.go
+++ b/meta/meta.go
@@ -76,6 +76,7 @@ var (
 	mPolicyPrefix     = "Policy"
 	mPolicyGlobalID   = []byte("PolicyGlobalID")
 	mPolicyMagicByte  = CurrentMagicByteVer
+	mInitDDLTable     = []byte("initDDLTable")
 )
 
 const (
@@ -486,6 +487,53 @@ func (m *Meta) CreateTableOrView(dbID int64, tableInfo *model.TableInfo) error {
 	}
 
 	return m.txn.HSet(dbKey, tableKey, data)
+}
+
+// SetDDLTables write a key into storage.
+func (m *Meta) SetDDLTables() error {
+	return m.txn.Set(mInitDDLTable, []byte("some value"))
+}
+
+// CreateMySQLSchema create mysql schema
+func (m *Meta) CreateMySQLSchema() (int64, error) {
+	dbs, err := m.ListDatabases()
+	if err != nil {
+		return 0, err
+	}
+	if len(dbs) != 0 {
+		for _, db := range dbs {
+			if db.Name.L == mysql.SystemDB {
+				return db.ID, nil
+			}
+		}
+	}
+
+	id, err := m.GenGlobalID()
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+	db := model.DBInfo{
+		ID:      id,
+		Name:    model.NewCIStr(mysql.SystemDB),
+		Charset: mysql.UTF8MB4Charset,
+		Collate: mysql.UTF8MB4DefaultCollation,
+		State:   model.StatePublic,
+	}
+	data, err := json.Marshal(db)
+	if err != nil {
+		return 0, errors.Trace(err)
+	}
+
+	return db.ID, m.txn.HSet(mDBs, m.dbKey(db.ID), data)
+}
+
+// CheckDDLTableExists check if the tables related to concurrent DDL exists.
+func (m *Meta) CheckDDLTableExists() (bool, error) {
+	v, err := m.txn.Get(mInitDDLTable)
+	if err != nil {
+		return false, errors.Trace(err)
+	}
+	return len(v) != 0, nil
 }
 
 // CreateTableAndSetAutoID creates a table with tableInfo in database,

--- a/session/session_test.go
+++ b/session/session_test.go
@@ -1,0 +1,54 @@
+// Copyright 2022 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package session_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/pingcap/tidb/session"
+	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/testkit/external"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInitMetaTable(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	for _, sql := range session.DDLJobTables {
+		tk.MustExec(sql)
+	}
+
+	tbls := map[string]struct{}{
+		"tidb_ddl_job":     {},
+		"tidb_ddl_reorg":   {},
+		"tidb_ddl_history": {},
+	}
+
+	for tbl := range tbls {
+		metaInMySQL := external.GetTableByName(t, tk, "mysql", tbl).Meta()
+		metaInTest := external.GetTableByName(t, tk, "test", tbl).Meta()
+
+		require.Greater(t, metaInMySQL.ID, 0)
+		require.Greater(t, metaInMySQL.UpdateTS, 0)
+
+		metaInTest.ID = metaInMySQL.ID
+		metaInMySQL.UpdateTS = metaInTest.UpdateTS
+		require.True(t, reflect.DeepEqual(metaInMySQL, metaInTest))
+	}
+}


### PR DESCRIPTION
create tidb_ddl_job, tidb_ddl_reorg, tidb_ddl_history tables with raw meta write, these 3 tables is use to replace the ddl job queue and reorg and history hash table

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
