### PR TITLE
Lightning: log improvement

### DIFF
--- a/br/pkg/lightning/backend/backend.go
+++ b/br/pkg/lightning/backend/backend.go
@@ -456,7 +456,7 @@ func (engine *ClosedEngine) Import(ctx context.Context, regionSplitSize, regionS
 	var err error
 
 	for i := 0; i < importMaxRetryTimes; i++ {
-		task := engine.logger.With(zap.Int("retryCnt", i)).Begin(zap.InfoLevel, "import")
+		task := engine.logger.With(zap.Int("retryCnt", i)).Begin(zap.InfoLevel, "Import engine temp KVs into tikv")
 		err = engine.backend.ImportEngine(ctx, engine.uuid, regionSplitSize, regionSplitKeys)
 		if !common.IsRetryableError(err) {
 			task.End(zap.ErrorLevel, err)

--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1053,7 +1053,7 @@ func (local *local) readAndSplitIntoRange(ctx context.Context, engine *Engine, r
 		return ranges, nil
 	}
 
-	logger := log.FromContext(ctx).With(zap.Stringer("engine", engine.UUID))
+	logger := log.FromContext(ctx).With(zap.Stringer("engineUUID", engine.UUID))
 	sizeProps, err := getSizeProperties(logger, engine.db, local.keyAdapter)
 	if err != nil {
 		return nil, errors.Trace(err)
@@ -1415,7 +1415,7 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID, regi
 		}()
 	}
 
-	log.FromContext(ctx).Info("start import engine", zap.Stringer("uuid", engineUUID),
+	log.FromContext(ctx).Info("import splitted ranges of engine", zap.Stringer("engineUUID", engineUUID),
 		zap.Int("ranges", len(ranges)), zap.Int64("count", lfLength), zap.Int64("size", lfTotalSize))
 
 	failpoint.Inject("ReadyForImportEngine", func() {})
@@ -1453,7 +1453,7 @@ func (local *local) ImportEngine(ctx context.Context, engineUUID uuid.UUID, regi
 		}
 	}
 
-	log.FromContext(ctx).Info("import engine success", zap.Stringer("uuid", engineUUID),
+	log.FromContext(ctx).Info("import splitted ranges of engine completed", zap.Stringer("engineUUID", engineUUID),
 		zap.Int64("size", lfTotalSize), zap.Int64("kvs", lfLength),
 		zap.Int64("importedSize", lf.importedKVSize.Load()), zap.Int64("importedCount", lf.importedKVCount.Load()))
 	return nil

--- a/br/pkg/lightning/backend/local/localhelper.go
+++ b/br/pkg/lightning/backend/local/localhelper.go
@@ -334,11 +334,11 @@ func (local *local) SplitAndScatterRegionByRanges(
 	startTime := time.Now()
 	scatterCount, err := local.waitForScatterRegions(ctx, scatterRegions)
 	if scatterCount == len(scatterRegions) {
-		log.FromContext(ctx).Info("waiting for scattering regions done",
+		log.FromContext(ctx).Info("scattering regions done",
 			zap.Int("skipped_keys", skippedKeys),
 			zap.Int("regions", len(scatterRegions)), zap.Duration("take", time.Since(startTime)))
 	} else {
-		log.FromContext(ctx).Info("waiting for scattering regions timeout",
+		log.FromContext(ctx).Info("scattering regions timeout",
 			zap.Int("skipped_keys", skippedKeys),
 			zap.Int("scatterCount", scatterCount),
 			zap.Int("regions", len(scatterRegions)),

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -239,7 +239,7 @@ func MakeTableRegions(
 		}
 	}
 
-	log.FromContext(ctx).Info("makeTableRegions", zap.Int("filesCount", len(meta.DataFiles)),
+	log.FromContext(ctx).Info("virtually splitted source table X data files into Y chunks(table regions) based on MaxRegionSize Z, and assign splitted chunks into W engines to concurrently restore table", zap.Int("filesCount", len(meta.DataFiles)),
 		zap.Int64("MaxRegionSize", int64(cfg.Mydumper.MaxRegionSize)),
 		zap.Int("RegionsCount", len(filesRegions)),
 		zap.Float64("BatchSize", batchSize),

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -239,7 +239,9 @@ func MakeTableRegions(
 		}
 	}
 
-	log.FromContext(ctx).Info("virtually splitted source table X data files into Y chunks(table regions) based on MaxRegionSize Z, and assign splitted chunks into W engines to concurrently restore table", zap.Int("filesCount", len(meta.DataFiles)),
+	log.FromContext(ctx).Info("virtually splitted source table data files into chunks(table regions) based on MaxRegionSize, and assign splitted chunks into engines to concurrently restore table",
+		zap.String("table", meta.Name),
+		zap.Int("filesCount", len(meta.DataFiles)),
 		zap.Int64("MaxRegionSize", int64(cfg.Mydumper.MaxRegionSize)),
 		zap.Int("RegionsCount", len(filesRegions)),
 		zap.Float64("BatchSize", batchSize),

--- a/br/pkg/lightning/mydump/region.go
+++ b/br/pkg/lightning/mydump/region.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/br/pkg/lightning/config"
 	"github.com/pingcap/tidb/br/pkg/lightning/log"
+	"github.com/pingcap/tidb/br/pkg/lightning/common"
 	"github.com/pingcap/tidb/br/pkg/lightning/worker"
 	"github.com/pingcap/tidb/br/pkg/storage"
 	"github.com/pingcap/tidb/util/mathutil"
@@ -239,8 +240,8 @@ func MakeTableRegions(
 		}
 	}
 
-	log.FromContext(ctx).Info("virtually splitted source table data files into chunks(table regions) based on MaxRegionSize, and assign splitted chunks into engines to concurrently restore table",
-		zap.String("table", meta.Name),
+	log.FromContext(ctx).Info("virtually split source table data files into chunks(table regions) based on MaxRegionSize, and assign split chunks into engines to concurrently restore table",
+		zap.String("table", common.UniqueTable(meta.DB, meta.Name)),
 		zap.Int("filesCount", len(meta.DataFiles)),
 		zap.Int64("MaxRegionSize", int64(cfg.Mydumper.MaxRegionSize)),
 		zap.Int("RegionsCount", len(filesRegions)),

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -2552,9 +2552,9 @@ func (cr *chunkRestore) restore(
 
 	logTask := t.logger.With(
 		zap.Int32("engineNumber", engineID),
-		zap.Int("fileIndex", cr.index),
+		zap.Int("chunk id", cr.index),
 		zap.Stringer("path", &cr.chunk.Key),
-	).Begin(zap.InfoLevel, "restore file")
+	).Begin(zap.InfoLevel, "transform an engine source data chunk into temp KVs start")
 
 	readTotalDur, encodeTotalDur, encodeErr := cr.encodeLoop(ctx, kvsCh, t, logTask.Logger, kvEncoder, deliverCompleteCh, rc)
 	var deliverErr error

--- a/br/pkg/lightning/restore/restore.go
+++ b/br/pkg/lightning/restore/restore.go
@@ -2554,7 +2554,7 @@ func (cr *chunkRestore) restore(
 		zap.Int32("engineNumber", engineID),
 		zap.Int("chunk id", cr.index),
 		zap.Stringer("path", &cr.chunk.Key),
-	).Begin(zap.InfoLevel, "transform an engine source data chunk into temp KVs start")
+	).Begin(zap.InfoLevel, "transform an engine source data chunk into temp KVs")
 
 	readTotalDur, encodeTotalDur, encodeErr := cr.encodeLoop(ctx, kvsCh, t, logTask.Logger, kvEncoder, deliverCompleteCh, rc)
 	var deliverErr error


### PR DESCRIPTION
### What problem does this PR solve?

Issue Number: close #35891 

Problem Summary:

### What is changed and how it works?
Part of the logs was rephrased to help the users have a better understanding of the import process using lightning. Below are the logs changed:

Before:

```
[INFO] [table_restore.go:91] ["load engines and files start"] [table=`sysbench`.`sbtest1`]
```
Change the description: Virtually reorganize source table data into engines start

Before:

```
[INFO] [region.go:241] [makeTableRegions] [filesCount=8] [MaxRegionSize=268435456] [RegionsCount=8] [BatchSize=107374182400] [cost=53.207µs]
```
Change the description: Virtually split source table X data files into Y chunks(table regions) based on MaxRegionSize Z, and assign split chunks into W engines to concurrently restore table

Before:

```
[INFO] [table_restore.go:129] ["load engines and files completed"] [table=`sysbench`.`sbtest1`] [enginesCnt=2] [ime=75.563µs] []
```
Change the description: Virtually reorganize source table data into engines completed

Before:

```
[INFO] [table_restore.go:270] ["import whole table start"] [table=`sysbench`.`sbtest1`]
```
Change the description: Restore all source data by engines start

Before:

```
[INFO] [table_restore.go:422] ["encode kv data and write start"] [table=`sysbench`.`sbtest1`] [engineNumber=0]
```
Change the description: transform engine source data into temp KVs start

Before:

```
[INFO] [restore.go:2482] ["restore file start"] [table=`sysbench`.`sbtest1`] [engineNumber=0] [fileIndex=0] [path=sysbench.sbtest1.000000000.sql:0]
```
Change the description: transform an engine source data chunk into temp KVs start
Change “fileIndex” to "chunk id"

Before:

```
[INFO] [restore.go:2492] ["restore file completed"] [table=`sysbench`.`sbtest1`] [engineNumber=0] [fileIndex=1] [path=sysbench.sbtest1.000000001.sql:0] [readDur=3.123667511s] [encodeDur=5.627497136s] [deliverDur=6.653498837s] [checksum="{cksum=6610977918434119862,size=336040251,kvs=2646056}"] [takeTime=15.474211783s] []
```
Change the description: transform an engine source data chunk into temp KVs completed

Before:

```
[INFO] [table_restore.go:584] ["encode kv data and write completed"] [table=`sysbench`.`sbtest1`] [engineNumber=0] [read=16] [written=2539933993] [takeTime=23.598662501s] []
```
Change the description: transform engine source data into temp KVs completed

Before:

```
[INFO] [backend.go:452] ["import start"] [engineTag=`sysbench`.`sbtest1`:0] [engineUUID=d173bb2e-b753-5da9-b72e-13a49a46f5d7] [retryCnt=0]
```
Change the description: Import engine temp KVs into tikv start

Before:

```
[INFO] [local.go:1023] ["split engine key ranges"] [engine=d173bb2e-b753-5da9-b72e-13a49a46f5d7] [totalSize=2159933993] [totalCount=10000000] [firstKey=74800000000000003F5F728000000000000001] [lastKey=74800000000000003F5F728000000000989680] [ranges=22]
```
”engine“ to “ engineUUID”

Before:

```
[INFO] [local.go:1336] ["start import engine"] [uuid=d173bb2e-b753-5da9-b72e-13a49a46f5d7] [ranges=22] [count=10000000] [size=2159933993]
```
Change the description: Import split ranges of engine start
"uuid" to "engineUUID"

Before:

```
[INFO] [local.go:1371] ["import engine success"] [uuid=d173bb2e-b753-5da9-b72e-13a49a46f5d7] [size=2159933993] [kvs=10000000] [importedSize=2159933993] [importedCount=10000000]
```
Change the description: Import split ranges of engine completed
"uuid" to "engineUUID"

Before:

```
[INFO] [localhelper.go:319] ["waiting for scattering regions done"] [skipped_keys=0] [regions=23] [take=6.505195ms]
```
Change the description: scattering regions done

Before:

```
[INFO] [backend.go:455] ["import completed"] [engineTag=`sysbench`.`sbtest1`:0] [engineUUID=d173bb2e-b753-5da9-b72e-13a49a46f5d7] [retryCnt=0] [takeTime=20.179184481s] []
```
Change the description: Import engine temp KVs into tikv completed

Before:

```
[INFO] [table_restore.go:345] ["import whole table completed"] [table=`sysbench`.`sbtest1`] [takeTime=47.421324969s] [] 
```
Change the description: Restore all source data by engines completed

Added new log [here](https://github.com/pingcap/tidb/blob/v5.4.0/br/pkg/lightning/restore/table_restore.go#L383):

```
[INFO] [table_restore.go:357] ["import source data index engine start"] [table=`test`.`order_line`]
[INFO] [table_restore.go:359] ["import source data index engine completed"] [table=`test`.`person`] [takeTime=78.88448ms] []

```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
