### PR TITLE
planer: make CheckPreparePriv asynchronous

### DIFF
--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -16,6 +16,7 @@ package core
 
 import (
 	"context"
+	"sync"
 
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/bindinfo"
@@ -209,18 +210,34 @@ func getPointQueryPlan(stmt *ast.Prepared, sessVars *variable.SessionVars, stmtC
 }
 
 func getGeneralPlan(sctx sessionctx.Context, cacheKey kvcache.Key, bindSQL string,
-	is infoschema.InfoSchema, stmt *PlanCacheStmt, paramTypes []*types.FieldType) (Plan,
-	[]*types.FieldName, bool, error) {
+	is infoschema.InfoSchema, stmt *PlanCacheStmt, paramTypes []*types.FieldType) (_ Plan,
+	_ []*types.FieldName, ok bool, err error) {
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
+
+	// asynchronously check privilege
+	needPrivilegeCheck := false
+	var privilegeCheckWg sync.WaitGroup
+	var privilegeCheckErr error
+	defer func() {
+		if needPrivilegeCheck {
+			privilegeCheckWg.Wait()
+			if privilegeCheckErr != nil {
+				err = privilegeCheckErr
+				ok = false
+			}
+		}
+	}()
+	go func() {
+		privilegeCheckErr = CheckPreparedPriv(sctx, stmt, is)
+		privilegeCheckWg.Done()
+	}()
 
 	cachedVal, exist := getValidPlanFromCache(sctx, cacheKey, paramTypes)
 	if !exist {
 		return nil, nil, false, nil
 	}
-	if err := CheckPreparedPriv(sctx, stmt, is); err != nil {
-		return nil, nil, false, err
-	}
+	needPrivilegeCheck = true
 	for tblInfo, unionScan := range cachedVal.TblInfo2UnionScan {
 		if !unionScan && tableHasDirtyContent(sctx, tblInfo) {
 			// TODO we can inject UnionScan into cached plan to avoid invalidating it, though
@@ -229,7 +246,7 @@ func getGeneralPlan(sctx sessionctx.Context, cacheKey kvcache.Key, bindSQL strin
 			return nil, nil, false, nil
 		}
 	}
-	err := RebuildPlan4CachedPlan(cachedVal.Plan)
+	err = RebuildPlan4CachedPlan(cachedVal.Plan)
 	if err != nil {
 		logutil.BgLogger().Debug("rebuild range failed", zap.Error(err))
 		return nil, nil, false, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36049

Problem Summary:

checkPreparePriv costs about 2% CPU time in the critical path of a performance sensitive workload. We could make it async to reduce a little latency.

The change may result in some unnecessary execution of the function if plan chche misses, however I assume that's a rare case.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
