### PR TITLE
executor: avoid log empty binary plan into slow log

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -1207,7 +1207,9 @@ func (a *ExecStmt) LogSlowQuery(txnTS uint64, succ bool, hasMoreResults bool) {
 	binaryPlan := ""
 	if variable.GenerateBinaryPlan.Load() {
 		binaryPlan = getBinaryPlan(a.Ctx)
-		binaryPlan = variable.SlowLogBinaryPlanPrefix + binaryPlan + variable.SlowLogPlanSuffix
+		if len(binaryPlan) > 0 {
+			binaryPlan = variable.SlowLogBinaryPlanPrefix + binaryPlan + variable.SlowLogPlanSuffix
+		}
 	}
 
 	resultRows := GetResultRowsCount(stmtCtx, a.Plan)


### PR DESCRIPTION

### What problem does this PR solve?

Issue Number: close #36617


### What is changed and how it works?

Do not add the `tidb_decode_binary_plan('` and `')` if it's an empty binary plan.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
