### PR TITLE
lightning: enable nogo checks for restore-opts

### DIFF
--- a/br/pkg/lightning/restore/opts/precheck_opts.go
+++ b/br/pkg/lightning/restore/opts/precheck_opts.go
@@ -16,19 +16,27 @@ package opts
 
 import "github.com/pingcap/tidb/br/pkg/lightning/mydump"
 
+// PrecheckItemBuilderConfig defines the config used in a precheck builder,
+// which affects the behavior for executing precheck items.
 type PrecheckItemBuilderConfig struct {
 	PreInfoGetterOptions []GetPreInfoOption
 	MDLoaderSetupOptions []mydump.MDLoaderSetupOption
 }
 
+// PrecheckItemBuilderOption defines the options when constructing a precheck builder,
+// which affects the behavior for executing precheck items.
 type PrecheckItemBuilderOption func(c *PrecheckItemBuilderConfig)
 
+// WithPreInfoGetterOptions generates a precheck item builder option
+// to control the get pre info behaviors.
 func WithPreInfoGetterOptions(opts ...GetPreInfoOption) PrecheckItemBuilderOption {
 	return func(c *PrecheckItemBuilderConfig) {
 		c.PreInfoGetterOptions = append([]GetPreInfoOption{}, opts...)
 	}
 }
 
+// WithMDLoaderSetupOptions generates a precheck item builder option
+// to control the mydumper loader setup behaviors.
 func WithMDLoaderSetupOptions(opts ...mydump.MDLoaderSetupOption) PrecheckItemBuilderOption {
 	return func(c *PrecheckItemBuilderConfig) {
 		c.MDLoaderSetupOptions = append([]mydump.MDLoaderSetupOption{}, opts...)

--- a/build/nogo_config.json
+++ b/build/nogo_config.json
@@ -198,6 +198,7 @@
     },
     "only_files": {
       "br/pkg/lightning/mydump/": "br/pkg/lightning/mydump/",
+      "br/pkg/lightning/restore/opts": "br/pkg/lightning/restore/opts",
       "executor/aggregate.go": "executor/aggregate.go",
       "types/json/binary_functions.go": "types/json/binary_functions.go",
       "types/json/binary_test.go": "types/json/binary_test.go",
@@ -324,6 +325,7 @@
     },
     "only_files": {
       "br/pkg/lightning/mydump/": "br/pkg/lightning/mydump/",
+      "br/pkg/lightning/restore/opts": "br/pkg/lightning/restore/opts",
       "kv/": "kv code",
       "util/memory": "util/memory",
       "ddl/": "ddl",
@@ -351,6 +353,7 @@
     },
     "only_files": {
       "br/pkg/lightning/mydump/": "br/pkg/lightning/mydump/",
+      "br/pkg/lightning/restore/opts": "br/pkg/lightning/restore/opts",
       "executor/aggregate.go": "executor/aggregate.go",
       "types/json/binary_functions.go": "types/json/binary_functions.go",
       "types/json/binary_test.go": "types/json/binary_test.go",
@@ -713,6 +716,7 @@
     },
     "only_files": {
       "br/pkg/lightning/mydump/": "br/pkg/lightning/mydump/",
+      "br/pkg/lightning/restore/opts": "br/pkg/lightning/restore/opts",
       "executor/aggregate.go": "executor/aggregate.go",
       "types/json/binary_functions.go": "types/json/binary_functions.go",
       "types/json/binary_test.go": "types/json/binary_test.go",


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37614 

Problem Summary:

### What is changed and how it works?
Enabled the no-go checks for restore/opts package, to improve the code quality.
Also fixed the issues found by the new no-go check.

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [x] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
