### PR TITLE
session: fix regression of BenchmarkRangeColumnPartitionPruning

### DIFF
--- a/session/bench_test.go
+++ b/session/bench_test.go
@@ -1604,6 +1604,10 @@ func BenchmarkRangeColumnPartitionPruning(b *testing.B) {
 	build.WriteString("partition p1023 values less than maxvalue)")
 	mustExecute(se, build.String())
 	alloc := chunk.NewAllocator()
+	_, err := se.Execute(ctx, "analyze table t")
+	if err != nil {
+		b.Fatal(err)
+	}
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rs, err := se.Execute(ctx, "select * from t where dt > '2020-05-01' and dt < '2020-06-07'")


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

<!--

Thank you for contributing to TiDB!

PR Title Format:
1. pkg [, pkg2, pkg3]: what's changed
2. *: what's changed

-->

### What problem does this PR solve?
<!--

Please create an issue first to describe the problem.

There MUST be one line starting with "Issue Number:  " and 
linking the relevant issues via the "close" or "ref".

For more info, check https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue.

-->

Issue Number: close #37708 

Problem Summary:

### What is changed and how it works?

For now using dynamic prune mode should have global stats, otherwise it will fallback to partition union plan, thus we analyze table in this case in order to generate global stats.

```sh
before fix
BenchmarkRangeColumnPartitionPruning-4   	     380	   2906818 ns/op

after fix
BenchmarkRangeColumnPartitionPruning-4   	    1765	    675119 ns/op
```

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test


### Release note

<!-- compatibility change, improvement, bugfix, and new feature need a release note -->

Please refer to [Release Notes Language Style Guide](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/release-notes-style-guide.html) to write a quality release note.

```release-note
None
```
