### PR TITLE
log-backup: fix wrong of rewrite table id 767 when do restore point

### DIFF
--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -310,7 +310,7 @@ func (importer *FileImporter) getKeyRangeForFiles(
 		if importer.isRawKvMode {
 			start, end = f.GetStartKey(), f.GetEndKey()
 		} else {
-			start, end, err = RewriteFileKeys(f, rewriteRules)
+			start, end, err = RewriteFileKeys(f, rewriteRules, true)
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
@@ -390,7 +390,7 @@ func (importer *FileImporter) ImportKVFiles(
 ) error {
 	startTime := time.Now()
 	log.Debug("import kv files", zap.String("file", file.Path))
-	startKey, endKey, err := RewriteFileKeys(file, rule)
+	startKey, endKey, err := RewriteFileKeys(file, rule, false)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/restore/import.go
+++ b/br/pkg/restore/import.go
@@ -310,7 +310,7 @@ func (importer *FileImporter) getKeyRangeForFiles(
 		if importer.isRawKvMode {
 			start, end = f.GetStartKey(), f.GetEndKey()
 		} else {
-			start, end, err = RewriteFileKeys(f, rewriteRules, true)
+			start, end, err = GetRewriteRawKeys(f, rewriteRules)
 			if err != nil {
 				return nil, nil, errors.Trace(err)
 			}
@@ -390,7 +390,7 @@ func (importer *FileImporter) ImportKVFiles(
 ) error {
 	startTime := time.Now()
 	log.Debug("import kv files", zap.String("file", file.Path))
-	startKey, endKey, err := RewriteFileKeys(file, rule, false)
+	startKey, endKey, err := GetRewriteEncodedKeys(file, rule)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -508,37 +508,46 @@ func findMatchedRewriteRule(file AppliedFile, rules *RewriteRules) *import_sstpb
 // RewriteFileKeys tries to choose and apply the rewrite rules to the file.
 // This method would try to detach whether the file key is encoded.
 // Note: Maybe add something like `GetEncodedStartKey` Or `GetRawStartkey` for `AppliedFile` for making it more determinable?
-func RewriteFileKeys(file AppliedFile, rewriteRules *RewriteRules, raw bool) (startKey, endKey []byte, err error) {
+func GetRewriteRawKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, endKey []byte, err error) {
 	startID := tablecodec.DecodeTableID(file.GetStartKey())
 	endID := tablecodec.DecodeTableID(file.GetEndKey())
 	var rule *import_sstpb.RewriteRule
 	if startID == endID {
-		if raw {
-			startKey, rule = rewriteRawKey(file.GetStartKey(), rewriteRules)
-			if rewriteRules != nil && rule == nil {
-				err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find rewrite rule for start key, startKey: %s", redact.Key(file.GetStartKey()))
-				return
-			}
-		} else {
-			startKey, rule = rewriteEncodedKey(file.GetStartKey(), rewriteRules)
-			if rewriteRules != nil && rule == nil {
-				err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find rewrite rule for start key, startKey: %s", redact.Key(file.GetStartKey()))
-				return
-			}
+		startKey, rule = rewriteRawKey(file.GetStartKey(), rewriteRules)
+		if rewriteRules != nil && rule == nil {
+			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find raw rewrite rule for start key, startKey: %s", redact.Key(file.GetStartKey()))
+			return
 		}
+		endKey, rule = rewriteRawKey(file.GetEndKey(), rewriteRules)
+		if rewriteRules != nil && rule == nil {
+			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find raw rewrite rule for end key, endKey: %s", redact.Key(file.GetEndKey()))
+			return
+		}
+	} else {
+		log.Error("table ids dont matched",
+			zap.Int64("startID", startID),
+			zap.Int64("endID", endID),
+			logutil.Key("startKey", startKey),
+			logutil.Key("endKey", endKey))
+		err = errors.Annotate(berrors.ErrRestoreInvalidRewrite, "invalid table id")
+	}
+	return
+}
 
-		if raw {
-			endKey, rule = rewriteRawKey(file.GetEndKey(), rewriteRules)
-			if rewriteRules != nil && rule == nil {
-				err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find rewrite rule for end key, endKey: %s", redact.Key(file.GetEndKey()))
-				return
-			}
-		} else {
-			endKey, rule = rewriteEncodedKey(file.GetEndKey(), rewriteRules)
-			if rewriteRules != nil && rule == nil {
-				err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find rewrite rule for end key, endKey: %s", redact.Key(file.GetEndKey()))
-				return
-			}
+func GetRewriteEncodedKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, endKey []byte, err error) {
+	startID := tablecodec.DecodeTableID(file.GetStartKey())
+	endID := tablecodec.DecodeTableID(file.GetEndKey())
+	var rule *import_sstpb.RewriteRule
+	if startID == endID {
+		startKey, rule = rewriteEncodedKey(file.GetStartKey(), rewriteRules)
+		if rewriteRules != nil && rule == nil {
+			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find encode rewrite rule for start key, startKey: %s", redact.Key(file.GetStartKey()))
+			return
+		}
+		endKey, rule = rewriteEncodedKey(file.GetEndKey(), rewriteRules)
+		if rewriteRules != nil && rule == nil {
+			err = errors.Annotatef(berrors.ErrRestoreInvalidRewrite, "cannot find encode rewrite rule for end key, endKey: %s", redact.Key(file.GetEndKey()))
+			return
 		}
 	} else {
 		log.Error("table ids dont matched",

--- a/br/pkg/restore/util.go
+++ b/br/pkg/restore/util.go
@@ -505,9 +505,7 @@ func findMatchedRewriteRule(file AppliedFile, rules *RewriteRules) *import_sstpb
 	return rule
 }
 
-// RewriteFileKeys tries to choose and apply the rewrite rules to the file.
-// This method would try to detach whether the file key is encoded.
-// Note: Maybe add something like `GetEncodedStartKey` Or `GetRawStartkey` for `AppliedFile` for making it more determinable?
+// GetRewriteRawKeys rewrites rules to the raw key.
 func GetRewriteRawKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, endKey []byte, err error) {
 	startID := tablecodec.DecodeTableID(file.GetStartKey())
 	endID := tablecodec.DecodeTableID(file.GetEndKey())
@@ -534,6 +532,7 @@ func GetRewriteRawKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, 
 	return
 }
 
+// GetRewriteRawKeys rewrites rules to the encoded key
 func GetRewriteEncodedKeys(file AppliedFile, rewriteRules *RewriteRules) (startKey, endKey []byte, err error) {
 	startID := tablecodec.DecodeTableID(file.GetStartKey())
 	endID := tablecodec.DecodeTableID(file.GetEndKey())

--- a/br/pkg/restore/util_test.go
+++ b/br/pkg/restore/util_test.go
@@ -349,5 +349,4 @@ func TestRewriteFileKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511)), start)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511).PrefixNext()), end)
-
 }

--- a/br/pkg/restore/util_test.go
+++ b/br/pkg/restore/util_test.go
@@ -314,7 +314,7 @@ func TestRewriteFileKeys(t *testing.T) {
 		StartKey: tablecodec.GenTableRecordPrefix(1),
 		EndKey:   tablecodec.GenTableRecordPrefix(1).PrefixNext(),
 	}
-	start, end, err := restore.RewriteFileKeys(&rawKeyFile, &rewriteRules, true)
+	start, end, err := restore.GetRewriteRawKeys(&rawKeyFile, &rewriteRules)
 	require.NoError(t, err)
 	_, end, err = codec.DecodeBytes(end, nil)
 	require.NoError(t, err)
@@ -328,7 +328,7 @@ func TestRewriteFileKeys(t *testing.T) {
 		StartKey: codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(1)),
 		EndKey:   codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(1).PrefixNext()),
 	}
