### PR TITLE
import: copy datum values when read first N rows

### DIFF
--- a/br/pkg/lightning/restore/get_pre_info.go
+++ b/br/pkg/lightning/restore/get_pre_info.go
@@ -493,7 +493,8 @@ func (p *PreRestoreInfoGetterImpl) ReadFirstNRowsByFileMeta(ctx context.Context,
 			}
 			break
 		}
-		rows = append(rows, parser.LastRow().Row)
+		lastRowDatums := append([]types.Datum{}, parser.LastRow().Row...)
+		rows = append(rows, lastRowDatums)
 	}
 	return parser.Columns(), rows, nil
 }

--- a/br/pkg/lightning/restore/mock/mock.go
+++ b/br/pkg/lightning/restore/mock/mock.go
@@ -113,6 +113,8 @@ func NewMockImportSource(dbSrcDataMap map[string]*MockDBSourceData) (*MockImport
 					fileInfo.FileMeta.Type = mydump.SourceTypeCSV
 				case strings.HasSuffix(tblDataFile.FileName, ".sql"):
 					fileInfo.FileMeta.Type = mydump.SourceTypeSQL
+				case strings.HasSuffix(tblDataFile.FileName, ".parquet"):
+					fileInfo.FileMeta.Type = mydump.SourceTypeParquet
 				default:
 					return nil, errors.Errorf("unsupported file type: %s", tblDataFile.FileName)
 				}


### PR DESCRIPTION
<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37726 

Problem Summary:

### What is changed and how it works?
When fetched the datum values slice, create a new slice with a copy of these datums, and append the new slice into the result.

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test
- [ ] Integration test
- [x] Manual test (add detailed scripts or steps below)
- [ ] No code

Side effects

- [ ] Performance regression: Consumes more CPU
- [ ] Performance regression: Consumes more Memory
- [ ] Breaking backward compatibility

Documentation

- [ ] Affects user behaviors
- [ ] Contains syntax changes
- [ ] Contains variable changes
- [ ] Contains experimental features
- [ ] Changes MySQL compatibility

### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
