### PR TITLE
executor: append warning for sorting non-scalar json value

### DIFF
--- a/executor/aggfuncs/builder.go
+++ b/executor/aggfuncs/builder.go
@@ -79,9 +79,9 @@ func Build(ctx sessionctx.Context, aggFuncDesc *aggregation.AggFuncDesc, ordinal
 func BuildWindowFunctions(ctx sessionctx.Context, windowFuncDesc *aggregation.AggFuncDesc, ordinal int, orderByCols []*expression.Column) AggFunc {
 	switch windowFuncDesc.Name {
 	case ast.WindowFuncRank:
-		return buildRank(ordinal, orderByCols, false)
+		return buildRank(ctx, ordinal, orderByCols, false)
 	case ast.WindowFuncDenseRank:
-		return buildRank(ordinal, orderByCols, true)
+		return buildRank(ctx, ordinal, orderByCols, true)
 	case ast.WindowFuncRowNumber:
 		return buildRowNumber(windowFuncDesc, ordinal)
 	case ast.WindowFuncFirstValue:
@@ -89,13 +89,13 @@ func BuildWindowFunctions(ctx sessionctx.Context, windowFuncDesc *aggregation.Ag
 	case ast.WindowFuncLastValue:
 		return buildLastValue(windowFuncDesc, ordinal)
 	case ast.WindowFuncCumeDist:
-		return buildCumeDist(ordinal, orderByCols)
+		return buildCumeDist(ctx, ordinal, orderByCols)
 	case ast.WindowFuncNthValue:
 		return buildNthValue(windowFuncDesc, ordinal)
 	case ast.WindowFuncNtile:
 		return buildNtile(windowFuncDesc, ordinal)
 	case ast.WindowFuncPercentRank:
-		return buildPercentRank(ordinal, orderByCols)
+		return buildPercentRank(ctx, ordinal, orderByCols)
 	case ast.WindowFuncLead:
 		return buildLead(ctx, windowFuncDesc, ordinal)
 	case ast.WindowFuncLag:
@@ -635,11 +635,11 @@ func buildRowNumber(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	return &rowNumber{base}
 }
 
-func buildRank(ordinal int, orderByCols []*expression.Column, isDense bool) AggFunc {
+func buildRank(ctx sessionctx.Context, ordinal int, orderByCols []*expression.Column, isDense bool) AggFunc {
 	base := baseAggFunc{
 		ordinal: ordinal,
 	}
-	r := &rank{baseAggFunc: base, isDense: isDense, rowComparer: buildRowComparer(orderByCols)}
+	r := &rank{baseAggFunc: base, isDense: isDense, rowComparer: buildRowComparer(ctx, orderByCols)}
 	return r
 }
 
@@ -659,11 +659,11 @@ func buildLastValue(aggFuncDesc *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	return &lastValue{baseAggFunc: base, tp: aggFuncDesc.RetTp}
 }
 
-func buildCumeDist(ordinal int, orderByCols []*expression.Column) AggFunc {
+func buildCumeDist(ctx sessionctx.Context, ordinal int, orderByCols []*expression.Column) AggFunc {
 	base := baseAggFunc{
 		ordinal: ordinal,
 	}
-	r := &cumeDist{baseAggFunc: base, rowComparer: buildRowComparer(orderByCols)}
+	r := &cumeDist{baseAggFunc: base, rowComparer: buildRowComparer(ctx, orderByCols)}
 	return r
 }
 
@@ -686,11 +686,11 @@ func buildNtile(aggFuncDes *aggregation.AggFuncDesc, ordinal int) AggFunc {
 	return &ntile{baseAggFunc: base, n: n}
 }
 
-func buildPercentRank(ordinal int, orderByCols []*expression.Column) AggFunc {
+func buildPercentRank(ctx sessionctx.Context, ordinal int, orderByCols []*expression.Column) AggFunc {
 	base := baseAggFunc{
 		ordinal: ordinal,
 	}
-	return &percentRank{baseAggFunc: base, rowComparer: buildRowComparer(orderByCols)}
+	return &percentRank{baseAggFunc: base, rowComparer: buildRowComparer(ctx, orderByCols)}
 }
 
 func buildLeadLag(ctx sessionctx.Context, aggFuncDesc *aggregation.AggFuncDesc, ordinal int) baseLeadLag {

--- a/executor/aggfuncs/func_rank.go
+++ b/executor/aggfuncs/func_rank.go
@@ -83,16 +83,18 @@ type rowComparer struct {
 	colIdx   []int
 }
 
-func buildRowComparer(cols []*expression.Column) rowComparer {
+func buildRowComparer(ctx sessionctx.Context, cols []*expression.Column) rowComparer {
+	wp := ctx.GetSessionVars().StmtCtx.AppendWarning
+
 	rc := rowComparer{}
 	rc.colIdx = make([]int, 0, len(cols))
 	rc.cmpFuncs = make([]chunk.CompareFunc, 0, len(cols))
 	for _, col := range cols {
-		cmpFunc := chunk.GetCompareFunc(col.RetType)
+		cmpFunc := chunk.GetCompareFunc(col.RetType, wp)
 		if cmpFunc == nil {
 			continue
 		}
-		rc.cmpFuncs = append(rc.cmpFuncs, chunk.GetCompareFunc(col.RetType))
+		rc.cmpFuncs = append(rc.cmpFuncs, chunk.GetCompareFunc(col.RetType, wp))
 		rc.colIdx = append(rc.colIdx, col.Index)
 	}
 	return rc

--- a/executor/sort.go
+++ b/executor/sort.go
@@ -237,7 +237,7 @@ func (e *SortExec) initCompareFuncs() {
 	e.keyCmpFuncs = make([]chunk.CompareFunc, len(e.ByItems))
 	for i := range e.ByItems {
 		keyType := e.ByItems[i].Expr.GetType()
-		e.keyCmpFuncs[i] = chunk.GetCompareFunc(keyType)
+		e.keyCmpFuncs[i] = chunk.GetCompareFunc(keyType, e.ctx.GetSessionVars().StmtCtx.AppendWarning)
 	}
 }
 

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1171,6 +1171,7 @@ var symmetricOp = map[string]string{
 // ColWithCmpFuncManager is used in index join to handle the column with compare functions(>=, >, <, <=).
 // It stores the compare functions and build ranges in execution phase.
 type ColWithCmpFuncManager struct {
+	ctx               sessionctx.Context
 	TargetCol         *expression.Column
 	colLength         int
 	OpType            []string
@@ -1188,7 +1189,7 @@ func (cwc *ColWithCmpFuncManager) appendNewExpr(opName string, arg expression.Ex
 		if cwc.affectedColSchema.Contains(col) {
 			continue
 		}
-		cwc.compareFuncs = append(cwc.compareFuncs, chunk.GetCompareFunc(col.RetType))
+		cwc.compareFuncs = append(cwc.compareFuncs, chunk.GetCompareFunc(col.RetType, cwc.ctx.GetSessionVars().StmtCtx.AppendWarning))
 		cwc.affectedColSchema.Append(col)
 	}
 }
@@ -1450,6 +1451,7 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(path *util.AccessPath
 	}
 	lastPossibleCol := path.IdxCols[lastColPos]
 	lastColManager := &ColWithCmpFuncManager{
+		ctx:               ijHelper.join.ctx,
 		TargetCol:         lastPossibleCol,
 		colLength:         path.IdxColLens[lastColPos],
 		affectedColSchema: expression.NewSchema(),


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37506 

Problem Summary:

TiDB doesn't report a warning for non-scalar json sort.

Append warning while sorting a non-scalar json value.

### What is changed and how it works?

The json comparater will report a warning for non-scalar json value (e.g. json array and json object), so does the 

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that sorting non-scalar json value doesn't report the warning
```
