### PR TITLE
br: Fix bug in TestDateFormat

### DIFF
--- a/br/pkg/stream/util_test.go
+++ b/br/pkg/stream/util_test.go
@@ -4,6 +4,7 @@ package stream
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
@@ -24,8 +25,9 @@ func TestDateFormat(t *testing.T) {
 		},
 	}
 
+	timeZone, _ := time.LoadLocation("Asia/Shanghai")
 	for _, ca := range cases {
-		date := FormatDate(oracle.GetTimeFromTS(ca.ts))
-		require.Equal(t, date, ca.target)
+		date := FormatDate(oracle.GetTimeFromTS(ca.ts).In(timeZone))
+		require.Equal(t, ca.target, date)
 	}
 }


### PR DESCRIPTION
Signed-off-by: Gaoming Zhang <zhanggaoming028@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #36802

Problem Summary:
Remove the timezone dependency of TestDateFormat.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Test Env:
```
$ ls -l /etc/localtime
lrwxrwxrwx 1 root root 33 5月  12 09:33 /etc/localtime -> /usr/share/zoneinfo/Asia/Shanghai
```

Run `export TZ=Europe/Amsterdam && go test -v -run TestDateFormat`
output: 
```
=== RUN   TestDateFormat
--- PASS: TestDateFormat (0.00s)
PASS
ok  	github.com/pingcap/tidb/br/pkg/stream	0.067s
```

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
