### PR TITLE
planner: costs of Selection operators from DataSources are not accumulated

### DIFF
--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -1295,6 +1295,11 @@ type PhysicalSelection struct {
 	basePhysicalPlan
 
 	Conditions []expression.Expression
+
+	// The flag indicates whether this Selection is from a DataSource.
+	// The flag is only used by cost model for compatibility and will be removed later.
+	// Please see https://github.com/pingcap/tidb/issues/36243 for more details.
+	fromDataSource bool
 }
 
 // Clone implements PhysicalPlan interface.

--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -81,6 +81,9 @@ func (p *PhysicalSelection) GetPlanCost(taskType property.TaskType, costFlag uin
 			return 0, errors.Errorf("unknown task type %v", taskType)
 		}
 		selfCost = getCardinality(p.children[0], costFlag) * cpuFactor
+		if p.fromDataSource {
+			selfCost = 0 // for compatibility, see https://github.com/pingcap/tidb/issues/36243
+		}
 	case modelVer2: // selection cost: rows * num-filters * cpu-factor
 		var cpuFactor float64
 		switch taskType {

--- a/planner/core/plan_cost_test.go
+++ b/planner/core/plan_cost_test.go
@@ -16,6 +16,7 @@ package core_test
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -966,4 +967,40 @@ func TestTrueCardCost(t *testing.T) {
 	checkPlanCost(`select * from t where a>10`)
 	checkPlanCost(`select * from t where a>10 limit 10`)
 	checkPlanCost(`select sum(a), b*2 from t use index(b) group by b order by sum(a) limit 10`)
+}
+
+func TestIssue36243(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (a int)`)
+	tk.MustExec(`insert into mysql.expr_pushdown_blacklist values ('>','tikv','')`)
+	tk.MustExec(`admin reload expr_pushdown_blacklist`)
+	tk.MustExec(`set @@tidb_enable_new_cost_interface=1`)
+
+	getCost := func() (selCost, readerCost float64) {
+		res := tk.MustQuery(`explain format=verbose select * from t where a>0`).Rows()
+		// TableScan -> TableReader -> Selection
+		require.Equal(t, len(res), 3)
+		require.Contains(t, res[0][0], "Selection")
+		require.Contains(t, res[1][0], "TableReader")
+		require.Contains(t, res[2][0], "Scan")
+		var err error
+		selCost, err = strconv.ParseFloat(res[0][2].(string), 64)
+		require.NoError(t, err)
+		readerCost, err = strconv.ParseFloat(res[1][2].(string), 64)
+		require.NoError(t, err)
+		return
+	}
+
+	tk.MustExec(`set @@tidb_cost_model_version=1`)
+	// Selection has the same cost with TableReader, ignore Selection cost for compatibility in cost model ver1.
+	selCost, readerCost := getCost()
+	require.Equal(t, selCost, readerCost)
+
+	tk.MustExec(`set @@tidb_cost_model_version=2`)
+	selCost, readerCost = getCost()
+	require.True(t, selCost > readerCost)
 }

--- a/planner/core/task.go
+++ b/planner/core/task.go
@@ -809,6 +809,7 @@ func (t *copTask) handleRootTaskConds(ctx sessionctx.Context, newTask *rootTask)
 			selectivity = SelectionFactor
 		}
 		sel := PhysicalSelection{Conditions: t.rootTaskConds}.Init(ctx, newTask.p.statsInfo().Scale(selectivity), newTask.p.SelectBlockOffset())
+		sel.fromDataSource = true
 		sel.SetChildren(newTask.p)
 		newTask.p = sel
 		sel.cost = newTask.cost()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36243

Problem Summary: costs of Selection operators from DataSources are not accumulated

### What is changed and how it works?

costs of Selection operators from DataSources are not accumulated

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
