### PR TITLE
planner: introduce the general plan cache

### DIFF
--- a/executor/prepared.go
+++ b/executor/prepared.go
@@ -319,7 +319,7 @@ func (e *DeallocateExec) Next(ctx context.Context, req *chunk.Chunk) error {
 			return err
 		}
 		if !vars.IgnorePreparedCacheCloseStmt { // keep the plan in cache
-			e.ctx.PreparedPlanCache().Delete(cacheKey)
+			e.ctx.GetPlanCache(false).Delete(cacheKey)
 		}
 	}
 	vars.RemovePreparedStmt(id)

--- a/executor/seqtest/prepared_test.go
+++ b/executor/seqtest/prepared_test.go
@@ -622,7 +622,7 @@ func TestPrepareDealloc(t *testing.T) {
 	tk.MustExec("drop table if exists prepare_test")
 	tk.MustExec("create table prepare_test (id int PRIMARY KEY, c1 int)")
 
-	require.Equal(t, 0, tk.Session().PreparedPlanCache().Size())
+	require.Equal(t, 0, tk.Session().GetPlanCache(false).Size())
 	tk.MustExec(`prepare stmt1 from 'select id from prepare_test'`)
 	tk.MustExec("execute stmt1")
 	tk.MustExec(`prepare stmt2 from 'select c1 from prepare_test'`)
@@ -631,20 +631,20 @@ func TestPrepareDealloc(t *testing.T) {
 	tk.MustExec("execute stmt3")
 	tk.MustExec(`prepare stmt4 from 'select * from prepare_test'`)
 	tk.MustExec("execute stmt4")
-	require.Equal(t, 3, tk.Session().PreparedPlanCache().Size())
+	require.Equal(t, 3, tk.Session().GetPlanCache(false).Size())
 
 	tk.MustExec("deallocate prepare stmt1")
-	require.Equal(t, 3, tk.Session().PreparedPlanCache().Size())
+	require.Equal(t, 3, tk.Session().GetPlanCache(false).Size())
 	tk.MustExec("deallocate prepare stmt2")
 	tk.MustExec("deallocate prepare stmt3")
 	tk.MustExec("deallocate prepare stmt4")
-	require.Equal(t, 0, tk.Session().PreparedPlanCache().Size())
+	require.Equal(t, 0, tk.Session().GetPlanCache(false).Size())
 
 	tk.MustExec(`prepare stmt1 from 'select * from prepare_test'`)
 	tk.MustExec(`execute stmt1`)
 	tk.MustExec(`prepare stmt2 from 'select * from prepare_test'`)
 	tk.MustExec(`execute stmt2`)
-	require.Equal(t, 1, tk.Session().PreparedPlanCache().Size()) // use the same cached plan since they have the same statement
+	require.Equal(t, 1, tk.Session().GetPlanCache(false).Size()) // use the same cached plan since they have the same statement
 
 	tk.MustExec(`drop database if exists plan_cache`)
 	tk.MustExec(`create database plan_cache`)
@@ -652,7 +652,7 @@ func TestPrepareDealloc(t *testing.T) {
 	tk.MustExec(`create table prepare_test (id int PRIMARY KEY, c1 int)`)
 	tk.MustExec(`prepare stmt3 from 'select * from prepare_test'`)
 	tk.MustExec(`execute stmt3`)
-	require.Equal(t, 2, tk.Session().PreparedPlanCache().Size()) // stmt3 has different DB
+	require.Equal(t, 2, tk.Session().GetPlanCache(false).Size()) // stmt3 has different DB
 }
 
 func TestPreparedIssue8153(t *testing.T) {

--- a/executor/simple.go
+++ b/executor/simple.go
@@ -1739,7 +1739,7 @@ func (e *SimpleExec) executeAdminFlushPlanCache(s *ast.AdminStmt) error {
 	}
 	now := types.NewTime(types.FromGoTime(time.Now().In(e.ctx.GetSessionVars().StmtCtx.TimeZone)), mysql.TypeTimestamp, 3)
 	e.ctx.GetSessionVars().LastUpdateTime4PC = now
-	e.ctx.PreparedPlanCache().DeleteAll()
+	e.ctx.GetPlanCache(false).DeleteAll()
 	if s.StatementScope == ast.StatementScopeInstance {
 		// Record the timestamp. When other sessions want to use the plan cache,
 		// it will check the timestamp first to decide whether the plan cache should be flushed.

--- a/parser/ast/misc.go
+++ b/parser/ast/misc.go
@@ -508,6 +508,10 @@ type ExecuteStmt struct {
 	BinaryArgs interface{}
 	PrepStmt   interface{} // the corresponding prepared statement
 	IdxInMulti int
+
+	// FromGeneralStmt indicates whether this execute-stmt is converted from a general query.
+	// e.g. select * from t where a>2 --> execute 'select * from t where a>?' using 2
+	FromGeneralStmt bool
 }
 
 // Restore implements Node interface.

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -42,7 +42,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func planCachePreprocess(sctx sessionctx.Context, is infoschema.InfoSchema,
+func planCachePreprocess(sctx sessionctx.Context, generalPlanCache bool, is infoschema.InfoSchema,
 	stmt *PlanCacheStmt, params []expression.Expression) error {
 	vars := sctx.GetSessionVars()
 	stmtAst := stmt.PreparedAst
@@ -102,7 +102,7 @@ func planCachePreprocess(sctx sessionctx.Context, is infoschema.InfoSchema,
 	// And update lastUpdateTime to the newest one.
 	expiredTimeStamp4PC := domain.GetDomain(sctx).ExpiredTimeStamp4PC()
 	if stmtAst.UseCache && expiredTimeStamp4PC.Compare(vars.LastUpdateTime4PC) > 0 {
-		sctx.PreparedPlanCache().DeleteAll()
+		sctx.GetPlanCache(generalPlanCache).DeleteAll()
 		stmtAst.CachedPlan = nil
 		vars.LastUpdateTime4PC = expiredTimeStamp4PC
 	}
@@ -112,9 +112,11 @@ func planCachePreprocess(sctx sessionctx.Context, is infoschema.InfoSchema,
 // GetPlanFromSessionPlanCache is the entry point of Plan Cache.
 // It tries to get a valid cached plan from this session's plan cache.
 // If there is no such a plan, it'll call the optimizer to generate a new one.
-func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt,
+// generalPlanCache indicates whether to use the general plan cache or the prepared plan cache.
+func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
+	generalPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
 	params []expression.Expression) (plan Plan, names []*types.FieldName, err error) {
-	if err := planCachePreprocess(sctx, is, stmt, params); err != nil {
+	if err := planCachePreprocess(sctx, generalPlanCache, is, stmt, params); err != nil {
 		return nil, nil, err
 	}
 
@@ -154,13 +156,13 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context, i
 	}
 
 	if stmtAst.UseCache && !ignorePlanCache { // for general plans
-		if plan, names, ok, err := getGeneralPlan(sctx, cacheKey, bindSQL, is, stmt,
+		if plan, names, ok, err := getGeneralPlan(sctx, generalPlanCache, cacheKey, bindSQL, is, stmt,
 			paramTypes); err != nil || ok {
 			return plan, names, err
 		}
 	}
 
-	return generateNewPlan(ctx, sctx, is, stmt, ignorePlanCache, cacheKey,
+	return generateNewPlan(ctx, sctx, generalPlanCache, is, stmt, ignorePlanCache, cacheKey,
 		latestSchemaVersion, paramNum, paramTypes, bindSQL)
 }
 
@@ -208,13 +210,13 @@ func getPointQueryPlan(stmt *ast.Prepared, sessVars *variable.SessionVars, stmtC
 	return plan, names, true, nil
 }
 
-func getGeneralPlan(sctx sessionctx.Context, cacheKey kvcache.Key, bindSQL string,
+func getGeneralPlan(sctx sessionctx.Context, generalPlanCache bool, cacheKey kvcache.Key, bindSQL string,
 	is infoschema.InfoSchema, stmt *PlanCacheStmt, paramTypes []*types.FieldType) (Plan,
 	[]*types.FieldName, bool, error) {
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
 
-	cachedVal, exist := getValidPlanFromCache(sctx, cacheKey, paramTypes)
+	cachedVal, exist := getValidPlanFromCache(sctx, generalPlanCache, cacheKey, paramTypes)
 	if !exist {
 		return nil, nil, false, nil
 	}
@@ -225,7 +227,7 @@ func getGeneralPlan(sctx sessionctx.Context, cacheKey kvcache.Key, bindSQL strin
 		if !unionScan && tableHasDirtyContent(sctx, tblInfo) {
 			// TODO we can inject UnionScan into cached plan to avoid invalidating it, though
 			// rebuilding the filters in UnionScan is pretty trivial.
-			sctx.PreparedPlanCache().Delete(cacheKey)
+			sctx.GetPlanCache(generalPlanCache).Delete(cacheKey)
 			return nil, nil, false, nil
 		}
 	}
@@ -251,7 +253,7 @@ func getGeneralPlan(sctx sessionctx.Context, cacheKey kvcache.Key, bindSQL strin
 
 // generateNewPlan call the optimizer to generate a new plan for current statement
 // and try to add it to cache
-func generateNewPlan(ctx context.Context, sctx sessionctx.Context, is infoschema.InfoSchema, stmt *PlanCacheStmt,
+func generateNewPlan(ctx context.Context, sctx sessionctx.Context, generalPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
 	ignorePlanCache bool, cacheKey kvcache.Key, latestSchemaVersion int64, paramNum int,
 	paramTypes []*types.FieldType, bindSQL string) (Plan, []*types.FieldName, error) {
 	stmtAst := stmt.PreparedAst
@@ -286,7 +288,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, is infoschema
 		stmt.NormalizedPlan, stmt.PlanDigest = NormalizePlan(p)
 		stmtCtx.SetPlan(p)
 		stmtCtx.SetPlanDigest(stmt.NormalizedPlan, stmt.PlanDigest)
-		putPlanIntoCache(sctx, cacheKey, cached)
+		putPlanIntoCache(sctx, generalPlanCache, cacheKey, cached)
 	}
 	sessVars.FoundInPlanCache = false
 	return p, names, err

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -42,7 +42,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func planCachePreprocess(sctx sessionctx.Context, generalPlanCache bool, is infoschema.InfoSchema,
+func planCachePreprocess(sctx sessionctx.Context, isGeneralPlanCache bool, is infoschema.InfoSchema,
 	stmt *PlanCacheStmt, params []expression.Expression) error {
 	vars := sctx.GetSessionVars()
 	stmtAst := stmt.PreparedAst
@@ -102,7 +102,7 @@ func planCachePreprocess(sctx sessionctx.Context, generalPlanCache bool, is info
 	// And update lastUpdateTime to the newest one.
 	expiredTimeStamp4PC := domain.GetDomain(sctx).ExpiredTimeStamp4PC()
 	if stmtAst.UseCache && expiredTimeStamp4PC.Compare(vars.LastUpdateTime4PC) > 0 {
-		sctx.GetPlanCache(generalPlanCache).DeleteAll()
+		sctx.GetPlanCache(isGeneralPlanCache).DeleteAll()
 		stmtAst.CachedPlan = nil
 		vars.LastUpdateTime4PC = expiredTimeStamp4PC
 	}
@@ -112,11 +112,11 @@ func planCachePreprocess(sctx sessionctx.Context, generalPlanCache bool, is info
 // GetPlanFromSessionPlanCache is the entry point of Plan Cache.
 // It tries to get a valid cached plan from this session's plan cache.
 // If there is no such a plan, it'll call the optimizer to generate a new one.
-// generalPlanCache indicates whether to use the general plan cache or the prepared plan cache.
+// isGeneralPlanCache indicates whether to use the general plan cache or the prepared plan cache.
 func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
-	generalPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
+	isGeneralPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
 	params []expression.Expression) (plan Plan, names []*types.FieldName, err error) {
-	if err := planCachePreprocess(sctx, generalPlanCache, is, stmt, params); err != nil {
+	if err := planCachePreprocess(sctx, isGeneralPlanCache, is, stmt, params); err != nil {
 		return nil, nil, err
 	}
 
@@ -156,13 +156,13 @@ func GetPlanFromSessionPlanCache(ctx context.Context, sctx sessionctx.Context,
 	}
 
 	if stmtAst.UseCache && !ignorePlanCache { // for general plans
-		if plan, names, ok, err := getGeneralPlan(sctx, generalPlanCache, cacheKey, bindSQL, is, stmt,
+		if plan, names, ok, err := getGeneralPlan(sctx, isGeneralPlanCache, cacheKey, bindSQL, is, stmt,
 			paramTypes); err != nil || ok {
 			return plan, names, err
 		}
 	}
 
-	return generateNewPlan(ctx, sctx, generalPlanCache, is, stmt, ignorePlanCache, cacheKey,
+	return generateNewPlan(ctx, sctx, isGeneralPlanCache, is, stmt, ignorePlanCache, cacheKey,
 		latestSchemaVersion, paramNum, paramTypes, bindSQL)
 }
 
@@ -210,13 +210,13 @@ func getPointQueryPlan(stmt *ast.Prepared, sessVars *variable.SessionVars, stmtC
 	return plan, names, true, nil
 }
 
-func getGeneralPlan(sctx sessionctx.Context, generalPlanCache bool, cacheKey kvcache.Key, bindSQL string,
+func getGeneralPlan(sctx sessionctx.Context, isGeneralPlanCache bool, cacheKey kvcache.Key, bindSQL string,
 	is infoschema.InfoSchema, stmt *PlanCacheStmt, paramTypes []*types.FieldType) (Plan,
 	[]*types.FieldName, bool, error) {
 	sessVars := sctx.GetSessionVars()
 	stmtCtx := sessVars.StmtCtx
 
-	cachedVal, exist := getValidPlanFromCache(sctx, generalPlanCache, cacheKey, paramTypes)
+	cachedVal, exist := getValidPlanFromCache(sctx, isGeneralPlanCache, cacheKey, paramTypes)
 	if !exist {
 		return nil, nil, false, nil
 	}
@@ -227,7 +227,7 @@ func getGeneralPlan(sctx sessionctx.Context, generalPlanCache bool, cacheKey kvc
 		if !unionScan && tableHasDirtyContent(sctx, tblInfo) {
 			// TODO we can inject UnionScan into cached plan to avoid invalidating it, though
 			// rebuilding the filters in UnionScan is pretty trivial.
-			sctx.GetPlanCache(generalPlanCache).Delete(cacheKey)
+			sctx.GetPlanCache(isGeneralPlanCache).Delete(cacheKey)
 			return nil, nil, false, nil
 		}
 	}
@@ -253,7 +253,7 @@ func getGeneralPlan(sctx sessionctx.Context, generalPlanCache bool, cacheKey kvc
 
 // generateNewPlan call the optimizer to generate a new plan for current statement
 // and try to add it to cache
-func generateNewPlan(ctx context.Context, sctx sessionctx.Context, generalPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
+func generateNewPlan(ctx context.Context, sctx sessionctx.Context, isGeneralPlanCache bool, is infoschema.InfoSchema, stmt *PlanCacheStmt,
 	ignorePlanCache bool, cacheKey kvcache.Key, latestSchemaVersion int64, paramNum int,
 	paramTypes []*types.FieldType, bindSQL string) (Plan, []*types.FieldName, error) {
 	stmtAst := stmt.PreparedAst
@@ -288,7 +288,7 @@ func generateNewPlan(ctx context.Context, sctx sessionctx.Context, generalPlanCa
 		stmt.NormalizedPlan, stmt.PlanDigest = NormalizePlan(p)
 		stmtCtx.SetPlan(p)
 		stmtCtx.SetPlanDigest(stmt.NormalizedPlan, stmt.PlanDigest)
-		putPlanIntoCache(sctx, generalPlanCache, cacheKey, cached)
+		putPlanIntoCache(sctx, isGeneralPlanCache, cacheKey, cached)
 	}
 	sessVars.FoundInPlanCache = false
 	return p, names, err

--- a/planner/core/plan_cache_utils.go
+++ b/planner/core/plan_cache_utils.go
@@ -39,8 +39,8 @@ var (
 	PreparedPlanCacheMaxMemory = *atomic2.NewUint64(math.MaxUint64)
 )
 
-func getValidPlanFromCache(sctx sessionctx.Context, generalPlanCache bool, key kvcache.Key, paramTypes []*types.FieldType) (*PlanCacheValue, bool) {
-	cache := sctx.GetPlanCache(generalPlanCache)
+func getValidPlanFromCache(sctx sessionctx.Context, isGeneralPlanCache bool, key kvcache.Key, paramTypes []*types.FieldType) (*PlanCacheValue, bool) {
+	cache := sctx.GetPlanCache(isGeneralPlanCache)
 	val, exist := cache.Get(key)
 	if !exist {
 		return nil, exist
@@ -54,8 +54,8 @@ func getValidPlanFromCache(sctx sessionctx.Context, generalPlanCache bool, key k
 	return nil, false
 }
 
-func putPlanIntoCache(sctx sessionctx.Context, generalPlanCache bool, key kvcache.Key, plan *PlanCacheValue) {
-	cache := sctx.GetPlanCache(generalPlanCache)
+func putPlanIntoCache(sctx sessionctx.Context, isGeneralPlanCache bool, key kvcache.Key, plan *PlanCacheValue) {
+	cache := sctx.GetPlanCache(isGeneralPlanCache)
 	val, exist := cache.Get(key)
 	if !exist {
 		cache.Put(key, []*PlanCacheValue{plan})

--- a/planner/core/plan_cache_utils.go
+++ b/planner/core/plan_cache_utils.go
@@ -39,8 +39,8 @@ var (
 	PreparedPlanCacheMaxMemory = *atomic2.NewUint64(math.MaxUint64)
 )
 
-func getValidPlanFromCache(sctx sessionctx.Context, key kvcache.Key, paramTypes []*types.FieldType) (*PlanCacheValue, bool) {
-	cache := sctx.PreparedPlanCache()
+func getValidPlanFromCache(sctx sessionctx.Context, generalPlanCache bool, key kvcache.Key, paramTypes []*types.FieldType) (*PlanCacheValue, bool) {
+	cache := sctx.GetPlanCache(generalPlanCache)
 	val, exist := cache.Get(key)
 	if !exist {
 		return nil, exist
@@ -54,8 +54,8 @@ func getValidPlanFromCache(sctx sessionctx.Context, key kvcache.Key, paramTypes 
 	return nil, false
 }
 
-func putPlanIntoCache(sctx sessionctx.Context, key kvcache.Key, plan *PlanCacheValue) {
-	cache := sctx.PreparedPlanCache()
+func putPlanIntoCache(sctx sessionctx.Context, generalPlanCache bool, key kvcache.Key, plan *PlanCacheValue) {
+	cache := sctx.GetPlanCache(generalPlanCache)
 	val, exist := cache.Get(key)
 	if !exist {
 		cache.Put(key, []*PlanCacheValue{plan})

--- a/planner/core/prepare_test.go
+++ b/planner/core/prepare_test.go
@@ -690,7 +690,7 @@ func TestPrepareCacheDeferredFunction(t *testing.T) {
 		require.True(t, ok)
 		err = executor.ResetContextOfStmt(tk.Session(), stmt)
 		require.NoError(t, err)
-		plan, _, err := core.GetPlanFromSessionPlanCache(ctx, tk.Session(), is, execPlan.PrepStmt, execPlan.Params)
+		plan, _, err := core.GetPlanFromSessionPlanCache(ctx, tk.Session(), false, is, execPlan.PrepStmt, execPlan.Params)
 		require.NoError(t, err)
 		planStr[i] = core.ToString(plan)
 		require.Regexpf(t, expectedPattern, planStr[i], "for %dth %s", i, sql1)

--- a/planner/optimize.go
+++ b/planner/optimize.go
@@ -374,7 +374,7 @@ func OptimizeExecStmt(ctx context.Context, sctx sessionctx.Context,
 	if !ok {
 		return nil, nil, errors.Errorf("invalid result plan type, should be Execute")
 	}
-	plan, names, err := core.GetPlanFromSessionPlanCache(ctx, sctx, is, exec.PrepStmt, exec.Params)
+	plan, names, err := core.GetPlanFromSessionPlanCache(ctx, sctx, execAst.FromGeneralStmt, is, exec.PrepStmt, exec.Params)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/server/driver_tidb.go
+++ b/server/driver_tidb.go
@@ -176,7 +176,7 @@ func (ts *TiDBStatement) Close() error {
 				return err
 			}
 			if !ts.ctx.GetSessionVars().IgnorePreparedCacheCloseStmt { // keep the plan in cache
-				ts.ctx.PreparedPlanCache().Delete(cacheKey)
+				ts.ctx.GetPlanCache(false).Delete(cacheKey)
 			}
 		}
 		ts.ctx.GetSessionVars().RemovePreparedStmt(ts.id)

--- a/session/session.go
+++ b/session/session.go
@@ -232,6 +232,7 @@ type session struct {
 	store kv.Storage
 
 	preparedPlanCache *kvcache.SimpleLRUCache
+	generalPlanCache  *kvcache.SimpleLRUCache
 
 	sessionVars    *variable.SessionVars
 	sessionManager util.SessionManager
@@ -371,7 +372,7 @@ func (s *session) cleanRetryInfo() {
 				plannercore.SetPstmtIDSchemaVersion(cacheKey, stmtText, preparedAst.SchemaVersion, s.sessionVars.IsolationReadEngines)
 			}
 			if !s.sessionVars.IgnorePreparedCacheCloseStmt { // keep the plan in cache
-				s.PreparedPlanCache().Delete(cacheKey)
+				s.GetPlanCache(false).Delete(cacheKey)
 			}
 		}
 		s.sessionVars.RemovePreparedStmt(stmtID)
@@ -430,7 +431,19 @@ func (s *session) SetCollation(coID int) error {
 	return s.sessionVars.SetSystemVarWithoutValidation(variable.CollationConnection, co)
 }
 
-func (s *session) PreparedPlanCache() *kvcache.SimpleLRUCache {
+func (s *session) GetPlanCache(generalPlanCache bool) *kvcache.SimpleLRUCache {
+	if generalPlanCache { // use the general plan cache
+		if !s.GetSessionVars().EnableGeneralPlanCache {
+			return nil
+		}
+		if s.generalPlanCache == nil { // lazy construction
+			s.generalPlanCache = kvcache.NewSimpleLRUCache(uint(s.GetSessionVars().GeneralPlanCacheSize),
+				variable.PreparedPlanCacheMemoryGuardRatio.Load(), plannercore.PreparedPlanCacheMaxMemory.Load())
+		}
+		return s.generalPlanCache
+	}
+
+	// use the prepared plan cache
 	if !s.GetSessionVars().EnablePreparedPlanCache {
 		return nil
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -432,7 +432,7 @@ func (s *session) SetCollation(coID int) error {
 }
 
 func (s *session) GetPlanCache(isGeneralPlanCache bool) *kvcache.SimpleLRUCache {
-	if generalPlanCache { // use the general plan cache
+	if isGeneralPlanCache { // use the general plan cache
 		if !s.GetSessionVars().EnableGeneralPlanCache {
 			return nil
 		}

--- a/session/session.go
+++ b/session/session.go
@@ -431,7 +431,7 @@ func (s *session) SetCollation(coID int) error {
 	return s.sessionVars.SetSystemVarWithoutValidation(variable.CollationConnection, co)
 }
 
-func (s *session) GetPlanCache(generalPlanCache bool) *kvcache.SimpleLRUCache {
+func (s *session) GetPlanCache(isGeneralPlanCache bool) *kvcache.SimpleLRUCache {
 	if generalPlanCache { // use the general plan cache
 		if !s.GetSessionVars().EnableGeneralPlanCache {
 			return nil

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -106,8 +106,9 @@ type Context interface {
 	// GetStore returns the store of session.
 	GetStore() kv.Storage
 
-	// PreparedPlanCache returns the cache of the physical plan
-	PreparedPlanCache() *kvcache.SimpleLRUCache
+	// GetPlanCache returns the cache of the physical plan.
+	// generalPlanCache indicates to return the general plan cache or the prepared plan cache.
+	GetPlanCache(generalPlanCache bool) *kvcache.SimpleLRUCache
 
 	// StoreQueryFeedback stores the query feedback.
 	StoreQueryFeedback(feedback interface{})

--- a/sessionctx/context.go
+++ b/sessionctx/context.go
@@ -108,7 +108,7 @@ type Context interface {
 
 	// GetPlanCache returns the cache of the physical plan.
 	// generalPlanCache indicates to return the general plan cache or the prepared plan cache.
-	GetPlanCache(generalPlanCache bool) *kvcache.SimpleLRUCache
+	GetPlanCache(isGeneralPlanCache bool) *kvcache.SimpleLRUCache
 
 	// StoreQueryFeedback stores the query feedback.
 	StoreQueryFeedback(feedback interface{})

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -1866,8 +1866,7 @@ func (k planCacheStmtKey) Hash() []byte {
 // AddGeneralPlanCacheStmt adds this PlanCacheStmt into general-plan-cache-stmt cache
 func (s *SessionVars) AddGeneralPlanCacheStmt(sql string, stmt interface{}) {
 	if s.generalPlanCacheStmts == nil {
-		// TODO: make it configurable
-		s.generalPlanCacheStmts = kvcache.NewSimpleLRUCache(100, 0, 0)
+		s.generalPlanCacheStmts = kvcache.NewSimpleLRUCache(uint(s.GeneralPlanCacheSize), 0, 0)
 	}
 	s.generalPlanCacheStmts.Put(planCacheStmtKey(sql), stmt)
 }

--- a/sessionctx/variable/session_test.go
+++ b/sessionctx/variable/session_test.go
@@ -387,6 +387,7 @@ func TestTransactionContextSavepoint(t *testing.T) {
 
 func TestGeneralPlanCacheStmt(t *testing.T) {
 	sessVars := variable.NewSessionVars()
+	sessVars.GeneralPlanCacheSize = 100
 	sql1 := "select * from t where a>?"
 	sql2 := "select * from t where a<?"
 	require.Nil(t, sessVars.GetGeneralPlanCacheStmt(sql1))

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -247,7 +247,7 @@ func (*Context) SetGlobalSysVar(_ sessionctx.Context, name string, value string)
 	return nil
 }
 
-// PreparedPlanCache implements the sessionctx.Context interface.
+// GetPlanCache implements the sessionctx.Context interface.
 func (c *Context) GetPlanCache(_ bool) *kvcache.SimpleLRUCache {
 	return c.pcache
 }

--- a/util/mock/context.go
+++ b/util/mock/context.go
@@ -248,7 +248,7 @@ func (*Context) SetGlobalSysVar(_ sessionctx.Context, name string, value string)
 }
 
 // PreparedPlanCache implements the sessionctx.Context interface.
-func (c *Context) PreparedPlanCache() *kvcache.SimpleLRUCache {
+func (c *Context) GetPlanCache(_ bool) *kvcache.SimpleLRUCache {
 	return c.pcache
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36598

Problem Summary: planner: introduce the general plan cache

### What is changed and how it works?

Introduce the general plan cache and refactor the interface to get plan cache from `session.PreparedPlanCache()` to `session.GetPlanCache(generalPlanCache bool)` where the argument `generalPlanCache` indicates whether to return the general plan cache or the prepared plan cache.

<img width="359" alt="image" src="https://user-images.githubusercontent.com/7499936/184850925-03dff7f8-e1e7-4907-8f6e-369d1232f412.png">


### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
