### PR TITLE
ddl: DROP TABLE/VIEW/SEQUENCE now use XXXStmt as parameter

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -106,9 +106,9 @@ type DDL interface {
 	DropSchema(ctx sessionctx.Context, schema model.CIStr) error
 	CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
-	DropTable(ctx sessionctx.Context, tableIdent ast.Ident) (err error)
+	DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	RecoverTable(ctx sessionctx.Context, recoverInfo *RecoverInfo) (err error)
-	DropView(ctx sessionctx.Context, tableIdent ast.Ident) (err error)
+	DropView(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	CreateIndex(ctx sessionctx.Context, tableIdent ast.Ident, keyType ast.IndexKeyType, indexName model.CIStr,
 		columnNames []*ast.IndexPartSpecification, indexOption *ast.IndexOption, ifNotExists bool) error
 	DropIndex(ctx sessionctx.Context, tableIdent ast.Ident, indexName model.CIStr, ifExists bool) error
@@ -122,7 +122,7 @@ type DDL interface {
 	UpdateTableReplicaInfo(ctx sessionctx.Context, physicalID int64, available bool) error
 	RepairTable(ctx sessionctx.Context, table *ast.TableName, createStmt *ast.CreateTableStmt) error
 	CreateSequence(ctx sessionctx.Context, stmt *ast.CreateSequenceStmt) error
-	DropSequence(ctx sessionctx.Context, tableIdent ast.Ident, ifExists bool) (err error)
+	DropSequence(ctx sessionctx.Context, stmt *ast.DropSequenceStmt) (err error)
 	AlterSequence(ctx sessionctx.Context, stmt *ast.AlterSequenceStmt) error
 	CreatePlacementPolicy(ctx sessionctx.Context, stmt *ast.CreatePlacementPolicyStmt) error
 	DropPlacementPolicy(ctx sessionctx.Context, stmt *ast.DropPlacementPolicyStmt) error

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5326,7 +5326,13 @@ func (d *ddl) dropTableObject(
 			return err
 		}
 
-		// precheck before build DDL job
+		// prechecks before build DDL job
+
+		// Protect important system table from been dropped by a mistake.
+		// I can hardly find a case that a user really need to do this.
+		if isSystemTable(tn.Schema.L, tn.Name.L) {
+			return errors.Errorf("Drop tidb system table '%s.%s' is forbidden", tn.Schema.L, tn.Name.L)
+		}
 		switch tableObjectType {
 		case tableObject:
 			if !tableInfo.Meta().IsBaseTable() {
@@ -5363,12 +5369,6 @@ func (d *ddl) dropTableObject(
 				}
 				return err
 			}
-		}
-
-		// Protect important system table from been dropped by a mistake.
-		// I can hardly find a case that a user really need to do this.
-		if isSystemTable(tn.Schema.L, tn.Name.L) {
-			return errors.Errorf("Drop tidb system table '%s.%s' is forbidden", tn.Schema.L, tn.Name.L)
 		}
 
 		job := &model.Job{

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5390,6 +5390,10 @@ func (d *ddl) dropTableObject(
 			return errors.Trace(err)
 		}
 
+		// unlock table after drop
+		if tableObjectType != tableObject {
+			continue
+		}
 		if !config.TableLockEnabled() {
 			continue
 		}

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -5385,12 +5385,13 @@ func (d *ddl) dropTableObject(
 		err = d.callHookOnChanged(job, err)
 		if infoschema.ErrDatabaseNotExists.Equal(err) || infoschema.ErrTableNotExists.Equal(err) {
 			notExistTables = append(notExistTables, fullti.String())
+			continue
 		} else if err != nil {
 			return errors.Trace(err)
 		}
 
 		if !config.TableLockEnabled() {
-			return nil
+			continue
 		}
 		if ok, _ := ctx.CheckTableLocked(tableInfo.Meta().ID); ok {
 			ctx.ReleaseTableLockByTableIDs([]int64{tableInfo.Meta().ID})


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35665 

Problem Summary:

### What is changed and how it works?

move some logic from DDL executor into DDL interface.

I'll open more PR for other DDL method. The goal is that DDL interface should accept ast.XXXStmt as parameters and handle all logic by the information of the statement, so the definition of DDL interface will have a more clear boundary.

### Check List

Tests <!-- At least one of them must be included. -->

- pass exising tests
- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
