### PR TITLE
*: restrict column range mem usage

### DIFF
--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1247,6 +1247,8 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx sessionctx.Context, row c
 		}
 		exprs = append(exprs, newExpr) // nozero
 	}
+	// TODO: We already limit range mem usage when buildTemplateRange for inner table of IndexJoin in optimizer phase,
+	// so we don't need and shouldn't limit range mem usage when we refill inner ranges during the execution phase.
 	ranges, _, _, err := ranger.BuildColumnRange(exprs, ctx, cwc.TargetCol.RetType, cwc.colLength, 0)
 	if err != nil {
 		return nil, err

--- a/planner/core/exhaust_physical_plans.go
+++ b/planner/core/exhaust_physical_plans.go
@@ -1247,7 +1247,7 @@ func (cwc *ColWithCmpFuncManager) BuildRangesByRow(ctx sessionctx.Context, row c
 		}
 		exprs = append(exprs, newExpr) // nozero
 	}
-	ranges, err := ranger.BuildColumnRange(exprs, ctx, cwc.TargetCol.RetType, cwc.colLength)
+	ranges, _, _, err := ranger.BuildColumnRange(exprs, ctx, cwc.TargetCol.RetType, cwc.colLength, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -1495,7 +1495,8 @@ func (ijHelper *indexJoinBuildHelper) analyzeLookUpFilters(path *util.AccessPath
 		var ranges, nextColRange []*ranger.Range
 		var err error
 		if len(colAccesses) > 0 {
-			nextColRange, err = ranger.BuildColumnRange(colAccesses, ijHelper.join.ctx, lastPossibleCol.RetType, path.IdxColLens[lastColPos])
+			// TODO: restrict the mem usage of column ranges
+			nextColRange, _, _, err = ranger.BuildColumnRange(colAccesses, ijHelper.join.ctx, lastPossibleCol.RetType, path.IdxColLens[lastColPos], 0)
 			if err != nil {
 				return false, err
 			}
@@ -1607,7 +1608,8 @@ func (ijHelper *indexJoinBuildHelper) buildTemplateRange(matchedKeyCnt int, eqAn
 			continue
 		}
 		exprs := []expression.Expression{eqAndInFuncs[j]}
-		oneColumnRan, err := ranger.BuildColumnRange(exprs, ijHelper.join.ctx, ijHelper.curNotUsedIndexCols[j].RetType, ijHelper.curNotUsedColLens[j])
+		// TODO: restrict the mem usage of column ranges
+		oneColumnRan, _, _, err := ranger.BuildColumnRange(exprs, ijHelper.join.ctx, ijHelper.curNotUsedIndexCols[j].RetType, ijHelper.curNotUsedColLens[j], 0)
 		if err != nil {
 			return nil, false, err
 		}

--- a/planner/core/find_best_task.go
+++ b/planner/core/find_best_task.go
@@ -1737,8 +1737,8 @@ func (ds *DataSource) crossEstimateRowCount(path *util.AccessPath, conds []expre
 	if len(accessConds) == 0 {
 		return 0, false, corr
 	}
-	ranges, err := ranger.BuildColumnRange(accessConds, ds.ctx, col.RetType, types.UnspecifiedLength)
-	if len(ranges) == 0 || err != nil {
+	ranges, accessConds, _, err := ranger.BuildColumnRange(accessConds, ds.ctx, col.RetType, types.UnspecifiedLength, ds.ctx.GetSessionVars().RangeMaxSize)
+	if len(ranges) == 0 || len(accessConds) == 0 || err != nil {
 		return 0, err == nil, corr
 	}
 	idxID, idxExists := ds.stats.HistColl.ColID2IdxID[colID]

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -7297,3 +7297,15 @@ func TestPlanCacheForTableRangeFallback(t *testing.T) {
 	// The plan with range fallback is not cached.
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
+
+func TestUT(t *testing.T) {
+	store := testkit.CreateMockStore(t)
+	tk := testkit.NewTestKit(t, store)
+
+	tk.MustExec("use test")
+	tk.MustExec("create table t(a int)")
+	tk.MustQuery("explain format='brief' select * from t where t.a is not null").Check(testkit.Rows(
+		"TableReader 9990.00 root  data:Selection",
+		"└─Selection 9990.00 cop[tikv]  not(isnull(test.t.a))",
+		"  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
+}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -7268,6 +7268,7 @@ func TestTableRangeFallback(t *testing.T) {
 		"TableReader 8000.00 root  data:Selection",
 		"└─Selection 8000.00 cop[tikv]  gt(test.t1.b, 1), in(test.t1.a, 10, 20, 30, 40, 50)",
 		"  └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Memory capacity of 10 bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen"))
 	tk.MustQuery("explain format='brief' select * from t1 join t2 on t1.b = t2.c where t1.a in (10, 20, 30, 40, 50)").Check(testkit.Rows(
 		"HashJoin 10000.00 root  inner join, equal:[eq(test.t1.b, test.t2.c)]",
 		"├─TableReader(Build) 8000.00 root  data:Selection",
@@ -7276,6 +7277,7 @@ func TestTableRangeFallback(t *testing.T) {
 		"└─TableReader(Probe) 8000.00 root  data:Selection",
 		"  └─Selection 8000.00 cop[tikv]  in(test.t1.a, 10, 20, 30, 40, 50), not(isnull(test.t1.b))",
 		"    └─TableFullScan 10000.00 cop[tikv] table:t1 keep order:false, stats:pseudo"))
+	tk.MustQuery("show warnings").Check(testkit.Rows("Warning 1105 Memory capacity of 10 bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen"))
 }
 
 func TestPlanCacheForTableRangeFallback(t *testing.T) {

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -7297,15 +7297,3 @@ func TestPlanCacheForTableRangeFallback(t *testing.T) {
 	// The plan with range fallback is not cached.
 	tk.MustQuery("select @@last_plan_from_cache").Check(testkit.Rows("0"))
 }
-
-func TestUT(t *testing.T) {
-	store := testkit.CreateMockStore(t)
-	tk := testkit.NewTestKit(t, store)
-
-	tk.MustExec("use test")
-	tk.MustExec("create table t(a int)")
-	tk.MustQuery("explain format='brief' select * from t where t.a is not null").Check(testkit.Rows(
-		"TableReader 9990.00 root  data:Selection",
-		"└─Selection 9990.00 cop[tikv]  not(isnull(test.t.a))",
-		"  └─TableFullScan 10000.00 cop[tikv] table:t keep order:false, stats:pseudo"))
-}

--- a/planner/core/integration_test.go
+++ b/planner/core/integration_test.go
@@ -7254,14 +7254,14 @@ func TestTableRangeFallback(t *testing.T) {
 	tk.MustExec("create table t1 (a int primary key, b int)")
 	tk.MustExec("create table t2 (c int)")
 	tk.MustQuery("explain format='brief' select * from t1 where a in (10, 20, 30, 40, 50) and b > 1").Check(testkit.Rows(
-		"Selection 0.12 root  gt(test.t1.b, 1)",
+		"Selection 1.67 root  gt(test.t1.b, 1)",
 		"└─Batch_Point_Get 5.00 root table:t1 handle:[10 20 30 40 50], keep order:false, desc:false"))
 	tk.MustQuery("explain format='brief' select * from t1 join t2 on t1.b = t2.c where t1.a in (10, 20, 30, 40, 50)").Check(testkit.Rows(
-		"HashJoin 0.16 root  inner join, equal:[eq(test.t1.b, test.t2.c)]",
-		"├─Selection(Build) 0.12 root  not(isnull(test.t1.b))",
+		"HashJoin 6.24 root  inner join, equal:[eq(test.t1.b, test.t2.c)]",
+		"├─Selection(Build) 5.00 root  not(isnull(test.t1.b))",
 		"│ └─Batch_Point_Get 5.00 root table:t1 handle:[10 20 30 40 50], keep order:false, desc:false",
-		"└─TableReader(Probe) 250.00 root  data:Selection",
-		"  └─Selection 250.00 cop[tikv]  not(isnull(test.t2.c))",
+		"└─TableReader(Probe) 9990.00 root  data:Selection",
+		"  └─Selection 9990.00 cop[tikv]  not(isnull(test.t2.c))",
 		"    └─TableFullScan 10000.00 cop[tikv] table:t2 keep order:false, stats:pseudo"))
 	tk.MustExec("set @@tidb_opt_range_max_size=10")
 	tk.MustQuery("explain format='brief' select * from t1 where a in (10, 20, 30, 40, 50) and b > 1").Check(testkit.Rows(

--- a/planner/core/logical_plans.go
+++ b/planner/core/logical_plans.go
@@ -1459,7 +1459,9 @@ func (ds *DataSource) deriveTablePathStats(path *util.AccessPath, conds []expres
 		path.CountAfterAccess = 1
 		return nil
 	}
-	path.Ranges, err = ranger.BuildTableRange(path.AccessConds, ds.ctx, pkCol.RetType)
+	var remainedConds []expression.Expression
+	path.Ranges, path.AccessConds, remainedConds, err = ranger.BuildTableRange(path.AccessConds, ds.ctx, pkCol.RetType, ds.ctx.GetSessionVars().RangeMaxSize)
+	path.TableFilters = append(path.TableFilters, remainedConds...)
 	if err != nil {
 		return err
 	}

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -681,7 +681,9 @@ func (ts *PhysicalTableScan) IsPartition() (bool, int64) {
 	return ts.isPartition, ts.physicalTableID
 }
 
-// ResolveCorrelatedColumns resolves the correlated columns in range access
+// ResolveCorrelatedColumns resolves the correlated columns in range access.
+// We already limit range mem usage when building ranges in optimizer phase, so we don't need and shouldn't limit range
+// mem usage when rebuilding ranges during the execution phase.
 func (ts *PhysicalTableScan) ResolveCorrelatedColumns() ([]*ranger.Range, error) {
 	access := ts.AccessCondition
 	if ts.Table.IsCommonHandle {

--- a/planner/core/physical_plans.go
+++ b/planner/core/physical_plans.go
@@ -701,7 +701,7 @@ func (ts *PhysicalTableScan) ResolveCorrelatedColumns() ([]*ranger.Range, error)
 	} else {
 		var err error
 		pkTP := ts.Table.GetPkColInfo().FieldType
-		ts.Ranges, err = ranger.BuildTableRange(access, ts.SCtx(), &pkTP)
+		ts.Ranges, _, _, err = ranger.BuildTableRange(access, ts.SCtx(), &pkTP, 0)
 		if err != nil {
 			return nil, err
 		}

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -371,7 +371,7 @@ func rebuildRange(p Plan) error {
 					}
 				}
 				if pkCol != nil {
-					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType)
+					ranges, _, _, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType, 0)
 					if err != nil {
 						return err
 					}
@@ -432,7 +432,7 @@ func rebuildRange(p Plan) error {
 					}
 				}
 				if pkCol != nil {
-					ranges, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType)
+					ranges, _, _, err := ranger.BuildTableRange(x.AccessConditions, x.ctx, pkCol.RetType, 0)
 					if err != nil {
 						return err
 					}
@@ -562,7 +562,7 @@ func buildRangeForTableScan(sctx sessionctx.Context, ts *PhysicalTableScan) (err
 			}
 		}
 		if pkCol != nil {
-			ts.Ranges, err = ranger.BuildTableRange(ts.AccessCondition, sctx, pkCol.RetType)
+			ts.Ranges, _, _, err = ranger.BuildTableRange(ts.AccessCondition, sctx, pkCol.RetType, 0)
 			if err != nil {
 				return err
 			}

--- a/planner/core/plan_cache.go
+++ b/planner/core/plan_cache.go
@@ -306,14 +306,14 @@ func RebuildPlan4CachedPlan(p Plan) error {
 }
 
 // rebuildRange doesn't set mem limit for building ranges. There are two reasons why we don't restrict range mem usage here.
-// 1. The cached plan must be able to build complete ranges under mem limit when it is generated. Hence we can just build
-//    ranges from x.AccessConditions. The only difference between the last ranges and new ranges is the change of parameter
-//    values, which doesn't cause much change on the mem usage of complete ranges.
-// 2. Different parameter values can change the mem usage of complete ranges. If we set range mem limit here, range fallback
-//    may heppen and cause correctness problem. For example, a in (?, ?, ?) is the access condition. When the plan is firstly
-//    generated, its complete ranges are ['a','a'], ['b','b'], ['c','c'], whose mem usage is under range mem limit 100B.
-//    When the cached plan is hit, the complete ranges may become ['aaa','aaa'], ['bbb','bbb'], ['ccc','ccc'], whose mem
-//    usage exceeds range mem limit 100B, and range fallback happens and tidb may fetch more rows than users expect.
+//  1. The cached plan must be able to build complete ranges under mem limit when it is generated. Hence we can just build
+//     ranges from x.AccessConditions. The only difference between the last ranges and new ranges is the change of parameter
+//     values, which doesn't cause much change on the mem usage of complete ranges.
+//  2. Different parameter values can change the mem usage of complete ranges. If we set range mem limit here, range fallback
+//     may heppen and cause correctness problem. For example, a in (?, ?, ?) is the access condition. When the plan is firstly
+//     generated, its complete ranges are ['a','a'], ['b','b'], ['c','c'], whose mem usage is under range mem limit 100B.
+//     When the cached plan is hit, the complete ranges may become ['aaa','aaa'], ['bbb','bbb'], ['ccc','ccc'], whose mem
+//     usage exceeds range mem limit 100B, and range fallback happens and tidb may fetch more rows than users expect.
 func rebuildRange(p Plan) error {
 	sctx := p.SCtx()
 	sc := p.SCtx().GetSessionVars().StmtCtx

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -509,7 +509,7 @@ func (ts *LogicalTableScan) DeriveStats(_ []*property.StatsInfo, _ *expression.S
 	// ts.Handle could be nil if PK is Handle, and PK column has been pruned.
 	// TODO: support clustered index.
 	if ts.HandleCols != nil {
-		// ts.AccessConds have already been determined here so we can build ranges without the memory limit.
+		// TODO: restrict mem usage of table ranges.
 		ts.Ranges, _, _, err = ranger.BuildTableRange(ts.AccessConds, ts.ctx, ts.HandleCols.GetCol(0).RetType, 0)
 	} else {
 		isUnsigned := false

--- a/planner/core/stats.go
+++ b/planner/core/stats.go
@@ -509,7 +509,8 @@ func (ts *LogicalTableScan) DeriveStats(_ []*property.StatsInfo, _ *expression.S
 	// ts.Handle could be nil if PK is Handle, and PK column has been pruned.
 	// TODO: support clustered index.
 	if ts.HandleCols != nil {
-		ts.Ranges, err = ranger.BuildTableRange(ts.AccessConds, ts.ctx, ts.HandleCols.GetCol(0).RetType)
+		// ts.AccessConds have already been determined here so we can build ranges without the memory limit.
+		ts.Ranges, _, _, err = ranger.BuildTableRange(ts.AccessConds, ts.ctx, ts.HandleCols.GetCol(0).RetType, 0)
 	} else {
 		isUnsigned := false
 		if ts.Source.tableInfo.PKIsHandle {

--- a/sessionctx/stmtctx/stmtctx.go
+++ b/sessionctx/stmtctx/stmtctx.go
@@ -989,10 +989,11 @@ func (sc *StatementContext) GetLockWaitStartTime() time.Time {
 	return time.Unix(0, startTime)
 }
 
-// AppendRangeFallbackWarning appends a warning to indicate that building complete ranges exceeds the memory limit so it
-// falls back to less accurate ranges such as full range. It only appends one warning even if building ranges happens
-// several times when optimizing one query.
-func (sc *StatementContext) AppendRangeFallbackWarning(rangeMaxSize int64) {
+// RecordRangeFallback records range fallback.
+func (sc *StatementContext) RecordRangeFallback(rangeMaxSize int64) {
+	// If range fallback happens, it means ether the query is unreasonable(for example, several long IN lists) or tidb_opt_range_max_size is too small
+	// and the generated plan is probably suboptimal. In that case we don't put it into plan cache.
+	sc.SkipPlanCache = true
 	if !sc.RangeFallback {
 		sc.AppendWarning(errors.Errorf("Memory capacity of %v bytes for 'tidb_opt_range_max_size' exceeded when building ranges. Less accurate ranges such as full range are chosen", rangeMaxSize))
 		sc.RangeFallback = true

--- a/statistics/selectivity.go
+++ b/statistics/selectivity.go
@@ -499,7 +499,7 @@ func getMaskAndRanges(ctx sessionctx.Context, exprs []expression.Expression, ran
 	switch rangeType {
 	case ranger.ColumnRangeType:
 		accessConds = ranger.ExtractAccessConditionsForColumn(exprs, cols[0])
-		ranges, err = ranger.BuildColumnRange(accessConds, ctx, cols[0].RetType, types.UnspecifiedLength)
+		ranges, accessConds, _, err = ranger.BuildColumnRange(accessConds, ctx, cols[0].RetType, types.UnspecifiedLength, ctx.GetSessionVars().RangeMaxSize)
 	case ranger.IndexRangeType:
 		if cachedPath != nil {
 			ranges, accessConds, remainedConds, isDNF = cachedPath.Ranges, cachedPath.AccessConds, cachedPath.TableFilters, cachedPath.IsDNFCond

--- a/util/ranger/detacher.go
+++ b/util/ranger/detacher.go
@@ -688,7 +688,8 @@ func (d *rangeDetacher) detachDNFCondAndBuildRangeForIndex(condition *expression
 				firstColumnChecker.shouldReserve = d.lengths[0] != types.UnspecifiedLength
 			}
 			points := rb.build(item, collate.GetCollator(newTpSlice[0].GetCollate()))
-			ranges, err := points2Ranges(d.sctx, points, newTpSlice[0])
+			// TODO: restrict the mem usage of ranges
+			ranges, _, err := points2Ranges(d.sctx, points, newTpSlice[0], 0)
 			if err != nil {
 				return nil, nil, nil, false, errors.Trace(err)
 			}

--- a/util/ranger/points.go
+++ b/util/ranger/points.go
@@ -157,26 +157,26 @@ func getNotNullFullRange() []*point {
 
 // FullIntRange is used for table range. Since table range cannot accept MaxValueDatum as the max value.
 // So we need to set it to MaxInt64.
-func FullIntRange(isUnsigned bool) []*Range {
+func FullIntRange(isUnsigned bool) Ranges {
 	if isUnsigned {
-		return []*Range{{LowVal: []types.Datum{types.NewUintDatum(0)}, HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)}, Collators: collate.GetBinaryCollatorSlice(1)}}
+		return Ranges{{LowVal: []types.Datum{types.NewUintDatum(0)}, HighVal: []types.Datum{types.NewUintDatum(math.MaxUint64)}, Collators: collate.GetBinaryCollatorSlice(1)}}
 	}
-	return []*Range{{LowVal: []types.Datum{types.NewIntDatum(math.MinInt64)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}, Collators: collate.GetBinaryCollatorSlice(1)}}
+	return Ranges{{LowVal: []types.Datum{types.NewIntDatum(math.MinInt64)}, HighVal: []types.Datum{types.NewIntDatum(math.MaxInt64)}, Collators: collate.GetBinaryCollatorSlice(1)}}
 }
 
 // FullRange is [null, +∞) for Range.
-func FullRange() []*Range {
-	return []*Range{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}, Collators: collate.GetBinaryCollatorSlice(1)}}
+func FullRange() Ranges {
+	return Ranges{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{types.MaxValueDatum()}, Collators: collate.GetBinaryCollatorSlice(1)}}
 }
 
 // FullNotNullRange is (-∞, +∞) for Range.
-func FullNotNullRange() []*Range {
-	return []*Range{{LowVal: []types.Datum{types.MinNotNullDatum()}, HighVal: []types.Datum{types.MaxValueDatum()}}}
+func FullNotNullRange() Ranges {
+	return Ranges{{LowVal: []types.Datum{types.MinNotNullDatum()}, HighVal: []types.Datum{types.MaxValueDatum()}}}
 }
 
 // NullRange is [null, null] for Range.
-func NullRange() []*Range {
-	return []*Range{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{{}}, Collators: collate.GetBinaryCollatorSlice(1)}}
+func NullRange() Ranges {
+	return Ranges{{LowVal: []types.Datum{{}}, HighVal: []types.Datum{{}}, Collators: collate.GetBinaryCollatorSlice(1)}}
 }
 
 // builder is the range builder struct.

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -352,7 +352,7 @@ func buildColumnRange(accessConditions []expression.Expression, sctx sessionctx.
 		return nil, nil, nil, errors.Trace(err)
 	}
 	if rangeFallback {
-		sctx.GetSessionVars().StmtCtx.AppendRangeFallbackWarning(rangeMaxSize)
+		sctx.GetSessionVars().StmtCtx.RecordRangeFallback(rangeMaxSize)
 		return FullRange(), nil, accessConditions, nil
 	}
 	if colLen != types.UnspecifiedLength {

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -378,6 +378,9 @@ func buildColumnRange(accessConditions []expression.Expression, sctx sessionctx.
 // BuildTableRange builds range of PK column for PhysicalTableScan.
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // The second return value is the conditions used to build ranges and the third return value is the remained conditions.
+// If you use the function to build ranges for some access path, you need to update the path's access conditions and filter
+// conditions by the second and third return values respectively.
+// If you ask that all conds must be used for building ranges, set rangeMemQuota to 0 to avoid range fallback.
 func BuildTableRange(accessConditions []expression.Expression, sctx sessionctx.Context, tp *types.FieldType,
 	rangeMaxSize int64) (Ranges, []expression.Expression, []expression.Expression, error) {
 	return buildColumnRange(accessConditions, sctx, tp, true, types.UnspecifiedLength, rangeMaxSize)
@@ -386,6 +389,9 @@ func BuildTableRange(accessConditions []expression.Expression, sctx sessionctx.C
 // BuildColumnRange builds range from access conditions for general columns.
 // rangeMaxSize is the max memory limit for ranges. O indicates no memory limit.
 // The second return value is the conditions used to build ranges and the third return value is the remained conditions.
+// If you use the function to build ranges for some access path, you need to update the path's access conditions and filter
+// conditions by the second and third return values respectively.
+// If you ask that all conds must be used for building ranges, set rangeMemQuota to 0 to avoid range fallback.
 func BuildColumnRange(conds []expression.Expression, sctx sessionctx.Context, tp *types.FieldType, colLen int,
 	rangeMemQuota int64) (Ranges, []expression.Expression, []expression.Expression, error) {
 	if len(conds) == 0 {

--- a/util/ranger/ranger.go
+++ b/util/ranger/ranger.go
@@ -346,7 +346,7 @@ func buildColumnRange(accessConditions []expression.Expression, sctx sessionctx.
 	if tableRange {
 		ranges, rangeFallback, err = points2TableRanges(sctx, rangePoints, newTp, rangeMaxSize)
 	} else {
-		ranges, rangeFallback, err = points2TableRanges(sctx, rangePoints, newTp, rangeMaxSize)
+		ranges, rangeFallback, err = points2Ranges(sctx, rangePoints, newTp, rangeMaxSize)
 	}
 	if err != nil {
 		return nil, nil, nil, errors.Trace(err)

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -2109,8 +2109,8 @@ func getSelectionFromQuery(t *testing.T, sctx sessionctx.Context, sql string) *p
 	require.NoError(t, err)
 	p, _, err := plannercore.BuildLogicalPlanForTest(ctx, sctx, stmts[0], ret.InfoSchema)
 	require.NoError(t, err)
-	selection := p.(plannercore.LogicalPlan).Children()[0].(*plannercore.LogicalSelection)
-	require.NotNil(t, selection)
+	selection, isSelection := p.(plannercore.LogicalPlan).Children()[0].(*plannercore.LogicalSelection)
+	require.True(t, isSelection)
 	return selection
 }
 

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -17,12 +17,12 @@ package ranger_test
 import (
 	"context"
 	"fmt"
-	"github.com/pingcap/tidb/parser/model"
 	"testing"
 
 	"github.com/pingcap/tidb/config"
 	"github.com/pingcap/tidb/expression"
 	"github.com/pingcap/tidb/parser/ast"
+	"github.com/pingcap/tidb/parser/model"
 	"github.com/pingcap/tidb/parser/mysql"
 	plannercore "github.com/pingcap/tidb/planner/core"
 	"github.com/pingcap/tidb/session"

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -2119,7 +2119,7 @@ func checkRangeFallbackAndReset(t *testing.T, sctx sessionctx.Context, expectedR
 	sctx.GetSessionVars().StmtCtx.RangeFallback = false
 }
 
-func TestRangeFallbackForBuildTableRange(t *testing.T) {
+func TestBuildTableRangeFallback(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -2153,7 +2153,7 @@ func TestRangeFallbackForBuildTableRange(t *testing.T) {
 	checkRangeFallbackAndReset(t, sctx, true)
 }
 
-func TestRangeFallbackForBuildColumnRange(t *testing.T) {
+func TestBuildColumnRangeFallback(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -2119,7 +2119,7 @@ func checkRangeFallbackAndReset(t *testing.T, sctx sessionctx.Context, expectedR
 	sctx.GetSessionVars().StmtCtx.RangeFallback = false
 }
 
-func TestRangeMemQuotaForBuildTableRange(t *testing.T) {
+func TestRangeFallbackForBuildTableRange(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")
@@ -2153,7 +2153,7 @@ func TestRangeMemQuotaForBuildTableRange(t *testing.T) {
 	checkRangeFallbackAndReset(t, sctx, true)
 }
 
-func TestRangeMemQuotaForBuildColumnRange(t *testing.T) {
+func TestRangeFallbackForBuildColumnRange(t *testing.T) {
 	store, dom := testkit.CreateMockStoreAndDomain(t)
 	tk := testkit.NewTestKit(t, store)
 	tk.MustExec("use test")

--- a/util/ranger/ranger_test.go
+++ b/util/ranger/ranger_test.go
@@ -17,6 +17,7 @@ package ranger_test
 import (
 	"context"
 	"fmt"
+	"github.com/pingcap/tidb/parser/model"
 	"testing"
 
 	"github.com/pingcap/tidb/config"
@@ -279,7 +280,7 @@ func TestTableRange(t *testing.T) {
 			conds, filter = ranger.DetachCondsForColumn(sctx, conds, col)
 			require.Equal(t, tt.accessConds, fmt.Sprintf("%s", conds))
 			require.Equal(t, tt.filterConds, fmt.Sprintf("%s", filter))
-			result, err := ranger.BuildTableRange(conds, sctx, col.RetType)
+			result, _, _, err := ranger.BuildTableRange(conds, sctx, col.RetType, 0)
 			require.NoError(t, err)
 			got := fmt.Sprintf("%v", result)
 			require.Equal(t, tt.resultStr, got)
@@ -828,7 +829,7 @@ func TestColumnRange(t *testing.T) {
 			require.NotNil(t, col)
 			conds = ranger.ExtractAccessConditionsForColumn(conds, col)
 			require.Equal(t, tt.accessConds, fmt.Sprintf("%s", conds))
-			result, err := ranger.BuildColumnRange(conds, sctx, col.RetType, tt.length)
+			result, _, _, err := ranger.BuildColumnRange(conds, sctx, col.RetType, tt.length, 0)
 			require.NoError(t, err)
 			got := fmt.Sprintf("%v", result)
 			require.Equal(t, tt.resultStr, got)
@@ -2096,4 +2097,92 @@ func TestShardIndexFuncSuites(t *testing.T) {
 		newConds, _ := ranger.AddExpr4EqAndInCondition(sctx, tt.inputConds, shardIndexCols)
 		require.Equal(t, fmt.Sprintf("%s", newConds), tt.outputConds)
 	}
+}
+
+func getSelectionFromQuery(t *testing.T, sctx sessionctx.Context, sql string) *plannercore.LogicalSelection {
+	ctx := context.Background()
+	stmts, err := session.Parse(sctx, sql)
+	require.NoError(t, err)
+	require.Len(t, stmts, 1)
+	ret := &plannercore.PreprocessorReturn{}
+	err = plannercore.Preprocess(sctx, stmts[0], plannercore.WithPreprocessorReturn(ret))
+	require.NoError(t, err)
+	p, _, err := plannercore.BuildLogicalPlanForTest(ctx, sctx, stmts[0], ret.InfoSchema)
+	require.NoError(t, err)
+	selection := p.(plannercore.LogicalPlan).Children()[0].(*plannercore.LogicalSelection)
+	require.NotNil(t, selection)
+	return selection
+}
+
+func checkRangeFallbackAndReset(t *testing.T, sctx sessionctx.Context, expectedRangeFallback bool) {
+	require.Equal(t, expectedRangeFallback, sctx.GetSessionVars().StmtCtx.RangeFallback)
+	sctx.GetSessionVars().StmtCtx.RangeFallback = false
+}
+
+func TestRangeMemQuotaForBuildTableRange(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a int primary key, b int)")
+	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	sctx := tk.Session().(sessionctx.Context)
+	sql := "select * from t where a in (10,20,30,40,50)"
+	selection := getSelectionFromQuery(t, sctx, sql)
+	conds := selection.Conditions
+	require.Equal(t, 1, len(conds))
+	col := expression.ColInfo2Col(selection.Schema().Columns, tblInfo.Columns[0])
+	var filters []expression.Expression
+	conds, filters = ranger.DetachCondsForColumn(sctx, conds, col)
+	require.Equal(t, 1, len(conds))
+	require.Equal(t, 0, len(filters))
+	ranges, access, remained, err := ranger.BuildTableRange(conds, sctx, col.RetType, 0)
+	require.NoError(t, err)
+	require.Equal(t, "[[10,10] [20,20] [30,30] [40,40] [50,50]]", fmt.Sprintf("%v", ranges))
+	require.Equal(t, "[in(test.t.a, 10, 20, 30, 40, 50)]", fmt.Sprintf("%v", access))
+	require.Equal(t, "[]", fmt.Sprintf("%v", remained))
+	checkRangeFallbackAndReset(t, sctx, false)
+	quota := ranges.MemUsage() - 1
+	ranges, access, remained, err = ranger.BuildTableRange(conds, sctx, col.RetType, quota)
+	require.NoError(t, err)
+	require.Equal(t, "[[NULL,+inf]]", fmt.Sprintf("%v", ranges))
+	require.Equal(t, "[]", fmt.Sprintf("%v", access))
+	require.Equal(t, "[in(test.t.a, 10, 20, 30, 40, 50)]", fmt.Sprintf("%v", remained))
+	checkRangeFallbackAndReset(t, sctx, true)
+}
+
+func TestRangeMemQuotaForBuildColumnRange(t *testing.T) {
+	store, dom := testkit.CreateMockStoreAndDomain(t)
+	tk := testkit.NewTestKit(t, store)
+	tk.MustExec("use test")
+	tk.MustExec("drop table if exists t")
+	tk.MustExec("create table t (a varchar(20), b int)")
+	tbl, err := dom.InfoSchema().TableByName(model.NewCIStr("test"), model.NewCIStr("t"))
+	require.NoError(t, err)
+	tblInfo := tbl.Meta()
+	sctx := tk.Session().(sessionctx.Context)
+	sql := "select * from t where a in ('aaa','bbb','ccc','ddd','eee')"
+	selection := getSelectionFromQuery(t, sctx, sql)
+	conds := selection.Conditions
+	require.Equal(t, 1, len(conds))
+	col := expression.ColInfo2Col(selection.Schema().Columns, tblInfo.Columns[0])
+	var filters []expression.Expression
+	conds, filters = ranger.DetachCondsForColumn(sctx, conds, col)
+	require.Equal(t, 1, len(conds))
+	require.Equal(t, 0, len(filters))
+	ranges, access, remained, err := ranger.BuildColumnRange(conds, sctx, col.RetType, types.UnspecifiedLength, 0)
+	require.NoError(t, err)
+	require.Equal(t, "[[\"aaa\",\"aaa\"] [\"bbb\",\"bbb\"] [\"ccc\",\"ccc\"] [\"ddd\",\"ddd\"] [\"eee\",\"eee\"]]", fmt.Sprintf("%v", ranges))
+	require.Equal(t, "[in(test.t.a, aaa, bbb, ccc, ddd, eee)]", fmt.Sprintf("%v", access))
+	require.Equal(t, "[]", fmt.Sprintf("%v", remained))
+	checkRangeFallbackAndReset(t, sctx, false)
+	quota := ranges.MemUsage() - 1
+	ranges, access, remained, err = ranger.BuildColumnRange(conds, sctx, col.RetType, types.UnspecifiedLength, quota)
+	require.NoError(t, err)
+	require.Equal(t, "[[NULL,+inf]]", fmt.Sprintf("%v", ranges))
+	require.Equal(t, "[]", fmt.Sprintf("%v", access))
+	require.Equal(t, "[in(test.t.a, aaa, bbb, ccc, ddd, eee)]", fmt.Sprintf("%v", remained))
+	checkRangeFallbackAndReset(t, sctx, true)
 }

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -51,6 +51,7 @@ func (Ranges) Rebuild() error {
 	return nil
 }
 
+// MemUsage gets the memory usage of ranges.
 func (rs Ranges) MemUsage() (sum int64) {
 	if len(rs) == 0 {
 		return
@@ -224,8 +225,10 @@ func (ran *Range) PrefixEqualLen(sc *stmtctx.StatementContext) (int, error) {
 	return len(ran.LowVal), nil
 }
 
+// EmptyRangeSize is the size of empty range.
 const EmptyRangeSize = int64(unsafe.Sizeof(Range{}))
 
+// MemUsage gets the memory usage of range.
 func (ran *Range) MemUsage() (sum int64) {
 	sum = EmptyRangeSize + int64(cap(ran.LowVal))*types.EmptyDatumSize + int64(cap(ran.HighVal))*types.EmptyDatumSize + int64(cap(ran.Collators))*16
 	for _, val := range ran.LowVal {

--- a/util/ranger/types.go
+++ b/util/ranger/types.go
@@ -230,6 +230,7 @@ const EmptyRangeSize = int64(unsafe.Sizeof(Range{}))
 
 // MemUsage gets the memory usage of range.
 func (ran *Range) MemUsage() (sum int64) {
+	// 16 is the size of Collator interface.
 	sum = EmptyRangeSize + int64(cap(ran.LowVal))*types.EmptyDatumSize + int64(cap(ran.HighVal))*types.EmptyDatumSize + int64(cap(ran.Collators))*16
 	for _, val := range ran.LowVal {
 		sum += val.MemUsage() - types.EmptyDatumSize

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -216,3 +216,22 @@ func TestIsFullRange(t *testing.T) {
 		require.Equal(t, v.isFullRange, v.ran.IsFullRange(v.unsignedIntHandle))
 	}
 }
+
+func TestRangeMemUsage(t *testing.T) {
+	r1 := ranger.Range{
+		LowVal:    []types.Datum{types.NewIntDatum(0)},
+		HighVal:   []types.Datum{types.NewIntDatum(1)},
+		Collators: collate.GetBinaryCollatorSlice(1),
+	}
+	mem1 := ranger.EmptyRangeSize + 2*types.EmptyDatumSize + 16
+	require.Equal(t, mem1, r1.MemUsage())
+	r2 := ranger.Range{
+		LowVal:    []types.Datum{types.NewStringDatum("abcde")},
+		HighVal:   []types.Datum{types.NewStringDatum("fghij")},
+		Collators: collate.GetBinaryCollatorSlice(1),
+	}
+	mem2 := mem1 + int64(cap(r2.LowVal[0].GetBytes())) + int64(len(r2.LowVal[0].Collation())) + int64(cap(r2.HighVal[0].GetBytes())) + int64(len(r2.HighVal[0].Collation()))
+	require.Equal(t, mem2, r2.MemUsage())
+	ranges := ranger.Ranges{&r1, &r2}
+	require.Equal(t, mem1+mem2, ranges.MemUsage())
+}

--- a/util/ranger/types_test.go
+++ b/util/ranger/types_test.go
@@ -233,5 +233,5 @@ func TestRangeMemUsage(t *testing.T) {
 	mem2 := mem1 + int64(cap(r2.LowVal[0].GetBytes())) + int64(len(r2.LowVal[0].Collation())) + int64(cap(r2.HighVal[0].GetBytes())) + int64(len(r2.HighVal[0].Collation()))
 	require.Equal(t, mem2, r2.MemUsage())
 	ranges := ranger.Ranges{&r1, &r2}
-	require.Equal(t, mem1+mem2, ranges.MemUsage())
+	require.Equal(t, mem1*2, ranges.MemUsage())
 }


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: ref #37176

Problem Summary:

### What is changed and how it works?

Restrict column range mem usage. If the optimizer estimates that complete column ranges would exceed `tidb_opt_range_max_size`, it chooses full range. Part 2 of #37160.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [ ] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
