### PR TITLE
executor: set the txn provider before building plan in 'show columns'

### DIFF
--- a/executor/infoschema_reader_test.go
+++ b/executor/infoschema_reader_test.go
@@ -717,3 +717,19 @@ SELECT
 `).Check(testkit.Rows("t a b"))
 	}
 }
+
+// https://github.com/pingcap/tidb/issues/36426.
+func TestShowColumnsWithSubQueryView(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+
+	tk.MustExec("CREATE TABLE added (`id` int(11),`name` text,`some_date` timestamp);")
+	tk.MustExec("CREATE TABLE incremental  (`id` int(11), `name`text, `some_date` timestamp);")
+	tk.MustExec("create view temp_view as (select * from `added` where id > (select max(id) from `incremental`));")
+	tk.MustQuery("show columns from temp_view;").Check(testkit.Rows(
+		"id int(11) YES  <nil> ",
+		"name text YES  <nil> ",
+		"some_date timestamp YES  <nil> "))
+}

--- a/executor/show.go
+++ b/executor/show.go
@@ -50,6 +50,7 @@ import (
 	"github.com/pingcap/tidb/sessionctx/sessionstates"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/sessionctx/variable"
+	"github.com/pingcap/tidb/sessiontxn"
 	"github.com/pingcap/tidb/store/helper"
 	"github.com/pingcap/tidb/table"
 	"github.com/pingcap/tidb/table/tables"
@@ -2088,6 +2089,12 @@ func runWithSystemSession(ctx context.Context, sctx sessionctx.Context, fn func(
 	if err != nil {
 		return err
 	}
+	// A new txn is required because it may need the sessiontxn.TxnContextProvider during the execution.
+	err = sessiontxn.NewTxn(ctx, sysCtx)
+	if err != nil {
+		return err
+	}
+	defer sysCtx.RollbackTxn(ctx)
 	defer b.releaseSysSession(ctx, sysCtx)
 	return fn(sysCtx)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36426.

Problem Summary:

The problem is from txnManager's "context provider not set". Here is the stack trace:

```
session.(*txnManager).GetStmtReadTS (txnmanager.go:72) github.com/pingcap/tidb/session
executor.(*executorBuilder).getSnapshotTS (builder.go:1594) github.com/pingcap/tidb/executor
executor.buildNoRangeTableReader (builder.go:3168) github.com/pingcap/tidb/executor
executor.(*executorBuilder).buildTableReader (builder.go:3263) github.com/pingcap/tidb/executor
executor.(*executorBuilder).build (builder.go:277) github.com/pingcap/tidb/executor
executor.(*executorBuilder).buildTopN (builder.go:1917) github.com/pingcap/tidb/executor
executor.(*executorBuilder).build (builder.go:241) github.com/pingcap/tidb/executor
executor.(*executorBuilder).buildStreamAgg (builder.go:1499) github.com/pingcap/tidb/executor
executor.(*executorBuilder).build (builder.go:263) github.com/pingcap/tidb/executor
executor.(*executorBuilder).buildMaxOneRow (builder.go:2025) github.com/pingcap/tidb/executor
executor.(*executorBuilder).build (builder.go:273) github.com/pingcap/tidb/executor
executor.init.1.func1 (executor.go:1427) github.com/pingcap/tidb/executor
core.(*expressionRewriter).handleScalarSubquery (expression_rewriter.go:1030) github.com/pingcap/tidb/planner/core
core.(*expressionRewriter).Enter (expression_rewriter.go:409) github.com/pingcap/tidb/planner/core
ast.(*SubqueryExpr).Accept (expressions.go:391) github.com/pingcap/tidb/parser/ast
ast.(*BinaryOperationExpr).Accept (expressions.go:217) github.com/pingcap/tidb/parser/ast
core.(*PlanBuilder).rewriteExprNode (expression_rewriter.go:199) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewriteWithPreprocess (expression_rewriter.go:145) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).rewrite (expression_rewriter.go:113) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildSelection (logical_plan_builder.go:1000) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).buildSelect (logical_plan_builder.go:3892) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).Build (planbuilder.go:718) github.com/pingcap/tidb/planner/core
core.(*PlanBuilder).BuildDataSourceFromView (logical_plan_builder.go:4837) github.com/pingcap/tidb/planner/core
executor.tryFillViewColumnType.func1 (show.go:2066) github.com/pingcap/tidb/executor
executor.runWithSystemSession (show.go:2092) github.com/pingcap/tidb/executor
executor.tryFillViewColumnType (show.go:2063) github.com/pingcap/tidb/executor
executor.(*ShowExec).fetchShowColumns (show.go:624) github.com/pingcap/tidb/executor
executor.(*ShowExec).fetchAll (show.go:149) github.com/pingcap/tidb/executor
executor.(*ShowExec).Next (show.go:116) github.com/pingcap/tidb/executor
executor.Next (executor.go:319) github.com/pingcap/tidb/executor
executor.(*ExecStmt).next (adapter.go:898) github.com/pingcap/tidb/executor
executor.(*recordSet).Next (adapter.go:152) github.com/pingcap/tidb/executor
<autogenerated>:2
server.(*tidbResultSet).Next (driver_tidb.go:405) github.com/pingcap/tidb/server
server.(*clientConn).writeChunks (conn.go:2250) github.com/pingcap/tidb/server
server.(*clientConn).writeResultset (conn.go:2200) github.com/pingcap/tidb/server
server.(*clientConn).handleStmt (conn.go:2081) github.com/pingcap/tidb/server
server.(*clientConn).handleQuery (conn.go:1913) github.com/pingcap/tidb/server
server.(*clientConn).dispatch (conn.go:1397) github.com/pingcap/tidb/server
server.(*clientConn).Run (conn.go:1142) github.com/pingcap/tidb/server
server.(*Server).onConn (server.go:563) github.com/pingcap/tidb/server
server.(*Server).startNetworkListener.func2 (server.go:454) github.com/pingcap/tidb/server
runtime.goexit (asm_arm64.s:1259) runtime
 - Async Stack Trace
server.(*Server).startNetworkListener (server.go:454) github.com/pingcap/tidb/server
```

To get the accurate field types of a view, we need to build a plan for the SQL in the view(see `tryFillViewColumnType`). An internal session is used to build the plan to prevent concurrent access to the same sesssion(this can happen in join scenarios, see https://github.com/pingcap/tidb/issues/32459). 

The transaction context is not needed in normal cases. However, for the views that contain scalar subquery, an executor is built and run for the scalar subquery evaluation, which requires a `startTS` from the transaction. Because no transaction is set before using the system session, the error "context provider not set" occurs.

### What is changed and how it works?

We can solve the issue by setting up a new transaction before using the internal session.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
