### PR TITLE
planner: allow requesting MPP task for simple selection or projection operator

### DIFF
--- a/bindinfo/bind_test.go
+++ b/bindinfo/bind_test.go
@@ -872,16 +872,17 @@ func TestNotEvolvePlanForReadStorageHint(t *testing.T) {
 	}
 
 	// Make sure the best plan of the SQL is use TiKV index.
-	tk.MustExec("set @@session.tidb_executor_concurrency = 4;")
+	tk.MustExec("set @@session.tidb_executor_concurrency = 4; set @@tidb_allow_mpp=0;")
 	rows := tk.MustQuery("explain select * from t where a >= 11 and b >= 11").Rows()
 	require.Equal(t, "cop[tikv]", fmt.Sprintf("%v", rows[len(rows)-1][2]))
+	tk.MustExec("set @@tidb_allow_mpp=1")
 
 	tk.MustExec("create global binding for select * from t where a >= 1 and b >= 1 using select /*+ read_from_storage(tiflash[t]) */ * from t where a >= 1 and b >= 1")
 	tk.MustExec("set @@tidb_evolve_plan_baselines=1")
 
 	// Even if index of TiKV has lower cost, it chooses TiFlash.
 	rows = tk.MustQuery("explain select * from t where a >= 11 and b >= 11").Rows()
-	require.Equal(t, "cop[tiflash]", fmt.Sprintf("%v", rows[len(rows)-1][2]))
+	require.Equal(t, "mpp[tiflash]", fmt.Sprintf("%v", rows[len(rows)-1][2]))
 
 	tk.MustExec("admin flush bindings")
 	rows = tk.MustQuery("show global bindings").Rows()
