### PR TITLE
expression: make `inet_aton` behavior same with mysql in different DDL

### DIFF
--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/parser/terror"
 	"github.com/pingcap/tidb/sessionctx"
@@ -505,17 +506,16 @@ func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 	if err != nil || isNull {
 		return 0, true, err
 	}
+	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, ast.InetAton)
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
 	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
 	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
-	err = stmtCtx.HandleTruncate(errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton"))
-
 	// ip address should not end with '.'.
 	if len(val) == 0 || val[len(val)-1] == '.' {
-		return 0, true, err
+		return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
 	}
 
 	var (
@@ -527,17 +527,17 @@ func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 			digit := uint64(c - '0')
 			byteResult = byteResult*10 + digit
 			if byteResult > 255 {
-				return 0, true, err
+				return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
 			}
 		} else if c == '.' {
 			dotCount++
 			if dotCount > 3 {
-				return 0, true, err
+				return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
 			}
 			result = (result << 8) + byteResult
 			byteResult = 0
 		} else {
-			return 0, true, err
+			return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
 		}
 	}
 	// 127 		-> 0.0.0.127
@@ -646,20 +646,20 @@ func (b *builtinInet6AtonSig) evalString(row chunk.Row) (string, bool, error) {
 	if err != nil || isNull {
 		return "", true, err
 	}
+	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, ast.Inet6Aton)
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
 	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
 	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
-	err = stmtCtx.HandleTruncate(errWrongValueForType.GenWithStackByArgs("string", val, "inet6_aton"))
 	if len(val) == 0 {
-		return "", true, err
+		return "", true, stmtCtx.HandleTruncate(errWrongValueForType)
 	}
 
 	ip := net.ParseIP(val)
 	if ip == nil {
-		return "", true, err
+		return "", true, stmtCtx.HandleTruncate(errWrongValueForType)
 	}
 
 	var isMappedIpv6 bool

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -505,16 +505,17 @@ func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 	if err != nil || isNull {
 		return 0, true, err
 	}
-	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
 	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
 	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
+	err = stmtCtx.HandleTruncate(errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton"))
+
 	// ip address should not end with '.'.
 	if len(val) == 0 || val[len(val)-1] == '.' {
-		return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
+		return 0, true, err
 	}
 
 	var (
@@ -526,17 +527,17 @@ func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 			digit := uint64(c - '0')
 			byteResult = byteResult*10 + digit
 			if byteResult > 255 {
-				return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
+				return 0, true, err
 			}
 		} else if c == '.' {
 			dotCount++
 			if dotCount > 3 {
-				return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
+				return 0, true, err
 			}
 			result = (result << 8) + byteResult
 			byteResult = 0
 		} else {
-			return 0, true, stmtCtx.HandleTruncate(errWrongValueForType)
+			return 0, true, err
 		}
 	}
 	// 127 		-> 0.0.0.127
@@ -645,20 +646,20 @@ func (b *builtinInet6AtonSig) evalString(row chunk.Row) (string, bool, error) {
 	if err != nil || isNull {
 		return "", true, err
 	}
-	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton6")
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
 	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
 	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
+	err = stmtCtx.HandleTruncate(errWrongValueForType.GenWithStackByArgs("string", val, "inet6_aton"))
 	if len(val) == 0 {
-		return "", true, stmtCtx.HandleTruncate(errWrongValueForType)
+		return "", true, err
 	}
 
 	ip := net.ParseIP(val)
 	if ip == nil {
-		return "", true, stmtCtx.HandleTruncate(errWrongValueForType)
+		return "", true, err
 	}
 
 	var isMappedIpv6 bool

--- a/expression/builtin_miscellaneous.go
+++ b/expression/builtin_miscellaneous.go
@@ -508,8 +508,8 @@ func (b *builtinInetAtonSig) evalInt(row chunk.Row) (int64, bool, error) {
 	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton")
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
-	shouldWarn := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
-	if shouldWarn {
+	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
+	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
 	// ip address should not end with '.'.
@@ -648,8 +648,8 @@ func (b *builtinInet6AtonSig) evalString(row chunk.Row) (string, bool, error) {
 	errWrongValueForType := errWrongValueForType.GenWithStackByArgs("string", val, "inet_aton6")
 	stmtCtx := b.ctx.GetSessionVars().StmtCtx
 	// Only in select, we will show warnings rather than error
-	shouldWarn := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
-	if shouldWarn {
+	truncateAsWarning := !(stmtCtx.InInsertStmt || stmtCtx.InUpdateStmt || stmtCtx.InDeleteStmt)
+	if truncateAsWarning {
 		stmtCtx.TruncateAsWarning = true
 	}
 	if len(val) == 0 {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35677 

Problem Summary: In MySQL, the function of `INET_ATON` behave differently in the DDL.
*  In `select`, it will return `NULL` and append warnings when the input is illegal
*  In `Insert`, `update`, `delete`, it will report err directly

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
