### PR TITLE
planner: disable collate clause support for enum or set column

### DIFF
--- a/cmd/explaintest/r/collation_agg_func_disabled.result
+++ b/cmd/explaintest/r/collation_agg_func_disabled.result
@@ -200,11 +200,9 @@ select min(b) from tt;
 min(b)
 B
 desc format='brief' select min(b collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:min(Column#8)->Column#6
-└─TableReader	1.00	root		data:StreamAgg
-  └─StreamAgg	1.00	cop[tikv]		funcs:min(cast(collation_agg_func.tt.b, enum('a','B','c')))->Column#8
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select min(b collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select max(b) from tt;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
@@ -215,11 +213,9 @@ select max(b) from tt;
 max(b)
 c
 desc format='brief' select max(b collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
-└─TableReader	1.00	root		data:StreamAgg
-  └─StreamAgg	1.00	cop[tikv]		funcs:max(cast(collation_agg_func.tt.b, enum('a','B','c')))->Column#8
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select max(b collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select min(c) from tt;
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:min(collation_agg_func.tt.c)->Column#6
@@ -229,11 +225,9 @@ select min(c) from tt;
 min(c)
 B
 desc format='brief' select min(c collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-HashAgg	1.00	root		funcs:min(Column#7)->Column#6
-└─Projection	10000.00	root		cast(collation_agg_func.tt.c, set('a','B','c'))->Column#7
-  └─TableReader	10000.00	root		data:TableFullScan
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select min(c collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select max(c) from tt;
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:max(collation_agg_func.tt.c)->Column#6
@@ -243,11 +237,9 @@ select max(c) from tt;
 max(c)
 c
 desc format='brief' select max(c collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-HashAgg	1.00	root		funcs:max(Column#7)->Column#6
-└─Projection	10000.00	root		cast(collation_agg_func.tt.c, set('a','B','c'))->Column#7
-  └─TableReader	10000.00	root		data:TableFullScan
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select max(c collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select min(d) from tt;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:min(collation_agg_func.tt.d)->Column#6

--- a/cmd/explaintest/r/collation_agg_func_enabled.result
+++ b/cmd/explaintest/r/collation_agg_func_enabled.result
@@ -197,11 +197,9 @@ select min(b) from tt;
 min(b)
 a
 desc format='brief' select min(b collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:min(Column#8)->Column#6
-└─TableReader	1.00	root		data:StreamAgg
-  └─StreamAgg	1.00	cop[tikv]		funcs:min(cast(collation_agg_func.tt.b, enum('a','B','c')))->Column#8
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select min(b collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select max(b) from tt;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
@@ -212,11 +210,9 @@ select max(b) from tt;
 max(b)
 c
 desc format='brief' select max(b collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-StreamAgg	1.00	root		funcs:max(Column#8)->Column#6
-└─TableReader	1.00	root		data:StreamAgg
-  └─StreamAgg	1.00	cop[tikv]		funcs:max(cast(collation_agg_func.tt.b, enum('a','B','c')))->Column#8
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select max(b collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select min(c) from tt;
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:min(collation_agg_func.tt.c)->Column#6
@@ -226,11 +222,9 @@ select min(c) from tt;
 min(c)
 a
 desc format='brief' select min(c collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-HashAgg	1.00	root		funcs:min(Column#7)->Column#6
-└─Projection	10000.00	root		cast(collation_agg_func.tt.c, set('a','B','c'))->Column#7
-  └─TableReader	10000.00	root		data:TableFullScan
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select min(c collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select max(c) from tt;
 id	estRows	task	access object	operator info
 HashAgg	1.00	root		funcs:max(collation_agg_func.tt.c)->Column#6
@@ -240,11 +234,9 @@ select max(c) from tt;
 max(c)
 c
 desc format='brief' select max(c collate utf8mb4_bin) from tt;
-id	estRows	task	access object	operator info
-HashAgg	1.00	root		funcs:max(Column#7)->Column#6
-└─Projection	10000.00	root		cast(collation_agg_func.tt.c, set('a','B','c'))->Column#7
-  └─TableReader	10000.00	root		data:TableFullScan
-    └─TableFullScan	10000.00	cop[tikv]	table:tt	keep order:false, stats:pseudo
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
+select max(c collate utf8mb4_bin) from tt;
+Error 1235: This version of TiDB doesn't yet support 'use collate clause for enum or set'
 desc format='brief' select min(d) from tt;
 id	estRows	task	access object	operator info
 StreamAgg	1.00	root		funcs:min(collation_agg_func.tt.d)->Column#6

--- a/cmd/explaintest/t/collation_agg_func.test
+++ b/cmd/explaintest/t/collation_agg_func.test
@@ -66,24 +66,28 @@ desc format='brief' select max(a collate utf8mb4_bin) from tt;
 select max(a collate utf8mb4_bin) from tt;
 desc format='brief' select min(b) from tt;
 select min(b) from tt;
+--error 1235
 desc format='brief' select min(b collate utf8mb4_bin) from tt;
-# Fix me later.
-# select min(b collate utf8mb4_bin) from tt;
+--error 1235
+select min(b collate utf8mb4_bin) from tt;
 desc format='brief' select max(b) from tt;
 select max(b) from tt;
+--error 1235
 desc format='brief' select max(b collate utf8mb4_bin) from tt;
-# Fix me later.
-# select max(b collate utf8mb4_bin) from tt;
+--error 1235
+select max(b collate utf8mb4_bin) from tt;
 desc format='brief' select min(c) from tt;
 select min(c) from tt;
+--error 1235
 desc format='brief' select min(c collate utf8mb4_bin) from tt;
-# Fix me later.
-# select min(c collate utf8mb4_bin) from tt;
+--error 1235
+select min(c collate utf8mb4_bin) from tt;
 desc format='brief' select max(c) from tt;
 select max(c) from tt;
+--error 1235
 desc format='brief' select max(c collate utf8mb4_bin) from tt;
-# Fix me later.
-# select max(c collate utf8mb4_bin) from tt;
+--error 1235
+select max(c collate utf8mb4_bin) from tt;
 desc format='brief' select min(d) from tt;
 select min(d) from tt;
 --error 1253

--- a/planner/core/expression_rewriter.go
+++ b/planner/core/expression_rewriter.go
@@ -1199,6 +1199,10 @@ func (er *expressionRewriter) Leave(originInNode ast.Node) (retNode ast.Node, ok
 		}
 		// SetCollationExpr sets the collation explicitly, even when the evaluation type of the expression is non-string.
 		if _, ok := arg.(*expression.Column); ok {
+			if arg.GetType().GetType() == mysql.TypeEnum || arg.GetType().GetType() == mysql.TypeSet {
+				er.err = ErrNotSupportedYet.GenWithStackByArgs("use collate clause for enum or set")
+				break
+			}
 			// Wrap a cast here to avoid changing the original FieldType of the column expression.
 			exprType := arg.GetType().Clone()
 			exprType.SetCollate(v.Collate)


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #31637

Problem Summary:
We can't cast enum or set currently, there is no way to implement collate clause support for enum or set column.
So this PR makes TiDB returns an error instead of panic.

### What is changed and how it works?
Return an error.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
