### PR TITLE
ddl: Add `sql_require_primary_key` sysvar

### DIFF
--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2000,6 +2000,11 @@ func checkTableInfoValidWithStmt(ctx sessionctx.Context, tbInfo *model.TableInfo
 	if err := checkGeneratedColumn(ctx, s.Cols); err != nil {
 		return errors.Trace(err)
 	}
+
+	// Check if table has a primary key if required.
+	if ctx.GetSessionVars().PrimaryKeyRequired && len(tbInfo.GetPkName().String()) == 0 {
+		return infoschema.ErrNoPrimaryKey.GenWithStackByArgs(tbInfo.Name)
+	}
 	if tbInfo.Partition != nil {
 		if err := checkPartitionDefinitionConstraints(ctx, tbInfo); err != nil {
 			return errors.Trace(err)

--- a/infoschema/error.go
+++ b/infoschema/error.go
@@ -82,4 +82,6 @@ var (
 	ErrEmptyDatabase = dbterror.ClassSchema.NewStd(mysql.ErrBadDB)
 	// ErrForbidSchemaChange returns when the schema change is illegal
 	ErrForbidSchemaChange = dbterror.ClassSchema.NewStd(mysql.ErrForbidSchemaChange)
+	// ErrNoPrimaryKey returns when there is no primary key on a table and sql_require_primary_key is set
+	ErrNoPrimaryKey = dbterror.ClassSchema.NewStd(mysql.ErrRequiresPrimaryKey)
 )

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1165,6 +1165,9 @@ type SessionVars struct {
 
 	// RequestSourceType is the type of inner request.
 	RequestSourceType string
+
+	// PrimaryKeyRequired indicates if sql_require_primary_key sysvar is set
+	PrimaryKeyRequired bool
 }
 
 // InitStatementContext initializes a StatementContext, the object is reused to reduce allocation.

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1673,6 +1673,10 @@ var defaultSysVars = []*SysVar{
 			metrics.ToggleSimplifiedMode(TiDBOptOn(s))
 			return nil
 		}},
+	{Scope: ScopeGlobal | ScopeSession, Name: SqlRequirePrimaryKey, Value: Off, Type: TypeBool, SetSession: func(s *SessionVars, val string) error {
+		s.PrimaryKeyRequired = TiDBOptOn(val)
+		return nil
+	}},
 }
 
 // FeedbackProbability points to the FeedbackProbability in statistics package.
@@ -1979,4 +1983,6 @@ const (
 	RandSeed1 = "rand_seed1"
 	// RandSeed2 is the name of 'rand_seed2' system variable.
 	RandSeed2 = "rand_seed2"
+	//SqlRequirePrimaryKey is the name of `sql_require_primary_key` system variable.
+	SqlRequirePrimaryKey = "sql_require_primary_key"
 )


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/28544

Problem Summary: 

This is a feature from MySQL 8.0:
https://dev.mysql.com/doc/refman/8.0/en/server-system-variables.html#sysvar_sql_require_primary_key

It allows you to enforce tables have a primary key. It has more meaning in MySQL because row-based replication benefits from it, and InnoDB is less efficient when using its internal primary key. But it's still useful.

### What is changed and how it works?

`sql_require_primary_key` sysvar has been added. When enabled it will throw an error if a create table ddl doesn't have a primary key.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
