### PR TITLE
expression: add json opaque value

### DIFF
--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -194,10 +194,7 @@ func (bj BinaryJSON) GetFloat64() float64 {
 
 // GetString gets the string value.
 func (bj BinaryJSON) GetString() []byte {
-	strLen, lenLen := uint64(bj.Value[0]), 1
-	if strLen >= utf8.RuneSelf {
-		strLen, lenLen = binary.Uvarint(bj.Value)
-	}
+	strLen, lenLen := binary.Uvarint(bj.Value)
 	return bj.Value[lenLen : lenLen+int(strLen)]
 }
 
@@ -213,10 +210,7 @@ type Opaque struct {
 func (bj BinaryJSON) GetOpaque() Opaque {
 	typ := bj.Value[0]
 
-	strLen, lenLen := uint64(bj.Value[1]), 1
-	if strLen >= utf8.RuneSelf {
-		strLen, lenLen = binary.Uvarint(bj.Value[1:])
-	}
+	strLen, lenLen := binary.Uvarint(bj.Value[1:])
 	bufStart := lenLen + 1
 	return Opaque{
 		TypeCode: typ,
@@ -268,17 +262,11 @@ func (bj BinaryJSON) valEntryGet(valEntryOff int) BinaryJSON {
 	case TypeCodeUint64, TypeCodeInt64, TypeCodeFloat64:
 		return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+8]}
 	case TypeCodeString:
-		strLen, lenLen := uint64(bj.Value[valOff]), 1
-		if strLen >= utf8.RuneSelf {
-			strLen, lenLen = binary.Uvarint(bj.Value[valOff:])
-		}
+		strLen, lenLen := binary.Uvarint(bj.Value[valOff:])
 		totalLen := uint32(lenLen) + uint32(strLen)
 		return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+totalLen]}
 	case TypeCodeOpaque:
-		strLen, lenLen := uint64(bj.Value[valOff+1]), 1
-		if strLen >= utf8.RuneSelf {
-			strLen, lenLen = binary.Uvarint(bj.Value[valOff+1:])
-		}
+		strLen, lenLen := binary.Uvarint(bj.Value[valOff+1:])
 		totalLen := 1 + uint32(lenLen) + uint32(strLen)
 		return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+totalLen]}
 	}

--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -274,6 +274,13 @@ func (bj BinaryJSON) valEntryGet(valEntryOff int) BinaryJSON {
 		}
 		totalLen := uint32(lenLen) + uint32(strLen)
 		return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+totalLen]}
+	case TypeCodeOpaque:
+		strLen, lenLen := uint64(bj.Value[valOff+1]), 1
+		if strLen >= utf8.RuneSelf {
+			strLen, lenLen = binary.Uvarint(bj.Value[valOff+1:])
+		}
+		totalLen := 1 + uint32(lenLen) + uint32(strLen)
+		return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+totalLen]}
 	}
 	dataSize := endian.Uint32(bj.Value[valOff+dataSizeOff:])
 	return BinaryJSON{TypeCode: tpCode, Value: bj.Value[valOff : valOff+dataSize]}

