### PR TITLE
log-backup: support calculating dynamic shift-start-ts when restoring kv-files belonging to default-cf

### DIFF
--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -1616,11 +1616,11 @@ func (rc *Client) ReadStreamDataFiles(
 	}
 
 	// sort files firstly.
-	sort.Slice(mFiles, func(i, j int) bool {
-		if mFiles[i].ResolvedTs > 0 && mFiles[j].ResolvedTs > 0 {
-			return mFiles[i].ResolvedTs < mFiles[j].ResolvedTs
+	slices.SortFunc(mFiles, func(i, j *backuppb.DataFileInfo) bool {
+		if i.ResolvedTs > 0 && j.ResolvedTs > 0 {
+			return i.ResolvedTs < j.ResolvedTs
 		} else {
-			return mFiles[i].MaxTs < mFiles[j].MaxTs
+			return i.MaxTs < j.MaxTs
 		}
 	})
 	return dFiles, mFiles, nil

--- a/br/pkg/restore/client.go
+++ b/br/pkg/restore/client.go
@@ -304,6 +304,8 @@ func (rc *Client) SetRestoreRangeTS(startTs, restoreTS, shiftStartTS uint64) {
 	rc.startTS = startTs
 	rc.restoreTS = restoreTS
 	rc.shiftStartTS = shiftStartTS
+	log.Info("set restore range ts", zap.Uint64("shift-start-ts", shiftStartTS),
+		zap.Uint64("start-ts", startTs), zap.Uint64("restored-ts", restoreTS))
 }
 
 func (rc *Client) SetCurrentTS(ts uint64) {
@@ -1612,6 +1614,15 @@ func (rc *Client) ReadStreamDataFiles(
 			log.Debug("backup stream collect data file", zap.String("file", d.Path))
 		}
 	}
+
+	// sort files firstly.
+	sort.Slice(mFiles, func(i, j int) bool {
+		if mFiles[i].ResolvedTs > 0 && mFiles[j].ResolvedTs > 0 {
+			return mFiles[i].ResolvedTs < mFiles[j].ResolvedTs
+		} else {
+			return mFiles[i].MaxTs < mFiles[j].MaxTs
+		}
+	})
 	return dFiles, mFiles, nil
 }
 
@@ -1678,6 +1689,7 @@ func (rc *Client) RestoreKVFiles(
 	ctx context.Context,
 	rules map[int64]*RewriteRules,
 	files []*backuppb.DataFileInfo,
+	updateStats func(kvCount uint64, size uint64),
 	onProgress func(),
 ) error {
 	var err error
@@ -1719,6 +1731,7 @@ func (rc *Client) RestoreKVFiles(
 				fileStart := time.Now()
 				defer func() {
 					onProgress()
+					updateStats(uint64(file.NumberOfEntries), file.Length)
 					summary.CollectInt("File", 1)
 					log.Info("import files done", zap.String("name", file.Path), zap.Duration("take", time.Since(fileStart)))
 				}()
@@ -1836,13 +1849,14 @@ func (rc *Client) RestoreMetaKVFiles(
 	ctx context.Context,
 	files []*backuppb.DataFileInfo,
 	schemasReplace *stream.SchemasReplace,
+	updateStats func(kvCount uint64, size uint64),
 	progressInc func(),
 ) error {
 	filesInWriteCF := make([]*backuppb.DataFileInfo, 0, len(files))
 
 	// The k-v events in default CF should be restored firstly. The reason is that:
-	// The error of transactions of meta will happen,
-	// if restore default CF events successfully, but failed to restore write CF events.
+	// The error of transactions of meta could happen if restore write CF events successfully,
+	// but failed to restore default CF events.
 	for _, f := range files {
 		if f.Cf == stream.WriteCF {
 			filesInWriteCF = append(filesInWriteCF, f)
@@ -1856,19 +1870,21 @@ func (rc *Client) RestoreMetaKVFiles(
 			continue
 		}
 
-		err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
+		kvCount, size, err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		updateStats(kvCount, size)
 		progressInc()
 	}
 
 	// Restore files in write CF.
 	for _, f := range filesInWriteCF {
-		err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
+		kvCount, size, err := rc.RestoreMetaKVFile(ctx, f, schemasReplace)
 		if err != nil {
 			return errors.Trace(err)
 		}
+		updateStats(kvCount, size)
 		progressInc()
 	}
 
@@ -1884,7 +1900,11 @@ func (rc *Client) RestoreMetaKVFile(
 	ctx context.Context,
 	file *backuppb.DataFileInfo,
 	sr *stream.SchemasReplace,
-) error {
+) (uint64, uint64, error) {
+	var (
+		kvCount uint64
+		size    uint64
+	)
 	log.Info("restore meta kv events", zap.String("file", file.Path),
 		zap.String("cf", file.Cf), zap.Int64("kv-count", file.NumberOfEntries),
 		zap.Uint64("min-ts", file.MinTs), zap.Uint64("max-ts", file.MaxTs))
@@ -1892,10 +1912,10 @@ func (rc *Client) RestoreMetaKVFile(
 	rc.rawKVClient.SetColumnFamily(file.GetCf())
 	buff, err := rc.storage.ReadFile(ctx, file.Path)
 	if err != nil {
-		return errors.Trace(err)
+		return 0, 0, errors.Trace(err)
 	}
 	if checksum := sha256.Sum256(buff); !bytes.Equal(checksum[:], file.GetSha256()) {
-		return errors.Annotatef(berrors.ErrInvalidMetaFile,
+		return 0, 0, errors.Annotatef(berrors.ErrInvalidMetaFile,
 			"checksum mismatch expect %x, got %x", file.GetSha256(), checksum[:])
 	}
 
@@ -1903,13 +1923,13 @@ func (rc *Client) RestoreMetaKVFile(
 	for iter.Valid() {
 		iter.Next()
 		if iter.GetError() != nil {
-			return errors.Trace(iter.GetError())
+			return 0, 0, errors.Trace(iter.GetError())
 		}
 
 		txnEntry := kv.Entry{Key: iter.Key(), Value: iter.Value()}
 		ts, err := GetKeyTS(txnEntry.Key)
 		if err != nil {
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		}
 
 		// The commitTs in write CF need be limited on [startTs, restoreTs].
@@ -1935,7 +1955,7 @@ func (rc *Client) RestoreMetaKVFile(
 		if err != nil {
 			log.Error("rewrite txn entry failed", zap.Int("klen", len(txnEntry.Key)),
 				logutil.Key("txn-key", txnEntry.Key))
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		} else if newEntry == nil {
 			continue
 		}
@@ -1943,11 +1963,14 @@ func (rc *Client) RestoreMetaKVFile(
 			zap.Int("newValue-len", len(txnEntry.Value)), zap.ByteString("newkey", newEntry.Key))
 
 		if err := rc.rawKVClient.Put(ctx, newEntry.Key, newEntry.Value, ts); err != nil {
-			return errors.Trace(err)
+			return 0, 0, errors.Trace(err)
 		}
+
+		kvCount += 1
+		size += uint64(len(newEntry.Key) + len(newEntry.Value))
 	}
 
-	return rc.rawKVClient.PutRest(ctx)
+	return kvCount, size, rc.rawKVClient.PutRest(ctx)
 }
 
 func transferBoolToValue(enable bool) string {

--- a/br/pkg/stream/stream_mgr.go
+++ b/br/pkg/stream/stream_mgr.go
@@ -16,6 +16,7 @@ package stream
 
 import (
 	"context"
+	"strings"
 
 	"github.com/pingcap/errors"
 	backuppb "github.com/pingcap/kvproto/pkg/brpb"
@@ -172,7 +173,11 @@ func FastUnmarshalMetaData(
 			m := &backuppb.Metadata{}
 			err = m.Unmarshal(b)
 			if err != nil {
-				return err
+				if !strings.HasSuffix(path, ".meta") {
+					return nil
+				} else {
+					return err
+				}
 			}
 			return fn(readPath, m)
 		})

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -691,7 +691,7 @@ func RunStreamPause(
 		utils.BRServiceSafePoint{
 			ID:       buildPauseSafePointName(ti.Info.Name),
 			TTL:      cfg.SafePointTTL,
-			BackupTS: globalCheckPointTS,
+			BackupTS: globalCheckPointTS - 1,
 		},
 	); err != nil {
 		return errors.Trace(err)
@@ -888,10 +888,17 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	}
 	readMetaDone()
 
-	fileCount := 0
-	shiftUntilTS := ShiftTS(cfg.Until)
+	var (
+		fileCount    uint64 = 0
+		kvCount      int64  = 0
+		totalSize    uint64 = 0
+		shiftUntilTS        = metas.CalculateShiftTS(cfg.Until)
+	)
+
 	metas.IterateFilesFullyBefore(shiftUntilTS, func(d *backuppb.DataFileInfo) (shouldBreak bool) {
 		fileCount++
+		totalSize += d.Length
+		kvCount += d.NumberOfEntries
 		return
 	})
 	console.Printf("We are going to remove %s files, until %s.\n",
@@ -904,6 +911,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 
 	removed := metas.RemoveDataBefore(shiftUntilTS)
 
+	// remove metadata
 	removeMetaDone := console.StartTask("Removing metadata... ")
 	if !cfg.DryRun {
 		if err := metas.DoWriteBack(ctx, storage); err != nil {
@@ -911,7 +919,10 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 		}
 	}
 	removeMetaDone()
-	clearDataFileDone := console.StartTask("Clearing data files... ")
+
+	// remove log
+	clearDataFileDone := console.StartTask(
+		fmt.Sprintf("Clearing data files done. kv-count = %v, total-size = %v", kvCount, totalSize))
 	worker := utils.NewWorkerPool(128, "delete files")
 	wg := new(sync.WaitGroup)
 	for _, f := range removed {
@@ -938,16 +949,6 @@ func RunStreamRestore(
 	cmdName string,
 	cfg *RestoreConfig,
 ) (err error) {
-	startTime := time.Now()
-	defer func() {
-		dur := time.Since(startTime)
-		if err != nil {
-			summary.Log(cmdName+" failed summary", zap.Error(err))
-		} else {
-			summary.Log(cmdName+" success summary", zap.Duration("total-take", dur),
-				zap.Uint64("restore-from", cfg.StartTS), zap.Uint64("restore-to", cfg.RestoreTS))
-		}
-	}()
 	ctx, cancelFn := context.WithCancel(c)
 	defer cancelFn()
 
@@ -1012,7 +1013,23 @@ func restoreStream(
 	g glue.Glue,
 	cfg *RestoreConfig,
 	logMinTS, logMaxTS uint64,
-) error {
+) (err error) {
+	var (
+		totalKVCount uint64
+		totalSize    uint64
+		mu           sync.Mutex
+		startTime    = time.Now()
+	)
+	defer func() {
+		if err != nil {
+			summary.Log("restore log failed summary", zap.Error(err))
+		} else {
+			summary.Log("restore log success summary", zap.Duration("total-take", time.Since(startTime)),
+				zap.Uint64("restore-from", cfg.StartTS), zap.Uint64("restore-to", cfg.RestoreTS),
+				zap.Uint64("total-kv-count", totalKVCount), zap.Uint64("total-size", totalSize))
+		}
+	}()
+
 	ctx, cancelFn := context.WithCancel(c)
 	defer cancelFn()
 
@@ -1042,7 +1059,6 @@ func restoreStream(
 	if err != nil {
 		return errors.Trace(err)
 	}
-	client.SetRestoreRangeTS(cfg.StartTS, cfg.RestoreTS, ShiftTS(cfg.StartTS))
 	client.SetCurrentTS(currentTS)
 
 	restoreSchedulers, err := restorePreWork(ctx, client, mgr, false)
@@ -1063,6 +1079,12 @@ func restoreStream(
 		return nil
 	}
 
+	shiftStartTS, exist := restore.CalculateShiftTS(metas, cfg.StartTS, cfg.RestoreTS)
+	if !exist {
+		shiftStartTS = cfg.StartTS
+	}
+	client.SetRestoreRangeTS(cfg.StartTS, cfg.RestoreTS, shiftStartTS)
+
 	// read data file by given ts.
 	dmlFiles, ddlFiles, err := client.ReadStreamDataFiles(ctx, metas)
 	if err != nil {
@@ -1081,10 +1103,16 @@ func restoreStream(
 		return errors.Trace(err)
 	}
 
+	updateStats := func(kvCount uint64, size uint64) {
+		mu.Lock()
+		defer mu.Unlock()
+		totalKVCount += kvCount
+		totalSize += size
+	}
 	pm := g.StartProgress(ctx, "Restore Meta Files", int64(len(ddlFiles)), !cfg.LogProgress)
 	if err = withProgress(pm, func(p glue.Progress) error {
 		client.RunGCRowsLoader(ctx)
-		return client.RestoreMetaKVFiles(ctx, ddlFiles, schemasReplace, p.Inc)
+		return client.RestoreMetaKVFiles(ctx, ddlFiles, schemasReplace, updateStats, p.Inc)
 	}); err != nil {
 		return errors.Annotate(err, "failed to restore meta files")
 	}
@@ -1098,7 +1126,7 @@ func restoreStream(
 
 	pd := g.StartProgress(ctx, "Restore KV Files", int64(len(dmlFiles)), !cfg.LogProgress)
 	err = withProgress(pd, func(p glue.Progress) error {
-		return client.RestoreKVFiles(ctx, rewriteRules, dmlFiles, p.Inc)
+		return client.RestoreKVFiles(ctx, rewriteRules, dmlFiles, updateStats, p.Inc)
 	})
 	if err != nil {
 		return errors.Annotate(err, "failed to restore kv files")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/36138

Problem Summary:

### What is changed and how it works?
This pr is cherry-pick the https://github.com/pingcap/tidb/pull/36089

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [x] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
