### PR TITLE
log-backup: fix checkpoint display

### DIFF
--- a/br/pkg/stream/stream_status.go
+++ b/br/pkg/stream/stream_status.go
@@ -136,6 +136,8 @@ func (p *printByTable) AddTask(task TaskStatus) {
 		info := fmt.Sprintf("%s; gap=%s", pTime, gapColor.Sprint(gap))
 		return info
 	}
+	cp := task.GetMinStoreCheckpoint()
+	table.Add("checkpoint[global]", formatTS(cp.TS))
 	p.addCheckpoints(&task, table, formatTS)
 	for store, e := range task.LastErrors {
 		table.Add(fmt.Sprintf("error[store=%d]", store), e.ErrorCode)
@@ -147,21 +149,15 @@ func (p *printByTable) AddTask(task TaskStatus) {
 
 func (p *printByTable) addCheckpoints(task *TaskStatus, table *glue.Table, formatTS func(uint64) string) {
 	cp := task.GetMinStoreCheckpoint()
-	items := make([][2]string, 0, len(task.Checkpoints))
 	if cp.Type() != CheckpointTypeGlobal {
 		for _, cp := range task.Checkpoints {
 			switch cp.Type() {
 			case CheckpointTypeStore:
-				items = append(items, [2]string{fmt.Sprintf("checkpoint[store=%d]", cp.ID), formatTS(cp.TS)})
+				table.Add(fmt.Sprintf("checkpoint[store=%d]", cp.ID), formatTS(cp.TS))
 			}
 		}
-	} else {
-		items = append(items, [2]string{"checkpoint[central-global]", formatTS(cp.TS)})
 	}
 
-	for _, item := range items {
-		table.Add(item[0], item[1])
-	}
 }
 
 func (p *printByTable) PrintTasks() {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: fixed #36092

Problem Summary:
Before, if there isn't any checkpoint in the global scope, `br log status` would display no checkpoints.

### What is changed and how it works?
This PR would make us display checkpoint no matter there are some checkpoints.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below) (TBD)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug that caused `br log status` returns no checkpoint.
```
