### PR TITLE
log-backup: get can restored global-checkpoint-ts when support v3 checkpoint advance

### DIFF
--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -1339,9 +1339,11 @@ func getGlobalResolvedTS(
 		return 0, errors.Trace(err)
 	}
 	var globalCheckpointTS uint64 = 0
-	// TODO change the logic after checkpoint v3 implemented
+	// If V3 global-checkpoint advance, the maximum value in storeMap.resolvedTSMap as global-checkpoint-ts.
+	// If v2 global-checkpoint advance, it need the minimal value in storeMap.resolvedTSMap as global-checkpoint-ts.
+	// Because each of store maintains own checkpoint-ts only.
 	for _, resolveTS := range storeMap.resolvedTSMap {
-		if resolveTS < globalCheckpointTS || globalCheckpointTS == 0 {
+		if globalCheckpointTS < resolveTS {
 			globalCheckpointTS = resolveTS
 		}
 	}

--- a/br/pkg/task/stream_test.go
+++ b/br/pkg/task/stream_test.go
@@ -277,7 +277,7 @@ func TestGetGlobalResolvedTS(t *testing.T) {
 	require.Nil(t, err)
 	globalResolvedTS, err := getGlobalResolvedTS(ctx, s)
 	require.Nil(t, err)
-	require.Equal(t, uint64(100), globalResolvedTS)
+	require.Equal(t, uint64(101), globalResolvedTS)
 }
 
 func TestGetGlobalResolvedTS2(t *testing.T) {
@@ -309,5 +309,5 @@ func TestGetGlobalResolvedTS2(t *testing.T) {
 	require.Nil(t, err)
 	globalResolvedTS, err := getGlobalResolvedTS(ctx, s)
 	require.Nil(t, err)
-	require.Equal(t, uint64(98), globalResolvedTS)
+	require.Equal(t, uint64(99), globalResolvedTS)
 }


### PR DESCRIPTION
Signed-off-by: joccau <zak.zhao@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/29501

Problem Summary:

### What is changed and how it works?
- If V3 global-checkpoint advance, the maximum value in storeMap.resolvedTSMap as global-checkpoint-ts.
- If v2 global-checkpoint advance, it need the minimal value in storeMap.resolvedTSMap as global-checkpoint-ts.Because each of store maintains own checkpoint-ts only.


### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
