### PR TITLE
sessionctx: fix data race in the TestLoadAndReadConcurrently

### DIFF
--- a/sessionctx/sessionstates/BUILD.bazel
+++ b/sessionctx/sessionstates/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
         "session_states_test.go",
         "session_token_test.go",
     ],
+    race = "on",
     embed = [":sessionstates"],
     deps = [
         "//config",

--- a/sessionctx/sessionstates/session_token_test.go
+++ b/sessionctx/sessionstates/session_token_test.go
@@ -238,8 +238,9 @@ func TestLoadAndReadConcurrently(t *testing.T) {
 	}
 	// the reader
 	for i := 0; i < 3; i++ {
+		id := i
 		wg.Run(func() {
-			username := fmt.Sprintf("test_user_%d", i)
+			username := fmt.Sprintf("test_user_%d", id)
 			for time.Now().Before(deadline) {
 				_, tokenBytes := createNewToken(t, username)
 				time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36203

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
