### PR TITLE
variable: Add a new variable `tidb_enable_ddl_service`

### DIFF
--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -3,10 +3,10 @@ name: License checker
 on:
   push:
     branches:
-      - master
+      - feature/ddl-as-service
   pull_request:
     branches:
-      - master
+      - feature/ddl-as-service
 
 concurrency:
   group: ${{ github.ref }}-${{ github.workflow }}

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -1774,6 +1774,12 @@ var defaultSysVars = []*SysVar{
 		DDLDiskQuota.Store(TidbOptInt64(val, DefTiDBDDLDiskQuota))
 		return nil
 	}},
+	{Scope: ScopeGlobal, Name: TiDBEnableDDLService, Value: BoolToOnOff(DefTiDBEnableDDLService), Type: TypeBool, GetGlobal: func(sv *SessionVars) (string, error) {
+		return BoolToOnOff(EnableDDLService.Load()), nil
+	}, SetGlobal: func(s *SessionVars, val string) error {
+		EnableDDLService.Store(TiDBOptOn(val))
+		return nil
+	}},
 }
 
 // FeedbackProbability points to the FeedbackProbability in statistics package.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -797,6 +797,9 @@ const (
 	TiDBDDLEnableFastReorg = "tidb_ddl_fast_reorg"
 	// TiDBDDLDiskQuota used to set disk quota for lightning add index.
 	TiDBDDLDiskQuota = "tidb_ddl_disk_quota"
+	// TiDBEnableDDLService indicates whether to enable the DDL service.
+	// When it is enabled, the current cluster will allow to run DDL jobs from other clusters registered in it.
+	TiDBEnableDDLService = "tidb_enable_ddl_service"
 )
 
 // TiDB intentional limits
@@ -1015,6 +1018,7 @@ const (
 	DefExecutorConcurrency                         = 5
 	DefTiDBEnableGeneralPlanCache                  = false
 	DefTiDBGeneralPlanCacheSize                    = 100
+	DefTiDBEnableDDLService                        = false
 	// MaxDDLReorgBatchSize is exported for testing.
 	MaxDDLReorgBatchSize           int32  = 10240
 	MinDDLReorgBatchSize           int32  = 32
@@ -1065,6 +1069,8 @@ var (
 	EnableFastReorg = atomic.NewBool(DefTiDBEnableFastReorg)
 	// DDLDiskQuota is the temporary variable for set disk quota for lightning
 	DDLDiskQuota = atomic.NewInt64(DefTiDBDDLDiskQuota)
+	// EnableDDLService indicates whether to enable DDL service
+	EnableDDLService = atomic.NewBool(DefTiDBEnableDDLService)
 )
 
 var (


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37303

### What is changed and how it works?

A variable `tidb_enable_ddl_service` is added. When it is on, the current cluster will be serving as a DDL service cluster. The default value is false.

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add new sys variable `tidb_enable_ddl_service`
```
