### PR TITLE
log-backup: support calculating dynamic shift-start-ts when restoring kv-files belonging to default-cf

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1660,6 +1660,7 @@ func (rc *Client) RestoreKVFiles(
 	ctx context.Context,
 	rules map[int64]*RewriteRules,
 	files []*backuppb.DataFileInfo,
+	updateStats func(kvCount uint64, size uint64),
 	onProgress func(),
 ) error {
 	var err error
@@ -1701,6 +1702,7 @@ func (rc *Client) RestoreKVFiles(
 				fileStart := time.Now()
 				defer func() {
 					onProgress()
+					updateStats(uint64(file.NumberOfEntries), file.Length)
 					summary.CollectInt("File", 1)
 					log.Info("import files done", zap.String("name", file.Path), zap.Duration("take", time.Since(fileStart)))
 				}()
@@ -1818,6 +1820,7 @@ func (rc *Client) RestoreMetaKVFiles(
 	ctx context.Context,
 	files []*backuppb.DataFileInfo,
 	schemasReplace *stream.SchemasReplace,
+	updateStats func(kvCount uint64, size uint64),
 	progressInc func(),
 ) error {
 	// sort files firstly.
@@ -1827,8 +1830,8 @@ func (rc *Client) RestoreMetaKVFiles(
 	filesInWriteCF := make([]*backuppb.DataFileInfo, 0, len(files))
 
 	// The k-v events in default CF should be restored firstly. The reason is that:
-	// The error of transactions of meta will happen,
-	// if restore default CF events successfully, but failed to restore write CF events.
+	// The error of transactions of meta could happen if restore write CF events successfully,
+	// but failed to restore default CF events.
 	for _, f := range files {
 		if f.Cf == stream.WriteCF {
 			filesInWriteCF = append(filesInWriteCF, f)
@@ -1842,19 +1845,21 @@ func (rc *Client) RestoreMetaKVFiles(
 			continue
 		}
 
-		err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
+		kvCount, size, err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		updateStats(kvCount, size)
 		progressInc()
 	}
 
 	// Restore files in write CF.
 	for _, f := range filesInWriteCF {
-		err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
+		kvCount, size, err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		updateStats(kvCount, size)
 		progressInc()
 	}
 
@@ -1870,7 +1875,11 @@ func (rc *Client) RestoreMetaKVFile(
 	ctx context.Context,
 	file *backuppb.DataFileInfo,
 	sr *stream.SchemasReplace,
-) error {
+) (uint64, uint64, error) {
+	var (
+		kvCount uint64
+		size    uint64
+	)
 	log.Info("restore meta kv events", zap.String("file", file.Path),
 		zap.String("cf", file.Cf), zap.Int64("kv-count", file.NumberOfEntries),
 		zap.Uint64("min-ts", file.MinTs), zap.Uint64("max-ts", file.MaxTs))
@@ -1878,10 +1887,10 @@ func (rc *Client) RestoreMetaKVFile(
 	rc.rawKVClient.SetColumnFamily(file.GetCf())
 	buff, err := rc.storage.ReadFile(ctx, file.Path)
 	if err != nil {
-		return errors.Trace(err)
+		return 0, 0, errors.Trace(err)
 	}
 	if checksum := sha256.Sum256(buff); !bytes.Equal(checksum[:], file.GetSha256()) {
-		return errors.Annotatef(berrors.ErrInvalidMetaFile,
+		return 0, 0, errors.Annotatef(berrors.ErrInvalidMetaFile,
 			"checksum mismatch expect %x, got %x", file.GetSha256(), checksum[:])
 	}
 
@@ -1889,13 +1898,13 @@ func (rc *Client) RestoreMetaKVFile(
 	for iter.Valid() {
 		iter.Next()
 		if iter.GetError() != nil {
-			return errors.Trace(iter.GetError())
+			return 0, 0, errors.Trace(iter.GetError())
 		}
 
 		txnEntry := kv.Entry{Key: iter.Key(), Value: iter.Value()}
 		ts, err := GetKeyTS(txnEntry.Key)
 		if err != nil {
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		}
 
 		// The commitTs in write CF need be limited on [startTs, restoreTs].
@@ -1921,7 +1930,7 @@ func (rc *Client) RestoreMetaKVFile(
 		if err != nil {
 			log.Error("rewrite txn entry failed", zap.Int("klen", len(txnEntry.Key)),
 				logutil.Key("txn-key", txnEntry.Key))
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		} else if newEntry == nil {
 			continue
 		}
@@ -1929,11 +1938,14 @@ func (rc *Client) RestoreMetaKVFile(
 			zap.Int("newValue-len", len(txnEntry.Value)), zap.ByteString("newkey", newEntry.Key))
 
 		if err := rc.rawKVClient.Put(ctx, newEntry.Key, newEntry.Value, ts); err != nil {
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		}
+
+		kvCount += 1
+		size += uint64(len(newEntry.Key) + len(newEntry.Value))
 	}
 
-	return rc.rawKVClient.PutRest(ctx)
+	return kvCount, size, rc.rawKVClient.PutRest(ctx)
 }
 
 func transferBoolToValue(enable bool) string {

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1522,6 +1522,10 @@ func (rc *Client) ReadStreamMetaByTS(ctx context.Context, restoreTS uint64) ([]*
 	streamBackupMetaFiles.metas = make([]*backuppb.Metadata, 0, 128)
 
 	err := stream.FastUnmarshalMetaData(ctx, rc.storage, func(path string, metadata *backuppb.Metadata) error {
+		if metadata.MinTs > restoreTS {
+			return nil
+		}
+
 		streamBackupMetaFiles.Lock()
 		streamBackupMetaFiles.metas = append(streamBackupMetaFiles.metas, metadata)
 		streamBackupMetaFiles.Unlock()

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -298,6 +298,8 @@ func (rc *Client) SetRestoreRangeTS(startTs, restoreTS, shiftStartTS uint64) {
 	rc.startTS = startTs
 	rc.restoreTS = restoreTS
 	rc.shiftStartTS = shiftStartTS
+	log.Info("set restore range ts", zap.Uint64("shift-start-ts", shiftStartTS),
+		zap.Uint64("start-ts", startTs), zap.Uint64("restored-ts", restoreTS))
 }
 
 func (rc *Client) SetCurrentTS(ts uint64) {
@@ -1564,37 +1566,6 @@ func (rc *Client) ReadStreamDataFiles(
 		}
 	}
 	return dFiles, mFiles, nil
-}
-
-func (rc *Client) CalcuateShiftTS(
-	metas []*backuppb.Metadata,
-) (uint64, bool) {
-	var (
-		min_begin_ts uint64
-		isExist      bool
-	)
-
-	for _, m := range metas {
-		if len(m.Files) == 0 || m.MinTs > rc.restoreTS || m.MaxTs < rc.startTS {
-			continue
-		}
-
-		for _, d := range m.Files {
-			if d.Cf == stream.WriteCF {
-				continue
-			}
-			if d.MinTs > rc.restoreTS || d.MaxTs < rc.startTS {
-				continue
-			}
-
-			if d.MinBeginTsInDefaultCf < min_begin_ts || isExist == false {
-				isExist = true
-				min_begin_ts = d.MinBeginTsInDefaultCf
-			}
-		}
-	}
-
-	return min_begin_ts, isExist
 }
 
 // FixIndex tries to fix a single index.

--- a/br/pkg/restore/stream_metas.go
+++ b/br/pkg/restore/stream_metas.go
@@ -240,8 +240,8 @@ func CalculateShiftTS(
 	restoreTS uint64,
 ) (uint64, bool) {
 	var (
-		min_begin_ts uint64
-		isExist      bool
+		minBeginTS uint64
+		isExist    bool
 	)
 	for _, m := range metas {
 		if len(m.Files) == 0 || m.MinTs > restoreTS || m.MaxTs < startTS {
@@ -249,18 +249,18 @@ func CalculateShiftTS(
 		}
 
 		for _, d := range m.Files {
-			if d.Cf == stream.DefaultCF {
+			if d.Cf == stream.DefaultCF || d.MinBeginTsInDefaultCf == 0 {
 				continue
 			}
 			if d.MinTs > restoreTS || d.MaxTs < startTS {
 				continue
 			}
-			if d.MinBeginTsInDefaultCf < min_begin_ts || !isExist {
+			if d.MinBeginTsInDefaultCf < minBeginTS || !isExist {
 				isExist = true
-				min_begin_ts = d.MinBeginTsInDefaultCf
+				minBeginTS = d.MinBeginTsInDefaultCf
 			}
 		}
 	}
 
-	return min_begin_ts, isExist
+	return minBeginTS, isExist
 }

--- a/br/pkg/restore/stream_metas.go
+++ b/br/pkg/restore/stream_metas.go
@@ -63,12 +63,12 @@ func (ms *StreamMetadataSet) CalculateShiftTS(startTS uint64) uint64 {
 		metadatas = append(metadatas, m)
 	}
 
-	min_begin_ts, exist := CalculateShiftTS(metadatas, startTS, mathutil.MaxUint)
+	minBeginTS, exist := CalculateShiftTS(metadatas, startTS, mathutil.MaxUint)
 	if !exist {
-		min_begin_ts = startTS
+		minBeginTS = startTS
 	}
-	log.Warn("calculate shift-ts", zap.Uint64("start-ts", startTS), zap.Uint64("shift-ts", min_begin_ts))
-	return min_begin_ts
+	log.Warn("calculate shift-ts", zap.Uint64("start-ts", startTS), zap.Uint64("shift-ts", minBeginTS))
+	return minBeginTS
 }
 
 // IterateFilesFullyBefore runs the function over all files contain data before the timestamp only.

--- a/br/pkg/restore/stream_metas.go
+++ b/br/pkg/restore/stream_metas.go
@@ -63,7 +63,7 @@ func (ms *StreamMetadataSet) CalculateShiftTS(startTS uint64) uint64 {
 		metadatas = append(metadatas, m)
 	}
 
-	min_begin_ts, exist := CalcuateShiftTS(metadatas, startTS, mathutil.MaxUint)
+	min_begin_ts, exist := CalculateShiftTS(metadatas, startTS, mathutil.MaxUint)
 	if !exist {
 		min_begin_ts = startTS
 	}
@@ -233,7 +233,8 @@ func SetTSToFile(
 	return truncateAndWrite(ctx, s, filename, []byte(content))
 }
 
-func CalcuateShiftTS(
+// CalculateShiftTS gets the minimal begin-ts about transaction according to the kv-event in write-cf.
+func CalculateShiftTS(
 	metas []*backuppb.Metadata,
 	startTS uint64,
 	restoreTS uint64,

--- a/br/pkg/restore/stream_metas_test.go
+++ b/br/pkg/restore/stream_metas_test.go
@@ -129,3 +129,60 @@ func TestTruncateSafepoint(t *testing.T) {
 		require.Equal(t, ts, n, "failed at %d round: truncate safepoint mismatch", i)
 	}
 }
+
+func fakeMetaDatas() []*backuppb.Metadata {
+	ms := []*backuppb.Metadata{
+		{
+			StoreId: 1,
+			MinTs:   1500,
+			MaxTs:   2000,
+			Files: []*backuppb.DataFileInfo{
+				{
+					MinTs:                 1500,
+					MaxTs:                 2000,
+					Cf:                    stream.WriteCF,
+					MinBeginTsInDefaultCf: 800,
+				},
+			},
+		},
+		{
+			StoreId: 2,
+			MinTs:   3000,
+			MaxTs:   4000,
+			Files: []*backuppb.DataFileInfo{
+				{
+					MinTs:                 3000,
+					MaxTs:                 4000,
+					Cf:                    stream.WriteCF,
+					MinBeginTsInDefaultCf: 2000,
+				},
+			},
+		},
+		{
+			StoreId: 3,
+			MinTs:   5100,
+			MaxTs:   6100,
+			Files: []*backuppb.DataFileInfo{
+				{
+					MinTs:                 5100,
+					MaxTs:                 6100,
+					Cf:                    stream.WriteCF,
+					MinBeginTsInDefaultCf: 5000,
+				},
+			},
+		},
+	}
+	return ms
+}
+
+func TestCalculateShiftTS(t *testing.T) {
+	var (
+		startTs   uint64 = 2900
+		restoreTS uint64 = 4500
+	)
+
+	ms := fakeMetaDatas()
+	shiftTS, exist := restore.CalculateShiftTS(ms, startTs, restoreTS)
+	require.Equal(t, shiftTS, uint64(2000))
+	require.Equal(t, exist, true)
+}

--- a/br/pkg/restore/stream_metas_test.go
+++ b/br/pkg/restore/stream_metas_test.go
@@ -196,6 +196,6 @@ func TestCalculateShiftTS(t *testing.T) {
 	require.Equal(t, exist, true)
 
 	ms = fakeMetaDatas(stream.DefaultCF)
-	shiftTS, exist = restore.CalculateShiftTS(ms, startTs, restoreTS)
+	_, exist = restore.CalculateShiftTS(ms, startTs, restoreTS)
 	require.Equal(t, exist, false)
 }

--- a/br/pkg/stream/stream_mgr.go
+++ b/br/pkg/stream/stream_mgr.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
@@ -173,7 +174,11 @@ func FastUnmarshalMetaData(
 			m := &backuppb.Metadata{}
 			err = m.Unmarshal(b)
 			if err != nil {
-				return err
+				if !strings.HasSuffix(path, ".meta") {
+					return nil
+				} else {
+					return err
+				}
 			}
 			return fn(readPath, m)
 		})

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1110,7 +1110,7 @@ func restoreStream(
 		return nil
 	}
 
-	shiftStartTS, exist := restore.CalcuateShiftTS(metas, cfg.StartTS, cfg.RestoreTS)
+	shiftStartTS, exist := restore.CalculateShiftTS(metas, cfg.StartTS, cfg.RestoreTS)
 	if !exist {
 		shiftStartTS = cfg.StartTS
 	}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1291,7 +1291,7 @@ func calcuateShiftTS(
 		}
 
 		for _, d := range m.Files {
-			if d.Cf == stream.WriteCF {
+			if d.Cf == stream.DefaultCF {
 				continue
 			}
 			if d.MinTs > restoreTS || d.MaxTs < startTS {

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -697,7 +697,7 @@ func RunStreamPause(
 		utils.BRServiceSafePoint{
 			ID:       buildPauseSafePointName(ti.Info.Name),
 			TTL:      cfg.SafePointTTL,
-			BackupTS: globalCheckPointTS,
+			BackupTS: globalCheckPointTS - 1,
 		},
 	); err != nil {
 		return errors.Trace(err)

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -921,7 +921,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 
 	var (
 		fileCount    uint64 = 0
-		kvPairCount  int64  = 0
+		kvCount      int64  = 0
 		totalSize    uint64 = 0
 		shiftUntilTS        = metas.CalculateShiftTS(cfg.Until)
 	)
@@ -929,7 +929,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	metas.IterateFilesFullyBefore(shiftUntilTS, func(d *backuppb.DataFileInfo) (shouldBreak bool) {
 		fileCount++
 		totalSize += d.Length
-		kvPairCount += d.NumberOfEntries
+		kvCount += d.NumberOfEntries
 		return
 	})
 	console.Printf("We are going to remove %s files, until %s.\n",
@@ -953,7 +953,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 
 	// remove log
 	clearDataFileDone := console.StartTask(
-		fmt.Sprintf("Clearing data files done. kv-count = %v, totalSize = %v", kvPairCount, totalSize))
+		fmt.Sprintf("Clearing data files done. kv-count = %v, total-size = %v", kvCount, totalSize))
 	worker := utils.NewWorkerPool(128, "delete files")
 	wg := new(sync.WaitGroup)
 	for _, f := range removed {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/36138

Problem Summary:
- Calculate the min-begin-ts(shift-ts) according to the start-ts in kv-pair at write-cf
- get the kv-count and total-size when restore log

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test
##### test1
- backup
  - create a log backup task with command `br log start`
  - begin transaction and insert 5 records
  - wait 30 minutes
  - create a full backup(ts=434516875680940033)
  - insert 5 record at the uncommitted transaction
  - commit the transaction 
- restore
  - PiTR from snapshot-ts to target restore-ts with the comand `br restore point`
- the result
  - restore successfully and the down-stream cluster has 10 record
  - the log like blow, it has calculate the `shift-start-ts`
[2022/07/11 23:13:45.818 +08:00] [INFO] [client.go:301] ["set restore range ts"] [shift-start-ts=434516138702667777] [start-ts=434516875680940033] [restored-ts=434517233926930433]
    - shift-start-ts=2022-07-11 21:52:06.179 +0800 CST
    - start-ts=2022-07-11 22:38:57.528 +0800 CST
    - restore-ts=2022-07-11 23:01:44.128 +0800 CST

##### test2 
- truncate log
  - truncate log with the command `br log truncate --until=434516875680940033`
  - the summary below
Reading Metadata... DONE; take = 450.577875ms
We are going to remove 51 files, until 2022-07-11 22:38:57.5280.
Sure? (y/N) y
Removing metadata... DONE; take = 495.779542ms
Clearing data files done. kv-count = 174, totalSize = 18722DONE; take = 127.192625ms
  - the low below about calculating shift-ts
[2022/07/12 12:54:53.754 +08:00] [WARN] [stream_metas.go:70] ["calculate shift-ts"] [start-ts=434516875680940033] [shift-ts=434516138702667777]
    - 434516138702667777=2022-07-11 21:52:06.179 +0800 CST
    - 434516875680940033=2022-07-11 22:38:57.528 +0800 CST
- restore point 
  - PiTR from snapshot-ts to target restore-ts with the comand `br restore point`
  - the log like blow, it prove `log truncate`


##### the restore summary:
[2022/07/11 23:13:48.274 +08:00] [INFO] [collector.go:69] ["restore log success summary"] [total-take=4.90154525s] [restore-from=434516875680940033] [restore-to=434517233926930433] [total-kv-count=10] [total-size=820]

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
