### PR TITLE
log-backup: fixed bugs about log truncate left some files and log truncate update log-min-date

### DIFF
--- a/br/pkg/stream/stream_mgr.go
+++ b/br/pkg/stream/stream_mgr.go
@@ -179,7 +179,7 @@ func FastUnmarshalMetaData(
 			m := &backuppb.Metadata{}
 			err = m.Unmarshal(b)
 			if err != nil {
-				if !strings.HasSuffix(path, ".meta") {
+				if !strings.HasSuffix(readPath, ".meta") {
 					return nil
 				} else {
 					return err

--- a/br/pkg/task/stream.go
+++ b/br/pkg/task/stream.go
@@ -878,12 +878,7 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 			return nil
 		}
 	}
-	if cfg.Until > sp && !cfg.DryRun {
-		if err := restore.SetTSToFile(
-			ctx, storage, cfg.Until, restore.TruncateSafePointFileName); err != nil {
-			return err
-		}
-	}
+
 	readMetaDone := console.ShowTask("Reading Metadata... ", glue.WithTimeCost())
 	metas := restore.StreamMetadataSet{
 		BeforeDoWriteBack: func(path string, last, current *backuppb.Metadata) (skip bool) {
@@ -919,16 +914,14 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 		return nil
 	}
 
-	removed := metas.RemoveDataBefore(shiftUntilTS)
-
-	// remove metadata
-	removeMetaDone := console.ShowTask("Removing metadata... ", glue.WithTimeCost())
-	if !cfg.DryRun {
-		if err := metas.DoWriteBack(ctx, storage); err != nil {
+	if cfg.Until > sp && !cfg.DryRun {
+		if err := restore.SetTSToFile(
+			ctx, storage, cfg.Until, restore.TruncateSafePointFileName); err != nil {
 			return err
 		}
 	}
-	removeMetaDone()
+
+	removed := metas.RemoveDataBefore(shiftUntilTS)
 
 	// remove log
 	clearDataFileDone := console.ShowTask(
@@ -941,17 +934,27 @@ func RunStreamTruncate(c context.Context, g glue.Glue, cmdName string, cfg *Stre
 	for _, f := range removed {
 		if !cfg.DryRun {
 			wg.Add(1)
+			finalFile := f
 			worker.Apply(func() {
 				defer wg.Done()
-				if err := storage.DeleteFile(ctx, f.Path); err != nil {
-					log.Warn("File not deleted.", zap.String("path", f.Path), logutil.ShortError(err))
-					console.Print("\n"+em(f.Path), "not deleted, you may clear it manually:", warn(err))
+				if err := storage.DeleteFile(ctx, finalFile.Path); err != nil {
+					log.Warn("File not deleted.", zap.String("path", finalFile.Path), logutil.ShortError(err))
+					console.Print("\n"+em(finalFile.Path), "not deleted, you may clear it manually:", warn(err))
 				}
 			})
 		}
 	}
 	wg.Wait()
 	clearDataFileDone()
+
+	// remove metadata
+	removeMetaDone := console.ShowTask("Removing metadata... ", glue.WithTimeCost())
+	if !cfg.DryRun {
+		if err := metas.DoWriteBack(ctx, storage); err != nil {
+			return err
+		}
+	}
+	removeMetaDone()
 	return nil
 }
 


### PR DESCRIPTION
log-backup: fixed bugs about log truncate left some files and log truncate update log-min-date

Signed-off-by: zhanggaoming <gaoming.zhang@pingcap.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36376, #36533, #36535

Problem Summary:

### What is changed and how it works?
- PiTR updates the safepoint after the user selects Y
- PiTR deletes the log file first and then deletes the meta file.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Manual Test
For issue-36535:
- Run `./bin/br log metadata -s s3://xxx`
- Run `./bin/br log truncate -s s3://xxx  --until '2022-07-26 20:20:00+0800'` and enter 'N'
- Run `./bin/br log metadata -s s3://xxx` again
output: log-min-date unchange.

For issue-36533:
- Run `./bin/br log truncate -s s3://xxx  --until '2022-07-26 20:20:00+0800'`
output: No files remain.

For issue-36376:
- Run `./bin/br log truncate -s s3://xxx  --until '2022-07-26 21:00:00+0800'`, and then interrupt it.
- Run `./bin/br log truncate -s s3://xxx  --until '2022-07-26 21:00:00+0800'` again
output: No files remain.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
