### PR TITLE
owner: fix the unstable test of `TestCluster`

### DIFF
--- a/owner/manager_test.go
+++ b/owner/manager_test.go
@@ -124,9 +124,7 @@ func TestCluster(t *testing.T) {
 		WithInfoCache(ic),
 	)
 
-	go func() {
-		require.NoError(t, d.OwnerManager().CampaignOwner())
-	}()
+	require.NoError(t, d.OwnerManager().CampaignOwner())
 
 	isOwner := checkOwner(d, true)
 	require.True(t, isOwner)
@@ -141,9 +139,7 @@ func TestCluster(t *testing.T) {
 		WithLease(testLease),
 		WithInfoCache(ic2),
 	)
-	go func() {
-		require.NoError(t, d1.OwnerManager().CampaignOwner())
-	}()
+	require.NoError(t, d1.OwnerManager().CampaignOwner())
 
 	isOwner = checkOwner(d1, false)
 	require.False(t, isOwner)
@@ -168,9 +164,7 @@ func TestCluster(t *testing.T) {
 		WithLease(testLease),
 		WithInfoCache(ic3),
 	)
-	go func() {
-		require.NoError(t, d3.OwnerManager().CampaignOwner())
-	}()
+	require.NoError(t, d3.OwnerManager().CampaignOwner())
 
 	isOwner = checkOwner(d3, false)
 	require.False(t, isOwner)


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close https://github.com/pingcap/tidb/issues/37557

Problem Summary:
In `CampaignOwner`, we do `NewSession` get an error because of `context canceled`.
<img width="1468" alt="Screenshot 2022-09-02 at 13 10 08" src="https://user-images.githubusercontent.com/4242506/188063328-6611c88f-3dad-4f7f-981d-291758602bff.png">

### What is changed and how it works?
In `CampaignOwner` we use `go m.campaignLoop(session)`, so I think we need to use `go` to call `CampaignOwner`.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
