### PR TITLE
charset: Support parsing CHARSET=utf8mb3

### DIFF
--- a/cmd/explaintest/r/collation_misc_disabled.result
+++ b/cmd/explaintest/r/collation_misc_disabled.result
@@ -91,6 +91,7 @@ binary	1
 gbk_bin	2
 latin1_bin	1
 utf8_bin	3
+utf8mb3_general_ci	3
 utf8mb4_bin	4
 SELECT character_set_name, id, sortlen FROM information_schema.collations ORDER BY collation_name, id;
 character_set_name	id	sortlen
@@ -99,6 +100,7 @@ binary	63	1
 gbk	87	1
 latin1	47	1
 utf8	83	1
+utf8mb3	33	1
 utf8mb4	46	1
 select * from information_schema.COLLATION_CHARACTER_SET_APPLICABILITY where COLLATION_NAME='utf8mb4_bin';
 COLLATION_NAME	CHARACTER_SET_NAME
@@ -110,9 +112,11 @@ binary	binary	binary	1
 gbk	Chinese Internal Code Specification	gbk_bin	2
 latin1	Latin1	latin1_bin	1
 utf8	UTF-8 Unicode	utf8_bin	3
+utf8mb3	UTF-8 Unicode	utf8mb3_general_ci	3
 utf8mb4	UTF-8 Unicode	utf8mb4_bin	4
 show collation;
 Collation	Charset	Id	Default	Compiled	Sortlen
+utf8mb3_general_ci	utf8mb3	33	Yes	Yes	1
 utf8mb4_bin	utf8mb4	46	Yes	Yes	1
 latin1_bin	latin1	47	Yes	Yes	1
 binary	binary	63	Yes	Yes	1

--- a/cmd/explaintest/r/collation_misc_enabled.result
+++ b/cmd/explaintest/r/collation_misc_enabled.result
@@ -94,6 +94,7 @@ binary	1
 gbk_chinese_ci	2
 latin1_bin	1
 utf8_bin	3
+utf8mb3_general_ci	3
 utf8mb4_bin	4
 SELECT character_set_name, id, sortlen FROM information_schema.collations ORDER BY collation_name, id;
 character_set_name	id	sortlen
@@ -118,6 +119,7 @@ binary	binary	binary	1
 gbk	Chinese Internal Code Specification	gbk_chinese_ci	2
 latin1	Latin1	latin1_bin	1
 utf8	UTF-8 Unicode	utf8_bin	3
+utf8mb3	UTF-8 Unicode	utf8mb3_general_ci	3
 utf8mb4	UTF-8 Unicode	utf8mb4_bin	4
 show collation;
 Collation	Charset	Id	Default	Compiled	Sortlen

--- a/parser/charset/charset.go
+++ b/parser/charset/charset.go
@@ -57,6 +57,7 @@ var supportedCollations = make([]*Collation, 0, len(supportedCollationNames))
 // CharacterSetInfos contains all the supported charsets.
 var CharacterSetInfos = map[string]*Charset{
 	CharsetUTF8:    {CharsetUTF8, CollationUTF8, make(map[string]*Collation), "UTF-8 Unicode", 3},
+	CharsetUTF8MB3: {CharsetUTF8MB3, CollationUTF8MB3, make(map[string]*Collation), "UTF-8 Unicode", 3},
 	CharsetUTF8MB4: {CharsetUTF8MB4, CollationUTF8MB4, make(map[string]*Collation), "UTF-8 Unicode", 4},
 	CharsetASCII:   {CharsetASCII, CollationASCII, make(map[string]*Collation), "US ASCII", 1},
 	CharsetLatin1:  {CharsetLatin1, CollationLatin1, make(map[string]*Collation), "Latin1", 1},
@@ -67,6 +68,7 @@ var CharacterSetInfos = map[string]*Charset{
 // All the names supported collations should be in the following table.
 var supportedCollationNames = map[string]struct{}{
 	CollationUTF8:    {},
+	CollationUTF8MB3: {},
 	CollationUTF8MB4: {},
 	CollationASCII:   {},
 	CollationLatin1:  {},
@@ -204,6 +206,8 @@ const (
 	CollationBin = "binary"
 	// CollationUTF8 is the default collation for CharsetUTF8.
 	CollationUTF8 = "utf8_bin"
+	// CollationUTF8MB3 is the default collation for CharsetUTF8MB3.
+	CollationUTF8MB3 = "utf8mb3_general_ci"
 	// CollationUTF8MB4 is the default collation for CharsetUTF8MB4.
 	CollationUTF8MB4 = "utf8mb4_bin"
 	// CollationASCII is the default collation for CharsetACSII.
@@ -225,6 +229,8 @@ const (
 	CharsetLatin1 = "latin1"
 	// CharsetUTF8 is the default charset for string types.
 	CharsetUTF8 = "utf8"
+	// CharsetUTF8MB3 is another name of CharsetUTF8.
+	CharsetUTF8MB3 = "utf8mb3"
 	// CharsetUTF8MB4 represents 4 bytes utf8, which works the same way as utf8 in Go.
 	CharsetUTF8MB4 = "utf8mb4"
 	//revive:disable:exported
@@ -344,6 +350,7 @@ var collations = []*Collation{
 	{31, "latin1", "latin1_german2_ci", false},
 	{32, "armscii8", "armscii8_general_ci", true},
 	{33, "utf8", "utf8_general_ci", false},
+	{33, "utf8mb3", "utf8mb3_general_ci", true},
 	{34, "cp1250", "cp1250_czech_cs", false},
 	{35, "ucs2", "ucs2_general_ci", true},
 	{36, "cp866", "cp866_general_ci", true},

--- a/parser/charset/charset_test.go
+++ b/parser/charset/charset_test.go
@@ -67,6 +67,7 @@ func TestGetDefaultCollation(t *testing.T) {
 	}{
 		{"utf8", "utf8_bin", true},
 		{"UTF8", "utf8_bin", true},
+		{"utf8mb3", "utf8mb3_general_ci", true},
 		{"utf8mb4", "utf8mb4_bin", true},
 		{"ascii", "ascii_bin", true},
 		{"binary", "binary", true},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/26226 close https://github.com/pingcap/tidb/issues/31790

Problem Summary: Support parsing CHARSET=utf8mb3

### What is changed and how it works?

utf8mb3 charset support is added.

If you specify `CHARSET=utf8` in MySQL 8, it's translated to `CHARSET=utf8mb3` when you use `SHOW CREATE TABLE` for example. Here's the definition I used to write this patch:

```
mysql> SHOW COLLATION WHERE Charset = 'utf8mb3' and `Default` = 'Yes';
+--------------------+---------+----+---------+----------+---------+---------------+
| Collation          | Charset | Id | Default | Compiled | Sortlen | Pad_attribute |
+--------------------+---------+----+---------+----------+---------+---------------+
| utf8mb3_general_ci | utf8mb3 | 33 | Yes     | Yes      |       1 | PAD SPACE     |
+--------------------+---------+----+---------+----------+---------+---------------+
1 row in set (0.00 sec)
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Support parsing CHARSET=utf8mb3
```
