### PR TITLE
*: fix data race in `TestTiFlashGroupIndexWhenStartup`

### DIFF
--- a/ddl/ddl_tiflash_test.go
+++ b/ddl/ddl_tiflash_test.go
@@ -998,18 +998,19 @@ func TestTiFlashBatchUnsupported(t *testing.T) {
 
 func TestTiFlashGroupIndexWhenStartup(t *testing.T) {
 	s, teardown := createTiFlashContext(t)
+	tiflash := s.tiflash
 	defer teardown()
 	_ = testkit.NewTestKit(t, s.store)
 	timeout := time.Now().Add(10 * time.Second)
 	errMsg := "time out"
 	for time.Now().Before(timeout) {
 		time.Sleep(100 * time.Millisecond)
-		if s.tiflash.GroupIndex != 0 {
+		if tiflash.GetRuleGroupIndex() != 0 {
 			errMsg = "invalid group index"
 			break
 		}
 	}
-	require.Equal(t, placement.RuleIndexTiFlash, s.tiflash.GroupIndex, errMsg)
-	require.Greater(t, s.tiflash.GroupIndex, placement.RuleIndexTable)
-	require.Greater(t, s.tiflash.GroupIndex, placement.RuleIndexPartition)
+	require.Equal(t, placement.RuleIndexTiFlash, tiflash.GetRuleGroupIndex(), errMsg)
+	require.Greater(t, tiflash.GetRuleGroupIndex(), placement.RuleIndexTable)
+	require.Greater(t, tiflash.GetRuleGroupIndex(), placement.RuleIndexPartition)
 }

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -305,7 +305,7 @@ func (m *mockTiFlashTableInfo) String() string {
 // MockTiFlash mocks a TiFlash, with necessary Pd support.
 type MockTiFlash struct {
 	sync.Mutex
-	GroupIndex                  int
+	groupIndex                  int
 	StatusAddr                  string
 	StatusServer                *httptest.Server
 	SyncStatus                  map[int]mockTiFlashTableInfo
@@ -373,7 +373,7 @@ func NewMockTiFlash() *MockTiFlash {
 func (tiflash *MockTiFlash) HandleSetPlacementRule(rule placement.TiFlashRule) error {
 	tiflash.Lock()
 	defer tiflash.Unlock()
-	tiflash.GroupIndex = placement.RuleIndexTiFlash
+	tiflash.groupIndex = placement.RuleIndexTiFlash
 	if !tiflash.PdEnabled {
 		logutil.BgLogger().Info("pd server is manually disabled, just quit")
 		return nil
@@ -492,6 +492,18 @@ func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	}
 }
 
+func (tiflash *MockTiFlash) SetRuleGroupIndex(groupIndex int) {
+	tiflash.Lock()
+	defer tiflash.Unlock()
+	tiflash.groupIndex = groupIndex
+}
+
+func (tiflash *MockTiFlash) GetRuleGroupIndex() int {
+	tiflash.Lock()
+	defer tiflash.Unlock()
+	return tiflash.groupIndex
+}
+
 // Compare supposed rule, and we actually get from TableInfo
 func isRuleMatch(rule placement.TiFlashRule, startKey string, endKey string, count int, labels []string) bool {
 	// Compute startKey
@@ -598,7 +610,7 @@ func (m *mockTiFlashPlacementManager) SetTiFlashGroupConfig(_ context.Context) e
 	if m.tiflash == nil {
 		return nil
 	}
-	m.tiflash.GroupIndex = placement.RuleIndexTiFlash
+	m.tiflash.SetRuleGroupIndex(placement.RuleIndexTiFlash)
 	return nil
 }
 

--- a/domain/infosync/tiflash_manager.go
+++ b/domain/infosync/tiflash_manager.go
@@ -492,12 +492,14 @@ func (tiflash *MockTiFlash) HandleGetStoresStat() *helper.StoresStat {
 	}
 }
 
+// SetRuleGroupIndex sets the group index of tiflash
 func (tiflash *MockTiFlash) SetRuleGroupIndex(groupIndex int) {
 	tiflash.Lock()
 	defer tiflash.Unlock()
 	tiflash.groupIndex = groupIndex
 }
 
+// GetRuleGroupIndex gets the group index of tiflash
 func (tiflash *MockTiFlash) GetRuleGroupIndex() int {
 	tiflash.Lock()
 	defer tiflash.Unlock()


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37370

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
