### PR TITLE
makefile: remove useless linter and enable revive for distsql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,17 +211,9 @@ tools/bin/xprog: tools/check/xprog.go
 	cd tools/check; \
 	$(GO) build -o ../bin/xprog xprog.go
 
-tools/bin/megacheck: tools/check/go.mod
-	cd tools/check; \
-	$(GO) build -o ../bin/megacheck honnef.co/go/tools/cmd/megacheck
-
 tools/bin/revive: tools/check/go.mod
 	cd tools/check; \
 	$(GO) build -o ../bin/revive github.com/mgechev/revive
-
-tools/bin/goword: tools/check/go.mod
-	cd tools/check; \
-	$(GO) build -o ../bin/goword github.com/chzchzchz/goword
 
 tools/bin/unconvert: tools/check/go.mod
 	cd tools/check; \

--- a/Makefile
+++ b/Makefile
@@ -43,10 +43,6 @@ goword:tools/bin/goword
 check-static: tools/bin/golangci-lint
 	GO111MODULE=on CGO_ENABLED=0 tools/bin/golangci-lint run -v $$($(PACKAGE_DIRECTORIES)) --config .golangci.yml
 
-unconvert:tools/bin/unconvert
-	@echo "unconvert check(skip check the generated or copied code in lightning)"
-	@GO111MODULE=on tools/bin/unconvert $(UNCONVERT_PACKAGES)
-
 gogenerate:
 	@echo "go generate ./..."
 	./tools/check/check-gogenerate.sh
@@ -214,10 +210,6 @@ tools/bin/xprog: tools/check/xprog.go
 tools/bin/revive: tools/check/go.mod
 	cd tools/check; \
 	$(GO) build -o ../bin/revive github.com/mgechev/revive
-
-tools/bin/unconvert: tools/check/go.mod
-	cd tools/check; \
-	$(GO) build -o ../bin/unconvert github.com/mdempsky/unconvert
 
 tools/bin/failpoint-ctl: tools/check/go.mod
 	cd tools/check; \

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -244,6 +244,8 @@
       ".*_generated\\.go$": "ignore generated code"
     },
     "only_files": {
+      "planner/core/rule_partition_eliminate.go": "planner/core/rule_partition_eliminate code",
+      "distsql/": "ignore distsql code",
       "dumpling/export": "dumpling/export code",
       "lock/": "lock file",
       "errno/": "errno code",

--- a/distsql/distsql.go
+++ b/distsql/distsql.go
@@ -58,7 +58,6 @@ func DispatchMPPTasks(ctx context.Context, sctx sessionctx.Context, tasks []*kv.
 		rootPlanID: rootID,
 		storeType:  kv.TiFlash,
 	}, nil
-
 }
 
 // Select sends a DAG request, returns SelectResult.

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -218,20 +218,19 @@ func (builder *RequestBuilder) SetAllowBatchCop(batchCop bool) *RequestBuilder {
 }
 
 // SetPartitionIDAndRanges sets `PartitionIDAndRanges` property.
-func (builder *RequestBuilder) SetPartitionIDAndRanges(PartitionIDAndRanges []kv.PartitionIDAndRanges) *RequestBuilder {
-	builder.PartitionIDAndRanges = PartitionIDAndRanges
+func (builder *RequestBuilder) SetPartitionIDAndRanges(partitionIDAndRanges []kv.PartitionIDAndRanges) *RequestBuilder {
+	builder.PartitionIDAndRanges = partitionIDAndRanges
 	return builder
 }
 
 func (builder *RequestBuilder) getIsolationLevel() kv.IsoLevel {
-	switch builder.Tp {
-	case kv.ReqTypeAnalyze:
+	if builder.Tp == kv.ReqTypeAnalyze {
 		return kv.RC
 	}
 	return kv.SI
 }
 
-func (builder *RequestBuilder) getKVPriority(sv *variable.SessionVars) int {
+func (*RequestBuilder) getKVPriority(sv *variable.SessionVars) int {
 	switch sv.StmtCtx.Priority {
 	case mysql.NoPriority, mysql.DelayedPriority:
 		return kv.PriorityNormal
@@ -689,7 +688,7 @@ func VerifyTxnScope(txnScope string, physicalTableID int64, is infoschema.InfoSc
 
 func indexRangesToKVWithoutSplit(sc *stmtctx.StatementContext, tids []int64, idxID int64, ranges []*ranger.Range, memTracker *memory.Tracker, interruptSignal *atomic.Value) ([]kv.KeyRange, error) {
 	krs := make([]kv.KeyRange, 0, len(ranges))
-	const CheckSignalStep = 8
+	const checkSignalStep = 8
 	var estimatedMemUsage int64
 	// encodeIndexKey and EncodeIndexSeekKey is time-consuming, thus we need to
 	// check the interrupt signal periodically.
@@ -709,7 +708,7 @@ func indexRangesToKVWithoutSplit(sc *stmtctx.StatementContext, tids []int64, idx
 			}
 			krs = append(krs, kv.KeyRange{StartKey: startKey, EndKey: endKey})
 		}
-		if i%CheckSignalStep == 0 {
+		if i%checkSignalStep == 0 {
 			if i == 0 && memTracker != nil {
 				estimatedMemUsage *= int64(len(ranges))
 				memTracker.Consume(estimatedMemUsage)

--- a/distsql/select_result.go
+++ b/distsql/select_result.go
@@ -618,6 +618,6 @@ func (s *selectResultRuntimeStats) String() string {
 }
 
 // Tp implements the RuntimeStats interface.
-func (s *selectResultRuntimeStats) Tp() int {
+func (*selectResultRuntimeStats) Tp() int {
 	return execdetails.TpSelectResultRuntimeStats
 }


### PR DESCRIPTION
Signed-off-by: Weizhen Wang <wangweizhen@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

```goword``` is replaced by ```misspell``` in the ```golangci-linter```.
```megacheck``` is replaced by ```staticcheck,``` ```gosimple``` and ```unused``` in the ```golangci-linter```.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
