### PR TITLE
kv,store/copr: make kv.KeyRange the same with coprocessor.KeyRange, so we can use unsafe optimization

### DIFF
--- a/kv/key.go
+++ b/kv/key.go
@@ -20,9 +20,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unsafe"
 
-	"github.com/pingcap/kvproto/pkg/coprocessor"
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/codec"
 	"github.com/pingcap/tidb/util/set"
@@ -99,18 +97,9 @@ type KeyRange struct {
 	StartKey Key
 	EndKey   Key
 
-	XXX_NoUnkeyedLiteral struct{}
-	XXX_unrecognized     []byte
-	XXX_sizecache        int32
-}
-
-func init() {
-	// kv.KeyRange and coprocessor.KeyRange should be the same layout, so we can exchange them.
-	var r1 KeyRange
-	var r2 coprocessor.KeyRange
-	if unsafe.Sizeof(r1) != unsafe.Sizeof(r2) {
-		panic("coprocessor protocol change?")
-	}
+	XXXNoUnkeyedLiteral struct{}
+	XXXunrecognized     []byte
+	XXXsizecache        int32
 }
 
 // IsPoint checks if the key range represents a point.

--- a/kv/key_test.go
+++ b/kv/key_test.go
@@ -20,7 +20,9 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"unsafe"
 
+	"github.com/pingcap/kvproto/pkg/coprocessor"
 	. "github.com/pingcap/tidb/kv"
 	"github.com/pingcap/tidb/sessionctx/stmtctx"
 	"github.com/pingcap/tidb/testkit/testutil"
@@ -210,6 +212,18 @@ func TestHandleMap(t *testing.T) {
 	})
 
 	assert.Equal(t, 2, cnt)
+}
+
+func TestKeyRangeDefinition(t *testing.T) {
+	// The struct layout for kv.KeyRange and coprocessor.KeyRange should be exactly the same.
+	// This allow us to use unsafe pointer to convert them and reduce allocation.
+	var r1 KeyRange
+	var r2 coprocessor.KeyRange
+	// Same size.
+	require.Equal(t, unsafe.Sizeof(r1), unsafe.Sizeof(r2))
+	// And same default value.
+	require.Equal(t, (*coprocessor.KeyRange)(unsafe.Pointer(&r1)), &r2)
+	require.Equal(t, &r1, (*KeyRange)(unsafe.Pointer(&r2)))
 }
 
 func BenchmarkIsPoint(b *testing.B) {

--- a/util/logutil/hex.go
+++ b/util/logutil/hex.go
@@ -57,7 +57,7 @@ func prettyPrint(w io.Writer, val reflect.Value) {
 		for i := 0; i < val.NumField(); i++ {
 			fv := val.Field(i)
 			ft := tp.Field(i)
-			if strings.HasPrefix(ft.Name, "XXX_") {
+			if strings.HasPrefix(ft.Name, "XXX") {
 				continue
 			}
 			if i != 0 {


### PR DESCRIPTION


<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37286

Problem Summary:

### What is changed and how it works?

make `kv.KeyRange` the same with `coprocessor.KeyRange` so we avoid converting and thus reduce object allocation.

The same workload, get the pprof

Before:

![](https://user-images.githubusercontent.com/1420062/186056457-9e58240b-4bbb-40e8-b596-33582f92c199.png)

After:

![image](https://user-images.githubusercontent.com/1420062/186057486-bb667e86-45ae-4866-a1ad-94bb1374eb6b.png)



### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

TPCH 50
Execute Query 16

```
explain analyze select p_brand, p_type, p_size, count(distinct ps_suppkey) as supplier_cnt from partsupp, part where p_partkey = ps_partkey and p_brand <> 'Brand#34' and p_type not like 'LARGE BRUSHED%' and p_size in (48, 19, 12, 4, 41, 7, 21, 39) and ps_suppkey not
in ( select s_suppkey from supplier where s_comment like '%Customer%Complaints%' ) group by p_brand, p_type, p_size order by supplier_cnt desc, p_brand, p_type, p_size;
```

Get the profile flamegraph.

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
