### PR TITLE
expression: remove duplicate element in `json_extract` function result

### DIFF
--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -154,6 +154,8 @@
       ".*_generated\\.go$": "ignore generated code"
     },
     "only_files": {
+      "types/json/binary_functions.go": "types/json/binary_functions.go",
+      "types/json/binary_test.go": "types/json/binary_test.go",
       "ddl/backfilling.go": "ddl/backfilling.go",
       "ddl/column.go": "ddl/column.go",
       "ddl/index.go": "ddl/index.go",
@@ -286,6 +288,8 @@
       ".*_generated\\.go$": "ignore generated code"
     },
     "only_files": {
+      "types/json/binary_functions.go": "types/json/binary_functions.go",
+      "types/json/binary_test.go": "types/json/binary_test.go",
       "ddl/backfilling.go": "ddl/backfilling.go",
       "ddl/column.go": "ddl/column.go",
       "ddl/index.go": "ddl/index.go",
@@ -644,6 +648,8 @@
       ".*_generated\\.go$": "ignore generated code"
     },
     "only_files": {
+      "types/json/binary_functions.go": "types/json/binary_functions.go",
+      "types/json/binary_test.go": "types/json/binary_test.go",
       "ddl/backfilling.go": "ddl/backfilling.go",
       "ddl/column.go": "ddl/column.go",
       "ddl/index.go": "ddl/index.go",

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -214,8 +214,9 @@ func quoteString(s string) string {
 func (bj BinaryJSON) Extract(pathExprList []PathExpression) (ret BinaryJSON, found bool) {
 	buf := make([]BinaryJSON, 0, 1)
 	for _, pathExpr := range pathExprList {
-		buf = bj.extractTo(buf, pathExpr)
+		buf = bj.extractTo(buf, pathExpr, make(map[*byte]struct{}), false)
 	}
+
 	if len(buf) == 0 {
 		found = false
 	} else if len(pathExprList) == 1 && len(buf) == 1 {
@@ -234,53 +235,68 @@ func (bj BinaryJSON) Extract(pathExprList []PathExpression) (ret BinaryJSON, fou
 	return
 }
 
-func (bj BinaryJSON) extractTo(buf []BinaryJSON, pathExpr PathExpression) []BinaryJSON {
+func (bj BinaryJSON) extractOne(pathExpr PathExpression) []BinaryJSON {
+	result := make([]BinaryJSON, 0, 1)
+	return bj.extractTo(result, pathExpr, nil, true)
+}
+
+func (bj BinaryJSON) extractTo(buf []BinaryJSON, pathExpr PathExpression, dup map[*byte]struct{}, one bool) []BinaryJSON {
 	if len(pathExpr.legs) == 0 {
+		if dup != nil {
+			if _, exists := dup[&bj.Value[0]]; exists {
+				return buf
+			}
+			dup[&bj.Value[0]] = struct{}{}
+		}
 		return append(buf, bj)
 	}
 	currentLeg, subPathExpr := pathExpr.popOneLeg()
 	if currentLeg.typ == pathLegIndex {
 		if bj.TypeCode != TypeCodeArray {
 			if currentLeg.arrayIndex <= 0 && currentLeg.arrayIndex != arrayIndexAsterisk {
-				buf = bj.extractTo(buf, subPathExpr)
+				buf = bj.extractTo(buf, subPathExpr, dup, one)
 			}
 			return buf
 		}
 		elemCount := bj.GetElemCount()
 		if currentLeg.arrayIndex == arrayIndexAsterisk {
-			for i := 0; i < elemCount; i++ {
-				buf = bj.arrayGetElem(i).extractTo(buf, subPathExpr)
+			for i := 0; i < elemCount && !finished(buf, one); i++ {
+				buf = bj.arrayGetElem(i).extractTo(buf, subPathExpr, dup, one)
 			}
 		} else if currentLeg.arrayIndex < elemCount {
-			buf = bj.arrayGetElem(currentLeg.arrayIndex).extractTo(buf, subPathExpr)
+			buf = bj.arrayGetElem(currentLeg.arrayIndex).extractTo(buf, subPathExpr, dup, one)
 		}
 	} else if currentLeg.typ == pathLegKey && bj.TypeCode == TypeCodeObject {
 		elemCount := bj.GetElemCount()
 		if currentLeg.dotKey == "*" {
-			for i := 0; i < elemCount; i++ {
-				buf = bj.objectGetVal(i).extractTo(buf, subPathExpr)
+			for i := 0; i < elemCount && !finished(buf, one); i++ {
+				buf = bj.objectGetVal(i).extractTo(buf, subPathExpr, dup, one)
 			}
 		} else {
 			child, ok := bj.objectSearchKey(hack.Slice(currentLeg.dotKey))
 			if ok {
-				buf = child.extractTo(buf, subPathExpr)
+				buf = child.extractTo(buf, subPathExpr, dup, one)
 			}
 		}
 	} else if currentLeg.typ == pathLegDoubleAsterisk {
-		buf = bj.extractTo(buf, subPathExpr)
+		buf = bj.extractTo(buf, subPathExpr, dup, one)
 		if bj.TypeCode == TypeCodeArray {
 			elemCount := bj.GetElemCount()
-			for i := 0; i < elemCount; i++ {
-				buf = bj.arrayGetElem(i).extractTo(buf, pathExpr)
+			for i := 0; i < elemCount && !finished(buf, one); i++ {
+				buf = bj.arrayGetElem(i).extractTo(buf, pathExpr, dup, one)
 			}
 		} else if bj.TypeCode == TypeCodeObject {
 			elemCount := bj.GetElemCount()
-			for i := 0; i < elemCount; i++ {
-				buf = bj.objectGetVal(i).extractTo(buf, pathExpr)
+			for i := 0; i < elemCount && !finished(buf, one); i++ {
+				buf = bj.objectGetVal(i).extractTo(buf, pathExpr, dup, one)
 			}
 		}
 	}
 	return buf
+}
+
+func finished(buf []BinaryJSON, one bool) bool {
+	return one && len(buf) > 0
 }
 
 func (bj BinaryJSON) objectSearchKey(key []byte) (BinaryJSON, bool) {
@@ -448,8 +464,7 @@ type binaryModifier struct {
 }
 
 func (bm *binaryModifier) set(path PathExpression, newBj BinaryJSON) BinaryJSON {
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, path)
+	result := bm.bj.extractOne(path)
 	if len(result) > 0 {
 		bm.modifyPtr = &result[0].Value[0]
 		bm.modifyValue = newBj
@@ -463,8 +478,7 @@ func (bm *binaryModifier) set(path PathExpression, newBj BinaryJSON) BinaryJSON 
 }
 
 func (bm *binaryModifier) replace(path PathExpression, newBj BinaryJSON) BinaryJSON {
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, path)
+	result := bm.bj.extractOne(path)
 	if len(result) == 0 {
 		return bm.bj
 	}
@@ -474,8 +488,7 @@ func (bm *binaryModifier) replace(path PathExpression, newBj BinaryJSON) BinaryJ
 }
 
 func (bm *binaryModifier) insert(path PathExpression, newBj BinaryJSON) BinaryJSON {
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, path)
+	result := bm.bj.extractOne(path)
 	if len(result) > 0 {
 		return bm.bj
 	}
@@ -489,8 +502,7 @@ func (bm *binaryModifier) insert(path PathExpression, newBj BinaryJSON) BinaryJS
 // doInsert inserts the newBj to its parent, and builds the new parent.
 func (bm *binaryModifier) doInsert(path PathExpression, newBj BinaryJSON) {
 	parentPath, lastLeg := path.popOneLastLeg()
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, parentPath)
+	result := bm.bj.extractOne(parentPath)
 	if len(result) == 0 {
 		return
 	}
@@ -537,8 +549,7 @@ func (bm *binaryModifier) doInsert(path PathExpression, newBj BinaryJSON) {
 }
 
 func (bm *binaryModifier) remove(path PathExpression) BinaryJSON {
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, path)
+	result := bm.bj.extractOne(path)
 	if len(result) == 0 {
 		return bm.bj
 	}
@@ -551,8 +562,7 @@ func (bm *binaryModifier) remove(path PathExpression) BinaryJSON {
 
 func (bm *binaryModifier) doRemove(path PathExpression) {
 	parentPath, lastLeg := path.popOneLastLeg()
-	result := make([]BinaryJSON, 0, 1)
-	result = bm.bj.extractTo(result, parentPath)
+	result := bm.bj.extractOne(parentPath)
 	if len(result) == 0 {
 		return
 	}

--- a/types/json/binary_test.go
+++ b/types/json/binary_test.go
@@ -44,6 +44,10 @@ func TestBinaryJSONExtract(t *testing.T) {
 	bj4 := mustParseBinaryFromString(t, `{"properties": {"$type$type": {"$a$a" : "TiDB"}}}`)
 	bj5 := mustParseBinaryFromString(t, `{"properties": {"$type": {"$a" : {"$b" : "TiDB"}}}}`)
 	bj6 := mustParseBinaryFromString(t, `{"properties": {"$type": {"$a$a" : "TiDB"}},"hello": {"$b$b": "world","$c": "amazing"}}`)
+	bj7 := mustParseBinaryFromString(t, `{ "a": { "x" : { "b": { "y": { "b": { "z": { "c": 100 } } } } } } }`)
+	bj8 := mustParseBinaryFromString(t, `{ "a": { "b" : [ 1, 2, 3 ] } }`)
+	bj9 := mustParseBinaryFromString(t, `[[0,1],[2,3],[4,[5,6]]]`)
+	bj10 := mustParseBinaryFromString(t, `[1]`)
 
 	var tests = []struct {
 		bj              BinaryJSON
@@ -74,6 +78,10 @@ func TestBinaryJSONExtract(t *testing.T) {
 		{bj2, []string{"$.a", "$[0]"}, mustParseBinaryFromString(t, `[{"a": 1, "b": true}]`), true, nil},
 		{bj6, []string{"$.properties", "$[1]"}, mustParseBinaryFromString(t, `[{"$type": {"$a$a" : "TiDB"}}]`), true, nil},
 		{bj6, []string{"$.hello", "$[2]"}, mustParseBinaryFromString(t, `[{"$b$b": "world","$c": "amazing"}]`), true, nil},
+		{bj7, []string{"$.a**.b**.c"}, mustParseBinaryFromString(t, `[100]`), true, nil},
+		{bj8, []string{"$**[0]"}, mustParseBinaryFromString(t, `[{"a": {"b": [1, 2, 3]}}, {"b": [1, 2, 3]}, 1, 2, 3]`), true, nil},
+		{bj9, []string{"$**[0]"}, mustParseBinaryFromString(t, `[[0, 1], 0, 1, 2, 3, 4, 5, 6] `), true, nil},
+		{bj10, []string{"$**[0]"}, mustParseBinaryFromString(t, `[1]`), true, nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Signed-off-by: xiongjiwei <xiongjiwei1996@outlook.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref https://github.com/pingcap/tidb/issues/37133

Problem Summary:

because of the `**` in json path, the result of `json_extract` may contain duplicate result, we should remove it

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
