### PR TITLE
executor: do not acqurie pessimistic lock for non-unique index keys (#36229)

### DIFF
--- a/session/tidb_test.go
+++ b/session/tidb_test.go
@@ -76,7 +76,8 @@ func TestParseErrorWarn(t *testing.T) {
 
 func TestKeysNeedLock(t *testing.T) {
 	rowKey := tablecodec.EncodeRowKeyWithHandle(1, kv.IntHandle(1))
-	indexKey := tablecodec.EncodeIndexSeekKey(1, 1, []byte{1})
+	uniqueIndexKey := tablecodec.EncodeIndexSeekKey(1, 1, []byte{1})
+	nonUniqueIndexKey := tablecodec.EncodeIndexSeekKey(1, 2, []byte{1})
 	uniqueValue := make([]byte, 8)
 	uniqueUntouched := append(uniqueValue, '1')
 	nonUniqueVal := []byte{'0'}
@@ -90,18 +91,20 @@ func TestKeysNeedLock(t *testing.T) {
 	}{
 		{rowKey, rowVal, true},
 		{rowKey, deleteVal, true},
-		{indexKey, nonUniqueVal, false},
-		{indexKey, nonUniqueUntouched, false},
-		{indexKey, uniqueValue, true},
-		{indexKey, uniqueUntouched, false},
-		{indexKey, deleteVal, false},
+		{nonUniqueIndexKey, nonUniqueVal, false},
+		{nonUniqueIndexKey, nonUniqueUntouched, false},
+		{uniqueIndexKey, uniqueValue, true},
+		{uniqueIndexKey, uniqueUntouched, false},
+		{uniqueIndexKey, deleteVal, false},
 	}
 
 	for _, test := range tests {
-		require.Equal(t, test.need, keyNeedToLock(test.key, test.val, 0))
-	}
+		need := keyNeedToLock(test.key, test.val, 0)
+		require.Equal(t, test.need, need)
 
-	flag := kv.KeyFlags(1)
-	require.True(t, flag.HasPresumeKeyNotExists())
-	require.True(t, keyNeedToLock(indexKey, deleteVal, flag))
+		flag := kv.KeyFlags(1)
+		need = keyNeedToLock(test.key, test.val, flag)
+		require.True(t, flag.HasPresumeKeyNotExists())
+		require.True(t, need)
+	}
 }

--- a/session/txn.go
+++ b/session/txn.go
@@ -447,9 +447,12 @@ func keyNeedToLock(k, v []byte, flags kv.KeyFlags) bool {
 	if tablecodec.IsUntouchedIndexKValue(k, v) {
 		return false
 	}
-	isNonUniqueIndex := tablecodec.IsIndexKey(k) && len(v) == 1
-	// Put row key and unique index need to lock.
-	return !isNonUniqueIndex
+
+	if !tablecodec.IsIndexKey(k) {
+		return true
+	}
+
+	return tablecodec.IndexKVIsUnique(v)
 }
 
 func getBinlogMutation(ctx sessionctx.Context, tableID int64) *binlog.TableMutation {

--- a/tablecodec/tablecodec.go
+++ b/tablecodec/tablecodec.go
@@ -1580,3 +1580,16 @@ func decodeIndexKvGeneral(key, value []byte, colsLen int, hdStatus HandleStatus,
 	}
 	return resultValues, nil
 }
+
+// IndexKVIsUnique uses to judge if an index is unique, it can handle the KV committed by txn already, it doesn't consider the untouched flag.
+func IndexKVIsUnique(value []byte) bool {
+	if len(value) <= MaxOldEncodeValueLen {
+		return len(value) == 8
+	}
+	if getIndexVersion(value) == 1 {
+		segs := SplitIndexValueForClusteredIndexVersion1(value)
+		return segs.CommonHandle != nil
+	}
+	segs := SplitIndexValue(value)
+	return segs.IntHandle != nil || segs.CommonHandle != nil
+}


### PR DESCRIPTION


close pingcap/tidb#36235

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
