### PR TITLE
types: save some cpu cycles in DatumsToString

### DIFF
--- a/types/datum.go
+++ b/types/datum.go
@@ -2248,7 +2248,7 @@ func DatumsToString(datums []Datum, handleSpecialValue bool) (string, error) {
 			return "", errors.Trace(err)
 		}
 		if datum.Kind() == KindString {
-			strs = append(strs, fmt.Sprintf("%q", str))
+			strs = append(strs, "\""+str+"\"")
 		} else {
 			strs = append(strs, str)
 		}


### PR DESCRIPTION
Signed-off-by: ekexium <eke@fastmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36049 

Problem Summary:

I found the Sprintf cost about 0.1% to 1% of the CPU time in my test. **If its only purpose is adding double quotes,** avoiding using Sprintf can save 1 allocation and make it ~10x faster, which is shown by a microbenchmark.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
