### PR TITLE
Lightning: change severity of clusterResourceCheckItem,emptyRegionCheckItem from Critical to Warn

### DIFF
--- a/br/pkg/lightning/restore/precheck_impl.go
+++ b/br/pkg/lightning/restore/precheck_impl.go
@@ -81,7 +81,7 @@ func (ci *clusterResourceCheckItem) getReplicaCount(ctx context.Context) (uint64
 func (ci *clusterResourceCheckItem) Check(ctx context.Context) (*CheckResult, error) {
 	theResult := &CheckResult{
 		Item:     ci.GetCheckItemID(),
-		Severity: Critical,
+		Severity: Warn,
 		Passed:   true,
 		Message:  "Cluster resources are rich for this import task",
 	}
@@ -208,7 +208,7 @@ func (ci *emptyRegionCheckItem) GetCheckItemID() CheckItemID {
 func (ci *emptyRegionCheckItem) Check(ctx context.Context) (*CheckResult, error) {
 	theResult := &CheckResult{
 		Item:     ci.GetCheckItemID(),
-		Severity: Critical,
+		Severity: Warn,
 		Passed:   true,
 		Message:  "Cluster doesn't have too many empty regions",
 	}

--- a/br/pkg/lightning/restore/precheck_impl_test.go
+++ b/br/pkg/lightning/restore/precheck_impl_test.go
@@ -125,6 +125,7 @@ func (s *precheckImplSuite) TestClusterResourceCheckBasic() {
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
 	s.T().Logf("check result message: %s", result.Message)
+	s.Require().Equal(Warn, result.Severity)
 	s.Require().True(result.Passed)
 
 	testMockSrcData := s.generateMockData(1, 1, 1,
@@ -142,6 +143,7 @@ func (s *precheckImplSuite) TestClusterResourceCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 
@@ -154,6 +156,7 @@ func (s *precheckImplSuite) TestClusterResourceCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckTargetClusterSize, result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 }
@@ -173,6 +176,7 @@ func (s *precheckImplSuite) TestClusterVersionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 }
@@ -192,6 +196,7 @@ func (s *precheckImplSuite) TestEmptyRegionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -214,6 +219,7 @@ func (s *precheckImplSuite) TestEmptyRegionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckTargetClusterEmptyRegion, result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -233,6 +239,7 @@ func (s *precheckImplSuite) TestRegionDistributionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -254,6 +261,7 @@ func (s *precheckImplSuite) TestRegionDistributionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckTargetClusterRegionDist, result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -274,6 +282,7 @@ func (s *precheckImplSuite) TestStoragePermissionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -282,6 +291,7 @@ func (s *precheckImplSuite) TestStoragePermissionCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckSourcePermission, result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -301,6 +311,7 @@ func (s *precheckImplSuite) TestLargeFileCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -319,6 +330,7 @@ func (s *precheckImplSuite) TestLargeFileCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -340,6 +352,7 @@ func (s *precheckImplSuite) TestLocalDiskPlacementCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -349,6 +362,7 @@ func (s *precheckImplSuite) TestLocalDiskPlacementCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckLocalDiskPlacement, result.Item)
+	s.Require().Equal(Warn, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -369,6 +383,7 @@ func (s *precheckImplSuite) TestLocalTempKVDirCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -387,6 +402,7 @@ func (s *precheckImplSuite) TestLocalTempKVDirCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -408,6 +424,7 @@ func (s *precheckImplSuite) TestCheckpointCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 }
@@ -445,6 +462,7 @@ func (s *precheckImplSuite) TestSchemaCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -463,6 +481,7 @@ func (s *precheckImplSuite) TestSchemaCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -499,6 +518,7 @@ func (s *precheckImplSuite) TestCSVHeaderCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -517,6 +537,7 @@ func (s *precheckImplSuite) TestCSVHeaderCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }
@@ -545,6 +566,7 @@ func (s *precheckImplSuite) TestTableEmptyCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(ci.GetCheckItemID(), result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().True(result.Passed)
 
@@ -555,6 +577,7 @@ func (s *precheckImplSuite) TestTableEmptyCheckBasic() {
 	s.Require().NoError(err)
 	s.Require().NotNil(result)
 	s.Require().Equal(CheckTargetTableEmpty, result.Item)
+	s.Require().Equal(Critical, result.Severity)
 	s.T().Logf("check result message: %s", result.Message)
 	s.Require().False(result.Passed)
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37654 

Problem Summary:

### What is changed and how it works?
- Change severity of clusterResourceCheckItem from Critical to Warn
- Change severity of emptyRegionCheckItem from Critical to Warn
### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [x] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
Change severity of clusterResourceCheckItem,emptyRegionCheckItem from Critical to Warn
```
