### PR TITLE
executor: revert #36498 to avoid perf regression

### DIFF
--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -733,7 +733,7 @@ func (a *ExecStmt) handlePessimisticDML(ctx context.Context, e Executor) error {
 		if err1 != nil {
 			return err1
 		}
-		keys = txnCtx.CollectUnchangedLockKeys(keys)
+		keys = txnCtx.CollectUnchangedRowKeys(keys)
 		if len(keys) == 0 {
 			return nil
 		}

--- a/executor/write.go
+++ b/executor/write.go
@@ -158,21 +158,7 @@ func updateRecord(ctx context.Context, sctx sessionctx.Context, h kv.Handle, old
 		unchangedRowKey := tablecodec.EncodeRowKeyWithHandle(physicalID, h)
 		txnCtx := sctx.GetSessionVars().TxnCtx
 		if txnCtx.IsPessimistic {
-			txnCtx.AddUnchangedLockKey(unchangedRowKey)
-			for _, idx := range t.Indices() {
-				if !idx.Meta().Unique {
-					continue
-				}
-				ukVals, err := idx.FetchValues(oldData, nil)
-				if err != nil {
-					return false, err
-				}
-				unchangedUniqueKey, _, err := idx.GenIndexKey(sc, ukVals, h, nil)
-				if err != nil {
-					return false, err
-				}
-				txnCtx.AddUnchangedLockKey(unchangedUniqueKey)
-			}
+			txnCtx.AddUnchangedRowKey(unchangedRowKey)
 		}
 		return false, nil
 	}

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -168,9 +168,8 @@ type TxnCtxNoNeedToRestore struct {
 	currentShard int64
 	shardRand    *rand.Rand
 
-	// unchangedLockKeys is used to store the unchanged keys that needs to lock for pessimistic transaction, including
-	// row keys and unique keys.
-	unchangedLockKeys map[string]struct{}
+	// unchangedRowKeys is used to store the unchanged rows that needs to lock for pessimistic transaction.
+	unchangedRowKeys map[string]struct{}
 
 	PessimisticCacheHit int
 
@@ -239,20 +238,20 @@ func (tc *TransactionContext) updateShard() {
 	tc.currentShard = int64(murmur3.Sum32(buf[:]))
 }
 
-// AddUnchangedLockKey adds an unchanged key in update statement for pessimistic lock.
-func (tc *TransactionContext) AddUnchangedLockKey(key []byte) {
-	if tc.unchangedLockKeys == nil {
-		tc.unchangedLockKeys = map[string]struct{}{}
+// AddUnchangedRowKey adds an unchanged row key in update statement for pessimistic lock.
+func (tc *TransactionContext) AddUnchangedRowKey(key []byte) {
+	if tc.unchangedRowKeys == nil {
+		tc.unchangedRowKeys = map[string]struct{}{}
 	}
-	tc.unchangedLockKeys[string(key)] = struct{}{}
+	tc.unchangedRowKeys[string(key)] = struct{}{}
 }
 
-// CollectUnchangedLockKeys collects unchanged keys for pessimistic lock.
-func (tc *TransactionContext) CollectUnchangedLockKeys(buf []kv.Key) []kv.Key {
-	for key := range tc.unchangedLockKeys {
+// CollectUnchangedRowKeys collects unchanged row keys for pessimistic lock.
+func (tc *TransactionContext) CollectUnchangedRowKeys(buf []kv.Key) []kv.Key {
+	for key := range tc.unchangedRowKeys {
 		buf = append(buf, kv.Key(key))
 	}
-	tc.unchangedLockKeys = nil
+	tc.unchangedRowKeys = nil
 	return buf
 }
 

--- a/tests/realtikvtest/pessimistictest/pessimistic_test.go
+++ b/tests/realtikvtest/pessimistictest/pessimistic_test.go
@@ -492,37 +492,6 @@ func TestLockUnchangedRowKey(t *testing.T) {
 	tk2.MustExec("rollback")
 }
 
-func TestLockUnchangedUniqueKey(t *testing.T) {
-	store := realtikvtest.CreateMockStoreAndSetup(t)
-
-	tk := testkit.NewTestKit(t, store)
-	tk2 := testkit.NewTestKit(t, store)
-	tk.MustExec("use test")
-	tk2.MustExec("use test")
-
-	// ref https://github.com/pingcap/tidb/issues/36438
-	tk.MustExec("drop table if exists t")
-	tk.MustExec("create table t (i varchar(10), unique key(i))")
-	tk.MustExec("insert into t values ('a')")
-	tk.MustExec("begin pessimistic")
-	tk.MustExec("update t set i = 'a'")
-
-	errCh := make(chan error, 1)
-	go func() {
-		_, err := tk2.Exec("insert into t values ('a')")
-		errCh <- err
-	}()
-
-	select {
-	case <-errCh:
-		require.Fail(t, "insert is not blocked by update")
-	case <-time.After(500 * time.Millisecond):
-		tk.MustExec("rollback")
-	}
-
-	require.Error(t, <-errCh)
-}
-
 func TestOptimisticConflicts(t *testing.T) {
 	store := realtikvtest.CreateMockStoreAndSetup(t)
 


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36438

Problem Summary: as described in https://github.com/pingcap/tidb/issues/36438#issuecomment-1209536885.

### What is changed and how it works?

Revert #36498 to avoid accumulating LOCK records on unique keys.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
