### PR TITLE
parser: let flashback cluster don't support expr

### DIFF
--- a/parser/parser.y
+++ b/parser/parser.y
@@ -2573,10 +2573,12 @@ RecoverTableStmt:
  *
  *******************************************************************/
 FlashbackClusterStmt:
-	"FLASHBACK" "CLUSTER" AsOfClause
+	"FLASHBACK" "CLUSTER" asof "TIMESTAMP" stringLit
 	{
 		$$ = &ast.FlashBackClusterStmt{
-			AsOf: *$3.(*ast.AsOfClause),
+			AsOf: ast.AsOfClause{
+				TsExpr: ast.NewValueExpr($5, "", ""),
+			},
 		}
 	}
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3235,8 +3235,9 @@ func TestDDL(t *testing.T) {
 		{"flashback table t TO t1", true, "FLASHBACK TABLE `t` TO `t1`"},
 
 		// for flashback cluster
-		{"flashback cluster as of timestamp '2021-05-26 16:45:26'", true, "FLASHBACK CLUSTER AS OF TIMESTAMP _UTF8MB4'2021-05-26 16:45:26'"},
-		{"flashback cluster as of timestamp TIDB_BOUNDED_STALENESS(DATE_SUB(NOW(), INTERVAL 3 SECOND), NOW())", true, "FLASHBACK CLUSTER AS OF TIMESTAMP TIDB_BOUNDED_STALENESS(DATE_SUB(NOW(), INTERVAL 3 SECOND), NOW())"},
+		{"flashback cluster as of timestamp '2021-05-26 16:45:26'", true, "FLASHBACK CLUSTER AS OF TIMESTAMP '2021-05-26 16:45:26'"},
+		{"flashback cluster as of timestamp TIDB_BOUNDED_STALENESS(DATE_SUB(NOW(), INTERVAL 3 SECOND), NOW())", false, ""},
+		{"flashback cluster as of timestamp DATE_SUB(NOW(), INTERVAL 3 SECOND)", false, ""},
 
 		// for remove partitioning
 		{"alter table t remove partitioning", true, "ALTER TABLE `t` REMOVE PARTITIONING"},


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37495 

Problem Summary: flashback cluster shouldn't support expr in timestamp

### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
flashback cluster shouldn't support expr in timestamp
```
