### PR TITLE
expression: set correct json storage size

### DIFF
--- a/expression/builtin_json.go
+++ b/expression/builtin_json.go
@@ -1385,12 +1385,8 @@ func (b *builtinJSONStorageSizeSig) evalInt(row chunk.Row) (res int64, isNull bo
 		return res, isNull, err
 	}
 
-	buf, err := obj.MarshalJSON()
-	if err != nil {
-		return res, isNull, err
-	}
-
-	return int64(len(buf)), false, nil
+	// returns the length of obj value plus 1 (the TypeCode)
+	return int64(len(obj.Value)) + 1, false, nil
 }
 
 type jsonDepthFunctionClass struct {

--- a/expression/builtin_json_test.go
+++ b/expression/builtin_json_test.go
@@ -994,17 +994,17 @@ func TestJSONStorageSize(t *testing.T) {
 		success  bool
 	}{
 		// Tests scalar arguments
-		{[]interface{}{`null`}, 4, true},
-		{[]interface{}{`true`}, 4, true},
-		{[]interface{}{`1`}, 1, true},
+		{[]interface{}{`null`}, 2, true},
+		{[]interface{}{`true`}, 2, true},
+		{[]interface{}{`1`}, 9, true},
 		{[]interface{}{`"1"`}, 3, true},
 		// Tests nil arguments
 		{[]interface{}{nil}, nil, true},
 		// Tests valid json documents
-		{[]interface{}{`{}`}, 2, true},
-		{[]interface{}{`{"a":1}`}, 8, true},
-		{[]interface{}{`[{"a":{"a":1},"b":2}]`}, 25, true},
-		{[]interface{}{`{"a": 1000, "b": "wxyz", "c": "[1, 3, 5, 7]"}`}, 45, true},
+		{[]interface{}{`{}`}, 9, true},
+		{[]interface{}{`{"a":1}`}, 29, true},
+		{[]interface{}{`[{"a":{"a":1},"b":2}]`}, 82, true},
+		{[]interface{}{`{"a": 1000, "b": "wxyz", "c": "[1, 3, 5, 7]"}`}, 71, true},
 		// Tests invalid json documents
 		{[]interface{}{`[{"a":1]`}, 0, false},
 		{[]interface{}{`[{a":1]`}, 0, false},

--- a/expression/builtin_json_vec.go
+++ b/expression/builtin_json_vec.go
@@ -126,12 +126,7 @@ func (b *builtinJSONStorageSizeSig) vecEvalInt(input *chunk.Chunk, result *chunk
 		}
 		j := buf.GetJSON(i)
 
-		jb, err := j.MarshalJSON()
-		if err != nil {
-			continue
-		}
-
-		int64s[i] = int64(len(jb))
+		int64s[i] = int64(len(j.Value)) + 1
 	}
 	return nil
 }

--- a/expression/distsql_builtin_test.go
+++ b/expression/distsql_builtin_test.go
@@ -153,7 +153,7 @@ func TestEval(t *testing.T) {
 				toPBFieldType(newIntFieldType()),
 				jsonDatumExpr(t, `[{"a":{"a":1},"b":2}]`),
 			),
-			types.NewIntDatum(25),
+			types.NewIntDatum(82),
 		},
 		{
 			scalarFunctionExpr(tipb.ScalarFuncSig_JsonSearchSig,


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

The `json_storagesize` usually returns the size of json string, which is not expected. It should return the binary size consumed by this json (which is usually bigger than the size of json string, for `object` and `array`).

Issue Number: close #37307 

### What is changed and how it works?

Returns the size of binary `JSONBinary`.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

### Release note

```release-note
Fix the issue that `json_storage_size` returns incorrect size.
```
