### PR TITLE
br: modify to send s3 region param to tikv

### DIFF
--- a/br/pkg/storage/s3.go
+++ b/br/pkg/storage/s3.go
@@ -338,6 +338,7 @@ func newS3Storage(backend *backuppb.S3, opts *ExternalStorageOptions) (obj *S3St
 		}
 
 		qs.Region = region
+		backend.Region = region
 		if region != defaultRegion {
 			awsConfig.WithRegion(region)
 			c = s3.New(ses, awsConfig)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36055

Problem Summary:

backup to s3 backend without region param failed.

### What is changed and how it works?

bind the region param get from s3 to backend object.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
  1. execute br before fix this bug
  ![backup-before](https://user-images.githubusercontent.com/13897016/177981320-989abae9-94b8-42c4-a175-64693f851d94.png)
  2. execute br after fixed this bug
  ![backup-after](https://user-images.githubusercontent.com/13897016/177981375-525b2519-a636-48a7-876e-1d7c4c673c35.png)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
