### PR TITLE
Revert "executor: reuse iterator4Slice and Row/RowPtrs slice in HashJoin. (#34878)"

### DIFF
--- a/executor/hash_table_test.go
+++ b/executor/hash_table_test.go
@@ -158,7 +158,7 @@ func testHashRowContainer(t *testing.T, hashFunc func() hash.Hash64, spill bool)
 	}
 	probeCtx.hasNull = make([]bool, 1)
 	probeCtx.hashVals = append(hCtx.hashVals, hashFunc())
-	matched, _, err := rowContainer.GetMatchedRowsAndPtrs(hCtx.hashVals[1].Sum64(), probeRow, probeCtx, nil, nil)
+	matched, _, err := rowContainer.GetMatchedRowsAndPtrs(hCtx.hashVals[1].Sum64(), probeRow, probeCtx)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(matched))
 	require.Equal(t, chk0.GetRow(1).GetDatumRow(colTypes), matched[0].GetDatumRow(colTypes))

--- a/util/chunk/iterator.go
+++ b/util/chunk/iterator.go
@@ -14,8 +14,6 @@
 
 package chunk
 
-import "sync"
-
 var (
 	_ Iterator = (*Iterator4Chunk)(nil)
 	_ Iterator = (*iterator4RowPtr)(nil)
@@ -24,22 +22,6 @@ var (
 	_ Iterator = (*iterator4RowContainer)(nil)
 	_ Iterator = (*multiIterator)(nil)
 )
-
-var (
-	iterator4SlicePool = &sync.Pool{New: func() any { return new(iterator4Slice) }}
-)
-
-// FreeIterator try to free and reuse the iterator.
-func FreeIterator(it any) {
-	switch it := it.(type) {
-	case *iterator4Slice:
-		it.rows = nil
-		it.cursor = 0
-		iterator4SlicePool.Put(it)
-	default:
-		// Do Nothing.
-	}
-}
 
 // Iterator is used to iterate a number of rows.
 //
@@ -71,10 +53,7 @@ type Iterator interface {
 
 // NewIterator4Slice returns a Iterator for Row slice.
 func NewIterator4Slice(rows []Row) Iterator {
-	it := iterator4SlicePool.Get().(*iterator4Slice)
-	it.rows = rows
-	it.cursor = 0
-	return it
+	return &iterator4Slice{rows: rows}
 }
 
 type iterator4Slice struct {


### PR DESCRIPTION

This reverts commit 8a4d45706872141fe37ba5ea35d6b1833ffb4cad.

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
