### PR TITLE
executor: add IsDrained hint to avoid unnecessary chunk renew

### DIFF
--- a/executor/batch_point_get.go
+++ b/executor/batch_point_get.go
@@ -197,6 +197,11 @@ func (e *BatchPointGetExec) Next(ctx context.Context, req *chunk.Chunk) error {
 	return nil
 }
 
+// IsDrained implements the Executor interface, overriding the default implementation.
+func (e *BatchPointGetExec) IsDrained() bool {
+	return e.index >= len(e.values)
+}
+
 func datumsContainNull(vals []types.Datum) bool {
 	for _, val := range vals {
 		if val.IsNull() {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -208,6 +208,12 @@ func (e *baseExecutor) Open(ctx context.Context) error {
 	return nil
 }
 
+// IsDrained provides a default implementation.
+// Real executors can override this method if necessary.
+func (e *baseExecutor) IsDrained() bool {
+	return false
+}
+
 // Close closes all executors and release all resources.
 func (e *baseExecutor) Close() error {
 	var firstErr error
@@ -294,6 +300,9 @@ type Executor interface {
 	base() *baseExecutor
 	Open(context.Context) error
 	Next(ctx context.Context, req *chunk.Chunk) error
+	// IsDrained returns a hint about whether the executor has returned all the results,
+	// so no more Next() needs to be called. It returns false if unsure.
+	IsDrained() bool
 	Close() error
 	Schema() *expression.Schema
 }

--- a/executor/point_get.go
+++ b/executor/point_get.go
@@ -192,6 +192,11 @@ func (e *PointGetExecutor) Open(context.Context) error {
 	return nil
 }
 
+// IsDrained implements the Executor interface, overriding the default implementation.
+func (e *PointGetExecutor) IsDrained() bool {
+	return e.done
+}
+
 // Close implements the Executor interface.
 func (e *PointGetExecutor) Close() error {
 	if e.runtimeStats != nil && e.snapshot != nil {

--- a/executor/projection.go
+++ b/executor/projection.go
@@ -293,6 +293,15 @@ func (e *ProjectionExec) drainOutputCh(ch chan *projectionOutput) {
 	}
 }
 
+// IsDrained implements the Executor interface, overriding the default implementation.
+func (e *ProjectionExec) IsDrained() bool {
+	if e.isUnparallelExec() {
+		return e.children[0].IsDrained()
+	}
+	// It's a bit hard to tell if it's drained in parallel mode. Just return false for uncertainty.
+	return false
+}
+
 // Close implements the Executor Close interface.
 func (e *ProjectionExec) Close() error {
 	// if e.baseExecutor.Open returns error, e.childResult will be nil, see https://github.com/pingcap/tidb/issues/24210

--- a/executor/update.go
+++ b/executor/update.go
@@ -320,6 +320,9 @@ func (e *UpdateExec) updateRows(ctx context.Context) (int, error) {
 			}
 		}
 		totalNumRows += chk.NumRows()
+		if e.children[0].IsDrained() {
+			break
+		}
 		chk = chunk.Renew(chk, e.maxChunkSize)
 	}
 	return totalNumRows, nil


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36049


### What is changed and how it works?

In `updateRows` and `runPessimisticSelectForUpdate`, the chunk is renewed after calling each `Next`. But in many OLTP cases, it's easy to know there are no more results. Renewing the chunk will be completely useless.

So, this PR adds `IsDrained` hint to `Executor`. So, before calling `Next`, it can use the hint to decide whether we need to `Next` again.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
