### PR TITLE
*: fix the order of `FallbackOldAndSetNewAction`

### DIFF
--- a/executor/executor_pkg_test.go
+++ b/executor/executor_pkg_test.go
@@ -510,7 +510,7 @@ func TestSortSpillDisk(t *testing.T) {
 	err = exec.Close()
 	require.NoError(t, err)
 
-	ctx.GetSessionVars().StmtCtx.MemTracker = memory.NewTracker(-1, 24000)
+	ctx.GetSessionVars().StmtCtx.MemTracker = memory.NewTracker(-1, 28000)
 	dataSource.prepareChunks()
 	err = exec.Open(tmpCtx)
 	require.NoError(t, err)
@@ -522,20 +522,9 @@ func TestSortSpillDisk(t *testing.T) {
 		}
 	}
 	// Test only 1 partition but spill disk.
-	// Now spilling is in parallel.
-	// Maybe the second add() will be called after spilling, depends on
-	// Golang goroutine scheduling. So the result has two possibilities.
-	if len(exec.partitionList) == 1 {
-		require.Len(t, exec.partitionList, 1)
-		require.Equal(t, true, exec.partitionList[0].AlreadySpilledSafeForTest())
-		require.Equal(t, 2048, exec.partitionList[0].NumRow())
-	} else {
-		require.Len(t, exec.partitionList, 2)
-		require.Equal(t, true, exec.partitionList[0].AlreadySpilledSafeForTest())
-		require.Equal(t, true, exec.partitionList[1].AlreadySpilledSafeForTest())
-		require.Equal(t, 1024, exec.partitionList[0].NumRow())
-		require.Equal(t, 1024, exec.partitionList[1].NumRow())
-	}
+	require.Len(t, exec.partitionList, 1)
+	require.Equal(t, true, exec.partitionList[0].AlreadySpilledSafeForTest())
+	require.Equal(t, 2048, exec.partitionList[0].NumRow())
 	err = exec.Close()
 	require.NoError(t, err)
 

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -224,10 +224,8 @@ func reArrangeFallback(a ActionOnExceed, b ActionOnExceed) ActionOnExceed {
 	}
 	if a.GetPriority() < b.GetPriority() {
 		a, b = b, a
-		a.SetFallback(b)
-	} else {
-		a.SetFallback(reArrangeFallback(a.GetFallback(), b))
 	}
+	a.SetFallback(reArrangeFallback(a.GetFallback(), b))
 	return a
 }
 

--- a/util/memory/tracker.go
+++ b/util/memory/tracker.go
@@ -193,7 +193,7 @@ func (t *Tracker) SetActionOnExceed(a ActionOnExceed) {
 func (t *Tracker) FallbackOldAndSetNewAction(a ActionOnExceed) {
 	t.actionMuForHardLimit.Lock()
 	defer t.actionMuForHardLimit.Unlock()
-	t.actionMuForHardLimit.actionOnExceed = reArrangeFallback(t.actionMuForHardLimit.actionOnExceed, a)
+	t.actionMuForHardLimit.actionOnExceed = reArrangeFallback(a, t.actionMuForHardLimit.actionOnExceed)
 }
 
 // FallbackOldAndSetNewActionForSoftLimit sets the action when memory usage exceeds bytesSoftLimit
@@ -201,7 +201,7 @@ func (t *Tracker) FallbackOldAndSetNewAction(a ActionOnExceed) {
 func (t *Tracker) FallbackOldAndSetNewActionForSoftLimit(a ActionOnExceed) {
 	t.actionMuForSoftLimit.Lock()
 	defer t.actionMuForSoftLimit.Unlock()
-	t.actionMuForSoftLimit.actionOnExceed = reArrangeFallback(t.actionMuForSoftLimit.actionOnExceed, a)
+	t.actionMuForSoftLimit.actionOnExceed = reArrangeFallback(a, t.actionMuForSoftLimit.actionOnExceed)
 }
 
 // GetFallbackForTest get the oom action used by test.

--- a/util/memory/tracker_test.go
+++ b/util/memory/tracker_test.go
@@ -190,8 +190,8 @@ func TestOOMAction(t *testing.T) {
 	require.False(t, action1.called)
 	require.False(t, action2.called)
 	tracker.Consume(10000)
-	require.True(t, action1.called)
-	require.False(t, action2.called)
+	require.True(t, action2.called)
+	require.False(t, action1.called)
 	tracker.Consume(10000)
 	require.True(t, action1.called)
 	require.True(t, action2.called)
@@ -201,20 +201,20 @@ func TestOOMAction(t *testing.T) {
 	action1 = &mockAction{}
 	action2 = &mockAction{}
 	action3 := &mockAction{}
-	tracker.FallbackOldAndSetNewActionForSoftLimit(action1)
+	tracker.SetActionOnExceed(action1)
 	tracker.FallbackOldAndSetNewActionForSoftLimit(action2)
-	tracker.SetActionOnExceed(action3)
+	tracker.FallbackOldAndSetNewActionForSoftLimit(action3)
+	require.False(t, action3.called)
+	require.False(t, action2.called)
 	require.False(t, action1.called)
-	require.False(t, action2.called)
-	require.False(t, action3.called)
 	tracker.Consume(80)
-	require.True(t, action1.called)
+	require.True(t, action3.called)
 	require.False(t, action2.called)
-	require.False(t, action3.called)
+	require.False(t, action1.called)
 	tracker.Consume(20)
-	require.True(t, action1.called)
+	require.True(t, action3.called)
 	require.True(t, action2.called) // SoftLimit fallback
-	require.True(t, action3.called) // HardLimit
+	require.True(t, action1.called) // HardLimit
 
 	// test fallback
 	action1 = &mockAction{}
@@ -227,13 +227,13 @@ func TestOOMAction(t *testing.T) {
 	tracker.FallbackOldAndSetNewAction(action3)
 	tracker.FallbackOldAndSetNewAction(action4)
 	tracker.FallbackOldAndSetNewAction(action5)
-	require.Equal(t, action1, tracker.actionMuForHardLimit.actionOnExceed)
-	require.Equal(t, action2, tracker.actionMuForHardLimit.actionOnExceed.GetFallback())
-	action2.SetFinished()
+	require.Equal(t, action5, tracker.actionMuForHardLimit.actionOnExceed)
+	require.Equal(t, action4, tracker.actionMuForHardLimit.actionOnExceed.GetFallback())
+	action4.SetFinished()
 	require.Equal(t, action3, tracker.actionMuForHardLimit.actionOnExceed.GetFallback())
 	action3.SetFinished()
-	action4.SetFinished()
-	require.Equal(t, action5, tracker.actionMuForHardLimit.actionOnExceed.GetFallback())
+	action2.SetFinished()
+	require.Equal(t, action1, tracker.actionMuForHardLimit.actionOnExceed.GetFallback())
 }
 
 type mockAction struct {


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37058

Problem Summary:

1. The order of `FallbackOldAndSetNewAction` is wrong. It should set the current action to the new one, and set the original one as its fallback (as how it's used, and described in the comments). However, it acts in the opposite way now :facepalm: , and cause the unstable test.
2. The bytes limit of the third test is too low, which may cause two partitions. I increased the bytes limit, and it will only spill one partition now.

### What is changed and how it works?

I rearrange the arguments order of the `FallbackOldAndSetNewAction`

### Check List

Tests

- [x] Unit test
- [ ]Integration test
- [x] Manual test
- [ ] No code

I manually, repeatedly run this test multiple times (in parallel, 32 jobs) for several minutes, and it seems that it's stable now :heart: .

### Release note

```release-note
Fix the issue that the action order of 
```
