### PR TITLE
br: add requirements checking when execute pitr

### DIFF
--- a/br/pkg/errors/errors.go
+++ b/br/pkg/errors/errors.go
@@ -49,6 +49,7 @@ var (
 	ErrRestoreWriteAndIngest   = errors.Normalize("failed to write and ingest", errors.RFCCodeText("BR:Restore:ErrRestoreWriteAndIngest"))
 	ErrRestoreSchemaNotExists  = errors.Normalize("schema not exists", errors.RFCCodeText("BR:Restore:ErrRestoreSchemaNotExists"))
 	ErrUnsupportedSystemTable  = errors.Normalize("the system table isn't supported for restoring yet", errors.RFCCodeText("BR:Restore:ErrUnsupportedSysTable"))
+	ErrDatabasesAlreadyExisted = errors.Normalize("databases already existed in restored cluster", errors.RFCCodeText("BR:Restore:ErrDatabasesAlreadyExisted"))
 
 	// ErrStreamLogTaskExist is the error when stream log task already exists, because of supporting single task currently.
 	ErrStreamLogTaskExist = errors.Normalize("stream task already exists", errors.RFCCodeText("BR:Stream:ErrStreamLogTaskExist"))

--- a/br/pkg/restore/db.go
+++ b/br/pkg/restore/db.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	tidbutil "github.com/pingcap/tidb/util"
 	"go.uber.org/zap"
 )
 
@@ -456,8 +457,8 @@ func GetExistedUserDBs(dom *domain.Domain) []*model.DBInfo {
 	databases := dom.InfoSchema().AllSchemas()
 	existedDatabases := make([]*model.DBInfo, 0, 16)
 	for _, db := range databases {
-		dbName, _ := utils.GetSysDBName(db.Name)
-		if utils.IsInSysDBs(dbName) {
+		dbName := db.Name.L
+		if tidbutil.IsMemOrSysDB(dbName) {
 			continue
 		} else if dbName == "test" && len(db.Tables) == 0 {
 			continue

--- a/br/pkg/utils/schema.go
+++ b/br/pkg/utils/schema.go
@@ -17,6 +17,14 @@ import (
 // temporaryDBNamePrefix is the prefix name of system db, e.g. mysql system db will be rename to __TiDB_BR_Temporary_mysql
 const temporaryDBNamePrefix = "__TiDB_BR_Temporary_"
 
+var sysDBMap = map[string]struct{}{
+	"INFORMATION_SCHEMA": {},
+	"PERFORMANCE_SCHEMA": {},
+	"METRICS_SCHEMA":     {},
+	"INSPECTION_SCHEMA":  {},
+	"MYSQL":              {},
+}
+
 // NeedAutoID checks whether the table needs backing up with an autoid.
 func NeedAutoID(tblInfo *model.TableInfo) bool {
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
@@ -100,6 +108,11 @@ func EncloseDBAndTable(database, table string) string {
 // Currently, the only system DB is mysql.
 func IsSysDB(dbLowerName string) bool {
 	return dbLowerName == mysql.SystemDB
+}
+
+func IsInSysDBs(dbName string) bool {
+	_, ok := sysDBMap[strings.ToUpper(dbName)]
+	return ok
 }
 
 // TemporaryDBName makes a 'private' database name.

--- a/br/pkg/utils/schema.go
+++ b/br/pkg/utils/schema.go
@@ -17,14 +17,6 @@ import (
 // temporaryDBNamePrefix is the prefix name of system db, e.g. mysql system db will be rename to __TiDB_BR_Temporary_mysql
 const temporaryDBNamePrefix = "__TiDB_BR_Temporary_"
 
-var sysDBMap = map[string]struct{}{
-	"INFORMATION_SCHEMA": {},
-	"PERFORMANCE_SCHEMA": {},
-	"METRICS_SCHEMA":     {},
-	"INSPECTION_SCHEMA":  {},
-	"MYSQL":              {},
-}
-
 // NeedAutoID checks whether the table needs backing up with an autoid.
 func NeedAutoID(tblInfo *model.TableInfo) bool {
 	hasRowID := !tblInfo.PKIsHandle && !tblInfo.IsCommonHandle
@@ -108,11 +100,6 @@ func EncloseDBAndTable(database, table string) string {
 // Currently, the only system DB is mysql.
 func IsSysDB(dbLowerName string) bool {
 	return dbLowerName == mysql.SystemDB
-}
-
-func IsInSysDBs(dbName string) bool {
-	_, ok := sysDBMap[strings.ToUpper(dbName)]
-	return ok
 }
 
 // TemporaryDBName makes a 'private' database name.

--- a/errors.toml
+++ b/errors.toml
@@ -171,6 +171,11 @@ error = '''
 task not found
 '''
 
+["BR:Restore:ErrDatabasesAlreadyExisted"]
+error = '''
+databases already existed in restored cluster
+'''
+
 ["BR:Restore:ErrRestoreChecksumMismatch"]
 error = '''
 restore checksum mismatch


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35294

Problem Summary:

When execute br restore point repeatedly, it may cause unexpected error because of use's data existed in restored cluster.

### What is changed and how it works?

Add validation when execute pitr, to make sure that restored cluster is an empty cluster. But when users only execute log restore, we won't add that limitation.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Integration test
- [x] Manual test (add detailed scripts or steps below)
   1. Create database `d1` in restored cluster, and create table `user` in database `test`. Then execute pitr.
   ![pitr_db2](https://user-images.githubusercontent.com/13897016/177320164-d0a91d7d-1788-4193-b343-ff03c61898c3.png)
   2. Drop database `d1` in restored cluster, then execute pitr.
   ![pitr-db1](https://user-images.githubusercontent.com/13897016/177320283-4a09ddc7-cfed-45e0-9707-4c55e681dcc6.png)
   3. Drop database `test` and recreate database `test` to make the cluster recover to original state. Then execute pitr.
   ![pitr-db0](https://user-images.githubusercontent.com/13897016/177320386-2b712f7c-b537-4c45-a777-d6363672c730.png)

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