--- a/types/json/binary.go
+++ b/types/json/binary.go
@@ -16,6 +16,7 @@ package json
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -47,6 +48,7 @@ import (
        0x0a |       // uint64
        0x0b |       // double
        0x0c |       // utf8mb4 string
+       0x0d |       // opaque value
 
    value ::=
        object  |
@@ -54,6 +56,7 @@ import (
        literal |
        number  |
        string  |
+       opaque  |
 
    object ::= element-count size key-entry* value-entry* key* value*
 
@@ -97,6 +100,10 @@ import (
                              // field. So we need 1 byte to represent
                              // lengths up to 127, 2 bytes to represent
                              // lengths up to 16383, and so on...
+
+   opaque ::= typeId data-length byte*
+
+   typeId ::= byte
 */
 
 // BinaryJSON represents a binary encoded JSON object.
@@ -128,6 +135,8 @@ func (bj BinaryJSON) MarshalJSON() ([]byte, error) {
 
 func (bj BinaryJSON) marshalTo(buf []byte) ([]byte, error) {
 	switch bj.TypeCode {
+	case TypeCodeOpaque:
+		return marshalOpaqueTo(buf, bj.GetOpaque()), nil
 	case TypeCodeString:
 		return marshalStringTo(buf, bj.GetString()), nil
 	case TypeCodeLiteral:
@@ -190,6 +199,34 @@ func (bj BinaryJSON) GetString() []byte {
 		strLen, lenLen = binary.Uvarint(bj.Value)
 	}
 	return bj.Value[lenLen : lenLen+int(strLen)]
+}
+
+// Opaque represents a raw binary type
+type Opaque struct {
+	// TypeCode is the same with database type code
+	TypeCode byte
+	// Buf is the underlying bytes of the data
+	Buf []byte
+}
+
+// GetOpaque gets the opaque value
+func (bj BinaryJSON) GetOpaque() Opaque {
+	typ := bj.Value[0]
+
+	strLen, lenLen := uint64(bj.Value[1]), 1
+	if strLen >= utf8.RuneSelf {
+		strLen, lenLen = binary.Uvarint(bj.Value[1:])
+	}
+	bufStart := lenLen + 1
+	return Opaque{
+		TypeCode: typ,
+		Buf:      bj.Value[bufStart : bufStart+int(strLen)],
+	}
+}
+
+// GetOpaqueFieldType returns the type of opaque value
+func (bj BinaryJSON) GetOpaqueFieldType() byte {
+	return bj.Value[0]
 }
 
 // GetKeys gets the keys of the object
@@ -380,6 +417,17 @@ func marshalStringTo(buf, s []byte) []byte {
 	return buf
 }
 
+// opaque value will yield "base64:typeXX:<base64 encoded string>"
+func marshalOpaqueTo(buf []byte, opaque Opaque) []byte {
+	b64 := base64.StdEncoding.EncodeToString(opaque.Buf)
+	output := fmt.Sprintf(`"base64:type%d:%s"`, opaque.TypeCode, b64)
+
+	// as the base64 string is simple and predictable, it could be appended
+	// to the buf directly.
+	buf = append(buf, output...)
+	return buf
+}
+
 func marshalLiteralTo(b []byte, litType byte) []byte {
 	switch litType {
 	case LiteralFalse:
@@ -514,6 +562,9 @@ func appendBinary(buf []byte, in interface{}) (TypeCode, []byte, error) {
 		if err != nil {
 			return typeCode, nil, errors.Trace(err)
 		}
+	case Opaque:
+		typeCode = TypeCodeOpaque
+		buf = appendBinaryOpaque(buf, x)
 	default:
 		msg := fmt.Sprintf(unknownTypeErrorMsg, reflect.TypeOf(in))
 		err = errors.New(msg)
@@ -572,6 +623,18 @@ func appendBinaryString(buf []byte, v string) []byte {
 	lenLen := binary.PutUvarint(buf[begin:], uint64(len(v)))
 	buf = buf[:len(buf)-binary.MaxVarintLen64+lenLen]
 	buf = append(buf, v...)
+	return buf
+}
+
+func appendBinaryOpaque(buf []byte, v Opaque) []byte {
+	buf = append(buf, v.TypeCode)
+
+	lenBegin := len(buf)
+	buf = appendZero(buf, binary.MaxVarintLen64)
+	lenLen := binary.PutUvarint(buf[lenBegin:], uint64(len(v.Buf)))
+
+	buf = buf[:len(buf)-binary.MaxVarintLen64+lenLen]
+	buf = append(buf, v.Buf...)
 	return buf
 }
 

--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -24,6 +24,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pingcap/errors"
+	"github.com/pingcap/tidb/parser/mysql"
 	"github.com/pingcap/tidb/util/hack"
 	"github.com/pingcap/tidb/util/stringutil"
 	"golang.org/x/exp/slices"
@@ -51,6 +52,16 @@ func (bj BinaryJSON) Type() string {
 		return "DOUBLE"
 	case TypeCodeString:
 		return "STRING"
+	case TypeCodeOpaque:
+		typ := bj.GetOpaqueFieldType()
+		switch typ {
+		case mysql.TypeTinyBlob, mysql.TypeMediumBlob, mysql.TypeLongBlob, mysql.TypeBlob, mysql.TypeString, mysql.TypeVarString, mysql.TypeVarchar:
+			return "BLOB"
+		case mysql.TypeBit:
+			return "BIT"
+		default:
+			return "OPAQUE"
+		}
 	default:
 		msg := fmt.Sprintf(unknownTypeCodeErrorMsg, bj.TypeCode)
 		panic(msg)
@@ -791,6 +802,8 @@ func CompareBinary(left, right BinaryJSON) int {
 					return cmp
 				}
 			}
+		case TypeCodeOpaque:
+			cmp = bytes.Compare(left.GetString(), right.GetString())
 		}
 	} else {
 		cmp = precedence1 - precedence2

--- a/types/json/constants.go
+++ b/types/json/constants.go
@@ -40,6 +40,8 @@ const (
 	TypeCodeFloat64 TypeCode = 0x0b
 	// TypeCodeString indicates the JSON is a string.
 	TypeCodeString TypeCode = 0x0c
+	// TypeCodeOpaque indicates the JSON is a opaque
+	TypeCodeOpaque TypeCode = 0x0d
 )
 
 const (


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #31918 , close #9996

Problem Summary:

The cast and comparison is incompatible with MySQL. It's because we didn't consider the "opaque json" values. With considering the opaque json, and add it to the comparison order (actually, it has been in the list for a while :laughing: ).

### What is changed and how it works?

This PR added a "Opaque JSON` values to store the binary strings. When this kind of json value is marshaled to the string, it's converted to `base64:typeXX:<base64 encoded string>`. It records both the mysql type (in `typeXX`), and the underlying binary data.

Considered three kinds of binary strings: `(.*)BLOB`, `BINARY`, `VARBINARY`. The `BLOB` and `VARBINARY` will not have extra zeros. However, the `BINARY` kind in opaque json will always have the same length (with padding zeros).

### Check List

Tests

- [x] Unit test
- [x] Manual test

Run the following SQL in both MySQL and TiDB:

```
drop table if exists t1, t2, t3, t4;
create table t1 (a binary(13));
insert into t1 values('');
create table t2 (a json);
insert into t2 values ('"str"');

create table t3 (a varbinary(13));
insert  into t3 values ('a');

create table t4 (a blob);
insert  into t4 values (x'AA');

select * from t1 join t2 on t1.a <= t2.a;
select cast(a as json) from t1;
select cast(a as json) from t3;
select cast(a as json) from t4;
```

### Release note

```release-note
Fix the issue that the cast and comparison between binary string and json is incompatible with MySQL
```
