### PR TITLE
helper: request another PD if one of them is unavailable

### DIFF
--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -840,20 +840,21 @@ func (h *Helper) requestPD(apiName, method, uri string, body io.Reader, res inte
 	if len(pdHosts) == 0 {
 		return errors.New("pd unavailable")
 	}
-	logutil.BgLogger().Debug("RequestPD URL", zap.String("url", util.InternalHTTPSchema()+"://"+pdHosts[0]+uri))
-	req := new(http.Request)
 	for _, host := range pdHosts {
-		req, err = http.NewRequest(method, util.InternalHTTPSchema()+"://"+host+uri, body)
-		if err != nil {
-			// Try to request from another PD node when some nodes may down.
-			if strings.Contains(err.Error(), "connection refused") {
-				continue
-			}
-			return errors.Trace(err)
+		err = requestPDForOneHost(host, apiName, method, uri, body, res)
+		if err == nil {
+			break
 		}
+		// Try to request from another PD node when some nodes may down.
 	}
+	return err
+}
+
+func requestPDForOneHost(host, apiName, method, uri string, body io.Reader, res interface{}) error {
+	logutil.BgLogger().Debug("RequestPD URL", zap.String("url", util.InternalHTTPSchema()+"://"+host+uri))
+	req, err := http.NewRequest(method, util.InternalHTTPSchema()+"://"+host+uri, body)
 	if err != nil {
-		return err
+		return errors.Trace(err)
 	}
 	start := time.Now()
 	resp, err := util.InternalHTTPClient().Do(req)
@@ -863,19 +864,16 @@ func (h *Helper) requestPD(apiName, method, uri string, body io.Reader, res inte
 	}
 	metrics.PDAPIExecutionHistogram.WithLabelValues(apiName).Observe(time.Since(start).Seconds())
 	metrics.PDAPIRequestCounter.WithLabelValues(apiName, resp.Status).Inc()
-
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
 			logutil.BgLogger().Error("close body failed", zap.Error(err))
 		}
 	}()
-
 	err = json.NewDecoder(resp.Body).Decode(res)
 	if err != nil {
 		return errors.Trace(err)
 	}
-
 	return nil
 }
 

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -855,7 +855,7 @@ func requestPDForOneHost(host, apiName, method, uri string, body io.Reader, res 
 	logutil.BgLogger().Debug("RequestPD URL", zap.String("url", urlVar))
 	req, err := http.NewRequest(method, urlVar, body)
 	if err != nil {
-		logutil.BgLogger().Warn("requestPDForOneHost new request",
+		logutil.BgLogger().Warn("requestPDForOneHost new request failed",
 			zap.String("url", urlVar), zap.Error(err))
 		return errors.Trace(err)
 	}
@@ -863,7 +863,7 @@ func requestPDForOneHost(host, apiName, method, uri string, body io.Reader, res 
 	resp, err := util.InternalHTTPClient().Do(req)
 	if err != nil {
 		metrics.PDAPIRequestCounter.WithLabelValues(apiName, "network error").Inc()
-		logutil.BgLogger().Warn("requestPDForOneHost do request",
+		logutil.BgLogger().Warn("requestPDForOneHost do request failed",
 			zap.String("url", urlVar), zap.Error(err))
 		return errors.Trace(err)
 	}
@@ -872,7 +872,7 @@ func requestPDForOneHost(host, apiName, method, uri string, body io.Reader, res 
 	defer func() {
 		err = resp.Body.Close()
 		if err != nil {
-			logutil.BgLogger().Warn("requestPDForOneHost close body",
+			logutil.BgLogger().Warn("requestPDForOneHost close body failed",
 				zap.String("url", urlVar), zap.Error(err))
 		}
 	}()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/35708.

Problem Summary:

`requestPD` should try the PD hosts one by one until the request is successful.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix an issue that TiDB cannot access `TIKV_REGION_STATUS` when one of the PD is down.
```
