### PR TITLE
compact: Add syntax for COMPACT command without specifying the replica

### DIFF
--- a/executor/builder.go
+++ b/executor/builder.go
@@ -5032,7 +5032,7 @@ func (b *executorBuilder) getCacheTable(tblInfo *model.TableInfo, startTS uint64
 }
 
 func (b *executorBuilder) buildCompactTable(v *plannercore.CompactTable) Executor {
-	if v.ReplicaKind != ast.CompactReplicaKindTiFlash {
+	if v.ReplicaKind != ast.CompactReplicaKindTiFlash && v.ReplicaKind != ast.CompactReplicaKindAll {
 		b.err = errors.Errorf("compact %v replica is not supported", strings.ToLower(string(v.ReplicaKind)))
 		return nil
 	}

--- a/executor/compact_table_test.go
+++ b/executor/compact_table_test.go
@@ -67,7 +67,7 @@ func TestCompactUnknownTable(t *testing.T) {
 	require.Equal(t, "[schema:1146]Table 'test.foo' doesn't exist", err.Error())
 
 	tk.MustExec("use test")
-	err = tk.ExecToErr(`alter table test.bar compact;`)
+	err = tk.ExecToErr(`alter table bar compact;`)
 	require.Equal(t, "[schema:1146]Table 'test.bar' doesn't exist", err.Error())
 }
 
@@ -194,7 +194,8 @@ func TestCompactTableNoRemaining(t *testing.T) {
 			CompactedEndKey:   []byte{0xFF},
 		}, nil
 	})
-	tk.MustExec(`alter table t compact;`)
+	tk = testkit.NewTestKit(t, store)
+	tk.MustExec(`alter table test.t compact;`)
 	tk.MustQuery(`show warnings;`).Check(testkit.Rows())
 	mocker.RequireAllHandlersHit()
 }

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -364,6 +364,9 @@ func (n *PlanReplayerStmt) Accept(v Visitor) (Node, bool) {
 type CompactReplicaKind string
 
 const (
+	// CompactReplicaKindAll means compacting both TiKV and TiFlash replicas.
+	CompactReplicaKindAll = "ALL"
+
 	// CompactReplicaKindTiFlash means compacting TiFlash replicas.
 	CompactReplicaKindTiFlash = "TIFLASH"
 
@@ -386,10 +389,15 @@ func (n *CompactTableStmt) Restore(ctx *format.RestoreCtx) error {
 		return errors.Annotate(err, "An error occurred while add table")
 	}
 
-	// Note: There is only TiFlash replica available now. TiKV will be added later.
-	ctx.WriteKeyWord(" COMPACT ")
-	ctx.WriteKeyWord(string(n.ReplicaKind))
-	ctx.WriteKeyWord(" REPLICA")
+	if n.ReplicaKind == CompactReplicaKindAll {
+		ctx.WriteKeyWord(" COMPACT")
+	} else {
+		// Note: There is only TiFlash replica available now. TiKV will be added later.
+		ctx.WriteKeyWord(" COMPACT ")
+		ctx.WriteKeyWord(string(n.ReplicaKind))
+		ctx.WriteKeyWord(" REPLICA")
+	}
+
 	return nil
 }
 

--- a/parser/ast/misc_test.go
+++ b/parser/ast/misc_test.go
@@ -345,6 +345,7 @@ func TestBRIESecureText(t *testing.T) {
 func TestCompactTableStmtRestore(t *testing.T) {
 	testCases := []NodeRestoreTestCase{
 		{"alter table abc compact tiflash replica", "ALTER TABLE `abc` COMPACT TIFLASH REPLICA"},
+		{"alter table abc compact", "ALTER TABLE `abc` COMPACT"},
 	}
 	extractNodeFunc := func(node ast.Node) ast.Node {
 		return node.(*ast.CompactTableStmt)

--- a/parser/ast/misc_test.go
+++ b/parser/ast/misc_test.go
@@ -346,6 +346,7 @@ func TestCompactTableStmtRestore(t *testing.T) {
 	testCases := []NodeRestoreTestCase{
 		{"alter table abc compact tiflash replica", "ALTER TABLE `abc` COMPACT TIFLASH REPLICA"},
 		{"alter table abc compact", "ALTER TABLE `abc` COMPACT"},
+		{"alter table test.abc compact", "ALTER TABLE `test`.`abc` COMPACT"},
 	}
 	extractNodeFunc := func(node ast.Node) ast.Node {
 		return node.(*ast.CompactTableStmt)

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -1517,6 +1517,13 @@ AlterTableStmt:
 			AnalyzeOpts:    $10.([]ast.AnalyzeOpt),
 		}
 	}
+|	"ALTER" IgnoreOptional "TABLE" TableName "COMPACT"
+	{
+		$$ = &ast.CompactTableStmt{
+			Table:       $4.(*ast.TableName),
+			ReplicaKind: ast.CompactReplicaKindAll,
+		}
+	}
 |	"ALTER" IgnoreOptional "TABLE" TableName "COMPACT" "TIFLASH" "REPLICA"
 	{
 		$$ = &ast.CompactTableStmt{


### PR DESCRIPTION
Signed-off-by: Wish <breezewish@outlook.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #34749

### What is changed and how it works?

This is an extension to the current syntax:

```sql
alter table T compact tiflash replica; 
```

that we additionally allow compaction without explicitly specifying the replica kind:

```sql
alter table T compact;
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
