### PR TITLE
*: make auto-analyze concurrency configurable & push part of order prop to partition table

### DIFF
--- a/ddl/db_partition_test.go
+++ b/ddl/db_partition_test.go
@@ -1376,7 +1376,7 @@ func TestAlterTableDropPartitionByList(t *testing.T) {
 	);`)
 	tk.MustExec(`insert into t values (1),(3),(5),(null)`)
 	tk.MustExec(`alter table t drop partition p1`)
-	tk.MustQuery("select * from t").Check(testkit.Rows("1", "5", "<nil>"))
+	tk.MustQuery("select * from t order by id").Check(testkit.Rows("<nil>", "1", "5"))
 	ctx := tk.Session()
 	is := domain.GetDomain(ctx).InfoSchema()
 	tbl, err := is.TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
@@ -1907,7 +1907,7 @@ func TestAlterTableExchangePartition(t *testing.T) {
 	// test disable exchange partition
 	tk.MustExec("ALTER TABLE e EXCHANGE PARTITION p0 WITH TABLE e2")
 	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 8200 Exchange Partition is disabled, please set 'tidb_enable_exchange_partition' if you need to need to enable it"))
-	tk.MustQuery("select * from e").Check(testkit.Rows("16", "1669", "337", "2005"))
+	tk.MustQuery("select * from e order by id").Check(testkit.Rows("16", "337", "1669", "2005"))
 	tk.MustQuery("select * from e2").Check(testkit.Rows())
 
 	// enable exchange partition

--- a/distsql/request_builder.go
+++ b/distsql/request_builder.go
@@ -187,6 +187,12 @@ func (builder *RequestBuilder) SetKeyRanges(keyRanges []kv.KeyRange) *RequestBui
 	return builder
 }
 
+// SetPartitionKeyRanges sets the "KeyRangesWithPartition" for "kv.Request".
+func (builder *RequestBuilder) SetPartitionKeyRanges(keyRanges [][]kv.KeyRange) *RequestBuilder {
+	builder.Request.KeyRangesWithPartition = keyRanges
+	return builder
+}
+
 // SetStartTS sets "StartTS" for "kv.Request".
 func (builder *RequestBuilder) SetStartTS(startTS uint64) *RequestBuilder {
 	builder.Request.StartTs = startTS
@@ -323,6 +329,16 @@ func (builder *RequestBuilder) verifyTxnScope() error {
 			visitPhysicalTableID[tableID] = struct{}{}
 		} else {
 			return errors.New("requestBuilder can't decode tableID from keyRange")
+		}
+	}
+	for _, partKeyRanges := range builder.Request.KeyRangesWithPartition {
+		for _, keyRange := range partKeyRanges {
+			tableID := tablecodec.DecodeTableID(keyRange.StartKey)
+			if tableID > 0 {
+				visitPhysicalTableID[tableID] = struct{}{}
+			} else {
+				return errors.New("requestBuilder can't decode tableID from keyRange")
+			}
 		}
 	}
 

--- a/executor/adapter.go
+++ b/executor/adapter.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"runtime/trace"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -401,8 +402,18 @@ func (a *ExecStmt) Exec(ctx context.Context) (_ sqlexec.RecordSet, err error) {
 		oriScan := sctx.GetSessionVars().DistSQLScanConcurrency()
 		oriIndex := sctx.GetSessionVars().IndexSerialScanConcurrency()
 		oriIso, _ := sctx.GetSessionVars().GetSystemVar(variable.TxnIsolation)
-		terror.Log(sctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, "1"))
-		sctx.GetSessionVars().SetDistSQLScanConcurrency(1)
+		autoConcurrency, err1 := variable.GetSessionOrGlobalSystemVar(sctx.GetSessionVars(), variable.TiDBAutoBuildStatsConcurrency)
+		terror.Log(err1)
+		if err1 == nil {
+			terror.Log(sctx.GetSessionVars().SetSystemVar(variable.TiDBBuildStatsConcurrency, autoConcurrency))
+		}
+		sVal, err2 := variable.GetSessionOrGlobalSystemVar(sctx.GetSessionVars(), variable.TiDBSysProcScanConcurrency)
+		terror.Log(err2)
+		if err2 == nil {
+			concurrency, err3 := strconv.ParseInt(sVal, 10, 64)
+			terror.Log(err3)
+			sctx.GetSessionVars().SetDistSQLScanConcurrency(int(concurrency))
+		}
 		sctx.GetSessionVars().SetIndexSerialScanConcurrency(1)
 		terror.Log(sctx.GetSessionVars().SetSystemVar(variable.TxnIsolation, ast.ReadCommitted))
 		defer func() {

--- a/executor/builder.go
+++ b/executor/builder.go
@@ -4055,17 +4055,16 @@ func (h kvRangeBuilderFromRangeAndPartition) buildKeyRangeSeparately(ranges []*r
 	return pids, ret, nil
 }
 
-func (h kvRangeBuilderFromRangeAndPartition) buildKeyRange(ranges []*ranger.Range) ([]kv.KeyRange, error) {
-	//nolint: prealloc
-	var ret []kv.KeyRange
-	for _, p := range h.partitions {
+func (h kvRangeBuilderFromRangeAndPartition) buildKeyRange(ranges []*ranger.Range) ([][]kv.KeyRange, error) {
+	ret := make([][]kv.KeyRange, len(h.partitions))
+	for i, p := range h.partitions {
 		pid := p.GetPhysicalID()
 		meta := p.Meta()
 		kvRange, err := distsql.TableHandleRangesToKVRanges(h.sctx.GetSessionVars().StmtCtx, []int64{pid}, meta != nil && meta.IsCommonHandle, ranges, nil)
 		if err != nil {
 			return nil, err
 		}
-		ret = append(ret, kvRange...)
+		ret[i] = append(ret[i], kvRange...)
 	}
 	return ret, nil
 }

--- a/executor/distsql.go
+++ b/executor/distsql.go
@@ -456,9 +456,6 @@ func (e *IndexLookUpExecutor) Open(ctx context.Context) error {
 func (e *IndexLookUpExecutor) buildTableKeyRanges() (err error) {
 	sc := e.ctx.GetSessionVars().StmtCtx
 	if e.partitionTableMode {
-		if e.keepOrder { // this case should be prevented by the optimizer
-			return errors.New("invalid execution plan: cannot keep order when accessing a partition table by IndexLookUpReader")
-		}
 		e.feedback.Invalidate() // feedback for partition tables is not ready
 		e.partitionKVRanges = make([][]kv.KeyRange, 0, len(e.prunedPartitions))
 		for _, p := range e.prunedPartitions {

--- a/executor/table_reader.go
+++ b/executor/table_reader.go
@@ -57,7 +57,7 @@ func (sr selectResultHook) SelectResult(ctx context.Context, sctx sessionctx.Con
 }
 
 type kvRangeBuilder interface {
-	buildKeyRange(ranges []*ranger.Range) ([]kv.KeyRange, error)
+	buildKeyRange(ranges []*ranger.Range) ([][]kv.KeyRange, error)
 	buildKeyRangeSeparately(ranges []*ranger.Range) ([]int64, [][]kv.KeyRange, error)
 }
 
@@ -201,13 +201,25 @@ func (e *TableReaderExecutor) Open(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+		if len(kvReq.KeyRanges) > 0 {
+			e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+		} else {
+			for _, kr := range kvReq.KeyRangesWithPartition {
+				e.kvRanges = append(e.kvRanges, kr...)
+			}
+		}
 		if len(secondPartRanges) != 0 {
 			kvReq, err = e.buildKVReq(ctx, secondPartRanges)
 			if err != nil {
 				return err
 			}
-			e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+			if len(kvReq.KeyRanges) > 0 {
+				e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+			} else {
+				for _, kr := range kvReq.KeyRangesWithPartition {
+					e.kvRanges = append(e.kvRanges, kr...)
+				}
+			}
 		}
 		return nil
 	}
@@ -310,10 +322,19 @@ func (e *TableReaderExecutor) buildResp(ctx context.Context, ranges []*ranger.Ra
 	if err != nil {
 		return nil, err
 	}
-	slices.SortFunc(kvReq.KeyRanges, func(i, j kv.KeyRange) bool {
-		return bytes.Compare(i.StartKey, j.StartKey) < 0
-	})
-	e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+	if len(kvReq.KeyRanges) > 0 {
+		slices.SortFunc(kvReq.KeyRanges, func(i, j kv.KeyRange) bool {
+			return bytes.Compare(i.StartKey, j.StartKey) < 0
+		})
+		e.kvRanges = append(e.kvRanges, kvReq.KeyRanges...)
+	} else {
+		for _, kr := range kvReq.KeyRangesWithPartition {
+			slices.SortFunc(kr, func(i, j kv.KeyRange) bool {
+				return bytes.Compare(i.StartKey, j.StartKey) < 0
+			})
+			e.kvRanges = append(e.kvRanges, kr...)
+		}
+	}
 
 	result, err := e.SelectResult(ctx, e.ctx, kvReq, retTypes(e), e.feedback, getPhysicalPlanIDs(e.plans), e.id)
 	if err != nil {
@@ -405,7 +426,7 @@ func (e *TableReaderExecutor) buildKVReq(ctx context.Context, ranges []*ranger.R
 		if err != nil {
 			return nil, err
 		}
-		reqBuilder = builder.SetKeyRanges(kvRange)
+		reqBuilder = builder.SetPartitionKeyRanges(kvRange)
 	} else {
 		reqBuilder = builder.SetHandleRanges(e.ctx.GetSessionVars().StmtCtx, getPhysicalTableID(e.table), e.table.Meta() != nil && e.table.Meta().IsCommonHandle, ranges, e.feedback)
 	}

--- a/kv/kv.go
+++ b/kv/kv.go
@@ -323,6 +323,10 @@ type Request struct {
 	Data      []byte
 	KeyRanges []KeyRange
 
+	// KeyRangesWithPartition makes sure that the request is sent first by partition then by region.
+	// When the table is small, it's possible that multiple partitions are in the same region.
+	KeyRangesWithPartition [][]KeyRange
+
 	// For PartitionTableScan used by tiflash.
 	PartitionIDAndRanges []PartitionIDAndRanges
 

--- a/planner/cascades/testdata/integration_suite_in.json
+++ b/planner/cascades/testdata/integration_suite_in.json
@@ -142,7 +142,7 @@
   {
     "name": "TestCascadePlannerHashedPartTable",
     "cases": [
-      "select * from pt1"
+      "select * from pt1 order by a"
     ]
   },
   {

--- a/planner/cascades/testdata/integration_suite_out.json
+++ b/planner/cascades/testdata/integration_suite_out.json
@@ -1197,17 +1197,18 @@
     "Name": "TestCascadePlannerHashedPartTable",
     "Cases": [
       {
-        "SQL": "select * from pt1",
+        "SQL": "select * from pt1 order by a",
         "Plan": [
-          "TableReader_5 10000.00 root partition:all data:TableFullScan_6",
-          "└─TableFullScan_6 10000.00 cop[tikv] table:pt1 keep order:false, stats:pseudo"
+          "Sort_11 10000.00 root  test.pt1.a",
+          "└─TableReader_9 10000.00 root partition:all data:TableFullScan_10",
+          "  └─TableFullScan_10 10000.00 cop[tikv] table:pt1 keep order:false, stats:pseudo"
         ],
         "Result": [
-          "4 40",
           "1 10",
-          "5 50",
           "2 20",
-          "3 30"
+          "3 30",
+          "4 40",
+          "5 50"
         ]
       }
     ]

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -2288,6 +2288,7 @@ func (ds *DataSource) getOriginalPhysicalIndexScan(prop *property.PhysicalProper
 		physicalTableID:  ds.physicalTableID,
 		tblColHists:      ds.TblColHists,
 		pkIsHandleCol:    ds.getPKIsHandleCol(),
+		constColsByCond:  path.ConstCols,
 		prop:             prop,
 	}.Init(ds.ctx, ds.blockOffset)
 	statsTbl := ds.statisticTable

--- a/planner/core/partition_pruner_test.go
+++ b/planner/core/partition_pruner_test.go
@@ -307,17 +307,20 @@ func TestListPartitionPruner(t *testing.T) {
 	partitionPrunerData.GetTestCases(t, &input, &output)
 	valid := false
 	for i, tt := range input {
+		if tt == "select * from t1 where (id = 1 and a = 1) or a is null" {
+			fmt.Println("1")
+		}
 		testdata.OnRecord(func() {
 			output[i].SQL = tt
-			output[i].Result = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Rows())
+			output[i].Result = testdata.ConvertRowsToStrings(tk.MustQuery(tt).Sort().Rows())
 			output[i].Plan = testdata.ConvertRowsToStrings(tk.MustQuery("explain format = 'brief' " + tt).Rows())
 		})
 		tk.MustQuery("explain format = 'brief' " + tt).Check(testkit.Rows(output[i].Plan...))
-		result := tk.MustQuery(tt)
+		result := tk.MustQuery(tt).Sort()
 		result.Check(testkit.Rows(output[i].Result...))
 		// If the query doesn't specified the partition, compare the result with normal table
 		if !strings.Contains(tt, "partition(") {
-			result.Check(tk2.MustQuery(tt).Rows())
+			result.Check(tk.MustQuery(tt).Sort().Rows())
 			valid = true
 		}
 		require.True(t, valid)
@@ -386,7 +389,7 @@ func TestListColumnsPartitionPruner(t *testing.T) {
 		indexPlanTree := testdata.ConvertRowsToStrings(indexPlan.Rows())
 		testdata.OnRecord(func() {
 			output[i].SQL = tt.SQL
-			output[i].Result = testdata.ConvertRowsToStrings(tk.MustQuery(tt.SQL).Rows())
+			output[i].Result = testdata.ConvertRowsToStrings(tk.MustQuery(tt.SQL).Sort().Rows())
 			// Test for table without index.
 			output[i].Plan = planTree
 			// Test for table with index.
@@ -401,14 +404,14 @@ func TestListColumnsPartitionPruner(t *testing.T) {
 		checkPrunePartitionInfo(t, tt.SQL, tt.Pruner, indexPlanTree)
 
 		// compare the result.
-		result := tk.MustQuery(tt.SQL)
+		result := tk.MustQuery(tt.SQL).Sort()
 		idxResult := tk1.MustQuery(tt.SQL)
-		result.Check(idxResult.Rows())
+		result.Check(idxResult.Sort().Rows())
 		result.Check(testkit.Rows(output[i].Result...))
 
 		// If the query doesn't specified the partition, compare the result with normal table
 		if !strings.Contains(tt.SQL, "partition(") {
-			result.Check(tk2.MustQuery(tt.SQL).Rows())
+			result.Check(tk2.MustQuery(tt.SQL).Sort().Rows())
 			valid = true
 		}
 	}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -488,7 +488,12 @@ type PhysicalIndexScan struct {
 	// tblColHists contains all columns before pruning, which are used to calculate row-size
 	tblColHists   *statistics.HistColl
 	pkIsHandleCol *expression.Column
-	prop          *property.PhysicalProperty
+
+	// constColsByCond records the constant part of the index columns caused by the access conds.
+	// e.g. the index is (a, b, c) and there's filter a = 1 and b = 2, then the column a and b are const part.
+	constColsByCond []bool
+
+	prop *property.PhysicalProperty
 }
 
 // Clone implements PhysicalPlan interface.

--- a/planner/core/testdata/partition_pruner_out.json
+++ b/planner/core/testdata/partition_pruner_out.json
@@ -847,9 +847,9 @@
       {
         "SQL": "select * from t7 where a is null or a > 0 order by a;",
         "Result": [
-          "<nil>",
           "1",
-          "2"
+          "2",
+          "<nil>"
         ],
         "Plan": [
           "Sort 3343.33 root  test_partition.t7.a",
@@ -866,8 +866,8 @@
       {
         "SQL": "select * from t1 order by id,a",
         "Result": [
-          "<nil> 10 <nil>",
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "3 3 3",
           "4 4 4",
@@ -876,7 +876,7 @@
           "7 7 7",
           "8 8 8",
           "9 9 9",
-          "10 10 10"
+          "<nil> 10 <nil>"
         ],
         "Plan": [
           "Sort 10000.00 root  test_partition.t1.id, test_partition.t1.a",
@@ -1341,8 +1341,8 @@
       {
         "SQL": "select * from t1 where a = 1 or true order by id,a",
         "Result": [
-          "<nil> 10 <nil>",
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "3 3 3",
           "4 4 4",
@@ -1351,7 +1351,7 @@
           "7 7 7",
           "8 8 8",
           "9 9 9",
-          "10 10 10"
+          "<nil> 10 <nil>"
         ],
         "Plan": [
           "Sort 10000.00 root  test_partition.t1.id, test_partition.t1.a",
@@ -1973,13 +1973,13 @@
         "SQL": "select * from t1 where a < 3 or b > 4",
         "Result": [
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "5 5 5",
           "6 6 6",
           "7 7 7",
           "8 8 8",
-          "9 9 9",
-          "10 10 10"
+          "9 9 9"
         ],
         "Plan": [
           "TableReader 5548.89 root partition:p0,p1 data:Selection",
@@ -2059,11 +2059,11 @@
         "SQL": "select * from t1 where (a<=1 and b<=1) or (a >=6 and b>=6)",
         "Result": [
           "1 1 1",
+          "10 10 10",
           "6 6 6",
           "7 7 7",
           "8 8 8",
-          "9 9 9",
-          "10 10 10"
+          "9 9 9"
         ],
         "Plan": [
           "TableReader 2092.85 root partition:p0,p1 data:Selection",
@@ -2080,6 +2080,7 @@
         "SQL": "select * from t1 where a <= 100 and b <= 100",
         "Result": [
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "3 3 3",
           "4 4 4",
@@ -2087,8 +2088,7 @@
           "6 6 6",
           "7 7 7",
           "8 8 8",
-          "9 9 9",
-          "10 10 10"
+          "9 9 9"
         ],
         "Plan": [
           "TableReader 1104.45 root partition:p0,p1 data:Selection",
@@ -2126,10 +2126,10 @@
       {
         "SQL": "select * from t1 left join t2 on true where (t1.a <=1 or t1.a <= 3 and (t1.b >=3 and t1.b <= 5)) and (t2.a >= 6 and t2.a <= 8) and t2.b>=7 and t2.id>=7 order by t1.id,t1.a",
         "Result": [
-          "1 1 1 8 8 8",
           "1 1 1 7 7 7",
-          "3 3 3 8 8 8",
-          "3 3 3 7 7 7"
+          "1 1 1 8 8 8",
+          "3 3 3 7 7 7",
+          "3 3 3 8 8 8"
         ],
         "Plan": [
           "Sort 93855.70 root  test_partition.t1.id, test_partition.t1.a",
@@ -2326,8 +2326,8 @@
       {
         "SQL": "select * from t1 where a = 3 or true order by id,a",
         "Result": [
-          "<nil> 10 <nil>",
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "3 3 3",
           "4 4 4",
@@ -2336,7 +2336,7 @@
           "7 7 7",
           "8 8 8",
           "9 9 9",
-          "10 10 10"
+          "<nil> 10 <nil>"
         ],
         "Plan": [
           "Sort 10000.00 root  test_partition.t1.id, test_partition.t1.a",
@@ -2463,6 +2463,7 @@
         "SQL": "select * from t1 where (a >= 1 and a <= 6) or (a>=3 and b >=3)",
         "Result": [
           "1 1 1",
+          "10 10 10",
           "2 2 2",
           "3 3 3",
           "4 4 4",
@@ -2470,8 +2471,7 @@
           "6 6 6",
           "7 7 7",
           "8 8 8",
-          "9 9 9",
-          "10 10 10"
+          "9 9 9"
         ],
         "Plan": [
           "TableReader 1333.33 root partition:p0,p1 data:Selection",

--- a/sessionctx/variable/sysvar.go
+++ b/sessionctx/variable/sysvar.go
@@ -839,6 +839,8 @@ var defaultSysVars = []*SysVar{
 	}, GetGlobal: func(s *SessionVars) (string, error) {
 		return BoolToOnOff(memory.EnableGCAwareMemoryTrack.Load()), nil
 	}},
+	{Scope: ScopeGlobal, Name: TiDBAutoBuildStatsConcurrency, Value: strconv.Itoa(DefTiDBAutoBuildStatsConcurrency), Type: TypeInt, MinValue: 1, MaxValue: MaxConfigurableConcurrency},
+	{Scope: ScopeGlobal, Name: TiDBSysProcScanConcurrency, Value: strconv.Itoa(DefTiDBSysProcScanConcurrency), Type: TypeInt, MinValue: 1, MaxValue: MaxConfigurableConcurrency},
 
 	/* The system variables below have GLOBAL and SESSION scope  */
 	{Scope: ScopeGlobal | ScopeSession, Name: SQLSelectLimit, Value: "18446744073709551615", Type: TypeUnsigned, MinValue: 0, MaxValue: math.MaxUint64, SetSession: func(s *SessionVars, val string) error {

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -784,6 +784,10 @@ const (
 	TiDBGenerateBinaryPlan = "tidb_generate_binary_plan"
 	// TiDBEnableGCAwareMemoryTrack indicates whether to turn-on GC-aware memory track.
 	TiDBEnableGCAwareMemoryTrack = "tidb_enable_gc_aware_memory_track"
+	// TiDBAutoBuildStatsConcurrency is used to set the build concurrency of auto-analyze.
+	TiDBAutoBuildStatsConcurrency = "tidb_auto_build_stats_concurrency"
+	// TiDBSysProcScanConcurrency is used to set the scan concurrency of for backend system processes, like auto-analyze.
+	TiDBSysProcScanConcurrency = "tidb_sysproc_scan_concurrency"
 )
 
 // TiDB intentional limits
@@ -996,6 +1000,8 @@ const (
 	DefTiDBGenerateBinaryPlan                      = true
 	DefEnableTiDBGCAwareMemoryTrack                = true
 	DefTiDBDefaultStrMatchSelectivity              = 0.8
+	DefTiDBAutoBuildStatsConcurrency        = 1
+	DefTiDBSysProcScanConcurrency           = 1
 )
 
 // Process global variables.

--- a/sessionctx/variable/tidb_vars.go
+++ b/sessionctx/variable/tidb_vars.go
@@ -1000,8 +1000,8 @@ const (
 	DefTiDBGenerateBinaryPlan                      = true
 	DefEnableTiDBGCAwareMemoryTrack                = true
 	DefTiDBDefaultStrMatchSelectivity              = 0.8
-	DefTiDBAutoBuildStatsConcurrency        = 1
-	DefTiDBSysProcScanConcurrency           = 1
+	DefTiDBAutoBuildStatsConcurrency               = 1
+	DefTiDBSysProcScanConcurrency                  = 1
 )
 
 // Process global variables.

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -113,10 +113,7 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 		tasks []*copTask
 		err   error
 	)
-	if len(req.KeyRanges) > 0 {
-		ranges := NewKeyRanges(req.KeyRanges)
-		tasks, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
-	} else {
+	if len(req.KeyRangesWithPartition) > 0 {
 		// Here we build the task by partition, not directly by region.
 		// This is because it's possible that TiDB merge multiple small partition into one region which break some assumption.
 		// Keep it split by partition would be more safe.
@@ -129,6 +126,9 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 			}
 			tasks = append(tasks, tasksInPartition...)
 		}
+	} else {
+		ranges := NewKeyRanges(req.KeyRanges)
+		tasks, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
 	}
 	reqType := "null"
 	if req.ClosestReplicaReadAdjuster != nil {

--- a/store/copr/coprocessor.go
+++ b/store/copr/coprocessor.go
@@ -109,8 +109,27 @@ func (c *CopClient) Send(ctx context.Context, req *kv.Request, variables interfa
 	ctx = context.WithValue(ctx, tikv.TxnStartKey(), req.StartTs)
 	ctx = context.WithValue(ctx, util.RequestSourceKey, req.RequestSource)
 	bo := backoff.NewBackofferWithVars(ctx, copBuildTaskMaxBackoff, vars)
-	ranges := NewKeyRanges(req.KeyRanges)
-	tasks, err := buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
+	var (
+		tasks []*copTask
+		err   error
+	)
+	if len(req.KeyRanges) > 0 {
+		ranges := NewKeyRanges(req.KeyRanges)
+		tasks, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
+	} else {
+		// Here we build the task by partition, not directly by region.
+		// This is because it's possible that TiDB merge multiple small partition into one region which break some assumption.
+		// Keep it split by partition would be more safe.
+		for _, kvRanges := range req.KeyRangesWithPartition {
+			ranges := NewKeyRanges(kvRanges)
+			var tasksInPartition []*copTask
+			tasksInPartition, err = buildCopTasks(bo, c.store.GetRegionCache(), ranges, req, eventCb)
+			if err != nil {
+				break
+			}
+			tasks = append(tasks, tasksInPartition...)
+		}
+	}
 	reqType := "null"
 	if req.ClosestReplicaReadAdjuster != nil {
 		reqType = "miss"

--- a/testkit/result.go
+++ b/testkit/result.go
@@ -49,6 +49,11 @@ func (res *Result) Check(expected [][]interface{}) {
 	res.require.Equal(needBuff.String(), resBuff.String(), res.comment)
 }
 
+// AddComment adds the extra comment for the Result's output.
+func (res *Result) AddComment(c string) {
+	res.comment += "\n" + c
+}
+
 // CheckWithFunc asserts the result match the expected results in the way `f` specifies.
 func (res *Result) CheckWithFunc(expected [][]interface{}, f func([]string, []interface{}) bool) {
 	res.require.Equal(len(res.rows), len(expected), res.comment+"\nResult length mismatch")


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #37483 
and cherry-pick #37477 

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
