### PR TITLE
statistics: fix panic when using wrong globalStats.Indices key

### DIFF
--- a/statistics/handle/ddl.go
+++ b/statistics/handle/ddl.go
@@ -129,12 +129,12 @@ func (h *Handle) updateGlobalStats(tblInfo *model.TableInfo) error {
 
 	// Generate the new index global-stats
 	globalIdxStatsTopNNum, globalIdxStatsBucketNum := 0, 0
-	for idx := range tblInfo.Indices {
-		globalIdxStatsTopN := globalStats.Indices[int64(idx)].TopN
+	for _, idx := range tblInfo.Indices {
+		globalIdxStatsTopN := globalStats.Indices[idx.ID].TopN
 		if globalIdxStatsTopN != nil && len(globalIdxStatsTopN.TopN) > globalIdxStatsTopNNum {
 			globalIdxStatsTopNNum = len(globalIdxStatsTopN.TopN)
 		}
-		globalIdxStats := globalStats.Indices[int64(idx)]
+		globalIdxStats := globalStats.Indices[idx.ID]
 		if globalIdxStats != nil && len(globalIdxStats.Buckets) > globalIdxStatsBucketNum {
 			globalIdxStatsBucketNum = len(globalIdxStats.Buckets)
 		}
@@ -144,7 +144,7 @@ func (h *Handle) updateGlobalStats(tblInfo *model.TableInfo) error {
 		if globalIdxStatsBucketNum != 0 {
 			opts[ast.AnalyzeOptNumBuckets] = uint64(globalIdxStatsBucketNum)
 		}
-		newIndexGlobalStats, err := h.mergePartitionStats2GlobalStats(h.mu.ctx, opts, is, tblInfo, 1, []int64{int64(idx)})
+		newIndexGlobalStats, err := h.mergePartitionStats2GlobalStats(h.mu.ctx, opts, is, tblInfo, 1, []int64{idx.ID})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Signed-off-by: lilinghai <lilinghai@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/35421

Problem Summary:
Before the fix, The idx in the expression`for idx := range tblInfo.Indices` start from 0, and the expression`globalStats.Indices[idx]` will get nil. We should use model.IndexInfo.ID as the key to access the content of globalStats.Indices.
### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
