### PR TITLE
*: fix global temp table will read tikv after schema change

### DIFF
--- a/executor/temporary_table_test.go
+++ b/executor/temporary_table_test.go
@@ -42,6 +42,14 @@ func TestTemporaryTableNoNetwork(t *testing.T) {
 		})
 	})
 
+	t.Run("global create and then create a normal table", func(t *testing.T) {
+		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+			tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
+			tk.MustExec("create table txx(a int)")
+			tk.MustExec("begin")
+		})
+	})
+
 	t.Run("local", func(t *testing.T) {
 		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
 			tk.MustExec("create temporary table tmp_t (id int primary key, a int, b int, index(a))")

--- a/executor/temporary_table_test.go
+++ b/executor/temporary_table_test.go
@@ -26,42 +26,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTemporaryTableNoNetwork(t *testing.T) {
-	t.Run("global", func(t *testing.T) {
-		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
-			tk.MustExec("begin")
-		})
+func TestNormalGlobalTemporaryTableNoNetwork(t *testing.T) {
+	assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+		tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
+		tk.MustExec("begin")
 	})
+}
 
-	t.Run("global create and then truncate", func(t *testing.T) {
-		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
-			tk.MustExec("truncate table tmp_t")
-			tk.MustExec("begin")
-		})
+func TestGlobalTemporaryTableNoNetworkWithCreateAndTruncate(t *testing.T) {
+	assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+		tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
+		tk.MustExec("truncate table tmp_t")
+		tk.MustExec("begin")
 	})
+}
 
-	t.Run("global create and then create a normal table", func(t *testing.T) {
-		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
-			tk.MustExec("create table txx(a int)")
-			tk.MustExec("begin")
-		})
+func TestGlobalTemporaryTableNoNetworkWithCreateAndThenCreateNormalTable(t *testing.T) {
+	assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+		tk.MustExec("create global temporary table tmp_t (id int primary key, a int, b int, index(a)) on commit delete rows")
+		tk.MustExec("create table txx(a int)")
+		tk.MustExec("begin")
 	})
+}
 
-	t.Run("local", func(t *testing.T) {
-		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("create temporary table tmp_t (id int primary key, a int, b int, index(a))")
-			tk.MustExec("begin")
-		})
+func TestLocalTemporaryTableNoNetworkWithCreateOutsideTxn(t *testing.T) {
+	assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+		tk.MustExec("create temporary table tmp_t (id int primary key, a int, b int, index(a))")
+		tk.MustExec("begin")
 	})
+}
 
-	t.Run("local and create table inside txn", func(t *testing.T) {
-		assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
-			tk.MustExec("begin")
-			tk.MustExec("create temporary table tmp_t (id int primary key, a int, b int, index(a))")
-		})
+func TestLocalTemporaryTableNoNetworkWithInsideTxn(t *testing.T) {
+	assertTemporaryTableNoNetwork(t, func(tk *testkit.TestKit) {
+		tk.MustExec("begin")
+		tk.MustExec("create temporary table tmp_t (id int primary key, a int, b int, index(a))")
 	})
 }
 

--- a/infoschema/builder.go
+++ b/infoschema/builder.go
@@ -786,6 +786,7 @@ func (b *Builder) InitWithOldInfoSchema(oldSchema InfoSchema) *Builder {
 	b.copySchemasMap(oldIS)
 	b.copyBundlesMap(oldIS)
 	b.copyPoliciesMap(oldIS)
+	b.copyTemporaryTableIDsMap(oldIS)
 
 	copy(b.is.sortedTablesBuckets, oldIS.sortedTablesBuckets)
 	return b
@@ -808,6 +809,19 @@ func (b *Builder) copyPoliciesMap(oldIS *infoSchema) {
 	is := b.is
 	for _, v := range oldIS.AllPlacementPolicies() {
 		is.policyMap[v.Name.L] = v
+	}
+}
+
+func (b *Builder) copyTemporaryTableIDsMap(oldIS *infoSchema) {
+	is := b.is
+	if len(oldIS.temporaryTableIDs) == 0 {
+		is.temporaryTableIDs = nil
+		return
+	}
+
+	is.temporaryTableIDs = make(map[int64]struct{})
+	for tblID := range oldIS.temporaryTableIDs {
+		is.temporaryTableIDs[tblID] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37306

Problem Summary:

This bug is introduced by #37225.  When the information schema applying diff, it will create a builder and then call `InitWithOldInfoSchema` to copy old schema to the new one. However, the previous PR forgot to copy `temporaryTableIDs` in it.

### What is changed and how it works?

copy `temporaryTableIDs` in `InitWithOldInfoSchema`

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
