### PR TITLE
parser/auth: Optimize caching sha2 speed

### DIFF
--- a/parser/auth/caching_sha2.go
+++ b/parser/auth/caching_sha2.go
@@ -46,134 +46,133 @@ const (
 	ITERATION_MULTIPLIER = 1000
 )
 
-func b64From24bit(b []byte, n int) []byte {
+func b64From24bit(b []byte, n int, buf *bytes.Buffer) {
 	b64t := []byte("./0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
 
 	w := (int64(b[0]) << 16) | (int64(b[1]) << 8) | int64(b[2])
-	ret := make([]byte, 0, n)
 	for n > 0 {
 		n--
-		ret = append(ret, b64t[w&0x3f])
+		buf.WriteByte(b64t[w&0x3f])
 		w >>= 6
 	}
-
-	return ret
 }
 
 func sha256crypt(plaintext string, salt []byte, iterations int) string {
 	// Numbers in the comments refer to the description of the algorithm on https://www.akkadia.org/drepper/SHA-crypt.txt
 
 	// 1, 2, 3
-	tmpA := sha256.New()
-	tmpA.Write([]byte(plaintext))
-	tmpA.Write(salt)
+	bufA := bytes.NewBuffer(make([]byte, 0, 4096))
+	bufA.Write([]byte(plaintext))
+	bufA.Write(salt)
 
 	// 4, 5, 6, 7, 8
-	tmpB := sha256.New()
-	tmpB.Write([]byte(plaintext))
-	tmpB.Write(salt)
-	tmpB.Write([]byte(plaintext))
-	sumB := tmpB.Sum(nil)
+	bufB := bytes.NewBuffer(make([]byte, 0, 4096))
+	bufB.Write([]byte(plaintext))
+	bufB.Write(salt)
+	bufB.Write([]byte(plaintext))
+	sumB := sha256.Sum256(bufB.Bytes())
+	bufB.Reset()
 
 	// 9, 10
 	var i int
 	for i = len(plaintext); i > MIXCHARS; i -= MIXCHARS {
-		tmpA.Write(sumB[:MIXCHARS])
+		bufA.Write(sumB[:MIXCHARS])
 	}
-	tmpA.Write(sumB[:i])
+	bufA.Write(sumB[:i])
 
 	// 11
 	for i = len(plaintext); i > 0; i >>= 1 {
 		if i%2 == 0 {
-			tmpA.Write([]byte(plaintext))
+			bufA.Write([]byte(plaintext))
 		} else {
-			tmpA.Write(sumB)
+			bufA.Write(sumB[:])
 		}
 	}
 
 	// 12
-	sumA := tmpA.Sum(nil)
+	sumA := sha256.Sum256(bufA.Bytes())
+	bufA.Reset()
 
 	// 13, 14, 15
-	tmpDP := sha256.New()
+	bufDP := bufA
 	for range []byte(plaintext) {
-		tmpDP.Write([]byte(plaintext))
+		bufDP.Write([]byte(plaintext))
 	}
-	sumDP := tmpDP.Sum(nil)
+	sumDP := sha256.Sum256(bufDP.Bytes())
+	bufDP.Reset()
 
 	// 16
 	p := make([]byte, 0, sha256.Size)
 	for i = len(plaintext); i > 0; i -= MIXCHARS {
 		if i > MIXCHARS {
-			p = append(p, sumDP...)
+			p = append(p, sumDP[:]...)
 		} else {
 			p = append(p, sumDP[0:i]...)
 		}
 	}
 
 	// 17, 18, 19
-	tmpDS := sha256.New()
+	bufDS := bufA
 	for i = 0; i < 16+int(sumA[0]); i++ {
-		tmpDS.Write(salt)
+		bufDS.Write(salt)
 	}
-	sumDS := tmpDS.Sum(nil)
+	sumDS := sha256.Sum256(bufDS.Bytes())
+	bufDS.Reset()
 
 	// 20
-	s := []byte{}
+	s := make([]byte, 0, 32)
 	for i = len(salt); i > 0; i -= MIXCHARS {
 		if i > MIXCHARS {
-			s = append(s, sumDS...)
+			s = append(s, sumDS[:]...)
 		} else {
 			s = append(s, sumDS[0:i]...)
 		}
 	}
 
 	// 21
-	tmpC := sha256.New()
-	var sumC []byte
+	bufC := bufA
+	var sumC [32]byte
 	for i = 0; i < iterations; i++ {
-		tmpC.Reset()
-
+		bufC.Reset()
 		if i&1 != 0 {
-			tmpC.Write(p)
+			bufC.Write(p)
 		} else {
-			tmpC.Write(sumA)
+			bufC.Write(sumA[:])
 		}
 		if i%3 != 0 {
-			tmpC.Write(s)
+			bufC.Write(s)
 		}
 		if i%7 != 0 {
-			tmpC.Write(p)
+			bufC.Write(p)
 		}
 		if i&1 != 0 {
-			tmpC.Write(sumA)
+			bufC.Write(sumA[:])
 		} else {
-			tmpC.Write(p)
+			bufC.Write(p)
 		}
-		sumC = tmpC.Sum(nil)
-		copy(sumA, tmpC.Sum(nil))
+		sumC = sha256.Sum256(bufC.Bytes())
+		sumA = sumC
 	}
 
 	// 22
-	buf := bytes.Buffer{}
-	buf.Grow(100) // FIXME
+	buf := bytes.NewBuffer(make([]byte, 0, 100))
 	buf.Write([]byte{'$', 'A', '$'})
 	rounds := fmt.Sprintf("%03d", iterations/ITERATION_MULTIPLIER)
 	buf.Write([]byte(rounds))
 	buf.Write([]byte{'$'})
 	buf.Write(salt)
 
-	buf.Write(b64From24bit([]byte{sumC[0], sumC[10], sumC[20]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[21], sumC[1], sumC[11]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[12], sumC[22], sumC[2]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[3], sumC[13], sumC[23]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[24], sumC[4], sumC[14]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[15], sumC[25], sumC[5]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[6], sumC[16], sumC[26]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[27], sumC[7], sumC[17]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[18], sumC[28], sumC[8]}, 4))
-	buf.Write(b64From24bit([]byte{sumC[9], sumC[19], sumC[29]}, 4))
-	buf.Write(b64From24bit([]byte{0, sumC[31], sumC[30]}, 3))
+	b64From24bit([]byte{sumC[0], sumC[10], sumC[20]}, 4, buf)
+	b64From24bit([]byte{sumC[21], sumC[1], sumC[11]}, 4, buf)
+	b64From24bit([]byte{sumC[12], sumC[22], sumC[2]}, 4, buf)
+	b64From24bit([]byte{sumC[3], sumC[13], sumC[23]}, 4, buf)
+	b64From24bit([]byte{sumC[24], sumC[4], sumC[14]}, 4, buf)
+	b64From24bit([]byte{sumC[15], sumC[25], sumC[5]}, 4, buf)
+	b64From24bit([]byte{sumC[6], sumC[16], sumC[26]}, 4, buf)
+	b64From24bit([]byte{sumC[27], sumC[7], sumC[17]}, 4, buf)
+	b64From24bit([]byte{sumC[18], sumC[28], sumC[8]}, 4, buf)
+	b64From24bit([]byte{sumC[9], sumC[19], sumC[29]}, 4, buf)
+	b64From24bit([]byte{0, sumC[31], sumC[30]}, 3, buf)
 
 	return buf.String()
 }

--- a/parser/auth/caching_sha2_test.go
+++ b/parser/auth/caching_sha2_test.go
@@ -20,10 +20,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var foobarPwdHash, _ = hex.DecodeString("24412430303524031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
+
 func TestCheckShaPasswordGood(t *testing.T) {
 	pwd := "foobar"
-	pwhash, _ := hex.DecodeString("24412430303524031A69251C34295C4B35167C7F1E5A7B63091349503974624D34504B5A424679354856336868686F52485A736E4A733368786E427575516C73446469496537")
-	r, err := CheckShaPassword(pwhash, pwd)
+	r, err := CheckShaPassword(foobarPwdHash, pwd)
 	require.NoError(t, err)
 	require.True(t, r)
 }
@@ -70,5 +71,13 @@ func TestNewSha2Password(t *testing.T) {
 		require.Less(t, pwhash[r], uint8(128))
 		require.NotEqual(t, pwhash[r], 0)  // NUL
 		require.NotEqual(t, pwhash[r], 36) // '$'
+	}
+}
+
+func BenchmarkShaPassword(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		m, err := CheckShaPassword(foobarPwdHash, "foobar")
+		require.Nil(b, err)
+		require.True(b, m)
 	}
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #35998 

the `Sum` method in `Hash` interface will copy the hash object 

https://cs.opensource.google/go/go/+/refs/tags/go1.18.3:src/crypto/sha256/sha256.go;l=207

it will make lots of hash object in the iteration loop  `for i = 0; i < iterations; i++`

```
goos: darwin
goarch: amd64
pkg: github.com/pingcap/tidb/parser/auth
cpu: Intel(R) Core(TM) i5-8257U CPU @ 1.40GHz
BenchmarkShaPassword

# this pr
BenchmarkShaPassword-8   	     699	   1697389 ns/op	    9738 B/op	       6 allocs/op

# master
BenchmarkShaPassword-8   	     382	   3101911 ns/op	  320674 B/op	   10022 allocs/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
- Improve database password verification speed
```