-	start, end, err = restore.RewriteFileKeys(&encodeKeyFile, &rewriteRules, false)
+	start, end, err = restore.GetRewriteEncodedKeys(&encodeKeyFile, &rewriteRules)
 	require.NoError(t, err)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2)), start)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2).PrefixNext()), end)
@@ -340,12 +340,12 @@ func TestRewriteFileKeys(t *testing.T) {
 		EndKey:   codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(767).PrefixNext()),
 	}
 	// use raw rewrite should no error but not equal
-	start, end, err = restore.RewriteFileKeys(&encodeKeyFile767, &rewriteRules, true)
+	start, end, err = restore.GetRewriteRawKeys(&encodeKeyFile767, &rewriteRules)
 	require.NoError(t, err)
 	require.NotEqual(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511)), start)
 	require.NotEqual(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511).PrefixNext()), end)
 	// use encode rewrite should no error and equal
-	start, end, err = restore.RewriteFileKeys(&encodeKeyFile767, &rewriteRules, false)
+	start, end, err = restore.GetRewriteEncodedKeys(&encodeKeyFile767, &rewriteRules)
 	require.NoError(t, err)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511)), start)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511).PrefixNext()), end)

--- a/br/pkg/restore/util_test.go
+++ b/br/pkg/restore/util_test.go
@@ -303,6 +303,10 @@ func TestRewriteFileKeys(t *testing.T) {
 				NewKeyPrefix: tablecodec.GenTablePrefix(2),
 				OldKeyPrefix: tablecodec.GenTablePrefix(1),
 			},
