### PR TITLE
expression: add extra `.0` and remove `+` in the scientific representation

### DIFF
--- a/types/json_binary_test.go
+++ b/types/json_binary_test.go
@@ -688,3 +688,46 @@ func TestBinaryJSONOpaque(t *testing.T) {
 		require.Equal(t, string(buf), test.expectedOutput)
 	}
 }
+
+func TestMarshalFloat64(t *testing.T) {
+	var tests = []struct {
+		json           string
+		expectedOutput string
+	}{
+		{
+			"1.0",
+			"1.0",
+		},
+		{
+			"123.456",
+			"123.456",
+		},
+		{
+			"1e20",
+			"100000000000000000000.0",
+		},
+		{
+			"1e21",
+			"1e21",
+		},
+		{
+			"[5, 6.0, 7.0, 6.32, 1e20, 1e21]",
+			"[5, 6.0, 7.0, 6.32, 100000000000000000000.0, 1e21]",
+		},
+		{
+			`{"a": 5, "b": 6.0, "c": 7.0, "d": 6.32, "e": 1e20, "f": 1e21}`,
+			`{"a": 5, "b": 6.0, "c": 7.0, "d": 6.32, "e": 100000000000000000000.0, "f": 1e21}`,
+		},
+	}
+
+	for _, test := range tests {
+		buf := []byte{}
+
+		bj, err := ParseBinaryJSONFromString(test.json)
+		require.NoError(t, err)
+
+		buf, err = bj.marshalTo(buf)
+		require.NoError(t, err)
+		require.Equal(t, string(buf), test.expectedOutput)
+	}
+}


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

### What problem does this PR solve?

Issue Number: close #37806 

Problem Summary:

1. Add extra `.0` for integer: `1` (float) will be marshaled to `1.0`
2. Remove `+` in the exponent part of scientific representation 

### What is changed and how it works?

Add some logic in the `marshalFloatTo` function.  

### Check List

Tests <!-- At least one of them must be included. -->

- [x] Unit test

### Release note

```release-note
Fix the issue that the json float number serialization is not compatible with TiKV
```
