### PR TITLE
test: correct TestAllHistory

### DIFF
--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -513,6 +513,7 @@ func (ts *basicHTTPHandlerTestSuite) prepareData(t *testing.T) {
 	require.NoError(t, err)
 	dbt.MustExec("alter table tidb.test add index idx1 (a, b);")
 	dbt.MustExec("alter table tidb.test drop index idx1;")
+	dbt.MustExec("alter table tidb.test add index idx1 (a, b);")
 	dbt.MustExec("alter table tidb.test add unique index idx2 (a, b);")
 
 	dbt.MustExec(`create table tidb.pt (a int primary key, b varchar(20), key idx(a, b))

--- a/server/http_handler_test.go
+++ b/server/http_handler_test.go
@@ -512,6 +512,7 @@ func (ts *basicHTTPHandlerTestSuite) prepareData(t *testing.T) {
 	err = txn1.Commit()
 	require.NoError(t, err)
 	dbt.MustExec("alter table tidb.test add index idx1 (a, b);")
+	dbt.MustExec("alter table tidb.test drop index idx1;")
 	dbt.MustExec("alter table tidb.test add unique index idx2 (a, b);")
 
 	dbt.MustExec(`create table tidb.pt (a int primary key, b varchar(20), key idx(a, b))
@@ -976,7 +977,14 @@ func TestAllHistory(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NoError(t, resp.Body.Close())
-	require.Equal(t, data, jobs)
+	require.Equal(t, len(data), len(jobs))
+	for i := range data {
+		// For the jobs that have arguments(job.Args) for GC delete range,
+		// the RawArgs should be the same after filtering the spaces.
+		data[i].RawArgs = filterSpaces(data[i].RawArgs)
+		jobs[i].RawArgs = filterSpaces(jobs[i].RawArgs)
+		require.Equal(t, data[i], jobs[i], i)
+	}
 
 	// Cover the start_job_id parameter.
 	resp, err = ts.fetchStatus("/ddl/history?start_job_id=41")
@@ -996,6 +1004,22 @@ func TestAllHistory(t *testing.T) {
 		lastID = job.ID
 	}
 	require.NoError(t, resp.Body.Close())
+}
+
+func filterSpaces(bs []byte) []byte {
+	if len(bs) == 0 {
+		return nil
+	}
+	tmp := bs[:0]
+	for _, b := range bs {
+		// 0xa is the line feed character.
+		// 0xd is the carriage return character.
+		// 0x20 is the space character.
+		if b != 0xa && b != 0xd && b != 0x20 {
+			tmp = append(tmp, b)
+		}
+	}
+	return tmp
 }
 
 func dummyRecord() *deadlockhistory.DeadlockRecord {


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #35983 

Problem Summary:

The origin test `TestAllHistory` has defect because when the `RawArgs` is non-empty, the job from HTTP API `/ddl/history` is unequal to the job from kv-get `GetAllHistoryDDLJobs`:

GetAllHistoryDDLJobs:
```
[{"L":"idx1","O":"idx1"},false,1,[]]
```

HTTP API `/ddl/history`:
```
[
   {
    "L": "idx1",
    "O": "idx1"
   },
   false,
   1,
   []
  ]
```


### What is changed and how it works?

### Check List

Tests <!-- At least one of them must be included. -->

- [ ] Unit test
- [x] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
