### PR TITLE
br: increase the retry backoff when scan regions

### DIFF
--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -50,7 +50,7 @@ const (
 )
 
 var (
-	ScanRegionAttemptTimes = 30
+	ScanRegionAttemptTimes = 60
 )
 
 // RegionSplitter is a executor of region split by rules.
@@ -490,9 +490,9 @@ func newScanRegionBackoffer() utils.Backoffer {
 // NextBackoff returns a duration to wait before retrying again
 func (b *scanRegionBackoffer) NextBackoff(err error) time.Duration {
 	if berrors.ErrPDBatchScanRegion.Equal(err) {
-		// 500ms * 30 could be enough for splitting remain regions in the hole.
+		// 1s * 60 could be enough for splitting remain regions in the hole.
 		b.attempt--
-		return 500 * time.Millisecond
+		return time.Second
 	}
 	b.attempt = 0
 	return 0


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/35657

Problem Summary:


### What is changed and how it works?
Increase the retry backoff when scan regions. 
Old backoff is 500ms * 30 times, the new is 1s * 60 times.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
