### PR TITLE
planner: handle the expected row count for pushed-down selection in mpp

### DIFF
--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1917,7 +1917,7 @@ func (ds *DataSource) convertToTableScan(prop *property.PhysicalProperty, candid
 			ColumnNames:    ds.names,
 		}
 		ts.cost = cost
-		mppTask = ts.addPushedDownSelectionToMppTask(mppTask, ds.stats)
+		mppTask = ts.addPushedDownSelectionToMppTask(mppTask, ds.stats.ScaleByExpectCnt(prop.ExpectedCnt))
 		return mppTask, nil
 	}
 	copTask := &copTask{

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -5952,7 +5952,7 @@
           "        │ └─ExchangeSender 9990.00 mpp[tiflash]  ExchangeType: Broadcast",
           "        │   └─Selection 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
           "        │     └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
-          "        └─Selection(Probe) 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
+          "        └─Selection(Probe) 0.80 mpp[tiflash]  not(isnull(test.t.id))",
           "          └─TableFullScan 0.80 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       },
@@ -5968,7 +5968,7 @@
           "        │ └─ExchangeSender 9990.00 mpp[tiflash]  ExchangeType: Broadcast",
           "        │   └─Selection 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
           "        │     └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
-          "        └─Selection(Probe) 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
+          "        └─Selection(Probe) 0.80 mpp[tiflash]  not(isnull(test.t.id))",
           "          └─TableFullScan 0.80 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       },
@@ -5985,7 +5985,7 @@
           "          │ └─ExchangeSender 9990.00 mpp[tiflash]  ExchangeType: Broadcast",
           "          │   └─Selection 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
           "          │     └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
-          "          └─Selection(Probe) 9990.00 mpp[tiflash]  not(isnull(test.t.id))",
+          "          └─Selection(Probe) 16.00 mpp[tiflash]  not(isnull(test.t.id))",
           "            └─TableFullScan 16.02 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
       }


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #36194

Problem Summary:

We didn't handle the expected row count for pushed-down selection in mpp task.

### What is changed and how it works?

Handle the row count for pushed-down selection for mpp task the same as other tasks:
https://github.com/pingcap/tidb/blob/bc1b152f0f958d02ceacc981a99457d678b3f667/planner/core/find_best_task.go#L1945


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
