### PR TITLE
br: remove the timeout for scan region

### DIFF
--- a/br/pkg/restore/import_retry.go
+++ b/br/pkg/restore/import_retry.go
@@ -107,30 +107,35 @@ func (o *OverRegionsInRangeController) handleInRegionError(ctx context.Context, 
 	return true
 }
 
-// Run executes the `regionFunc` over the regions in `o.start` and `o.end`.
-// It would retry the errors according to the `rpcResponse`.
-func (o *OverRegionsInRangeController) Run(ctx context.Context, f RegionFunc) error {
-	if !o.rs.ShouldRetry() {
-		return o.errors
-	}
-	tctx, cancel := context.WithTimeout(ctx, importScanRegionTime)
-	defer cancel()
-	// Scan regions covered by the file range
-	regionInfos, errScanRegion := PaginateScanRegion(
-		tctx, o.metaClient, o.start, o.end, ScanRegionPaginationLimit)
-	if errScanRegion != nil {
-		return errors.Trace(errScanRegion)
-	}
-
-	// Try to download and ingest the file in every region
+func (o *OverRegionsInRangeController) prepareLogCtx(ctx context.Context) context.Context {
 	lctx := logutil.ContextWithField(
 		ctx,
 		logutil.Key("startKey", o.start),
 		logutil.Key("endKey", o.end),
 	)
+	return lctx
+}
+
+// Run executes the `regionFunc` over the regions in `o.start` and `o.end`.
+// It would retry the errors according to the `rpcResponse`.
+func (o *OverRegionsInRangeController) Run(ctx context.Context, f RegionFunc) error {
+	return o.runOverRegions(o.prepareLogCtx(ctx), f)
+}
+
+func (o *OverRegionsInRangeController) runOverRegions(ctx context.Context, f RegionFunc) error {
+	if !o.rs.ShouldRetry() {
+		return o.errors
+	}
+
+	// Scan regions covered by the file range
+	regionInfos, errScanRegion := PaginateScanRegion(
+		ctx, o.metaClient, o.start, o.end, ScanRegionPaginationLimit)
+	if errScanRegion != nil {
+		return errors.Trace(errScanRegion)
+	}
 
 	for _, region := range regionInfos {
-		cont, err := o.runInRegion(lctx, f, region)
+		cont, err := o.runInRegion(ctx, f, region)
 		if err != nil {
 			return err
 		}
@@ -157,7 +162,7 @@ func (o *OverRegionsInRangeController) runInRegion(ctx context.Context, f Region
 		case StrategyFromThisRegion:
 			logutil.CL(ctx).Warn("retry for region", logutil.Region(region.Region), logutil.ShortError(&result))
 			if !o.handleInRegionError(ctx, result, region) {
-				return false, o.Run(ctx, f)
+				return false, o.runOverRegions(ctx, f)
 			}
 			return o.runInRegion(ctx, f, region)
 		case StrategyFromStart:
@@ -165,7 +170,7 @@ func (o *OverRegionsInRangeController) runInRegion(ctx context.Context, f Region
 			// TODO: make a backoffer considering more about the error info,
 			//       instead of ingore the result and retry.
 			time.Sleep(o.rs.ExponentialBackoff())
-			return false, o.Run(ctx, f)
+			return false, o.runOverRegions(ctx, f)
 		}
 	}
 	return true, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

this PR is cherry-picked from https://github.com/pingcap/tidb/pull/35716

Issue Number: close #35657

Problem Summary:

Currently, we use a context with 10s timeout for scanning regions. This is not enough for PiTR restore condition.

### What is changed and how it works?

Removed the deadline, at the same time, we fixed a problem that may cause the start key and end key added to the logger multi times.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
