### PR TITLE
statistics: fix unstable TestAnalyzeGlobalStatsWithOpts2

### DIFF
--- a/statistics/handle/handle_test.go
+++ b/statistics/handle/handle_test.go
@@ -982,9 +982,12 @@ func TestAnalyzeGlobalStatsWithOpts2(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	originalVal1 := tk.MustQuery("select @@tidb_persist_analyze_options").Rows()[0][0].(string)
+	originalVal2 := tk.MustQuery("select @@tidb_enable_auto_analyze").Rows()[0][0].(string)
 	defer func() {
 		tk.MustExec(fmt.Sprintf("set global tidb_persist_analyze_options = %v", originalVal1))
+		tk.MustExec(fmt.Sprintf("set global tidb_enable_auto_analyze = %v", originalVal2))
 	}()
+	tk.MustExec("set global tidb_enable_auto_analyze = false")
 	tk.MustExec("set global tidb_persist_analyze_options=false")
 	prepareForGlobalStatsWithOpts(t, dom, tk, "test_gstats_opt2", "test_gstats_opt2")
 


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #37647 

Problem Summary:

### What is changed and how it works?

auto analyze may affect TestAnalyzeGlobalStatsWithOpts2, we disbaled this in this test

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
