### PR TITLE
executor: let analyze isolevel controlled by tidb_enable_analyze_snapshot 

### DIFF
--- a/distsql/distsql_test.go
+++ b/distsql/distsql_test.go
@@ -157,7 +157,7 @@ func TestAnalyze(t *testing.T) {
 	sctx := newMockSessionContext()
 	sctx.GetSessionVars().EnableChunkRPC = false
 	request, err := (&RequestBuilder{}).SetKeyRanges(nil).
-		SetAnalyzeRequest(&tipb.AnalyzeReq{}).
+		SetAnalyzeRequest(&tipb.AnalyzeReq{}, kv.RC).
 		SetKeepOrder(true).
 		Build()
 	require.NoError(t, err)

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -158,12 +158,12 @@ func (builder *RequestBuilder) SetDAGRequest(dag *tipb.DAGRequest) *RequestBuild
 }
 
 // SetAnalyzeRequest sets the request type to "ReqTypeAnalyze" and construct request data.
-func (builder *RequestBuilder) SetAnalyzeRequest(ana *tipb.AnalyzeReq) *RequestBuilder {
+func (builder *RequestBuilder) SetAnalyzeRequest(ana *tipb.AnalyzeReq, isoLevel kv.IsoLevel) *RequestBuilder {
 	if builder.err == nil {
 		builder.Request.Tp = kv.ReqTypeAnalyze
 		builder.Request.Data, builder.err = ana.Marshal()
 		builder.Request.NotFillCache = true
-		builder.Request.IsolationLevel = kv.SI
+		builder.Request.IsolationLevel = isoLevel
 		builder.Request.Priority = kv.PriorityLow
 	}
 

--- a/distsql/request_builder_test.go
+++ b/distsql/request_builder_test.go
@@ -481,7 +481,7 @@ func TestRequestBuilder5(t *testing.T) {
 	}
 
 	actual, err := (&RequestBuilder{}).SetKeyRanges(keyRanges).
-		SetAnalyzeRequest(&tipb.AnalyzeReq{}).
+		SetAnalyzeRequest(&tipb.AnalyzeReq{}, kv.RC).
 		SetKeepOrder(true).
 		SetConcurrency(15).
 		Build()
@@ -494,7 +494,7 @@ func TestRequestBuilder5(t *testing.T) {
 		KeepOrder:        true,
 		Desc:             false,
 		Concurrency:      15,
-		IsolationLevel:   kv.SI,
+		IsolationLevel:   kv.RC,
 		Priority:         1,
 		NotFillCache:     true,
 		ReadReplicaScope: kv.GlobalReplicaScope,

--- a/executor/analyze_idx.go
+++ b/executor/analyze_idx.go
@@ -24,6 +24,7 @@ import (
 	"github.com/pingcap/failpoint"
 	"github.com/pingcap/tidb/distsql"
 	"github.com/pingcap/tidb/domain"
+	"github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/parser/ast"
 	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
@@ -144,11 +145,13 @@ func (e *AnalyzeIndexExec) fetchAnalyzeResult(ranges []*ranger.Range, isNullRang
 	}
 	kvReqBuilder.SetResourceGroupTagger(e.ctx.GetSessionVars().StmtCtx.GetResourceGroupTagger())
 	startTS := uint64(math.MaxUint64)
+	isoLevel := kv.RC
 	if e.ctx.GetSessionVars().EnableAnalyzeSnapshot {
 		startTS = e.snapshot
+		isoLevel = kv.SI
 	}
 	kvReq, err := kvReqBuilder.
-		SetAnalyzeRequest(e.analyzePB).
+		SetAnalyzeRequest(e.analyzePB, isoLevel).
 		SetStartTS(startTS).
 		SetKeepOrder(true).
 		SetConcurrency(e.concurrency).


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36983

Problem Summary:

The default SI isolation level with max ts will meet txn conflict with high possibility if there exists writes. Thus we use tidb_enable_analyze_snapshot to control the isolevel.

### What is changed and how it works?

let analyze isolevel controlled by tidb_enable_analyze_snapshot 

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