+			{
+				NewKeyPrefix: tablecodec.GenTablePrefix(511),
+				OldKeyPrefix: tablecodec.GenTablePrefix(767),
+			},
 		},
 	}
 	rawKeyFile := backuppb.File{
@@ -310,7 +314,7 @@ func TestRewriteFileKeys(t *testing.T) {
 		StartKey: tablecodec.GenTableRecordPrefix(1),
 		EndKey:   tablecodec.GenTableRecordPrefix(1).PrefixNext(),
 	}
-	start, end, err := restore.RewriteFileKeys(&rawKeyFile, &rewriteRules)
+	start, end, err := restore.RewriteFileKeys(&rawKeyFile, &rewriteRules, true)
 	require.NoError(t, err)
 	_, end, err = codec.DecodeBytes(end, nil)
 	require.NoError(t, err)
@@ -324,8 +328,26 @@ func TestRewriteFileKeys(t *testing.T) {
 		StartKey: codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(1)),
 		EndKey:   codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(1).PrefixNext()),
 	}
-	start, end, err = restore.RewriteFileKeys(&encodeKeyFile, &rewriteRules)
+	start, end, err = restore.RewriteFileKeys(&encodeKeyFile, &rewriteRules, false)
 	require.NoError(t, err)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2)), start)
 	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(2).PrefixNext()), end)
+
+	// test for table id 767
+	encodeKeyFile767 := backuppb.DataFileInfo{
+		Path:     "bakcup.log",
+		StartKey: codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(767)),
+		EndKey:   codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(767).PrefixNext()),
+	}
+	// use raw rewrite should no error but not equal
+	start, end, err = restore.RewriteFileKeys(&encodeKeyFile767, &rewriteRules, true)
+	require.NoError(t, err)
+	require.NotEqual(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511)), start)
+	require.NotEqual(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511).PrefixNext()), end)
+	// use encode rewrite should no error and equal
+	start, end, err = restore.RewriteFileKeys(&encodeKeyFile767, &rewriteRules, false)
+	require.NoError(t, err)
+	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511)), start)
+	require.Equal(t, codec.EncodeBytes(nil, tablecodec.GenTableRecordPrefix(511).PrefixNext()), end)
+
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37063 

Problem Summary: 

fix wrong of rewrite table id 767 when do restore point
The original logic is firstly try to rewrite the key in the way of rawKey, and then try the way of encodeKey if error.
But for the rewrite the encodeKey with table id 767 can success to be rewrited in the way of rawKey.
### What is changed and how it works?
don't try both, just separate treatment.
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [x] Manual test (add detailed scripts or steps below)
- [x] No code


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
