### PR TITLE
log_backup: make deleting file concurrently, show the time cost of truncating

### DIFF
--- a/br/pkg/glue/console_glue.go
+++ b/br/pkg/glue/console_glue.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/pingcap/log"
@@ -20,6 +21,15 @@ import (
 // ConsoleOperations are some operations based on ConsoleGlue.
 type ConsoleOperations struct {
 	ConsoleGlue
+}
+
+// StartTask prints a task start information, and mark as finished when the returned function called.
+func (ops ConsoleOperations) StartTask(message string) func() {
+	start := time.Now()
+	ops.Print(message)
+	return func() {
+		ops.Printf("%s; take = %s\n", color.HiGreenString("DONE"), time.Since(start))
+	}
 }
 
 func (ops ConsoleOperations) RootFrame() Frame {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fatih/color"
@@ -839,7 +840,6 @@ func RunStreamStatus(
 func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *StreamConfig) error {
 	console := glue.GetConsole(g)
 	em := color.New(color.Bold).SprintFunc()
-	done := color.New(color.FgGreen).SprintFunc()
 	warn := color.New(color.Bold, color.FgHiRed).SprintFunc()
 	formatTS := func(ts uint64) string {
 		return oracle.GetTimeFromTS(ts).Format("2006-01-02 15:04:05.0000")
@@ -873,7 +873,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 			return err
 		}
 	}
-
+	readMetaDone := console.StartTask("Reading Metadata... ")
 	metas := restore.StreamMetadataSet{
 		BeforeDoWriteBack: func(path string, last, current *backuppb.Metadata) (skip bool) {
 			log.Info("Updating metadata.", zap.String("file", path),
@@ -885,20 +885,17 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	if err := metas.LoadFrom(ctx, storage); err != nil {
 		return err
 	}
+	readMetaDone()
 
 	fileCount := 0
-	minTS := oracle.GoTimeToTS(time.Now())
 	shiftUntilTS := ShiftTS(cfg.Until)
 	metas.IterateFilesFullyBefore(shiftUntilTS, func(d *backuppb.DataFileInfo) (shouldBreak bool) {
-		if d.MaxTs < minTS {
-			minTS = d.MaxTs
-		}
 		fileCount++
 		return
 	})
 	console.Printf("We are going to remove %s files, until %s.\n",
 		em(fileCount),
-		em(formatTS(minTS)),
+		em(formatTS(cfg.Until)),
 	)
 	if !cfg.SkipPrompt && !console.PromptBool(warn("Sure? ")) {
 		return nil
@@ -906,23 +903,30 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 
 	removed := metas.RemoveDataBefore(shiftUntilTS)
 
-	console.Print("Removing metadata... ")
+	removeMetaDone := console.StartTask("Removing metadata... ")
 	if !cfg.DryRun {
 		if err := metas.DoWriteBack(ctx, storage); err != nil {
 			return err
 		}
 	}
-	console.Println(done("DONE"))
-	console.Print("Clearing data files... ")
+	removeMetaDone()
+	clearDataFileDone := console.StartTask("Clearing data files... ")
+	worker := utils.NewWorkerPool(128, "delete files")
+	wg := new(sync.WaitGroup)
 	for _, f := range removed {
 		if !cfg.DryRun {
-			if err := storage.DeleteFile(ctx, f.Path); err != nil {
-				log.Warn("File not deleted.", zap.String("path", f.Path), logutil.ShortError(err))
-				console.Print("\n"+em(f.Path), "not deleted, you may clear it manually:", warn(err))
-			}
+			wg.Add(1)
+			worker.Apply(func() {
+				defer wg.Done()
+				if err := storage.DeleteFile(ctx, f.Path); err != nil {
+					log.Warn("File not deleted.", zap.String("path", f.Path), logutil.ShortError(err))
+					console.Print("\n"+em(f.Path), "not deleted, you may clear it manually:", warn(err))
+				}
+			})
 		}
 	}
-	console.Println(done("DONE"))
+	wg.Wait()
+	clearDataFileDone()
 	return nil
 }
 


### PR DESCRIPTION
Signed-off-by: Yu Juncen <yujuncen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #(TBD)

Problem Summary:
Log truncate is too slow and there isn't time cost information.

### What is changed and how it works?
This PR added time cost for `log truncate`, and using a 128 threads concurrency for deleting the files in S3. (Will this be too frequently?)

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/36239017/175008291-52ccb9ac-0879-498c-8019-3a266617d90c.png">
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/36239017/175008306-567d3281-6791-4b17-89be-a6b6121d5b14.png">
- [ ] No code

### Release note

```release-note
Now, `br log truncate` command would display the time cost of each steps.
```
