### PR TITLE
ddl: support adding constraint with column in one spec

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -3004,6 +3004,7 @@ func resolveAlterTableAddColumns(spec *ast.AlterTableSpec) []*ast.AlterTableSpec
 		t.NewConstraints = []*ast.Constraint{}
 		specs = append(specs, &t)
 	}
+	// Split the add constraints from AlterTableSpec.
 	for _, con := range spec.NewConstraints {
 		t := *spec
 		t.NewColumns = []*ast.ColumnDef{}

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -42,7 +42,7 @@ func TestMultiSchemaChangeAddColumns(t *testing.T) {
 	tk.MustExec("alter table t add column b int default 2, add column c int default 3;")
 	tk.MustQuery("select * from t;").Check(testkit.Rows("1 2 3"))
 
-	// Test add multiple columns in one spec.
+	// Test add multiple columns and constraints in one spec.
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (a int);")
 	tk.MustExec("insert into t values (1);")
@@ -54,6 +54,24 @@ func TestMultiSchemaChangeAddColumns(t *testing.T) {
 	tk.MustExec("insert into t values (1, 2, 3);")
 	tk.MustExec("alter table t add column (d int default 4, e int default 5);")
 	tk.MustQuery("select * from t;").Check(testkit.Rows("1 2 3 4 5"))
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (1);")
+	tk.MustExec("alter table t add column (index i(a), index i1(a));")
+	tk.MustQuery("select * from t use index (i, i1);").Check(testkit.Rows("1"))
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (1);")
+	tk.MustExec("alter table t add column (b int default 2, index i(a), primary key (a));")
+	tk.MustQuery("select * from t use index (i, primary)").Check(testkit.Rows("1 2"))
+
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int);")
+	tk.MustExec("insert into t values (1);")
+	tk.MustExec("alter table t add column (index i(a));")
+	tk.MustQuery("select * from t use index (i)").Check(testkit.Rows("1"))
 
 	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (a int default 1);")

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -323,6 +323,13 @@ func TestMultiSchemaChangeAddIndexes(t *testing.T) {
 	tk.MustQuery("select * from t use index (t, t1, t2, t3);").Check(testkit.Rows("1 2 3"))
 	tk.MustExec("admin check table t;")
 
+	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int, b int, c int);")
+	tk.MustExec("insert into t values (1, 2, 3);")
+	tk.MustExec("alter table t add column (index i1(a, b, c), index i2(c, b, a));")
+	tk.MustQuery("select * from t use index (i1, i2);").Check(testkit.Rows("1 2 3"))
+	tk.MustExec("admin check table t;")
+
 	// Test add multiple indexes with same name.
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t (a int, b int, c int)")

--- a/ddl/multi_schema_change_test.go
+++ b/ddl/multi_schema_change_test.go
@@ -74,6 +74,13 @@ func TestMultiSchemaChangeAddColumns(t *testing.T) {
 	tk.MustQuery("select * from t use index (i)").Check(testkit.Rows("1"))
 
 	tk.MustExec("drop table if exists t;")
+	tk.MustExec("create table t (a int, b int, c int);")
+	tk.MustExec("insert into t values (1, 2, 3);")
+	tk.MustExec("alter table t add column (index i1(a, b, c), index i2(c, b, a), index i3((a + 1)), index i4((c - 1)));")
+	tk.MustQuery("select * from t use index (i1, i2);").Check(testkit.Rows("1 2 3"))
+	tk.MustExec("admin check table t;")
+
+	tk.MustExec("drop table if exists t;")
 	tk.MustExec("create table t (a int default 1);")
 	tk.MustExec("insert into t values ();")
 	tk.MustExec("alter table t add column if not exists (b int default 2, c int default 3);")
@@ -321,13 +328,6 @@ func TestMultiSchemaChangeAddIndexes(t *testing.T) {
 	tk.MustExec("alter table t add index t(a, b), add index t1(a);")
 	tk.MustExec("alter table t add index t2(a), add index t3(a, b);")
 	tk.MustQuery("select * from t use index (t, t1, t2, t3);").Check(testkit.Rows("1 2 3"))
-	tk.MustExec("admin check table t;")
-
-	tk.MustExec("drop table if exists t;")
-	tk.MustExec("create table t (a int, b int, c int);")
-	tk.MustExec("insert into t values (1, 2, 3);")
-	tk.MustExec("alter table t add column (index i1(a, b, c), index i2(c, b, a));")
-	tk.MustQuery("select * from t use index (i1, i2);").Check(testkit.Rows("1 2 3"))
 	tk.MustExec("admin check table t;")
 
 	// Test add multiple indexes with same name.


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/14766

Problem Summary:

This PR supports adding primary key or indexes along with columns:

```sql
alter table t add column (b int default 2, index i(a), primary key (a));
```

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
