### PR TITLE
*: rename TemporaryTableAttachedInfoSchema

### DIFF
--- a/ddl/db_integration_test.go
+++ b/ddl/db_integration_test.go
@@ -3460,7 +3460,7 @@ func TestDropTemporaryTable(t *testing.T) {
 	require.NoError(t, err)
 	sessionVars := tk.Session().GetSessionVars()
 	sessVarsTempTable := sessionVars.LocalTemporaryTables
-	localTemporaryTable := sessVarsTempTable.(*infoschema.LocalTemporaryTables)
+	localTemporaryTable := sessVarsTempTable.(*infoschema.SessionTables)
 	tbl, exist := localTemporaryTable.TableByName(model.NewCIStr("test"), model.NewCIStr("a_local_temp_table_7"))
 	require.True(t, exist)
 	tblInfo := tbl.Meta()
@@ -3719,7 +3719,7 @@ func TestTruncateLocalTemporaryTable(t *testing.T) {
 	tk.MustExec("create temporary table t1 (id int primary key auto_increment)")
 
 	// truncate temporary table will clear session data
-	localTemporaryTables := tk.Session().GetSessionVars().LocalTemporaryTables.(*infoschema.LocalTemporaryTables)
+	localTemporaryTables := tk.Session().GetSessionVars().LocalTemporaryTables.(*infoschema.SessionTables)
 	tb1, exist := localTemporaryTables.TableByName(model.NewCIStr("test"), model.NewCIStr("t1"))
 	tbl1Info := tb1.Meta()
 	tablePrefix := tablecodec.EncodeTablePrefix(tbl1Info.ID)

--- a/infoschema/infoschema.go
+++ b/infoschema/infoschema.go
@@ -417,8 +417,8 @@ func (is *infoSchema) deletePolicy(name string) {
 	delete(is.policyMap, name)
 }
 
-// LocalTemporaryTables store local temporary tables
-type LocalTemporaryTables struct {
+// SessionTables store local temporary tables
+type SessionTables struct {
 	// Local temporary tables can be accessed after the db is dropped, so there needs a way to retain the DBInfo.
 	// schemaTables.dbInfo will only be used when the db is dropped and it may be stale after the db is created again.
 	// But it's fine because we only need its name.
@@ -426,16 +426,16 @@ type LocalTemporaryTables struct {
 	idx2table map[int64]table.Table
 }
 
-// NewLocalTemporaryTables creates a new NewLocalTemporaryTables object
-func NewLocalTemporaryTables() *LocalTemporaryTables {
-	return &LocalTemporaryTables{
+// NewSessionTables creates a new NewSessionTables object
+func NewSessionTables() *SessionTables {
+	return &SessionTables{
 		schemaMap: make(map[string]*schemaTables),
 		idx2table: make(map[int64]table.Table),
 	}
 }
 
 // TableByName get table by name
-func (is *LocalTemporaryTables) TableByName(schema, table model.CIStr) (table.Table, bool) {
+func (is *SessionTables) TableByName(schema, table model.CIStr) (table.Table, bool) {
 	if tbNames, ok := is.schemaMap[schema.L]; ok {
 		if t, ok := tbNames.tables[table.L]; ok {
 			return t, true
@@ -445,19 +445,19 @@ func (is *LocalTemporaryTables) TableByName(schema, table model.CIStr) (table.Ta
 }
 
 // TableExists check if table with the name exists
-func (is *LocalTemporaryTables) TableExists(schema, table model.CIStr) (ok bool) {
+func (is *SessionTables) TableExists(schema, table model.CIStr) (ok bool) {
 	_, ok = is.TableByName(schema, table)
 	return
 }
 
 // TableByID get table by table id
-func (is *LocalTemporaryTables) TableByID(id int64) (tbl table.Table, ok bool) {
+func (is *SessionTables) TableByID(id int64) (tbl table.Table, ok bool) {
 	tbl, ok = is.idx2table[id]
 	return
 }
 
 // AddTable add a table
-func (is *LocalTemporaryTables) AddTable(db *model.DBInfo, tbl table.Table) error {
+func (is *SessionTables) AddTable(db *model.DBInfo, tbl table.Table) error {
 	schemaTables := is.ensureSchema(db)
 
 	tblMeta := tbl.Meta()
@@ -476,7 +476,7 @@ func (is *LocalTemporaryTables) AddTable(db *model.DBInfo, tbl table.Table) erro
 }
 
 // RemoveTable remove a table
-func (is *LocalTemporaryTables) RemoveTable(schema, table model.CIStr) (exist bool) {
+func (is *SessionTables) RemoveTable(schema, table model.CIStr) (exist bool) {
 	tbls := is.schemaTables(schema)
 	if tbls == nil {
 		return false
@@ -496,12 +496,12 @@ func (is *LocalTemporaryTables) RemoveTable(schema, table model.CIStr) (exist bo
 }
 
 // Count gets the count of the temporary tables.
-func (is *LocalTemporaryTables) Count() int {
+func (is *SessionTables) Count() int {
 	return len(is.idx2table)
 }
 
 // SchemaByTable get a table's schema name
-func (is *LocalTemporaryTables) SchemaByTable(tableInfo *model.TableInfo) (*model.DBInfo, bool) {
+func (is *SessionTables) SchemaByTable(tableInfo *model.TableInfo) (*model.DBInfo, bool) {
 	if tableInfo == nil {
 		return nil, false
 	}
@@ -517,7 +517,7 @@ func (is *LocalTemporaryTables) SchemaByTable(tableInfo *model.TableInfo) (*mode
 	return nil, false
 }
 
-func (is *LocalTemporaryTables) ensureSchema(db *model.DBInfo) *schemaTables {
+func (is *SessionTables) ensureSchema(db *model.DBInfo) *schemaTables {
 	if tbls, ok := is.schemaMap[db.Name.L]; ok {
 		return tbls
 	}
@@ -527,7 +527,7 @@ func (is *LocalTemporaryTables) ensureSchema(db *model.DBInfo) *schemaTables {
 	return tbls
 }
 
-func (is *LocalTemporaryTables) schemaTables(schema model.CIStr) *schemaTables {
+func (is *SessionTables) schemaTables(schema model.CIStr) *schemaTables {
 	if is.schemaMap == nil {
 		return nil
 	}
@@ -539,16 +539,16 @@ func (is *LocalTemporaryTables) schemaTables(schema model.CIStr) *schemaTables {
 	return nil
 }
 
-// TemporaryTableAttachedInfoSchema implements InfoSchema
+// SessionExtendedInfoSchema implements InfoSchema
 // Local temporary table has a loose relationship with database.
 // So when a database is dropped, its temporary tables still exist and can be returned by TableByName/TableByID.
-type TemporaryTableAttachedInfoSchema struct {
+type SessionExtendedInfoSchema struct {
 	InfoSchema
-	LocalTemporaryTables *LocalTemporaryTables
+	LocalTemporaryTables *SessionTables
 }
 
 // TableByName implements InfoSchema.TableByName
-func (ts *TemporaryTableAttachedInfoSchema) TableByName(schema, table model.CIStr) (table.Table, error) {
+func (ts *SessionExtendedInfoSchema) TableByName(schema, table model.CIStr) (table.Table, error) {
 	if tbl, ok := ts.LocalTemporaryTables.TableByName(schema, table); ok {
 		return tbl, nil
 	}
@@ -557,7 +557,7 @@ func (ts *TemporaryTableAttachedInfoSchema) TableByName(schema, table model.CISt
 }
 
 // TableByID implements InfoSchema.TableByID
-func (ts *TemporaryTableAttachedInfoSchema) TableByID(id int64) (table.Table, bool) {
+func (ts *SessionExtendedInfoSchema) TableByID(id int64) (table.Table, bool) {
 	if tbl, ok := ts.LocalTemporaryTables.TableByID(id); ok {
 		return tbl, true
 	}
@@ -566,7 +566,7 @@ func (ts *TemporaryTableAttachedInfoSchema) TableByID(id int64) (table.Table, bo
 }
 
 // SchemaByTable implements InfoSchema.SchemaByTable, it returns a stale DBInfo even if it's dropped.
-func (ts *TemporaryTableAttachedInfoSchema) SchemaByTable(tableInfo *model.TableInfo) (*model.DBInfo, bool) {
+func (ts *SessionExtendedInfoSchema) SchemaByTable(tableInfo *model.TableInfo) (*model.DBInfo, bool) {
 	if tableInfo == nil {
 		return nil, false
 	}
@@ -579,6 +579,6 @@ func (ts *TemporaryTableAttachedInfoSchema) SchemaByTable(tableInfo *model.Table
 }
 
 // HasTemporaryTable returns whether information schema has temporary table
-func (ts *TemporaryTableAttachedInfoSchema) HasTemporaryTable() bool {
+func (ts *SessionExtendedInfoSchema) HasTemporaryTable() bool {
 	return ts.LocalTemporaryTables.Count() > 0 || ts.InfoSchema.HasTemporaryTable()
 }

--- a/infoschema/infoschema_test.go
+++ b/infoschema/infoschema_test.go
@@ -591,7 +591,7 @@ func TestLocalTemporaryTables(t *testing.T) {
 		return tbl
 	}
 
-	assertTableByName := func(sc *infoschema.LocalTemporaryTables, schemaName, tableName string, schema *model.DBInfo, tb table.Table) {
+	assertTableByName := func(sc *infoschema.SessionTables, schemaName, tableName string, schema *model.DBInfo, tb table.Table) {
 		got, ok := sc.TableByName(model.NewCIStr(schemaName), model.NewCIStr(tableName))
 		if tb == nil {
 			require.Nil(t, schema)
@@ -604,12 +604,12 @@ func TestLocalTemporaryTables(t *testing.T) {
 		}
 	}
 
-	assertTableExists := func(sc *infoschema.LocalTemporaryTables, schemaName, tableName string, exists bool) {
+	assertTableExists := func(sc *infoschema.SessionTables, schemaName, tableName string, exists bool) {
 		got := sc.TableExists(model.NewCIStr(schemaName), model.NewCIStr(tableName))
 		require.Equal(t, exists, got)
 	}
 
-	assertTableByID := func(sc *infoschema.LocalTemporaryTables, tbID int64, schema *model.DBInfo, tb table.Table) {
+	assertTableByID := func(sc *infoschema.SessionTables, tbID int64, schema *model.DBInfo, tb table.Table) {
 		got, ok := sc.TableByID(tbID)
 		if tb == nil {
 			require.Nil(t, schema)
@@ -622,7 +622,7 @@ func TestLocalTemporaryTables(t *testing.T) {
 		}
 	}
 
-	assertSchemaByTable := func(sc *infoschema.LocalTemporaryTables, db *model.DBInfo, tb *model.TableInfo) {
+	assertSchemaByTable := func(sc *infoschema.SessionTables, db *model.DBInfo, tb *model.TableInfo) {
 		got, ok := sc.SchemaByTable(tb)
 		if db == nil {
 			require.Nil(t, got)
@@ -634,7 +634,7 @@ func TestLocalTemporaryTables(t *testing.T) {
 		}
 	}
 
-	sc := infoschema.NewLocalTemporaryTables()
+	sc := infoschema.NewSessionTables()
 	db1 := createNewSchemaInfo("db1")
 	tb11 := createNewTable(db1.ID, "tb1", model.TempTableLocal)
 	tb12 := createNewTable(db1.ID, "Tb2", model.TempTableLocal)
@@ -737,14 +737,14 @@ func TestLocalTemporaryTables(t *testing.T) {
 	assertSchemaByTable(sc, nil, tb22.Meta())
 	assertSchemaByTable(sc, nil, nil)
 
-	// test TemporaryTableAttachedInfoSchema
+	// test SessionExtendedInfoSchema
 	dbTest := createNewSchemaInfo("test")
 	tmpTbTestA := createNewTable(dbTest.ID, "tba", model.TempTableLocal)
 	normalTbTestA := createNewTable(dbTest.ID, "tba", model.TempTableNone)
 	normalTbTestB := createNewTable(dbTest.ID, "tbb", model.TempTableNone)
 	normalTbTestC := createNewTable(db1.ID, "tbc", model.TempTableNone)
 
-	is := &infoschema.TemporaryTableAttachedInfoSchema{
+	is := &infoschema.SessionExtendedInfoSchema{
 		InfoSchema:           infoschema.MockInfoSchema([]*model.TableInfo{normalTbTestA.Meta(), normalTbTestB.Meta()}),
 		LocalTemporaryTables: sc,
 	}

--- a/session/session.go
+++ b/session/session.go
@@ -796,13 +796,13 @@ func (s *session) commitTxnWithTemporaryData(ctx context.Context, txn kv.Transac
 	sessionData := sessVars.TemporaryTableData
 	var (
 		stage           kv.StagingHandle
-		localTempTables *infoschema.LocalTemporaryTables
+		localTempTables *infoschema.SessionTables
 	)
 
 	if sessVars.LocalTemporaryTables != nil {
-		localTempTables = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables)
+		localTempTables = sessVars.LocalTemporaryTables.(*infoschema.SessionTables)
 	} else {
-		localTempTables = new(infoschema.LocalTemporaryTables)
+		localTempTables = new(infoschema.SessionTables)
 	}
 
 	defer func() {
@@ -3473,7 +3473,7 @@ func (s *session) EncodeSessionStates(ctx context.Context, sctx sessionctx.Conte
 	// Data in local temporary tables is hard to encode, so we do not support it.
 	// Check temporary tables here to avoid circle dependency.
 	if s.sessionVars.LocalTemporaryTables != nil {
-		localTempTables := s.sessionVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables)
+		localTempTables := s.sessionVars.LocalTemporaryTables.(*infoschema.SessionTables)
 		if localTempTables.Count() > 0 {
 			return sessionstates.ErrCannotMigrateSession.GenWithStackByArgs("session has local temporary tables")
 		}

--- a/sessiontxn/failpoint.go
+++ b/sessiontxn/failpoint.go
@@ -75,9 +75,9 @@ func AssertTxnManagerInfoSchema(sctx sessionctx.Context, is interface{}) {
 	}
 
 	if localTables := sctx.GetSessionVars().LocalTemporaryTables; localTables != nil {
-		got, ok := GetTxnManager(sctx).GetTxnInfoSchema().(*infoschema.TemporaryTableAttachedInfoSchema)
+		got, ok := GetTxnManager(sctx).GetTxnInfoSchema().(*infoschema.SessionExtendedInfoSchema)
 		if !ok {
-			panic("Expected to be a TemporaryTableAttachedInfoSchema")
+			panic("Expected to be a SessionExtendedInfoSchema")
 		}
 
 		if got.LocalTemporaryTables != localTables {

--- a/sessiontxn/isolation/optimistic_test.go
+++ b/sessiontxn/isolation/optimistic_test.go
@@ -322,7 +322,7 @@ func TestTidbSnapshotVarInOptimisticTxn(t *testing.T) {
 	checkUseSnapshot := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, snapshotISVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.Equal(t, snapshotTS, readTS)
@@ -334,7 +334,7 @@ func TestTidbSnapshotVarInOptimisticTxn(t *testing.T) {
 	checkUseTxn := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, isVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.NotEqual(t, snapshotTS, readTS)

--- a/sessiontxn/isolation/readcommitted_test.go
+++ b/sessiontxn/isolation/readcommitted_test.go
@@ -391,7 +391,7 @@ func TestTidbSnapshotVarInRC(t *testing.T) {
 	checkUseSnapshot := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, snapshotISVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.Equal(t, snapshotTS, readTS)
@@ -403,7 +403,7 @@ func TestTidbSnapshotVarInRC(t *testing.T) {
 	checkUseTxn := func(useTxnTs bool) {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, isVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.NotEqual(t, snapshotTS, readTS)

--- a/sessiontxn/isolation/repeatable_read_test.go
+++ b/sessiontxn/isolation/repeatable_read_test.go
@@ -286,7 +286,7 @@ func TestTidbSnapshotVarInPessimisticRepeatableRead(t *testing.T) {
 	checkUseSnapshot := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, snapshotISVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.Equal(t, snapshotTS, readTS)
@@ -298,7 +298,7 @@ func TestTidbSnapshotVarInPessimisticRepeatableRead(t *testing.T) {
 	checkUseTxn := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, isVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.NotEqual(t, snapshotTS, readTS)

--- a/sessiontxn/isolation/serializable_test.go
+++ b/sessiontxn/isolation/serializable_test.go
@@ -206,7 +206,7 @@ func TestTidbSnapshotVarInSerialize(t *testing.T) {
 	checkUseSnapshot := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, snapshotISVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.Equal(t, snapshotTS, readTS)
@@ -218,7 +218,7 @@ func TestTidbSnapshotVarInSerialize(t *testing.T) {
 	checkUseTxn := func() {
 		is := provider.GetTxnInfoSchema()
 		require.Equal(t, isVersion, is.SchemaMetaVersion())
-		require.IsType(t, &infoschema.TemporaryTableAttachedInfoSchema{}, is)
+		require.IsType(t, &infoschema.SessionExtendedInfoSchema{}, is)
 		readTS, err := provider.GetStmtReadTS()
 		require.NoError(t, err)
 		require.NotEqual(t, snapshotTS, readTS)

--- a/sessiontxn/txn_manager_test.go
+++ b/sessiontxn/txn_manager_test.go
@@ -182,7 +182,7 @@ func TestEnterNewTxn(t *testing.T) {
 				require.Equal(t, stalenessTS, txn.StartTS())
 				is := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema()
 				require.Equal(t, is1.SchemaMetaVersion(), is.SchemaMetaVersion())
-				_, ok := is.(*infoschema.TemporaryTableAttachedInfoSchema)
+				_, ok := is.(*infoschema.SessionExtendedInfoSchema)
 				require.True(t, ok)
 
 				sessVars := sctx.GetSessionVars()
@@ -567,10 +567,10 @@ func checkNonActiveStalenessTxn(t *testing.T, sctx sessionctx.Context, ts uint64
 }
 
 func checkInfoSchemaVersion(t *testing.T, sctx sessionctx.Context, ver int64) {
-	is1, ok := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().(*infoschema.TemporaryTableAttachedInfoSchema)
+	is1, ok := sessiontxn.GetTxnManager(sctx).GetTxnInfoSchema().(*infoschema.SessionExtendedInfoSchema)
 	require.True(t, ok)
 
-	is2 := sctx.GetSessionVars().TxnCtx.InfoSchema.(*infoschema.TemporaryTableAttachedInfoSchema)
+	is2 := sctx.GetSessionVars().TxnCtx.InfoSchema.(*infoschema.SessionExtendedInfoSchema)
 	require.True(t, ok)
 
 	require.Equal(t, ver, is1.SchemaMetaVersion())

--- a/table/temptable/ddl_test.go
+++ b/table/temptable/ddl_test.go
@@ -63,7 +63,7 @@ func TestAddLocalTemporaryTable(t *testing.T) {
 	require.NotNil(t, sessVars.LocalTemporaryTables)
 	require.NotNil(t, sessVars.TemporaryTableData)
 	require.Equal(t, int64(1), tbl1.ID)
-	got, exists := sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists := sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1)
 
@@ -71,7 +71,7 @@ func TestAddLocalTemporaryTable(t *testing.T) {
 	err = ddl.CreateLocalTemporaryTable(db1, tbl2)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), tbl2.ID)
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t2"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t2"))
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl2)
 
@@ -88,20 +88,20 @@ func TestAddLocalTemporaryTable(t *testing.T) {
 	tbl1x := newMockTable("t1")
 	err = ddl.CreateLocalTemporaryTable(db1, tbl1x)
 	require.True(t, infoschema.ErrTableExists.Equal(err))
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1)
 
 	// insert should be success for same table name in different db
 	err = ddl.CreateLocalTemporaryTable(db2, tbl1x)
 	require.NoError(t, err)
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db2"), model.NewCIStr("t1"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db2"), model.NewCIStr("t1"))
 	require.Equal(t, int64(4), got.Meta().ID)
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1x)
 
 	// tbl1 still exist
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1)
 }
@@ -134,7 +134,7 @@ func TestRemoveLocalTemporaryTable(t *testing.T) {
 	require.True(t, infoschema.ErrTableNotExists.Equal(err))
 
 	// check failed remove should have no effects
-	got, exists := sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByID(tbl1.ID)
+	got, exists := sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByID(tbl1.ID)
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1)
 	val, err := sessVars.TemporaryTableData.Get(context.Background(), k)
@@ -144,7 +144,7 @@ func TestRemoveLocalTemporaryTable(t *testing.T) {
 	// remove success
 	err = ddl.DropLocalTemporaryTable(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.NoError(t, err)
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.Nil(t, got)
 	require.False(t, exists)
 	val, err = sessVars.TemporaryTableData.Get(context.Background(), k)
@@ -180,7 +180,7 @@ func TestTruncateLocalTemporaryTable(t *testing.T) {
 	require.True(t, infoschema.ErrTableNotExists.Equal(err))
 
 	// check failed should have no effects
-	got, exists := sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists := sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.True(t, exists)
 	require.Equal(t, got.Meta(), tbl1)
 	val, err := sessVars.TemporaryTableData.Get(context.Background(), k)
@@ -199,7 +199,7 @@ func TestTruncateLocalTemporaryTable(t *testing.T) {
 	// truncate success
 	err = ddl.TruncateLocalTemporaryTable(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.NoError(t, err)
-	got, exists = sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
+	got, exists = sessVars.LocalTemporaryTables.(*infoschema.SessionTables).TableByName(model.NewCIStr("db1"), model.NewCIStr("t1"))
 	require.True(t, exists)
 	require.NotEqual(t, got.Meta(), tbl1)
 	require.Equal(t, int64(3), got.Meta().ID)

--- a/table/temptable/infoschema.go
+++ b/table/temptable/infoschema.go
@@ -26,11 +26,11 @@ func AttachLocalTemporaryTableInfoSchema(sctx sessionctx.Context, is infoschema.
 		return is
 	}
 
-	if _, ok := is.(*infoschema.TemporaryTableAttachedInfoSchema); ok {
+	if _, ok := is.(*infoschema.SessionExtendedInfoSchema); ok {
 		return is
 	}
 
-	return &infoschema.TemporaryTableAttachedInfoSchema{
+	return &infoschema.SessionExtendedInfoSchema{
 		InfoSchema:           is,
 		LocalTemporaryTables: localTemporaryTables,
 	}
@@ -38,29 +38,29 @@ func AttachLocalTemporaryTableInfoSchema(sctx sessionctx.Context, is infoschema.
 
 // DetachLocalTemporaryTableInfoSchema detach local temporary table information schema from is
 func DetachLocalTemporaryTableInfoSchema(is infoschema.InfoSchema) infoschema.InfoSchema {
-	if attachedInfoSchema, ok := is.(*infoschema.TemporaryTableAttachedInfoSchema); ok {
+	if attachedInfoSchema, ok := is.(*infoschema.SessionExtendedInfoSchema); ok {
 		return attachedInfoSchema.InfoSchema
 	}
 
 	return is
 }
 
-func getLocalTemporaryTables(sctx sessionctx.Context) *infoschema.LocalTemporaryTables {
+func getLocalTemporaryTables(sctx sessionctx.Context) *infoschema.SessionTables {
 	localTemporaryTables := sctx.GetSessionVars().LocalTemporaryTables
 	if localTemporaryTables == nil {
 		return nil
 	}
 
-	return localTemporaryTables.(*infoschema.LocalTemporaryTables)
+	return localTemporaryTables.(*infoschema.SessionTables)
 }
 
-func ensureLocalTemporaryTables(sctx sessionctx.Context) *infoschema.LocalTemporaryTables {
+func ensureLocalTemporaryTables(sctx sessionctx.Context) *infoschema.SessionTables {
 	sessVars := sctx.GetSessionVars()
 	if sessVars.LocalTemporaryTables == nil {
-		localTempTables := infoschema.NewLocalTemporaryTables()
+		localTempTables := infoschema.NewSessionTables()
 		sessVars.LocalTemporaryTables = localTempTables
 		return localTempTables
 	}
 
-	return sessVars.LocalTemporaryTables.(*infoschema.LocalTemporaryTables)
+	return sessVars.LocalTemporaryTables.(*infoschema.SessionTables)
 }


### PR DESCRIPTION
Signed-off-by: wjhuang2016 <huangwenjun1997@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->


Problem Summary:
TemporaryTableAttachedInfoSchema will save MDL table's tableInfo later, rename it now.

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
