### PR TITLE
executor: distinguish query types of prepared stmt

### DIFF
--- a/executor/compiler.go
+++ b/executor/compiler.go
@@ -102,8 +102,11 @@ func (c *Compiler) Compile(ctx context.Context, stmtNode ast.StmtNode) (*ExecStm
 		staleread.AssertStmtStaleness(c.Ctx, val.(bool))
 	})
 
-	// TODO: Should we use the Execute statement or the corresponding Prepare statement to record？
-	CountStmtNode(stmtNode, sessVars.InRestrictedSQL)
+	if preparedObj != nil {
+		CountStmtNode(preparedObj.PreparedAst.Stmt, sessVars.InRestrictedSQL)
+	} else {
+		CountStmtNode(stmtNode, sessVars.InRestrictedSQL)
+	}
 	var lowerPriority bool
 	if c.Ctx.GetSessionVars().StmtCtx.Priority == mysql.NoPriority {
 		lowerPriority = needLowerPriority(finalPlan)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2112,10 +2112,10 @@ func (cli *testServerClient) runTestStmtCount(t *testing.T) {
 		require.Equal(t, originStmtCnt["CreateTable"]+1, currentStmtCnt["CreateTable"])
 		require.Equal(t, originStmtCnt["Insert"]+5, currentStmtCnt["Insert"])
 		require.Equal(t, originStmtCnt["Delete"]+1, currentStmtCnt["Delete"])
-		require.Equal(t, originStmtCnt["Update"]+1, currentStmtCnt["Update"])
-		require.Equal(t, originStmtCnt["Select"]+2, currentStmtCnt["Select"])
+		require.Equal(t, originStmtCnt["Update"]+2, currentStmtCnt["Update"])
+		require.Equal(t, originStmtCnt["Select"]+3, currentStmtCnt["Select"])
 		require.Equal(t, originStmtCnt["Prepare"]+2, currentStmtCnt["Prepare"])
-		require.Equal(t, originStmtCnt["Execute"]+2, currentStmtCnt["Execute"])
+		require.Equal(t, originStmtCnt["Execute"]+0, currentStmtCnt["Execute"])
 		require.Equal(t, originStmtCnt["Replace"]+1, currentStmtCnt["Replace"])
 	})
 }


### PR DESCRIPTION
Signed-off-by: zyguan <zhongyangguan@gmail.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37503

Problem Summary: as described in #37503

### What is changed and how it works?

`CountStmtNode` with `preparedObj.PreparedAst.Stmt` if the `stmtNode` is an `*ExecuteStmt`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
