### PR TITLE
br: deal with mddljob when pitr restores (#35976)

### DIFF
--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -351,3 +351,50 @@ func TestSetSpeedLimit(t *testing.T) {
 		require.Equal(t, mockStores[i].Id, recordStores.stores[i])
 	}
 }
+
+func TestDeleteRangeQuery(t *testing.T) {
+	ctx := context.Background()
+	m := mc
+	mockStores := []*metapb.Store{
+		{
+			Id: 1,
+			Labels: []*metapb.StoreLabel{
+				{
+					Key:   "engine",
+					Value: "tiflash",
+				},
+			},
+		},
+		{
+			Id: 2,
+			Labels: []*metapb.StoreLabel{
+				{
+					Key:   "engine",
+					Value: "tiflash",
+				},
+			},
+		},
+	}
+
+	g := gluetidb.New()
+	client := restore.NewRestoreClient(fakePDClient{
+		stores: mockStores,
+	}, nil, defaultKeepaliveCfg, false)
+	err := client.Init(g, m.Storage)
+	require.NoError(t, err)
+
+	client.RunGCRowsLoader(ctx)
+
+	client.InsertDeleteRangeForTable(2, []int64{3})
+	client.InsertDeleteRangeForTable(4, []int64{5, 6})
+
+	elementID := int64(1)
+	client.InsertDeleteRangeForIndex(7, &elementID, 8, []int64{1})
+	client.InsertDeleteRangeForIndex(9, &elementID, 10, []int64{1, 2})
+
+	querys := client.GetGCRows()
+	require.Equal(t, querys[0], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (2, 1, '748000000000000003', '748000000000000004', %[1]d)")
+	require.Equal(t, querys[1], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (4, 1, '748000000000000005', '748000000000000006', %[1]d),(4, 2, '748000000000000006', '748000000000000007', %[1]d)")
+	require.Equal(t, querys[2], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (7, 1, '7480000000000000085f698000000000000001', '7480000000000000085f698000000000000002', %[1]d)")
+	require.Equal(t, querys[3], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (9, 2, '74800000000000000a5f698000000000000001', '74800000000000000a5f698000000000000002', %[1]d),(9, 3, '74800000000000000a5f698000000000000002', '74800000000000000a5f698000000000000003', %[1]d)")
+}

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -432,9 +432,26 @@ func (sr *SchemasReplace) rewriteValue(
 }
 
 // RewriteKvEntry uses to rewrite tableID/dbID in entry.key and entry.value
-func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string) (*kv.Entry, error) {
+func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string, insertDeleteRangeForTable InsertDeleteRangeForTable, insertDeleteRangeForIndex InsertDeleteRangeForIndex) (*kv.Entry, error) {
 	// skip mDDLJob
+
 	if !strings.HasPrefix(string(e.Key), "mDB") {
+		if strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
+			job := &model.Job{}
+			if err := job.Decode(e.Value); err != nil {
+				log.Debug("failed to decode the job", zap.String("error", err.Error()), zap.String("job", string(e.Value)))
+				// The value in write-cf is like "p\XXXX\XXX" need not restore. skip it
+				// The value in default-cf that can Decode() need restore.
+				return nil, nil
+			}
+			if jobNeedGC(job) {
+				return nil, sr.deleteRange(job, insertDeleteRangeForTable, insertDeleteRangeForIndex)
+			}
+
+			if job.Type == model.ActionExchangeTablePartition {
+				return nil, errors.Errorf("restore of ddl `exchange-table-partition` is not supported")
+			}
+		}
 		return nil, nil
 	}
 
@@ -460,4 +477,322 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string) (*kv.Entry, err
 	} else {
 		return nil, nil
 	}
+}
+
+type InsertDeleteRangeForTable func(int64, []int64)
+type InsertDeleteRangeForIndex func(int64, *int64, int64, []int64)
+
+func jobNeedGC(job *model.Job) bool {
+	if !job.IsCancelled() {
+		switch job.Type {
+		case model.ActionAddIndex, model.ActionAddPrimaryKey:
+			return job.State == model.JobStateRollbackDone
+		case model.ActionDropSchema, model.ActionDropTable, model.ActionTruncateTable, model.ActionDropIndex, model.ActionDropPrimaryKey,
+			model.ActionDropTablePartition, model.ActionTruncateTablePartition, model.ActionDropColumn, model.ActionDropColumns, model.ActionModifyColumn, model.ActionDropIndexes:
+			return job.State == model.JobStateSynced
+		}
+	}
+	return false
+}
+
+func (sr *SchemasReplace) deleteRange(job *model.Job, insertDeleteRangeForTable InsertDeleteRangeForTable, insertDeleteRangeForIndex InsertDeleteRangeForIndex) error {
+	dbReplace, exist := sr.DbMap[job.SchemaID]
+	if !exist {
+		// skip this mddljob, the same below
+		log.Debug("try to drop a non-existent range, missing oldDBID", zap.Int64("oldDBID", job.SchemaID))
+		return nil
+	}
+
+	// allocate a new fake job id to avoid row conflicts in table `gc_delete_range`
+	newJobID, err := sr.genGenGlobalID(context.Background())
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	switch job.Type {
+	case model.ActionDropSchema:
+		var tableIDs []int64
+		if err := job.DecodeArgs(&tableIDs); err != nil {
+			return errors.Trace(err)
+		}
+		// Note: tableIDs contains partition ids, cannot directly use dbReplace.TableMap
+		/* TODO: use global ID replace map
+		 *
+		 *	for i := 0; i < len(tableIDs); i++ {
+		 *		tableReplace, exist := dbReplace.TableMap[tableIDs[i]]
+		 *		if !exist {
+		 *			return errors.Errorf("DropSchema: try to drop a non-existent table, missing oldTableID")
+		 *		}
+		 *		tableIDs[i] = tableReplace.NewTableID
+		 *	}
+		 */
+
+		argsSet := make(map[int64]struct{}, len(tableIDs))
+		for _, tableID := range tableIDs {
+			argsSet[tableID] = struct{}{}
+		}
+
+		newTableIDs := make([]int64, 0, len(tableIDs))
+		for tableID, tableReplace := range dbReplace.TableMap {
+			if _, exist := argsSet[tableID]; !exist {
+				log.Debug("DropSchema: record a table, but it doesn't exist in job args", zap.Int64("oldTableID", tableID))
+				continue
+			}
+			newTableIDs = append(newTableIDs, tableReplace.NewTableID)
+			for partitionID, newPartitionID := range tableReplace.PartitionMap {
+				if _, exist := argsSet[partitionID]; !exist {
+					log.Debug("DropSchema: record a partition, but it doesn't exist in job args", zap.Int64("oldPartitionID", partitionID))
+					continue
+				}
+				newTableIDs = append(newTableIDs, newPartitionID)
+			}
+		}
+
+		if len(newTableIDs) != len(tableIDs) {
+			log.Debug("DropSchema: try to drop a non-existent table/partition, whose oldID doesn't exist in tableReplace")
+			// only drop newTableIDs' ranges
+		}
+
+		if len(newTableIDs) > 0 {
+			insertDeleteRangeForTable(newJobID, newTableIDs)
+		}
+
+		return nil
+	// Truncate will generates new id for table or partition, so ts can be large enough
+	case model.ActionDropTable, model.ActionTruncateTable:
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("DropTable/TruncateTable: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+
+		// The startKey here is for compatibility with previous versions, old version did not endKey so don't have to deal with.
+		var startKey kv.Key // unused
+		var physicalTableIDs []int64
+		var ruleIDs []string // unused
+		if err := job.DecodeArgs(&startKey, &physicalTableIDs, &ruleIDs); err != nil {
+			return errors.Trace(err)
+		}
+		if len(physicalTableIDs) > 0 {
+			// delete partition id instead of table id
+			for i := 0; i < len(physicalTableIDs); i++ {
+				newPid, exist := tableReplace.PartitionMap[physicalTableIDs[i]]
+				if !exist {
+					log.Debug("DropTable/TruncateTable: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", physicalTableIDs[i]))
+					continue
+				}
+				physicalTableIDs[i] = newPid
+			}
+			if len(physicalTableIDs) > 0 {
+				insertDeleteRangeForTable(newJobID, physicalTableIDs)
+			}
+			return nil
+		}
+
+		insertDeleteRangeForTable(newJobID, []int64{tableReplace.NewTableID})
+		return nil
+	case model.ActionDropTablePartition, model.ActionTruncateTablePartition:
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("DropTablePartition/TruncateTablePartition: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+		var physicalTableIDs []int64
+		if err := job.DecodeArgs(&physicalTableIDs); err != nil {
+			return errors.Trace(err)
+		}
+
+		for i := 0; i < len(physicalTableIDs); i++ {
+			newPid, exist := tableReplace.PartitionMap[physicalTableIDs[i]]
+			if !exist {
+				log.Debug("DropTablePartition/TruncateTablePartition: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", physicalTableIDs[i]))
+				continue
+			}
+			physicalTableIDs[i] = newPid
+		}
+		if len(physicalTableIDs) > 0 {
+			insertDeleteRangeForTable(newJobID, physicalTableIDs)
+		}
+		return nil
+	// ActionAddIndex, ActionAddPrimaryKey needs do it, because it needs to be rolled back when it's canceled.
+	case model.ActionAddIndex, model.ActionAddPrimaryKey:
+		// iff job.State = model.JobStateRollbackDone
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("AddIndex/AddPrimaryKey roll-back: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+		var indexID int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&indexID, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+
+		var elementID int64 = 1
+		indexIDs := []int64{indexID}
+
+		if len(partitionIDs) > 0 {
+			for _, oldPid := range partitionIDs {
+				newPid, exist := tableReplace.PartitionMap[oldPid]
+				if !exist {
+					log.Debug("AddIndex/AddPrimaryKey roll-back: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+					continue
+				}
+
+				insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+			}
+		} else {
+			insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+		}
+		return nil
+	case model.ActionDropIndex, model.ActionDropPrimaryKey:
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("DropIndex/DropPrimaryKey: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+
+		var indexName interface{}
+		var indexID int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&indexName, &indexID, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+
+		var elementID int64 = 1
+		indexIDs := []int64{indexID}
+
+		if len(partitionIDs) > 0 {
+			for _, oldPid := range partitionIDs {
+				newPid, exist := tableReplace.PartitionMap[oldPid]
+				if !exist {
+					log.Debug("DropIndex/DropPrimaryKey: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+					continue
+				}
+				// len(indexIDs) = 1
+				insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+			}
+		} else {
+			insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+		}
+		return nil
+	case model.ActionDropIndexes:
+		var indexIDs []int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&[]model.CIStr{}, &[]bool{}, &indexIDs, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+		// Remove data in TiKV.
+		if len(indexIDs) == 0 {
+			return nil
+		}
+
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("DropIndexes: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+
+		var elementID int64 = 1
+		if len(partitionIDs) > 0 {
+			for _, oldPid := range partitionIDs {
+				newPid, exist := tableReplace.PartitionMap[oldPid]
+				if !exist {
+					log.Debug("DropIndexes: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+					continue
+				}
+				insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+			}
+		} else {
+			insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+		}
+		return nil
+	case model.ActionDropColumn:
+		var colName model.CIStr
+		var indexIDs []int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&colName, &indexIDs, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+		if len(indexIDs) > 0 {
+			tableReplace, exist := dbReplace.TableMap[job.TableID]
+			if !exist {
+				log.Debug("DropColumn: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+				return nil
+			}
+
+			var elementID int64 = 1
+			if len(partitionIDs) > 0 {
+				for _, oldPid := range partitionIDs {
+					newPid, exist := tableReplace.PartitionMap[oldPid]
+					if !exist {
+						log.Debug("DropColumn: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+						continue
+					}
+					insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+				}
+			} else {
+				insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+			}
+		}
+		return nil
+	case model.ActionDropColumns:
+		var colNames []model.CIStr
+		var ifExists []bool
+		var indexIDs []int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&colNames, &ifExists, &indexIDs, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+		if len(indexIDs) > 0 {
+			tableReplace, exist := dbReplace.TableMap[job.TableID]
+			if !exist {
+				log.Debug("DropColumns: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+				return nil
+			}
+
+			var elementID int64 = 1
+			if len(partitionIDs) > 0 {
+				for _, oldPid := range partitionIDs {
+					newPid, exist := tableReplace.PartitionMap[oldPid]
+					if !exist {
+						log.Debug("DropColumns: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+						continue
+					}
+					insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+				}
+			} else {
+				insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+			}
+		}
+	case model.ActionModifyColumn:
+		var indexIDs []int64
+		var partitionIDs []int64
+		if err := job.DecodeArgs(&indexIDs, &partitionIDs); err != nil {
+			return errors.Trace(err)
+		}
+		if len(indexIDs) == 0 {
+			return nil
+		}
+		tableReplace, exist := dbReplace.TableMap[job.TableID]
+		if !exist {
+			log.Debug("DropColumn: try to drop a non-existent table, missing oldTableID", zap.Int64("oldTableID", job.TableID))
+			return nil
+		}
+
+		var elementID int64 = 1
+		if len(partitionIDs) > 0 {
+			for _, oldPid := range partitionIDs {
+				newPid, exist := tableReplace.PartitionMap[oldPid]
+				if !exist {
+					log.Debug("DropColumn: try to drop a non-existent table, missing oldPartitionID", zap.Int64("oldPartitionID", oldPid))
+					continue
+				}
+				insertDeleteRangeForIndex(newJobID, &elementID, newPid, indexIDs)
+			}
+		} else {
+			insertDeleteRangeForIndex(newJobID, &elementID, tableReplace.NewTableID, indexIDs)
+		}
+	}
+	return nil
 }

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -436,7 +436,7 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string, insertDeleteRan
 	// skip mDDLJob
 
 	if !strings.HasPrefix(string(e.Key), "mDB") {
-		if strings.HasPrefix(cf, "default") && strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
+		if cf == DefaultCF && strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
 			job := &model.Job{}
 			if err := job.Decode(e.Value); err != nil {
 				log.Debug("failed to decode the job", zap.String("error", err.Error()), zap.String("job", string(e.Value)))

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -436,7 +436,7 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string, insertDeleteRan
 	// skip mDDLJob
 
 	if !strings.HasPrefix(string(e.Key), "mDB") {
-		if strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
+		if cf == "default_cf" && strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
 			job := &model.Job{}
 			if err := job.Decode(e.Value); err != nil {
 				log.Debug("failed to decode the job", zap.String("error", err.Error()), zap.String("job", string(e.Value)))

--- a/br/pkg/stream/rewrite_meta_rawkv.go
+++ b/br/pkg/stream/rewrite_meta_rawkv.go
@@ -436,7 +436,7 @@ func (sr *SchemasReplace) RewriteKvEntry(e *kv.Entry, cf string, insertDeleteRan
 	// skip mDDLJob
 
 	if !strings.HasPrefix(string(e.Key), "mDB") {
-		if cf == "default_cf" && strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
+		if strings.HasPrefix(cf, "default") && strings.HasPrefix(string(e.Key), "mDDLJobH") { // mDDLJobHistory
 			job := &model.Job{}
 			if err := job.Decode(e.Value); err != nil {
 				log.Debug("failed to decode the job", zap.String("error", err.Error()), zap.String("job", string(e.Value)))

--- a/br/pkg/stream/rewrite_meta_rawkv_test.go
+++ b/br/pkg/stream/rewrite_meta_rawkv_test.go
@@ -206,3 +206,303 @@ func TestRewriteValueForPartitionTable(t *testing.T) {
 	)
 	require.Equal(t, tableInfo.Partition.Definitions[1].ID, newID2)
 }
+
+// db:70->80 -
+//           | - t0:71->81 -
+//           |             | - p0:72->82
+//           |             | - p1:73->83
+//           |             | - p2:74->84
+//           | - t1:75->85
+
+const (
+	mDDLJobDBOldID int64 = 70 + iota
+	mDDLJobTable0OldID
+	mDDLJobPartition0OldID
+	mDDLJobPartition1OldID
+	mDDLJobPartition2OldID
+	mDDLJobTable1OldID
+)
+
+const (
+	mDDLJobDBNewID int64 = 80 + iota
+	mDDLJobTable0NewID
+	mDDLJobPartition0NewID
+	mDDLJobPartition1NewID
+	mDDLJobPartition2NewID
+	mDDLJobTable1NewID
+)
+
+var (
+	mDDLJobALLNewTableIDSet = map[int64]struct{}{
+		mDDLJobTable0NewID:     {},
+		mDDLJobPartition0NewID: {},
+		mDDLJobPartition1NewID: {},
+		mDDLJobPartition2NewID: {},
+		mDDLJobTable1NewID:     {},
+	}
+	mDDLJobALLNewPartitionIDSet = map[int64]struct{}{
+		mDDLJobPartition0NewID: {},
+		mDDLJobPartition1NewID: {},
+		mDDLJobPartition2NewID: {},
+	}
+	mDDLJobALLIndexesIDSet = map[int64]struct{}{
+		2: {},
+		3: {},
+	}
+)
+
+var (
+	dropSchemaJob           = &model.Job{Type: model.ActionDropSchema, SchemaID: mDDLJobDBOldID, RawArgs: json.RawMessage(`[[71,72,73,74,75]]`)}
+	dropTable0Job           = &model.Job{Type: model.ActionDropTable, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`["",[72,73,74],[""]]`)}
+	dropTable1Job           = &model.Job{Type: model.ActionDropTable, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`["",[],[""]]`)}
+	dropTable0Partition1Job = &model.Job{Type: model.ActionDropTablePartition, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`[[73]]`)}
+	rollBackTable0IndexJob  = &model.Job{Type: model.ActionAddIndex, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`[2,[72,73,74]]`)}
+	rollBackTable1IndexJob  = &model.Job{Type: model.ActionAddIndex, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`[2,[]]`)}
+	dropTable0IndexJob      = &model.Job{Type: model.ActionDropIndex, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`["",2,[72,73,74]]`)}
+	dropTable1IndexJob      = &model.Job{Type: model.ActionDropIndex, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`["",2,[]]`)}
+	dropTable0IndexesJob    = &model.Job{Type: model.ActionDropIndexes, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`[[],[],[2,3],[72,73,74]]`)}
+	dropTable1IndexesJob    = &model.Job{Type: model.ActionDropIndexes, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`[[],[],[2,3],[]]`)}
+	dropTable0ColumnJob     = &model.Job{Type: model.ActionDropColumn, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`["",[2,3],[72,73,74]]`)}
+	dropTable1ColumnJob     = &model.Job{Type: model.ActionDropColumn, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`["",[2,3],[]]`)}
+	dropTable0ColumnsJob    = &model.Job{Type: model.ActionDropColumns, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`[[],[],[2,3],[72,73,74]]`)}
+	dropTable1ColumnsJob    = &model.Job{Type: model.ActionDropColumns, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`[[],[],[2,3],[]]`)}
+	modifyTable0ColumnJob   = &model.Job{Type: model.ActionModifyColumn, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable0OldID, RawArgs: json.RawMessage(`[[2,3],[72,73,74]]`)}
+	modifyTable1ColumnJob   = &model.Job{Type: model.ActionModifyColumn, SchemaID: mDDLJobDBOldID, TableID: mDDLJobTable1OldID, RawArgs: json.RawMessage(`[[2,3],[]]`)}
+)
+
+type TableDeletQueryArgs struct {
+	tableIDs []int64
+}
+
+type IndexDeleteQueryArgs struct {
+	tableID  int64
+	indexIDs []int64
+}
+
+type mockInsertDeleteRange struct {
+	tableCh chan TableDeletQueryArgs
+	indexCh chan IndexDeleteQueryArgs
+}
+
+func newMockInsertDeleteRange() *mockInsertDeleteRange {
+	// Since there is only single thread, we need to set the channel buf large enough.
+	return &mockInsertDeleteRange{
+		tableCh: make(chan TableDeletQueryArgs, 10),
+		indexCh: make(chan IndexDeleteQueryArgs, 10),
+	}
+}
+
+func (midr *mockInsertDeleteRange) mockInsertDeleteRangeForTable(jobID int64, tableIDs []int64) {
+	midr.tableCh <- TableDeletQueryArgs{
+		tableIDs: tableIDs,
+	}
+}
+
+func (midr *mockInsertDeleteRange) mockInsertDeleteRangeForIndex(jobID int64, elementID *int64, tableID int64, indexIDs []int64) {
+	midr.indexCh <- IndexDeleteQueryArgs{
+		tableID:  tableID,
+		indexIDs: indexIDs,
+	}
+}
+
+func TestDeleteRangeForMDDLJob(t *testing.T) {
+	schemaReplace := MockEmptySchemasReplace()
+	partitionMap := map[int64]int64{
+		mDDLJobPartition0OldID: mDDLJobPartition0NewID,
+		mDDLJobPartition1OldID: mDDLJobPartition1NewID,
+		mDDLJobPartition2OldID: mDDLJobPartition2NewID,
+	}
+	tableReplace0 := &TableReplace{
+		NewTableID:   mDDLJobTable0NewID,
+		PartitionMap: partitionMap,
+	}
+	tableReplace1 := &TableReplace{
+		NewTableID: mDDLJobTable1NewID,
+	}
+	tableMap := map[int64]*TableReplace{
+		mDDLJobTable0OldID: tableReplace0,
+		mDDLJobTable1OldID: tableReplace1,
+	}
+	dbReplace := &DBReplace{
+		NewDBID:  mDDLJobDBNewID,
+		TableMap: tableMap,
+	}
+	schemaReplace.DbMap[mDDLJobDBOldID] = dbReplace
+
+	midr := newMockInsertDeleteRange()
+
+	var targs TableDeletQueryArgs
+	var iargs IndexDeleteQueryArgs
+	var err error
+	// drop schema
+	err = schemaReplace.deleteRange(dropSchemaJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	targs = <-midr.tableCh
+	require.Equal(t, len(targs.tableIDs), len(mDDLJobALLNewTableIDSet))
+	for _, tableID := range targs.tableIDs {
+		_, exist := mDDLJobALLNewTableIDSet[tableID]
+		require.True(t, exist)
+	}
+
+	// drop table0
+	err = schemaReplace.deleteRange(dropTable0Job, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	targs = <-midr.tableCh
+	require.Equal(t, len(targs.tableIDs), len(mDDLJobALLNewPartitionIDSet))
+	for _, tableID := range targs.tableIDs {
+		_, exist := mDDLJobALLNewPartitionIDSet[tableID]
+		require.True(t, exist)
+	}
+
+	// drop table1
+	err = schemaReplace.deleteRange(dropTable1Job, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	targs = <-midr.tableCh
+	require.Equal(t, len(targs.tableIDs), 1)
+	require.Equal(t, targs.tableIDs[0], mDDLJobTable1NewID)
+
+	// drop table partition1
+	err = schemaReplace.deleteRange(dropTable0Partition1Job, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	targs = <-midr.tableCh
+	require.Equal(t, len(targs.tableIDs), 1)
+	require.Equal(t, targs.tableIDs[0], mDDLJobPartition1NewID)
+
+	// roll back add index for table0
+	err = schemaReplace.deleteRange(rollBackTable0IndexJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), 1)
+		require.Equal(t, iargs.indexIDs[0], int64(2))
+	}
+
+	// roll back add index for table1
+	err = schemaReplace.deleteRange(rollBackTable1IndexJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), 1)
+	require.Equal(t, iargs.indexIDs[0], int64(2))
+
+	// drop index for table0
+	err = schemaReplace.deleteRange(dropTable0IndexJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), 1)
+		require.Equal(t, iargs.indexIDs[0], int64(2))
+	}
+
+	// drop index for table1
+	err = schemaReplace.deleteRange(dropTable1IndexJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), 1)
+	require.Equal(t, iargs.indexIDs[0], int64(2))
+
+	// drop indexes for table0
+	err = schemaReplace.deleteRange(dropTable0IndexesJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+		for _, indexID := range iargs.indexIDs {
+			_, exist := mDDLJobALLIndexesIDSet[indexID]
+			require.True(t, exist)
+		}
+	}
+
+	// drop indexes for table1
+	err = schemaReplace.deleteRange(dropTable1IndexesJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+	for _, indexID := range iargs.indexIDs {
+		_, exist := mDDLJobALLIndexesIDSet[indexID]
+		require.True(t, exist)
+	}
+
+	// drop column for table0
+	err = schemaReplace.deleteRange(dropTable0ColumnJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+		for _, indexID := range iargs.indexIDs {
+			_, exist := mDDLJobALLIndexesIDSet[indexID]
+			require.True(t, exist)
+		}
+	}
+
+	// drop column for table1
+	err = schemaReplace.deleteRange(dropTable1ColumnJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+	for _, indexID := range iargs.indexIDs {
+		_, exist := mDDLJobALLIndexesIDSet[indexID]
+		require.True(t, exist)
+	}
+
+	// drop columns for table0
+	err = schemaReplace.deleteRange(dropTable0ColumnsJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+		for _, indexID := range iargs.indexIDs {
+			_, exist := mDDLJobALLIndexesIDSet[indexID]
+			require.True(t, exist)
+		}
+	}
+
+	// drop columns for table1
+	err = schemaReplace.deleteRange(dropTable1ColumnsJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+	for _, indexID := range iargs.indexIDs {
+		_, exist := mDDLJobALLIndexesIDSet[indexID]
+		require.True(t, exist)
+	}
+
+	// drop columns for table0
+	err = schemaReplace.deleteRange(modifyTable0ColumnJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	for i := 0; i < len(mDDLJobALLNewPartitionIDSet); i++ {
+		iargs = <-midr.indexCh
+		_, exist := mDDLJobALLNewPartitionIDSet[iargs.tableID]
+		require.True(t, exist)
+		require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+		for _, indexID := range iargs.indexIDs {
+			_, exist := mDDLJobALLIndexesIDSet[indexID]
+			require.True(t, exist)
+		}
+	}
+
+	// drop columns for table1
+	err = schemaReplace.deleteRange(modifyTable1ColumnJob, midr.mockInsertDeleteRangeForTable, midr.mockInsertDeleteRangeForIndex)
+	require.NoError(t, err)
+	iargs = <-midr.indexCh
+	require.Equal(t, iargs.tableID, mDDLJobTable1NewID)
+	require.Equal(t, len(iargs.indexIDs), len(mDDLJobALLIndexesIDSet))
+	for _, indexID := range iargs.indexIDs {
+		_, exist := mDDLJobALLIndexesIDSet[indexID]
+		require.True(t, exist)
+	}
+}

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1083,6 +1083,7 @@ func restoreStream(
 
 	pm := g.StartProgress(ctx, "Restore Meta Files", int64(len(ddlFiles)), !cfg.LogProgress)
 	if err = withProgress(pm, func(p glue.Progress) error {
+		client.RunGCRowsLoader(ctx)
 		return client.RestoreMetaKVFiles(ctx, ddlFiles, schemasReplace, p.Inc)
 	}); err != nil {
 		return errors.Annotate(err, "failed to restore meta files")
@@ -1110,6 +1111,11 @@ func restoreStream(
 	if err = client.SaveSchemas(ctx, schemasReplace, logMinTS, cfg.RestoreTS); err != nil {
 		return errors.Trace(err)
 	}
+
+	if err = client.InsertGCRows(ctx); err != nil {
+		return errors.Annotate(err, "failed to insert rows into gc_delete_range")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/35372

Problem Summary: drop table meta only, not delete record and index belonged to table.

### What is changed and how it works?

deal with the mddl job, and insert rows into table mysql.gc_delete_range.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
