### PR TITLE
expression: implement comparison between json opaque

### DIFF
--- a/types/json/binary_functions.go
+++ b/types/json/binary_functions.go
@@ -803,10 +803,15 @@ func CompareBinary(left, right BinaryJSON) int {
 				}
 			}
 		case TypeCodeOpaque:
-			cmp = bytes.Compare(left.GetString(), right.GetString())
+			cmp = bytes.Compare(left.GetOpaque().Buf, right.GetOpaque().Buf)
 		}
 	} else {
 		cmp = precedence1 - precedence2
+		if cmp > 0 {
+			cmp = 1
+		} else if cmp < 0 {
+			cmp = -1
+		}
 	}
 	return cmp
 }

--- a/types/json/binary_functions_test.go
+++ b/types/json/binary_functions_test.go
@@ -49,3 +49,57 @@ func BenchmarkMergeBinary(b *testing.B) {
 		_ = MergeBinary([]BinaryJSON{valueA, valueB})
 	}
 }
+
+func TestBinaryCompare(t *testing.T) {
+	tests := []struct {
+		left   BinaryJSON
+		right  BinaryJSON
+		result int
+	}{
+		{
+			CreateBinary("a"),
+			CreateBinary("b"),
+			-1,
+		},
+		{
+			CreateBinary(Opaque{
+				TypeCode: 0,
+				Buf:      []byte{0, 1, 2, 3},
+			}),
+			CreateBinary(Opaque{
+				TypeCode: 0,
+				Buf:      []byte{0, 1, 2},
+			}),
+			1,
+		},
+		{
+			CreateBinary(Opaque{
+				TypeCode: 0,
+				Buf:      []byte{0, 1, 2, 3},
+			}),
+			CreateBinary(Opaque{
+				TypeCode: 0,
+				Buf:      []byte{0, 2, 1},
+			}),
+			-1,
+		},
+		{
+			CreateBinary("test"),
+			CreateBinary(Opaque{
+				TypeCode: 0,
+				Buf:      []byte{0, 2, 1},
+			}),
+			-1,
+		},
+	}
+
+	compareMsg := map[int]string{
+		1:  "greater than",
+		0:  "equal with",
+		-1: "smaller than",
+	}
+
+	for _, test := range tests {
+		require.Equal(t, test.result, CompareBinary(test.left, test.right), "%s should be %s %s", test.left.String(), compareMsg[test.result], test.right.String())
+	}
+}


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37315

Problem Summary:

The comparison between json opaque is not implemented. They are currently comparing the `.GetString` of them, which will cause panic!

### What is changed and how it works?

Implement the json opaque through comparing the `.GetOpaque().Buf`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue that comparison between json opaque will cause panic
```
