### PR TITLE
statistics: stablize `(*Table).GetColRowCount()`

### DIFF
--- a/statistics/table.go
+++ b/statistics/table.go
@@ -395,8 +395,15 @@ func (t *Table) GetStatsInfo(ID int64, isIndex bool) (int64, *Histogram, *CMSket
 // GetColRowCount tries to get the row count of the a column if possible.
 // This method is useful because this row count doesn't consider the modify count.
 func (t *Table) GetColRowCount() float64 {
-	for _, col := range t.Columns {
+	IDs := make([]int64, 0, len(t.Columns))
+	for id := range t.Columns {
+		IDs = append(IDs, id)
+	}
+	slices.Sort(IDs)
+	for _, id := range IDs {
+		col := t.Columns[id]
 		// need to make sure stats on this column is loaded.
+		// TODO: use the new method to check if it's loaded
 		if col != nil && !(col.Histogram.NDV > 0 && col.notNullCount() == 0) && col.TotalRowCount() != 0 {
 			return col.TotalRowCount()
 		}


### PR DESCRIPTION


### What problem does this PR solve?


Issue Number: close #37080

Problem Summary:

Please see the issue.

### What is changed and how it works?

Make the order of iterating the map in (t *Table) GetColRowCount() is stable.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
