### PR TITLE
test,planner: only increase `optimizeCnt` for specified sql in test

### DIFF
--- a/bindinfo/optimize_test.go
+++ b/bindinfo/optimize_test.go
@@ -30,7 +30,7 @@ func TestOptimizeOnlyOnce(t *testing.T) {
 	tk.MustExec("drop table if exists t")
 	tk.MustExec("create table t(a int, b int, index idxa(a))")
 	tk.MustExec("create global binding for select * from t using select * from t use index(idxa)")
-	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/planner/checkOptimizeCountOne", "return"))
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/planner/checkOptimizeCountOne", "return(\"select * from t\")"))
 	defer func() {
 		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/planner/checkOptimizeCountOne"))
 	}()

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -299,10 +299,13 @@ var planBuilderPool = sync.Pool{
 var optimizeCnt int
 
 func optimize(ctx context.Context, sctx sessionctx.Context, node ast.Node, is infoschema.InfoSchema) (core.Plan, types.NameSlice, float64, error) {
-	failpoint.Inject("checkOptimizeCountOne", func() {
-		optimizeCnt++
-		if optimizeCnt > 1 {
-			failpoint.Return(nil, nil, 0, errors.New("gofail wrong optimizerCnt error"))
+	failpoint.Inject("checkOptimizeCountOne", func(val failpoint.Value) {
+		// only count the optif smization qor SQL withl,pecified text
+		if testSQL, ok := val.(string); ok && testSQL == node.OriginalText() {
+			optimizeCnt++
+			if optimizeCnt > 1 {
+				failpoint.Return(nil, nil, 0, errors.New("gofail wrong optimizerCnt error"))
+			}
 		}
 	})
 	failpoint.Inject("mockHighLoadForOptimize", func() {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37059 

Problem Summary:

The test counts the times the `optimize` function is called. However, it's not expected. We only want ot validate the `optimize` time for a specified SQL (`select * from t` in the test).

### What is changed and how it works?

I added a condition in the failpoint to compare the input node with the failpoint value, to make it only increate the counter for the specific sql.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
None
```
