### PR TITLE
executor: reduce a place of object allocation for HashAggExec

### DIFF
--- a/executor/aggregate.go
+++ b/executor/aggregate.go
@@ -1027,6 +1027,7 @@ func (e *HashAggExec) execute(ctx context.Context) (err error) {
 
 		allMemDelta := int64(0)
 		sel := make([]int, 0, e.childResult.NumRows())
+		var tmpBuf [1]chunk.Row
 		for j := 0; j < e.childResult.NumRows(); j++ {
 			groupKey := string(e.groupKeyBuffer[j]) // do memory copy here, because e.groupKeyBuffer may be reused.
 			if !e.groupSet.Exist(groupKey) {
@@ -1039,7 +1040,8 @@ func (e *HashAggExec) execute(ctx context.Context) (err error) {
 			}
 			partialResults := e.getPartialResults(groupKey)
 			for i, af := range e.PartialAggFuncs {
-				memDelta, err := af.UpdatePartialResult(e.ctx, []chunk.Row{e.childResult.GetRow(j)}, partialResults[i])
+				tmpBuf[0] = e.childResult.GetRow(j)
+				memDelta, err := af.UpdatePartialResult(e.ctx, tmpBuf[:], partialResults[i])
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37299

Problem Summary:

### What is changed and how it works?

The parameter for `UpdatePartialResult` is []chunk.Row, but there is only one row here.
`[]chunkRow{row}`  cause unnecessary object allocation.

Before:

![](https://user-images.githubusercontent.com/1420062/186087224-db424423-9b53-4f07-82dc-e87122482455.png)

After:

![image](https://user-images.githubusercontent.com/1420062/186087651-39166905-1959-4891-8d84-279e96f86c3b.png)

The `runtime.newobject` disappear after the change.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [X] Manual test (add detailed scripts or steps below)

Run tpch16 and capture the flamegraph

- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
