### PR TITLE
store/copr: fix building cop task for global kill

### DIFF
--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -91,10 +91,7 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 		tasks []*copTask
 		err   error
 	)
-	if len(req.KeyRanges) > 0 {
-		ranges := NewKeyRanges(req.KeyRanges)
-		tasks, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
-	} else {
+	if len(req.KeyRangesWithPartition) > 0 {
 		// Here we build the task by partition, not directly by region.
 		// This is because it's possible that TiDB merge multiple small partition into one region which break some assumption.
 		// Keep it split by partition would be more safe.
@@ -107,6 +104,9 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 			}
 			tasks = append(tasks, tasksInPartition...)
 		}
+	} else {
+		ranges := NewKeyRanges(req.KeyRanges)
+		tasks, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
 	}
 	if err != nil {
 		return copErrorResponse{err}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #36108 ref #37421

Problem Summary:

### What is changed and how it works?

After #36108 or #37421, global kill request doesn't build any cop task so global kill doesn't take effect. We adjust the logic of building cop tasks so that global kill request can build the cop task, which will be sent to another TiDB for executing kill command.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
