### PR TITLE
*: more concise bazel log

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,24 +1,26 @@
 startup --host_jvm_args=-Xmx8g
 startup --unlimit_coredumps
 
+run:ci --color=yes
+
 build --java_language_version=17
 build --java_runtime_version=17
 build --tool_java_language_version=17
 build --tool_java_runtime_version=17
+build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build:ci --color=yes
-run:ci --color=yes
-
+build:ci --experimental_remote_cache_compression
 build:release --workspace_status_command=./build/print-workspace-status.sh --stamp
 build:release --config=ci
-build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
-build:ci --experimental_remote_cache_compression
-test:ci --color=yes
-test:ci --verbose_failures
-test:ci --test_env=GO_TEST_WRAP_TESTV=1 --test_verbose_timeout_warnings
-test:ci --test_env=TZ=Asia/Shanghai --test_output=errors --experimental_ui_max_stdouterr_bytes=104857600
-
 build:race --config=ci
 build:race --@io_bazel_rules_go//go/config:race --test_env=GORACE=halt_on_error=1 --test_sharding_strategy=disabled
+
+test --test_env=TZ=Asia/Shanghai
+test --test_output=errors --test_summary=testcase
+test:ci --color=yes
+test:ci --verbose_failures --test_verbose_timeout_warnings
+test:ci --test_env=GO_TEST_WRAP_TESTV=1
+test:ci --experimental_ui_max_stdouterr_bytes=104857600
 test:race --test_timeout=1200,6000,18000,72000
 
 try-import /data/bazel


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close None

Problem Summary: Enable CI to output more compat logs, i.e. without lots of `coverage.dat` or `attempt_1.log` or the result of each test package(nobody really cares). Only the count of succeeded/failed tests are shown as a summary.

What is changed:

1. Use `--test_summary=testcase`
2. group bazel config by command type
3. Use `--test_env=TZ=Asia/Shanghai --test_output=errors` in non-ci environment but not `--experimental_ui_max_stdouterr_bytes=104857600`

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
