### PR TITLE
Lightning : check cluster id and fix data inconsistency

### DIFF
--- a/br/pkg/lightning/backend/local/local.go
+++ b/br/pkg/lightning/backend/local/local.go
@@ -1658,6 +1658,14 @@ func (local *local) CheckRequirements(ctx context.Context, checkCtx *backend.Che
 	if err != nil {
 		return errors.Trace(err)
 	}
+	clusterId, err := local.g.GetSQLExecutor().ObtainStringWithLog(
+		ctx,
+		"select substring(type,8) from METRICS_SCHEMA.PD_CLUSTER_METADATA limit 1;",
+		"check TiDB Cluster ID",
+		log.L())
+	if err != nil {
+		return errors.Trace(err)
+	}
 	if err := checkTiDBVersion(ctx, versionStr, localMinTiDBVersion, localMaxTiDBVersion); err != nil {
 		return err
 	}
@@ -1665,6 +1673,9 @@ func (local *local) CheckRequirements(ctx context.Context, checkCtx *backend.Che
 		return err
 	}
 	if err := tikv.CheckTiKVVersion(ctx, local.tls, local.pdAddr, localMinTiKVVersion, localMaxTiKVVersion); err != nil {
+		return err
+	}
+	if err := tikv.CheckTiDBDestination(ctx, local.tls, local.pdAddr, clusterId); err != nil {
 		return err
 	}
 

--- a/br/pkg/lightning/tikv/tikv.go
+++ b/br/pkg/lightning/tikv/tikv.go
@@ -217,6 +217,18 @@ func CheckPDVersion(ctx context.Context, tls *common.TLS, pdAddr string, require
 	return version.CheckVersion("PD", *ver, requiredMinVersion, requiredMaxVersion)
 }
 
+func CheckTiDBDestination(ctx context.Context, tls *common.TLS, pdAddr string, clusterId string) error {
+	id, err := pdutil.FetchClusterID(ctx, tls, pdAddr)
+	if err != nil {
+		return errors.Trace(err)
+	}
+
+	if id != clusterId {
+		return errors.Errorf("Failed to match the cluster ID, Please check whether status-port is correct")
+	}
+	return nil
+}
+
 func CheckTiKVVersion(ctx context.Context, tls *common.TLS, pdAddr string, requiredMinVersion, requiredMaxVersion semver.Version) error {
 	return ForAllStores(
 		ctx,

--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -13,6 +13,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -875,4 +876,22 @@ func FetchPDVersion(ctx context.Context, tls *common.TLS, pdAddr string) (*semve
 	}
 
 	return parseVersion([]byte(rawVersion.Version)), nil
+}
+
+// FetchClusterID get Cluster ID
+func FetchClusterID(ctx context.Context, tls *common.TLS, pdAddr string) (string, error) {
+	// An example of PD Cluster ID API.
+	// curl http://pd_address/pd/api/v1/cluster
+	// {
+	//   "id": 7125154571691814555
+	// }
+	var rawClusterID struct {
+		Id int `json:"id"`
+	}
+	err := tls.WithHost(pdAddr).GetJSON(ctx, "/pd/api/v1/cluster", &rawClusterID)
+	if err != nil {
+		return strconv.Itoa(rawClusterID.Id), errors.Trace(err)
+	}
+
+	return strings.TrimSpace(strconv.Itoa(rawClusterID.Id)), nil
 }


### PR DESCRIPTION
<!--
Thank you for working on BR! Please read BR's [CONTRIBUTING](https://github.com/pingcap/br/blob/master/CONTRIBUTING.md) document **BEFORE** filing this PR.
-->
Issue Number: close #36653

### What problem does this PR solve? <!--add issue link with summary if exists-->
avoid table data inconsistency with table index.

### What is changed and how it works?
1. get cluster id from tidb port using `select substring(type,8) from METRICS_SCHEMA.PD_CLUSTER_METADATA limit 1;`
2. get cluster id from pd api using `/pd/api/v1/cluster`
3. compare result of the two value,if it's equal,it will continue.

### Check List <!--REMOVE the items that are not applicable-->

Tests <!-- At least one of them must be included. -->

 - Unit test
 - Integration test
 - Manual test (add detailed scripts or steps below)
 - No code

Code changes

 - Has exported function/method change
 - Has exported variable/fields change
 - Has interface methods change
 - Has persistent data change

Side effects

 - Possible performance regression
 - Increased code complexity
 - Breaking backward compatibility

Related changes

 - Need to cherry-pick to the release branch
 - Need to update the documentation

### Release note

 -

<!-- fill in the release note, or just write "No release note" -->
