### PR TITLE
session: fix multiple domain creation racing in domap

### DIFF
--- a/session/tidb.go
+++ b/session/tidb.go
@@ -44,24 +44,17 @@ import (
 )
 
 type domainMap struct {
+	sync.Mutex
 	domains map[string]*domain.Domain
-	mu      sync.RWMutex
 }
 
 func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
-	dm.mu.RLock()
-
-	// If this is the only domain instance, and the caller doesn't provide store.
-	if len(dm.domains) == 1 && store == nil {
-		for _, r := range dm.domains {
-			dm.mu.RUnlock()
-			return r, nil
-		}
-	}
-
 	key := store.UUID()
+
+	dm.Lock()
+	defer dm.Unlock()
+
 	d = dm.domains[key]
-	dm.mu.RUnlock()
 	if d != nil {
 		return
 	}
@@ -94,21 +87,16 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	if err != nil {
 		return nil, err
 	}
-	dm.Set(store, d)
+
+	dm.domains[key] = d
 
 	return
 }
 
 func (dm *domainMap) Delete(store kv.Storage) {
-	dm.mu.Lock()
+	dm.Lock()
 	delete(dm.domains, store.UUID())
-	dm.mu.Unlock()
-}
-
-func (dm *domainMap) Set(store kv.Storage, domain *domain.Domain) {
-	dm.mu.Lock()
-	dm.domains[store.UUID()] = domain
-	dm.mu.Unlock()
+	dm.Unlock()
 }
 
 var (

--- a/session/tidb.go
+++ b/session/tidb.go
@@ -44,15 +44,15 @@ import (
 )
 
 type domainMap struct {
-	sync.Mutex
+	mu      sync.Mutex
 	domains map[string]*domain.Domain
 }
 
 func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 	key := store.UUID()
 
-	dm.Lock()
-	defer dm.Unlock()
+	dm.mu.Lock()
+	defer dm.mu.Unlock()
 
 	d = dm.domains[key]
 	if d != nil {
@@ -94,9 +94,9 @@ func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
 }
 
 func (dm *domainMap) Delete(store kv.Storage) {
-	dm.Lock()
+	dm.mu.Lock()
 	delete(dm.domains, store.UUID())
-	dm.Unlock()
+	dm.mu.Unlock()
 }
 
 var (


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36791

Problem Summary: As title, refer the issue. After investigation,  rwmutex did not bring notable performance gain. Also no one will ever pass a nil store, verified by running all tests, so  `if len(dm.domains) == 1 && store == nil {` removed.

```
xhe@M1PRO testkit % cat 1
creating domains:

// mutex
BenchmarkDomain-8 5 241125350 ns/op
// rwmutex
BenchmarkDomain-8 5 229305383 ns/op

one domain, creating sessions:

// mutex
BenchmarkDomain-8 128607 9408 ns/op
BenchmarkDomain-8 125948 9338 ns/op
// rwmutex
BenchmarkDomain-8 132254 9853 ns/op
BenchmarkDomain-8 107743 9331 ns/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix that incorrect TiDB states may appear on startup under very, very, very extreme cases 
```
