### PR TITLE
planner: fix cte-schema-clone will clone the old hashcode of its column if any (#35415)

### DIFF
--- a/cmd/explaintest/r/explain_cte.result
+++ b/cmd/explaintest/r/explain_cte.result
@@ -479,3 +479,22 @@ CTE_1	8000.00	root		Non-Recursive CTE
 CTE_0	10000.00	root		Non-Recursive CTE
 └─TableReader(Seed Part)	10000.00	root		data:TableFullScan
   └─TableFullScan	10000.00	cop[tikv]	table:t1	keep order:false, stats:pseudo
+drop table if exists tbl;
+create table tbl (id int);
+explain with t1 as (select id from tbl), t2 as (select a.id from t1 a join t1 b on a.id = b.id) select * from t2 where id in (select id from t2);
+id	estRows	task	access object	operator info
+HashJoin_33	8000.00	root		inner join, equal:[eq(test.tbl.id, test.tbl.id)]
+├─HashAgg_37(Build)	5120.00	root		group by:test.tbl.id, funcs:firstrow(test.tbl.id)->test.tbl.id
+│ └─Selection_38	8000.00	root		not(isnull(test.tbl.id))
+│   └─CTEFullScan_39	10000.00	root	CTE:t2	data:CTE_1
+└─Selection_35(Probe)	8000.00	root		not(isnull(test.tbl.id))
+  └─CTEFullScan_36	10000.00	root	CTE:t2	data:CTE_1
+CTE_1	10000.00	root		Non-Recursive CTE
+└─HashJoin_25(Seed Part)	10000.00	root		inner join, equal:[eq(test.tbl.id, test.tbl.id)]
+  ├─Selection_29(Build)	8000.00	root		not(isnull(test.tbl.id))
+  │ └─CTEFullScan_30	10000.00	root	CTE:b	data:CTE_0
+  └─Selection_27(Probe)	8000.00	root		not(isnull(test.tbl.id))
+    └─CTEFullScan_28	10000.00	root	CTE:a	data:CTE_0
+CTE_0	10000.00	root		Non-Recursive CTE
+└─TableReader_22(Seed Part)	10000.00	root		data:TableFullScan_21
+  └─TableFullScan_21	10000.00	cop[tikv]	table:tbl	keep order:false, stats:pseudo

--- a/cmd/explaintest/t/explain_cte.test
+++ b/cmd/explaintest/t/explain_cte.test
@@ -258,3 +258,8 @@ desc format='brief' with all_data as
 select v1.tps v1_tps,v2.tps v2_tps
 from version1 v1, version2 v2
 where v1.bench_type =v2.bench_type;
+
+# issue 35404
+drop table if exists tbl;
+create table tbl (id int);
+explain with t1 as (select id from tbl), t2 as (select a.id from t1 a join t1 b on a.id = b.id) select * from t2 where id in (select id from t2);

--- a/expression/column.go
+++ b/expression/column.go
@@ -490,6 +490,11 @@ func (col *Column) HashCode(_ *stmtctx.StatementContext) []byte {
 	return col.hashcode
 }
 
+// CleanHashCode will clean the hashcode you may be cached before. It's used especially in schema-cloned & reallocated-uniqueID's cases.
+func (col *Column) CleanHashCode() {
+	col.hashcode = make([]byte, 0, 9)
+}
+
 // ResolveIndices implements Expression interface.
 func (col *Column) ResolveIndices(schema *Schema) (Expression, error) {
 	newCol := col.Clone()

--- a/planner/core/logical_plan_builder.go
+++ b/planner/core/logical_plan_builder.go
@@ -6889,6 +6889,8 @@ func getResultCTESchema(seedSchema *expression.Schema, svar *variable.SessionVar
 		col.RetType = col.RetType.Clone()
 		col.UniqueID = svar.AllocPlanColumnID()
 		col.RetType.DelFlag(mysql.NotNullFlag)
+		// Since you have reallocated unique id here, the old-cloned-cached hash code is not valid anymore.
+		col.CleanHashCode()
 	}
 	return res
 }


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/35415 to release-6.1-20220619

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35404

Problem Summary:
After #33158, the predicate pushdown for CTE has been supported. While some cases will have some problems when it comes to projection elimination using column's hashcode mapping.

In building dataSource,  we clone CTE schema with some newly assigned uniqueID when referring to a CTE. In PR #33158, code as following
```
for i, col := range lp.schema.Columns {
	lp.cte.ColumnMap[string(col.HashCode(nil))] = prevSchema.Columns[i]
}
```
here will generate hashcode in columns of the schema of CTE when building CTE itself.
Later when building the main select clause, CTE reference will clone CTE's schema and assign new uniqueIDs, here should clean these hashcodes because they are not valid anymore.(new uniqueID)

### What is changed and how it works?

Just a quick test for verity resolveIndices error when select statement with join of CTE reference

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
