### PR TITLE
executor: support dispatch cop request to closest replica adaptively

### DIFF
--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -368,6 +368,12 @@ func (builder *RequestBuilder) SetIsStaleness(is bool) *RequestBuilder {
 	return builder
 }
 
+// SetClosestReplicaReadChecker sets request ClosestReadChecker
+func (builder *RequestBuilder) SetClosestReplicaReadChecker(chkFn kv.ClosestReadChecker) *RequestBuilder {
+	builder.ClosestReplicaReadChecker = chkFn
+	return builder
+}
+
 // TableHandleRangesToKVRanges convert table handle ranges to "KeyRanges" for multiple tables.
 func TableHandleRangesToKVRanges(sc *stmtctx.StatementContext, tid []int64, isCommonHandle bool, ranges []*ranger.Range, fb *statistics.QueryFeedback) ([]kv.KeyRange, error) {
 	if !isCommonHandle {

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -360,6 +360,8 @@ type Request struct {
 	ReadReplicaScope string
 	// IsStaleness indicates whether the request read staleness data
 	IsStaleness bool
+	// ClosestReplicaReadChecker used to check whether a copTask can be executed by the closest replica
+	ClosestReplicaReadChecker ClosestReadChecker
 	// MatchStoreLabels indicates the labels the store should be matched
 	MatchStoreLabels []*metapb.StoreLabel
 	// ResourceGroupTagger indicates the kv request task group tagger.
@@ -369,6 +371,11 @@ type Request struct {
 	// RequestSource indicates whether the request is an internal request.
 	RequestSource util.RequestSource
 }
+
+// ClosestReadChecker is used to check whether a copTask can be executed by a follower
+// the input is the number of cop tasks, return true means this copTask can be send to
+// a follower.
+type ClosestReadChecker func(*Request, int) bool
 
 // PartitionIDAndRanges used by PartitionTableScan in tiflash.
 type PartitionIDAndRanges struct {

--- a/kv/option.go
+++ b/kv/option.go
@@ -103,6 +103,8 @@ const (
 	ReplicaReadMixed
 	// ReplicaReadClosest stands for 'read from leader and follower which locates with the same zone'
 	ReplicaReadClosest
+	// ReplicaReadClosestAdaptive stands for 'read from follower which locates in the same zone iff the response size exceed certain threshold'
+	ReplicaReadClosestAdaptive
 )
 
 // IsFollowerRead checks if follower is going to be used to read data.

--- a/metrics/distsql.go
+++ b/metrics/distsql.go
@@ -60,4 +60,19 @@ var (
 			Name:      "copr_cache",
 			Help:      "coprocessor cache hit, evict and miss number",
 		}, []string{LblType})
+	DistSQLCoprClosestReadHitCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: "tidb",
+			Subsystem: "distsql",
+			Name:      "copr_closest_read_hit_rate",
+			Help:      "counter of total copr read local read hit",
+		}, []string{LblType})
+	DistSQLCoprRespBodySize = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: "tidb",
+			Subsystem: "distsql",
+			Name:      "copr_resp_size",
+			Help:      "copr task wait wall time of ms",
+			Buckets:   prometheus.ExponentialBuckets(1024, 2, 20),
+		}, []string{LblStore})
 )

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -103,6 +103,8 @@ func RegisterMetrics() {
 	prometheus.MustRegister(DeploySyncerHistogram)
 	prometheus.MustRegister(DistSQLPartialCountHistogram)
 	prometheus.MustRegister(DistSQLCoprCacheCounter)
+	prometheus.MustRegister(DistSQLCoprClosestReadHitCounter)
+	prometheus.MustRegister(DistSQLCoprRespBodySize)
 	prometheus.MustRegister(DistSQLQueryHistogram)
 	prometheus.MustRegister(DistSQLScanKeysHistogram)
 	prometheus.MustRegister(DistSQLScanKeysPartialHistogram)

--- a/planner/core/plan.go
+++ b/planner/core/plan.go
@@ -331,6 +331,9 @@ type PhysicalPlan interface {
 	// GetPlanCost calculates the cost of the plan if it has not been calculated yet and returns the cost.
 	GetPlanCost(taskType property.TaskType, costFlag uint64) (float64, error)
 
+	// GetNetworkCost calculates the cost of the plan in network data transfer.
+	GetNetworkCost() float64
+
 	// attach2Task makes the current physical plan as the father of task's physicalPlan and updates the cost of
 	// current task. If the child's task is cop task, some operator may close this task and return a new rootTask.
 	attach2Task(...task) task

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -972,6 +972,8 @@ type SessionVars struct {
 
 	// replicaRead is used for reading data from replicas, only follower is supported at this time.
 	replicaRead kv.ReplicaReadType
+	// AdaptiveClosestReadThreshold is the minimum response body size that a cop request should be sent to the closest replica.
+	AdaptiveClosestReadThreshold int64
 
 	// IsolationReadEngines is used to isolation read, tidb only read from the stores whose engine type is in the engines.
 	IsolationReadEngines map[kv.StoreType]struct{}

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1423,7 +1423,7 @@ var defaultSysVars = []*SysVar{
 		s.NoopFuncsMode = TiDBOptOnOffWarn(val)
 		return nil
 	}},
-	{Scope: ScopeGlobal | ScopeSession, Name: TiDBReplicaRead, Value: "leader", Type: TypeEnum, PossibleValues: []string{"leader", "follower", "leader-and-follower", "closest-replicas"}, SetSession: func(s *SessionVars, val string) error {
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBReplicaRead, Value: "leader", Type: TypeEnum, PossibleValues: []string{"leader", "follower", "leader-and-follower", "closest-replicas", "closest-adaptive"}, SetSession: func(s *SessionVars, val string) error {
 		if strings.EqualFold(val, "follower") {
 			s.SetReplicaRead(kv.ReplicaReadFollower)
 		} else if strings.EqualFold(val, "leader-and-follower") {
@@ -1432,7 +1432,13 @@ var defaultSysVars = []*SysVar{
 			s.SetReplicaRead(kv.ReplicaReadLeader)
 		} else if strings.EqualFold(val, "closest-replicas") {
 			s.SetReplicaRead(kv.ReplicaReadClosest)
+		} else if strings.EqualFold(val, "closest-adaptive") {
+			s.SetReplicaRead(kv.ReplicaReadClosestAdaptive)
 		}
+		return nil
+	}},
+	{Scope: ScopeGlobal | ScopeSession, Name: TiDBAdaptiveClosestReadThreshold, Value: strconv.Itoa(DefAdaptiveClosestReadThreshold), Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxInt64, SetSession: func(s *SessionVars, val string) error {
+		s.AdaptiveClosestReadThreshold = TidbOptInt64(val, DefAdaptiveClosestReadThreshold)
 		return nil
 	}},
 	{Scope: ScopeGlobal | ScopeSession, Name: TiDBUsePlanBaselines, Value: BoolToOnOff(DefTiDBUsePlanBaselines), Type: TypeBool, SetSession: func(s *SessionVars, val string) error {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -164,6 +164,10 @@ const (
 	// TiDBReplicaRead is used for reading data from replicas, followers for example.
 	TiDBReplicaRead = "tidb_replica_read"
 
+	// TiDBAdaptiveClosestReadThreshold is used to determinate whether a scan request should
+	// adaptively read from local follower.
+	TiDBAdaptiveClosestReadThreshold = "tidb_adaptive_closest_read_threshold"
+
 	// TiDBAllowRemoveAutoInc indicates whether a user can drop the auto_increment column attribute or not.
 	TiDBAllowRemoveAutoInc = "tidb_allow_remove_auto_inc"
 
@@ -942,6 +946,7 @@ const (
 	DefTiDBEnableConcurrentDDL                   = true
 	DefTiDBSimplifiedMetrics                     = false
 	DefTiDBEnablePaging                          = true
+	DefAdaptiveClosestReadThreshold              = 8192
 )
 
 // Process global variables.

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -97,6 +97,14 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 	bo := backoff.NewBackofferWithVars(ctx, copBuildTaskMaxBackoff, vars)
 	ranges := NewKeyRanges(req.KeyRanges)
 	tasks, err := buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
+	reqType := "null"
+	if req.ClosestReplicaReadChecker != nil {
+		reqType = "miss"
+		if req.ClosestReplicaReadChecker(req, len(tasks)) {
+			reqType = "hit"
+		}
+	}
+	tidbmetrics.DistSQLCoprClosestReadHitCounter.WithLabelValues(reqType).Inc()
 	if err != nil {
 		return copErrorResponse{err}
 	}
@@ -776,18 +784,20 @@ func (worker *copIteratorWorker) handleTaskOnce(bo *Backoffer, task *copTask, ch
 	// Set task.storeAddr field so its task.String() method have the store address information.
 	task.storeAddr = storeAddr
 	costTime := time.Since(startTime)
+	copResp := resp.Resp.(*coprocessor.Response)
 	if costTime > minLogCopTaskTime {
-		worker.logTimeCopTask(costTime, task, bo, resp)
+		worker.logTimeCopTask(costTime, task, bo, copResp)
 	}
 	storeID := strconv.FormatUint(req.Context.GetPeer().GetStoreId(), 10)
 	metrics.TiKVCoprocessorHistogram.WithLabelValues(storeID, strconv.FormatBool(staleRead)).Observe(costTime.Seconds())
+	tidbmetrics.DistSQLCoprRespBodySize.WithLabelValues(storeAddr).Observe(float64(len(copResp.Data)))
 
 	if worker.req.Paging {
-		return worker.handleCopPagingResult(bo, rpcCtx, &copResponse{pbResp: resp.Resp.(*coprocessor.Response)}, cacheKey, cacheValue, task, ch, costTime)
+		return worker.handleCopPagingResult(bo, rpcCtx, &copResponse{pbResp: copResp}, cacheKey, cacheValue, task, ch, costTime)
 	}
 
 	// Handles the response for non-paging copTask.
-	return worker.handleCopResponse(bo, rpcCtx, &copResponse{pbResp: resp.Resp.(*coprocessor.Response)}, cacheKey, cacheValue, task, ch, nil, costTime)
+	return worker.handleCopResponse(bo, rpcCtx, &copResponse{pbResp: copResp}, cacheKey, cacheValue, task, ch, nil, costTime)
 }
 
 const (
@@ -795,27 +805,18 @@ const (
 	minLogKVProcessTime = 100
 )
 
-func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *copTask, bo *Backoffer, resp *tikvrpc.Response) {
+func (worker *copIteratorWorker) logTimeCopTask(costTime time.Duration, task *copTask, bo *Backoffer, resp *coprocessor.Response) {
 	logStr := fmt.Sprintf("[TIME_COP_PROCESS] resp_time:%s txnStartTS:%d region_id:%d store_addr:%s", costTime, worker.req.StartTs, task.region.GetID(), task.storeAddr)
 	if bo.GetTotalSleep() > minLogBackoffTime {
 		backoffTypes := strings.Replace(fmt.Sprintf("%v", bo.TiKVBackoffer().GetTypes()), " ", ",", -1)
 		logStr += fmt.Sprintf(" backoff_ms:%d backoff_types:%s", bo.GetTotalSleep(), backoffTypes)
 	}
-	var detailV2 *kvrpcpb.ExecDetailsV2
-	var detail *kvrpcpb.ExecDetails
-	if resp.Resp != nil {
-		switch r := resp.Resp.(type) {
-		case *coprocessor.Response:
-			detailV2 = r.ExecDetailsV2
-			detail = r.ExecDetails
-		default:
-			panic("unreachable")
-		}
-	}
 
 	var timeDetail *kvrpcpb.TimeDetail
+	detailV2 := resp.ExecDetailsV2
+	detail := resp.ExecDetails
 	if detailV2 != nil && detailV2.TimeDetail != nil {
-		timeDetail = detailV2.TimeDetail
+		timeDetail = resp.ExecDetailsV2.TimeDetail
 	} else if detail != nil && detail.TimeDetail != nil {
 		timeDetail = detail.TimeDetail
 	}

--- a/store/driver/options/options.go
+++ b/store/driver/options/options.go
@@ -30,6 +30,8 @@ func GetTiKVReplicaReadType(t kv.ReplicaReadType) storekv.ReplicaReadType {
 		return storekv.ReplicaReadMixed
 	case kv.ReplicaReadClosest:
 		return storekv.ReplicaReadMixed
+	case kv.ReplicaReadClosestAdaptive:
+		return storekv.ReplicaReadMixed
 	}
 	return 0
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35926

Problem Summary:

### What is changed and how it works?

Add an extra value choice `closest-adaptive` for tidb_replica_read to enable closest follower read only when the response size exceed certain threshold. The theshold is define by a new variable "tidb_adaptive_closest_read_threshold".

This PR only affect coprocessor request. PointGet/BatchPointGet will be supported in a separated PR as they require some changes in the `client-go` repo.



### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
