### PR TITLE
[DNM]ddl: support update multi TiFlash replica available value in single ddl.

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -120,6 +120,7 @@ type DDL interface {
 	UnlockTables(ctx sessionctx.Context, lockedTables []model.TableLockTpInfo) error
 	CleanupTableLock(ctx sessionctx.Context, tables []*ast.TableName) error
 	UpdateTableReplicaInfo(ctx sessionctx.Context, physicalID int64, available bool) error
+	UpdateTableReplicaInfos(ctx sessionctx.Context, physicalIDs []int64, available bool) error
 	RepairTable(ctx sessionctx.Context, table *ast.TableName, createStmt *ast.CreateTableStmt) error
 	CreateSequence(ctx sessionctx.Context, stmt *ast.CreateSequenceStmt) error
 	DropSequence(ctx sessionctx.Context, tableIdent ast.Ident, ifExists bool) (err error)
@@ -193,6 +194,15 @@ type DDL interface {
 type limitJobTask struct {
 	job *model.Job
 	err chan error
+}
+
+type TiFlashReplicaDDLArg struct {
+	SchemaID   int64  `json:"schema_id"`
+	TableID    int64  `json:"table_id"`
+	SchemaName string `json:"schema_name"`
+	TableName  string `json:"table_name"`
+	PhysicalID int64  `json:"physical_id"`
+	Available  bool   `json:"available"`
 }
 
 // ddl is used to handle the statements that define the structure or schema of the database.

--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -23,6 +23,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"reflect"
+	"sort"
 	"strings"
 	"time"
 
@@ -223,6 +225,10 @@ var (
 	PollTiFlashBackoffCapacity int = 1000
 	// PollTiFlashBackoffRate is growth rate of exponential backoff threshold.
 	PollTiFlashBackoffRate TiFlashTick = 1.5
+	// PollTiFlashUpdateInterval is the interval between every pollTiFlashPeerInfo call.
+	PollTiFlashPeerInfoInterval = 2 * time.Minute
+	// LastSyncTiFlashStoreTick indicates the time of the last call pollTiFlashPeerInfo
+	LastTimeSyncTiFlashStore = time.Now()
 )
 
 func getTiflashHTTPAddr(host string, statusAddr string) (string, error) {
@@ -284,6 +290,48 @@ func GetTiFlashReplicaInfo(tblInfo *model.TableInfo, tableList *[]TiFlashReplica
 	} else {
 		logutil.BgLogger().Debug(fmt.Sprintf("Table %v has no partition\n", tblInfo.ID))
 		*tableList = append(*tableList, TiFlashReplicaStatus{tblInfo.ID, tblInfo.TiFlashReplica.Count, tblInfo.TiFlashReplica.LocationLabels, tblInfo.TiFlashReplica.Available, false, false})
+	}
+}
+
+func GetTiFlashReplicaMapInfo(tblInfo *model.TableInfo, tableMap *map[int64]TiFlashReplicaStatus) {
+	if tblInfo.TiFlashReplica == nil {
+		// reject tables that has no tiflash replica such like `INFORMATION_SCHEMA`
+		return
+	}
+	if pi := tblInfo.GetPartitionInfo(); pi != nil {
+		for _, p := range pi.Definitions {
+			logutil.BgLogger().Debug(fmt.Sprintf("Table %v has partition %v\n", tblInfo.ID, p.ID))
+			(*tableMap)[p.ID] = TiFlashReplicaStatus{
+				p.ID,
+				tblInfo.TiFlashReplica.Count,
+				tblInfo.TiFlashReplica.LocationLabels,
+				tblInfo.TiFlashReplica.IsPartitionAvailable(p.ID),
+				false,
+				true,
+			}
+		}
+		// partitions that in adding mid-state
+		for _, p := range pi.AddingDefinitions {
+			logutil.BgLogger().Debug(fmt.Sprintf("Table %v has partition adding %v\n", tblInfo.ID, p.ID))
+			(*tableMap)[p.ID] = TiFlashReplicaStatus{
+				p.ID,
+				tblInfo.TiFlashReplica.Count,
+				tblInfo.TiFlashReplica.LocationLabels,
+				tblInfo.TiFlashReplica.IsPartitionAvailable(p.ID),
+				true,
+				true,
+			}
+		}
+	} else {
+		logutil.BgLogger().Debug(fmt.Sprintf("Table %v has no partition\n", tblInfo.ID))
+		(*tableMap)[tblInfo.ID] = TiFlashReplicaStatus{
+			tblInfo.ID,
+			tblInfo.TiFlashReplica.Count,
+			tblInfo.TiFlashReplica.LocationLabels,
+			tblInfo.TiFlashReplica.Available,
+			false,
+			false,
+		}
 	}
 }
 
@@ -463,6 +511,105 @@ func (d *ddl) pollTiFlashReplicaStatus(ctx sessionctx.Context, pollTiFlashContex
 	return allReplicaReady, nil
 }
 
+func (d *ddl) pollTiFlashPeerInfo(ctx sessionctx.Context, pollTiFlashContext *TiFlashManagementContext) (bool, error) {
+	allReplicaReady := true
+
+	// Start to process every table.
+	schema := d.GetInfoSchemaWithInterceptor(ctx)
+	if schema == nil {
+		return false, errors.New("Schema is nil")
+	}
+
+	var tableMap = make(map[int64]TiFlashReplicaStatus)
+	// Collect TiFlash Replica info, for every table.
+	for _, db := range schema.AllSchemas() {
+		tbls := schema.SchemaTables(db.Name)
+		for _, tbl := range tbls {
+			tblInfo := tbl.Meta()
+			GetTiFlashReplicaMapInfo(tblInfo, &tableMap)
+		}
+	}
+
+	tiflashStoreIds := make([]int64, len(pollTiFlashContext.TiFlashStores))
+	for i, store := range pollTiFlashContext.TiFlashStores {
+		// TBD: not sure it is peer id or store id
+		tiflashStoreIds[i] = store.Store.ID
+	}
+
+	sort.Slice(tiflashStoreIds, func(i, j int) bool { return tiflashStoreIds[i] < tiflashStoreIds[j] })
+
+	isTiflashPeer := func(tiflashPeerIds []int64, peerId int64) bool {
+		for _, tiflashPeerId := range tiflashPeerIds {
+			if tiflashPeerId == peerId {
+				return true
+			}
+		}
+
+		return false
+	}
+
+	isTiflashAllPeerDown := func(tiflashPeerIds []int64, tiflashDownPeerIds []int64) bool {
+		return reflect.DeepEqual(tiflashPeerIds, tiflashDownPeerIds)
+	}
+
+	var invaildRegions helper.RegionsInfo
+
+	if err := infosync.GetTiFlashPDInvalidRegionsInfo(context.Background(), &invaildRegions); err != nil {
+		return false, errors.Trace(err)
+	}
+
+	// There are no down-peer/pending-peer
+	if invaildRegions.Count == 0 {
+		return true, nil
+	}
+	var invalidTableIDs []int64
+	for _, invaildRegion := range invaildRegions.Regions {
+		var invalidPeers []int64
+		for _, downPeer := range invaildRegion.DownPeers {
+			if isTiflashPeer(tiflashStoreIds, downPeer.Peer.ID) {
+				invalidPeers = append(invalidPeers, downPeer.Peer.ID)
+			}
+		}
+
+		for _, pendingPeer := range invaildRegion.PendingPeers {
+			if isTiflashPeer(tiflashStoreIds, pendingPeer.ID) {
+				invalidPeers = append(invalidPeers, pendingPeer.ID)
+			}
+		}
+
+		if len(invalidPeers) != 0 {
+			sort.Slice(invalidPeers, func(i, j int) bool { return invalidPeers[i] < invalidPeers[j] })
+			if isTiflashAllPeerDown(tiflashStoreIds, invalidPeers) {
+				invaildTableID := helper.GetTiFlashTableIDFromEndKey(invaildRegion.EndKey)
+				invalidTableIDs = append(invalidTableIDs, invaildTableID)
+			}
+		}
+	}
+
+	for _, invalidTableID := range invalidTableIDs {
+		tableInfo, exist := tableMap[invalidTableID]
+		if !exist {
+			logutil.BgLogger().Info("No exist table info in Tiflash", zap.Int64("tableId", invalidTableID))
+			continue
+		}
+
+		if !tableInfo.Available {
+			continue
+		}
+
+		// Will call `onUpdateFlashReplicaStatus` to update `TiFlashReplica`.
+		if err := d.UpdateTableReplicaInfo(ctx, invalidTableID, false); err != nil {
+			if infoschema.ErrTableNotExists.Equal(err) && tableInfo.IsPartition {
+				logutil.BgLogger().Info("updating TiFlash replica status err, maybe false alarm by blocking add", zap.Error(err), zap.Int64("tableID", tableInfo.ID), zap.Bool("isPartition", tableInfo.IsPartition))
+			} else {
+				logutil.BgLogger().Error("updating TiFlash replica status err", zap.Error(err), zap.Int64("tableID", tableInfo.ID), zap.Bool("isPartition", tableInfo.IsPartition))
+			}
+		}
+	}
+
+	return allReplicaReady, nil
+}
+
 func getDropOrTruncateTableTiflash(ctx sessionctx.Context, currentSchema infoschema.InfoSchema, tikvHelper *helper.Helper, replicaInfos *[]TiFlashReplicaStatus) error {
 	store := tikvHelper.Store.(kv.Storage)
 
@@ -597,6 +744,16 @@ func (d *ddl) PollTiFlashRoutine() {
 						default:
 							logutil.BgLogger().Warn("pollTiFlashReplicaStatus returns error", zap.Error(err))
 						}
+					}
+
+					syncElapsed := time.Since(LastTimeSyncTiFlashStore)
+					if syncElapsed > PollTiFlashPeerInfoInterval {
+						_, err := d.pollTiFlashPeerInfo(sctx, pollTiflashContext)
+						if err != nil {
+							logutil.BgLogger().Warn("pollTiFlashPeerInfo returns error", zap.Error(err))
+						}
+
+						LastTimeSyncTiFlashStore = time.Now()
 					}
 				}
 				d.sessPool.put(sctx)

--- a/ddl/ddl_tiflash_api.go
+++ b/ddl/ddl_tiflash_api.go
@@ -537,7 +537,6 @@ func (d *ddl) pollTiFlashPeerInfo(ctx sessionctx.Context, pollTiFlashContext *Ti
 	tiflashStoreIds := make([]int64, len(pollTiFlashContext.TiFlashStores))
 
 	for i, store := range pollTiFlashContext.TiFlashStores {
-		// TBD: not sure it is peer id or store id
 		tiflashStoreIds[i-1] = store.Store.ID
 	}
 

--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -636,8 +636,6 @@ func TestTiFlashBackoffer(t *testing.T) {
 		require.Equal(t, ori, e.Threshold)
 		require.Equal(t, c+1, e.Counter)
 		require.Equal(t, oriTotal+1, total)
-
-		logutil.BgLogger().Info(fmt.Sprintf("Table %v mustNotGrow Counter: %v,total : %v \n", ID, e.Counter, total))
 	}
 	mustGrow := func(ID int64) {
 		e := mustGet(ID)
@@ -649,8 +647,6 @@ func TestTiFlashBackoffer(t *testing.T) {
 		require.Equal(t, e.Threshold, rate*ori)
 		require.Equal(t, 1, e.Counter)
 		require.Equal(t, oriTotal+1, total)
-
-		logutil.BgLogger().Info(fmt.Sprintf("Table %v mustNotGrow Counter: %v,total : %v \n", ID, e.Counter, total))
 	}
 	// Test grow
 	ok := backoff.Put(1)

--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -636,6 +636,8 @@ func TestTiFlashBackoffer(t *testing.T) {
 		require.Equal(t, ori, e.Threshold)
 		require.Equal(t, c+1, e.Counter)
 		require.Equal(t, oriTotal+1, total)
+
+		logutil.BgLogger().Info(fmt.Sprintf("Table %v mustNotGrow Counter: %v,total : %v \n", ID, e.Counter, total))
 	}
 	mustGrow := func(ID int64) {
 		e := mustGet(ID)
@@ -647,6 +649,8 @@ func TestTiFlashBackoffer(t *testing.T) {
 		require.Equal(t, e.Threshold, rate*ori)
 		require.Equal(t, 1, e.Counter)
 		require.Equal(t, oriTotal+1, total)
+
+		logutil.BgLogger().Info(fmt.Sprintf("Table %v mustNotGrow Counter: %v,total : %v \n", ID, e.Counter, total))
 	}
 	// Test grow
 	ok := backoff.Put(1)

--- a/domain/infosync/info.go
+++ b/domain/infosync/info.go
@@ -1023,6 +1023,15 @@ func GetTiFlashPDRegionRecordStats(ctx context.Context, tableID int64, stats *he
 	return is.tiflashPlacementManager.GetPDRegionRecordStats(ctx, tableID, stats)
 }
 
+// GetTiFlashPDInvalidRegionsInfo is a helper function calling `regions/check/down-peer|pending-peer`.
+func GetTiFlashPDInvalidRegionsInfo(ctx context.Context, regionInfo *helper.RegionsInfo) error {
+	is, err := getGlobalInfoSyncer()
+	if err != nil {
+		return errors.Trace(err)
+	}
+	return is.tiflashPlacementManager.GetPDInvalidRegionsInfo(ctx, regionInfo)
+}
+
 // GetTiFlashStoresStat gets the TiKV store information by accessing PD's api.
 func GetTiFlashStoresStat(ctx context.Context) (*helper.StoresStat, error) {
 	is, err := getGlobalInfoSyncer()

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -450,15 +450,15 @@ func (tiflash *MockTiFlash) HandleGetPDInvalidRegionsInfo() helper.RegionsInfo {
 		Regions: []helper.RegionInfo{
 			{
 				ID:       1,
-				StartKey: "7480000000000000015f72", // table 1 without index
-				EndKey:   "7480000000000000015f73",
+				StartKey: "7480000000000000FF4500000000000000F8", // table 69 without index
+				EndKey:   "7480000000000000FF4600000000000000F8",
 				Epoch: helper.RegionEpoch{
 					ConfVer: 1,
 					Version: 1,
 				},
 				Peers: []helper.RegionPeer{
 					{
-						ID:        50,
+						ID:        1,
 						StoreID:   20,
 						IsLearner: false,
 					},
@@ -472,7 +472,7 @@ func (tiflash *MockTiFlash) HandleGetPDInvalidRegionsInfo() helper.RegionsInfo {
 					{
 						DownSec: 1000,
 						Peer: helper.RegionPeer{
-							ID:        51,
+							ID:        1,
 							StoreID:   20,
 							IsLearner: false,
 						},
@@ -480,7 +480,7 @@ func (tiflash *MockTiFlash) HandleGetPDInvalidRegionsInfo() helper.RegionsInfo {
 				},
 				PendingPeers: []helper.RegionPeer{
 					{
-						ID:        52,
+						ID:        1,
 						StoreID:   20,
 						IsLearner: false,
 					},

--- a/store/helper/helper.go
+++ b/store/helper/helper.go
@@ -791,20 +791,6 @@ func bytesKeyToHex(key []byte) string {
 	return strings.ToUpper(hex.EncodeToString(key))
 }
 
-// GetPendingRegionsInfo gets the pending regions information of current store by using PD's api.
-func (h *Helper) GetPendingRegionsInfo() (*RegionsInfo, error) {
-	var regionsInfo RegionsInfo
-	err := h.requestPD("GetRegions", "GET", pdapi.Regions+"/check/pending-peer/", nil, &regionsInfo)
-	return &regionsInfo, err
-}
-
-// GetDownRegionsInfo gets the down regions information of current store by using PD's api.
-func (h *Helper) GetDownRegionsInfo() (*RegionsInfo, error) {
-	var regionsInfo RegionsInfo
-	err := h.requestPD("GetRegions", "GET", pdapi.Regions+"/check/down-peer/", nil, &regionsInfo)
-	return &regionsInfo, err
-}
-
 // GetRegionsInfo gets the region information of current store by using PD's api.
 func (h *Helper) GetRegionsInfo() (*RegionsInfo, error) {
 	var regionsInfo RegionsInfo

--- a/store/helper/helper_test.go
+++ b/store/helper/helper_test.go
@@ -483,3 +483,8 @@ func TestTableRange(t *testing.T) {
 	// t+(id+1)
 	require.Equal(t, "748000000000000002", endKey.String())
 }
+
+func TestGetTiFlashTableIDFromEndKey(t *testing.T) {
+	tableId := helper.GetTiFlashTableIDFromEndKey("7480000000000000FF4600000000000000F8")
+	require.Equal(t, int64(69), tableId)
+}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35914

Problem Summary:

### What is changed and how it works?
- make ddl type `ActionUpdateTiFlashReplicaStatus` support `multi-db + multi-table` as the args.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
