### PR TITLE
br: increased PD time out

### DIFF
--- a/br/pkg/pdutil/pd.go
+++ b/br/pkg/pdutil/pd.go
@@ -237,7 +237,9 @@ func NewPdController(
 	pdClient, err := pd.NewClientWithContext(
 		ctx, addrs, securityOption,
 		pd.WithGRPCDialOptions(maxCallMsgSize...),
-		pd.WithCustomTimeoutOption(10*time.Second),
+		// If the time too short, we may scatter a region many times, because
+		// the interface `ScatterRegions` may time out.
+		pd.WithCustomTimeoutOption(60*time.Second),
 		pd.WithMaxErrorRetry(3),
 	)
 	if err != nil {

--- a/br/pkg/restore/split.go
+++ b/br/pkg/restore/split.go
@@ -387,6 +387,9 @@ func (rs *RegionSplitter) ScatterRegions(ctx context.Context, newRegions []*Regi
 				})
 			return nil
 		}
+		if err != nil {
+			log.Warn("scatter region meet error", logutil.ShortError(err))
+		}
 		return err
 		// the retry is for the temporary network errors during sending request.
 	}, &exponentialBackoffer{attempt: 3, baseBackoff: 500 * time.Millisecond})

--- a/br/pkg/restore/split_client.go
+++ b/br/pkg/restore/split_client.go
@@ -126,6 +126,9 @@ func (c *pdClient) ScatterRegions(ctx context.Context, regionInfo []*RegionInfo)
 	regionsID := make([]uint64, 0, len(regionInfo))
 	for _, v := range regionInfo {
 		regionsID = append(regionsID, v.Region.Id)
+		log.Info("scattering regions", logutil.Key("start", v.Region.StartKey),
+			logutil.Key("end", v.Region.EndKey),
+			zap.Uint64("id", v.Region.Id))
 	}
 	resp, err := c.client.ScatterRegions(ctx, regionsID)
 	if err != nil {

--- a/br/pkg/restore/split_client.go
+++ b/br/pkg/restore/split_client.go
@@ -126,7 +126,7 @@ func (c *pdClient) ScatterRegions(ctx context.Context, regionInfo []*RegionInfo)
 	regionsID := make([]uint64, 0, len(regionInfo))
 	for _, v := range regionInfo {
 		regionsID = append(regionsID, v.Region.Id)
-		log.Info("scattering regions", logutil.Key("start", v.Region.StartKey),
+		log.Debug("scattering regions", logutil.Key("start", v.Region.StartKey),
 			logutil.Key("end", v.Region.EndKey),
 			zap.Uint64("id", v.Region.Id))
 	}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37549 

Problem Summary:
In huge clusters, we may fail to send `ScatterRegions` request with high concurrency config due to the timeout. Then we would retry it, however according to the PD team, scatter a region multiple times would make region unbalanced.

### What is changed and how it works?
Added the timeout of requesting PD to 60s.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Fixed a bug caused when restoring with high `concurrency` the regions aren't balanced.
```
