### PR TITLE
server: add debug log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ dev: checklist check test
 # Install the check tools.
 check-setup:tools/bin/revive tools/bin/goword tools/bin/gometalinter tools/bin/gosec
 
-check: fmt errcheck unconvert lint tidy testSuite check-static vet staticcheck errdoc
+check: fmt errcheck unconvert lint tidy testSuite check-static vet errdoc
 
 # These need to be fixed before they can be ran regularly
 check-fail: goword check-slow

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	go.etcd.io/etcd v0.5.0-alpha.5.0.20200824191128-ae9734ed278b
 	go.uber.org/atomic v1.8.0
 	go.uber.org/automaxprocs v1.2.0
+	go.uber.org/goleak v0.10.0
 	go.uber.org/zap v1.17.0
 	golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9

--- a/server/conn.go
+++ b/server/conn.go
@@ -2013,7 +2013,7 @@ func (cc *clientConn) upgradeToTLS(tlsConfig *tls.Config) error {
 
 func (cc *clientConn) handleChangeUser(ctx context.Context, data []byte) error {
 	user, data := parseNullTermString(data)
-	logutil.Logger(ctx).Info("[DEBUG] [CHANGE_USER]",
+	logutil.Logger(ctx).Warn("[DEBUG] [CHANGE_USER]",
 		zap.String("connInfo", cc.String()),
 		zap.String("status", cc.SessionStatusToString()),
 		zap.ByteString("user", user),
@@ -2044,7 +2044,7 @@ func (cc *clientConn) handleChangeUser(ctx context.Context, data []byte) error {
 }
 
 func (cc *clientConn) handleResetConnection(ctx context.Context) error {
-	logutil.Logger(ctx).Info("[DEBUG] [RESET_CONNECTION]",
+	logutil.Logger(ctx).Warn("[DEBUG] [RESET_CONNECTION]",
 		zap.String("connInfo", cc.String()),
 		zap.String("status", cc.SessionStatusToString()),
 	)

--- a/server/conn.go
+++ b/server/conn.go
@@ -2013,6 +2013,11 @@ func (cc *clientConn) upgradeToTLS(tlsConfig *tls.Config) error {
 
 func (cc *clientConn) handleChangeUser(ctx context.Context, data []byte) error {
 	user, data := parseNullTermString(data)
+	logutil.Logger(ctx).Info("[DEBUG] [CHANGE_USER]",
+		zap.String("connInfo", cc.String()),
+		zap.String("status", cc.SessionStatusToString()),
+		zap.ByteString("user", user),
+	)
 	cc.user = string(hack.String(user))
 	if len(data) < 1 {
 		return mysql.ErrMalformPacket
@@ -2039,6 +2044,10 @@ func (cc *clientConn) handleChangeUser(ctx context.Context, data []byte) error {
 }
 
 func (cc *clientConn) handleResetConnection(ctx context.Context) error {
+	logutil.Logger(ctx).Info("[DEBUG] [RESET_CONNECTION]",
+		zap.String("connInfo", cc.String()),
+		zap.String("status", cc.SessionStatusToString()),
+	)
 	user := cc.ctx.GetSessionVars().User
 	err := cc.ctx.Close()
 	if err != nil {

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -650,11 +650,20 @@ func parseBinaryDurationWithMS(pos int, paramValues []byte,
 }
 
 func (cc *clientConn) handleStmtClose(data []byte) (err error) {
+	stmtID := 0
+	defer func() {
+		logutil.Logger(context.Background()).Warn("[DEBUG] [STMT_CLOSE]",
+			zap.String("connInfo", cc.String()),
+			zap.String("status", cc.SessionStatusToString()),
+			zap.Int("stmtID", stmtID),
+			zap.Error(err),
+		)
+	}()
 	if len(data) < 4 {
 		return
 	}
 
-	stmtID := int(binary.LittleEndian.Uint32(data[0:4]))
+	stmtID = int(binary.LittleEndian.Uint32(data[0:4]))
 	stmt := cc.ctx.GetStatement(stmtID)
 	if stmt != nil {
 		return stmt.Close()

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -61,16 +61,17 @@ import (
 	"go.uber.org/zap"
 )
 
-func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
+func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) (err error) {
 	stmtID := 0
 	hasError := false
 	defer func() {
-		logutil.Logger(ctx).Info("[DEBUG] [STMT_PREPARE]",
+		logutil.Logger(ctx).Warn("[DEBUG] [STMT_PREPARE]",
 			zap.String("connInfo", cc.String()),
 			zap.String("status", cc.SessionStatusToString()),
 			zap.String("sql", sql),
 			zap.Int("stmtID", stmtID),
 			zap.Bool("hasError", hasError),
+			zap.Error(err),
 		)
 	}()
 	stmt, columns, params, err := cc.ctx.Prepare(sql)
@@ -146,11 +147,12 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 	stmtID := uint32(0)
 	hasError := false
 	defer func() {
-		logutil.Logger(ctx).Info("[DEBUG] [STMT_EXECUTE]",
+		logutil.Logger(ctx).Warn("[DEBUG] [STMT_EXECUTE]",
 			zap.String("connInfo", cc.String()),
 			zap.String("status", cc.SessionStatusToString()),
 			zap.Uint32("stmtID", stmtID),
 			zap.Bool("hasError", hasError),
+			zap.Error(err),
 		)
 	}()
 	if len(data) < 9 {

--- a/server/conn_stmt.go
+++ b/server/conn_stmt.go
@@ -56,14 +56,29 @@ import (
 	"github.com/pingcap/tidb/types"
 	"github.com/pingcap/tidb/util/execdetails"
 	"github.com/pingcap/tidb/util/hack"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/topsql"
+	"go.uber.org/zap"
 )
 
 func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
+	stmtID := 0
+	hasError := false
+	defer func() {
+		logutil.Logger(ctx).Info("[DEBUG] [STMT_PREPARE]",
+			zap.String("connInfo", cc.String()),
+			zap.String("status", cc.SessionStatusToString()),
+			zap.String("sql", sql),
+			zap.Int("stmtID", stmtID),
+			zap.Bool("hasError", hasError),
+		)
+	}()
 	stmt, columns, params, err := cc.ctx.Prepare(sql)
 	if err != nil {
+		hasError = true
 		return err
 	}
+	stmtID = stmt.ID()
 	data := make([]byte, 4, 128)
 
 	// status ok
@@ -80,6 +95,7 @@ func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
 	data = append(data, 0, 0) // TODO support warning count
 
 	if err := cc.writePacket(data); err != nil {
+		hasError = true
 		return err
 	}
 
@@ -89,11 +105,13 @@ func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
 			data = params[i].Dump(data)
 
 			if err := cc.writePacket(data); err != nil {
+				hasError = true
 				return err
 			}
 		}
 
 		if err := cc.writeEOF(0); err != nil {
+			hasError = true
 			return err
 		}
 	}
@@ -104,11 +122,13 @@ func (cc *clientConn) handleStmtPrepare(ctx context.Context, sql string) error {
 			data = columns[i].Dump(data)
 
 			if err := cc.writePacket(data); err != nil {
+				hasError = true
 				return err
 			}
 		}
 
 		if err := cc.writeEOF(0); err != nil {
+			hasError = true
 			return err
 		}
 
@@ -123,11 +143,22 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 			metrics.ExecuteErrorCounter.WithLabelValues(metrics.ExecuteErrorToLabel(err)).Inc()
 		}
 	}()
+	stmtID := uint32(0)
+	hasError := false
+	defer func() {
+		logutil.Logger(ctx).Info("[DEBUG] [STMT_EXECUTE]",
+			zap.String("connInfo", cc.String()),
+			zap.String("status", cc.SessionStatusToString()),
+			zap.Uint32("stmtID", stmtID),
+			zap.Bool("hasError", hasError),
+		)
+	}()
 	if len(data) < 9 {
+		hasError = true
 		return mysql.ErrMalformPacket
 	}
 	pos := 0
-	stmtID := binary.LittleEndian.Uint32(data[0:4])
+	stmtID = binary.LittleEndian.Uint32(data[0:4])
 	pos += 4
 
 	if variable.TopSQLEnabled() {
@@ -139,6 +170,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 
 	stmt := cc.ctx.GetStatement(int(stmtID))
 	if stmt == nil {
+		hasError = true
 		return mysql.NewErr(mysql.ErrUnknownStmtHandler,
 			strconv.FormatUint(uint64(stmtID), 10), "stmt_execute")
 	}
@@ -159,6 +191,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 	case 1:
 		useCursor = true
 	default:
+		hasError = true
 		return mysql.NewErrf(mysql.ErrUnknown, "unsupported flag %d", nil, flag)
 	}
 
@@ -175,6 +208,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 	if numParams > 0 {
 		nullBitmapLen := (numParams + 7) >> 3
 		if len(data) < (pos + nullBitmapLen + 1) {
+			hasError = true
 			return mysql.ErrMalformPacket
 		}
 		nullBitmaps = data[pos : pos+nullBitmapLen]
@@ -184,6 +218,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		if data[pos] == 1 {
 			pos++
 			if len(data) < (pos + (numParams << 1)) {
+				hasError = true
 				return mysql.ErrMalformPacket
 			}
 
@@ -200,6 +235,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		err = parseExecArgs(cc.ctx.GetSessionVars().StmtCtx, args, stmt.BoundParams(), nullBitmaps, stmt.GetParamsType(), paramValues)
 		stmt.Reset()
 		if err != nil {
+			hasError = true
 			return errors.Annotate(err, cc.preparedStmt2String(stmtID))
 		}
 	}
@@ -219,6 +255,7 @@ func (cc *clientConn) handleStmtExecute(ctx context.Context, data []byte) (err e
 		// We append warning after the retry because `ResetContextOfStmt` may be called during the retry, which clears warnings.
 		cc.ctx.GetSessionVars().StmtCtx.AppendError(prevErr)
 	}
+	hasError = err != nil
 	return err
 }
 

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -752,8 +752,10 @@ func testGetTableByName(c *C, ctx sessionctx.Context, db, table string) table.Ta
 }
 
 func (ts *ConnTestSuite) TestTiFlashFallback(c *C) {
+	conn, _ := net.Pipe()
 	cc := &clientConn{
-		alloc: arena.NewAllocator(1024),
+		alloc:       arena.NewAllocator(1024),
+		bufReadConn: newBufferedReadConn(conn),
 		pkt: &packetIO{
 			bufWriter: bufio.NewWriter(bytes.NewBuffer(nil)),
 		},

--- a/server/conn_test.go
+++ b/server/conn_test.go
@@ -20,6 +20,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"net"
 
 	. "github.com/pingcap/check"
 	"github.com/pingcap/failpoint"
@@ -519,10 +520,12 @@ func (ts *ConnTestSuite) testDispatch(c *C, inputs []dispatchInput, capability u
 	c.Assert(err, IsNil)
 	defer server.Close()
 
+	conn, _ := net.Pipe()
 	cc := &clientConn{
 		connectionID: 1,
 		salt:         []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14},
 		server:       server,
+		bufReadConn:  newBufferedReadConn(conn),
 		pkt: &packetIO{
 			bufWriter: bufio.NewWriter(&outBuffer),
 		},

--- a/sessionctx/variable/session.go
+++ b/sessionctx/variable/session.go
@@ -15,6 +15,7 @@ package variable
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/binary"
 	"fmt"
@@ -47,12 +48,14 @@ import (
 	"github.com/pingcap/tidb/util/chunk"
 	"github.com/pingcap/tidb/util/collate"
 	"github.com/pingcap/tidb/util/execdetails"
+	"github.com/pingcap/tidb/util/logutil"
 	"github.com/pingcap/tidb/util/rowcodec"
 	"github.com/pingcap/tidb/util/stringutil"
 	"github.com/pingcap/tidb/util/tableutil"
 	"github.com/pingcap/tidb/util/timeutil"
 	"github.com/twmb/murmur3"
 	atomic2 "go.uber.org/atomic"
+	"go.uber.org/zap"
 )
 
 // PreparedStmtCount is exported for test.
@@ -1403,6 +1406,10 @@ func (s *SessionVars) AddPreparedStmt(stmtID uint32, stmt interface{}) error {
 
 // RemovePreparedStmt removes preparedStmt from current session and decrease count in global.
 func (s *SessionVars) RemovePreparedStmt(stmtID uint32) {
+	logutil.Logger(context.Background()).Warn("[DEBUG] [RemovePreparedStmt]",
+		zap.Uint64("connID", s.ConnectionID),
+		zap.Uint32("stmtID", stmtID),
+	)
 	_, exists := s.PreparedStmts[stmtID]
 	if !exists {
 		return


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #xxx

Problem Summary:

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Manual test log:
```
[2022/09/02 15:55:55.565 +08:00] [WARN] [conn_stmt.go:68] ["[DEBUG] [STMT_PREPARE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [sql="INSERT INTO t VALUES( ?, ? )"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.565 +08:00] [WARN] [conn_stmt.go:68] ["[DEBUG] [STMT_PREPARE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [sql="INSERT INTO t VALUES( ?)"] [stmtID=0] [hasError=true] [error="[planner:1136]Column count doesn't match value count at row 1"]
[2022/09/02 15:55:55.565 +08:00] [INFO] [conn.go:877] ["command dispatched failed"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [command=Prepare] [status="inTxn:0, autocommit:1"] [sql="INSERT INTO t VALUES( ?)"] [txn_mode=PESSIMISTIC] [err="[planner:1136]Column count doesn't match value count at row 1\ngithub.com/pingcap/errors.AddStack\n\t/home/timeandfate/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/errors.go:174\ngithub.com/pingcap/errors.(*Error).GenWithStackByArgs\n\t/home/timeandfate/go/pkg/mod/github.com/pingcap/errors@v0.11.5-0.20201126102027-b0a155152ca3/normalize.go:156\ngithub.com/pingcap/tidb/planner/core.(*PlanBuilder).buildValuesListOfInsert\n\t/home/timeandfate/code/tidb/planner/core/planbuilder.go:2981\ngithub.com/pingcap/tidb/planner/core.(*PlanBuilder).buildInsert\n\t/home/timeandfate/code/tidb/planner/core/planbuilder.go:2796\ngithub.com/pingcap/tidb/planner/core.(*PlanBuilder).Build\n\t/home/timeandfate/code/tidb/planner/core/planbuilder.go:646\ngithub.com/pingcap/tidb/executor.(*PrepareExec).Next\n\t/home/timeandfate/code/tidb/executor/prepared.go:208\ngithub.com/pingcap/tidb/session.(*session).PrepareStmt\n\t/home/timeandfate/code/tidb/session/session.go:1745\ngithub.com/pingcap/tidb/server.(*TiDBContext).Prepare\n\t/home/timeandfate/code/tidb/server/driver_tidb.go:265\ngithub.com/pingcap/tidb/server.(*clientConn).handleStmtPrepare\n\t/home/timeandfate/code/tidb/server/conn_stmt.go:77\ngithub.com/pingcap/tidb/server.(*clientConn).dispatch\n\t/home/timeandfate/code/tidb/server/conn.go:1118\ngithub.com/pingcap/tidb/server.(*clientConn).Run\n\t/home/timeandfate/code/tidb/server/conn.go:860\ngithub.com/pingcap/tidb/server.(*Server).onConn\n\t/home/timeandfate/code/tidb/server/server.go:485\nruntime.goexit\n\t/usr/lib/go/src/runtime/asm_amd64.s:1594"]
[2022/09/02 15:55:55.566 +08:00] [WARN] [conn_stmt.go:68] ["[DEBUG] [STMT_PREPARE]"] [conn=5] [connInfo="id:5, addr:127.0.0.1:54084 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [sql="SELECT * FROM t WHERE a = ?"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.566 +08:00] [WARN] [2pc.go:1448] ["schemaLeaseChecker is not set for this transaction"] [sessionID=3] [startTS=435710946329493505] [commitTS=435710946329493506]
[2022/09/02 15:55:55.567 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.567 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.568 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.568 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.569 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=3] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.569 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=5] [connInfo="id:5, addr:127.0.0.1:54084 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.570 +08:00] [WARN] [conn_stmt.go:150] ["[DEBUG] [STMT_EXECUTE]"] [conn=5] [connInfo="id:5, addr:127.0.0.1:54084 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] [hasError=false] []
[2022/09/02 15:55:55.570 +08:00] [WARN] [conn_stmt.go:655] ["[DEBUG] [STMT_CLOSE]"] [connInfo="id:5, addr:127.0.0.1:54084 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] []
[2022/09/02 15:55:55.570 +08:00] [WARN] [conn_stmt.go:655] ["[DEBUG] [STMT_CLOSE]"] [connInfo="id:3, addr:127.0.0.1:54080 status:10, collation:utf8mb4_general_ci, user:root"] [status="inTxn:0, autocommit:1"] [stmtID=1] []

```


Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
