### PR TITLE
ddl: Support flashback schema

### DIFF
--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -85,6 +85,16 @@ const (
 
 	reorgWorkerCnt   = 10
 	generalWorkerCnt = 1
+
+	// checkFlagIndexInJobArgs is the recoverCheckFlag index used in RecoverTable/RecoverSchema job arg list.
+	checkFlagIndexInJobArgs = 1
+)
+
+const (
+	// The recoverCheckFlag is used to judge the gc work status when RecoverTable/RecoverSchema.
+	recoverCheckFlagNone int64 = iota
+	recoverCheckFlagEnableGC
+	recoverCheckFlagDisableGC
 )
 
 // OnExist specifies what to do when a new object has a name collision.

--- a/ddl/ddl.go
+++ b/ddl/ddl.go
@@ -160,6 +160,7 @@ type DDL interface {
 	CreateView(ctx sessionctx.Context, stmt *ast.CreateViewStmt) error
 	DropTable(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	RecoverTable(ctx sessionctx.Context, recoverInfo *RecoverInfo) (err error)
+	RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *RecoverSchemaInfo) error
 	DropView(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error)
 	CreateIndex(ctx sessionctx.Context, stmt *ast.CreateIndexStmt) error
 	DropIndex(ctx sessionctx.Context, stmt *ast.DropIndexStmt) error
@@ -1260,6 +1261,15 @@ type RecoverInfo struct {
 	AutoIDs       meta.AutoIDGroup
 	OldSchemaName string
 	OldTableName  string
+}
+
+// RecoverSchemaInfo contains information needed by DDL.RecoverSchema.
+type RecoverSchemaInfo struct {
+	*model.DBInfo
+	RecoverTabsInfo []*RecoverInfo
+	DropJobID       int64
+	SnapshotTS      uint64
+	OldSchemaName   model.CIStr
 }
 
 // delayForAsyncCommit sleeps `SafeWindow + AllowedClockDrift` before a DDL job finishes.

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -638,7 +638,7 @@ func (d *ddl) RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *RecoverSc
 	job := &model.Job{
 		Type:       model.ActionRecoverSchema,
 		BinlogInfo: &model.HistoryInfo{},
-		Args:       []interface{}{recoverSchemaInfo, recoverSchemaCheckFlagNone},
+		Args:       []interface{}{recoverSchemaInfo, recoverCheckFlagNone},
 	}
 	err := d.DoDDLJob(ctx, job)
 	err = d.callHookOnChanged(job, err)
@@ -2707,7 +2707,7 @@ func (d *ddl) RecoverTable(ctx sessionctx.Context, recoverInfo *RecoverInfo) (er
 
 		Type:       model.ActionRecoverTable,
 		BinlogInfo: &model.HistoryInfo{},
-		Args:       []interface{}{recoverInfo, recoverTableCheckFlagNone},
+		Args:       []interface{}{recoverInfo, recoverCheckFlagNone},
 	}
 	err = d.DoDDLJob(ctx, job)
 	err = d.callHookOnChanged(job, err)

--- a/ddl/ddl_api.go
+++ b/ddl/ddl_api.go
@@ -2707,9 +2707,7 @@ func (d *ddl) RecoverTable(ctx sessionctx.Context, recoverInfo *RecoverInfo) (er
 
 		Type:       model.ActionRecoverTable,
 		BinlogInfo: &model.HistoryInfo{},
-		Args: []interface{}{tbInfo, recoverInfo.AutoIDs.RowID, recoverInfo.DropJobID,
-			recoverInfo.SnapshotTS, recoverTableCheckFlagNone, recoverInfo.AutoIDs.RandomID,
-			recoverInfo.OldSchemaName, recoverInfo.OldTableName},
+		Args:       []interface{}{recoverInfo, recoverTableCheckFlagNone},
 	}
 	err = d.DoDDLJob(ctx, job)
 	err = d.callHookOnChanged(job, err)

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -1543,11 +1543,17 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 			}
 		}
 	case model.ActionRecoverSchema:
-		var recoverSchemaInfo *RecoverSchemaInfo
-		err = job.DecodeArgs(&recoverSchemaInfo)
+		var (
+			recoverSchemaInfo      *RecoverSchemaInfo
+			recoverSchemaCheckFlag int64
+		)
+		const checkFlagIndexInJobArgs = 1 // The index of `recoverSchemaCheckFlag` in job arg list.
+		err = job.DecodeArgs(&recoverSchemaInfo, &recoverSchemaCheckFlag)
 		if err != nil {
 			return 0, errors.Trace(err)
 		}
