### PR TITLE
*: [security] neutralizes externally-controlled format DSN strings

### DIFF
--- a/br/pkg/lightning/common/util.go
+++ b/br/pkg/lightning/common/util.go
@@ -62,7 +62,7 @@ func (param *MySQLConnectParam) ToDSN() string {
 	hostPort := net.JoinHostPort(param.Host, strconv.Itoa(param.Port))
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/?charset=utf8mb4&sql_mode='%s'&maxAllowedPacket=%d&tls=%s",
 		param.User, param.Password, hostPort,
-		param.SQLMode, param.MaxAllowedPacket, param.TLS)
+		url.QueryEscape(param.SQLMode), param.MaxAllowedPacket, url.QueryEscape(param.TLS))
 
 	for k, v := range param.Vars {
 		dsn += fmt.Sprintf("&%s='%s'", k, url.QueryEscape(v))

--- a/cmd/explaintest/main.go
+++ b/cmd/explaintest/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strings"
@@ -688,7 +689,11 @@ func main() {
 
 	mdb, err = openDBWithRetry(
 		"mysql",
-		"root@tcp(localhost:"+fmt.Sprint(port)+")/"+dbName+"?allowAllFiles=true",
+		fmt.Sprintf(
+			"root@tcp(localhost:%d)/%s?allowAllFiles=true",
+			port,
+			url.QueryEscape(dbName),
+		),
 	)
 	if err != nil {
 		log.Fatal("open DB failed", zap.Error(err))

--- a/cmd/importer/db.go
+++ b/cmd/importer/db.go
@@ -19,6 +19,8 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"net"
+	"net/url"
 	"strconv"
 	"strings"
 
@@ -318,7 +320,8 @@ func execSQL(db *sql.DB, sql string) error {
 }
 
 func createDB(cfg DBConfig) (*sql.DB, error) {
-	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Name)
+	hostPort := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+	dbDSN := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8", cfg.User, cfg.Password, hostPort, url.QueryEscape(cfg.Name))
 	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
 		return nil, errors.Trace(err)

--- a/dumpling/export/config.go
+++ b/dumpling/export/config.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
+	"net/url"
 	"strconv"
 	"strings"
 	"text/template"
@@ -208,7 +209,7 @@ func (conf *Config) GetDSN(db string) string {
 	// https://github.com/go-sql-driver/mysql#maxallowedpacket
 	hostPort := net.JoinHostPort(conf.Host, strconv.Itoa(conf.Port))
 	dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?collation=utf8mb4_general_ci&readTimeout=%s&writeTimeout=30s&interpolateParams=true&maxAllowedPacket=0",
-		conf.User, conf.Password, hostPort, db, conf.ReadTimeout)
+		conf.User, conf.Password, hostPort, url.QueryEscape(db), conf.ReadTimeout)
 	if len(conf.Security.CAPath) > 0 {
 		dsn += "&tls=dumpling-tls-target"
 	}

--- a/dumpling/tests/s3/import.go
+++ b/dumpling/tests/s3/import.go
@@ -6,7 +6,10 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"net"
+	"net/url"
 	"os"
+	"strconv"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
@@ -48,7 +51,7 @@ func main() {
 			return errors.Trace(err)
 		}
 
-		dsn := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8mb4", "root", "", "127.0.0.1", port, database)
+		dsn := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8mb4", "root", "", net.JoinHostPort("127.0.0.1", strconv.Itoa(port)), url.QueryEscape(database))
 		db, err := sql.Open("mysql", dsn)
 		if err != nil {
 			return errors.Trace(err)

--- a/util/dbutil/common.go
+++ b/util/dbutil/common.go
@@ -19,6 +19,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
@@ -107,12 +108,14 @@ func GetDBConfigFromEnv(schema string) DBConfig {
 
 // OpenDB opens a mysql connection FD
 func OpenDB(cfg DBConfig, vars map[string]string) (*sql.DB, error) {
-	var dbDSN string
+	var dbDSN, hostPort string
+
+	hostPort = net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
 	if len(cfg.Snapshot) != 0 {
 		log.Info("create connection with snapshot", zap.String("snapshot", cfg.Snapshot))
-		dbDSN = fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4&tidb_snapshot=%s", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Snapshot)
+		dbDSN = fmt.Sprintf("%s:%s@tcp(%s)/?charset=utf8mb4&tidb_snapshot=%s", cfg.User, cfg.Password, hostPort, url.QueryEscape(cfg.Snapshot))
 	} else {
-		dbDSN = fmt.Sprintf("%s:%s@tcp(%s:%d)/?charset=utf8mb4", cfg.User, cfg.Password, cfg.Host, cfg.Port)
+		dbDSN = fmt.Sprintf("%s:%s@tcp(%s)/?charset=utf8mb4", cfg.User, cfg.Password, hostPort)
 	}
 
 	for key, val := range vars {

--- a/util/importer/db.go
+++ b/util/importer/db.go
@@ -18,6 +18,8 @@ import (
 	"database/sql"
 	"fmt"
 	"math"
+	"net"
+	"net/url"
 	"strconv"
 
 	_ "github.com/go-sql-driver/mysql" // for mysql driver
@@ -228,7 +230,8 @@ func execSQL(db *sql.DB, sql string) error {
 }
 
 func createDB(cfg dbutil.DBConfig) (*sql.DB, error) {
-	dbDSN := fmt.Sprintf("%s:%s@tcp(%s:%d)/%s?charset=utf8", cfg.User, cfg.Password, cfg.Host, cfg.Port, cfg.Schema)
+	hostPort := net.JoinHostPort(cfg.Host, strconv.Itoa(cfg.Port))
+	dbDSN := fmt.Sprintf("%s:%s@tcp(%s)/%s?charset=utf8", cfg.User, cfg.Password, hostPort, url.QueryEscape(cfg.Schema))
 	db, err := sql.Open("mysql", dbDSN)
 	if err != nil {
 		return nil, errors.Trace(err)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close [120f1346-e958-49d0-b66c-0f889a469540](https://huntr.dev/bounties/120f1346-e958-49d0-b66c-0f889a469540/) (external)

Problem Summary:

TiDB uses Go MySQL Driver for connecting to MySQL servers. The Data Source Name (DSN) strings for describing database connections is not neutralized so they can escape and add new parameters to use as data source name.

### What is changed and how it works?

- Escape any untrusted input to connect by DSN strings.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fix the issue of arbitrary file read via data source name injection (CVE-2022-3023).
```
