### PR TITLE
dumpling: display the SQL which causes error

### DIFF
--- a/dumpling/export/consistency.go
+++ b/dumpling/export/consistency.go
@@ -148,7 +148,7 @@ func (c *ConsistencyLockDumpingTables) Setup(tctx *tcontext.Context) error {
 				})
 			}
 		}
-		return errors.Trace(err)
+		return errors.Annotatef(err, "sql: %s", lockTablesSQL)
 	}, newLockTablesBackoffer(tctx, blockList, c.conf))
 }
 


### PR DESCRIPTION
Signed-off-by: lance6716 <lance6716@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/36547

Problem Summary:

In DM's integration tests, after fallback to LOCK TABLES, the error message becomes

```
                                "Message": "mydumper/dumpling runs with error, with output (may empty): ",
                                "RawCause": "Error 1044: Access denied for user 'dm_full'@'%' to database 'full_mode'",
```

We don't know what happened

### What is changed and how it works?

add the SQL to error

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test (will be done at DM's side)
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
