### PR TITLE
planner: prefer to use TiKV to process small table scans and consider IndexJoin batch size in cost model ver2

### DIFF
--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -421,6 +421,11 @@ func (p *PhysicalTableScan) GetPlanCost(taskType property.TaskType, costFlag uin
 		rowSize := math.Max(p.getScanRowSize(), 2.0) // to guarantee logRowSize >= 1
 		logRowSize := math.Log2(rowSize)
 		selfCost = getCardinality(p, costFlag) * logRowSize * scanFactor
+
+		// give TiFlash a start-up cost to let the optimizer prefers to use TiKV to process small table scans.
+		if p.StoreType == kv.TiFlash {
+			selfCost += 2000 * logRowSize * scanFactor
+		}
 	}
 
 	p.planCost = selfCost

--- a/planner/core/plan_cost.go
+++ b/planner/core/plan_cost.go
@@ -516,7 +516,7 @@ func (p *PhysicalIndexJoin) GetCost(outerCnt, innerCnt, outerCost, innerCost flo
 		//  `innerCostPerBatch * numberOfBatche` instead of `innerCostPerRow * numberOfOuterRow`.
 		// Use an empirical value batchRatio to handle this now.
 		// TODO: remove this empirical value.
-		batchRatio := 50.0
+		batchRatio := 30.0
 		innerPlanCost /= batchRatio
 	}
 	return outerCost + innerPlanCost + cpuCost + memoryCost + p.estDoubleReadCost(outerCnt)

--- a/planner/core/plan_cost_test.go
+++ b/planner/core/plan_cost_test.go
@@ -966,3 +966,39 @@ func TestTrueCardCost(t *testing.T) {
 	checkPlanCost(`select * from t where a>10 limit 10`)
 	checkPlanCost(`select sum(a), b*2 from t use index(b) group by b order by sum(a) limit 10`)
 }
+
+func TestScanOnSmallTable(t *testing.T) {
+	store, clean := testkit.CreateMockStore(t)
+	defer clean()
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec(`create table t (a int)`)
+	tk.MustExec("insert into t values (1), (2), (3), (4), (5)")
+	tk.MustExec("analyze table t")
+	tk.MustExec(`set @@tidb_cost_model_version=2`)
+
+	// Create virtual tiflash replica info.
+	dom := domain.GetDomain(tk.Session())
+	is := dom.InfoSchema()
+	db, exists := is.SchemaByName(model.NewCIStr("test"))
+	require.True(t, exists)
+	for _, tblInfo := range db.Tables {
+		if tblInfo.Name.L == "t" {
+			tblInfo.TiFlashReplica = &model.TiFlashReplicaInfo{
+				Count:     1,
+				Available: true,
+			}
+		}
+	}
+
+	rs := tk.MustQuery("explain select * from t").Rows()
+	useTiKVScan := false
+	for _, r := range rs {
+		op := r[0].(string)
+		task := r[2].(string)
+		if strings.Contains(op, "Scan") && strings.Contains(task, "tikv") {
+			useTiKVScan = true
+		}
+	}
+	require.True(t, useTiKVScan)
+}


### PR DESCRIPTION
pick https://github.com/pingcap/tidb/pull/36690 

```release-note
None
```