### PR TITLE
ddl: make ToProxyJob return value to avoid heap allocation

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -724,6 +724,7 @@ func (d *ddl) DoDDLJob(ctx sessionctx.Context, job *model.Job) error {
 	failpoint.Inject("mockParallelSameDDLJobTwice", func(val failpoint.Value) {
 		if val.(bool) {
 			// The same job will be put to the DDL queue twice.
+			job = job.Clone()
 			task1 := &limitJobTask{job, make(chan error)}
 			d.limitJobCh <- task1
 			<-task.err

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -452,7 +452,7 @@ func jobNeedGC(job *model.Job) bool {
 		case model.ActionMultiSchemaChange:
 			for _, sub := range job.MultiSchemaInfo.SubJobs {
 				proxyJob := sub.ToProxyJob(job)
-				needGC := jobNeedGC(proxyJob)
+				needGC := jobNeedGC(&proxyJob)
 				if needGC {
 					return true
 				}

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -115,7 +115,7 @@ func insertJobIntoDeleteRangeTableMultiSchema(ctx context.Context, sctx sessionc
 	for _, sub := range job.MultiSchemaInfo.SubJobs {
 		proxyJob := sub.ToProxyJob(job)
 		if jobNeedGC(&proxyJob) {
-			err := insertJobIntoDeleteRangeTable(ctx, sctx, proxyJob, &ea)
+			err := insertJobIntoDeleteRangeTable(ctx, sctx, &proxyJob, &ea)
 			if err != nil {
 				return errors.Trace(err)
 			}

--- a/ddl/delete_range.go
+++ b/ddl/delete_range.go
@@ -114,7 +114,7 @@ func insertJobIntoDeleteRangeTableMultiSchema(ctx context.Context, sctx sessionc
 	var ea elementIDAlloc
 	for _, sub := range job.MultiSchemaInfo.SubJobs {
 		proxyJob := sub.ToProxyJob(job)
-		if jobNeedGC(proxyJob) {
+		if jobNeedGC(&proxyJob) {
 			err := insertJobIntoDeleteRangeTable(ctx, sctx, proxyJob, &ea)
 			if err != nil {
 				return errors.Trace(err)

--- a/ddl/multi_schema_change.go
+++ b/ddl/multi_schema_change.go
@@ -68,8 +68,8 @@ func onMultiSchemaChange(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 					continue
 				}
 				proxyJob := sub.ToProxyJob(job)
-				ver, err = w.runDDLJob(d, t, proxyJob)
-				sub.FromProxyJob(proxyJob)
+				ver, err = w.runDDLJob(d, t, &proxyJob)
+				sub.FromProxyJob(&proxyJob)
 				return ver, err
 			}
 			// The last rollback/cancelling sub-job is done.
@@ -87,8 +87,8 @@ func onMultiSchemaChange(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 				continue
 			}
 			proxyJob := sub.ToProxyJob(job)
-			ver, err = w.runDDLJob(d, t, proxyJob)
-			sub.FromProxyJob(proxyJob)
+			ver, err = w.runDDLJob(d, t, &proxyJob)
+			sub.FromProxyJob(&proxyJob)
 			handleRevertibleException(job, sub, proxyJob.Error)
 			return ver, err
 		}
@@ -107,8 +107,8 @@ func onMultiSchemaChange(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 			}
 			subJobs[i] = *sub
 			proxyJob := sub.ToProxyJob(job)
-			ver, err = w.runDDLJob(d, t, proxyJob)
-			sub.FromProxyJob(proxyJob)
+			ver, err = w.runDDLJob(d, t, &proxyJob)
+			sub.FromProxyJob(&proxyJob)
 			if err != nil || proxyJob.Error != nil {
 				for j := i - 1; j >= 0; j-- {
 					job.MultiSchemaInfo.SubJobs[j] = &subJobs[j]
@@ -129,8 +129,8 @@ func onMultiSchemaChange(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) (ve
 			continue
 		}
 		proxyJob := sub.ToProxyJob(job)
-		ver, err = w.runDDLJob(d, t, proxyJob)
-		sub.FromProxyJob(proxyJob)
+		ver, err = w.runDDLJob(d, t, &proxyJob)
+		sub.FromProxyJob(&proxyJob)
 		return ver, err
 	}
 	job.State = model.JobStateDone

--- a/ddl/sanity_check.go
+++ b/ddl/sanity_check.go
@@ -144,7 +144,7 @@ func expectedDeleteRangeCnt(job *model.Job) (int, error) {
 		totalExpectedCnt := 0
 		for _, sub := range job.MultiSchemaInfo.SubJobs {
 			p := sub.ToProxyJob(job)
-			cnt, err := expectedDeleteRangeCnt(p)
+			cnt, err := expectedDeleteRangeCnt(&p)
 			if err != nil {
 				return 0, err
 			}

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -308,8 +308,8 @@ func (sub *SubJob) IsFinished() bool {
 }
 
 // ToProxyJob converts a sub-job to a proxy job.
-func (sub *SubJob) ToProxyJob(parentJob *Job) *Job {
-	return &Job{
+func (sub *SubJob) ToProxyJob(parentJob *Job) Job {
+	return Job{
 		ID:              parentJob.ID,
 		Type:            sub.Type,
 		SchemaID:        parentJob.SchemaID,
@@ -434,6 +434,28 @@ func (job *Job) MarkNonRevertible() {
 	if job.MultiSchemaInfo != nil {
 		job.MultiSchemaInfo.Revertible = false
 	}
+}
+
+// Clone returns a copy of the job.
+func (job *Job) Clone() *Job {
+	encode, err := job.Encode(true)
+	if err != nil {
+		return nil
+	}
+	var clone Job
+	err = clone.Decode(encode)
+	if err != nil {
+		return nil
+	}
+	if len(job.Args) > 0 {
+		clone.Args = make([]interface{}, len(job.Args))
+		copy(clone.Args, job.Args)
+	}
+	for i, sub := range job.MultiSchemaInfo.SubJobs {
+		clone.MultiSchemaInfo.SubJobs[i].Args = make([]interface{}, len(sub.Args))
+		copy(clone.MultiSchemaInfo.SubJobs[i].Args, sub.Args)
+	}
+	return &clone
 }
 
 // TSConvert2Time converts timestamp to time.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/14766

Problem Summary:

### What is changed and how it works?

- Makes `ToProxyJob` return a value instead of a pointer.
- Clone the job in the failpoint `mockParallelSameDDLJobTwice` to prevent sharing the same instance(which will fail in concurrent DDL implementation).

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
