### PR TITLE
log-backup: restore meta kv with batch method (#37100)

### DIFF
--- a/br/pkg/restore/client_test.go
+++ b/br/pkg/restore/client_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/pingcap/failpoint"
+	backuppb "github.com/pingcap/kvproto/pkg/brpb"
 	"github.com/pingcap/kvproto/pkg/import_sstpb"
 	"github.com/pingcap/kvproto/pkg/metapb"
 	berrors "github.com/pingcap/tidb/br/pkg/errors"
@@ -20,6 +21,7 @@ import (
 	"github.com/pingcap/tidb/br/pkg/metautil"
 	"github.com/pingcap/tidb/br/pkg/mock"
 	"github.com/pingcap/tidb/br/pkg/restore"
+	"github.com/pingcap/tidb/br/pkg/stream"
 	"github.com/pingcap/tidb/br/pkg/utils"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -551,4 +553,216 @@ func TestDeleteRangeQuery(t *testing.T) {
 	require.Equal(t, querys[1], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (4, 1, '748000000000000005', '748000000000000006', %[1]d),(4, 2, '748000000000000006', '748000000000000007', %[1]d)")
 	require.Equal(t, querys[2], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (7, 1, '7480000000000000085f698000000000000001', '7480000000000000085f698000000000000002', %[1]d)")
 	require.Equal(t, querys[3], "INSERT IGNORE INTO mysql.gc_delete_range VALUES (9, 2, '74800000000000000a5f698000000000000001', '74800000000000000a5f698000000000000002', %[1]d),(9, 3, '74800000000000000a5f698000000000000002', '74800000000000000a5f698000000000000003', %[1]d)")
+}
+
+func TestRestoreMetaKVFilesWithBatchMethod1(t *testing.T) {
+	files := []*backuppb.DataFileInfo{}
+	batchCount := 0
+
+	client := restore.MockClient(nil)
+	err := client.RestoreMetaKVFilesWithBatchMethod(
+		context.Background(),
+		files,
+		nil,
+		nil,
+		nil,
+		func(
+			ctx context.Context,
+			files []*backuppb.DataFileInfo,
+			schemasReplace *stream.SchemasReplace,
+			updateStats func(kvCount uint64, size uint64),
+			progressInc func(),
+		) error {
+			batchCount++
+			return nil
+		},
+	)
+	require.Nil(t, err)
+	require.Equal(t, batchCount, 0)
+}
+
+func TestRestoreMetaKVFilesWithBatchMethod2(t *testing.T) {
+	files := []*backuppb.DataFileInfo{
+		{
+			Path:  "f1",
+			MinTs: 100,
+			MaxTs: 120,
+		},
+	}
+	batchCount := 0
+	result := make(map[int][]*backuppb.DataFileInfo)
+
+	client := restore.MockClient(nil)
+	err := client.RestoreMetaKVFilesWithBatchMethod(
+		context.Background(),
+		files,
+		nil,
+		nil,
+		nil,
+		func(
+			ctx context.Context,
+			fs []*backuppb.DataFileInfo,
+			schemasReplace *stream.SchemasReplace,
+			updateStats func(kvCount uint64, size uint64),
+			progressInc func(),
+		) error {
+			result[batchCount] = fs
+			batchCount++
+			return nil
+		},
+	)
+	require.Nil(t, err)
+	require.Equal(t, batchCount, 1)
+	require.Equal(t, len(result), 1)
+	require.Equal(t, result[0], files)
+}
+
+func TestRestoreMetaKVFilesWithBatchMethod3(t *testing.T) {
+	files := []*backuppb.DataFileInfo{
+		{
+			Path:  "f1",
+			MinTs: 100,
+			MaxTs: 120,
+		},
+		{
+			Path:  "f2",
+			MinTs: 100,
+			MaxTs: 120,
+		},
+		{
+			Path:  "f3",
+			MinTs: 110,
+			MaxTs: 130,
+		},
+		{
+			Path:  "f4",
+			MinTs: 140,
+			MaxTs: 150,
+		},
+		{
+			Path:  "f5",
+			MinTs: 150,
+			MaxTs: 160,
+		},
+	}
+	batchCount := 0
+	result := make(map[int][]*backuppb.DataFileInfo)
+
+	client := restore.MockClient(nil)
+	err := client.RestoreMetaKVFilesWithBatchMethod(
+		context.Background(),
+		files,
+		nil,
+		nil,
+		nil,
+		func(
+			ctx context.Context,
+			fs []*backuppb.DataFileInfo,
+			schemasReplace *stream.SchemasReplace,
+			updateStats func(kvCount uint64, size uint64),
+			progressInc func(),
+		) error {
+			result[batchCount] = fs
+			batchCount++
+			return nil
+		},
+	)
+	require.Nil(t, err)
+	require.Equal(t, len(result), 2)
+	require.Equal(t, result[0], files[0:3])
+	require.Equal(t, result[1], files[3:])
+}
+
+func TestRestoreMetaKVFilesWithBatchMethod4(t *testing.T) {
+	files := []*backuppb.DataFileInfo{
+		{
+			Path:  "f1",
+			MinTs: 100,
+			MaxTs: 100,
+		},
+		{
+			Path:  "f2",
+			MinTs: 100,
+			MaxTs: 100,
+		},
+		{
+			Path:  "f3",
+			MinTs: 110,
+			MaxTs: 130,
+		},
+		{
+			Path:  "f4",
+			MinTs: 110,
+			MaxTs: 150,
+		},
+	}
+	batchCount := 0
+	result := make(map[int][]*backuppb.DataFileInfo)
+
+	client := restore.MockClient(nil)
+	err := client.RestoreMetaKVFilesWithBatchMethod(
+		context.Background(),
+		files,
+		nil,
+		nil,
+		nil,
+		func(
+			ctx context.Context,
+			fs []*backuppb.DataFileInfo,
+			schemasReplace *stream.SchemasReplace,
+			updateStats func(kvCount uint64, size uint64),
+			progressInc func(),
+		) error {
+			result[batchCount] = fs
+			batchCount++
+			return nil
+		},
+	)
+	require.Nil(t, err)
+	require.Equal(t, len(result), 2)
+	require.Equal(t, result[0], files[0:2])
+	require.Equal(t, result[1], files[2:])
+}
+
+func TestSortMetaKVFiles(t *testing.T) {
+	files := []*backuppb.DataFileInfo{
+		{
+			Path:       "f5",
+			MinTs:      110,
+			MaxTs:      150,
+			ResolvedTs: 120,
+		},
+		{
+			Path:       "f1",
+			MinTs:      100,
+			MaxTs:      100,
+			ResolvedTs: 80,
+		},
+		{
+			Path:       "f2",
+			MinTs:      100,
+			MaxTs:      100,
+			ResolvedTs: 90,
+		},
+		{
+			Path:       "f4",
+			MinTs:      110,
+			MaxTs:      130,
+			ResolvedTs: 120,
+		},
+		{
+			Path:       "f3",
+			MinTs:      105,
+			MaxTs:      130,
+			ResolvedTs: 100,
+		},
+	}
+
+	files = restore.SortMetaKVFiles(files)
+	require.Equal(t, len(files), 5)
+	require.Equal(t, files[0].Path, "f1")
+	require.Equal(t, files[1].Path, "f2")
+	require.Equal(t, files[2].Path, "f3")
+	require.Equal(t, files[3].Path, "f4")
+	require.Equal(t, files[4].Path, "f5")
 }


### PR DESCRIPTION
cherry-pick https://github.com/pingcap/tidb/pull/37100

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/37111

Problem Summary:
- Failed to restore index after PiTR to down-stream cluster.
- The current reason for this issue is that the same meta KV appears multiple times and is overwritten by the old KV record after restoring to the latest tableInfo.

### What is changed and how it works?
Set a lots of batch kv files and sort and restore these kv entries in batch files.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Manual test
- reproduce the test in https://github.com/pingcap/tidb/issues/37111
- The result after PiTR with old code
`
MySQL [(none)]> show create table test.sbtest43;
| sbtest43 | CREATE TABLE `sbtest43` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `k` int(11) NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=1019915 |
`
- The result after PiTR with modified code
`
MySQL [(none)]> show create table test.sbtest43;
| sbtest43 | CREATE TABLE `sbtest43` (
  `id` int(11) NOT NULL AUTO_INCREMENT,
  `k` int(11) NOT NULL DEFAULT '0',
  `c` char(120) NOT NULL DEFAULT '',
  `pad` char(60) NOT NULL DEFAULT '',
  PRIMARY KEY (`id`) /*T![clustered_index] CLUSTERED */,
  KEY `k_43` (`k`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin AUTO_INCREMENT=1019915 |
`

The Key `K-43`(``) has been restored in above test.


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
