### PR TITLE
session: handle nil store for plugins

### DIFF
--- a/session/tidb.go
+++ b/session/tidb.go
@@ -51,10 +51,18 @@ type domainMap struct {
 }
 
 func (dm *domainMap) Get(store kv.Storage) (d *domain.Domain, err error) {
-	key := store.UUID()
-
 	dm.mu.Lock()
 	defer dm.mu.Unlock()
+
+	if store == nil {
+		for _, d := range dm.domains {
+			// return available domain if any
+			return d, nil
+		}
+		return nil, errors.New("can not find available domain for a nil store")
+	}
+
+	key := store.UUID()
 
 	d = dm.domains[key]
 	if d != nil {

--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -26,6 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestDomapHandleNil(t *testing.T) {
+	// this is required for enterprise plugins
+	// ref: https://github.com/pingcap/tidb/issues/37319
+	require.NotPanics(t, func() {
+		_, _ = domap.Get(nil)
+	})
+}
+
 func TestSysSessionPoolGoroutineLeak(t *testing.T) {
 	store, dom := createStoreAndBootstrap(t)
 	defer func() { require.NoError(t, store.Close()) }()


### PR DESCRIPTION
Signed-off-by: xhe <xw897002528@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37319

Problem Summary: Enterprise plugin will pass nil store.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix panic of enterprise plugin on 6.1
```