+		// Reserved recoverSchemaCheckFlag value for gc work judgment.
+		job.Args[checkFlagIndexInJobArgs] = recoverSchemaCheckFlag
 		recoverTabsInfo := recoverSchemaInfo.RecoverTabsInfo
 		diff.AffectedOpts = make([]*model.AffectedOption, len(recoverTabsInfo))
 		for i := range recoverTabsInfo {

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -650,10 +650,11 @@ func (w *worker) writeDDLSeqNum(job *model.Job) {
 }
 
 func finishRecoverTable(w *worker, job *model.Job) error {
-	tbInfo := &model.TableInfo{}
-	var autoIncID, autoRandID, dropJobID, recoverTableCheckFlag int64
-	var snapshotTS uint64
-	err := job.DecodeArgs(tbInfo, &autoIncID, &dropJobID, &snapshotTS, &recoverTableCheckFlag, &autoRandID)
+	var (
+		recoverInfo           *RecoverInfo
+		recoverTableCheckFlag int64
+	)
+	err := job.DecodeArgs(&recoverInfo, &recoverTableCheckFlag)
 	if err != nil {
 		return errors.Trace(err)
 	}

--- a/ddl/ddl_worker.go
+++ b/ddl/ddl_worker.go
@@ -658,7 +658,7 @@ func finishRecoverTable(w *worker, job *model.Job) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if recoverTableCheckFlag == recoverTableCheckFlagEnableGC {
+	if recoverTableCheckFlag == recoverCheckFlagEnableGC {
 		err = enableGC(w)
 		if err != nil {
 			return errors.Trace(err)
@@ -676,7 +676,7 @@ func finishRecoverSchema(w *worker, job *model.Job) error {
 	if err != nil {
 		return errors.Trace(err)
 	}
-	if recoverSchemaCheckFlag == recoverSchemaCheckFlagEnableGC {
+	if recoverSchemaCheckFlag == recoverCheckFlagEnableGC {
 		err = enableGC(w)
 		if err != nil {
 			return errors.Trace(err)
@@ -1548,7 +1548,6 @@ func updateSchemaVersion(d *ddlCtx, t *meta.Meta, job *model.Job, multiInfos ...
 			recoverSchemaInfo      *RecoverSchemaInfo
 			recoverSchemaCheckFlag int64
 		)
-		const checkFlagIndexInJobArgs = 1 // The index of `recoverSchemaCheckFlag` in job arg list.
 		err = job.DecodeArgs(&recoverSchemaInfo, &recoverSchemaCheckFlag)
 		if err != nil {
 			return 0, errors.Trace(err)

--- a/ddl/rollingback.go
+++ b/ddl/rollingback.go
@@ -388,7 +388,8 @@ func convertJob2RollbackJob(w *worker, d *ddlCtx, t *meta.Meta, job *model.Job) 
 		model.ActionModifyTableCharsetAndCollate, model.ActionTruncateTablePartition,
 		model.ActionModifySchemaCharsetAndCollate, model.ActionRepairTable,
 		model.ActionModifyTableAutoIdCache, model.ActionAlterIndexVisibility,
-		model.ActionExchangeTablePartition, model.ActionModifySchemaDefaultPlacement:
+		model.ActionExchangeTablePartition, model.ActionModifySchemaDefaultPlacement,
+		model.ActionRecoverSchema:
 		ver, err = cancelOnlyNotHandledJob(job, model.StateNone)
 	case model.ActionMultiSchemaChange:
 		err = rollingBackMultiSchemaChange(job)

--- a/ddl/schema.go
+++ b/ddl/schema.go
@@ -253,18 +253,11 @@ func onDropSchema(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 	return ver, errors.Trace(err)
 }
 
-const (
-	recoverSchemaCheckFlagNone int64 = iota
-	recoverSchemaCheckFlagEnableGC
-	recoverSchemaCheckFlagDisableGC
-)
-
 func (w *worker) onRecoverSchema(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
 	var (
 		recoverSchemaInfo      *RecoverSchemaInfo
 		recoverSchemaCheckFlag int64
 	)
-	const checkFlagIndexInJobArgs = 1 // The index of `recoverSchemaCheckFlag` in job arg list.
 	if err := job.DecodeArgs(&recoverSchemaInfo, &recoverSchemaCheckFlag); err != nil {
 		// Invalid arguments, cancel this job.
 		job.State = model.JobStateCancelled
@@ -282,9 +275,9 @@ func (w *worker) onRecoverSchema(d *ddlCtx, t *meta.Meta, job *model.Job) (ver i
 		// none -> write only
 		// check GC enable and update flag.
 		if gcEnable {
-			job.Args[checkFlagIndexInJobArgs] = recoverSchemaCheckFlagEnableGC
+			job.Args[checkFlagIndexInJobArgs] = recoverCheckFlagEnableGC
 		} else {
-			job.Args[checkFlagIndexInJobArgs] = recoverSchemaCheckFlagDisableGC
+			job.Args[checkFlagIndexInJobArgs] = recoverCheckFlagDisableGC
 		}
 		// Clear all placement when recover
 		for _, recoverTabInfo := range recoverSchemaInfo.RecoverTabsInfo {

--- a/ddl/schema.go
+++ b/ddl/schema.go
@@ -253,6 +253,98 @@ func onDropSchema(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) 
 	return ver, errors.Trace(err)
 }
 
+const (
+	recoverSchemaCheckFlagNone int64 = iota
+	recoverSchemaCheckFlagEnableGC
+	recoverSchemaCheckFlagDisableGC
+)
+
+func (w *worker) onRecoverSchema(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ error) {
+	var (
+		recoverSchemaInfo      *RecoverSchemaInfo
+		recoverSchemaCheckFlag int64
+	)
+	const checkFlagIndexInJobArgs = 1 // The index of `recoverSchemaCheckFlag` in job arg list.
+	if err := job.DecodeArgs(&recoverSchemaInfo, &recoverSchemaCheckFlag); err != nil {
+		// Invalid arguments, cancel this job.
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+	schemaInfo := recoverSchemaInfo.DBInfo
+	// check GC and safe point
+	gcEnable, err := checkGCEnable(w)
+	if err != nil {
+		job.State = model.JobStateCancelled
+		return ver, errors.Trace(err)
+	}
+	switch schemaInfo.State {
+	case model.StateNone:
+		// none -> write only
+		// check GC enable and update flag.
+		if gcEnable {
+			job.Args[checkFlagIndexInJobArgs] = recoverSchemaCheckFlagEnableGC
+		} else {
+			job.Args[checkFlagIndexInJobArgs] = recoverSchemaCheckFlagDisableGC
+		}
+		// Clear all placement when recover
+		for _, recoverTabInfo := range recoverSchemaInfo.RecoverTabsInfo {
+			err = clearTablePlacementAndBundles(recoverTabInfo.TableInfo)
+			if err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Wrapf(err, "failed to notify PD the placement rules")
+			}
+		}
+		schemaInfo.State = model.StateWriteOnly
+		job.SchemaState = model.StateWriteOnly
+	case model.StateWriteOnly:
+		// write only -> public
+		// do recover schema and tables.
+		if gcEnable {
+			err = disableGC(w)
+			if err != nil {
+				job.State = model.JobStateCancelled
+				return ver, errors.Errorf("disable gc failed, try again later. err: %v", err)
+			}
+		}
+		dbInfo := schemaInfo.Clone()
+		dbInfo.State = model.StatePublic
+		err = t.CreateDatabase(dbInfo)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+		// check GC safe point
+		err = checkSafePoint(w, recoverSchemaInfo.SnapshotTS)
+		if err != nil {
+			job.State = model.JobStateCancelled
+			return ver, errors.Trace(err)
+		}
+		for _, recoverInfo := range recoverSchemaInfo.RecoverTabsInfo {
+			ver, err = w.recoverTable(t, job, recoverInfo)
+			if err != nil {
+				return ver, errors.Trace(err)
+			}
+		}
+		schemaInfo.State = model.StatePublic
+		for _, recoverInfo := range recoverSchemaInfo.RecoverTabsInfo {
+			recoverInfo.TableInfo.State = model.StatePublic
+			recoverInfo.TableInfo.UpdateTS = t.StartTS
+		}
+		// use to update InfoSchema
+		job.SchemaID = schemaInfo.ID
+		ver, err = updateSchemaVersion(d, t, job)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
+		// Finish this job.
+		job.FinishDBJob(model.JobStateDone, model.StatePublic, ver, schemaInfo)
+		return ver, nil
+	default:
+		// We can't enter here.
+		return ver, errors.Errorf("invalid db state %v", schemaInfo.State)
+	}
+	return ver, errors.Trace(err)
+}
+
 func checkSchemaExistAndCancelNotExistJob(t *meta.Meta, job *model.Job) (*model.DBInfo, error) {
 	dbInfo, err := t.GetDatabase(job.SchemaID)
 	if err != nil {

--- a/ddl/schematracker/checker.go
+++ b/ddl/schematracker/checker.go
@@ -212,8 +212,7 @@ func (d Checker) DropSchema(ctx sessionctx.Context, stmt *ast.DropDatabaseStmt) 
 
 // RecoverSchema implements the DDL interface.
 func (d Checker) RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *ddl.RecoverSchemaInfo) (err error) {
-	//TODO implement me
-	panic("implement me")
+	return nil
 }
 
 // CreateTable implements the DDL interface.

--- a/ddl/schematracker/checker.go
+++ b/ddl/schematracker/checker.go
@@ -210,6 +210,12 @@ func (d Checker) DropSchema(ctx sessionctx.Context, stmt *ast.DropDatabaseStmt) 
 	return nil
 }
 
+// RecoverSchema implements the DDL interface.
+func (d Checker) RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *ddl.RecoverSchemaInfo) (err error) {
+	//TODO implement me
+	panic("implement me")
+}
+
 // CreateTable implements the DDL interface.
 func (d Checker) CreateTable(ctx sessionctx.Context, stmt *ast.CreateTableStmt) error {
 	err := d.realDDL.CreateTable(ctx, stmt)

--- a/ddl/schematracker/dm_tracker.go
+++ b/ddl/schematracker/dm_tracker.go
@@ -313,6 +313,11 @@ func (d SchemaTracker) FlashbackCluster(ctx sessionctx.Context, flashbackTS uint
 	return nil
 }
 
+// RecoverSchema implements the DDL interface, which is no-op in DM's case.
+func (d SchemaTracker) RecoverSchema(ctx sessionctx.Context, recoverSchemaInfo *ddl.RecoverSchemaInfo) (err error) {
+	return nil
+}
+
 // DropView implements the DDL interface.
 func (d SchemaTracker) DropView(ctx sessionctx.Context, stmt *ast.DropTableStmt) (err error) {
 	notExistTables := make([]string, 0, len(stmt.Tables))

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -497,14 +497,14 @@ func (w *worker) onRecoverTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver in
 			job.State = model.JobStateCancelled
 			return ver, errors.Trace(err)
 		}
-		job.CtxVars = []interface{}{tids}
-		ver, err = updateVersionAndTableInfo(d, t, job, tblInfo.Clone(), true)
-		if err != nil {
-			return ver, errors.Trace(err)
-		}
 
 		tblInfo.State = model.StatePublic
 		tblInfo.UpdateTS = t.StartTS
+		job.CtxVars = []interface{}{tids}
+		ver, err = updateVersionAndTableInfo(d, t, job, tblInfo, true)
+		if err != nil {
+			return ver, errors.Trace(err)
+		}
 		// Finish this job.
 		job.FinishTableJob(model.JobStateDone, model.StatePublic, ver, tblInfo)
 	default:

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -513,7 +513,7 @@ func (w *worker) recoverTable(t *meta.Meta, job *model.Job, recoverInfo *Recover
 		return ver, errors.Wrapf(err, "failed to get old label rules from PD")
 	}
 	// Remove dropped table DDL job from gc_delete_range table.
-	err = w.delRangeManager.removeFromGCDeleteRange(w.ctx, recoverInfo.DropJobID, tids)
+	err = w.delRangeManager.removeFromGCDeleteRange(w.ctx, recoverInfo.DropJobID)
 	if err != nil {
 		return ver, errors.Trace(err)
 	}

--- a/ddl/table.go
+++ b/ddl/table.go
@@ -391,18 +391,11 @@ func onDropTableOrView(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, _ er
 	return ver, errors.Trace(err)
 }
 
-const (
-	recoverTableCheckFlagNone int64 = iota
-	recoverTableCheckFlagEnableGC
-	recoverTableCheckFlagDisableGC
-)
-
 func (w *worker) onRecoverTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver int64, err error) {
 	var (
 		recoverInfo           *RecoverInfo
 		recoverTableCheckFlag int64
 	)
-	const checkFlagIndexInJobArgs = 1 // The index of `recoverTableCheckFlag` in job arg list.
 	if err = job.DecodeArgs(&recoverInfo, &recoverTableCheckFlag); err != nil {
 		// Invalid arguments, cancel this job.
 		job.State = model.JobStateCancelled
@@ -455,9 +448,9 @@ func (w *worker) onRecoverTable(d *ddlCtx, t *meta.Meta, job *model.Job) (ver in
 		// none -> write only
 		// check GC enable and update flag.
 		if gcEnable {
-			job.Args[checkFlagIndexInJobArgs] = recoverTableCheckFlagEnableGC
+			job.Args[checkFlagIndexInJobArgs] = recoverCheckFlagEnableGC
 		} else {
-			job.Args[checkFlagIndexInJobArgs] = recoverTableCheckFlagDisableGC
+			job.Args[checkFlagIndexInJobArgs] = recoverCheckFlagDisableGC
 		}
 
 		// Clear all placement when recover

--- a/executor/recover_test.go
+++ b/executor/recover_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/sessionctx/variable"
 	"github.com/pingcap/tidb/testkit"
+	"github.com/pingcap/tidb/util/dbterror"
 	"github.com/pingcap/tidb/util/gcutil"
 	"github.com/stretchr/testify/require"
 	"github.com/tikv/client-go/v2/oracle"
@@ -172,6 +173,7 @@ func TestFlashbackTable(t *testing.T) {
 	// Test for flashback to new table.
 	tk.MustExec("drop table t_flashback")
 	tk.MustExec("create table t_flashback (a int);")
+	tk.MustGetErrMsg("flashback table t_flashback to ` `", dbterror.ErrWrongTableName.GenWithStack("Incorrect table name ' '").Error())
 	tk.MustExec("flashback table t_flashback to t_flashback2")
 	// Check flashback table meta and data record.
 	tk.MustQuery("select * from t_flashback2;").Check(testkit.Rows("1", "2", "3", "4", "5", "6"))

--- a/executor/recover_test.go
+++ b/executor/recover_test.go
@@ -441,7 +441,7 @@ func TestFlashbackSchema(t *testing.T) {
 	defer resetGC()
 
 	// if GC safe point is not exists in mysql.tidb
-	tk.MustGetErrMsg("flashback database test_flashback", "can not get 'tikv_gc_safe_point'")
+	tk.MustGetErrMsg("flashback database db_not_exists", "can not get 'tikv_gc_safe_point'")
 	// Set GC safe point
 	tk.MustExec(fmt.Sprintf(safePointSQL, timeBeforeDrop))
 	// Set GC enable.
@@ -451,7 +451,7 @@ func TestFlashbackSchema(t *testing.T) {
 	tk.MustExec("drop database test_flashback")
 
 	// Test flashback database with db_not_exists name.
-	tk.MustGetErrMsg("flashback database db_not_exists", "Can't find dropped database 'db_not_exists' in GC safe point")
+	tk.MustGetErrMsg("flashback database db_not_exists", "Can't find dropped database: db_not_exists in DDL history jobs")
 	tk.MustExec("flashback database test_flashback")
 	tk.MustGetErrMsg("flashback database test_flashback to test_flashback2", "Schema 'test_flashback' already been recover to 'test_flashback', can't be recover repeatedly")
 

--- a/executor/recover_test.go
+++ b/executor/recover_test.go
@@ -423,6 +423,63 @@ func TestFlashbackWithSafeTs(t *testing.T) {
 	require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/ddl/mockFlashbackTest"))
 }
 
+func TestFlashbackSchema(t *testing.T) {
+	require.NoError(t, failpoint.Enable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange", `return(true)`))
+	defer func() {
+		require.NoError(t, failpoint.Disable("github.com/pingcap/tidb/meta/autoid/mockAutoIDChange"))
+	}()
+
+	store := testkit.CreateMockStore(t)
+
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("create database if not exists test_flashback")
+	tk.MustExec("use test_flashback")
+	tk.MustExec("drop table if exists t_flashback")
+	tk.MustExec("create table t_flashback (a int)")
+
+	timeBeforeDrop, _, safePointSQL, resetGC := MockGC(tk)
+	defer resetGC()
+
+	// if GC safe point is not exists in mysql.tidb
+	tk.MustGetErrMsg("flashback database test_flashback", "can not get 'tikv_gc_safe_point'")
+	// Set GC safe point
+	tk.MustExec(fmt.Sprintf(safePointSQL, timeBeforeDrop))
+	// Set GC enable.
+	require.NoError(t, gcutil.EnableGC(tk.Session()))
+
+	tk.MustExec("insert into t_flashback values (1),(2),(3)")
+	tk.MustExec("drop database test_flashback")
+
+	// Test flashback database with db_not_exists name.
+	tk.MustGetErrMsg("flashback database db_not_exists", "Can't find dropped database 'db_not_exists' in GC safe point")
+	tk.MustExec("flashback database test_flashback")
+	tk.MustGetErrMsg("flashback database test_flashback to test_flashback2", "Schema 'test_flashback' already been recover to 'test_flashback', can't be recover repeatedly")
+
+	// Test flashback database failed by there is already a new database with the same name.
+	// If there is a new database with the same name, should return failed.
+	tk.MustExec("create database db_flashback")
+	tk.MustGetErrMsg("flashback schema db_flashback", infoschema.ErrDatabaseExists.GenWithStackByArgs("db_flashback").Error())
+
+	//  Test for flashback schema.
+	tk.MustExec("drop database if exists test1")
+	tk.MustExec("create database test1")
+	tk.MustExec("use test1")
+	tk.MustExec("create table t (a int)")
+	tk.MustExec("create table t1 (a int)")
+	tk.MustExec("insert into t values (1),(2),(3)")
+	tk.MustExec("insert into t1 values (4),(5),(6)")
+	tk.MustExec("drop database test1")
+	tk.MustExec("flashback schema test1")
+	tk.MustExec("use test1")
+	tk.MustQuery("select a from t order by a").Check(testkit.Rows("1", "2", "3"))
+	tk.MustQuery("select a from t1 order by a").Check(testkit.Rows("4", "5", "6"))
+	tk.MustExec("drop database test1")
+	tk.MustExec("flashback schema test1 to test2")
+	tk.MustExec("use test2")
+	tk.MustQuery("select a from t order by a").Check(testkit.Rows("1", "2", "3"))
+	tk.MustQuery("select a from t1 order by a").Check(testkit.Rows("4", "5", "6"))
+}
+
 // MockGC is used to make GC work in the test environment.
 func MockGC(tk *testkit.TestKit) (string, string, string, func()) {
 	originGC := ddlutil.IsEmulatorGCEnable()

--- a/executor/recover_test.go
+++ b/executor/recover_test.go
@@ -455,7 +455,7 @@ func TestFlashbackSchema(t *testing.T) {
 	// Test flashback database with db_not_exists name.
 	tk.MustGetErrMsg("flashback database db_not_exists", "Can't find dropped database: db_not_exists in DDL history jobs")
 	tk.MustExec("flashback database test_flashback")
-	tk.MustGetErrMsg("flashback database test_flashback to test_flashback2", "Schema 'test_flashback' already been recover to 'test_flashback', can't be recover repeatedly")
+	tk.MustGetErrMsg("flashback database test_flashback to test_flashback2", infoschema.ErrDatabaseExists.GenWithStack("Schema 'test_flashback' already been recover to 'test_flashback', can't be recover repeatedly").Error())
 
 	// Test flashback database failed by there is already a new database with the same name.
 	// If there is a new database with the same name, should return failed.

--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -35,6 +35,7 @@ var (
 	_ DDLNode = &CreateSequenceStmt{}
 	_ DDLNode = &CreatePlacementPolicyStmt{}
 	_ DDLNode = &DropDatabaseStmt{}
+	_ DDLNode = &FlashBackDatabaseStmt{}
 	_ DDLNode = &DropIndexStmt{}
 	_ DDLNode = &DropTableStmt{}
 	_ DDLNode = &DropSequenceStmt{}
@@ -250,6 +251,35 @@ func (n *DropDatabaseStmt) Accept(v Visitor) (Node, bool) {
 		return v.Leave(newNode)
 	}
 	n = newNode.(*DropDatabaseStmt)
+	return v.Leave(n)
+}
+
+// FlashBackDatabaseStmt is a statement to restore a database and all tables in the database.
+type FlashBackDatabaseStmt struct {
+	ddlNode
+
+	DBName  model.CIStr
+	NewName string
+}
+
+// Restore implements Node interface.
+func (n *FlashBackDatabaseStmt) Restore(ctx *format.RestoreCtx) error {
+	ctx.WriteKeyWord("FLASHBACK DATABASE")
+	ctx.WriteName(n.DBName.O)
+	if len(n.NewName) > 0 {
+		ctx.WriteKeyWord(" TO ")
+		ctx.WriteName(n.NewName)
+	}
+	return nil
+}
+
+// Accept implements Node Accept interface.
+func (n *FlashBackDatabaseStmt) Accept(v Visitor) (Node, bool) {
+	newNode, skipChildren := v.Enter(n)
+	if skipChildren {
+		return v.Leave(newNode)
+	}
+	n = newNode.(*FlashBackDatabaseStmt)
 	return v.Leave(n)
 }
 

--- a/parser/ast/ddl.go
+++ b/parser/ast/ddl.go
@@ -264,7 +264,7 @@ type FlashBackDatabaseStmt struct {
 
 // Restore implements Node interface.
 func (n *FlashBackDatabaseStmt) Restore(ctx *format.RestoreCtx) error {
-	ctx.WriteKeyWord("FLASHBACK DATABASE")
+	ctx.WriteKeyWord("FLASHBACK DATABASE ")
 	ctx.WriteName(n.DBName.O)
 	if len(n.NewName) > 0 {
 		ctx.WriteKeyWord(" TO ")

--- a/parser/ast/ddl_test.go
+++ b/parser/ast/ddl_test.go
@@ -827,3 +827,16 @@ func TestRemovePlacementRestore(t *testing.T) {
 		runNodeRestoreTestWithFlagsStmtChange(t, testCases, "%s", extractNodeFunc, f)
 	}
 }
+
+func TestFlashBackDatabaseRestore(t *testing.T) {
+	testCases := []NodeRestoreTestCase{
+		{"flashback database M", "FLASHBACK DATABASE M"},
+		{"flashback schema M", "FLASHBACK DATABASE M"},
+		{"flashback database M to n", "FLASHBACK DATABASE M TO `n`"},
+		{"flashback schema M to N", "FLASHBACK DATABASE M TO `N`"},
+	}
+	extractNodeFunc := func(node Node) Node {
+		return node
+	}
+	runNodeRestoreTest(t, testCases, "%s", extractNodeFunc)
+}

--- a/parser/ast/ddl_test.go
+++ b/parser/ast/ddl_test.go
@@ -830,10 +830,10 @@ func TestRemovePlacementRestore(t *testing.T) {
 
 func TestFlashBackDatabaseRestore(t *testing.T) {
 	testCases := []NodeRestoreTestCase{
-		{"flashback database M", "FLASHBACK DATABASE M"},
-		{"flashback schema M", "FLASHBACK DATABASE M"},
-		{"flashback database M to n", "FLASHBACK DATABASE M TO `n`"},
-		{"flashback schema M to N", "FLASHBACK DATABASE M TO `N`"},
+		{"flashback database M", "FLASHBACK DATABASE `M`"},
+		{"flashback schema M", "FLASHBACK DATABASE `M`"},
+		{"flashback database M to n", "FLASHBACK DATABASE `M` TO `n`"},
+		{"flashback schema M to N", "FLASHBACK DATABASE `M` TO `N`"},
 	}
 	extractNodeFunc := func(node Node) Node {
 		return node

--- a/parser/model/ddl.go
+++ b/parser/model/ddl.go
@@ -97,6 +97,7 @@ const (
 	ActionCreateTables                  ActionType = 60
 	ActionMultiSchemaChange             ActionType = 61
 	ActionFlashbackCluster              ActionType = 62
+	ActionRecoverSchema                 ActionType = 63
 )
 
 var actionMap = map[ActionType]string{
@@ -158,6 +159,7 @@ var actionMap = map[ActionType]string{
 	ActionAlterTableStatsOptions:        "alter table statistics options",
 	ActionMultiSchemaChange:             "alter table multi-schema change",
 	ActionFlashbackCluster:              "flashback cluster",
+	ActionRecoverSchema:                 "flashback schema",
 
 	// `ActionAlterTableAlterPartition` is removed and will never be used.
 	// Just left a tombstone here for compatibility.

--- a/parser/parser.y
+++ b/parser/parser.y
@@ -901,6 +901,7 @@ import (
 	FlushStmt                  "Flush statement"
 	FlashbackTableStmt         "Flashback table statement"
 	FlashbackClusterStmt       "Flashback cluster statement"
+	FlashbackDatabaseStmt      "Flashback Database statement"
 	GrantStmt                  "Grant statement"
 	GrantProxyStmt             "Grant proxy statement"
 	GrantRoleStmt              "Grant role statement"
@@ -2620,6 +2621,23 @@ FlashbackToNewName:
 |	"TO" Identifier
 	{
 		$$ = $2
+	}
+
+/*******************************************************************
+ *
+ *  Flush Back Database Statement
+ *
+ *  Example:
+ *      FLASHBACK DATABASE/SCHEMA DBName TO newDBName
+ *
+ *******************************************************************/
+FlashbackDatabaseStmt:
+	"FLASHBACK" DatabaseSym DBName FlashbackToNewName
+	{
+		$$ = &ast.FlashBackDatabaseStmt{
+			DBName:  model.NewCIStr($3),
+			NewName: $4,
+		}
 	}
 
 /*******************************************************************
@@ -11333,6 +11351,7 @@ Statement:
 |	FlushStmt
 |	FlashbackClusterStmt
 |	FlashbackTableStmt
+|	FlashbackDatabaseStmt
 |	GrantStmt
 |	GrantProxyStmt
 |	GrantRoleStmt

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3246,6 +3246,11 @@ func TestDDL(t *testing.T) {
 		// for flashback table.
 		{"flashback table t", true, "FLASHBACK TABLE `t`"},
 		{"flashback table t TO t1", true, "FLASHBACK TABLE `t` TO `t1`"},
+		// for flashback database.
+		{"flashback database db1", true, "FLASHBACK DATABASE `db1`"},
+		{"flashback schema db1", true, "FLASHBACK DATABASE `db1`"},
+		{"flashback database db1 to db2", true, "FLASHBACK DATABASE `db1` TO `db2`"},
+		{"flashback schema db1 to db2", true, "FLASHBACK DATABASE `db1` TO `db2`"},
 
 		// for flashback cluster
 		{"flashback cluster to timestamp '2021-05-26 16:45:26'", true, "FLASHBACK CLUSTER TO TIMESTAMP '2021-05-26 16:45:26'"},

--- a/planner/core/planbuilder.go
+++ b/planner/core/planbuilder.go
@@ -4545,7 +4545,7 @@ func (b *PlanBuilder) buildDDL(ctx context.Context, node ast.DDLNode) (Plan, err
 		}
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.InsertPriv, v.TableToTables[0].NewTable.Schema.L,
 			v.TableToTables[0].NewTable.Name.L, "", authErr)
-	case *ast.RecoverTableStmt, *ast.FlashBackTableStmt:
+	case *ast.RecoverTableStmt, *ast.FlashBackTableStmt, *ast.FlashBackDatabaseStmt:
 		// Recover table command can only be executed by administrator.
 		b.visitInfo = appendVisitInfo(b.visitInfo, mysql.SuperPriv, "", "", "", nil)
 	case *ast.LockTablesStmt:

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -309,10 +309,15 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 			p.checkBindGrammar(node.OriginNode, node.HintedNode, p.sctx.GetSessionVars().CurrentDB)
 		}
 		return in, true
-	case *ast.RecoverTableStmt, *ast.FlashBackTableStmt:
+	case *ast.RecoverTableStmt:
 		// The specified table in recover table statement maybe already been dropped.
 		// So skip check table name here, otherwise, recover table [table_name] syntax will return
 		// table not exists error. But recover table statement is use to recover the dropped table. So skip children here.
+		return in, true
+	case *ast.FlashBackTableStmt:
+		if len(node.NewName) > 0 {
+			p.checkFlashbackTableGrammar(node)
+		}
 		return in, true
 	case *ast.FlashBackDatabaseStmt:
 		if len(node.NewName) > 0 {
@@ -790,6 +795,12 @@ func (p *preprocessor) checkAlterDatabaseGrammar(stmt *ast.AlterDatabaseStmt) {
 func (p *preprocessor) checkDropDatabaseGrammar(stmt *ast.DropDatabaseStmt) {
 	if isIncorrectName(stmt.Name.L) {
 		p.err = dbterror.ErrWrongDBName.GenWithStackByArgs(stmt.Name)
+	}
+}
+
+func (p *preprocessor) checkFlashbackTableGrammar(stmt *ast.FlashBackTableStmt) {
+	if isIncorrectName(stmt.NewName) {
+		p.err = dbterror.ErrWrongTableName.GenWithStackByArgs(stmt.NewName)
 	}
 }
 

--- a/planner/core/preprocess.go
+++ b/planner/core/preprocess.go
@@ -314,6 +314,11 @@ func (p *preprocessor) Enter(in ast.Node) (out ast.Node, skipChildren bool) {
 		// So skip check table name here, otherwise, recover table [table_name] syntax will return
 		// table not exists error. But recover table statement is use to recover the dropped table. So skip children here.
 		return in, true
+	case *ast.FlashBackDatabaseStmt:
+		if len(node.NewName) > 0 {
+			p.checkFlashbackDatabaseGrammar(node)
+		}
+		return in, true
 	case *ast.RepairTableStmt:
 		p.stmtTp = TypeRepair
 		// The RepairTable should consist of the logic for creating tables and renaming tables.
@@ -785,6 +790,12 @@ func (p *preprocessor) checkAlterDatabaseGrammar(stmt *ast.AlterDatabaseStmt) {
 func (p *preprocessor) checkDropDatabaseGrammar(stmt *ast.DropDatabaseStmt) {
 	if isIncorrectName(stmt.Name.L) {
 		p.err = dbterror.ErrWrongDBName.GenWithStackByArgs(stmt.Name)
+	}
+}
+
+func (p *preprocessor) checkFlashbackDatabaseGrammar(stmt *ast.FlashBackDatabaseStmt) {
+	if isIncorrectName(stmt.NewName) {
+		p.err = dbterror.ErrWrongDBName.GenWithStackByArgs(stmt.NewName)
 	}
 }
 


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #20463

Problem Summary:

### What is changed and how it works?
1.Add RecoverSchemaInfo struct contains SchemaInfo and TableInfo.
2.Add recoverSchema code logical like the recovertable .
### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
```
mysql> drop database m;
Query OK, 0 rows affected (0.43 sec)
mysql> create database m;
Query OK, 0 rows affected (0.20 sec)
mysql> use m;
Database changed
mysql> CREATE TABLE t(id int PRIMARY KEY AUTO_INCREMENT, c int);
Query OK, 0 rows affected (0.19 sec)
mysql> INSERT INTO t(c) VALUES (1);
Query OK, 1 row affected (0.03 sec)
mysql> INSERT INTO t(c) VALUES (2);
Query OK, 1 row affected (0.01 sec)
mysql> drop database m;
Query OK, 0 rows affected (0.42 sec)
mysql> flashback database m;
Query OK, 0 rows affected (0.97 sec)
mysql> use m ;
Database changed
mysql> select * from t;
+----+------+
| id | c    |
+----+------+
|  1 |    1 |
|  2 |    2 |
+----+------+
2 rows in set (0.01 sec)
mysql>
```

Side effects

- N/A

Documentation

- N/A

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Add support `flashback database` command.
```
