### PR TITLE
perfschema: add `session_variables` table to `performance_schema`

### DIFF
--- a/executor/infoschema_reader.go
+++ b/executor/infoschema_reader.go
@@ -150,7 +150,7 @@ func (e *memtableRetriever) retrieve(ctx context.Context, sctx sessionctx.Contex
 		case infoschema.TableConstraints:
 			e.setDataFromTableConstraints(sctx, dbs)
 		case infoschema.TableSessionVar:
-			err = e.setDataFromSessionVar(sctx)
+			e.rows, err = infoschema.GetDataFromSessionVariables(sctx)
 		case infoschema.TableTiDBServersInfo:
 			err = e.setDataForServersInfo(sctx)
 		case infoschema.TableTiFlashReplica:
@@ -1939,24 +1939,6 @@ func (e *tableStorageStatsRetriever) setDataForTableStorageStats(ctx sessionctx.
 		e.curTable++
 	}
 	return rows, nil
-}
-
-func (e *memtableRetriever) setDataFromSessionVar(ctx sessionctx.Context) error {
-	var err error
-	sessionVars := ctx.GetSessionVars()
-	sysVars := variable.GetSysVars()
-	rows := make([][]types.Datum, 0, len(sysVars))
-	for _, v := range sysVars {
-		var value string
-		value, err = variable.GetSessionOrGlobalSystemVar(sessionVars, v.Name)
-		if err != nil {
-			return err
-		}
-		row := types.MakeDatums(v.Name, value)
-		rows = append(rows, row)
-	}
-	e.rows = rows
-	return nil
 }
 
 // dataForAnalyzeStatusHelper is a helper function which can be used in show_stats.go

--- a/infoschema/perfschema/const.go
+++ b/infoschema/perfschema/const.go
@@ -29,6 +29,7 @@ var perfSchemaTables = []string{
 	tableTransCurrent,
 	tableTransHistory,
 	tableTransHistoryLong,
+	tableSessionVariables,
 	tableStagesCurrent,
 	tableStagesHistory,
 	tableStagesHistoryLong,
@@ -544,3 +545,8 @@ const tablePDProfileGoroutines = "CREATE TABLE IF NOT EXISTS " + tableNamePDProf
 	"ID INT(8) NOT NULL," +
 	"STATE VARCHAR(16) NOT NULL," +
 	"LOCATION VARCHAR(512) NOT NULL);"
+
+// tableSessionVariables contains the
+const tableSessionVariables = "CREATE TABLE IF NOT EXISTS " + tableNameSessionVariables + " (" +
+	"VARIABLE_NAME VARCHAR(64) NOT NULL," +
+	"VARIABLE_VALUE VARCHAR(1024) NOT NULL);"

--- a/infoschema/perfschema/tables.go
+++ b/infoschema/perfschema/tables.go
@@ -68,6 +68,7 @@ const (
 	tableNamePDProfileAllocs                 = "pd_profile_allocs"
 	tableNamePDProfileBlock                  = "pd_profile_block"
 	tableNamePDProfileGoroutines             = "pd_profile_goroutines"
+	tableNameSessionVariables                = "session_variables"
 )
 
 var tableIDMap = map[string]int64{
@@ -101,6 +102,7 @@ var tableIDMap = map[string]int64{
 	tableNamePDProfileAllocs:                 autoid.PerformanceSchemaDBID + 28,
 	tableNamePDProfileBlock:                  autoid.PerformanceSchemaDBID + 29,
 	tableNamePDProfileGoroutines:             autoid.PerformanceSchemaDBID + 30,
+	tableNameSessionVariables:                autoid.PerformanceSchemaDBID + 31,
 }
 
 // perfSchemaTable stands for the fake table all its data is in the memory.
@@ -247,6 +249,8 @@ func (vt *perfSchemaTable) getRows(ctx sessionctx.Context, cols []*table.Column)
 		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/block", false)
 	case tableNamePDProfileGoroutines:
 		fullRows, err = dataForRemoteProfile(ctx, "pd", "/pd/api/v1/debug/pprof/goroutine?debug=2", true)
+	case tableNameSessionVariables:
+		fullRows, err = infoschema.GetDataFromSessionVariables(ctx)
 	}
 	if err != nil {
 		return

--- a/infoschema/perfschema/tables_test.go
+++ b/infoschema/perfschema/tables_test.go
@@ -51,6 +51,15 @@ func TestPerfSchemaTables(t *testing.T) {
 	tk.MustQuery("select * from events_stages_history_long").Check(testkit.Rows())
 }
 
+func TestSessionVariables(t *testing.T) {
+	store, clean := newMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+
+	res := tk.MustQuery("select variable_value from performance_schema.session_variables order by variable_name limit 10;")
+	tk.MustQuery("select variable_value from information_schema.session_variables order by variable_name limit 10;").Check(res.Rows())
+}
+
 func TestTiKVProfileCPU(t *testing.T) {
 	store, clean := newMockStore(t)
 	defer clean()

--- a/infoschema/tables.go
+++ b/infoschema/tables.go
@@ -1831,6 +1831,23 @@ func GetTiFlashStoreCount(ctx sessionctx.Context) (cnt uint64, err error) {
 	return cnt, nil
 }
 
+// GetDataFromSessionVariables return the [name, value] of all session variables
+func GetDataFromSessionVariables(ctx sessionctx.Context) ([][]types.Datum, error) {
+	sessionVars := ctx.GetSessionVars()
+	sysVars := variable.GetSysVars()
+	rows := make([][]types.Datum, 0, len(sysVars))
+	for _, v := range sysVars {
+		var value string
+		value, err := variable.GetSessionOrGlobalSystemVar(sessionVars, v.Name)
+		if err != nil {
+			return nil, err
+		}
+		row := types.MakeDatums(v.Name, value)
+		rows = append(rows, row)
+	}
+	return rows, nil
+}
+
 var tableNameToColumns = map[string][]columnInfo{
 	TableSchemata:                           schemataCols,
 	TableTables:                             tablesCols,


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #35894

Problem Summary: add `session_variables` table to `performance_schema`. Keep it same as `information_schema.session_variables`

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
For compatible with MySQL 5.7.22+ and MySQL 8.x, add `session_variables` table to `performance_schema`
```
