### PR TITLE
log-backup: use a worker pool to speed up read metafile set.

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -129,15 +129,15 @@ type Client struct {
 
 	supportPolicy bool
 
-	// startTS and restoreTs are used for kv file restore.
+	// startTS and restoreTS are used for kv file restore.
 	// TiKV will filter the key space that don't belong to [startTS, restoreTS].
 	startTS   uint64
 	restoreTS uint64
 
-	// If the the commit-ts of txn-entry is belong [startTS, restoreTS],
-	// the start-ts of txn-entry may be smaller than startTS.
-	// We need maintain and restore more entries in default-cf
-	// (the start-ts in these entries is belong to [shiftStartTS, startTS]).
+	// If the commitTS of txn-entry belong to [startTS, restoreTS],
+	// the startTS of txn-entry may be smaller than startTS.
+	// We need maintain and restore more entries in default cf
+	// (the startTS in these entries belong to [shiftStartTS, startTS]).
 	shiftStartTS uint64
 
 	// currentTS is used for rewrite meta kv when restore stream.
@@ -1848,7 +1848,7 @@ func (rc *Client) RestoreMetaKVFile(
 	sr *stream.SchemasReplace,
 ) error {
 	log.Info("restore meta kv events", zap.String("file", file.Path),
-		zap.String("cf", file.Cf), zap.Int64(("kv-count"), file.NumberOfEntries),
+		zap.String("cf", file.Cf), zap.Int64("kv-count", file.NumberOfEntries),
 		zap.Uint64("min-ts", file.MinTs), zap.Uint64("max-ts", file.MaxTs))
 
 	rc.rawKVClient.SetColumnFamily(file.GetCf())

--- a/br/pkg/restore/stream_metas_test.go
+++ b/br/pkg/restore/stream_metas_test.go
@@ -5,6 +5,7 @@ package restore_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/br/pkg/stream"
 	"math/rand"
 	"path/filepath"
 	"testing"
@@ -47,7 +48,7 @@ func fakeStreamBackup(s storage.ExternalStorage) error {
 		if err != nil {
 			panic("failed to marshal test meta")
 		}
-		name := fmt.Sprintf("%s/%04d.meta", restore.GetStreamBackupMetaPrefix(), i)
+		name := fmt.Sprintf("%s/%04d.meta", stream.GetStreamBackupMetaPrefix(), i)
 		if err = s.WriteFile(ctx, name, bs); err != nil {
 			return errors.Trace(err)
 		}
@@ -60,7 +61,7 @@ func fakeStreamBackup(s storage.ExternalStorage) error {
 func TestTruncateLog(t *testing.T) {
 	ctx := context.Background()
 	tmpdir := t.TempDir()
-	backupMetaDir := filepath.Join(tmpdir, restore.GetStreamBackupMetaPrefix())
+	backupMetaDir := filepath.Join(tmpdir, stream.GetStreamBackupMetaPrefix())
 	_, err := storage.NewLocalStorage(backupMetaDir)
 	require.NoError(t, err)
 
@@ -103,7 +104,7 @@ func TestTruncateLog(t *testing.T) {
 	})
 
 	l.WalkDir(ctx, &storage.WalkOption{
-		SubDir: restore.GetStreamBackupMetaPrefix(),
+		SubDir: stream.GetStreamBackupMetaPrefix(),
 	}, func(s string, i int64) error {
 		require.NotContains(t, deletedFiles, s)
 		return nil

--- a/br/pkg/stream/stream_mgr.go
+++ b/br/pkg/stream/stream_mgr.go
@@ -15,16 +15,30 @@
 package stream
 
 import (
+	"context"
 	"github.com/pingcap/errors"
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/log"
+	"github.com/pingcap/tidb/br/pkg/storage"
+	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/meta"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/tablecodec"
 	"github.com/pingcap/tidb/util"
 	filter "github.com/pingcap/tidb/util/table-filter"
+
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 )
+
+const (
+	streamBackupMetaPrefix = "v1/backupmeta"
+)
+
+func GetStreamBackupMetaPrefix() string {
+	return streamBackupMetaPrefix
+}
 
 // appendTableObserveRanges builds key ranges corresponding to `tblIDS`.
 func appendTableObserveRanges(tblIDs []int64) []kv.KeyRange {
@@ -132,4 +146,37 @@ func BuildObserveMetaRange() *kv.KeyRange {
 	ek := sk.PrefixNext()
 
 	return &kv.KeyRange{StartKey: sk, EndKey: ek}
+}
+
+// FastUnmarshalMetaData used a 128 worker pool to speed up
+// read metadata content from external_storage.
+func FastUnmarshalMetaData(
+	ctx context.Context,
+	s storage.ExternalStorage,
+	fn func (path string, m *backuppb.Metadata) error,
+) error {
+	pool := utils.NewWorkerPool(128, "metadata")
+	eg, ectx := errgroup.WithContext(ctx)
+	opt := &storage.WalkOption{SubDir: GetStreamBackupMetaPrefix()}
+	err := s.WalkDir(ectx, opt, func(path string, size int64) error {
+		readPath := path
+		pool.ApplyOnErrorGroup(eg, func() error {
+			log.Info("fast read meta file from storage", zap.String("path", readPath))
+			b, err := s.ReadFile(ectx, readPath)
+			if err != nil {
+				return errors.Trace(err)
+			}
+			m := &backuppb.Metadata{}
+			err = m.Unmarshal(b)
+			if err != nil {
+				return err
+			}
+			return fn(readPath, m)
+		})
+		return nil
+	})
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return eg.Wait()
 }

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1462,13 +1462,15 @@ func FastUnmarshalMetaData(
 	opt := &storage.WalkOption{SubDir: restore.GetStreamBackupMetaPrefix()}
 	err := s.WalkDir(ectx, opt, func(path string, size int64) error {
 		if strings.Contains(path, restore.GetStreamBackupMetaPrefix()) {
-			b, err := s.ReadFile(ectx, path)
-			if err != nil {
-				return errors.Trace(err)
-			}
+			readPath := path
 			pool.ApplyOnErrorGroup(eg, func() error {
+				log.Info("read file in", zap.String("path", readPath))
+				b, err := s.ReadFile(ectx, readPath)
+				if err != nil {
+					return errors.Trace(err)
+				}
 				m := &backuppb.Metadata{}
-				err := m.Unmarshal(b)
+				err = m.Unmarshal(b)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/35530 

Problem Summary:
when we have 10000+ metafile from external_storage. This read I/O is becoming bottleneck, and other place like `log metadata` and `log truncate` will also benefit
### What is changed and how it works?
use a worker pool to speed up the read progress. I set the pool size to 128, and this is enough for 1 week.
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) 
The time costs from 5mins -> 37s
![KJUpdthnsS](https://user-images.githubusercontent.com/5906259/176596937-491bcc49-ee8a-490a-ada4-dbf4986b6e5a.jpg)

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