@@ -920,7 +921,7 @@ func TestBindingWithIsolationRead(t *testing.T) {
 	// Even if we build a binding use index for SQL, but after we set the isolation read for TiFlash, it choose TiFlash instead of index of TiKV.
 	tk.MustExec("set @@tidb_isolation_read_engines = \"tiflash\"")
 	rows = tk.MustQuery("explain select * from t where a >= 11 and b >= 11").Rows()
-	require.Equal(t, "cop[tiflash]", rows[len(rows)-1][2])
+	require.Equal(t, "mpp[tiflash]", rows[len(rows)-1][2])
 }
 
 func TestReCreateBindAfterEvolvePlan(t *testing.T) {

--- a/bindinfo/capture_test.go
+++ b/bindinfo/capture_test.go
@@ -294,7 +294,7 @@ func TestCapturePlanBaselineIgnoreTiFlash(t *testing.T) {
 	}
 	// Here the plan is the TiFlash plan.
 	rows := tk.MustQuery("explain select * from t").Rows()
-	require.Equal(t, "cop[tiflash]", fmt.Sprintf("%v", rows[len(rows)-1][2]))
+	require.Equal(t, "mpp[tiflash]", fmt.Sprintf("%v", rows[len(rows)-1][2]))
 
 	tk.MustQuery("show global bindings").Check(testkit.Rows())
 	tk.MustExec("admin capture bindings")

--- a/executor/prepared_test.go
+++ b/executor/prepared_test.go
@@ -1197,6 +1197,9 @@ func TestPrepareStmtAfterIsolationReadChange(t *testing.T) {
 	require.Equal(t, "cop[tikv]", rows[len(rows)-1][2])
 
 	tk.MustExec("set @@session.tidb_isolation_read_engines='tiflash'")
+	// allowing mpp will generate mpp[tiflash] plan, the test framework will time out due to
+	// "retry for TiFlash peer with region missing", so disable mpp mode to use cop mode instead.
+	tk.MustExec("set @@session.tidb_allow_mpp=0")
 	tk.MustExec("execute stmt")
 	tkProcess = tk.Session().ShowProcess()
 	ps = []*util.ProcessInfo{tkProcess}

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -2045,8 +2045,8 @@ func (p *LogicalProjection) exhaustPhysicalPlans(prop *property.PhysicalProperty
 		return nil, true, nil
 	}
 	newProps := []*property.PhysicalProperty{newProp}
-	// generate a mpp task candidate if enforced mpp
-	if newProp.TaskTp != property.MppTaskType && p.SCtx().GetSessionVars().IsMPPEnforced() && p.canPushToCop(kv.TiFlash) &&
+	// generate a mpp task candidate if mpp mode is allowed
+	if newProp.TaskTp != property.MppTaskType && p.SCtx().GetSessionVars().IsMPPAllowed() && p.canPushToCop(kv.TiFlash) &&
 		expression.CanExprsPushDown(p.SCtx().GetSessionVars().StmtCtx, p.Exprs, p.SCtx().GetClient(), kv.TiFlash) {
 		mppProp := newProp.CloneEssentialFields()
 		mppProp.TaskTp = property.MppTaskType

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -6346,8 +6346,9 @@ func TestIssue31202(t *testing.T) {
 	tbl.Meta().TiFlashReplica = &model.TiFlashReplicaInfo{Count: 1, Available: true}
 
 	tk.MustQuery("explain format = 'brief' select * from t31202;").Check(testkit.Rows(
-		"TableReader 10000.00 root  data:TableFullScan",
-		"└─TableFullScan 10000.00 cop[tiflash] table:t31202 keep order:false, stats:pseudo"))
+		"TableReader 10000.00 root  data:ExchangeSender",
+		"└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+		"  └─TableFullScan 10000.00 mpp[tiflash] table:t31202 keep order:false, stats:pseudo"))
 
 	tk.MustQuery("explain format = 'brief' select * from t31202 use index (primary);").Check(testkit.Rows(
 		"TableReader 10000.00 root  data:TableFullScan",

--- a/planner/core/physical_plan_test.go
+++ b/planner/core/physical_plan_test.go
@@ -2009,7 +2009,7 @@ func TestMPPSinglePartitionType(t *testing.T) {
 	tk.MustExec("use test")
 	tk.MustExec("drop table if exists employee")
 	tk.MustExec("create table employee(empid int, deptid int, salary decimal(10,2))")
-	tk.MustExec("set tidb_enforce_mpp=1")
+	tk.MustExec("set tidb_enforce_mpp=0")
 
 	is := dom.InfoSchema()
 	db, exists := is.SchemaByName(model.NewCIStr("test"))

--- a/planner/core/plan_cost_test.go
+++ b/planner/core/plan_cost_test.go
@@ -1024,12 +1024,12 @@ func TestScanOnSmallTable(t *testing.T) {
 	}
 
 	rs := tk.MustQuery("explain select * from t").Rows()
-	useTiKVScan := false
+	useTiKVScan := true
 	for _, r := range rs {
 		op := r[0].(string)
 		task := r[2].(string)
 		if strings.Contains(op, "Scan") && strings.Contains(task, "tikv") {
-			useTiKVScan = true
+			useTiKVScan = false
 		}
 	}
 	require.True(t, useTiKVScan)

--- a/planner/core/plan_test.go
+++ b/planner/core/plan_test.go
@@ -559,14 +559,14 @@ func TestExplainFormatHintRecoverableForTiFlashReplica(t *testing.T) {
 	}
 
 	rows := tk.MustQuery("explain select * from t").Rows()
-	require.Equal(t, rows[len(rows)-1][2], "cop[tiflash]")
+	require.Equal(t, rows[len(rows)-1][2], "mpp[tiflash]")
 
 	rows = tk.MustQuery("explain format='hint' select * from t").Rows()
 	require.Equal(t, rows[0][0], "read_from_storage(@`sel_1` tiflash[`test`.`t`])")
 
 	hints := tk.MustQuery("explain format='hint' select * from t;").Rows()[0][0]
 	rows = tk.MustQuery(fmt.Sprintf("explain select /*+ %s */ * from t", hints)).Rows()
-	require.Equal(t, rows[len(rows)-1][2], "cop[tiflash]")
+	require.Equal(t, rows[len(rows)-1][2], "mpp[tiflash]")
 }
 
 func TestNthPlanHint(t *testing.T) {

--- a/planner/core/testdata/analyze_suite_out.json
+++ b/planner/core/testdata/analyze_suite_out.json
@@ -286,19 +286,21 @@
     "Name": "TestTiFlashCostModel",
     "Cases": [
       [
-        "TableReader_7 10000.00 root  data:TableFullScan_6",
-        "└─TableFullScan_6 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+        "TableReader_11 10000.00 root  data:ExchangeSender_10",
+        "└─ExchangeSender_10 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+        "  └─TableFullScan_9 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
       ],
       [
-        "TableReader_5 10000.00 root  data:TableFullScan_4",
-        "└─TableFullScan_4 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
+        "TableReader_6 10000.00 root  data:TableFullScan_5",
+        "└─TableFullScan_5 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"
       ],
       [
         "Batch_Point_Get_5 2.00 root table:t handle:[1 2], keep order:false, desc:false"
       ],
       [
-        "TableReader_6 2.00 root  data:TableRangeScan_5",
-        "└─TableRangeScan_5 2.00 cop[tiflash] table:t range:[1,1], [2,2], keep order:false, stats:pseudo"
+        "TableReader_10 2.00 root  data:ExchangeSender_9",
+        "└─ExchangeSender_9 2.00 mpp[tiflash]  ExchangeType: PassThrough",
+        "  └─TableRangeScan_8 2.00 mpp[tiflash] table:t range:[1,1], [2,2], keep order:false, stats:pseudo"
       ]
     ]
   },

--- a/planner/core/testdata/enforce_mpp_suite_out.json
+++ b/planner/core/testdata/enforce_mpp_suite_out.json
@@ -72,32 +72,32 @@
       {
         "SQL": "explain format='verbose' select count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_30 1.00 35.88 root  funcs:count(Column#7)->Column#4",
-          "└─IndexReader_31 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 465.00 cop[tikv]  funcs:count(1)->Column#7",
-          "    └─IndexRangeScan_29 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
+          "StreamAgg_31 1.00 35.88 root  funcs:count(Column#7)->Column#4",
+          "└─IndexReader_32 1.00 32.88 root  index:StreamAgg_11",
+          "  └─StreamAgg_11 1.00 465.00 cop[tikv]  funcs:count(1)->Column#7",
+          "    └─IndexRangeScan_30 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_18 1.00 35.88 root  funcs:count(Column#6)->Column#4",
-          "└─IndexReader_19 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 465.00 cop[tikv]  funcs:count(1)->Column#6",
-          "    └─IndexRangeScan_17 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
+          "StreamAgg_19 1.00 35.88 root  funcs:count(Column#6)->Column#4",
+          "└─IndexReader_20 1.00 32.88 root  index:StreamAgg_11",
+          "  └─StreamAgg_11 1.00 465.00 cop[tikv]  funcs:count(1)->Column#6",
+          "    └─IndexRangeScan_18 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tiflash[t]) */ count(*) from t where a=1",
         "Plan": [
-          "HashAgg_21 1.00 11910.73 root  funcs:count(Column#6)->Column#4",
-          "└─TableReader_23 1.00 11877.13 root  data:ExchangeSender_22",
-          "  └─ExchangeSender_22 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_9 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
-          "      └─Selection_20 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
-          "        └─TableFullScan_19 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_22 1.00 11910.73 root  funcs:count(Column#6)->Column#4",
+          "└─TableReader_24 1.00 11877.13 root  data:ExchangeSender_23",
+          "  └─ExchangeSender_23 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_10 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
+          "      └─Selection_21 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
+          "        └─TableFullScan_20 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
@@ -109,34 +109,34 @@
       {
         "SQL": "explain format='verbose' select count(*) from t where a=1",
         "Plan": [
-          "HashAgg_24 1.00 33.89 root  funcs:count(Column#6)->Column#4",
-          "└─TableReader_26 1.00 0.29 root  data:ExchangeSender_25",
-          "  └─ExchangeSender_25 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_9 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
-          "      └─Selection_23 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
-          "        └─TableFullScan_22 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_25 1.00 33.89 root  funcs:count(Column#6)->Column#4",
+          "└─TableReader_27 1.00 0.29 root  data:ExchangeSender_26",
+          "  └─ExchangeSender_26 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_10 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
+          "      └─Selection_24 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
+          "        └─TableFullScan_23 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tikv[t]) */ count(*) from t where a=1",
         "Plan": [
-          "StreamAgg_18 1.00 35.88 root  funcs:count(Column#6)->Column#4",
-          "└─IndexReader_19 1.00 32.88 root  index:StreamAgg_10",
-          "  └─StreamAgg_10 1.00 465.00 cop[tikv]  funcs:count(1)->Column#6",
-          "    └─IndexRangeScan_17 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
+          "StreamAgg_19 1.00 35.88 root  funcs:count(Column#6)->Column#4",
+          "└─IndexReader_20 1.00 32.88 root  index:StreamAgg_11",
+          "  └─StreamAgg_11 1.00 465.00 cop[tikv]  funcs:count(1)->Column#6",
+          "    └─IndexRangeScan_18 10.00 435.00 cop[tikv] table:t, index:idx(a) range:[1,1], keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format='verbose' select /*+ read_from_storage(tiflash[t]) */ count(*) from t where a=1",
         "Plan": [
-          "HashAgg_21 1.00 33.89 root  funcs:count(Column#6)->Column#4",
-          "└─TableReader_23 1.00 0.29 root  data:ExchangeSender_22",
-          "  └─ExchangeSender_22 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg_9 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
-          "      └─Selection_20 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
-          "        └─TableFullScan_19 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg_22 1.00 33.89 root  funcs:count(Column#6)->Column#4",
+          "└─TableReader_24 1.00 0.29 root  data:ExchangeSender_23",
+          "  └─ExchangeSender_23 1.00 285030.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg_10 1.00 285030.00 mpp[tiflash]  funcs:count(1)->Column#6",
+          "      └─Selection_21 10.00 285000.00 mpp[tiflash]  eq(test.t.a, 1)",
+          "        └─TableFullScan_20 10000.00 255000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },

--- a/planner/core/testdata/integration_suite_out.json
+++ b/planner/core/testdata/integration_suite_out.json
@@ -2433,10 +2433,10 @@
       {
         "SQL": "explain format = 'verbose' select count(*) from t2",
         "Plan": [
-          "StreamAgg_25 1.00 8.18 root  funcs:count(Column#7)->Column#4",
-          "└─TableReader_26 1.00 5.17 root  data:StreamAgg_9",
-          "  └─StreamAgg_9 1.00 49.50 batchCop[tiflash]  funcs:count(1)->Column#7",
-          "    └─TableFullScan_24 3.00 40.50 batchCop[tiflash] table:t2 keep order:false"
+          "StreamAgg_26 1.00 8.18 root  funcs:count(Column#7)->Column#4",
+          "└─TableReader_27 1.00 5.17 root  data:StreamAgg_10",
+          "  └─StreamAgg_10 1.00 49.50 batchCop[tiflash]  funcs:count(1)->Column#7",
+          "    └─TableFullScan_25 3.00 40.50 batchCop[tiflash] table:t2 keep order:false"
         ]
       },
       {
@@ -2476,13 +2476,13 @@
       {
         "SQL": "explain format = 'verbose' select count(*) from t2 group by a",
         "Plan": [
-          "TableReader_24 3.00 4.16 root  data:ExchangeSender_23",
-          "└─ExchangeSender_23 3.00 76.80 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection_22 3.00 76.80 mpp[tiflash]  Column#4",
-          "    └─HashAgg_8 3.00 57.00 mpp[tiflash]  group by:test.t2.a, funcs:count(1)->Column#4",
-          "      └─ExchangeReceiver_21 3.00 48.00 mpp[tiflash]  ",
-          "        └─ExchangeSender_20 3.00 45.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t2.a, collate: binary]",
-          "          └─TableFullScan_19 3.00 45.00 mpp[tiflash] table:t2 keep order:false"
+          "TableReader_44 3.00 4.98 root  data:ExchangeSender_43",
+          "└─ExchangeSender_43 3.00 96.60 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection_38 3.00 76.80 mpp[tiflash]  Column#4",
+          "    └─HashAgg_36 3.00 57.00 mpp[tiflash]  group by:test.t2.a, funcs:count(1)->Column#4",
+          "      └─ExchangeReceiver_22 3.00 48.00 mpp[tiflash]  ",
+          "        └─ExchangeSender_21 3.00 45.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t2.a, collate: binary]",
+          "          └─TableFullScan_20 3.00 45.00 mpp[tiflash] table:t2 keep order:false"
         ]
       },
       {
@@ -2505,10 +2505,10 @@
       {
         "SQL": "explain format = 'verbose' select count(*) from t2 where a = 0",
         "Plan": [
-          "StreamAgg_11 1.00 4.93 root  funcs:count(1)->Column#4",
-          "└─TableReader_23 0.00 4.93 root  data:Selection_22",
-          "  └─Selection_22 0.00 54.00 cop[tiflash]  eq(test.t2.a, 0)",
-          "    └─TableFullScan_21 3.00 45.00 cop[tiflash] table:t2 keep order:false"
+          "StreamAgg_12 1.00 4.93 root  funcs:count(1)->Column#4",
+          "└─TableReader_24 0.00 4.93 root  data:Selection_23",
+          "  └─Selection_23 0.00 54.00 cop[tiflash]  eq(test.t2.a, 0)",
+          "    └─TableFullScan_22 3.00 45.00 cop[tiflash] table:t2 keep order:false"
         ]
       },
       {
@@ -2526,16 +2526,16 @@
       {
         "SQL": "explain format = 'verbose' select count(*) from t1 join t2 on t1.a = t2.a",
         "Plan": [
-          "StreamAgg_14 1.00 18.93 root  funcs:count(1)->Column#7",
-          "└─TableReader_46 3.00 9.93 root  data:ExchangeSender_45",
-          "  └─ExchangeSender_45 3.00 195.38 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashJoin_42 3.00 195.38 mpp[tiflash]  inner join, equal:[eq(test.t1.a, test.t2.a)]",
-          "      ├─ExchangeReceiver_21(Build) 3.00 57.00 mpp[tiflash]  ",
-          "      │ └─ExchangeSender_20 3.00 54.00 mpp[tiflash]  ExchangeType: Broadcast",
-          "      │   └─Selection_19 3.00 54.00 mpp[tiflash]  not(isnull(test.t1.a))",
-          "      │     └─TableFullScan_18 3.00 45.00 mpp[tiflash] table:t1 keep order:false",
-          "      └─Selection_23(Probe) 3.00 54.00 mpp[tiflash]  not(isnull(test.t2.a))",
-          "        └─TableFullScan_22 3.00 45.00 mpp[tiflash] table:t2 keep order:false"
+          "StreamAgg_15 1.00 18.93 root  funcs:count(1)->Column#7",
+          "└─TableReader_47 3.00 9.93 root  data:ExchangeSender_46",
+          "  └─ExchangeSender_46 3.00 195.38 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashJoin_43 3.00 195.38 mpp[tiflash]  inner join, equal:[eq(test.t1.a, test.t2.a)]",
+          "      ├─ExchangeReceiver_22(Build) 3.00 57.00 mpp[tiflash]  ",
+          "      │ └─ExchangeSender_21 3.00 54.00 mpp[tiflash]  ExchangeType: Broadcast",
+          "      │   └─Selection_20 3.00 54.00 mpp[tiflash]  not(isnull(test.t1.a))",
+          "      │     └─TableFullScan_19 3.00 45.00 mpp[tiflash] table:t1 keep order:false",
+          "      └─Selection_24(Probe) 3.00 54.00 mpp[tiflash]  not(isnull(test.t2.a))",
+          "        └─TableFullScan_23 3.00 45.00 mpp[tiflash] table:t2 keep order:false"
         ]
       },
       {
@@ -2580,16 +2580,16 @@
       {
         "SQL": "explain format = 'verbose' select /*+ merge_join(t1) */ count(*) from t1 join t2 on t1.a = t2.a",
         "Plan": [
-          "StreamAgg_13 1.00 59.65 root  funcs:count(1)->Column#7",
-          "└─MergeJoin_31 3.00 50.65 root  inner join, left key:test.t1.a, right key:test.t2.a",
-          "  ├─Sort_29(Build) 3.00 20.83 root  test.t2.a",
-          "  │ └─TableReader_28 3.00 6.56 root  data:Selection_27",
-          "  │   └─Selection_27 3.00 54.00 cop[tiflash]  not(isnull(test.t2.a))",
-          "  │     └─TableFullScan_26 3.00 45.00 cop[tiflash] table:t2 keep order:false",
-          "  └─Sort_22(Probe) 3.00 20.83 root  test.t1.a",
-          "    └─TableReader_21 3.00 6.56 root  data:Selection_20",
-          "      └─Selection_20 3.00 54.00 cop[tiflash]  not(isnull(test.t1.a))",
-          "        └─TableFullScan_19 3.00 45.00 cop[tiflash] table:t1 keep order:false"
+          "StreamAgg_14 1.00 59.65 root  funcs:count(1)->Column#7",
+          "└─MergeJoin_32 3.00 50.65 root  inner join, left key:test.t1.a, right key:test.t2.a",
+          "  ├─Sort_30(Build) 3.00 20.83 root  test.t2.a",
+          "  │ └─TableReader_29 3.00 6.56 root  data:Selection_28",
+          "  │   └─Selection_28 3.00 54.00 cop[tiflash]  not(isnull(test.t2.a))",
+          "  │     └─TableFullScan_27 3.00 45.00 cop[tiflash] table:t2 keep order:false",
+          "  └─Sort_23(Probe) 3.00 20.83 root  test.t1.a",
+          "    └─TableReader_22 3.00 6.56 root  data:Selection_21",
+          "      └─Selection_21 3.00 54.00 cop[tiflash]  not(isnull(test.t1.a))",
+          "        └─TableFullScan_20 3.00 45.00 cop[tiflash] table:t1 keep order:false"
         ]
       }
     ]
@@ -4107,12 +4107,12 @@
       {
         "SQL": "explain format = 'brief' select /*+ avg_to_cop() */ id, avg(value+1),avg(value) from table_1 group by id",
         "Plan": [
-          "Projection 2.00 root  test.table_1.id, Column#4, Column#5",
-          "└─TableReader 2.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 2.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─Projection 2.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#11, 0), 1, Column#11), decimal(20,0) BINARY))->Column#4, div(Column#5, cast(case(eq(Column#12, 0), 1, Column#12), decimal(20,0) BINARY))->Column#5, test.table_1.id",
-          "      └─HashAgg 2.00 mpp[tiflash]  group by:Column#30, funcs:count(Column#25)->Column#11, funcs:sum(Column#26)->Column#4, funcs:count(Column#27)->Column#12, funcs:sum(Column#28)->Column#5, funcs:firstrow(Column#29)->test.table_1.id",
-          "        └─Projection 2.00 mpp[tiflash]  plus(test.table_1.value, 1)->Column#25, plus(test.table_1.value, 1)->Column#26, test.table_1.value, test.table_1.value, test.table_1.id, test.table_1.id",
+          "TableReader 2.00 root  data:ExchangeSender",
+          "└─ExchangeSender 2.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 2.00 mpp[tiflash]  test.table_1.id, Column#4, Column#5",
+          "    └─Projection 2.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#25, 0), 1, Column#25), decimal(20,0) BINARY))->Column#4, div(Column#5, cast(case(eq(Column#26, 0), 1, Column#26), decimal(20,0) BINARY))->Column#5, test.table_1.id",
+          "      └─HashAgg 2.00 mpp[tiflash]  group by:Column#39, funcs:count(Column#34)->Column#25, funcs:sum(Column#35)->Column#4, funcs:count(Column#36)->Column#26, funcs:sum(Column#37)->Column#5, funcs:firstrow(Column#38)->test.table_1.id",
+          "        └─Projection 2.00 mpp[tiflash]  plus(test.table_1.value, 1)->Column#34, plus(test.table_1.value, 1)->Column#35, test.table_1.value, test.table_1.value, test.table_1.id, test.table_1.id",
           "          └─ExchangeReceiver 2.00 mpp[tiflash]  ",
           "            └─ExchangeSender 2.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.table_1.id, collate: binary]",
           "              └─TableFullScan 2.00 mpp[tiflash] table:table_1 keep order:false"
@@ -4336,15 +4336,17 @@
       {
         "SQL": "explain format = 'brief' select * from t where t.a = 1",
         "Result": [
-          "TableReader 1.00 root  data:TableRangeScan",
-          "└─TableRangeScan 1.00 cop[tiflash] table:t range:[1,1], keep order:false, stats:pseudo"
+          "TableReader 1.00 root  data:ExchangeSender",
+          "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableRangeScan 1.00 mpp[tiflash] table:t range:[1,1], keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "explain format = 'brief' select * from t where t.a in (1, 2)",
         "Result": [
-          "TableReader 2.00 root  data:TableRangeScan",
-          "└─TableRangeScan 2.00 cop[tiflash] table:t range:[1,1], [2,2], keep order:false, stats:pseudo"
+          "TableReader 2.00 root  data:ExchangeSender",
+          "└─ExchangeSender 2.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableRangeScan 2.00 mpp[tiflash] table:t range:[1,1], [2,2], keep order:false, stats:pseudo"
         ]
       }
     ]
@@ -4355,24 +4357,27 @@
       {
         "SQL": "explain format = 'brief' select * from t",
         "Plan": [
-          "TableReader 10000.00 root  data:TableFullScan",
-          "└─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format = 'brief' select * from t use index();",
         "Plan": [
-          "TableReader 10000.00 root  data:TableFullScan",
-          "└─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       },
       {
         "SQL": "explain format = 'brief' select /*+ use_index(t, idx)*/ * from t",
         "Plan": [
-          "TableReader 10000.00 root  data:TableFullScan",
-          "└─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": [
           "TiDB doesn't support index in the isolation read engines(value: 'tiflash')"
@@ -4381,8 +4386,9 @@
       {
         "SQL": "explain format = 'brief' select /*+ use_index(t)*/ * from t",
         "Plan": [
-          "TableReader 10000.00 root  data:TableFullScan",
-          "└─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ],
         "Warn": null
       }
@@ -4669,17 +4675,19 @@
       {
         "SQL": "desc format = 'brief' select i * 2 from t",
         "Plan": [
-          "TableReader 10000.00 root  data:Projection",
-          "└─Projection 10000.00 cop[tiflash]  mul(test.t.i, 2)->Column#13",
-          "  └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  mul(test.t.i, 2)->Column#13",
+          "    └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "desc format = 'brief' select DATE_FORMAT(t, '%Y-%m-%d %H') as date from t",
         "Plan": [
-          "TableReader 10000.00 root  data:Projection",
-          "└─Projection 10000.00 cop[tiflash]  date_format(test.t.t, %Y-%m-%d %H)->Column#13",
-          "  └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  date_format(test.t.t, %Y-%m-%d %H)->Column#13",
+          "    └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -4705,8 +4713,8 @@
           "HashAgg 1.00 root  funcs:count(Column#17)->Column#14",
           "└─TableReader 1.00 root  data:ExchangeSender",
           "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(Column#18)->Column#17",
-          "      └─Projection 10000.00 mpp[tiflash]  plus(test.t.id, 1)->Column#18",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(Column#19)->Column#17",
+          "      └─Projection 10000.00 mpp[tiflash]  plus(test.t.id, 1)->Column#19",
           "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
@@ -4726,38 +4734,41 @@
           "HashAgg 1.00 root  funcs:sum(Column#17)->Column#14",
           "└─TableReader 1.00 root  data:ExchangeSender",
           "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg 1.00 mpp[tiflash]  funcs:sum(Column#18)->Column#17",
-          "      └─Projection 10000.00 mpp[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#18",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:sum(Column#19)->Column#17",
+          "      └─Projection 10000.00 mpp[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#19",
           "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "desc format = 'brief' select /*+ stream_agg()*/ count(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg 1.00 root  funcs:count(Column#16)->Column#14",
-          "└─TableReader 1.00 root  data:StreamAgg",
-          "  └─StreamAgg 1.00 batchCop[tiflash]  funcs:count(Column#18)->Column#16",
-          "    └─Projection 10000.00 batchCop[tiflash]  plus(test.t.id, 1)->Column#18",
-          "      └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg 1.00 root  funcs:count(Column#18)->Column#14",
+          "└─TableReader 1.00 root  data:ExchangeSender",
+          "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(Column#19)->Column#18",
+          "      └─Projection 10000.00 mpp[tiflash]  plus(test.t.id, 1)->Column#19",
+          "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "desc format = 'brief' select /*+ stream_agg()*/ count(*) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg 1.00 root  funcs:count(Column#15)->Column#14",
-          "└─TableReader 1.00 root  data:StreamAgg",
-          "  └─StreamAgg 1.00 batchCop[tiflash]  funcs:count(1)->Column#15",
-          "    └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg 1.00 root  funcs:count(Column#17)->Column#14",
+          "└─TableReader 1.00 root  data:ExchangeSender",
+          "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(1)->Column#17",
+          "      └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "desc format = 'brief' select /*+ stream_agg()*/ sum(b) from  (select id + 1 as b from t)A",
         "Plan": [
-          "StreamAgg 1.00 root  funcs:sum(Column#16)->Column#14",
-          "└─TableReader 1.00 root  data:StreamAgg",
-          "  └─StreamAgg 1.00 batchCop[tiflash]  funcs:sum(Column#18)->Column#16",
-          "    └─Projection 10000.00 batchCop[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#18",
-          "      └─TableFullScan 10000.00 batchCop[tiflash] table:t keep order:false, stats:pseudo"
+          "HashAgg 1.00 root  funcs:sum(Column#18)->Column#14",
+          "└─TableReader 1.00 root  data:ExchangeSender",
+          "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:sum(Column#19)->Column#18",
+          "      └─Projection 10000.00 mpp[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#19",
+          "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
@@ -4780,10 +4791,11 @@
         "SQL": "desc format = 'brief' select * from t join (select id-2 as b from t) A on A.b=t.id",
         "Plan": [
           "HashJoin 10000.00 root  inner join, equal:[eq(test.t.id, Column#25)]",
-          "├─TableReader(Build) 8000.00 root  data:Projection",
-          "│ └─Projection 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#25",
-          "│   └─Selection 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
-          "│     └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "├─TableReader(Build) 8000.00 root  data:ExchangeSender",
+          "│ └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "│   └─Projection 8000.00 mpp[tiflash]  minus(test.t.id, 2)->Column#25",
+          "│     └─Selection 8000.00 mpp[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "│       └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
           "└─TableReader(Probe) 9990.00 root  data:Selection",
           "  └─Selection 9990.00 cop[tiflash]  not(isnull(test.t.id))",
           "    └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
@@ -4793,10 +4805,11 @@
         "SQL": "desc format = 'brief' select * from t left join (select id-2 as b from t) A on A.b=t.id",
         "Plan": [
           "HashJoin 10000.00 root  left outer join, equal:[eq(test.t.id, Column#25)]",
-          "├─TableReader(Build) 8000.00 root  data:Projection",
-          "│ └─Projection 8000.00 cop[tiflash]  minus(test.t.id, 2)->Column#25",
-          "│   └─Selection 8000.00 cop[tiflash]  not(isnull(minus(test.t.id, 2)))",
-          "│     └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
+          "├─TableReader(Build) 8000.00 root  data:ExchangeSender",
+          "│ └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "│   └─Projection 8000.00 mpp[tiflash]  minus(test.t.id, 2)->Column#25",
+          "│     └─Selection 8000.00 mpp[tiflash]  not(isnull(minus(test.t.id, 2)))",
+          "│       └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
           "└─TableReader(Probe) 10000.00 root  data:TableFullScan",
           "  └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
         ]
@@ -4808,17 +4821,18 @@
           "├─TableReader(Build) 9990.00 root  data:Selection",
           "│ └─Selection 9990.00 cop[tiflash]  not(isnull(test.t.id))",
           "│   └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo",
-          "└─TableReader(Probe) 10000.00 root  data:Projection",
-          "  └─Projection 10000.00 cop[tiflash]  minus(test.t.id, 2)->Column#25",
-          "    └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "└─TableReader(Probe) 10000.00 root  data:ExchangeSender",
+          "  └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "    └─Projection 10000.00 mpp[tiflash]  minus(test.t.id, 2)->Column#25",
+          "      └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
       {
         "SQL": "desc format = 'brief' select A.b, B.b from (select id-2 as b from t) B join (select id-2 as b from t) A on A.b=B.b",
         "Plan": [
-          "Projection 10000.00 root  Column#26, Column#13",
-          "└─TableReader 10000.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  Column#26, Column#13",
           "    └─HashJoin 10000.00 mpp[tiflash]  inner join, equal:[eq(Column#13, Column#26)]",
           "      ├─ExchangeReceiver(Build) 8000.00 mpp[tiflash]  ",
           "      │ └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: Broadcast",
@@ -4859,9 +4873,10 @@
       {
         "SQL": "desc format = 'brief' SELECT FROM_UNIXTIME(name,'%Y-%m-%d')  FROM t;",
         "Plan": [
-          "Projection 10000.00 root  from_unixtime(cast(test.t.name, decimal(65,0) BINARY), %Y-%m-%d)->Column#13",
-          "└─TableReader 10000.00 root  data:TableFullScan",
-          "  └─TableFullScan 10000.00 cop[tiflash] table:t keep order:false, stats:pseudo"
+          "TableReader 10000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 10000.00 mpp[tiflash]  from_unixtime(cast(test.t.name, decimal(65,0) BINARY), %Y-%m-%d)->Column#13",
+          "    └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       }
     ]
@@ -5326,13 +5341,13 @@
       {
         "SQL": "desc format = 'brief' select t1.c1, t1.c2, t2.c1, t2.c2, t2.c3 from t t1 join t t2 on t1.c1 + 1 = t2.c2 - 10 and t1.c1 * 3 = t2.c3 / 2",
         "Plan": [
-          "Projection 12500.00 root  test.t.c1, test.t.c2, test.t.c1, test.t.c2, test.t.c3",
-          "└─TableReader 12500.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 12500.00 root  data:ExchangeSender",
+          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12500.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c1, test.t.c2, test.t.c3",
           "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(Column#13, Column#14) eq(Column#15, Column#16)]",
           "      ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#21, collate: binary], [name: Column#22, collate: binary]",
-          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, Column#13, Column#15, cast(Column#13, decimal(13,8) BINARY)->Column#21, cast(Column#15, decimal(10,5) BINARY)->Column#22",
+          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#23, collate: binary], [name: Column#24, collate: binary]",
+          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, Column#13, Column#15, cast(Column#13, decimal(13,8) BINARY)->Column#23, cast(Column#15, decimal(10,5) BINARY)->Column#24",
           "      │     └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, mul(test.t.c1, 3)->Column#13, plus(test.t.c1, 1)->Column#15",
           "      │       └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo",
           "      └─ExchangeReceiver(Probe) 10000.00 mpp[tiflash]  ",
@@ -5344,13 +5359,13 @@
       {
         "SQL": "desc format = 'brief' select * from (select c1, c2, c5, count(*) c from t group by c1, c2, c5) t1 join (select c1, c2, c3, count(*) c from t group by c1, c2, c3) t2 on t1.c1 = t2.c2 and t1.c2 = t2.c3 and t1.c5 = t2.c1",
         "Plan": [
-          "Projection 7976.02 root  test.t.c1, test.t.c2, test.t.c5, Column#7, test.t.c1, test.t.c2, test.t.c3, Column#14",
-          "└─TableReader 7976.02 root  data:ExchangeSender",
-          "  └─ExchangeSender 7976.02 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 7976.02 root  data:ExchangeSender",
+          "└─ExchangeSender 7976.02 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 7976.02 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c5, Column#7, test.t.c1, test.t.c2, test.t.c3, Column#14",
           "    └─HashJoin 7976.02 mpp[tiflash]  inner join, equal:[eq(test.t.c1, test.t.c2) eq(test.t.c2, test.t.c3) eq(test.t.c5, test.t.c1)]",
           "      ├─ExchangeReceiver(Build) 7976.02 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 7976.02 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#31, collate: binary], [name: test.t.c5, collate: binary]",
-          "      │   └─Projection 7976.02 mpp[tiflash]  Column#7, test.t.c1, test.t.c2, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#31",
+          "      │ └─ExchangeSender 7976.02 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#58, collate: binary], [name: test.t.c5, collate: binary]",
+          "      │   └─Projection 7976.02 mpp[tiflash]  Column#7, test.t.c1, test.t.c2, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#58",
           "      │     └─Projection 7976.02 mpp[tiflash]  Column#7, test.t.c1, test.t.c2, test.t.c5",
           "      │       └─HashAgg 7976.02 mpp[tiflash]  group by:test.t.c1, test.t.c2, test.t.c5, funcs:count(1)->Column#7, funcs:firstrow(test.t.c1)->test.t.c1, funcs:firstrow(test.t.c2)->test.t.c2, funcs:firstrow(test.t.c5)->test.t.c5",
           "      │         └─ExchangeReceiver 9970.03 mpp[tiflash]  ",
@@ -5358,8 +5373,8 @@
           "      │             └─Selection 9970.03 mpp[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2)), not(isnull(test.t.c5))",
           "      │               └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo",
           "      └─ExchangeReceiver(Probe) 7984.01 mpp[tiflash]  ",
-          "        └─ExchangeSender 7984.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#32, collate: binary], [name: Column#33, collate: binary]",
-          "          └─Projection 7984.01 mpp[tiflash]  Column#14, test.t.c1, test.t.c2, test.t.c3, cast(test.t.c3, decimal(10,5))->Column#32, cast(test.t.c1, decimal(40,20))->Column#33",
+          "        └─ExchangeSender 7984.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#59, collate: binary], [name: Column#60, collate: binary]",
+          "          └─Projection 7984.01 mpp[tiflash]  Column#14, test.t.c1, test.t.c2, test.t.c3, cast(test.t.c3, decimal(10,5))->Column#59, cast(test.t.c1, decimal(40,20))->Column#60",
           "            └─Projection 7984.01 mpp[tiflash]  Column#14, test.t.c1, test.t.c2, test.t.c3",
           "              └─HashAgg 7984.01 mpp[tiflash]  group by:test.t.c1, test.t.c2, test.t.c3, funcs:count(1)->Column#14, funcs:firstrow(test.t.c1)->test.t.c1, funcs:firstrow(test.t.c2)->test.t.c2, funcs:firstrow(test.t.c3)->test.t.c3",
           "                └─ExchangeReceiver 9980.01 mpp[tiflash]  ",
@@ -5387,18 +5402,18 @@
       {
         "SQL": "desc format = 'brief' select * from t t1 join t t2 on t1.c1 = t2.c2 and t1.c2 = t2.c3 and t1.c3 = t2.c1 and t1.c4 = t2.c3 and t1.c1 = t2.c5",
         "Plan": [
-          "Projection 12462.54 root  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
-          "└─TableReader 12462.54 root  data:ExchangeSender",
-          "  └─ExchangeSender 12462.54 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 12462.54 root  data:ExchangeSender",
+          "└─ExchangeSender 12462.54 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12462.54 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
           "    └─HashJoin 12462.54 mpp[tiflash]  inner join, equal:[eq(test.t.c2, test.t.c1) eq(test.t.c3, test.t.c2) eq(test.t.c1, test.t.c3) eq(test.t.c3, test.t.c4) eq(test.t.c5, test.t.c1)]",
           "      ├─ExchangeReceiver(Build) 9970.03 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 9970.03 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#13, collate: binary], [name: Column#15, collate: binary], [name: test.t.c3, collate: binary], [name: test.t.c5, collate: binary]",
-          "      │   └─Projection 9970.03 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c3, decimal(10,5))->Column#13, cast(test.t.c1, decimal(10,5))->Column#15",
+          "      │ └─ExchangeSender 9970.03 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#18, collate: binary], [name: Column#20, collate: binary], [name: test.t.c3, collate: binary], [name: test.t.c5, collate: binary]",
+          "      │   └─Projection 9970.03 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c3, decimal(10,5))->Column#18, cast(test.t.c1, decimal(10,5))->Column#20",
           "      │     └─Selection 9970.03 mpp[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2)), not(isnull(test.t.c5))",
           "      │       └─TableFullScan 10000.00 mpp[tiflash] table:t2 keep order:false, stats:pseudo",
           "      └─ExchangeReceiver(Probe) 9980.01 mpp[tiflash]  ",
-          "        └─ExchangeSender 9980.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#14, collate: binary], [name: Column#16, collate: binary], [name: test.t.c4, collate: binary], [name: Column#17, collate: binary]",
-          "          └─Projection 9980.01 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#14, cast(test.t.c3, decimal(10,5))->Column#16, cast(test.t.c1, decimal(40,20))->Column#17",
+          "        └─ExchangeSender 9980.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#19, collate: binary], [name: Column#21, collate: binary], [name: test.t.c4, collate: binary], [name: Column#22, collate: binary]",
+          "          └─Projection 9980.01 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#19, cast(test.t.c3, decimal(10,5))->Column#21, cast(test.t.c1, decimal(40,20))->Column#22",
           "            └─Selection 9980.01 mpp[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2))",
           "              └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
@@ -5406,13 +5421,13 @@
       {
         "SQL": "desc format = 'brief' select * from t t1 join t t2 on t1.c1 + t1.c2 = t2.c2 / t2.c3",
         "Plan": [
-          "Projection 12500.00 root  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
-          "└─TableReader 12500.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 12500.00 root  data:ExchangeSender",
+          "└─ExchangeSender 12500.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 12500.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
           "    └─HashJoin 12500.00 mpp[tiflash]  inner join, equal:[eq(Column#13, Column#14)]",
           "      ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#17, collate: binary]",
-          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, Column#13, cast(Column#13, decimal(17,9) BINARY)->Column#17",
+          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#18, collate: binary]",
+          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, Column#13, cast(Column#13, decimal(17,9) BINARY)->Column#18",
           "      │     └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, plus(test.t.c1, test.t.c2)->Column#13",
           "      │       └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo",
           "      └─ExchangeReceiver(Probe) 10000.00 mpp[tiflash]  ",
@@ -5424,18 +5439,18 @@
       {
         "SQL": "desc format = 'brief' select * from t t1 where exists (select * from t t2 where t1.c1 = t2.c2 and t1.c2 = t2.c3 and t1.c3 = t2.c1 and t1.c4 = t2.c3 and t1.c1 = t2.c5)",
         "Plan": [
-          "Projection 7984.01 root  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
-          "└─TableReader 7984.01 root  data:ExchangeSender",
-          "  └─ExchangeSender 7984.01 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 7984.01 root  data:ExchangeSender",
+          "└─ExchangeSender 7984.01 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 7984.01 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
           "    └─HashJoin 7984.01 mpp[tiflash]  semi join, equal:[eq(test.t.c1, test.t.c2) eq(test.t.c2, test.t.c3) eq(test.t.c3, test.t.c1) eq(test.t.c4, test.t.c3) eq(test.t.c1, test.t.c5)]",
           "      ├─ExchangeReceiver(Build) 9970.03 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 9970.03 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#14, collate: binary], [name: Column#16, collate: binary], [name: test.t.c3, collate: binary], [name: test.t.c5, collate: binary]",
-          "      │   └─Projection 9970.03 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c5, cast(test.t.c3, decimal(10,5))->Column#14, cast(test.t.c1, decimal(10,5))->Column#16",
+          "      │ └─ExchangeSender 9970.03 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c2, collate: binary], [name: Column#19, collate: binary], [name: Column#21, collate: binary], [name: test.t.c3, collate: binary], [name: test.t.c5, collate: binary]",
+          "      │   └─Projection 9970.03 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c5, cast(test.t.c3, decimal(10,5))->Column#19, cast(test.t.c1, decimal(10,5))->Column#21",
           "      │     └─Selection 9970.03 mpp[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2)), not(isnull(test.t.c5))",
           "      │       └─TableFullScan 10000.00 mpp[tiflash] table:t2 keep order:false, stats:pseudo",
           "      └─ExchangeReceiver(Probe) 9980.01 mpp[tiflash]  ",
-          "        └─ExchangeSender 9980.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#13, collate: binary], [name: Column#15, collate: binary], [name: test.t.c4, collate: binary], [name: Column#17, collate: binary]",
-          "          └─Projection 9980.01 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#13, cast(test.t.c3, decimal(10,5))->Column#15, cast(test.t.c1, decimal(40,20))->Column#17",
+          "        └─ExchangeSender 9980.01 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.c1, collate: binary], [name: Column#18, collate: binary], [name: Column#20, collate: binary], [name: test.t.c4, collate: binary], [name: Column#22, collate: binary]",
+          "          └─Projection 9980.01 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c2, decimal(10,5))->Column#18, cast(test.t.c3, decimal(10,5))->Column#20, cast(test.t.c1, decimal(40,20))->Column#22",
           "            └─Selection 9980.01 mpp[tiflash]  not(isnull(test.t.c1)), not(isnull(test.t.c2))",
           "              └─TableFullScan 10000.00 mpp[tiflash] table:t1 keep order:false, stats:pseudo"
         ]
@@ -5443,13 +5458,13 @@
       {
         "SQL": "desc format = 'brief' select * from t t1 left join t t2 on t1.c1 = t2.c2 join t t3 on t2.c5 = t3.c3 right join t t4 on t3.c3 = t4.c4 ",
         "Plan": [
-          "Projection 19492.21 root  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
-          "└─TableReader 19492.21 root  data:ExchangeSender",
-          "  └─ExchangeSender 19492.21 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 19492.21 root  data:ExchangeSender",
+          "└─ExchangeSender 19492.21 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 19492.21 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
           "    └─HashJoin 19492.21 mpp[tiflash]  right outer join, equal:[eq(test.t.c3, test.t.c4)]",
           "      ├─ExchangeReceiver(Build) 10000.00 mpp[tiflash]  ",
-          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#27, collate: binary]",
-          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c4, decimal(40,20))->Column#27",
+          "      │ └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#29, collate: binary]",
+          "      │   └─Projection 10000.00 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, cast(test.t.c4, decimal(40,20))->Column#29",
           "      │     └─TableFullScan 10000.00 mpp[tiflash] table:t4 keep order:false, stats:pseudo",
           "      └─Projection(Probe) 15593.77 mpp[tiflash]  test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5, test.t.c1, test.t.c2, test.t.c3, test.t.c4, test.t.c5",
           "        └─HashJoin 15593.77 mpp[tiflash]  inner join, equal:[eq(test.t.c5, test.t.c3)]",
@@ -5507,8 +5522,8 @@
           "HashAgg 1.00 root  funcs:count(Column#8)->Column#5",
           "└─TableReader 1.00 root  data:ExchangeSender",
           "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(Column#9)->Column#8",
-          "      └─Projection 10000.00 mpp[tiflash]  plus(test.t.id, 1)->Column#9",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(Column#10)->Column#8",
+          "      └─Projection 10000.00 mpp[tiflash]  plus(test.t.id, 1)->Column#10",
           "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
@@ -5528,8 +5543,8 @@
           "HashAgg 1.00 root  funcs:sum(Column#8)->Column#5",
           "└─TableReader 1.00 root  data:ExchangeSender",
           "  └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─HashAgg 1.00 mpp[tiflash]  funcs:sum(Column#9)->Column#8",
-          "      └─Projection 10000.00 mpp[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#9",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:sum(Column#10)->Column#8",
+          "      └─Projection 10000.00 mpp[tiflash]  cast(plus(test.t.id, 1), decimal(20,0) BINARY)->Column#10",
           "        └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
@@ -5558,15 +5573,15 @@
       {
         "SQL": "desc format = 'brief' select count(*), id + 1 from t group by id + 1",
         "Plan": [
-          "Projection 8000.00 root  Column#4, plus(test.t.id, 1)->Column#5",
-          "└─TableReader 8000.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 8000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  Column#4, plus(test.t.id, 1)->Column#5",
           "    └─Projection 8000.00 mpp[tiflash]  Column#4, test.t.id",
-          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#10, funcs:sum(Column#11)->Column#4, funcs:firstrow(Column#12)->test.t.id",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:Column#16, funcs:sum(Column#17)->Column#4, funcs:firstrow(Column#18)->test.t.id",
           "        └─ExchangeReceiver 8000.00 mpp[tiflash]  ",
-          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#10, collate: binary]",
-          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#17, funcs:count(1)->Column#11, funcs:firstrow(Column#16)->Column#12",
-          "              └─Projection 10000.00 mpp[tiflash]  test.t.id, plus(test.t.id, 1)->Column#17",
+          "          └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: Column#16, collate: binary]",
+          "            └─HashAgg 8000.00 mpp[tiflash]  group by:Column#20, funcs:count(1)->Column#17, funcs:firstrow(Column#19)->Column#18",
+          "              └─Projection 10000.00 mpp[tiflash]  test.t.id, plus(test.t.id, 1)->Column#20",
           "                └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       },
@@ -5607,8 +5622,8 @@
         "Plan": [
           "TableReader 8000.00 root  data:ExchangeSender",
           "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 8000.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#8, 0), 1, Column#8), decimal(20,0) BINARY))->Column#4, test.t.id",
-          "    └─HashAgg 8000.00 mpp[tiflash]  group by:test.t.id, funcs:count(test.t.value)->Column#8, funcs:sum(test.t.value)->Column#4, funcs:firstrow(test.t.id)->test.t.id",
+          "  └─Projection 8000.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#16, 0), 1, Column#16), decimal(20,0) BINARY))->Column#4, test.t.id",
+          "    └─HashAgg 8000.00 mpp[tiflash]  group by:test.t.id, funcs:count(test.t.value)->Column#16, funcs:sum(test.t.value)->Column#4, funcs:firstrow(test.t.id)->test.t.id",
           "      └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
           "        └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.id, collate: binary]",
           "          └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
@@ -5631,9 +5646,9 @@
       {
         "SQL": "desc format = 'brief' select id from t group by id having avg(value)>0",
         "Plan": [
-          "Projection 6400.00 root  test.t.id",
-          "└─TableReader 6400.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 6400.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 6400.00 root  data:ExchangeSender",
+          "└─ExchangeSender 6400.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 6400.00 mpp[tiflash]  test.t.id",
           "    └─Selection 6400.00 mpp[tiflash]  gt(Column#4, 0)",
           "      └─Projection 8000.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#17, 0), 1, Column#17), decimal(20,0) BINARY))->Column#4, test.t.id",
           "        └─HashAgg 8000.00 mpp[tiflash]  group by:test.t.id, funcs:count(test.t.value)->Column#17, funcs:sum(test.t.value)->Column#4, funcs:firstrow(test.t.id)->test.t.id",
@@ -5658,11 +5673,11 @@
       {
         "SQL": "desc format = 'brief' select avg(value) +1,id from t group by id",
         "Plan": [
-          "Projection 8000.00 root  plus(Column#4, 1)->Column#5, test.t.id",
-          "└─TableReader 8000.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "    └─Projection 8000.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#10, 0), 1, Column#10), decimal(20,0) BINARY))->Column#4, test.t.id",
-          "      └─HashAgg 8000.00 mpp[tiflash]  group by:test.t.id, funcs:count(test.t.value)->Column#10, funcs:sum(test.t.value)->Column#4, funcs:firstrow(test.t.id)->test.t.id",
+          "TableReader 8000.00 root  data:ExchangeSender",
+          "└─ExchangeSender 8000.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 8000.00 mpp[tiflash]  plus(Column#4, 1)->Column#5, test.t.id",
+          "    └─Projection 8000.00 mpp[tiflash]  div(Column#4, cast(case(eq(Column#18, 0), 1, Column#18), decimal(20,0) BINARY))->Column#4, test.t.id",
+          "      └─HashAgg 8000.00 mpp[tiflash]  group by:test.t.id, funcs:count(test.t.value)->Column#18, funcs:sum(test.t.value)->Column#4, funcs:firstrow(test.t.id)->test.t.id",
           "        └─ExchangeReceiver 10000.00 mpp[tiflash]  ",
           "          └─ExchangeSender 10000.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.id, collate: binary]",
           "            └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
@@ -5674,8 +5689,8 @@
           "TableReader 7992.00 root  data:ExchangeSender",
           "└─ExchangeSender 7992.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 7992.00 mpp[tiflash]  Column#7",
-          "    └─HashAgg 7992.00 mpp[tiflash]  group by:Column#11, funcs:sum(Column#10)->Column#7",
-          "      └─Projection 12487.50 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#10, test.t.id",
+          "    └─HashAgg 7992.00 mpp[tiflash]  group by:Column#12, funcs:sum(Column#11)->Column#7",
+          "      └─Projection 12487.50 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#11, test.t.id",
           "        └─HashJoin 12487.50 mpp[tiflash]  inner join, equal:[eq(test.t.id, test.t.id)]",
           "          ├─ExchangeReceiver(Build) 9990.00 mpp[tiflash]  ",
           "          │ └─ExchangeSender 9990.00 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.id, collate: binary]",
@@ -5780,8 +5795,8 @@
           "TableReader 6400.00 root  data:ExchangeSender",
           "└─ExchangeSender 6400.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 6400.00 mpp[tiflash]  Column#4",
-          "    └─HashAgg 6400.00 mpp[tiflash]  group by:Column#20, funcs:sum(Column#19)->Column#4",
-          "      └─Projection 6400.00 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#19, test.t.value",
+          "    └─HashAgg 6400.00 mpp[tiflash]  group by:Column#21, funcs:sum(Column#20)->Column#4",
+          "      └─Projection 6400.00 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#20, test.t.value",
           "        └─Projection 6400.00 mpp[tiflash]  test.t.id, test.t.value",
           "          └─HashAgg 6400.00 mpp[tiflash]  group by:test.t.id, test.t.value, funcs:firstrow(test.t.id)->test.t.id, funcs:firstrow(test.t.value)->test.t.value",
           "            └─ExchangeReceiver 6400.00 mpp[tiflash]  ",
@@ -5844,11 +5859,11 @@
         "Plan": [
           "TableReader 1.00 root  data:ExchangeSender",
           "└─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "  └─Projection 1.00 mpp[tiflash]  Column#4, Column#5, div(Column#6, cast(case(eq(Column#7, 0), 1, Column#7), decimal(20,0) BINARY))->Column#6",
-          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(distinct test.t.value)->Column#4, funcs:sum(Column#8)->Column#5, funcs:sum(Column#9)->Column#7, funcs:sum(Column#10)->Column#6",
+          "  └─Projection 1.00 mpp[tiflash]  Column#4, Column#5, div(Column#6, cast(case(eq(Column#11, 0), 1, Column#11), decimal(20,0) BINARY))->Column#6",
+          "    └─HashAgg 1.00 mpp[tiflash]  funcs:count(distinct test.t.value)->Column#4, funcs:sum(Column#12)->Column#5, funcs:sum(Column#13)->Column#11, funcs:sum(Column#14)->Column#6",
           "      └─ExchangeReceiver 1.00 mpp[tiflash]  ",
           "        └─ExchangeSender 1.00 mpp[tiflash]  ExchangeType: PassThrough",
-          "          └─HashAgg 1.00 mpp[tiflash]  group by:test.t.value, funcs:count(test.t.value)->Column#8, funcs:count(test.t.value)->Column#9, funcs:sum(test.t.value)->Column#10",
+          "          └─HashAgg 1.00 mpp[tiflash]  group by:test.t.value, funcs:count(test.t.value)->Column#12, funcs:count(test.t.value)->Column#13, funcs:sum(test.t.value)->Column#14",
           "            └─TableFullScan 10000.00 mpp[tiflash] table:t keep order:false, stats:pseudo"
         ]
       }
@@ -5897,9 +5912,9 @@
       {
         "SQL": "desc format = 'brief' select * from t join ( select count(*) as v, id from t group by value,id having value+v <10) as A on A.id = t.id",
         "Plan": [
-          "Projection 7992.00 root  test.t.id, test.t.value, Column#7, test.t.id",
-          "└─TableReader 7992.00 root  data:ExchangeSender",
-          "  └─ExchangeSender 7992.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "TableReader 7992.00 root  data:ExchangeSender",
+          "└─ExchangeSender 7992.00 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 7992.00 mpp[tiflash]  test.t.id, test.t.value, Column#7, test.t.id",
           "    └─HashJoin 7992.00 mpp[tiflash]  inner join, equal:[eq(test.t.id, test.t.id)]",
           "      ├─ExchangeReceiver(Build) 6393.60 mpp[tiflash]  ",
           "      │ └─ExchangeSender 6393.60 mpp[tiflash]  ExchangeType: Broadcast",
@@ -5934,8 +5949,8 @@
           "TableReader 7992.00 root  data:ExchangeSender",
           "└─ExchangeSender 7992.00 mpp[tiflash]  ExchangeType: PassThrough",
           "  └─Projection 7992.00 mpp[tiflash]  Column#7",
-          "    └─HashAgg 7992.00 mpp[tiflash]  group by:Column#11, funcs:sum(Column#10)->Column#7",
-          "      └─Projection 12487.50 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#10, test.t.id",
+          "    └─HashAgg 7992.00 mpp[tiflash]  group by:Column#12, funcs:sum(Column#11)->Column#7",
+          "      └─Projection 12487.50 mpp[tiflash]  cast(test.t.id, decimal(10,0) BINARY)->Column#11, test.t.id",
           "        └─ExchangeReceiver 12487.50 mpp[tiflash]  ",
           "          └─ExchangeSender 12487.50 mpp[tiflash]  ExchangeType: HashPartition, Hash Cols: [name: test.t.id, collate: binary]",
           "            └─HashJoin 12487.50 mpp[tiflash]  inner join, equal:[eq(test.t.id, test.t.id)]",

--- a/planner/core/testdata/plan_normalized_suite_out.json
+++ b/planner/core/testdata/plan_normalized_suite_out.json
@@ -259,10 +259,11 @@
     "Name": "TestNormalizedPlanForDiffStore",
     "Cases": [
       {
-        "Digest": "f970a867275a8e8878e3b0a7960a3d15e7fecda7cf31957ba2624b0afd91ddee",
+        "Digest": "2cb2b27afb3aec316c4ee9af4cefbc25495ce42fe560933acb713c95829857c9",
         "Plan": [
-          " TableReader     root         ",
-          " └─TableFullScan cop[tiflash] table:t1, range:[?,?], keep order:false"
+          " TableReader       root         ",
+          " └─ExchangeSender  cop[tiflash] ",
+          "   └─TableFullScan cop[tiflash] table:t1, range:[?,?], keep order:false"
         ]
       },
       {
@@ -273,12 +274,13 @@
         ]
       },
       {
-        "Digest": "35da54afee3417b46607d9d836b9e3aea3a450537980d65abedda63498298784",
+        "Digest": "5fc0a796273b90410acda281d59ff137547ace7422739f9b1dbf90ded8cb836c",
         "Plan": [
-          " Projection          root         plus(test.t1.a, test.t1.b)",
-          " └─TableReader       root         ",
-          "   └─Selection       cop[tiflash] lt(plus(test.t1.a, test.t1.b), ?)",
-          "     └─TableFullScan cop[tiflash] table:t1, range:[?,?], keep order:false"
+          " TableReader           root         ",
+          " └─ExchangeSender      cop[tiflash] ",
+          "   └─Projection        cop[tiflash] plus(test.t1.a, test.t1.b)",
+          "     └─Selection       cop[tiflash] lt(plus(test.t1.a, test.t1.b), ?)",
+          "       └─TableFullScan cop[tiflash] table:t1, range:[?,?], keep order:false"
         ]
       },
       {

--- a/planner/core/testdata/plan_suite_in.json
+++ b/planner/core/testdata/plan_suite_in.json
@@ -782,6 +782,8 @@
   {
     "name": "TestMPPSinglePartitionType",
     "cases": [
+      "select * from employee where deptid>1",
+      "select deptid+5, empid*10  from employee where deptid>1",
       // test normal aggregation, MPP2Phase.
       "select count(*) from employee group by deptid+1",
       // test normal aggregation, MPPScalar.

--- a/planner/core/testdata/plan_suite_out.json
+++ b/planner/core/testdata/plan_suite_out.json
@@ -437,7 +437,7 @@
       },
       {
         "SQL": "select * from ((SELECT 1 a,6 b) UNION (SELECT 2,5) UNION (SELECT 2, 4) ORDER BY 1) t order by 1, 2",
-        "Best": "UnionAll{Dual->Projection->Dual->Projection->Dual->Projection}->HashAgg->Sort->Sort"
+        "Best": "UnionAll{Dual->Projection->Projection->Dual->Projection->Projection->Dual->Projection->Projection}->HashAgg->Projection->Sort"
       },
       {
         "SQL": "select * from (select *, NULL as xxx from t) t order by xxx",
@@ -3055,6 +3055,25 @@
   {
     "Name": "TestMPPSinglePartitionType",
     "Cases": [
+      {
+        "SQL": "select * from employee where deptid>1",
+        "Plan": [
+          "TableReader 3333.33 root  data:ExchangeSender",
+          "└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Selection 3333.33 mpp[tiflash]  gt(test.employee.deptid, 1)",
+          "    └─TableFullScan 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"
+        ]
+      },
+      {
+        "SQL": "select deptid+5, empid*10  from employee where deptid>1",
+        "Plan": [
+          "TableReader 3333.33 root  data:ExchangeSender",
+          "└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough",
+          "  └─Projection 3333.33 mpp[tiflash]  plus(test.employee.deptid, 5)->Column#5, mul(test.employee.empid, 10)->Column#6",
+          "    └─Selection 3333.33 mpp[tiflash]  gt(test.employee.deptid, 1)",
+          "      └─TableFullScan 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo"
+        ]
+      },
       {
         "SQL": "select count(*) from employee group by deptid+1",
         "Plan": [


### PR DESCRIPTION
### What problem does this PR solve?
For simple query like `select * from table where id > 1`, MPP mode should also have higher priority over cop mode because in cop mode, the data access is based on region, if the table have thousands of regions, TiFlash will receiver thousands of cop requests, and in MPP mode, the data access is based on TiFlash node, that is one TiFlash node only receiver one MPP request. Obviously, the latter one is more friendly to TiFlash. This patch solves above issue.

Before this patch:
```sql
explain select * from employee where deptid>1;

TableReader 3333.33 root  data:Selection
└─Selection 3333.33 cop[tiflash]  gt(test.employee.deptid, 1)
  └─TableFullScan 10000.00 cop[tiflash] table:employee keep order:false, stats:pseudo
```
After this patch:
```sql
explain select * from employee where deptid>1;

TableReader 3333.33 root  data:ExchangeSender
└─ExchangeSender 3333.33 mpp[tiflash]  ExchangeType: PassThrough
  └─Selection 3333.33 mpp[tiflash]  gt(test.employee.deptid, 1)
    └─TableFullScan 10000.00 mpp[tiflash] table:employee keep order:false, stats:pseudo
```

Issue Number: close #35875

Problem Summary:

### What is changed and how it works?

### Check List

Tests 

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note


```release-note
None
```
