### PR TITLE
store/copr: adjust the cop cache admission process time for paging

### DIFF
--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -991,7 +991,7 @@ func (worker *copIteratorWorker) handleCopResponse(bo *Backoffer, rpcCtx *tikv.R
 		// Cache not hit or cache hit but not valid: update the cache if the response can be cached.
 		if cacheKey != nil && resp.pbResp.CanBeCached && resp.pbResp.CacheLastVersion > 0 {
 			if resp.detail != nil {
-				if worker.store.coprCache.CheckResponseAdmission(resp.pbResp.Data.Size(), resp.detail.TimeDetail.ProcessTime) {
+				if worker.store.coprCache.CheckResponseAdmission(resp.pbResp.Data.Size(), resp.detail.TimeDetail.ProcessTime, worker.req.Paging) {
 					data := make([]byte, len(resp.pbResp.Data))
 					copy(data, resp.pbResp.Data)
 

--- a/store/copr/coprocessor_cache.go
+++ b/store/copr/coprocessor_cache.go
@@ -185,14 +185,19 @@ func (c *coprCache) CheckRequestAdmission(ranges int) bool {
 }
 
 // CheckResponseAdmission checks whether a response item is worth caching.
-func (c *coprCache) CheckResponseAdmission(dataSize int, processTime time.Duration) bool {
+func (c *coprCache) CheckResponseAdmission(dataSize int, processTime time.Duration, paging bool) bool {
 	if c == nil {
 		return false
 	}
 	if dataSize == 0 || dataSize > c.admissionMaxSize {
 		return false
 	}
-	if processTime < c.admissionMinProcessTime {
+
+	admissionMinProcessTime := c.admissionMinProcessTime
+	if paging {
+		admissionMinProcessTime = admissionMinProcessTime / 3
+	}
+	if processTime < admissionMinProcessTime {
 		return false
 	}
 	return true


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36156

Problem Summary:

For coprocessor paging request, process time is shorter, if we use the old value, many request can't be cached.

### What is changed and how it works?

Adjust the `admissionMinProcessTime` for paging so it's easier to get cached.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [X] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Adjust the cop cache admission process time for coprocessor paging protocol so the response data are easier to get cached. 
```
