### PR TITLE
expression: use cloned RetType at `evaluateExprWithNull` when it may be changed.

### DIFF
--- a/expression/expression.go
+++ b/expression/expression.go
@@ -807,7 +807,7 @@ func evaluateExprWithNull(ctx sessionctx.Context, schema *Schema, expr Expressio
 		for i, arg := range x.GetArgs() {
 			args[i] = evaluateExprWithNull(ctx, schema, arg)
 		}
-		return NewFunctionInternal(ctx, x.FuncName.L, x.RetType, args...)
+		return NewFunctionInternal(ctx, x.FuncName.L, x.RetType.Clone(), args...)
 	case *Column:
 		if !schema.Contains(x) {
 			return x

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -79,6 +79,30 @@ func TestEvaluateExprWithNullAndParameters(t *testing.T) {
 	require.True(t, isScalarFunc) // the expression with parameters is not evaluated
 }
 
+func TestEvaluateExprWithNullNoChangeRetType(t *testing.T) {
+	ctx := createContext(t)
+	tblInfo := newTestTableBuilder("").add("col_str", mysql.TypeString, 0).build()
+	schema := tableInfoToSchemaForTest(tblInfo)
+
+	castStrAsJson := BuildCastFunction(ctx, schema.Columns[0], types.NewFieldType(mysql.TypeJSON))
+	jsonConstant := &Constant{Value: types.NewDatum("123"), RetType: types.NewFieldType(mysql.TypeJSON)}
+
+	// initially has ParseToJSONFlag
+	flagInCast := castStrAsJson.(*ScalarFunction).RetType.GetFlag()
+	require.True(t, mysql.HasParseToJSONFlag(flagInCast))
+
+	// cast's ParseToJSONFlag removed by `DisableParseJSONFlag4Expr`
+	eq, err := newFunctionForTest(ctx, ast.EQ, jsonConstant, castStrAsJson)
+	require.NoError(t, err)
+	flagInCast = eq.(*ScalarFunction).GetArgs()[1].(*ScalarFunction).RetType.GetFlag()
+	require.False(t, mysql.HasParseToJSONFlag(flagInCast))
+
+	// after EvaluateExprWithNull, this flag should be still false
+	EvaluateExprWithNull(ctx, schema, eq)
+	flagInCast = eq.(*ScalarFunction).GetArgs()[1].(*ScalarFunction).RetType.GetFlag()
+	require.False(t, mysql.HasParseToJSONFlag(flagInCast))
+}
+
 func TestConstant(t *testing.T) {
 	ctx := createContext(t)
 	sc := &stmtctx.StatementContext{TimeZone: time.Local}

--- a/expression/expression_test.go
+++ b/expression/expression_test.go
@@ -84,15 +84,15 @@ func TestEvaluateExprWithNullNoChangeRetType(t *testing.T) {
 	tblInfo := newTestTableBuilder("").add("col_str", mysql.TypeString, 0).build()
 	schema := tableInfoToSchemaForTest(tblInfo)
 
-	castStrAsJson := BuildCastFunction(ctx, schema.Columns[0], types.NewFieldType(mysql.TypeJSON))
+	castStrAsJSON := BuildCastFunction(ctx, schema.Columns[0], types.NewFieldType(mysql.TypeJSON))
 	jsonConstant := &Constant{Value: types.NewDatum("123"), RetType: types.NewFieldType(mysql.TypeJSON)}
 
 	// initially has ParseToJSONFlag
-	flagInCast := castStrAsJson.(*ScalarFunction).RetType.GetFlag()
+	flagInCast := castStrAsJSON.(*ScalarFunction).RetType.GetFlag()
 	require.True(t, mysql.HasParseToJSONFlag(flagInCast))
 
 	// cast's ParseToJSONFlag removed by `DisableParseJSONFlag4Expr`
-	eq, err := newFunctionForTest(ctx, ast.EQ, jsonConstant, castStrAsJson)
+	eq, err := newFunctionForTest(ctx, ast.EQ, jsonConstant, castStrAsJSON)
 	require.NoError(t, err)
 	flagInCast = eq.(*ScalarFunction).GetArgs()[1].(*ScalarFunction).RetType.GetFlag()
 	require.False(t, mysql.HasParseToJSONFlag(flagInCast))

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -6717,3 +6717,22 @@ func TestIssue35083(t *testing.T) {
 		"└─Projection 10000.00 cop[tikv]  cast(test.t1.a, datetime BINARY)->Column#4",
 		"  └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"))
 }
+
+func TestIssue25813(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a json);")
+	tk.MustExec("insert into t values('{\"id\": \"ish\"}');")
+	tk.MustQuery("select t2.a from t t1 left join t t2 on t1.a=t2.a where t2.a->'$.id'='ish';").Check(testkit.Rows("{\"id\": \"ish\"}"))
+
+	tk.MustQuery("explain format = 'brief' select * from t t1 left join t t2 on t1.a=t2.a where t2.a->'$.id'='ish';").Check(testkit.Rows(
+		"Selection 8000.00 root  eq(json_extract(test.t.a, \"$.id\"), cast(\"ish\", json BINARY))",
+		"└─HashJoin 10000.00 root  left outer join, equal:[eq(test.t.a, test.t.a)]",
+		"  ├─TableReader(Build) 8000.00 root  data:Selection",
+		"  │ └─Selection 8000.00 cop[tikv]  not(isnull(cast(test.t.a, var_string(4294967295))))",
+		"  │   └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo",
+		"  └─TableReader(Probe) 10000.00 root  data:TableFullScan",
+		"    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"))
+}


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close https://github.com/pingcap/tidb/issues/25813

Problem Summary:

`evaluateExprWithNull` will pass the expression's RetType to `NewFunctionInternal`, which may change it unexpectedly.

### What is changed and how it works?

pass its clone instead of itself.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test

### Release note

```release-note
Fixed a bug that may cause comparisons between json and string report.
```
